### PR TITLE
Ensure last breadcrumb doesn't have an href so that it can have aria-disabled="true"

### DIFF
--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -58,7 +58,12 @@ describe('BreadcrumbGroup Component', () => {
 
       links.forEach((link, i) => {
         expect(link.getElement()).toHaveTextContent(items[i].text);
-        expect(link.getElement()).toHaveAttribute('href', items[i].href);
+        if (i === links.length - 1) {
+          // last item should not have an href
+          expect(link.getElement()).not.toHaveAttribute('href', items[i].href);
+        } else {
+          expect(link.getElement()).toHaveAttribute('href', items[i].href);
+        }
       });
     });
 
@@ -136,7 +141,12 @@ describe('BreadcrumbGroup Component', () => {
     });
 
     test('does not throw an error when a safe javascript: URL is passed', () => {
-      const element = renderBreadcrumbGroup({ items: [{ text: '', href: 'javascript:void(0)' }] });
+      const element = renderBreadcrumbGroup({
+        items: [
+          { text: '1', href: 'javascript:void(0)' },
+          { text: '2', href: 'javascript:void(0)' },
+        ],
+      });
       expect((element.findBreadcrumbLink(1)!.getElement() as HTMLAnchorElement).href).toBe('javascript:void(0)');
       expect(console.warn).toHaveBeenCalledTimes(0);
     });

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -105,8 +105,8 @@ describe('BreadcrumbGroup Item', () => {
       lastLink = links[links.length - 1];
     });
 
-    test('has a link', () => {
-      expect(lastLink.getElement()).toHaveAttribute('href', '#');
+    test('does not have an href', () => {
+      expect(lastLink.getElement()).not.toHaveAttribute('href', '#');
     });
 
     test('has correct aria attributes', () => {

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -28,11 +28,12 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
     <div className={clsx(styles.breadcrumb, isLast && styles.last)}>
       <a
         {...focusVisible}
-        href={item.href || '#'}
+        href={isLast ? undefined : item.href || '#'}
         className={clsx(styles.anchor, { [styles.compressed]: isCompressed })}
         aria-current={isLast ? 'page' : undefined} // Active breadcrumb item is implemented according to WAI-ARIA 1.1
         aria-disabled={isLast && 'true'}
         onClick={isLast ? preventDefault : onClickHandler}
+        tabIndex={isLast ? 0 : undefined} // tabIndex is added to the last crumb to keep it in the index without an href
       >
         <span className={styles.text}>{item.text}</span>
       </a>


### PR DESCRIPTION
### Description

Removed href on last breadcrump in a group so that we can use aria-disabled on it while retaining validity of the HTML. 

### How has this been tested?

* Ran axe-core against build
* Validated rendered HTML in W3C Nu Validator
* Inspected rendered DOM

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

AWSUI-18939

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X]  _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X]  _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
