### PR TITLE
Move date-picker calendar TabTrap to date-picker itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,12 @@
         "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
+    "@awsui/global-styles": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@awsui/global-styles/-/global-styles-1.0.16.tgz",
+      "integrity": "sha512-x90ELJGNWFXecjoruC99mkwoUWHdML1oh1byQX71qqLZ0y8+nu/IPVEeJ/me7znRCHXOzvelZ9ypQtccgMMswQ==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -2917,23 +2923,6 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "aws-sdk": {
-      "version": "2.1136.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1136.0.tgz",
-      "integrity": "sha512-cuXPB1lNoiK/oNTAN+Bud2Pp8/PvY7erL2DYPVN2zsk2nh9e8VG3yldf6KcEO6mm4q/FgZc4X6Zq+fOyuBY/wA==",
-      "dev": true,
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
       }
     },
     "axe-core": {
@@ -14964,12 +14953,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/src/date-picker/calendar/index.tsx
+++ b/src/date-picker/calendar/index.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { addDays, addMonths, isSameMonth, startOfMonth } from 'date-fns';
 import styles from '../styles.css.js';
-import TabTrap, { FocusNextElement } from '../../internal/components/tab-trap';
+import { FocusNextElement } from '../../internal/components/tab-trap';
 import { BaseComponentProps } from '../../internal/base-component';
 import useFocusVisible from '../../internal/hooks/focus-visible/index.js';
 import { DatePickerProps } from '../interfaces';
@@ -132,7 +132,6 @@ const Calendar = ({
 
   return (
     <>
-      {calendarHasFocus && <TabTrap focusNextCallback={focusCurrentDate} />}
       <div
         {...focusVisible}
         className={styles.calendar}
@@ -167,7 +166,6 @@ const Calendar = ({
             />
           </div>
         </div>
-        {calendarHasFocus && <TabTrap focusNextCallback={() => elementRef.current?.focus()} />}
       </div>
     </>
   );

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -26,6 +26,7 @@ import { InternalButton } from '../button/internal';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import TabTrap, { FocusNextElement } from '../internal/components/tab-trap';
 
 export { DatePickerProps };
 
@@ -157,6 +158,10 @@ const DatePicker = React.forwardRef(
       }
     }
 
+    const elementRef = useRef<HTMLDivElement>(null);
+    const focusCurrentDate: FocusNextElement = () =>
+      (elementRef.current?.querySelector(`.${styles['calendar-day-focusable']}`) as HTMLDivElement)?.focus();
+
     const DateInputElement = (
       <div className={styles['date-picker-trigger']}>
         <div className={styles['date-picker-input']}>
@@ -227,21 +232,25 @@ const DatePicker = React.forwardRef(
           dropdownId={dropdownId}
         >
           {isDropDownOpen && (
-            <Calendar
-              selectedDate={memoizedDate('value', selectedDate)}
-              focusedDate={memoizedDate('focused', focusedDate)}
-              displayedDate={memoizedDate('displayed', displayedDate)}
-              locale={normalizedLocale}
-              startOfWeek={normalizedStartOfWeek}
-              isDateEnabled={isDateEnabled ? isDateEnabled : () => true}
-              calendarHasFocus={calendarHasFocus}
-              nextMonthLabel={nextMonthAriaLabel}
-              previousMonthLabel={previousMonthAriaLabel}
-              todayAriaLabel={todayAriaLabel}
-              onChangeMonth={onChangeMonthHandler}
-              onSelectDate={onSelectDateHandler}
-              onFocusDate={onDateFocusHandler}
-            />
+            <>
+              {calendarHasFocus && <TabTrap focusNextCallback={focusCurrentDate} />}
+              <Calendar
+                selectedDate={memoizedDate('value', selectedDate)}
+                focusedDate={memoizedDate('focused', focusedDate)}
+                displayedDate={memoizedDate('displayed', displayedDate)}
+                locale={normalizedLocale}
+                startOfWeek={normalizedStartOfWeek}
+                isDateEnabled={isDateEnabled ? isDateEnabled : () => true}
+                calendarHasFocus={calendarHasFocus}
+                nextMonthLabel={nextMonthAriaLabel}
+                previousMonthLabel={previousMonthAriaLabel}
+                todayAriaLabel={todayAriaLabel}
+                onChangeMonth={onChangeMonthHandler}
+                onSelectDate={onSelectDateHandler}
+                onFocusDate={onDateFocusHandler}
+              />
+              {calendarHasFocus && <TabTrap focusNextCallback={() => elementRef.current?.focus()} />}
+            </>
           )}
         </Dropdown>
       </div>


### PR DESCRIPTION
### Changes Done

This change removes the TabTrap for the Date-picker Calendar component and adds it to the Date picker dropdown itself

### Why?

This change allows this calendar component to be embedded within other components and prevents the user from being tab trapped within said calendar.

### Testing

Manual testing

### Writing approval

N/A

### Related Links

SIM: AWSUI-9912
QUIP: Date-fields-in-Property-Filter-Technical-Design

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_
