### PR TITLE
chore: Remove preventDefault from annotation-popover to allow links to work

### DIFF
--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -78,10 +78,6 @@ export function AnnotationPopover({
   onPreviousButtonClick,
   i18nStrings,
 }: AnnotationPopoverProps) {
-  const preventDefault = useCallback((event: React.MouseEvent) => {
-    event.preventDefault();
-  }, []);
-
   const dismissButtonRefCallback = useCallback(
     (element: ButtonProps.Ref) => {
       if (element) {
@@ -101,84 +97,77 @@ export function AnnotationPopover({
       arrow={arrow}
       zIndex={1000}
     >
-      <div onClick={preventDefault}>
-        <PopoverBody
-          size="medium"
-          fixedWidth={false}
-          dismissButton={true}
-          dismissAriaLabel={i18nStrings.labelDismissAnnotation}
-          header={
-            <InternalBox
-              color="text-body-secondary"
-              fontSize="body-s"
-              margin={{ top: 'xxxs' }}
-              className={styles.header}
-            >
-              {title}
-            </InternalBox>
-          }
-          onDismiss={onDismiss}
-          className={styles.annotation}
-          variant="annotation"
-          overflowVisible="content"
-          dismissButtonRef={dismissButtonRefCallback}
-        >
+      <PopoverBody
+        size="medium"
+        fixedWidth={false}
+        dismissButton={true}
+        dismissAriaLabel={i18nStrings.labelDismissAnnotation}
+        header={
+          <InternalBox color="text-body-secondary" fontSize="body-s" margin={{ top: 'xxxs' }} className={styles.header}>
+            {title}
+          </InternalBox>
+        }
+        onDismiss={onDismiss}
+        className={styles.annotation}
+        variant="annotation"
+        overflowVisible="content"
+        dismissButtonRef={dismissButtonRefCallback}
+      >
+        <InternalSpaceBetween size="s">
+          <div className={styles.description}>
+            <InternalBox className={styles.content}>{content}</InternalBox>
+          </div>
+
+          {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
+
           <InternalSpaceBetween size="s">
-            <div className={styles.description}>
-              <InternalBox className={styles.content}>{content}</InternalBox>
-            </div>
+            <div className={styles.divider} />
 
-            {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
-
-            <InternalSpaceBetween size="s">
-              <div className={styles.divider} />
-
-              <div className={styles.actionBar}>
-                <div className={styles.stepCounter}>
-                  <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
-                    {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
-                  </InternalBox>
-                </div>
-                <InternalSpaceBetween size="xs" direction="horizontal">
-                  {showPreviousButton && (
-                    <InternalButton
-                      variant="link"
-                      onClick={onPreviousButtonClick}
-                      disabled={!previousButtonEnabled}
-                      formAction="none"
-                      ariaLabel={i18nStrings.previousButtonText}
-                      className={styles['previous-button']}
-                    >
-                      {i18nStrings.previousButtonText}
-                    </InternalButton>
-                  )}
-
-                  {showFinishButton ? (
-                    <InternalButton
-                      onClick={onFinish}
-                      formAction="none"
-                      ariaLabel={i18nStrings.finishButtonText}
-                      className={styles['finish-button']}
-                    >
-                      {i18nStrings.finishButtonText}
-                    </InternalButton>
-                  ) : (
-                    <InternalButton
-                      onClick={onNextButtonClick}
-                      disabled={!nextButtonEnabled}
-                      formAction="none"
-                      ariaLabel={i18nStrings.nextButtonText}
-                      className={styles['next-button']}
-                    >
-                      {i18nStrings.nextButtonText}
-                    </InternalButton>
-                  )}
-                </InternalSpaceBetween>
+            <div className={styles.actionBar}>
+              <div className={styles.stepCounter}>
+                <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
+                  {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
+                </InternalBox>
               </div>
-            </InternalSpaceBetween>
+              <InternalSpaceBetween size="xs" direction="horizontal">
+                {showPreviousButton && (
+                  <InternalButton
+                    variant="link"
+                    onClick={onPreviousButtonClick}
+                    disabled={!previousButtonEnabled}
+                    formAction="none"
+                    ariaLabel={i18nStrings.previousButtonText}
+                    className={styles['previous-button']}
+                  >
+                    {i18nStrings.previousButtonText}
+                  </InternalButton>
+                )}
+
+                {showFinishButton ? (
+                  <InternalButton
+                    onClick={onFinish}
+                    formAction="none"
+                    ariaLabel={i18nStrings.finishButtonText}
+                    className={styles['finish-button']}
+                  >
+                    {i18nStrings.finishButtonText}
+                  </InternalButton>
+                ) : (
+                  <InternalButton
+                    onClick={onNextButtonClick}
+                    disabled={!nextButtonEnabled}
+                    formAction="none"
+                    ariaLabel={i18nStrings.nextButtonText}
+                    className={styles['next-button']}
+                  >
+                    {i18nStrings.nextButtonText}
+                  </InternalButton>
+                )}
+              </InternalSpaceBetween>
+            </div>
           </InternalSpaceBetween>
-        </PopoverBody>
-      </div>
+        </InternalSpaceBetween>
+      </PopoverBody>
     </PopoverContainer>
   );
 }


### PR DESCRIPTION
### Description

Removed unnecessary `preventDefault` wrapper, which was preventing annotation-popover links to be opened.

### How has this been tested?

Locally and with existing tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
