### PR TITLE
fix(app-layout): Allow split panel to extend to full height on height-constrained viewports

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -114,6 +114,20 @@ test(
   })
 );
 
+test(
+  `should have extended max height for constrained heights`,
+  setupTest(async page => {
+    // Simulating 200% zoom on medium screens (1366x768 / 2 ~= 680x360 ).
+    await page.setWindowSize({ width: 680, height: 360 });
+    await page.openPanel();
+    const { height } = await page.getWindowSize();
+    await page.dragResizerTo({ x: 0, y: height });
+    expect((await page.getSplitPanelSize()).height).toEqual(160);
+    await page.dragResizerTo({ x: 0, y: 0 });
+    expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
+  })
+);
+
 [
   { url: '#/light/app-layout/disable-paddings-with-split-panel', name: 'paddings disabled' },
   { url: '#/light/app-layout/with-split-panel', name: 'paddings enabled' },

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -22,7 +22,12 @@ import { useContainerQuery } from '../internal/hooks/container-queries';
 import { useStableEventHandler } from '../internal/hooks/use-stable-event-handler';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { SplitPanelContextProps, SplitPanelLastInteraction } from '../internal/context/split-panel-context';
-import { getSplitPanelDefaultSize, MAIN_PANEL_MIN_HEIGHT } from '../split-panel/utils/size-utils';
+import {
+  CONSTRAINED_MAIN_PANEL_MIN_HEIGHT,
+  CONSTRAINED_PAGE_HEIGHT,
+  getSplitPanelDefaultSize,
+  MAIN_PANEL_MIN_HEIGHT,
+} from '../split-panel/utils/size-utils';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import ContentWrapper, { ContentWrapperProps } from './content-wrapper';
@@ -255,9 +260,13 @@ const OldAppLayout = React.forwardRef(
       if (typeof document === 'undefined') {
         return 0; // render the split panel in its minimum possible size
       } else if (disableBodyScroll && legacyScrollRootRef.current) {
-        return legacyScrollRootRef.current.clientHeight - MAIN_PANEL_MIN_HEIGHT;
+        const availableHeight = legacyScrollRootRef.current.clientHeight;
+        return availableHeight < CONSTRAINED_PAGE_HEIGHT ? availableHeight : availableHeight - MAIN_PANEL_MIN_HEIGHT;
       } else {
-        return document.documentElement.clientHeight - headerHeight - footerHeight - MAIN_PANEL_MIN_HEIGHT;
+        const availableHeight = document.documentElement.clientHeight - headerHeight - footerHeight;
+        return availableHeight < CONSTRAINED_PAGE_HEIGHT
+          ? availableHeight - CONSTRAINED_MAIN_PANEL_MIN_HEIGHT
+          : availableHeight - MAIN_PANEL_MIN_HEIGHT;
       }
     });
 

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useContext, useLayoutEffect, useState } from 'react';
+import React, { useContext, useLayoutEffect } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
 import { SplitPanelContext } from '../../internal/context/split-panel-context';
-import { useResizeObserver } from '../../internal/hooks/container-queries';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 import { AppLayoutProps } from '../interfaces';
@@ -27,9 +26,9 @@ export default function Layout({ children }: LayoutProps) {
     disableBodyScroll,
     disableContentHeaderOverlap,
     dynamicOverlapHeight,
-    footerSelector,
+    footerHeight,
     hasNotificationsContent,
-    headerSelector,
+    headerHeight,
     isNavigationOpen,
     isSplitPanelOpen,
     isToolsOpen,
@@ -53,18 +52,6 @@ export default function Layout({ children }: LayoutProps) {
   } = useContext(SplitPanelContext);
 
   const isOverlapDisabled = getOverlapDisabled(dynamicOverlapHeight, contentHeader, disableContentHeaderOverlap);
-
-  /**
-   * Query the DOM for the header and footer elements based on the selectors provided
-   * by the properties and pass the heights to the custom property definitions.
-   */
-  const [headerHeight, setHeaderHeight] = useState(0);
-  const getHeader = useCallback(() => document.querySelector(headerSelector), [headerSelector]);
-  useResizeObserver(getHeader, entry => setHeaderHeight(entry.borderBoxHeight));
-
-  const [footerHeight, setFooterHeight] = useState(0);
-  const getFooter = useCallback(() => document.querySelector(footerSelector), [footerSelector]);
-  useResizeObserver(getFooter, entry => setFooterHeight(entry.borderBoxHeight));
 
   // Content gaps on the left and right are used with the minmax function in the CSS grid column definition
   const hasContentGapLeft = getContentGapLeft(isNavigationOpen, navigationHide);

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -30,6 +30,8 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     setSplitPanelReportedSize,
     splitPanelPosition,
     splitPanelSize,
+    headerHeight,
+    footerHeight,
   } = useContext(AppLayoutContext);
 
   const [openButtonAriaLabel, setOpenButtonAriaLabel] = useState<undefined | string>(undefined);
