### PR TITLE
Refactor property-filter operator parsing to support wider range of operators

### DIFF
--- a/src/property-filter/__tests__/utils.test.ts
+++ b/src/property-filter/__tests__/utils.test.ts
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PropertyFilterProps } from '../interfaces';
+import { matchFilteringProperty, matchOperator, matchOperatorPrefix } from '../utils';
+
+const filteringProperties: PropertyFilterProps.FilteringProperty[] = [
+  {
+    key: 'instanceId',
+    propertyLabel: 'Instance ID',
+    operators: ['!:', ':'],
+    groupValuesLabel: '',
+  },
+  {
+    key: 'averageLatency',
+    propertyLabel: 'Averange latency',
+    operators: ['=', '!=', '<', '<=', '>', '>='],
+    groupValuesLabel: '',
+  },
+];
+
+const operators: PropertyFilterProps.ComparisonOperator[] = ['!:', ':', 'contains', 'does not contain'] as any;
+
+describe('matchFilteringProperty', () => {
+  test('should match property by label when filtering text equals to it', () => {
+    const property = matchFilteringProperty(filteringProperties, 'Averange latency');
+    expect(property).toBe(filteringProperties[1]);
+  });
+  test('should match property by label ignoring case', () => {
+    const property = matchFilteringProperty(filteringProperties, 'averange Latency');
+    expect(property).toBe(filteringProperties[1]);
+  });
+  test('should match property by label when filtering text has trailing space', () => {
+    const property = matchFilteringProperty(filteringProperties, 'Averange latency ');
+    expect(property).toBe(filteringProperties[1]);
+  });
+  test('should match property by label when filtering text has trailing symbol', () => {
+    const property = matchFilteringProperty(filteringProperties, 'Averange latencyX');
+    expect(property).toBe(filteringProperties[1]);
+  });
+  test('should not match property by label when filtering text has leading space', () => {
+    const property = matchFilteringProperty(filteringProperties, ' Averange latency');
+    expect(property).toBe(null);
+  });
+});
+
+describe('matchOperator', () => {
+  test('should match operator when filtering text equals to it', () => {
+    const operator = matchOperator(operators, 'does not contain');
+    expect(operator).toBe(operators[3]);
+  });
+  test('should match operator ignoring case', () => {
+    const operator = matchOperator(operators, 'does NOT contain');
+    expect(operator).toBe(operators[3]);
+  });
+  test('should match operator when filtering text has trailing space', () => {
+    const operator = matchOperator(operators, '!: ');
+    expect(operator).toBe(operators[0]);
+  });
+  test('should match operator when filtering text has trailing symbol', () => {
+    const operator = matchOperator(operators, ':!');
+    expect(operator).toBe(operators[1]);
+  });
+  test('should not match operator when filtering text has leading space', () => {
+    const operator = matchOperator(operators, ' :');
+    expect(operator).toBe(null);
+  });
+});
+
+describe('matchOperatorPrefix', () => {
+  test('should return empty string if filtering text is empty', () => {
+    const operatorPrefix = matchOperatorPrefix(operators, '');
+    expect(operatorPrefix).toBe('');
+  });
+  test('should return empty string if filtering text only has spaces', () => {
+    const operatorPrefix = matchOperatorPrefix(operators, '   ');
+    expect(operatorPrefix).toBe('');
+  });
+  test('should return filtering text if it matches some operator prefix', () => {
+    const operatorPrefix = matchOperatorPrefix(operators, '!');
+    expect(operatorPrefix).toBe('!');
+  });
+  test('should return filtering text if it matches some operator prefix ignoring case', () => {
+    const operatorPrefix = matchOperatorPrefix(operators, 'DOES');
+    expect(operatorPrefix).toBe('DOES');
+  });
+  test('should return null if filtering text has leading space', () => {
+    const operatorPrefix = matchOperatorPrefix(operators, ' !');
+    expect(operatorPrefix).toBe(null);
+  });
+});

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PropertyFilterProps } from './interfaces';
+
+// Finds the longest property the filtering text starts from.
+export function matchFilteringProperty(
+  filteringProperties: readonly PropertyFilterProps.FilteringProperty[],
+  filteringText: string
+): null | PropertyFilterProps.FilteringProperty {
+  filteringText = filteringText.toLowerCase();
+
+  let maxLength = 0;
+  let matchedProperty: null | PropertyFilterProps.FilteringProperty = null;
+
+  for (const property of filteringProperties) {
+    if (property.propertyLabel.length > maxLength && startsWith(filteringText, property.propertyLabel.toLowerCase())) {
+      maxLength = property.propertyLabel.length;
+      matchedProperty = property;
+    }
+  }
+
+  return matchedProperty;
+}
+
+// Finds the longest operator the filtering text starts from.
+export function matchOperator(
+  allowedOperators: readonly PropertyFilterProps.ComparisonOperator[],
+  filteringText: string
+): null | PropertyFilterProps.ComparisonOperator {
+  filteringText = filteringText.toLowerCase();
+
+  let maxLength = 0;
+  let matchedOperator: null | PropertyFilterProps.ComparisonOperator = null;
+
+  for (const operator of allowedOperators) {
+    if (operator.length > maxLength && startsWith(filteringText, operator.toLowerCase())) {
+      maxLength = operator.length;
+      matchedOperator = operator;
+    }
+  }
+
+  return matchedOperator;
+}
+
+// Finds if the filtering text matches any operator prefix.
+export function matchOperatorPrefix(
+  allowedOperators: readonly PropertyFilterProps.ComparisonOperator[],
+  filteringText: string
+): null | string {
+  if (filteringText.trim().length === 0) {
+    return '';
+  }
+  for (const operator of allowedOperators) {
+    if (startsWith(operator.toLowerCase(), filteringText.toLowerCase())) {
+      return filteringText;
+    }
+  }
+  return null;
+}
+
+export function trimStart(source: string): string {
+  let spacesLength = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === ' ') {
+      spacesLength++;
+    } else {
+      break;
+    }
+  }
+  return source.slice(spacesLength);
+}
+
+export function trimFirstSpace(source: string): string {
+  return source[0] === ' ' ? source.slice(1) : source;
+}
+
+function startsWith(source: string, target: string): boolean {
+  return source.indexOf(target) === 0;
+}


### PR DESCRIPTION
### Description

Parse property filter operators in about the same way as property names to support wider range of operators anticipating new non-symbolic operators.

### How has this been tested?

Existing unit- and integration tests, manual testing.

New unit tests were added to cover the new utils.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
