### PR TITLE
Move date-picker calendar TabTrap to date-picker itself

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -79,6 +79,7 @@ const DatePicker = React.forwardRef(
 
     const internalInputRef = useRef<HTMLInputElement>(null);
     const buttonRef = useRef<ButtonProps.Ref>(null);
+    const calendarRef = useRef<HTMLDivElement>(null);
     useForwardFocus(ref, internalInputRef);
 
     const rootRef = useRef<HTMLDivElement>(null);
@@ -158,9 +159,8 @@ const DatePicker = React.forwardRef(
       }
     }
 
-    const elementRef = useRef<HTMLDivElement>(null);
     const focusCurrentDate = () =>
-      (elementRef.current?.querySelector(`.${styles['calendar-day-focusable']}`) as HTMLDivElement)?.focus();
+      (calendarRef.current?.querySelector(`.${styles['calendar-day-focusable']}`) as HTMLDivElement)?.focus();
 
     const DateInputElement = (
       <div className={styles['date-picker-trigger']}>
@@ -235,6 +235,7 @@ const DatePicker = React.forwardRef(
             <>
               {calendarHasFocus && <TabTrap focusNextCallback={focusCurrentDate} />}
               <Calendar
+                ref={calendarRef}
                 selectedDate={memoizedDate('value', selectedDate)}
                 focusedDate={memoizedDate('focused', focusedDate)}
                 displayedDate={memoizedDate('displayed', displayedDate)}
@@ -249,7 +250,7 @@ const DatePicker = React.forwardRef(
                 onSelectDate={onSelectDateHandler}
                 onFocusDate={onDateFocusHandler}
               />
-              {calendarHasFocus && <TabTrap focusNextCallback={() => __internalRootRef.current?.focus()} />}
+              {calendarHasFocus && <TabTrap focusNextCallback={() => calendarRef.current?.focus()} />}
             </>
           )}
         </Dropdown>


### PR DESCRIPTION
Changes Done
This change removes the TabTrap for the Date-picker Calendar component and adds it to the Date picker dropdown itself

Why?
This change allows this calendar component to be embedded within other components and prevents the user from being tab trapped within said calendar.

Testing
Manual testing

Writing approval
N/A

Related Links
SIM: AWSUI-9912
QUIP: Date-fields-in-Property-Filter-Technical-Design

Review Checklist
The following items are to be evaluated by the author(s) and the reviewer(s).

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_