@@ -46,7 +48,11 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
 
   const context: SplitPanelContextProps = {
     bottomOffset: 0,
-    getMaxHeight: () => document.documentElement.clientHeight - 250,
+    getMaxHeight: () => {
+      const availableHeight = document.documentElement.clientHeight - headerHeight - footerHeight;
+      // If the page is likely zoomed in at 200%, allow the split panel to fill the content area.
+      return availableHeight < 400 ? availableHeight - 40 : availableHeight - 250;
+    },
     getMaxWidth: () => document.documentElement.clientWidth,
     getHeader: () => splitPanelHeaderRef.current,
     isForcedPosition: isSplitPanelForcedPosition,

--- a/src/split-panel/utils/size-utils.ts
+++ b/src/split-panel/utils/size-utils.ts
@@ -1,6 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export const MAIN_PANEL_MIN_HEIGHT = 250; // approximate height of breadcrumb, table header, and the first table row
+
+/**
+ * The page height where the page is considered constrained.
+ */
+export const CONSTRAINED_PAGE_HEIGHT = 400;
+
+/**
+ * Based on approximate height of breadcrumb, table header, and the first table row
+ */
+export const MAIN_PANEL_MIN_HEIGHT = 250;
+
+/**
+ * Based on approximate height of app bar on comfortable mode on mobile.
+ */
+export const CONSTRAINED_MAIN_PANEL_MIN_HEIGHT = 40;
+
 /**
  * Estimate a default split panel size for the first render based on the document size.
  */


### PR DESCRIPTION
### Changes Done

Fixing the poor experience when the page is zoomed to 200%. The split panel is too small at that zoom level, and we don't allow resizing because it hits all the minimum/maximum thresholds for the split panel at that size.

Had a chat with a bunch of folks in the team about the "right" way to do this and I think this is the best middle ground of complexity. Adding all the complexity to measure the mobile app bar is way too unnecessary, but doing % or static difference of clientHeight didn't work great in local testing because a single line additional line of header text or the addition of a footer could end up changing the available height by 10-20%, so it could be anything from 60-85%.

So, I just lift the height calculation into the context level (don't see anything "wrong" with that), and just subtract a static offset (40px) to make sure we always clear the mobile app bar. And I'm happy with this.

### Testing

Added an integ test for this.

### Related Links

AWSUI-16329

### Review Checklist

<details>
 <summary>The following items are to be evaluated by the author(s) and the reviewer(s).</summary>


#### Correctness

- [ ] _Changes are backward-compatible if not indicated._
- [ ] _Changes are covered with automated tests if not indicated._
- [ ] _Changes do not include unsupported browser features._
- [ ] _Changes to UX were approved by the designer._
- [ ] _Changes to UX were manually tested for accessibility._

#### Security

- [ ] _Changes do not include XSS vulnerability._
- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Completeness

- [ ] _All API changes were reviewed by the team and the corresponding doc is linked._
- [ ] _All API doc strings were reviewed by the writer._
- [ ] _If a bug bash was conducted to cover the changes, the corresponding doc is linked._
- [ ] _The code, code comments, readme files, and CR combined provide enough context to understand the changes._
- [ ] _Tickets are created for unresolved TODOs and comments._

#### Testing

- [ ] _Is there enough coverage with new/existing unit tests?_
- [ ] _Is there enough coverage with new/existing integration tests?_
- [ ] _Is there enough coverage with new/existing screenshot tests?_

</details>