### PR TITLE
fix(container): Fix sticky offset calculation under disableBodyScroll

### DIFF
--- a/pages/app-layout/legacy-table-sticky-notifications.page.tsx
+++ b/pages/app-layout/legacy-table-sticky-notifications.page.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import AppLayout from '~components/app-layout';
+import Flashbar from '~components/flashbar';
+import Table from '~components/table';
+import Header from '~components/header';
+import labels from './utils/labels';
+import { Breadcrumbs } from './utils/content-blocks';
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        stickyNotifications={true}
+        breadcrumbs={<Breadcrumbs />}
+        disableBodyScroll={true}
+        contentType="table"
+        notifications={
+          <Flashbar
+            items={[
+              {
+                type: 'success',
+                header: 'Success message',
+              },
+              {
+                type: 'info',
+                header: 'Info message',
+              },
+            ]}
+          />
+        }
+        content={
+          <>
+            <h1>Sticky Notifications + Table Header</h1>
+            <Table
+              header={<Header>Sticky Table Header 1</Header>}
+              footer={<div style={{ height: '100vh' }}></div>}
+              items={[]}
+              columnDefinitions={[]}
+              stickyHeader={true}
+            />
+          </>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -459,6 +459,7 @@ const OldAppLayout = React.forwardRef(
               ref={legacyScrollRootRef}
               className={clsx(styles['layout-main'], {
                 [styles['layout-main-scrollable']]: disableBodyScroll,
+                [testutilStyles['disable-body-scroll-root']]: disableBodyScroll,
                 [styles.unfocusable]: isMobile && anyPanelOpen,
               })}
             >
@@ -471,7 +472,7 @@ const OldAppLayout = React.forwardRef(
                 {notifications && (
                   <DarkHeader
                     {...contentHeaderProps}
-                    topOffset={headerHeight}
+                    topOffset={disableBodyScroll ? 0 : headerHeight}
                     sticky={!isMobile && darkStickyHeaderContentType && stickyNotifications}
                   >
                     <Notifications
@@ -542,7 +543,8 @@ const OldAppLayout = React.forwardRef(
                   <AppLayoutDomContext.RootProvider
                     value={{
                       stickyOffsetTop:
-                        headerHeight + (stickyNotificationsHeight !== null ? stickyNotificationsHeight : 0),
+                        (disableBodyScroll ? 0 : headerHeight) +
+                        (stickyNotificationsHeight !== null ? stickyNotificationsHeight : 0),
                       stickyOffsetBottom: footerHeight + (splitPanelBottomOffset || 0),
                     }}
                     // eslint-disable-next-line react/forbid-component-props

--- a/src/app-layout/test-classes/styles.scss
+++ b/src/app-layout/test-classes/styles.scss
@@ -37,5 +37,8 @@
   /* used in test-utils */
 }
 .mobile-bar {
-  /* used in test-utils */
+  /* used in tests */
+}
+.disable-body-scroll-root {
+  /* used in tests */
 }

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -115,6 +115,7 @@ export default function Layout({ children }: LayoutProps) {
         styles[`split-panel-position-${splitPanelPosition ?? 'bottom'}`],
         {
           [styles['disable-body-scroll']]: disableBodyScroll,
+          [testutilStyles['disable-body-scroll-root']]: disableBodyScroll,
           [styles['has-content-gap-left']]: hasContentGapLeft,
           [styles['has-content-gap-right']]: hasContentGapRight,
           [styles['has-max-content-width']]: maxContentWidth && maxContentWidth > 0,

--- a/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
+++ b/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from '../../app-layout/__integ__/constants';
+
+import appLayoutSelectors from '../../../lib/components/app-layout/test-classes/styles.selectors.js';
+
+const appLayoutWrapper = createWrapper().findAppLayout();
+const containerWrapper = appLayoutWrapper.findContentRegion().findContainer();
+const containerHeaderSelector = containerWrapper.findHeader().toSelector();
+const flashBarSelector = createWrapper().findFlashbar().toSelector();
+
+const CLASSIC_STICKY_OFFSET_SPACE = -1; // Container border (1px) offset
+const VISUAL_REFRESH_STICKY_OFFSET_SPACE = 4; // space-xxs (container border offset is 0px)
+
+class AppLayoutLegacyStickyPage extends BasePageObject {
+  async areNotificationsVisible() {
+    const elements = await this.browser.$$(appLayoutWrapper.findNotifications().toSelector());
+    if (elements.length === 0) {
+      return false;
+    }
+    return elements[0].isDisplayedInViewport();
+  }
+
+  scrollTo(params: { top?: number; left?: number }) {
+    return this.elementScrollTo(`.${appLayoutSelectors['disable-body-scroll-root']}`, params);
+  }
+}
+
+describe.each([
+  ['classic', CLASSIC_STICKY_OFFSET_SPACE],
+  ['visualRefresh', VISUAL_REFRESH_STICKY_OFFSET_SPACE],
+])('In %s', (type, stickyOffset) => {
+  function setupTest({ viewport = viewports.desktop }, testFn: (page: AppLayoutLegacyStickyPage) => Promise<void>) {
+    return useBrowser(async browser => {
+      const page = new AppLayoutLegacyStickyPage(browser);
+      await page.setWindowSize(viewport);
+      await browser.url(
+        `#/light/app-layout/legacy-table-sticky-notifications/?visualRefresh=${type === 'visualRefresh'}`
+      );
+      await page.waitForVisible(appLayoutWrapper.findContentRegion().toSelector());
+      await testFn(page);
+    });
+  }
+
+  test(
+    'Sticky header is offset by the height of the sticky notifications',
+    setupTest({}, async page => {
+      const { top: containerTopBefore } = await page.getBoundingBox(containerHeaderSelector);
+      const { bottom: flashBarBottomBefore } = await page.getBoundingBox(flashBarSelector);
+      expect(containerTopBefore).toBeGreaterThan(flashBarBottomBefore);
+      await page.scrollTo({ top: 400 });
+      const { top: containerTopAfter } = await page.getBoundingBox(containerHeaderSelector);
+      const { bottom: flashBarBottomAfter } = await page.getBoundingBox(flashBarSelector);
+      expect(containerTopAfter).toEqual(flashBarBottomAfter + stickyOffset);
+    })
+  );
+
+  test(
+    'Does not stick in narrow viewports',
+    setupTest({ viewport: viewports.mobile }, async page => {
+      const { top: topBefore } = await page.getBoundingBox(containerHeaderSelector);
+      expect(topBefore).toBeGreaterThan(0);
+      await page.scrollTo({ top: 400 });
+      const { top: topAfter } = await page.getBoundingBox(containerHeaderSelector);
+      expect(topAfter).toBeLessThan(0);
+    })
+  );
+});

--- a/src/table/__tests__/empty-state.test.tsx
+++ b/src/table/__tests__/empty-state.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../../../lib/components/internal/hooks/container-queries', () => ({
 jest.mock('../../../lib/components/internal/utils/dom', () => ({
   supportsStickyPosition: jest.fn(),
   getContainingBlock: jest.fn(() => null),
+  findUpUntil: jest.fn(),
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
### Changes Done

Fixed multiple issues:
- In a classic app layout with `contentType="table"` and `disableBodyScroll={true}`, don't include the header height in provided top offset (see `src/app-layout/index.tsx`)
- In classic and visual refresh, `disableBodyScroll={true}` caused sticky scroll in headers to ignore the top offset because they incorrectly considered the app layout to be an invalidating scrolling container. Changed the logic to stop searching when it hits the app layout scrolling root (see `src/container/use-sticky-header.ts`)

The rest are test classes, dev pages, and integration tests.

### Testing

Added an integration test for sticky positioning inside `disableBodyScroll`.

### Related Links

AWSUI-18582

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated._
- [x] _Changes are covered with automated tests if not indicated._
- [x] _Changes do not include unsupported browser features._
- [x] _Changes to UX were approved by the designer._
- [x] _Changes to UX were manually tested for accessibility._

#### Security

- [x] _Changes do not include XSS vulnerability._
- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [x] _All API changes were reviewed by the team and the corresponding doc is linked._
- [x] _All API doc strings were reviewed by the writer._
- [x] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [x] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [x] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [x] _Is there enough coverage with new/existing unit tests?_
- [x] _Is there enough coverage with new/existing integration tests?_
- [x] _Is there enough coverage with new/existing screenshot tests?_

It's much more robust to test this in integ than in unit tests, so that's what I went with. No screenshot testing really necessary here.
