### PR TITLE
fix: Add ariacontrols to combobox

### DIFF
--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -106,7 +106,11 @@ describe('useSelect', () => {
     test('should return getFilterProps that configures the filter', () => {
       const { ref, __nativeAttributes } = getFilterProps();
       expect({ ref, __nativeAttributes }).toEqual({
-        __nativeAttributes: { 'aria-activedescendant': undefined, 'aria-owns': __nativeAttributes!['aria-owns'] },
+        __nativeAttributes: {
+          'aria-activedescendant': undefined,
+          'aria-owns': __nativeAttributes!['aria-owns'],
+          'aria-controls': __nativeAttributes!['aria-controls'],
+        },
         ref: { current: null },
       });
     });

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -195,6 +195,7 @@ export function useSelect({
       __nativeAttributes: {
         'aria-activedescendant': highlightedOptionId,
         ['aria-owns']: menuId,
+        ['aria-controls']: menuId,
       },
     };
   };


### PR DESCRIPTION
### Description

Add aria-controls to combobox

### How has this been tested?

Manually test and unit test.


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-18450


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
