### PR TITLE
chore(readme): Update contributing guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can [create bug reports or feature requests](https://github.com/cloudscape-d
 
 ## Contributing
 
-The [contribution guidelines](/CONTRIBUTING.md) contains information on how to contribute, as well as our support model and versioning strategy.
+The [contribution guidelines]([/CONTRIBUTING.md](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md) contains information on how to contribute, as well as our support model and versioning strategy.
 
 ## License
 


### PR DESCRIPTION
### Changes Done

Changing relative URL it to an absolute URL.

### Why?

NPM Artifacts do not contain CONTRIBUTING.md and so this relative link will not resolve. Changing it to an absolute URL means we do not need to increase the artifact size. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
