### PR TITLE
fix(date-picker,date-range-picker): Restrict expandToViewport dropdowns to only stretch to edge of viewport

### DIFF
--- a/pages/date-range-picker/small-viewport.page.tsx
+++ b/pages/date-range-picker/small-viewport.page.tsx
@@ -8,29 +8,37 @@ import { i18nStrings, isValid, relativeOptions } from './common';
 export default function DatePickerScenario() {
   const [value, setValue] = useState<DateRangePickerProps['value']>(null);
   const [expandToViewport, setExpandToViewport] = useState(false);
+  const [sticky, setSticky] = useState(false);
 
   return (
-    <ScreenshotArea gutters={false}>
+    <ScreenshotArea>
       <h1>Date range picker in small viewport</h1>
       <button id="toggle-expand-to-viewport" type="button" onClick={() => setExpandToViewport(!expandToViewport)}>
         {expandToViewport ? 'Disable' : 'Enable'} expandToViewport
       </button>
+      <button id="toggle-sticky" type="button" onClick={() => setSticky(!sticky)}>
+        {sticky ? 'Disable' : 'Enable'} sticky
+      </button>
       <button id="focus-dismiss-helper" type="button">
         Focusable element
       </button>
-      <FormField label="Date Range Picker field">
-        <DateRangePicker
-          value={value}
-          locale={'en-EN'}
-          i18nStrings={i18nStrings}
-          placeholder={'Filter by a date and time range'}
-          onChange={e => setValue(e.detail.value)}
-          relativeOptions={relativeOptions}
-          isValidRange={isValid}
-          timeInputFormat="hh:mm"
-          expandToViewport={expandToViewport}
-        />
-      </FormField>
+      <div style={sticky ? { minHeight: '200vh' } : {}}>
+        <div style={sticky ? { position: 'sticky', top: 200 } : {}}>
+          <FormField label="Date Range Picker field">
+            <DateRangePicker
+              value={value}
+              locale="en-EN"
+              i18nStrings={i18nStrings}
+              placeholder="Filter by a date and time range"
+              onChange={e => setValue(e.detail.value)}
+              relativeOptions={relativeOptions}
+              isValidRange={isValid}
+              timeInputFormat="hh:mm"
+              expandToViewport={expandToViewport}
+            />
+          </FormField>
+        </div>
+      </div>
     </ScreenshotArea>
   );
 }

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -165,7 +165,7 @@ export const getDropdownPosition = (
   const dropUp = availableSpace.below < dropdown.offsetHeight && availableSpace.above > availableSpace.below;
   const availableHeight = dropUp ? availableSpace.above : availableSpace.below;
   // Try and crop the bottom item when all options can't be displayed, affordance for "there's more"
-  const croppedHeight = Math.floor(availableHeight / 31) * 31 + 16;
+  const croppedHeight = stretchHeight ? availableHeight : Math.floor(availableHeight / 31) * 31 + 16;
 
   return {
     dropUp,

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -37,7 +37,7 @@ export const getOverflowParentDimensions = (
         };
       });
 
-  if (canExpandOutsideViewport) {
+  if (canExpandOutsideViewport && !expandToViewport) {
     const documentDimensions = document.documentElement.getBoundingClientRect();
     parents.push({
       width: Math.max(documentDimensions.width, document.documentElement.clientWidth),


### PR DESCRIPTION
### Changes Done

We had an issue where expanded dropdowns (i.e. for date picker and date range picker) would get cut off in constrained spaces. This was fixed (by me) by treating the entire document as a valid area for expansion, so you could scroll down to see the rest of the dropdown. But this is still an issue inside sticky elements (like a sticky table header) because the assumption that you could just scroll down to see the rest of the dropdown isn't true there.

### Testing

Given the complex nesting going on, screenshots are probably the best way to test this. Amended the screenshot page, going to add a test for this.

### Related Links

AWSUI-16571

### Review Checklist

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated._
- [x] _Changes are covered with automated tests if not indicated._
- [x] _Changes do not include unsupported browser features._
- [x] _Changes to UX were approved by the designer._
- [x] _Changes to UX were manually tested for accessibility._

#### Security

- [x] _Changes do not include XSS vulnerability._
- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [x] _All API changes were reviewed by the team and the corresponding doc is linked._
- [x] _All API doc strings were reviewed by the writer._
- [x] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [x] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [x] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [x] _Is there enough coverage with new/existing unit tests?_
- [x] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_
  - This PR makes the change in the screenshot page, but the test will be added separately.
