### PR TITLE
Add dropdown focus trap

### DIFF
--- a/pages/dropdown/focus-trap.page.tsx
+++ b/pages/dropdown/focus-trap.page.tsx
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+import Dropdown from '~components/internal/components/dropdown';
+import { useState } from 'react';
+import AppContext, { AppContextType } from '../app/app-context';
+import { Box, SpaceBetween, Button } from '~components';
+
+type PageContext = React.Context<
+  AppContextType<{
+    expandToViewport: boolean;
+    trapFocus: boolean;
+    disableHeader: boolean;
+    disableContent: boolean;
+    disableFooter: boolean;
+  }>
+>;
+
+export default function DropdownScenario() {
+  const {
+    urlParams: {
+      expandToViewport = true,
+      trapFocus = true,
+      disableHeader = false,
+      disableContent = false,
+      disableFooter = false,
+    },
+    setUrlParams,
+  } = useContext(AppContext as PageContext);
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <article>
+      <h1>Dropdown focus-trap tests</h1>
+
+      <Box margin="m">
+        <SpaceBetween direction="vertical" size="m">
+          <label>
+            <input
+              type="checkbox"
+              checked={expandToViewport}
+              onChange={event => setUrlParams({ expandToViewport: event.target.checked })}
+            />
+            expandToViewport
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={trapFocus}
+              onChange={event => setUrlParams({ trapFocus: event.target.checked })}
+            />
+            trapFocus
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={disableHeader}
+              onChange={event => setUrlParams({ disableHeader: event.target.checked })}
+            />
+            disableHeader
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={disableFooter}
+              onChange={event => setUrlParams({ disableFooter: event.target.checked })}
+            />
+            disableFooter
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={disableContent}
+              onChange={event => setUrlParams({ disableContent: event.target.checked })}
+            />
+            disableContent
+          </label>
+
+          <div id="test-target">
+            <Dropdown
+              trigger={
+                <Button className="trigger" onClick={() => setIsOpen(!isOpen)}>
+                  Trigger
+                </Button>
+              }
+              open={isOpen}
+              onDropdownClose={() => setIsOpen(false)}
+              header={
+                <div style={{ padding: 8 }}>
+                  <Button disabled={disableHeader}>header-1</Button>
+                  <Button disabled={disableHeader}>header-2</Button>
+                </div>
+              }
+              footer={
+                <div style={{ padding: 8 }}>
+                  <Button disabled={disableFooter}>footer-1</Button>
+                  <Button disabled={disableFooter}>footer-2</Button>
+                </div>
+              }
+              expandToViewport={expandToViewport}
+              trapFocus={trapFocus}
+            >
+              <div style={{ padding: 8 }}>
+                <Button disabled={disableContent}>content-1</Button>
+                <Button disabled={disableContent}>content-2</Button>
+              </div>
+            </Dropdown>
+          </div>
+        </SpaceBetween>
+      </Box>
+    </article>
+  );
+}

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -23,7 +23,6 @@ import { checkOptionValueField } from '../select/utils/check-option-value-field'
 import checkControlled from '../internal/hooks/check-controlled';
 import { fireCancelableEvent } from '../internal/events/index';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import TabTrap from '../internal/components/tab-trap';
 import AutosuggestOptionsList from './options-list';
 
 export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {
@@ -226,30 +225,24 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
         minWidth={__dropdownWidth}
         stretchWidth={!__dropdownWidth}
         trigger={
-          <>
-            <InternalInput
-              type="search"
-              value={value}
-              onChange={handleInputChange}
-              __onDelayedInput={event => fireLoadMore(true, false, event.detail.value)}
-              onFocus={handleInputFocus}
-              onKeyDown={handleKeyDown}
-              onKeyUp={onKeyUp}
-              disabled={disabled}
-              disableBrowserAutocorrect={disableBrowserAutocorrect}
-              readOnly={readOnly}
-              ariaRequired={ariaRequired}
-              ref={inputRef}
-              autoComplete={false}
-              __nativeAttributes={nativeAttributes}
-              {...formFieldContext}
-              controlId={controlId}
-            />
-            <TabTrap
-              focusNextCallback={() => dropdownStatus.focusRecoveryLink()}
-              disabled={!open || !showRecoveryLink}
-            />
-          </>
+          <InternalInput
+            type="search"
+            value={value}
+            onChange={handleInputChange}
+            __onDelayedInput={event => fireLoadMore(true, false, event.detail.value)}
+            onFocus={handleInputFocus}
+            onKeyDown={handleKeyDown}
+            onKeyUp={onKeyUp}
+            disabled={disabled}
+            disableBrowserAutocorrect={disableBrowserAutocorrect}
+            readOnly={readOnly}
+            ariaRequired={ariaRequired}
+            ref={inputRef}
+            autoComplete={false}
+            __nativeAttributes={nativeAttributes}
+            {...formFieldContext}
+            controlId={controlId}
+          />
         }
         onMouseDown={handleMouseDown}
         open={open}
@@ -257,14 +250,13 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
         footer={
           dropdownStatus.isSticky ? (
             <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>
-              <TabTrap focusNextCallback={() => inputRef.current?.focus()} disabled={!showRecoveryLink} />
               <DropdownFooter content={dropdownStatus.content} hasItems={filteredItems.length >= 1} />
-              <TabTrap focusNextCallback={() => inputRef.current?.focus()} disabled={!showRecoveryLink} />
             </div>
           ) : null
         }
         expandToViewport={expandToViewport}
         hasContent={filteredItems.length >= 1 || dropdownStatus.content !== null}
+        trapFocus={!!showRecoveryLink}
       >
         {open && (
           <AutosuggestOptionsList

--- a/src/internal/components/dropdown/__integ__/dropdown-focus-trap.test.ts
+++ b/src/internal/components/dropdown/__integ__/dropdown-focus-trap.test.ts
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { DropdownPageObject } from './dropdown-page-object';
+import qs from 'qs';
+
+interface PageSettings {
+  expandToViewport: boolean;
+  disableHeader?: boolean;
+  disableContent?: boolean;
+  disableFooter?: boolean;
+}
+
+function setupTest(settings: PageSettings, testFn: (page: DropdownPageObject) => Promise<void>) {
+  return useBrowser(async browser => {
+    await browser.url(`#/light/dropdown/focus-trap?${qs.stringify(settings)}`);
+    const page = new DropdownPageObject('test-target', browser);
+    await page.waitForVisible(page.getDropdown());
+    await page.click(page.getTrigger());
+    await testFn(page);
+  });
+}
+
+describe.each([false, true])('Dropdown focus trap', expandToViewport => {
+  test(
+    'focus is forward-circled between trigger, header, content and footer',
+    setupTest({ expandToViewport }, async page => {
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+      await page.keys(['Tab', 'Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('header-2');
+      await page.keys(['Tab', 'Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('content-2');
+      await page.keys(['Tab', 'Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-2');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+    })
+  );
+
+  test(
+    'focus is forward-circled between trigger and footer',
+    setupTest({ expandToViewport, disableHeader: true, disableContent: true }, async page => {
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-1');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-2');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+    })
+  );
+
+  test(
+    'focus is not backward-circled',
+    setupTest({ expandToViewport, disableHeader: true, disableContent: true }, async page => {
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-1');
+      await page.keys(['Tab']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-2');
+      await page.keys(['Shift', 'Tab', 'Null']);
+      await expect(page.getFocusedElementText()).resolves.toBe('footer-1');
+      await page.keys(['Shift', 'Tab', 'Null']);
+      await expect(page.getFocusedElementText()).resolves.toBe('Trigger');
+      await page.keys(['Shift', 'Tab', 'Null']);
+      await expect(page.getFocusedElementText()).resolves.not.toBe('Trigger');
+      await expect(page.getFocusedElementText()).resolves.not.toBe('footer-1');
+      await expect(page.getFocusedElementText()).resolves.not.toBe('footer-2');
+    })
+  );
+});

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -117,6 +117,10 @@ export interface DropdownProps extends ExpandToViewport {
    * Whether the dropdown will have a scrollbar or not
    */
   scrollable?: boolean;
+  /**
+   * Whether the dropdown will have a focus trap including trigger, header, content and footer.
+   */
+  trapFocus?: boolean;
 }
 
 export interface ExpandToViewport {


### PR DESCRIPTION
### Description

Add dropdown focus trap as a generalised solution over recovery focus trap in autosuggest.

The change is needed to decouple autosuggest trigger and footer.

### How has this been tested?

Added new integration tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
