### PR TITLE
fix(link): Fire event on keyDown instead of keyUp

### DIFF
--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -64,14 +64,8 @@ const InternalLink = React.forwardRef(
     };
 
     const handleButtonKeyDown = (event: React.KeyboardEvent) => {
-      // Prevent the page from scrolling down when spacebar is pressed.
-      if (event.keyCode === KeyCode.space) {
-        event.preventDefault();
-      }
-    };
-
-    const handleButtonKeyUp = (event: React.KeyboardEvent) => {
       if (event.keyCode === KeyCode.space || event.keyCode === KeyCode.enter) {
+        event.preventDefault();
         fireFollowEvent(event);
       }
     };
@@ -120,14 +114,7 @@ const InternalLink = React.forwardRef(
 
     if (isButton) {
       return (
-        <a
-          {...sharedProps}
-          role="button"
-          tabIndex={0}
-          onKeyDown={handleButtonKeyDown}
-          onKeyUp={handleButtonKeyUp}
-          onClick={handleButtonClick}
-        >
+        <a {...sharedProps} role="button" tabIndex={0} onKeyDown={handleButtonKeyDown} onClick={handleButtonClick}>
           {content}
         </a>
       );


### PR DESCRIPTION
### Description

This moves the `onFollow` event of (the button variant of) the Link to be fired when the key is pressed down instead of when the key is released.

This aligns it with the behaviour of the native HTML button and the Cloudscape button.

It also prevents an issue that occurs when the Link is used to open a Model: when closing the Modal by pressing and releasing the Enter key, the Link used to fire an `onFollow` event (because it caught the releasing of the key) where it shouldn't.

### How has this been tested?

_How did you test to verify your changes?_  
Manual testing in the dev pages

_How can reviewers test these changes efficiently?_  
Modify `pages/modal/simple.page.tsx` to use a Link (without href) instead of a button, and open and close the Modal using the Enter key.


[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

*Do the changes include any API documentation changes?*
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-18874


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [X] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
