### PR TITLE
date-range-picker: Do not display custom time units in date-only mode

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { act, render } from '@testing-library/react';
 import Mockdate from 'mockdate';
-import createWrapper from '../../../lib/components/test-utils/dom';
+import createWrapper, { DateRangePickerWrapper } from '../../../lib/components/test-utils/dom';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
 import { NonCancelableEventHandler } from '../../../lib/components/internal/events';
 import { i18nStrings } from './i18n-strings';
@@ -37,6 +37,15 @@ function renderDateRangePicker(props: DateRangePickerProps = defaultProps) {
   const wrapper = createWrapper(container).findDateRangePicker()!;
 
   return { container, wrapper, ref, getByTestId };
+}
+
+function getCustomRelativeRangeUnits(wrapper: DateRangePickerWrapper) {
+  return wrapper
+    .findDropdown()!
+    .findCustomRelativeRangeUnit()!
+    .findDropdown()
+    .findOptions()
+    .map(option => option.getElement().textContent!.trim());
 }
 
 describe('Date range picker', () => {
@@ -159,6 +168,39 @@ describe('Date range picker', () => {
       changeMode(wrapper, 'relative');
 
       expect(wrapper.findDropdown()!.getElement().textContent).toContain('Set a custom range in the past');
+    });
+
+    test('shows all custom units by default', () => {
+      const { wrapper } = renderDateRangePicker({
+        ...defaultProps,
+        rangeSelectorMode: 'relative-only',
+        relativeOptions: [],
+      });
+      act(() => wrapper.findLabel().click());
+
+      wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
+      expect(getCustomRelativeRangeUnits(wrapper)).toEqual([
+        'seconds',
+        'minutes',
+        'hours',
+        'days',
+        'weeks',
+        'months',
+        'years',
+      ]);
+    });
+
+    test('shows only days and above units in dateOnly mode', () => {
+      const { wrapper } = renderDateRangePicker({
+        ...defaultProps,
+        rangeSelectorMode: 'relative-only',
+        relativeOptions: [],
+        dateOnly: true,
+      });
+      act(() => wrapper.findLabel().click());
+
+      wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
+      expect(getCustomRelativeRangeUnits(wrapper)).toEqual(['days', 'weeks', 'months', 'years']);
     });
   });
 });

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -213,6 +213,7 @@ export function DateRangePickerDropdown({
                     ref={focusRefs['relative-only']}
                     isSingleGrid={isSingleGrid}
                     options={relativeOptions}
+                    dateOnly={dateOnly}
                     initialSelection={selectedRelativeRange}
                     onChange={range => setSelectedRelativeRange(range)}
                     i18nStrings={i18nStrings}

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -13,6 +13,7 @@ import InternalSpaceBetween from '../../space-between/internal';
 import styles from './styles.css.js';
 
 export interface RelativeRangePickerProps {
+  dateOnly: boolean;
   options: ReadonlyArray<DateRangePickerProps.RelativeOption>;
   initialSelection: DateRangePickerProps.RelativeValue | null;
   onChange: (range: DateRangePickerProps.RelativeValue) => void;
@@ -25,23 +26,16 @@ interface UnitSelectOption {
   label: string;
 }
 
-const units: ReadonlyArray<DateRangePickerProps.TimeUnit> = [
-  'second',
-  'minute',
-  'hour',
-  'day',
-  'week',
-  'month',
-  'year',
-];
+const dayUnits: ReadonlyArray<DateRangePickerProps.TimeUnit> = ['day', 'week', 'month', 'year'];
+const units: ReadonlyArray<DateRangePickerProps.TimeUnit> = ['second', 'minute', 'hour', ...dayUnits];
 
 const CUSTOM_OPTION_SELECT_KEY = 'awsui-internal-custom-duration-key';
-const DEFAULT_CUSTOM_UNIT_OF_TIME = 'minute';
 
 export default forwardRef(RelativeRangePicker);
 
 function RelativeRangePicker(
   {
+    dateOnly,
     options: clientOptions = [],
     initialSelection: initialRange,
     onChange: onChangeRangeSize,
@@ -75,8 +69,9 @@ function RelativeRangePicker(
     return NaN;
   });
 
+  const initialCustomTimeUnit = dateOnly ? 'day' : 'minute';
   const [customUnitOfTime, setCustomUnitOfTime] = useState<DateRangePickerProps.TimeUnit>(
-    initialRange?.unit ?? DEFAULT_CUSTOM_UNIT_OF_TIME
+    initialRange?.unit ?? initialCustomTimeUnit
   );
 
   const showRadioControl = clientOptions.length > 0;
@@ -104,10 +99,10 @@ function RelativeRangePicker(
 
                 if (detail.value === CUSTOM_OPTION_SELECT_KEY) {
                   setCustomDuration(NaN);
-                  setCustomUnitOfTime(DEFAULT_CUSTOM_UNIT_OF_TIME);
+                  setCustomUnitOfTime(initialCustomTimeUnit);
                   onChangeRangeSize({
                     amount: NaN,
-                    unit: DEFAULT_CUSTOM_UNIT_OF_TIME,
+                    unit: initialCustomTimeUnit,
                     type: 'relative',
                   });
                 } else {
@@ -172,7 +167,7 @@ function RelativeRangePicker(
                         setCustomUnitOfTime(unit);
                         onChangeRangeSize({ amount: customDuration, unit, type: 'relative' });
                       }}
-                      options={units.map(unit => ({
+                      options={(dateOnly ? dayUnits : units).map(unit => ({
                         value: unit,
                         label: i18nStrings.formatUnit(unit, customDuration),
                       }))}


### PR DESCRIPTION
### Changes Done

Do not display time units in custom range selector in dateOnly mode

### Why?

Because they are not expected in that case.

AWSUI-18629

### Testing

Added extra unit tests

<details>
<summary>Checklist</summary>


### Writing approval

[*Did you include our UX Writer if there are changes to content that will appear on the website (e.g. API documentation)?*]

### Related Links

[*Ticket IDs (no internal links), related pull requests*]

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_

</details>