### PR TITLE
Make startOfWeek normalization a shared function for date (range) picker

### DIFF
--- a/src/date-picker/calendar/index.tsx
+++ b/src/date-picker/calendar/index.tsx
@@ -13,8 +13,7 @@ import moveFocusHandler from './utils/move-focus-handler';
 import { useUniqueId } from '../../internal/hooks/use-unique-id/index.js';
 import { formatDate, memoizedDate } from './utils/date.js';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update.js';
-import { getWeekStartByLocale } from 'weekstart';
-
+import { normalizeStartOfWeek } from './utils/locales.js';
 export interface DateChangeHandler {
   (detail: CalendarTypes.DateDetail): void;
 }
@@ -55,9 +54,7 @@ const Calendar = ({
   previousMonthLabel,
   nextMonthLabel,
 }: CalendarProps) => {
-  const normalizedStartOfWeek = (
-    typeof startOfWeek === 'number' ? startOfWeek : getWeekStartByLocale(locale)
-  ) as DayIndex;
+  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, locale);
   const focusVisible = useFocusVisible();
   const headerId = useUniqueId('calendar-dialog-title-');
   const elementRef = useRef<HTMLDivElement>(null);

--- a/src/date-picker/calendar/utils/locales.ts
+++ b/src/date-picker/calendar/utils/locales.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { warnOnce } from '../../../internal/logging';
+import { getWeekStartByLocale } from 'weekstart';
+import { DayIndex } from '..';
 
 const getHtmlElement = () => (typeof document !== 'undefined' ? document.querySelector('html') : null);
 
@@ -43,4 +45,8 @@ export function normalizeLocale(component: string, locale: string | null): strin
     return mergeLocales(htmlLocale, browserLocale);
   }
   return browserLocale;
+}
+
+export function normalizeStartOfWeek(startOfWeek: number | undefined, locale: string) {
+  return (typeof startOfWeek === 'number' ? startOfWeek % 7 : getWeekStartByLocale(locale)) as DayIndex;
 }

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -27,7 +27,7 @@ import { getBaseDate } from './get-base-date.js';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getDateLabel, renderTimeLabel } from '../../date-picker/calendar/utils/intl';
 import LiveRegion from '../../internal/components/live-region';
-import { getWeekStartByLocale } from 'weekstart';
+import { normalizeStartOfWeek } from '../../date-picker/calendar/utils/locales';
 
 export interface DateChangeHandler {
   (detail: Date): void;
@@ -75,9 +75,7 @@ function Calendar(
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
 
-  const normalizedStartOfWeek = (
-    typeof startOfWeek === 'number' ? startOfWeek % 7 : getWeekStartByLocale(locale)
-  ) as DayIndex;
+  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, locale);
 
   useImperativeHandle(ref, () => ({
     focus() {


### PR DESCRIPTION
### Description

We were previously duplicating this normalizeStartOfWeek functionality across both date picker and date range picker. This PR creates a shared function to be used by both

### How has this been tested?

Existing tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
