### PR TITLE
docs(property-filter): Improve documentation of `defaultOperator`

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -8279,7 +8279,7 @@ in a slight, visible lag when scrolling complex pages.",
 * groupValuesLabel [string]: Localized string to display for the 'Values' group label for a specific property.
 * key [string]: The identifier of this property.
 * propertyLabel [string]: A human-readable string for the property.
-* operators [Array]: A list of all operators supported by this property. Equals operator should always be supported, even if you omit it in the list.
+* operators [Array]: A list of all operators supported by this property. If you omit the equals operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
 * group [string]: Optional identifier of a custom group that this filtering option is assigned to. Use to create additional groups below the default one. Make sure to also define labels for the group in the customGroupsText property. Notice that only one level of options nesting is supported.
 * defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support \\"equals\\" filtering terms with this property.
 ",

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -54,7 +54,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * * groupValuesLabel [string]: Localized string to display for the 'Values' group label for a specific property.
    * * key [string]: The identifier of this property.
    * * propertyLabel [string]: A human-readable string for the property.
-   * * operators [Array]: A list of all operators supported by this property. Equals operator should always be supported, even if you omit it in the list.
+   * * operators [Array]: A list of all operators supported by this property. If you omit the equals operator because your API does not support it, make sure to set `defaultOperator` to a supported operator from this list.
    * * group [string]: Optional identifier of a custom group that this filtering option is assigned to. Use to create additional groups below the default one. Make sure to also define labels for the group in the customGroupsText property. Notice that only one level of options nesting is supported.
    * * defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.
    */


### PR DESCRIPTION
### Description

Improving some of the documentation of [Property filter](https://cloudscape.design/components/property-filter/). When the default Equals operator ("=") is excluded from the list of `operators`, customers need to also specify a new `defaultOperator`. The motivation with this change is to make that dependency more clear.

Before (see https://cloudscape.design/components/property-filter/?tabId=api):

> * operators [Array]: A list of all operators supported by this property. **Equals operator should always be supported, even if you omit it in the list.**
> * defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.

After:
> * operators [Array]: A list of all operators supported by this property. **If you omit the equals operator because your API does not support it, make sure to set `defaultOperator` to a supported operator from this list.**
> * defaultOperator [ComparisonOperator]: Optional parameter that changes the default operator used with this filtering property. Use it only if your API does not support "equals" filtering terms with this property.

Changes in bold. This replaces the old sentence which was slightly misleading.

### How has this been tested?

It's just a documentation change.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
