### PR TITLE
fix(date-picker,date-range-picker): Focus outline radius

### DIFF
--- a/src/date-picker/styles.scss
+++ b/src/date-picker/styles.scss
@@ -186,8 +186,9 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
       }
     }
   }
+
   @include styles.styles-reset;
   @include focus-visible.when-visible {
-    @include styles.container-focus();
+    @include styles.container-focus(awsui.$border-radius-dropdown);
   }
 }

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -179,7 +179,7 @@ $calendar-grid-width: awsui.$size-calendar-grid-width;
     outline: none;
   }
   @include focus-visible.when-visible {
-    @include styles.container-focus();
+    @include styles.container-focus(awsui.$border-radius-dropdown);
   }
 }
 

--- a/src/internal/styles/forms/mixins.scss
+++ b/src/internal/styles/forms/mixins.scss
@@ -21,7 +21,7 @@
   box-shadow: 0 0 0 awsui.$border-link-focus-ring-shadow-spread awsui.$color-border-item-focused;
 }
 
-@mixin container-focus {
+@mixin container-focus($border-radius: awsui.$border-radius-container) {
   // This mixin is different to `focus-highlight` because it needs to supports overflowing
   // content. Using a pseudo element does not take the width or height of the overflowing
   // children.
@@ -30,7 +30,7 @@
   outline: 2px dotted transparent;
   outline-offset: 2px;
 
-  border-radius: awsui.$border-radius-container;
+  border-radius: $border-radius;
   box-shadow: foundation.$box-shadow-focused;
 }
 


### PR DESCRIPTION
### Description

This change updates the radius of the focus outline for the dropdown part of the Date Picker and the Date Range Picker. While the dropdown acts as a container, it has a different `border-radius` than the Container component. The radius for the focus outline did not match this different border-radius.


### Before
![Screenshot of the state before the fix](https://user-images.githubusercontent.com/9086585/179536320-38b76a8f-e492-4ee0-8065-17ea00f2a0a9.png)

### After

![Screenshot of the state after the fix](https://user-images.githubusercontent.com/9086585/179536384-bfa0bbae-6521-4dc1-abe0-fb5f6aab0ec2.png)


### How has this been tested?

_How did you test to verify your changes?_  
Manual testing in the browser

_How can reviewers test these changes efficiently?_  
- Open http://localhost:8080/#/light/date-picker/simple
- Focus the input field
- Press <kbd>Tab</kbd> to move the focus to the button, and <kbd>Enter</kbd> to open the dropdown
- Observe the focus radius around the dropdown

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

*Do the changes include any API documentation changes?*
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

n/a




<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [X] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
