### PR TITLE
fix(code-editor): Do not propagate error state inside preferences modal

### DIFF
--- a/src/code-editor/__tests__/form-field-intergration.test.tsx
+++ b/src/code-editor/__tests__/form-field-intergration.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
 import CodeEditor from '../../../lib/components/code-editor';
 import FormField from '../../../lib/components/form-field';
 import { defaultProps, editorMock } from './util';
@@ -40,4 +41,15 @@ test('inherits aria-attributes from surrounding form field', () => {
   expect(editorMock.renderer.textarea).toHaveAttribute('id', '123');
   expect(editorMock.renderer.textarea).toHaveAttribute('aria-labelledby', '123-label');
   expect(editorMock.renderer.textarea).toHaveAttribute('aria-describedby', '123-description');
+});
+
+test('does not render invalid state inside preferences modal', () => {
+  render(
+    <FormField label="Some code" errorText="Some error">
+      <CodeEditor {...defaultProps} />
+    </FormField>
+  );
+  const wrapper = createWrapper();
+  wrapper.findCodeEditor()!.findSettingsButton()!.click();
+  expect(wrapper.findModal()!.findContent().find('[aria-invalid]')).toBeFalsy();
 });

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -11,6 +11,7 @@ import InternalModal from '../modal/internal';
 import { SelectProps } from '../select/interfaces';
 import InternalSelect from '../select/internal';
 import InternalSpaceBetween from '../space-between/internal';
+import { FormFieldDomContext } from '../internal/context/form-field-context';
 import { NonCancelableCustomEvent } from '../internal/events';
 import { LightThemes, DarkThemes } from './ace-themes';
 import { CodeEditorProps } from './interfaces';
@@ -49,43 +50,45 @@ export default (props: PreferencesModalProps) => {
   };
 
   return (
-    <InternalModal
-      size="medium"
-      visible={true}
-      onDismiss={props.onDismiss}
-      header={props.i18nStrings.header}
-      closeAriaLabel={props.i18nStrings.cancel}
-      footer={
-        <InternalBox float="right">
-          <InternalSpaceBetween direction="horizontal" size="xs">
-            <InternalButton onClick={props.onDismiss}>{props.i18nStrings.cancel}</InternalButton>
-            <InternalButton onClick={() => props.onConfirm({ wrapLines, theme })} variant="primary">
-              {props.i18nStrings.confirm}
-            </InternalButton>
-          </InternalSpaceBetween>
-        </InternalBox>
-      }
-    >
-      <InternalColumnLayout columns={2} variant="text-grid">
-        <div>
-          <InternalCheckbox checked={wrapLines} onChange={e => setWrapLines(e.detail.checked)}>
-            {props.i18nStrings.wrapLines}
-          </InternalCheckbox>
-        </div>
-        <div>
-          <InternalFormField label={props.i18nStrings.theme}>
-            <InternalSelect
-              selectedOption={selectedThemeOption}
-              onChange={onThemeSelected}
-              options={[
-                { label: props.i18nStrings.lightThemes, options: LightThemes },
-                { label: props.i18nStrings.darkThemes, options: DarkThemes },
-              ]}
-              filteringType="auto"
-            />
-          </InternalFormField>
-        </div>
-      </InternalColumnLayout>
-    </InternalModal>
+    <FormFieldDomContext.RootProvider value={{}}>
+      <InternalModal
+        size="medium"
+        visible={true}
+        onDismiss={props.onDismiss}
+        header={props.i18nStrings.header}
+        closeAriaLabel={props.i18nStrings.cancel}
+        footer={
+          <InternalBox float="right">
+            <InternalSpaceBetween direction="horizontal" size="xs">
+              <InternalButton onClick={props.onDismiss}>{props.i18nStrings.cancel}</InternalButton>
+              <InternalButton onClick={() => props.onConfirm({ wrapLines, theme })} variant="primary">
+                {props.i18nStrings.confirm}
+              </InternalButton>
+            </InternalSpaceBetween>
+          </InternalBox>
+        }
+      >
+        <InternalColumnLayout columns={2} variant="text-grid">
+          <div>
+            <InternalCheckbox checked={wrapLines} onChange={e => setWrapLines(e.detail.checked)}>
+              {props.i18nStrings.wrapLines}
+            </InternalCheckbox>
+          </div>
+          <div>
+            <InternalFormField label={props.i18nStrings.theme}>
+              <InternalSelect
+                selectedOption={selectedThemeOption}
+                onChange={onThemeSelected}
+                options={[
+                  { label: props.i18nStrings.lightThemes, options: LightThemes },
+                  { label: props.i18nStrings.darkThemes, options: DarkThemes },
+                ]}
+                filteringType="auto"
+              />
+            </InternalFormField>
+          </div>
+        </InternalColumnLayout>
+      </InternalModal>
+    </FormFieldDomContext.RootProvider>
   );
 };


### PR DESCRIPTION
### Changes Done

Prevent preferences modal content from reading outer form field context

### Why?

Because current behavior causes error highlight inside the modal, when code content is invalid. This is a bug

### Testing

Added an extra unit test

<details>
<summary>Checklist</summary>


### Writing approval

[*Did you include our UX Writer if there are changes to content that will appear on the website (e.g. API documentation)?*]

### Related Links

[*Ticket IDs (no internal links), related pull requests*]

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_

</details>