### PR TITLE
remove aria-valuemax from progress bar

### DIFF
--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -36,7 +36,6 @@ export const Progress = ({ value, isInFlash, labelId }: ProgressProps) => {
         )}
         aria-valuenow={progressValue}
         aria-valuemin={0}
-        aria-valuemax={MAX_VALUE}
         max={MAX_VALUE}
         value={progressValue}
         aria-labelledby={labelId}


### PR DESCRIPTION
### Description

Removes redundant `aria-valuemax` in favor of using just the `max` attribute

### How has this been tested?

Built locally and reviewed rendered HTML to confirm that` aria-valuemax `has been removed 


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ X] _No._

### Related Links

See AWSUI-18906﻿


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
