### PR TITLE
feat: Make all public design tokens themeable

### DIFF
--- a/src/__tests__/__snapshots__/public-design-tokens.test.tsx.snap
+++ b/src/__tests__/__snapshots__/public-design-tokens.test.tsx.snap
@@ -1045,7 +1045,7 @@ Array [
   Object {
     "description": "The default color for group labels. For example: group label in dropdown part of button dropdown, select, and multiselect, and group label in table and cards' preferences content selector.",
     "name": "color-text-group-label",
-    "themeable": false,
+    "themeable": true,
   },
   Object {
     "description": "The default color for headings 1-5. For example: headings in tables, card collections, containers, form sections, forms, and app layout panels.",
@@ -1115,7 +1115,7 @@ Array [
   Object {
     "description": "The hover color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
     "name": "color-text-link-hover",
-    "themeable": false,
+    "themeable": true,
   },
   Object {
     "description": "Default text color for notifications. For example: the text on badges and flashes.",
@@ -2205,7 +2205,7 @@ Array [
   Object {
     "description": "The default color for group labels. For example: group label in dropdown part of button dropdown, select, and multiselect, and group label in table and cards' preferences content selector.",
     "name": "color-text-group-label",
-    "themeable": false,
+    "themeable": true,
   },
   Object {
     "description": "The default color for headings 1-5. For example: headings in tables, card collections, containers, form sections, forms, and app layout panels.",
@@ -2275,7 +2275,7 @@ Array [
   Object {
     "description": "The hover color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
     "name": "color-text-link-hover",
-    "themeable": false,
+    "themeable": true,
   },
   Object {
     "description": "Default text color for notifications. For example: the text on badges and flashes.",

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -366,6 +366,7 @@ const metadata: StyleDictionary.MetadataIndex = {
     description:
       "The default color for group labels. For example: group label in dropdown part of button dropdown, select, and multiselect, and group label in table and cards' preferences content selector.",
     public: true,
+    themeable: true,
   },
   colorTextHeadingDefault: {
     description:
@@ -445,6 +446,7 @@ const metadata: StyleDictionary.MetadataIndex = {
     description:
       'The hover color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.',
     public: true,
+    themeable: true,
   },
   colorTextNotificationDefault: {
     description: 'Default text color for notifications. For example: the text on badges and flashes.',


### PR DESCRIPTION
### Changes Done

This change enables the themeability of the last two remaining public colour design tokens. After this change, _all_ public colour design tokens are themeable.

### Why?

To allow better theming results.

### Testing

[_How did you test your changes?_]

n/a

[_Did you run screenshot tests in the dev-pipeline?_]

n/a

[_How can reviewers test these changes efficiently?_]

\[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md) for details._\]

### Writing approval

[*Did you include our UX Writer if there are changes to content that will appear on the website (e.g. API documentation)?*]

n/a

### Related Links

Document: `aejsAmMtYCGj/A#temp:C:cGW5e74af5ea83d467d864d342d5`

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._ n/a
- [X] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._ n/a
- [ ] _Changes to UX were manually tested for accessibility._ n/a

#### Security

- [X] _Changes do not include XSS vulnerability._
- [X] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._ n/a
- [ ] _All API doc strings were reviewed by the writer._ n/a
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._ n/a
- [X] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._ n/a

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_ n/a
- [ ] _Is there enough coverage with new/existing integration tests?_ n/a
- [ ] _Is there enough coverage with new/existing screenshot tests?_ n/a
