### PR TITLE
convert select option item divs into spans to preserve HTML validity

### DIFF
--- a/src/internal/components/option/index.tsx
+++ b/src/internal/components/option/index.tsx
@@ -58,7 +58,7 @@ const Option = ({
   );
 
   return (
-    <div
+    <span
       title={option.label || option.value}
       data-value={option.value}
       className={className}
@@ -66,8 +66,8 @@ const Option = ({
       {...baseProps}
     >
       {icon}
-      <div className={clsx(styles.content)}>
-        <div className={clsx(styles['label-content'])}>
+      <span className={clsx(styles.content)}>
+        <span className={clsx(styles['label-content'])}>
           <Label
             label={option.label || option.value}
             prefix={option.__labelPrefix}
@@ -75,7 +75,7 @@ const Option = ({
             triggerVariant={triggerVariant}
           />
           <LabelTag labelTag={option.labelTag} highlightText={highlightText} triggerVariant={triggerVariant} />
-        </div>
+        </span>
         <Description description={option.description} highlightText={highlightText} triggerVariant={triggerVariant} />
         <Tags tags={option.tags} highlightText={highlightText} triggerVariant={triggerVariant} />
         <FilteringTags
@@ -83,8 +83,8 @@ const Option = ({
           highlightText={highlightText}
           triggerVariant={triggerVariant}
         />
-      </div>
-    </div>
+      </span>
+    </span>
   );
 };
 

--- a/src/internal/components/option/option-parts.tsx
+++ b/src/internal/components/option/option-parts.tsx
@@ -43,9 +43,9 @@ export const Description = ({ description, highlightText, triggerVariant }: Desc
   description ? (
     // We do not reach AA compliance in Dark mode for highlighted state
     // TODO: Remove aria-disabled={true} when we fix AWSUI-10333
-    <div className={clsx(styles.description, triggerVariant && styles['trigger-variant'])} aria-disabled={true}>
+    <span className={clsx(styles.description, triggerVariant && styles['trigger-variant'])} aria-disabled={true}>
       <HighlightMatch str={description} highlightText={highlightText} />
-    </div>
+    </span>
   ) : null;
 
 interface TagsProps {
@@ -55,7 +55,7 @@ interface TagsProps {
 }
 export const Tags = ({ tags, highlightText, triggerVariant }: TagsProps) =>
   tags ? (
-    <div className={clsx(styles.tags)}>
+    <span className={clsx(styles.tags)}>
       {tags.map((tag, idx) => (
         // We do not reach AA compliance in Dark mode for highlighted state
         // TODO: Remove aria-disabled={true} when we fix AWSUI-10333
@@ -63,7 +63,7 @@ export const Tags = ({ tags, highlightText, triggerVariant }: TagsProps) =>
           <HighlightMatch str={tag} highlightText={highlightText} />
         </span>
       ))}
-    </div>
+    </span>
   ) : null;
 
 interface FilteringTagProps {
@@ -79,7 +79,7 @@ export const FilteringTags = ({ filteringTags, highlightText, triggerVariant }: 
   const searchElement = highlightText.toLowerCase();
 
   return (
-    <div className={clsx(styles.tags)}>
+    <span className={clsx(styles.tags)}>
       {filteringTags.map((filteringTag, key) => {
         const match = filteringTag.toLowerCase().indexOf(searchElement) !== -1;
         if (match) {
@@ -97,7 +97,7 @@ export const FilteringTags = ({ filteringTags, highlightText, triggerVariant }: 
         }
         return null;
       })}
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
### Description

Converts divs that are parts of an option item into spans because they are sometimes the child of a button tag and buttons cannot have div children


### How has this been tested?

* Visual Diff
* Inspected rendered DOM
* Validated with W3C Nu Validator

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

AWSUI-18930


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X]_Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
