### PR TITLE
Enable Visual Regression Tests again

### DIFF
--- a/.github/workflows/visuals.yml
+++ b/.github/workflows/visuals.yml
@@ -1,13 +1,12 @@
 name: Visual Regression Tests
 
 on:
-  workflow_dispatch:
-  # pull_request:
-  #   branches:
-  #     - main
-  # push:
-  #   branches:
-  #     - gh-readonly-queue/main/**
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - gh-readonly-queue/main/**
 
 defaults:
   run:


### PR DESCRIPTION
### Description

This reverts commit b5fc5b2c5e9a26851cbe64119c5c54ee5e488771 and enables visual regression tests again. They were originally disabled because they cannot easily run without the dependencies being published to npm.

### How has this been tested?
We have used this in the past, so it should work.

~~This initial run will fail, though, because there will be no reference images. It will work as normal with the PR after this one.~~ Because we kept the original testing files and just disabled the workflow, this should just work immediately after merging.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
