### PR TITLE
feat: Add ariaExpanded property to Button component

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2465,6 +2465,12 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
   "name": "Button",
   "properties": Array [
     Object {
+      "description": " Adds aria-expanded to the button element. Use when the button controls an expandable element.",
+      "name": "ariaExpanded",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "description": "Adds \`aria-label\` to the button element. It should be used in buttons that don't have text in order to make
 them accessible.",
       "name": "ariaLabel",

--- a/src/app-layout/toggles/index.tsx
+++ b/src/app-layout/toggles/index.tsx
@@ -44,9 +44,7 @@ export const AppLayoutButton = React.forwardRef(
         onClick={onClick}
         iconName={iconName}
         disabled={disabled}
-        __nativeAttributes={{
-          'aria-expanded': ariaExpanded,
-        }}
+        ariaExpanded={ariaExpanded}
       />
     );
   }

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -55,7 +55,7 @@ export default function AppBar() {
         >
           <InternalButton
             ariaLabel={ariaLabels?.navigationToggle ?? undefined}
-            aria-expanded={isNavigationOpen}
+            ariaExpanded={isNavigationOpen}
             iconName="menu"
             formAction="none"
             onClick={() => handleNavigationClick(true)}
@@ -86,7 +86,7 @@ export default function AppBar() {
         >
           <InternalButton
             className={testutilStyles['tools-toggle']}
-            aria-expanded={isToolsOpen}
+            ariaExpanded={isToolsOpen}
             disabled={isAnyPanelOpen}
             ariaLabel={ariaLabels?.toolsToggle ?? undefined}
             iconName="status-info"

--- a/src/breadcrumb-group/internal.tsx
+++ b/src/breadcrumb-group/internal.tsx
@@ -31,7 +31,7 @@ const DropdownTrigger = (
         clickHandler();
       }}
       ref={ref}
-      aria-expanded={isExpanded ? true : null}
+      aria-expanded={isExpanded ? true : undefined}
       aria-haspopup={true}
       variant="breadcrumb-group"
     >

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -124,7 +124,7 @@ const InternalButtonDropdown = React.forwardRef(
         }}
         ariaLabel={ariaLabel}
         aria-haspopup={true}
-        aria-expanded={canBeOpened && isOpen}
+        ariaExpanded={canBeOpened && isOpen}
         formAction="none"
       >
         {children}

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -97,6 +97,14 @@ describe('Button Component', () => {
     });
   });
 
+  describe('ariaExpanded property', () => {
+    test('adds aria-expanded property to button', () => {
+      const wrapper = renderButton({ ariaExpanded: true });
+      console.log(wrapper.getElement());
+      expect(wrapper.getElement()).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
   describe('iconUrl property', () => {
     const iconUrl = 'data:image/png;base64,aaaa';
     const iconAlt = 'Custom icon';

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -13,8 +13,8 @@ test('specific properties take precedence over nativeAttributes', () => {
 });
 
 test('supports providing custom attributes', () => {
-  const { container } = render(<InternalButton __nativeAttributes={{ 'aria-expanded': 'true' }} />);
-  expect(container.querySelector('button')).toHaveAttribute('aria-expanded', 'true');
+  const { container } = render(<InternalButton __nativeAttributes={{ 'aria-hidden': 'true' }} />);
+  expect(container.querySelector('button')).toHaveAttribute('aria-hidden', 'true');
 });
 
 test('supports __iconClass property', () => {

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -29,6 +29,7 @@ const Button = React.forwardRef(
       ariaLabel,
       onClick,
       onFollow,
+      ariaExpanded,
       ...props
     }: ButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -56,6 +57,7 @@ const Button = React.forwardRef(
         ariaLabel={ariaLabel}
         onClick={onClick}
         onFollow={onFollow}
+        ariaExpanded={ariaExpanded}
       >
         {children}
       </InternalButton>

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -114,6 +114,12 @@ export interface ButtonProps extends BaseComponentProps {
    * modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an `href` set.
    */
   onFollow?: CancelableEventHandler<null>;
+
+  /**
+   *  Adds aria-expanded to the button element. Use when the button controls an expandable element.
+   */
+
+  ariaExpanded?: boolean;
 }
 
 export namespace ButtonProps {

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -40,6 +40,7 @@ export const InternalButton = React.forwardRef(
       download,
       formAction = 'submit',
       ariaLabel,
+      ariaExpanded,
       __nativeAttributes,
       __internalRootRef = null,
       __activated = false,
@@ -87,6 +88,7 @@ export const InternalButton = React.forwardRef(
       // https://github.com/microsoft/TypeScript/issues/36659
       ref: useMergeRefs(buttonRef as any, __internalRootRef),
       'aria-label': ariaLabel,
+      'aria-expanded': ariaExpanded,
       className: buttonClass,
       onClick: handleClick,
     } as const;

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -151,9 +151,9 @@ function Tutorial({
             <InternalButton
               id={triggerControldId}
               variant="icon"
+              ariaExpanded={expanded}
               __nativeAttributes={{
                 'aria-controls': controlId,
-                'aria-expanded': expanded,
                 'aria-labelledby': headerId,
               }}
               formAction="none"


### PR DESCRIPTION
### Changes Done

Add ariaExpanded property to Button component

reviewed in PR #264

### Why?

When a button is used for controlling an expandable element this property is used to indicate if a control is expanded or collapsed

### Testing

Added a unit test

### Writing approval

done

### Related Links

AWSUI-18577

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_
