### PR TITLE
Refactor focus handling in the date-picker calendar

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -214,7 +214,7 @@ const DatePicker = React.forwardRef(
           dropdownId={dropdownId}
         >
           {isDropDownOpen && (
-            <FocusLock>
+            <FocusLock autoFocus={true}>
               <Calendar
                 selectedDate={memoizedDate('value', selectedDate)}
                 displayedDate={memoizedDate('displayed', displayedDate)}

--- a/src/internal/components/focus-lock/index.tsx
+++ b/src/internal/components/focus-lock/index.tsx
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import TabTrap from '../tab-trap/index';
 import { getFirstFocusable, getLastFocusable } from './utils';
 
 export interface FocusLockProps {
   disabled?: boolean;
+  autoFocus?: boolean;
   children: React.ReactNode;
 }
 
-export default function FocusLock({ disabled, children }: FocusLockProps) {
+export default function FocusLock({ disabled, autoFocus, children }: FocusLockProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const focusFirst = () => {
@@ -23,6 +24,12 @@ export default function FocusLock({ disabled, children }: FocusLockProps) {
       getLastFocusable(containerRef.current)?.focus();
     }
   };
+
+  useEffect(() => {
+    if (autoFocus) {
+      focusFirst();
+    }
+  }, [autoFocus]);
 
   return (
     <>

--- a/src/internal/components/focus-lock/utils.ts
+++ b/src/internal/components/focus-lock/utils.ts
@@ -25,8 +25,10 @@ const tabbables = [
   '[autofocus]',
 ].join(',');
 
-export function getFocusables(container: HTMLElement) {
-  return Array.prototype.slice.call(container.querySelectorAll(tabbables));
+export function getFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.prototype.slice
+    .call(container.querySelectorAll(tabbables))
+    .filter((element: HTMLElement) => element.tabIndex !== -1);
 }
 
 export function getFirstFocusable(container: HTMLElement) {


### PR DESCRIPTION
### Description

The date picker calendar has a tricky focusing logic as it requires to focus on the date buttons every time when a keyboard selection is made. Also, the calendar is automatically focused when rendered. That is not suitable if the calendar needs to be rendered as standalone.

### How has this been tested?

Existing tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
