### PR TITLE
Format date-range-picker absolute range as string

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -45,29 +45,37 @@ function formatDateRange(
     );
   }
 
-  if (range.type === 'relative') {
-    return (
-      <InternalBox fontWeight="normal" display="inline" color="inherit">
-        {formatRelativeRange(range)}
-      </InternalBox>
+  const formatted =
+    range.type === 'relative' ? (
+      formatRelativeRange(range)
+    ) : (
+      <BreakSpaces text={formatAbsoluteRange(range, timeOffset)} />
     );
-  }
 
-  if (range.type === 'absolute') {
-    const formattedOffset = isDateOnly(range) ? '' : formatOffset(timeOffset);
-    return (
-      <InternalBox fontWeight="normal" display="inline" color="inherit">
-        <span className={styles['preferred-wordbreak']}>
-          {range.startDate}
-          {formattedOffset} &mdash;
-        </span>{' '}
-        <span className={styles['preferred-wordbreak']}>
-          {range.endDate}
-          {formattedOffset}
-        </span>
-      </InternalBox>
-    );
-  }
+  return (
+    <InternalBox fontWeight="normal" display="inline" color="inherit">
+      {formatted}
+    </InternalBox>
+  );
+}
+
+function BreakSpaces({ text }: { text: string }) {
+  const tokens = text.split(/( )/);
+  return (
+    <div style={{ whiteSpace: 'nowrap' }}>
+      {tokens.map((token, index) => (
+        <React.Fragment key={index}>
+          {token}
+          {token === ' ' && <wbr />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+function formatAbsoluteRange(value: DateRangePickerProps.AbsoluteValue, timeOffset: number): string {
+  const formattedOffset = isDateOnly(value) ? '' : formatOffset(timeOffset);
+  return value.startDate + formattedOffset + ' ' + '—' + ' ' + value.endDate + formattedOffset;
 }
 
 function isDateOnly(value: null | DateRangePickerProps.Value) {

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -27,10 +27,6 @@ $calendar-grid-width: awsui.$size-calendar-grid-width;
   display: flex;
 }
 
-.preferred-wordbreak {
-  display: inline-block;
-}
-
 .calendar {
   display: block;
   width: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs});


### PR DESCRIPTION
### Description

Format date-range-picker absolute range as string which allows to decouple the formatter from styling.

### How has this been tested?

Existing tests. Manually checked responsiveness.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
