### PR TITLE
chore(box): Mention in docs that box sizes are automatically scaled

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2172,6 +2172,7 @@ Note: If you don't set it, the display depends on the variant.
 \`\`\`
 
 The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \`xxl\`, \`xxxl\`, where \`n\` stands for none.
+Sizes are automatically scaled down in compact mode.
 
  For example, \`margin=\\"s\\"\` adds a small margin to all sides.
 \`margin={{ right: \\"l\\", bottom: \\"s\\" }}\` adds a small margin to the bottom and a large margin to the right.
@@ -2196,6 +2197,7 @@ The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \
 \`\`\`
 
 The size can be \`n\`, \`xxxs\`, \`xxs\`, \`xs\`, \`s\`, \`m\`, \`l\`, \`xl\`, \`xxl\`, \`xxxl\`, where \`n\` stands for none.
+Sizes are automatically scaled down in compact mode.
 
  For example, \`padding=\\"s\\"\` adds small padding to all sides.
 \`padding={{ right: \\"l\\", bottom: \\"s\\" }}\` adds small padding to the bottom and large padding to the right.

--- a/src/box/interfaces.ts
+++ b/src/box/interfaces.ts
@@ -45,6 +45,7 @@ export interface BoxProps extends BaseComponentProps {
    * ```
    *
    * The size can be `n`, `xxxs`, `xxs`, `xs`, `s`, `m`, `l`, `xl`, `xxl`, `xxxl`, where `n` stands for none.
+   * Sizes are automatically scaled down in compact mode.
    *
    *  For example, `margin="s"` adds a small margin to all sides.
    * `margin={{ right: "l", bottom: "s" }}` adds a small margin to the bottom and a large margin to the right.
@@ -67,6 +68,7 @@ export interface BoxProps extends BaseComponentProps {
    * ```
    *
    * The size can be `n`, `xxxs`, `xxs`, `xs`, `s`, `m`, `l`, `xl`, `xxl`, `xxxl`, where `n` stands for none.
+   * Sizes are automatically scaled down in compact mode.
    *
    *  For example, `padding="s"` adds small padding to all sides.
    * `padding={{ right: "l", bottom: "s" }}` adds small padding to the bottom and large padding to the right.


### PR DESCRIPTION
### Changes Done

Add "Sizes are scaled down automatically in compact mode." to margin and padding for box.

### Why?

Spotted as part of the spacing design tokens sign-off. Since we expose both static and scaled design tokens, we should make it clear in box that the sizing names it uses are scaled, not static.

### Testing

### Writing approval

Adding as a reviewer to this PR.

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated._
- [x] _Changes are covered with automated tests if not indicated._
- [x] _Changes do not include unsupported browser features._
- [x] _Changes to UX were approved by the designer._
- [x] _Changes to UX were manually tested for accessibility._

#### Security

- [x] _Changes do not include XSS vulnerability._
- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [x] _All API changes were reviewed by the team and the corresponding doc is linked._
- [x] _All API doc strings were reviewed by the writer._
- [x] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [x] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [x] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [x] _Is there enough coverage with new/existing unit tests?_
- [x] _Is there enough coverage with new/existing integration tests?_
- [x] _Is there enough coverage with new/existing screenshot tests?_
