### PR TITLE
Revert "Remove mutation observer from useVisualRefresh (#31)"

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -4,7 +4,6 @@ import React, { Suspense, useContext, useEffect } from 'react';
 import { render } from 'react-dom';
 import { HashRouter, Redirect } from 'react-router-dom';
 import { applyMode, applyDensity, disableMotion } from '@cloudscape-design/global-styles';
-import { useEffectOnUpdate } from '~components/internal/hooks/use-effect-on-update';
 import './polyfills';
 
 // import font-size reset and Ember font
@@ -24,10 +23,6 @@ function App() {
     pageId,
     urlParams: { density, motionDisabled, visualRefresh },
   } = useContext(AppContext);
-
-  useEffectOnUpdate(() => {
-    window.location.reload();
-  }, [visualRefresh]);
 
   const isAppLayout =
     pageId !== undefined && (pageId.indexOf('app-layout') > -1 || pageId.indexOf('content-layout') > -1);

--- a/pages/date-range-picker/calendar-permutations.page.tsx
+++ b/pages/date-range-picker/calendar-permutations.page.tsx
@@ -52,7 +52,6 @@ export default function DateRangePickerCalendarPage() {
                   <Dropdown
                     stretchWidth={true}
                     stretchHeight={true}
-                    stretchToTriggerWidth={false}
                     open={true}
                     onDropdownClose={() => {}}
                     onMouseDown={() => {}}

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
@@ -42,9 +42,10 @@ export default function InternalAlert({
   const baseProps = getBaseProps(rest);
 
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
+  const refObject = useRef(null);
+  const mergedRef = useMergeRefs(breakpointRef, refObject, __internalRootRef);
 
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(refObject);
   const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
 
   const actionButton = action || (

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -52,7 +52,7 @@ const AppLayout = React.forwardRef(
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent<HTMLDivElement>('AppLayout');
-    const isRefresh = useVisualRefresh();
+    const isRefresh = useVisualRefresh(__internalRootRef);
 
     // This re-builds the props including the default values
     const props = { contentType, headerSelector, footerSelector, ...rest };

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -50,7 +50,7 @@ const Cards = React.forwardRef(function <T = any>(
 ) {
   const { __internalRootRef } = useBaseComponent('Cards');
   const baseProps = getBaseProps(rest);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(__internalRootRef);
   const computedVariant = isRefresh ? variant : 'container';
 
   const [columns, measureRef] = useContainerQuery<number>(

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -97,9 +97,10 @@ export default function CodeEditor(props: CodeEditorProps) {
   const warningsTabRef = useRef<HTMLButtonElement>(null);
 
   const [codeEditorWidth, codeEditorMeasureRef] = useContainerQuery(rect => rect.width);
-  const mergedRef = useMergeRefs(codeEditorMeasureRef, __internalRootRef);
+  const refObject = useRef(null);
+  const mergedRef = useMergeRefs(codeEditorMeasureRef, refObject, __internalRootRef);
 
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(refObject);
 
   useEffect(() => {
     editor?.resize();

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -45,7 +45,7 @@ export default function InternalContainer({
   const baseProps = getBaseProps(restProps);
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(rootRef);
   const hasDynamicHeight = isRefresh && variant === 'full-page';
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
 

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -36,7 +36,7 @@ export const useStickyHeader = (
   // of other sticky elements positioned on top of the view.
   const { stickyOffsetTop } = useAppLayoutContext();
   const isSticky = useSupportsStickyHeader() && !!__stickyHeader;
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(rootRef);
 
   // If it has overflow parents inside the app layout, we shouldn't apply a sticky offset.
   const [hasInnerOverflowParents, setHasInnerOverflowParents] = useState(false);

--- a/src/date-picker/__integ__/date-picker-dropdown.test.ts
+++ b/src/date-picker/__integ__/date-picker-dropdown.test.ts
@@ -108,13 +108,9 @@ describe('Date picker Dropdown interactions', () => {
     setupTest(async page => {
       await page.clickOpenCalendar();
       await page.clickDate(3, 3);
-
       await page.clickOpenCalendar();
-      await page.keys('\uE052'); // Corresponds to right Alt key. Workaround for an issue with useFocusVisible
-
       await page.keys(['Tab', 'Tab', 'Tab', 'Tab']);
       await expect(page.isDropdownFocused()).resolves.toBe(true);
-
       await page.keys(['Shift', 'Tab', 'Null']);
       await expect(page.isDateFocused()).resolves.toBe(true);
     })
@@ -125,12 +121,9 @@ describe('Date picker Dropdown interactions', () => {
     setupTest(async page => {
       await page.setInputValue('2012/02/03', false);
       await page.clickOpenCalendar();
-      await page.keys('\uE052'); // Corresponds to right Alt key. Workaround for an issue with useFocusVisible
-
       // select next month button
       await page.keys(['Tab', 'Tab', 'Enter']);
       await expect(page.isDropdownOpen()).resolves.toBe(true);
-
       // select first date of month
       await page.keys(['Tab', 'Enter']);
       await expect(page.isDropdownOpen()).resolves.toBe(false);

--- a/src/flashbar/index.tsx
+++ b/src/flashbar/index.tsx
@@ -21,7 +21,7 @@ export { FlashbarProps };
 export default function Flashbar({ items, ...restProps }: FlashbarProps) {
   const { __internalRootRef } = useBaseComponent('Flashbar');
   const [breakpoint, ref] = useContainerBreakpoints(['xs']);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(__internalRootRef);
   const baseProps = getBaseProps(restProps);
 
   const mergedRef = useMergeRefs(ref, __internalRootRef);

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
@@ -14,6 +14,7 @@ import { getAriaDescribedBy, getGridDefinition, getSlotIds } from './util';
 
 import styles from './styles.css.js';
 import { InternalFormFieldProps } from './interfaces';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { joinStrings } from '../internal/utils/strings';
 
 interface FormFieldErrorProps {
@@ -49,7 +50,8 @@ export default function InternalFormField({
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
-  const isRefresh = useVisualRefresh();
+  const ref = useRef<HTMLElement>(null);
+  const isRefresh = useVisualRefresh(ref);
 
   const instanceUniqueId = useUniqueId('formField');
   const generatedControlId = controlId || instanceUniqueId;
@@ -73,8 +75,10 @@ export default function InternalFormField({
     invalid: !!errorText || !!parentInvalid,
   };
 
+  const mergedRef = useMergeRefs(ref, __internalRootRef);
+
   return (
-    <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
+    <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={mergedRef}>
       <div className={clsx(__hideLabel && styles['visually-hidden'])}>
         {label && (
           <label className={styles.label} id={slotIds.label} htmlFor={generatedControlId}>

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useContext } from 'react';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import React, { useContext, useRef } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import { StickyHeaderContext } from '../container/use-sticky-header';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -29,9 +30,11 @@ export default function InternalHeader({
   const HeadingTag = headingTagOverride ?? (variant === 'awsui-h1-sticky' ? 'h1' : variant);
   const { isStuck } = useContext(StickyHeaderContext);
   const baseProps = getBaseProps(restProps);
-  const isRefresh = useVisualRefresh();
+  const ref = useRef(null);
+  const isRefresh = useVisualRefresh(ref);
   const dynamicVariant = isStuck ? 'h2' : 'h1';
   const variantOverride = variant === 'awsui-h1-sticky' ? (isRefresh ? dynamicVariant : 'h2') : variant;
+  const mergedRef = useMergeRefs(ref, __internalRootRef);
   return (
     <div
       {...baseProps}
@@ -44,7 +47,7 @@ export default function InternalHeader({
         description && [styles[`root-has-description`]],
         __disableActionsWrapping && [styles['root-no-wrap']]
       )}
-      ref={__internalRootRef}
+      ref={mergedRef}
     >
       <div
         className={clsx(

--- a/src/icon/internal.tsx
+++ b/src/icon/internal.tsx
@@ -48,7 +48,7 @@ const InternalIcon = ({
 }: InternalIconProps) => {
   const iconRef = useRef<HTMLElement>(null);
   // To ensure a re-render is triggered on visual mode changes
-  useVisualRefresh();
+  useVisualRefresh(iconRef);
   const [parentHeight, setParentHeight] = useState<number | null>(null);
   const contextualSize = size === 'inherit';
   const iconSize = contextualSize ? iconSizeMap(parentHeight) : size;

--- a/src/internal/components/checkbox-icon/index.tsx
+++ b/src/internal/components/checkbox-icon/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React from 'react';
+import React, { useRef } from 'react';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
 import styles from './styles.css.js';
@@ -42,10 +42,18 @@ export const dimensionsByTheme: Record<NonNullable<'default' | 'refresh'>, Dimen
 
 const CheckboxIcon = ({ checked, indeterminate, disabled = false, ...restProps }: CheckboxIconProps) => {
   const baseProps = getBaseProps(restProps);
-  const theme = useVisualRefresh() ? 'refresh' : 'default';
+  const checkboxRef = useRef(null);
+  const theme = useVisualRefresh(checkboxRef) ? 'refresh' : 'default';
   const dimensions = dimensionsByTheme[theme];
   return (
-    <svg className={styles.root} viewBox={dimensions.viewBox} aria-hidden="true" focusable="false" {...baseProps}>
+    <svg
+      className={styles.root}
+      viewBox={dimensions.viewBox}
+      aria-hidden="true"
+      focusable="false"
+      ref={checkboxRef}
+      {...baseProps}
+    >
       <rect
         className={clsx(styles['styled-box'], {
           [styles['styled-box-checked']]: checked,

--- a/src/internal/components/content-layout/index.tsx
+++ b/src/internal/components/content-layout/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useLayoutEffect } from 'react';
+import React, { useContext, useLayoutEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from '../../../app-layout/visual-refresh/context';
 import { ContentLayoutProps } from './interfaces';
@@ -12,7 +12,8 @@ export { ContentLayoutProps };
 
 export default function ContentLayout({ children, disableOverlap, header }: ContentLayoutProps) {
   const { breadcrumbs, setDynamicOverlapHeight } = useContext(AppLayoutContext);
-  const isVisualRefresh = useVisualRefresh();
+  const rootElement = useRef<HTMLDivElement>(null);
+  const isVisualRefresh = useVisualRefresh(rootElement);
   const isOverlapDisabled = !children || !header || disableOverlap;
 
   // Documentation to be added.
@@ -33,6 +34,7 @@ export default function ContentLayout({ children, disableOverlap, header }: Cont
         [styles['is-overlap-disabled']]: isOverlapDisabled,
         [styles['is-visual-refresh']]: isVisualRefresh,
       })}
+      ref={rootElement}
     >
       <div
         className={clsx(

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -130,7 +130,7 @@ const Dropdown = ({
   // To keep track of the initial position (drop up/down) which is kept the same during fixed repositioning
   const fixedPosition = useRef<DropdownPosition | null>(null);
 
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(triggerRef);
 
   const dropdownClasses = usePortalModeClasses(triggerRef);
   const [position, setPosition] = useState<DropdownContextProviderProps['position']>('bottom-right');

--- a/src/internal/hooks/use-mutation-observer/index.ts
+++ b/src/internal/hooks/use-mutation-observer/index.ts
@@ -10,11 +10,6 @@ const useMutationSingleton = createSingletonHandler<void>(handler => {
   return () => observer.disconnect();
 });
 
-/**
- * Fires onChange with the given target element as an argument every time any DOM node attribute changes.
- *
- * @deprecated The hook has performance implications. Consider alternatives.
- */
 export function useMutationObserver(
   elementRef: React.RefObject<HTMLElement>,
   onChange: (element: HTMLElement) => void

--- a/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
+++ b/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
@@ -4,16 +4,6 @@ import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { usePortalModeClasses } from '../../../../../lib/components/internal/hooks/use-portal-mode-classes';
 import VisualContext from '../../../../../lib/components/internal/components/visual-context';
-import { useVisualRefresh } from '../../../../../lib/components/internal/hooks/use-visual-mode';
-
-jest.mock('../../../../../lib/components/internal/hooks/use-visual-mode', () => {
-  const original = jest.requireActual('../../../../../lib/components/internal/hooks/use-visual-mode');
-  return { ...original, useVisualRefresh: jest.fn() };
-});
-
-afterEach(() => {
-  (useVisualRefresh as jest.Mock).mockReset();
-});
 
 describe('usePortalModeClasses', () => {
   function RenderTest({ refClasses }: { refClasses: string }) {
@@ -53,9 +43,7 @@ describe('usePortalModeClasses', () => {
     // as an integration test.
     window.CSS.supports = jest.fn(() => true);
 
-    (useVisualRefresh as jest.Mock).mockImplementation(() => true);
-
-    render(<RenderTest refClasses="" />);
+    render(<RenderTest refClasses="awsui-visual-refresh" />);
     expect(screen.getByTestId('subject')).toHaveClass('awsui-visual-refresh', { exact: true });
   });
 

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -9,7 +9,7 @@ export function usePortalModeClasses(ref: React.RefObject<HTMLElement>) {
   const colorMode = useCurrentMode(ref);
   const densityMode = useDensityMode(ref);
   const context = useVisualContext(ref);
-  const visualRefresh = useVisualRefresh();
+  const visualRefresh = useVisualRefresh(ref);
   return clsx({
     'awsui-polaris-dark-mode awsui-dark-mode': colorMode === 'dark',
     'awsui-polaris-compact-mode awsui-compact-mode': densityMode === 'compact',

--- a/src/internal/hooks/use-singleton-handler/index.ts
+++ b/src/internal/hooks/use-singleton-handler/index.ts
@@ -5,9 +5,8 @@ import { unstable_batchedUpdates } from 'react-dom';
 
 type ValueCallback<T> = (value: T) => void;
 type CleanupCallback = () => void;
-export type UseSingleton<T> = (listener: ValueCallback<T>) => void;
 
-export function createSingletonHandler<T>(factory: (handler: ValueCallback<T>) => CleanupCallback): UseSingleton<T> {
+export function createSingletonHandler<T>(factory: (handler: ValueCallback<T>) => CleanupCallback) {
   const listeners: Array<ValueCallback<T>> = [];
   const callback: ValueCallback<T> = value => {
     unstable_batchedUpdates(() => {

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
@@ -77,15 +77,32 @@ describe('useCurrentMode', () => {
   });
 });
 
+// most of the functionality is covered by the suite above, which uses the same implementation
+// here we only test the specific stuff
 describe('useVisualRefresh', () => {
-  function App() {
-    const isRefresh = useVisualRefresh();
-    return <div data-testid="current-mode">{isRefresh.toString()}</div>;
+  function RefreshRender() {
+    const ref = useRef(null);
+    const isRefresh = useVisualRefresh(ref);
+    return (
+      <div ref={ref} data-testid="current-mode">
+        {isRefresh.toString()}
+      </div>
+    );
   }
+  test('should detect mode switch both ways', async () => {
+    const { container } = render(<RefreshRender />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    await mutate(() => container.classList.add('awsui-visual-refresh'));
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    await mutate(() => container.classList.remove('awsui-visual-refresh'));
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+  });
 
-  test('should return false when CSS-variables are not supported', () => {
+  test('should return false when CSS-variables are not supported', async () => {
     (window.CSS.supports as jest.Mock).mockReturnValue(false);
-    render(<App />);
+    const { container } = render(<RefreshRender />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    await mutate(() => container.classList.add('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
   });
 });

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useRef } from 'react';
 import { useVisualRefresh } from '../index';
 import { render, screen } from '@testing-library/react';
+import { mutate } from './utils';
 
 jest.mock('../../../environment', () => ({ ALWAYS_VISUAL_REFRESH: true }), { virtual: true });
 
@@ -16,13 +17,28 @@ afterEach(() => {
 });
 
 describe('useVisualRefresh with locked visual refresh mode', () => {
-  function App() {
-    const isRefresh = useVisualRefresh();
-    return <div data-testid="current-mode">{isRefresh.toString()}</div>;
+  function RefreshRender() {
+    const ref = useRef(null);
+    const isRefresh = useVisualRefresh(ref);
+    return (
+      <div ref={ref} data-testid="current-mode">
+        {isRefresh.toString()}
+      </div>
+    );
   }
 
   test('should return true when the environment is locked in visual refresh mode', () => {
-    render(<App />);
+    render(<RefreshRender />);
+
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+  });
+
+  test('cannot not change visual refresh state', async () => {
+    const { container } = render(<RefreshRender />);
+
+    await mutate(() => container.classList.add('awsui-visual-refresh'));
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    await mutate(() => container.classList.remove('awsui-visual-refresh'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
   });
 });

--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -30,22 +30,17 @@ export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
   return value;
 }
 
-// We expect VR is to be set only once and before the application is rendered.
-let visualRefreshState: undefined | boolean = undefined;
-
-export function useVisualRefresh() {
-  if (visualRefreshState === undefined) {
-    const supportsCSSVariables = typeof window !== 'undefined' && window.CSS?.supports?.('color', 'var(--test-var)');
-
-    if (ALWAYS_VISUAL_REFRESH) {
-      visualRefreshState = true;
-    } else if (!supportsCSSVariables) {
-      visualRefreshState = false;
-    } else {
-      visualRefreshState = !!document.querySelector('.awsui-visual-refresh');
+export function useVisualRefresh(elementRef: React.RefObject<HTMLElement>) {
+  const [value, setValue] = useState(Boolean(ALWAYS_VISUAL_REFRESH));
+  useMutationObserver(elementRef, node => {
+    const supportsCSSVariables = window.CSS?.supports?.('color', 'var(--test-var)');
+    if (!supportsCSSVariables || ALWAYS_VISUAL_REFRESH) {
+      return;
     }
-  }
-  return visualRefreshState;
+    const visualRefreshParent = findUpUntil(node, node => node.classList.contains('awsui-visual-refresh'));
+    setValue(!!visualRefreshParent);
+  });
+  return value;
 }
 
 export function useReducedMotion(elementRef: React.RefObject<HTMLElement>) {

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -77,7 +77,7 @@ const InternalLink = React.forwardRef(
     };
 
     const linkRef = useRef<HTMLElement>(null);
-    const isVisualRefresh = useVisualRefresh();
+    const isVisualRefresh = useVisualRefresh(linkRef);
     useForwardFocus(ref, linkRef);
 
     // Visual refresh should only add styles to buttons that don't already have unique styles (e.g. primary/secondary variants)

--- a/src/mixed-line-bar-chart/bar-series.tsx
+++ b/src/mixed-line-bar-chart/bar-series.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { ScaleContinuousNumeric, ScaleTime } from 'd3-scale';
 
@@ -47,7 +47,8 @@ export default function BarSeries<T extends ChartDataTypes>({
   plotSize,
   chartAreaClipPath,
 }: BarSeriesProps<T>) {
-  const isRefresh = useVisualRefresh();
+  const seriesRef = useRef(null);
+  const isRefresh = useVisualRefresh(seriesRef);
 
   const xCoordinates = useMemo(() => {
     if (series.type !== 'bar' || !xScale.isCategorical()) {
@@ -109,6 +110,7 @@ export default function BarSeries<T extends ChartDataTypes>({
         [styles['series--highlighted']]: highlighted,
         [styles['series--dimmed']]: dimmed,
       })}
+      ref={seriesRef}
     >
       {xCoordinates.map(
         ({ x, y, width, height }, i) =>

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -115,7 +115,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
 
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(containerRefObject);
 
   const linesOnly = series.every(({ series }) => series.type === 'line' || series.type === 'threshold');
 

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -46,7 +46,7 @@ export default function InternalModal({
   const refObject = useRef<HTMLDivElement>(null);
   const mergedRef = useMergeRefs(breakpointsRef, refObject, __internalRootRef);
 
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(useRef(modalRoot ?? document.body));
 
   const baseProps = getBaseProps(rest);
 

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -88,7 +88,7 @@ export default <T extends PieChartProps.Datum>({
   const containerRef = useRef<HTMLDivElement>(null);
   const focusedSegmentRef = useRef<SVGGElement>(null);
   const popoverTrackRef = useRef<SVGCircleElement>(null);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(containerRef);
 
   const dimensions = isRefresh ? refreshDimensionsBySize[size] : dimensionsBySize[size];
   const radius = dimensions.outerRadius;
@@ -313,6 +313,7 @@ export default <T extends PieChartProps.Datum>({
               pieData={pieData}
               size={size}
               variant={variant}
+              containerRef={containerRef}
               focusedSegmentRef={focusedSegmentRef}
               popoverTrackRef={popoverTrackRef}
               highlightedSegment={highlightedSegment}

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -15,6 +15,7 @@ interface SegmentsProps<T> {
   highlightedSegment: T | null;
   size: NonNullable<PieChartProps['size']>;
   variant: PieChartProps['variant'];
+  containerRef: React.RefObject<HTMLDivElement>;
   focusedSegmentRef: React.RefObject<SVGGElement>;
   popoverTrackRef: React.RefObject<SVGCircleElement>;
   segmentAriaRoleDescription?: string;
@@ -29,6 +30,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   highlightedSegment,
   size,
   variant,
+  containerRef,
   focusedSegmentRef,
   popoverTrackRef,
   segmentAriaRoleDescription,
@@ -36,7 +38,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   onMouseOver,
   onMouseOut,
 }: SegmentsProps<T>) {
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(containerRef);
 
   const { arcFactory, highlightedArcFactory } = useMemo(() => {
     const dimensions = isRefresh ? refreshDimensionsBySize[size] : dimensionsBySize[size];

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -52,7 +52,7 @@ export default function PopoverContainer({
 
   const [inlineStyle, setInlineStyle] = useState<CSSProperties>(INITIAL_STYLES);
   const [internalPosition, setInternalPosition] = useState<InternalPosition | null>(null);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(ref);
 
   // Store the handler in a ref so that it can still be replaced from outside of the listener closure.
   const positionHandlerRef = useRef<() => void>(() => {});

--- a/src/radio-group/radio-button.tsx
+++ b/src/radio-group/radio-button.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React from 'react';
+import React, { useRef } from 'react';
 import AbstractSwitch from '../internal/components/abstract-switch';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
@@ -26,7 +26,8 @@ export default function RadioButton({
   controlId,
   onChange,
 }: RadioButtonProps) {
-  const isVisualRefresh = useVisualRefresh();
+  const radioRef = useRef(null);
+  const isVisualRefresh = useVisualRefresh(radioRef);
   return (
     <AbstractSwitch
       className={clsx(styles.radio, description && styles['radio--has-description'])}
@@ -47,7 +48,7 @@ export default function RadioButton({
         />
       )}
       styledControl={
-        <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true">
+        <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true" ref={radioRef}>
           <circle
             className={clsx(styles['styled-circle-border'], { [styles['styled-circle-disabled']]: disabled })}
             strokeWidth={isVisualRefresh ? 12 : 8}

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -108,14 +108,15 @@ export function S3Modal({
   const [{ currentView, breadcrumbs, selectedItem }, dispatch] = useReducer(s3BrowseReducer, initialBrowseState);
   const forwardFocusRef = useRef<ForwardFocusRef>(null);
 
-  const isVisualRefresh = useVisualRefresh();
+  const modalWrapperRef = useRef(null);
+  const isVisualRefresh = useVisualRefresh(modalWrapperRef);
 
   useEffectOnUpdate(() => {
     forwardFocusRef.current?.focus();
   }, [breadcrumbs]);
 
   return (
-    <div>
+    <div ref={modalWrapperRef}>
       <InternalModal
         visible={true}
         size="max"

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -119,7 +119,7 @@ const InternalTable = React.forwardRef(
       }
     }
 
-    const isRefresh = useVisualRefresh();
+    const isRefresh = useVisualRefresh(tableRefObject);
     const computedVariant = isRefresh
       ? variant
       : ['embedded', 'full-page'].indexOf(variant) > -1

--- a/src/table/sticky-scrollbar.tsx
+++ b/src/table/sticky-scrollbar.tsx
@@ -19,7 +19,7 @@ export default forwardRef(StickyScrollbar);
 function StickyScrollbar({ wrapperRef, tableRef, onScroll }: StickyScrollbarProps, ref: React.Ref<HTMLDivElement>) {
   const scrollbarRef = React.useRef<HTMLDivElement>(null);
   const scrollbarContentRef = React.useRef<HTMLDivElement>(null);
-  const isRefresh = useVisualRefresh();
+  const isRefresh = useVisualRefresh(scrollbarRef);
   const mergedRef = useMergeRefs(ref, scrollbarRef);
 
   /**

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -43,7 +43,7 @@ export function TabHeaderBar({
   const activeTabHeaderRef = useRef<HTMLAnchorElement>(null);
   const leftOverflowButton = useRef<HTMLElement>(null);
 
-  const isVisualRefresh = useVisualRefresh();
+  const isVisualRefresh = useVisualRefresh(headerBarRef);
 
   const [widthChange, containerRef] = useContainerQuery<number>(rect => rect.width);
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map());

--- a/src/tutorial-panel/components/tutorial-detail-view/index.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { TutorialPanelProps } from '../../interfaces';
 import InternalBox from '../../../box/internal';
 import { InternalButton } from '../../../button/internal';
@@ -25,7 +25,8 @@ export default function TutorialDetailView({
   onFeedbackClick: TutorialPanelProps['onFeedbackClick'];
   i18nStrings: TutorialPanelProps['i18nStrings'];
 }) {
-  const isRefresh = useVisualRefresh();
+  const refreshRef = useRef(null);
+  const isRefresh = useVisualRefresh(refreshRef);
 
   const onExitTutorial = useCallback(() => {
     fireNonCancelableEvent(onExitTutorialHandler, { tutorial });
@@ -38,7 +39,7 @@ export default function TutorialDetailView({
   return (
     <>
       <InternalSpaceBetween size="xl">
-        <div className={styles['tutorial-title']}>
+        <div className={styles['tutorial-title']} ref={refreshRef}>
           <InternalButton
             variant="icon"
             onClick={onExitTutorial}

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useRef } from 'react';
 import styles from './styles.css.js';
 import { TutorialPanelProps } from '../../interfaces';
 import InternalBox from '../../../box/internal';
@@ -50,7 +50,8 @@ export default function TutorialList({
   */
 
   const focusVisible = useFocusVisible();
-  const isRefresh = useVisualRefresh();
+  const tutorialListRef = useRef(null);
+  const isRefresh = useVisualRefresh(tutorialListRef);
 
   return (
     <>
@@ -86,7 +87,7 @@ export default function TutorialList({
             <InternalStatusIndicator type="loading">{i18nStrings.loadingText}</InternalStatusIndicator>
           ) : (
             <>
-              <ul className={styles['tutorial-list']} role="list">
+              <ul className={styles['tutorial-list']} role="list" ref={tutorialListRef}>
                 {tutorials.map((tutorial, index) => (
                   <Tutorial
                     tutorial={tutorial}
@@ -119,7 +120,8 @@ function Tutorial({
   const triggerControldId = useUniqueId();
   const headerId = useUniqueId();
 
-  const isRefresh = useVisualRefresh();
+  const tutorialRef = useRef(null);
+  const isRefresh = useVisualRefresh(tutorialRef);
 
   const onStartTutorial = useCallback(() => {
     fireNonCancelableEvent(onStartTutorialEventHandler, { tutorial });
@@ -132,7 +134,7 @@ function Tutorial({
   }, []);
 
   return (
-    <li className={styles['tutorial-box']} role="listitem">
+    <li className={styles['tutorial-box']} role="listitem" ref={tutorialRef}>
       <InternalSpaceBetween size="xs">
         <div className={styles['tutorial-box-title']}>
           <InternalBox

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -47,7 +47,8 @@ export default function Wizard({
   const baseProps = getBaseProps(rest);
 
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
-  const ref = useMergeRefs(breakpointsRef, __internalRootRef);
+  const refObject = useRef(null);
+  const ref = useMergeRefs(breakpointsRef, refObject, __internalRootRef);
 
   const smallContainer = breakpoint === 'default';
 
@@ -66,7 +67,7 @@ export default function Wizard({
     scrollToTop(internalRef);
   }, [actualActiveStepIndex]);
 
-  const isVisualRefresh = useVisualRefresh();
+  const isVisualRefresh = useVisualRefresh(refObject);
   const isLastStep = actualActiveStepIndex >= steps.length - 1;
 
   const navigationEvent = (requestedStepIndex: number, reason: WizardProps.NavigationReason) => {


### PR DESCRIPTION
This reverts commit f1a19d10ff6112b0293a541c5131f8d0c9f9f093.

The [original PR](https://github.com/cloudscape-design/components/pull/31) was merged by accident. Can't merge before notifying the customers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
