### PR TITLE
Remove calendarHasFocus from date-range-picker/calendar as unneeded

### DIFF
--- a/src/date-range-picker/calendar/header/button/index.tsx
+++ b/src/date-range-picker/calendar/header/button/index.tsx
@@ -7,15 +7,13 @@ import styles from '../../../styles.css.js';
 interface HeaderButtonProps {
   ariaLabel: string;
   isPrevious: boolean;
-  focusable: boolean;
   onChangeMonth: (isPrevious: boolean) => void;
 }
 
-const HeaderButton = ({ ariaLabel, isPrevious, onChangeMonth, focusable }: HeaderButtonProps) => {
+const HeaderButton = ({ ariaLabel, isPrevious, onChangeMonth }: HeaderButtonProps) => {
   const iconName = isPrevious ? 'angle-left' : 'angle-right';
   const additionalAttributes: React.HTMLAttributes<HTMLButtonElement> = {
     className: isPrevious ? styles['calendar-prev-month-btn'] : styles['calendar-next-month-btn'],
-    tabIndex: focusable ? 0 : -1,
   };
 
   const onClick = () => onChangeMonth(isPrevious);

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -12,7 +12,6 @@ interface CalendarHeaderProps {
   onChangeMonth: (prev?: boolean) => void;
   previousMonthLabel: string;
   nextMonthLabel: string;
-  calendarHasFocus: boolean;
   isSingleGrid: boolean;
 }
 
@@ -22,17 +21,11 @@ const CalendarHeader = ({
   onChangeMonth,
   previousMonthLabel,
   nextMonthLabel,
-  calendarHasFocus,
   isSingleGrid,
 }: CalendarHeaderProps) => {
   return (
     <div className={styles['calendar-header']}>
-      <HeaderButton
-        ariaLabel={previousMonthLabel}
-        isPrevious={true}
-        onChangeMonth={onChangeMonth}
-        focusable={calendarHasFocus}
-      />
+      <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
       <div aria-live="polite" className={styles['calendar-header-months-wrapper']}>
         {!isSingleGrid && (
           <div className={styles['calendar-header-month']}>
@@ -41,12 +34,7 @@ const CalendarHeader = ({
         )}
         <div className={styles['calendar-header-month']}>{renderMonthAndYear(locale, baseDate)}</div>
       </div>
-      <HeaderButton
-        ariaLabel={nextMonthLabel}
-        isPrevious={false}
-        onChangeMonth={onChangeMonth}
-        focusable={calendarHasFocus}
-      />
+      <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
     </div>
   );
 };

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -301,7 +301,6 @@ function Calendar(
             onChangeMonth={onHeaderChangeMonthHandler}
             previousMonthLabel={i18nStrings.previousMonthAriaLabel}
             nextMonthLabel={i18nStrings.nextMonthAriaLabel}
-            calendarHasFocus={true}
             isSingleGrid={isSingleGrid}
           />
 


### PR DESCRIPTION
### Description

Refactor date picker calendar by removing unneeded variable.

### How has this been tested?

Existing tests -- no behaviour changes expected

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
