### PR TITLE
fix(dynamic-overlap) No set on disabled

### DIFF
--- a/src/app-layout/visual-refresh/hooks/use-dynamic-overlap.ts
+++ b/src/app-layout/visual-refresh/hooks/use-dynamic-overlap.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 import { useContext, useLayoutEffect } from 'react';
 
 import { AppLayoutContext } from '../context';
@@ -24,16 +23,19 @@ export function useDynamicOverlap(props?: UseDynamicOverlapProps) {
   const { setDynamicOverlapHeight } = useContext(AppLayoutContext);
   const [overlapContainerQuery, overlapElementRef] = useContainerQuery(rect => rect.height);
 
-  const hasOverlap = !disabled && overlapContainerQuery !== null;
   useLayoutEffect(
     function handleDynamicOverlapHeight() {
-      setDynamicOverlapHeight(hasOverlap ? overlapContainerQuery : 0);
+      if (!disabled) {
+        setDynamicOverlapHeight(overlapContainerQuery ?? 0);
+      }
 
       return () => {
-        setDynamicOverlapHeight(0);
+        if (!disabled) {
+          setDynamicOverlapHeight(0);
+        }
       };
     },
-    [hasOverlap, overlapContainerQuery, setDynamicOverlapHeight]
+    [disabled, overlapContainerQuery, setDynamicOverlapHeight]
   );
 
   return overlapElementRef;


### PR DESCRIPTION
### Description

In this n-to-1 mapping between context and utility hook, `disabled` means **no effect at all**. Otherwise, the last call takes precedence leading to unexpected behavior. 

### How has this been tested?

Screenshot testing.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
