### PR TITLE
fix markdown issues in flashbar documentation

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4909,15 +4909,15 @@ our UX guidelines only allow you to add a button.
 * \`buttonText\` (string) - Specifies that an action button should be displayed, with the specified text.
 When a user clicks on this button the \`onButtonClick\` handler is called. If the \`action\` property is set, this property is ignored.
 **Deprecated**, replaced by \`action\`.
-*\`id\` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
-1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
-2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.",
+* \`onButtonClick\` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
+  using the \`action\` property. **Deprecated**, replaced by \`action\`.
+* \`id\` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
+  1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
+  2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FlashbarProps.MessageDefinition>",
-      "visualRefreshTag": "\`id\` property
-* \`onButtonClick\` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
-  using the \`action\` property. **Deprecated**, replaced by \`action\`.",
+      "visualRefreshTag": "\`id\` property",
     },
   ],
   "regions": Array [],

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -40,12 +40,12 @@ export interface FlashbarProps extends BaseComponentProps {
    * * `buttonText` (string) - Specifies that an action button should be displayed, with the specified text.
    * When a user clicks on this button the `onButtonClick` handler is called. If the `action` property is set, this property is ignored.
    * **Deprecated**, replaced by `action`.
-   * *`id` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
-   * 1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
-   * 2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
-   * @visualrefresh `id` property
    * * `onButtonClick` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
    *   using the `action` property. **Deprecated**, replaced by `action`.
+   * * `id` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
+   *   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
+   *   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
+   * @visualrefresh `id` property
    */
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;
 }


### PR DESCRIPTION
### Description

`@visualrefresh` has to be below the general list, otherwise it will be cut in two

### How has this been tested?

Locally launched our doc website, it renders correctly now

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

Affected docs page: https://cloudscape.design/components/flashbar/?tabId=api


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
