### PR TITLE
feat(tag-editor): Provide tag limit to the additional info i18n callback

### DIFF
--- a/pages/tag-editor/shared.ts
+++ b/pages/tag-editor/shared.ts
@@ -31,8 +31,12 @@ export const I18N_STRINGS: TagEditorProps.I18nStrings = {
   invalidValueError:
     'Invalid value. Values can only contain alphanumeric characters, spaces and any of the following: _.:/=+@-',
   awsPrefixError: 'Cannot start with aws:',
-  tagLimit: availableTags =>
-    availableTags === 1 ? 'You can add up to 1 more tag.' : `You can add up to ${availableTags} more tags.`,
+  tagLimit: (availableTags, tagLimit) =>
+    availableTags === tagLimit
+      ? `You can up to ${tagLimit} tags.`
+      : availableTags === 1
+      ? 'You can add up to 1 more tag.'
+      : `You can add up to ${availableTags} more tags.`,
   tagLimitReached: tagLimit =>
     tagLimit === 1 ? 'You have reached the limit of 1 tag.' : `You have reached the limit of ${tagLimit} tags.`,
   tagLimitExceeded: tagLimit =>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10843,7 +10843,7 @@ character validation. You should use this property only when absolutely necessar
           Object {
             "name": "tagLimit",
             "optional": false,
-            "type": "(availableTags: number) => string",
+            "type": "(availableTags: number, tagLimit: number) => string",
           },
           Object {
             "name": "tagLimitExceeded",

--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -117,7 +117,7 @@ describe('Tag Editor component', () => {
       expect(removeButtonElement).toHaveTextContent(i18nStrings.removeButton);
       expect(undoPromptElement).toHaveTextContent(i18nStrings.undoPrompt);
       expect(undoButtonElement).toHaveTextContent(i18nStrings.undoButton);
-      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(48));
+      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(48, 50));
     });
 
     test('uses the correct string when the component has no tags', () => {
@@ -244,30 +244,30 @@ describe('Tag Editor component', () => {
       const { wrapper } = renderTagEditor();
       const additionalInfoElement = wrapper.findAdditionalInfo()!.getElement();
 
-      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(50));
+      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(50, 50));
     });
 
     test('uses the correct value when component contains existing tags', () => {
       const { wrapper } = renderTagEditor({ tags: [{ key: 'key', value: 'value', existing: true }] });
       const additionalInfoElement = wrapper.findAdditionalInfo()!.getElement();
 
-      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(49));
+      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(49, 50));
     });
 
     test('uses the correct value when tags are added to the component', () => {
       const { wrapper } = renderTagEditor({ tags: [{ key: 'key', value: 'value', existing: false }] });
       const additionalInfoElement = wrapper.findAdditionalInfo()!.getElement();
 
-      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(49));
+      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(49, 50));
     });
 
-    test('uses the correct value when existing tag)s are marked for removal', () => {
+    test('uses the correct value when existing tags are marked for removal', () => {
       const { wrapper } = renderTagEditor({
         tags: [{ key: 'key', value: 'value', existing: false, markedForRemoval: true }],
       });
       const additionalInfoElement = wrapper.findAdditionalInfo()!.getElement();
 
-      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(50));
+      expect(additionalInfoElement).toHaveTextContent(i18nStrings.tagLimit(50, 50));
     });
   });
 

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -265,7 +265,7 @@ const TagEditor = React.forwardRef(
             ) : remainingTags === 0 ? (
               i18nStrings.tagLimitReached(tagLimit) ?? ''
             ) : (
-              i18nStrings.tagLimit(remainingTags)
+              i18nStrings.tagLimit(remainingTags, tagLimit)
             )}
           </div>
         }

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -119,7 +119,7 @@ export namespace TagEditorProps {
     invalidKeyError: string;
     invalidValueError: string;
     awsPrefixError: string;
-    tagLimit: (availableTags: number) => string;
+    tagLimit: (availableTags: number, tagLimit: number) => string;
     tagLimitReached: (tagLimit: number) => string;
     tagLimitExceeded: (tagLimit: number) => string;
     enteredKeyLabel: (enteredText: string) => string;


### PR DESCRIPTION
### Description

There's some info text below the add button in the tag editor specifying the number of tags that can be added. Text like "You can add up to N _more_ tags" doesn't read well in the empty state, where there aren't any tags to begin with. This PR allows devs to write an empty state only message in a cleaner way:

```javascript
tagLimit: (availableTags, tagLimit) =>
  availableTags === tagLimit
    ? `You can up to ${tagLimit} tags.`
    : availableTags === 1
    ? 'You can add up to 1 more tag.'
    : `You can add up to ${availableTags} more tags.`,
```

Thankfully, function arity isn't checked by TypeScript, so this is a backward compatible change.

### How has this been tested?

Visual tests, basically. The dev pages build fine and this change should be reflected as internal screenshot changes.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _No._

### Related Links

AWSUI-18760

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

We're verifying them by making sure the dev pages build and checking that the strings are different in screenshots.

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
