### PR TITLE
Mark visible property on alert as deprecated

### DIFF
--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -14,6 +14,7 @@ export interface AlertProps extends BaseComponentProps {
   type?: AlertProps.Type;
   /**
    * Determines whether the alert is displayed.
+   * @deprecated Use conditional rendering in your code instead of this prop
    */
   visible?: boolean;
   /**

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -177,7 +177,7 @@ function Tutorial({
             <InternalSpaceBetween size="l">
               <InternalSpaceBetween size="m">
                 {tutorial.prerequisitesNeeded && tutorial.prerequisitesAlert && (
-                  <InternalAlert type="info" className={styles['prerequisites-alert']} visible={true}>
+                  <InternalAlert type="info" className={styles['prerequisites-alert']}>
                     {tutorial.prerequisitesAlert}
                   </InternalAlert>
                 )}


### PR DESCRIPTION
### Description

Mark `visible` property as deprecated. It should not be used in new code, `{condition && <Alert />}` does the same thing

### How has this been tested?

Only JSDOC change

### Documentation changes

- [x] _Yes, this change contains documentation changes._
- [ ] _No._ 


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
