### PR TITLE
Move focusedDate state inside date picker calendar

### DIFF
--- a/pages/calendar/simple.page.tsx
+++ b/pages/calendar/simple.page.tsx
@@ -18,7 +18,6 @@ export default function CalendarPage() {
       >
         <Calendar
           selectedDate={new Date('2021-8-20')}
-          focusedDate={null}
           displayedDate={new Date('2021-8-13')}
           locale="en-EN"
           startOfWeek={1}
@@ -29,11 +28,9 @@ export default function CalendarPage() {
           todayAriaLabel="Today"
           onChangeMonth={() => {}}
           onSelectDate={() => {}}
-          onFocusDate={() => {}}
         />
         <Calendar
           selectedDate={null}
-          focusedDate={null}
           displayedDate={new Date()}
           locale="en-EN"
           startOfWeek={1}
@@ -44,7 +41,6 @@ export default function CalendarPage() {
           todayAriaLabel="Today"
           onChangeMonth={() => {}}
           onSelectDate={() => {}}
-          onFocusDate={() => {}}
         />
       </Dropdown>
     </article>

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -75,7 +75,6 @@ const DatePicker = React.forwardRef(
 
     const defaultDisplayedDate = value.length >= 10 ? value : formatDate(new Date());
     const [displayedDate, setDisplayedDate] = useState<string>(defaultDisplayedDate);
-    const [focusedDate, setFocusedDate] = useState<string | null>(null);
 
     const internalInputRef = useRef<HTMLInputElement>(null);
     const buttonRef = useRef<ButtonProps.Ref>(null);
@@ -90,7 +89,6 @@ const DatePicker = React.forwardRef(
 
     const onChangeMonthHandler = (newMonth: Date) => {
       setDisplayedDate(formatDate(newMonth));
-      setFocusedDate(null);
     };
 
     const onSelectDateHandler = ({ date }: CalendarTypes.DateDetail) => {
@@ -100,15 +98,7 @@ const DatePicker = React.forwardRef(
       setSelectedDate(formattedDate);
       setDisplayedDate(formattedDate);
       setCalendarHasFocus(false);
-      setFocusedDate(null);
       fireNonCancelableEvent(onChange, { value: formattedDate });
-    };
-
-    const onDateFocusHandler = ({ date }: CalendarTypes.DateDetailNullable) => {
-      if (date) {
-        const value = formatDate(date);
-        setFocusedDate(value);
-      }
     };
 
     const onDropdownCloseHandler = useCallback(() => {
@@ -237,7 +227,6 @@ const DatePicker = React.forwardRef(
               <Calendar
                 ref={calendarRef}
                 selectedDate={memoizedDate('value', selectedDate)}
-                focusedDate={memoizedDate('focused', focusedDate)}
                 displayedDate={memoizedDate('displayed', displayedDate)}
                 locale={normalizedLocale}
                 startOfWeek={normalizedStartOfWeek}
@@ -248,7 +237,6 @@ const DatePicker = React.forwardRef(
                 todayAriaLabel={todayAriaLabel}
                 onChangeMonth={onChangeMonthHandler}
                 onSelectDate={onSelectDateHandler}
-                onFocusDate={onDateFocusHandler}
               />
               {calendarHasFocus && <TabTrap focusNextCallback={() => calendarRef.current?.focus()} />}
             </>


### PR DESCRIPTION
### Description

Move focusedDate state inside date picker calendar to separate the concerns better.

### How has this been tested?

Existing tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
