### PR TITLE
fix(icon): Improve default size when server rendering

### DIFF
--- a/src/icon/__tests__/icon-ssr.test.tsx
+++ b/src/icon/__tests__/icon-ssr.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable header/header */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Icon from '../../../lib/components/icon';
+import styles from '../../../lib/components/icon/styles.css.js';
+
+test('renders with a normal size when rendering outside the DOM', () => {
+  const content = renderToStaticMarkup(<Icon size="inherit" name="settings" />);
+  expect(content).toContain(styles['size-normal']);
+  expect(content).not.toContain('style=');
+});

--- a/src/icon/__tests__/icon.test.tsx
+++ b/src/icon/__tests__/icon.test.tsx
@@ -39,10 +39,6 @@ describe('Icon Component', () => {
       const { container } = render(<Icon size="inherit" name="settings" />);
       expect(container.firstElementChild).toHaveClass(styles['icon-flex-height']);
     });
-    it('renders with inline style for height', () => {
-      const { container } = render(<Icon size="inherit" name="settings" />);
-      expect(container.firstElementChild).toHaveAttribute('style', 'height: 0px;');
-    });
   });
 
   describe('custom icons', () => {

--- a/src/icon/internal.tsx
+++ b/src/icon/internal.tsx
@@ -16,19 +16,22 @@ type InternalIconProps = IconProps &
     badge?: boolean;
   };
 
-function iconSizeMap(height: number) {
-  if (height) {
-    if (height >= 50) {
-      return 'large';
-    } else if (height >= 36) {
-      return 'big';
-    } else if (height >= 24) {
-      return 'medium';
-    } else if (height <= 16) {
-      return 'small';
-    } else {
-      return 'normal';
-    }
+function iconSizeMap(height: number | null) {
+  if (height === null) {
+    // This is the best guess for the contextual height while server rendering.
+    return 'normal';
+  }
+
+  if (height >= 50) {
+    return 'large';
+  } else if (height >= 36) {
+    return 'big';
+  } else if (height >= 24) {
+    return 'medium';
+  } else if (height <= 16) {
+    return 'small';
+  } else {
+    return 'normal';
   }
 }
 
@@ -46,10 +49,10 @@ const InternalIcon = ({
   const iconRef = useRef<HTMLElement>(null);
   // To ensure a re-render is triggered on visual mode changes
   useVisualRefresh(iconRef);
-  const [parentHeight, setParentHeight] = useState(0);
+  const [parentHeight, setParentHeight] = useState<number | null>(null);
   const contextualSize = size === 'inherit';
   const iconSize = contextualSize ? iconSizeMap(parentHeight) : size;
-  const inlineStyles = { height: contextualSize ? `${parentHeight}px` : '' };
+  const inlineStyles = contextualSize && parentHeight !== null ? { height: `${parentHeight}px` } : {};
   const baseProps = getBaseProps(props);
 
   baseProps.className = clsx(


### PR DESCRIPTION
### Description

Icons don't have a contextual height when used with `size="inherit"` until TTI.

### How has this been tested?

Only locally. Do it yourself:

```
<div dangerouslySetInnerHTML={{
  __html: ReactDOMServer.renderToString(<Icon name="external" size="inherit" />)
}} />
```

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _No._

### Related Links

AWSUI-18521

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

Only manual testing for now, we probably need to do SSR stuff in a more comprehensive way.

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
