### PR TITLE
Make useVisualRefresh only observe document.body

### DIFF
--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
@@ -42,10 +42,9 @@ export default function InternalAlert({
   const baseProps = getBaseProps(rest);
 
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const refObject = useRef(null);
-  const mergedRef = useMergeRefs(breakpointRef, refObject, __internalRootRef);
+  const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
-  const isRefresh = useVisualRefresh(refObject);
+  const isRefresh = useVisualRefresh();
   const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
 
   const actionButton = action || (

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -47,7 +47,7 @@ const AppLayout = React.forwardRef(
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent<HTMLDivElement>('AppLayout');
-    const isRefresh = useVisualRefresh(__internalRootRef);
+    const isRefresh = useVisualRefresh();
 
     // This re-builds the props including the default values
     const props = { contentType, headerSelector, footerSelector, ...rest };

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -50,7 +50,7 @@ const Cards = React.forwardRef(function <T = any>(
 ) {
   const { __internalRootRef } = useBaseComponent('Cards');
   const baseProps = getBaseProps(rest);
-  const isRefresh = useVisualRefresh(__internalRootRef);
+  const isRefresh = useVisualRefresh();
   const computedVariant = isRefresh ? variant : 'container';
 
   const [columns, measureRef] = useContainerQuery<number>(

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -97,10 +97,9 @@ export default function CodeEditor(props: CodeEditorProps) {
   const warningsTabRef = useRef<HTMLButtonElement>(null);
 
   const [codeEditorWidth, codeEditorMeasureRef] = useContainerQuery(rect => rect.width);
-  const refObject = useRef(null);
-  const mergedRef = useMergeRefs(codeEditorMeasureRef, refObject, __internalRootRef);
+  const mergedRef = useMergeRefs(codeEditorMeasureRef, __internalRootRef);
 
-  const isRefresh = useVisualRefresh(refObject);
+  const isRefresh = useVisualRefresh();
 
   useEffect(() => {
     editor?.resize();

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -45,7 +45,7 @@ export default function InternalContainer({
   const baseProps = getBaseProps(restProps);
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const isRefresh = useVisualRefresh(rootRef);
+  const isRefresh = useVisualRefresh();
   const hasDynamicHeight = isRefresh && variant === 'full-page';
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
 

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -44,7 +44,7 @@ export const useStickyHeader = (
   const { stickyOffsetTop } = useAppLayoutContext();
   const effectiveStickyOffset = __stickyOffset ?? (usesBodyScroll ? stickyOffsetTop : 0);
   const isSticky = useSupportsStickyHeader() && !!__stickyHeader;
-  const isRefresh = useVisualRefresh(rootRef);
+  const isRefresh = useVisualRefresh();
 
   /**
    * The AppLayout refactor removed the need for passing the sticky offset in px all the time through the

--- a/src/flashbar/index.tsx
+++ b/src/flashbar/index.tsx
@@ -21,7 +21,7 @@ export { FlashbarProps };
 export default function Flashbar({ items, ...restProps }: FlashbarProps) {
   const { __internalRootRef } = useBaseComponent('Flashbar');
   const [breakpoint, ref] = useContainerBreakpoints(['xs']);
-  const isRefresh = useVisualRefresh(__internalRootRef);
+  const isRefresh = useVisualRefresh();
   const baseProps = getBaseProps(restProps);
 
   const mergedRef = useMergeRefs(ref, __internalRootRef);

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
@@ -14,7 +14,6 @@ import { getAriaDescribedBy, getGridDefinition, getSlotIds } from './util';
 
 import styles from './styles.css.js';
 import { InternalFormFieldProps } from './interfaces';
-import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { joinStrings } from '../internal/utils/strings';
 
 interface FormFieldErrorProps {
@@ -50,8 +49,7 @@ export default function InternalFormField({
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
-  const ref = useRef<HTMLElement>(null);
-  const isRefresh = useVisualRefresh(ref);
+  const isRefresh = useVisualRefresh();
 
   const instanceUniqueId = useUniqueId('formField');
   const generatedControlId = controlId || instanceUniqueId;
@@ -75,10 +73,8 @@ export default function InternalFormField({
     invalid: !!errorText || !!parentInvalid,
   };
 
-  const mergedRef = useMergeRefs(ref, __internalRootRef);
-
   return (
-    <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={mergedRef}>
+    <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
       <div className={clsx(__hideLabel && styles['visually-hidden'])}>
         {label && (
           <label className={styles.label} id={slotIds.label} htmlFor={generatedControlId}>

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import { useMergeRefs } from '../internal/hooks/use-merge-refs';
-import React, { useContext, useRef } from 'react';
+import React, { useContext } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import { StickyHeaderContext } from '../container/use-sticky-header';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -30,11 +29,9 @@ export default function InternalHeader({
   const HeadingTag = headingTagOverride ?? (variant === 'awsui-h1-sticky' ? 'h1' : variant);
   const { isStuck } = useContext(StickyHeaderContext);
   const baseProps = getBaseProps(restProps);
-  const ref = useRef(null);
-  const isRefresh = useVisualRefresh(ref);
+  const isRefresh = useVisualRefresh();
   const dynamicVariant = isStuck ? 'h2' : 'h1';
   const variantOverride = variant === 'awsui-h1-sticky' ? (isRefresh ? dynamicVariant : 'h2') : variant;
-  const mergedRef = useMergeRefs(ref, __internalRootRef);
   return (
     <div
       {...baseProps}
@@ -47,7 +44,7 @@ export default function InternalHeader({
         description && [styles[`root-has-description`]],
         __disableActionsWrapping && [styles['root-no-wrap']]
       )}
-      ref={mergedRef}
+      ref={__internalRootRef}
     >
       <div
         className={clsx(

--- a/src/icon/internal.tsx
+++ b/src/icon/internal.tsx
@@ -45,7 +45,7 @@ const InternalIcon = ({
 }: InternalIconProps) => {
   const iconRef = useRef<HTMLElement>(null);
   // To ensure a re-render is triggered on visual mode changes
-  useVisualRefresh(iconRef);
+  useVisualRefresh();
   const [parentHeight, setParentHeight] = useState(0);
   const contextualSize = size === 'inherit';
   const iconSize = contextualSize ? iconSizeMap(parentHeight) : size;

--- a/src/internal/components/checkbox-icon/index.tsx
+++ b/src/internal/components/checkbox-icon/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useRef } from 'react';
+import React from 'react';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
 import styles from './styles.css.js';
@@ -42,18 +42,10 @@ export const dimensionsByTheme: Record<NonNullable<'default' | 'refresh'>, Dimen
 
 const CheckboxIcon = ({ checked, indeterminate, disabled = false, ...restProps }: CheckboxIconProps) => {
   const baseProps = getBaseProps(restProps);
-  const checkboxRef = useRef(null);
-  const theme = useVisualRefresh(checkboxRef) ? 'refresh' : 'default';
+  const theme = useVisualRefresh() ? 'refresh' : 'default';
   const dimensions = dimensionsByTheme[theme];
   return (
-    <svg
-      className={styles.root}
-      viewBox={dimensions.viewBox}
-      aria-hidden="true"
-      focusable="false"
-      ref={checkboxRef}
-      {...baseProps}
-    >
+    <svg className={styles.root} viewBox={dimensions.viewBox} aria-hidden="true" focusable="false" {...baseProps}>
       <rect
         className={clsx(styles['styled-box'], {
           [styles['styled-box-checked']]: checked,

--- a/src/internal/components/content-layout/index.tsx
+++ b/src/internal/components/content-layout/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useLayoutEffect, useRef } from 'react';
+import React, { useContext, useLayoutEffect } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from '../../../app-layout/visual-refresh/context';
 import { ContentLayoutProps } from './interfaces';
@@ -12,8 +12,7 @@ export { ContentLayoutProps };
 
 export default function ContentLayout({ children, disableOverlap, header }: ContentLayoutProps) {
   const { breadcrumbs, setDynamicOverlapHeight } = useContext(AppLayoutContext);
-  const rootElement = useRef<HTMLDivElement>(null);
-  const isVisualRefresh = useVisualRefresh(rootElement);
+  const isVisualRefresh = useVisualRefresh();
   const isOverlapDisabled = !children || !header || disableOverlap;
 
   // Documentation to be added.
@@ -34,7 +33,6 @@ export default function ContentLayout({ children, disableOverlap, header }: Cont
         [styles['is-overlap-disabled']]: isOverlapDisabled,
         [styles['is-visual-refresh']]: isVisualRefresh,
       })}
-      ref={rootElement}
     >
       <div
         className={clsx(

--- a/src/internal/components/dark-ribbon/index.tsx
+++ b/src/internal/components/dark-ribbon/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef } from 'react';
-import { useMutationObserver } from '../../hooks/use-mutation-observer';
+import { useAttributesMutationObserver } from '../../hooks/use-mutation-observer';
 import { useStableEventHandler } from '../../hooks/use-stable-event-handler';
 import styles from './styles.css.js';
 
@@ -34,7 +34,7 @@ export default function DarkRibbon({ children, isRefresh, hasPlainStyling }: Dar
       newRight => (to.style.right = newRight)
     );
   });
-  useMutationObserver(containerRef, node => {
+  useAttributesMutationObserver(containerRef, node => {
     if (fillRef.current) {
       syncSizes(node, fillRef.current);
     }

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -130,7 +130,7 @@ const Dropdown = ({
   // To keep track of the initial position (drop up/down) which is kept the same during fixed repositioning
   const fixedPosition = useRef<DropdownPosition | null>(null);
 
-  const isRefresh = useVisualRefresh(triggerRef);
+  const isRefresh = useVisualRefresh();
 
   const dropdownClasses = usePortalModeClasses(triggerRef);
   const [position, setPosition] = useState<DropdownContextProviderProps['position']>('bottom-right');

--- a/src/internal/components/visual-context/index.tsx
+++ b/src/internal/components/visual-context/index.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
 import React, { useState } from 'react';
-import { useMutationObserver } from '../../hooks/use-mutation-observer';
+import { useAttributesMutationObserver } from '../../hooks/use-mutation-observer';
 import { findUpUntil } from '../../utils/dom';
 
 export const useVisualContext = (elementRef: React.RefObject<HTMLElement>) => {
   const contextMatch = /awsui-context-([\w-]+)/;
   const [value, setValue] = useState('');
-  useMutationObserver(elementRef, node => {
+  useAttributesMutationObserver(elementRef, node => {
     const contextParent = findUpUntil(node, node => !!node.className.match(contextMatch));
     setValue(contextParent ? contextParent.className.match(contextMatch)![1] : '');
   });

--- a/src/internal/hooks/use-mutation-observer/index.ts
+++ b/src/internal/hooks/use-mutation-observer/index.ts
@@ -1,16 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useStableEventHandler } from '../use-stable-event-handler';
-import { createSingletonHandler } from '../use-singleton-handler';
+import { createSingletonHandler, UseSingleton } from '../use-singleton-handler';
 
-const useMutationSingleton = createSingletonHandler<void>(handler => {
+// Map of selector -> use-mutation-singleton.
+const observerSingletons = new Map<string, UseSingleton<void>>();
+
+const useAttributesMutationSingleton = createSingletonHandler<void>(handler => {
   const observer = new MutationObserver(() => handler());
   observer.observe(document.body, { attributes: true, subtree: true });
   return () => observer.disconnect();
 });
 
-export function useMutationObserver(
+/**
+ * Fires onChange with the given target element as an argument every time any DOM node attribute changes.
+ *
+ * @deprecated The hook has significant performance implications. Consider alternatives.
+ */
+export function useAttributesMutationObserver(
   elementRef: React.RefObject<HTMLElement>,
   onChange: (element: HTMLElement) => void
 ) {
@@ -19,9 +27,56 @@ export function useMutationObserver(
       onChange(elementRef.current);
     }
   });
-  useMutationSingleton(handler);
+  useAttributesMutationSingleton(handler);
 
   useEffect(() => {
     handler();
   }, [handler]);
+}
+
+/**
+ * Attaches mutation observer to a node described by the given selector. Only one mutation observer
+ * instance is created per selector. When callbacks are no longer attached the observer is disconnected.
+ * When the target node is removed from the DOM the observer is disconnected.
+ *
+ * Note: the observers are cached by selector. Using different selectors for the same node will result in
+ * creation of multiple observer instances.
+ *
+ * @param selector - DOM selector of the target element. Use unique IDs for arbitrary elements.
+ * @param onObserve - callback fired when the mutation is observed.
+ * @param options - MutationObserver options.
+ */
+export function useMutationObserver(
+  selector: string,
+  onObserve: (element: HTMLElement) => void,
+  options: MutationObserverInit = { attributes: true }
+) {
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  const handler = useStableEventHandler(() => {
+    if (elementRef.current) {
+      onObserve(elementRef.current);
+    }
+  });
+
+  useEffect(() => {
+    elementRef.current = document.querySelector(selector);
+    handler();
+  }, [handler, selector]);
+
+  const useMutationSingleton =
+    observerSingletons.get(selector) ||
+    createSingletonHandler(handler => {
+      const element = document.querySelector(selector);
+      if (element) {
+        const observer = new MutationObserver(() => handler());
+        observer.observe(element, options);
+        return () => observer.disconnect();
+      }
+      return () => undefined;
+    });
+
+  observerSingletons.set(selector, useMutationSingleton);
+
+  useMutationSingleton(handler);
 }

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -9,7 +9,7 @@ export function usePortalModeClasses(ref: React.RefObject<HTMLElement>) {
   const colorMode = useCurrentMode(ref);
   const densityMode = useDensityMode(ref);
   const context = useVisualContext(ref);
-  const visualRefresh = useVisualRefresh(ref);
+  const visualRefresh = useVisualRefresh();
   return clsx({
     'awsui-polaris-dark-mode awsui-dark-mode': colorMode === 'dark',
     'awsui-polaris-compact-mode awsui-compact-mode': densityMode === 'compact',

--- a/src/internal/hooks/use-singleton-handler/index.ts
+++ b/src/internal/hooks/use-singleton-handler/index.ts
@@ -5,8 +5,9 @@ import { unstable_batchedUpdates } from 'react-dom';
 
 type ValueCallback<T> = (value: T) => void;
 type CleanupCallback = () => void;
+export type UseSingleton<T> = (listener: ValueCallback<T>) => void;
 
-export function createSingletonHandler<T>(factory: (handler: ValueCallback<T>) => CleanupCallback) {
+export function createSingletonHandler<T>(factory: (handler: ValueCallback<T>) => CleanupCallback): UseSingleton<T> {
   const listeners: Array<ValueCallback<T>> = [];
   const callback: ValueCallback<T> = value => {
     unstable_batchedUpdates(() => {

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
@@ -80,29 +80,24 @@ describe('useCurrentMode', () => {
 // most of the functionality is covered by the suite above, which uses the same implementation
 // here we only test the specific stuff
 describe('useVisualRefresh', () => {
-  function RefreshRender() {
-    const ref = useRef(null);
-    const isRefresh = useVisualRefresh(ref);
-    return (
-      <div ref={ref} data-testid="current-mode">
-        {isRefresh.toString()}
-      </div>
-    );
+  function App() {
+    const isRefresh = useVisualRefresh();
+    return <div data-testid="current-mode">{isRefresh.toString()}</div>;
   }
   test('should detect mode switch both ways', async () => {
-    const { container } = render(<RefreshRender />);
+    render(<App />);
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
-    await mutate(() => container.classList.add('awsui-visual-refresh'));
+    await mutate(() => document.body.classList.add('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
-    await mutate(() => container.classList.remove('awsui-visual-refresh'));
+    await mutate(() => document.body.classList.remove('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
   });
 
   test('should return false when CSS-variables are not supported', async () => {
     (window.CSS.supports as jest.Mock).mockReturnValue(false);
-    const { container } = render(<RefreshRender />);
+    render(<App />);
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
-    await mutate(() => container.classList.add('awsui-visual-refresh'));
+    await mutate(() => document.body.classList.add('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
   });
 });

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React from 'react';
 import { useVisualRefresh } from '../index';
 import { render, screen } from '@testing-library/react';
 import { mutate } from './utils';
@@ -17,28 +17,25 @@ afterEach(() => {
 });
 
 describe('useVisualRefresh with locked visual refresh mode', () => {
-  function RefreshRender() {
-    const ref = useRef(null);
-    const isRefresh = useVisualRefresh(ref);
+  function App() {
+    const isRefresh = useVisualRefresh();
     return (
-      <div ref={ref} data-testid="current-mode">
-        {isRefresh.toString()}
-      </div>
+      <body>
+        <div data-testid="current-mode">{isRefresh.toString()}</div>
+      </body>
     );
   }
 
   test('should return true when the environment is locked in visual refresh mode', () => {
-    render(<RefreshRender />);
-
+    render(<App />);
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
   });
 
   test('cannot not change visual refresh state', async () => {
-    const { container } = render(<RefreshRender />);
-
-    await mutate(() => container.classList.add('awsui-visual-refresh'));
+    render(<App />);
+    await mutate(() => document.body.classList.add('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
-    await mutate(() => container.classList.remove('awsui-visual-refresh'));
+    await mutate(() => document.body.classList.remove('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
   });
 });

--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -4,11 +4,11 @@ import React, { useState } from 'react';
 import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 import { isMotionDisabled } from '../../motion';
 import { findUpUntil } from '../../utils/dom';
-import { useMutationObserver } from '../use-mutation-observer';
+import { useAttributesMutationObserver, useMutationObserver } from '../use-mutation-observer';
 
 export function useCurrentMode(elementRef: React.RefObject<HTMLElement>) {
   const [value, setValue] = useState<'light' | 'dark'>('light');
-  useMutationObserver(elementRef, node => {
+  useAttributesMutationObserver(elementRef, node => {
     const darkModeParent = findUpUntil(
       node,
       node => node.classList.contains('awsui-polaris-dark-mode') || node.classList.contains('awsui-dark-mode')
@@ -20,7 +20,7 @@ export function useCurrentMode(elementRef: React.RefObject<HTMLElement>) {
 
 export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
   const [value, setValue] = useState<'comfortable' | 'compact'>('comfortable');
-  useMutationObserver(elementRef, node => {
+  useAttributesMutationObserver(elementRef, node => {
     const compactModeParent = findUpUntil(
       node,
       node => node.classList.contains('awsui-polaris-compact-mode') || node.classList.contains('awsui-compact-mode')
@@ -30,22 +30,21 @@ export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
   return value;
 }
 
-export function useVisualRefresh(elementRef: React.RefObject<HTMLElement>) {
+export function useVisualRefresh() {
   const [value, setValue] = useState(Boolean(ALWAYS_VISUAL_REFRESH));
-  useMutationObserver(elementRef, node => {
+  useMutationObserver('body', body => {
     const supportsCSSVariables = window.CSS?.supports?.('color', 'var(--test-var)');
     if (!supportsCSSVariables || ALWAYS_VISUAL_REFRESH) {
       return;
     }
-    const visualRefreshParent = findUpUntil(node, node => node.classList.contains('awsui-visual-refresh'));
-    setValue(!!visualRefreshParent);
+    setValue(body.classList.contains('awsui-visual-refresh'));
   });
   return value;
 }
 
 export function useReducedMotion(elementRef: React.RefObject<HTMLElement>) {
   const [value, setValue] = useState(false);
-  useMutationObserver(elementRef, node => {
+  useAttributesMutationObserver(elementRef, node => {
     setValue(isMotionDisabled(node));
   });
   return value;

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -77,7 +77,7 @@ const InternalLink = React.forwardRef(
     };
 
     const linkRef = useRef<HTMLElement>(null);
-    const isVisualRefresh = useVisualRefresh(linkRef);
+    const isVisualRefresh = useVisualRefresh();
     useForwardFocus(ref, linkRef);
 
     // Visual refresh should only add styles to buttons that don't already have unique styles (e.g. primary/secondary variants)

--- a/src/mixed-line-bar-chart/bar-series.tsx
+++ b/src/mixed-line-bar-chart/bar-series.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import clsx from 'clsx';
 import { ScaleContinuousNumeric, ScaleTime } from 'd3-scale';
 
@@ -47,8 +47,7 @@ export default function BarSeries<T extends ChartDataTypes>({
   plotSize,
   chartAreaClipPath,
 }: BarSeriesProps<T>) {
-  const seriesRef = useRef(null);
-  const isRefresh = useVisualRefresh(seriesRef);
+  const isRefresh = useVisualRefresh();
 
   const xCoordinates = useMemo(() => {
     if (series.type !== 'bar' || !xScale.isCategorical()) {
@@ -110,7 +109,6 @@ export default function BarSeries<T extends ChartDataTypes>({
         [styles['series--highlighted']]: highlighted,
         [styles['series--dimmed']]: dimmed,
       })}
-      ref={seriesRef}
     >
       {xCoordinates.map(
         ({ x, y, width, height }, i) =>

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -115,7 +115,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
 
-  const isRefresh = useVisualRefresh(containerRefObject);
+  const isRefresh = useVisualRefresh();
 
   const linesOnly = series.every(({ series }) => series.type === 'line' || series.type === 'threshold');
 

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -46,7 +46,7 @@ export default function InternalModal({
   const refObject = useRef<HTMLDivElement>(null);
   const mergedRef = useMergeRefs(breakpointsRef, refObject, __internalRootRef);
 
-  const isRefresh = useVisualRefresh(useRef(modalRoot ?? document.body));
+  const isRefresh = useVisualRefresh();
 
   const baseProps = getBaseProps(rest);
 

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -88,7 +88,7 @@ export default <T extends PieChartProps.Datum>({
   const containerRef = useRef<HTMLDivElement>(null);
   const focusedSegmentRef = useRef<SVGGElement>(null);
   const popoverTrackRef = useRef<SVGCircleElement>(null);
-  const isRefresh = useVisualRefresh(containerRef);
+  const isRefresh = useVisualRefresh();
 
   const dimensions = isRefresh ? refreshDimensionsBySize[size] : dimensionsBySize[size];
   const radius = dimensions.outerRadius;
@@ -313,7 +313,6 @@ export default <T extends PieChartProps.Datum>({
               pieData={pieData}
               size={size}
               variant={variant}
-              containerRef={containerRef}
               focusedSegmentRef={focusedSegmentRef}
               popoverTrackRef={popoverTrackRef}
               highlightedSegment={highlightedSegment}

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -15,7 +15,6 @@ interface SegmentsProps<T> {
   highlightedSegment: T | null;
   size: NonNullable<PieChartProps['size']>;
   variant: PieChartProps['variant'];
-  containerRef: React.RefObject<HTMLDivElement>;
   focusedSegmentRef: React.RefObject<SVGGElement>;
   popoverTrackRef: React.RefObject<SVGCircleElement>;
   segmentAriaRoleDescription?: string;
@@ -30,7 +29,6 @@ export default function Segments<T extends PieChartProps.Datum>({
   highlightedSegment,
   size,
   variant,
-  containerRef,
   focusedSegmentRef,
   popoverTrackRef,
   segmentAriaRoleDescription,
@@ -38,7 +36,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   onMouseOver,
   onMouseOut,
 }: SegmentsProps<T>) {
-  const isRefresh = useVisualRefresh(containerRef);
+  const isRefresh = useVisualRefresh();
 
   const { arcFactory, highlightedArcFactory } = useMemo(() => {
     const dimensions = isRefresh ? refreshDimensionsBySize[size] : dimensionsBySize[size];

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -52,7 +52,7 @@ export default function PopoverContainer({
 
   const [inlineStyle, setInlineStyle] = useState<CSSProperties>(INITIAL_STYLES);
   const [internalPosition, setInternalPosition] = useState<InternalPosition | null>(null);
-  const isRefresh = useVisualRefresh(ref);
+  const isRefresh = useVisualRefresh();
 
   // Store the handler in a ref so that it can still be replaced from outside of the listener closure.
   const positionHandlerRef = useRef<() => void>(() => {});

--- a/src/radio-group/radio-button.tsx
+++ b/src/radio-group/radio-button.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useRef } from 'react';
+import React from 'react';
 import AbstractSwitch from '../internal/components/abstract-switch';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
@@ -26,8 +26,7 @@ export default function RadioButton({
   controlId,
   onChange,
 }: RadioButtonProps) {
-  const radioRef = useRef(null);
-  const isVisualRefresh = useVisualRefresh(radioRef);
+  const isVisualRefresh = useVisualRefresh();
   return (
     <AbstractSwitch
       className={clsx(styles.radio, description && styles['radio--has-description'])}
@@ -48,7 +47,7 @@ export default function RadioButton({
         />
       )}
       styledControl={
-        <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true" ref={radioRef}>
+        <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true">
           <circle
             className={clsx(styles['styled-circle-border'], { [styles['styled-circle-disabled']]: disabled })}
             strokeWidth={isVisualRefresh ? 12 : 8}

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -108,15 +108,14 @@ export function S3Modal({
   const [{ currentView, breadcrumbs, selectedItem }, dispatch] = useReducer(s3BrowseReducer, initialBrowseState);
   const forwardFocusRef = useRef<ForwardFocusRef>(null);
 
-  const modalWrapperRef = useRef(null);
-  const isVisualRefresh = useVisualRefresh(modalWrapperRef);
+  const isVisualRefresh = useVisualRefresh();
 
   useEffectOnUpdate(() => {
     forwardFocusRef.current?.focus();
   }, [breadcrumbs]);
 
   return (
-    <div ref={modalWrapperRef}>
+    <div>
       <InternalModal
         visible={true}
         size="max"

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -119,7 +119,7 @@ const InternalTable = React.forwardRef(
       }
     }
 
-    const isRefresh = useVisualRefresh(tableRefObject);
+    const isRefresh = useVisualRefresh();
     const computedVariant = isRefresh
       ? variant
       : ['embedded', 'full-page'].indexOf(variant) > -1

--- a/src/table/sticky-scrollbar.tsx
+++ b/src/table/sticky-scrollbar.tsx
@@ -19,7 +19,7 @@ export default forwardRef(StickyScrollbar);
 function StickyScrollbar({ wrapperRef, tableRef, onScroll }: StickyScrollbarProps, ref: React.Ref<HTMLDivElement>) {
   const scrollbarRef = React.useRef<HTMLDivElement>(null);
   const scrollbarContentRef = React.useRef<HTMLDivElement>(null);
-  const isRefresh = useVisualRefresh(scrollbarRef);
+  const isRefresh = useVisualRefresh();
   const mergedRef = useMergeRefs(ref, scrollbarRef);
 
   /**

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -43,7 +43,7 @@ export function TabHeaderBar({
   const activeTabHeaderRef = useRef<HTMLAnchorElement>(null);
   const leftOverflowButton = useRef<HTMLElement>(null);
 
-  const isVisualRefresh = useVisualRefresh(headerBarRef);
+  const isVisualRefresh = useVisualRefresh();
 
   const [widthChange, containerRef] = useContainerQuery<number>(rect => rect.width);
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map());

--- a/src/tutorial-panel/components/tutorial-detail-view/index.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import { TutorialPanelProps } from '../../interfaces';
 import InternalBox from '../../../box/internal';
 import { InternalButton } from '../../../button/internal';
@@ -25,8 +25,7 @@ export default function TutorialDetailView({
   onFeedbackClick: TutorialPanelProps['onFeedbackClick'];
   i18nStrings: TutorialPanelProps['i18nStrings'];
 }) {
-  const refreshRef = useRef(null);
-  const isRefresh = useVisualRefresh(refreshRef);
+  const isRefresh = useVisualRefresh();
 
   const onExitTutorial = useCallback(() => {
     fireNonCancelableEvent(onExitTutorialHandler, { tutorial });
@@ -39,7 +38,7 @@ export default function TutorialDetailView({
   return (
     <>
       <InternalSpaceBetween size="xl">
-        <div className={styles['tutorial-title']} ref={refreshRef}>
+        <div className={styles['tutorial-title']}>
           <InternalButton
             variant="icon"
             onClick={onExitTutorial}

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useCallback, useState } from 'react';
 import styles from './styles.css.js';
 import { TutorialPanelProps } from '../../interfaces';
 import InternalBox from '../../../box/internal';
@@ -50,8 +50,7 @@ export default function TutorialList({
   */
 
   const focusVisible = useFocusVisible();
-  const tutorialListRef = useRef(null);
-  const isRefresh = useVisualRefresh(tutorialListRef);
+  const isRefresh = useVisualRefresh();
 
   return (
     <>
@@ -87,7 +86,7 @@ export default function TutorialList({
             <InternalStatusIndicator type="loading">{i18nStrings.loadingText}</InternalStatusIndicator>
           ) : (
             <>
-              <ul className={styles['tutorial-list']} role="list" ref={tutorialListRef}>
+              <ul className={styles['tutorial-list']} role="list">
                 {tutorials.map((tutorial, index) => (
                   <Tutorial
                     tutorial={tutorial}
@@ -120,8 +119,7 @@ function Tutorial({
   const triggerControldId = useUniqueId();
   const headerId = useUniqueId();
 
-  const tutorialRef = useRef(null);
-  const isRefresh = useVisualRefresh(tutorialRef);
+  const isRefresh = useVisualRefresh();
 
   const onStartTutorial = useCallback(() => {
     fireNonCancelableEvent(onStartTutorialEventHandler, { tutorial });
@@ -134,7 +132,7 @@ function Tutorial({
   }, []);
 
   return (
-    <li className={styles['tutorial-box']} role="listitem" ref={tutorialRef}>
+    <li className={styles['tutorial-box']} role="listitem">
       <InternalSpaceBetween size="xs">
         <div className={styles['tutorial-box-title']}>
           <InternalBox

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -47,8 +47,7 @@ export default function Wizard({
   const baseProps = getBaseProps(rest);
 
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
-  const refObject = useRef(null);
-  const ref = useMergeRefs(breakpointsRef, refObject, __internalRootRef);
+  const ref = useMergeRefs(breakpointsRef, __internalRootRef);
 
   const smallContainer = breakpoint === 'default';
 
@@ -67,7 +66,7 @@ export default function Wizard({
     scrollToTop(internalRef);
   }, [actualActiveStepIndex]);
 
-  const isVisualRefresh = useVisualRefresh(refObject);
+  const isVisualRefresh = useVisualRefresh();
   const isLastStep = actualActiveStepIndex >= steps.length - 1;
 
   const navigationEvent = (requestedStepIndex: number, reason: WizardProps.NavigationReason) => {


### PR DESCRIPTION
### Changes Done

Make useVisualRefresh only observe document.body

### Why?

The current mutation observer implementation has a performance implication as it watches over any attribute change of any DOM element. The useVisualRefresh is the most-used consumer of the useMutationObserver and it has been reported by the customer as having a significant performance impact.

When the observations are scoped to a single DOM node (document.body) the callbacks are only fired once for the initial render and if the body element attribute changes.

The change is not backward-compatible as now the observation only works of the VR class is assigned to the body. However, that is not expected to impact prod as the VR switch is only used for development. For that reason we cannot use the same solution for other visual-mode hooks.

### Testing

To test how it works you can add a breakpoint or a logging to the useVisualRefresh mutation observer callback and check how many times and when does it fire.

### Related Links

QUIP:    "MutationObserver performance impact"
Ticket:   18840

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_
