### PR TITLE
Move startOfWeek normalization to the date range picker calendar

### DIFF
--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -27,6 +27,7 @@ import { getBaseDate } from './get-base-date.js';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getDateLabel, renderTimeLabel } from '../../date-picker/calendar/utils/intl';
 import LiveRegion from '../../internal/components/live-region';
+import { getWeekStartByLocale } from 'weekstart';
 
 export interface DateChangeHandler {
   (detail: Date): void;
@@ -44,7 +45,7 @@ interface HeaderChangeMonthHandler {
 
 export interface CalendarProps extends BaseComponentProps {
   locale: string;
-  startOfWeek: DayIndex;
+  startOfWeek: number | undefined;
   isDateEnabled: DateRangePickerProps.IsDateEnabledFunction;
   onSelectDateRange: (value: DateRangePickerProps.AbsoluteValue) => void;
   initialStartDate: string | undefined;
@@ -73,6 +74,10 @@ function Calendar(
   ref: React.Ref<Focusable>
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
+
+  const normalizedStartOfWeek = (
+    typeof startOfWeek === 'number' ? startOfWeek % 7 : getWeekStartByLocale(locale)
+  ) as DayIndex;
 
   useImperativeHandle(ref, () => ({
     focus() {
@@ -313,7 +318,7 @@ function Calendar(
             isDateEnabled={isDateEnabled}
             onSelectDate={onSelectDateHandler}
             onChangeMonth={setCurrentMonth}
-            startOfWeek={startOfWeek}
+            startOfWeek={normalizedStartOfWeek}
             todayAriaLabel={i18nStrings.todayAriaLabel}
             selectedStartDate={selectedStartDate}
             selectedEndDate={selectedEndDate}

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
 import { DateRangePickerProps, Focusable } from './interfaces';
-import Calendar, { DayIndex } from './calendar';
+import Calendar from './calendar';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import FocusLock from '../internal/components/focus-lock';
@@ -51,7 +51,7 @@ export interface DateRangePickerDropdownProps
   > {
   onClear: () => void;
   onApply: (value: null | DateRangePickerProps.Value) => DateRangePickerProps.ValidationResult;
-  startOfWeek: DayIndex;
+  startOfWeek: number | undefined;
   onDropdownClose: () => void;
   isSingleGrid: boolean;
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -3,9 +3,7 @@
 import React, { Ref, useEffect, useRef, useState } from 'react';
 import styles from './styles.css.js';
 import { DateRangePickerProps } from './interfaces';
-import { DayIndex } from './calendar';
 import { normalizeLocale } from '../date-picker/calendar/utils/locales';
-import { getWeekStartByLocale } from 'weekstart';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { KeyCode } from '../internal/keycode';
 import clsx from 'clsx';
@@ -145,9 +143,6 @@ const DateRangePicker = React.forwardRef(
     const [isDropDownOpen, setIsDropDownOpen] = useState<boolean>(false);
 
     const normalizedLocale = normalizeLocale('DateRangePicker', locale ?? '');
-    const normalizedStartOfWeek = (
-      typeof startOfWeek === 'number' ? startOfWeek % 7 : getWeekStartByLocale(normalizedLocale)
-    ) as DayIndex;
 
     const closeDropdown = (focusTrigger = false) => {
       setIsDropDownOpen(false);
@@ -267,7 +262,7 @@ const DateRangePicker = React.forwardRef(
         >
           {isDropDownOpen && (
             <DateRangePickerDropdown
-              startOfWeek={normalizedStartOfWeek}
+              startOfWeek={startOfWeek}
               locale={normalizedLocale}
               isSingleGrid={isSingleGrid}
               onDropdownClose={() => closeDropdown(true)}


### PR DESCRIPTION
### Description

This change moves the start of week normalization from the date range picker level to the calendar level (as was done with date picker calendar)

### How has this been tested?

Existing tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
