### PR TITLE
Make autosuggest onSelect cancellable

### DIFF
--- a/pages/autosuggest/internal.page.tsx
+++ b/pages/autosuggest/internal.page.tsx
@@ -22,14 +22,12 @@ export default function AutosuggestPage() {
       <h1>Internal autosuggest features</h1>
       <InternalAutosuggest
         __filterText={value.substr(2)}
-        __onOptionClick={e => {
-          e.preventDefault();
-        }}
         __dropdownWidth={300}
         __disableShowAll={true}
         value={value}
         options={options}
         onChange={event => setValue(event.detail.value)}
+        onSelect={event => event.preventDefault()}
         enteredTextLabel={enteredTextLabel}
         ariaLabel={'internal autosuggest'}
         virtualScroll={true}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1263,12 +1263,17 @@ The detail object contains the following properties:
       "name": "onLoadItems",
     },
     Object {
-      "cancelable": false,
+      "cancelable": true,
       "description": "Called whenever a user selects an option in the dropdown. Don't use this event as the only way to handle user input.
 Instead, use \`onSelect\` in combination with the \`onChange\` handler only as an optional convenience for the user.",
       "detailInlineType": Object {
         "name": "AutosuggestProps.SelectDetail",
         "properties": Array [
+          Object {
+            "name": "option",
+            "optional": false,
+            "type": "AutosuggestProps.Option | AutosuggestProps.OptionGroup",
+          },
           Object {
             "name": "value",
             "optional": false,

--- a/src/autosuggest/__tests__/internal.test.tsx
+++ b/src/autosuggest/__tests__/internal.test.tsx
@@ -43,57 +43,7 @@ describe('Internal autosuggest features', () => {
       expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('123');
     });
   });
-  describe('`__onOptionClick`', () => {
-    const handleSelectedSpy = jest.fn();
-    let wrapper: AutosuggestWrapper;
-    beforeEach(() => {
-      handleSelectedSpy.mockReset();
-      wrapper = renderAutosuggest(
-        <InternalAutosuggest
-          options={options}
-          enteredTextLabel={() => ''}
-          __onOptionClick={handleSelectedSpy}
-          value=""
-          onChange={() => {}}
-          filteringType="auto"
-          statusType="finished"
-          disableBrowserAutocorrect={false}
-        />
-      ).wrapper;
-      wrapper.focus();
-    });
-    test('called when selecting an item with a mouse', () => {
-      wrapper.selectSuggestion(1);
-      expect(handleSelectedSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ detail: { ...options[0], option: options[0] } })
-      );
-    });
-    test('called when selecting an item with a keyboard', () => {
-      wrapper.findNativeInput().keydown(KeyCode.down);
-      wrapper.findNativeInput().keydown(KeyCode.enter);
-      expect(handleSelectedSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ detail: { ...options[0], option: options[0] } })
-      );
-    });
-    test('could be prevented to stop dropdown from closing', () => {
-      handleSelectedSpy.mockImplementation(e => {
-        e.preventDefault();
-      });
-      wrapper.selectSuggestion(1);
-      expect(handleSelectedSpy).toHaveBeenCalled();
-      expect(wrapper.findDropdown().findOpenDropdown()).toBeTruthy();
-    });
-    test('highlight gets reset when selecting an option, even if the dropdown did not close', () => {
-      handleSelectedSpy.mockImplementation(e => {
-        e.preventDefault();
-      });
-      wrapper.findNativeInput().keydown(KeyCode.down);
-      expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('123');
-      wrapper.findNativeInput().keydown(KeyCode.enter);
-      expect(wrapper.findDropdown().findOpenDropdown()).toBeTruthy();
-      expect(wrapper.findDropdown().findHighlightedOption()).toBeNull();
-    });
-  });
+
   test('`__disableShowAll`: forces the list of suggestions to be filtered, when the input is focused', () => {
     const wrapper: AutosuggestWrapper = renderAutosuggest(
       <InternalAutosuggest

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -11,7 +11,7 @@ import {
 } from '../internal/components/dropdown/interfaces';
 import { DropdownStatusProps } from '../internal/components/dropdown-status';
 import { BaseInputProps, InputKeyEvents, InputProps } from '../input/interfaces';
-import { NonCancelableEventHandler } from '../internal/events';
+import { CancelableEventHandler } from '../internal/events';
 
 export interface AutosuggestProps
   extends BaseComponentProps,
@@ -84,7 +84,7 @@ export interface AutosuggestProps
    * Called whenever a user selects an option in the dropdown. Don't use this event as the only way to handle user input.
    * Instead, use `onSelect` in combination with the `onChange` handler only as an optional convenience for the user.
    */
-  onSelect?: NonCancelableEventHandler<AutosuggestProps.SelectDetail>;
+  onSelect?: CancelableEventHandler<AutosuggestProps.SelectDetail>;
 
   /**
    * Specifies the localized string that describes an option as being selected.
@@ -121,6 +121,7 @@ export namespace AutosuggestProps {
   export type StatusType = DropdownStatusProps.StatusType;
   export interface SelectDetail {
     value: string;
+    option: Option | OptionGroup;
   }
 
   export interface ContainingOptionAndGroupString {

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -28,7 +28,6 @@ import AutosuggestOptionsList from './options-list';
 export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {
   __filterText?: string;
   __dropdownWidth?: number;
-  __onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
   __disableShowAll?: boolean;
   __hideEnteredTextOption?: boolean;
   __onOpen?: CancelableEventHandler<null>;
@@ -88,7 +87,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     selectedAriaLabel,
     renderHighlightedAriaLive,
     __dropdownWidth,
-    __onOptionClick,
     __disableShowAll,
     __hideEnteredTextOption,
     __onOpen,
@@ -131,13 +129,12 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const selectOption = (option: AutosuggestItem) => {
     const value = option.value || '';
     fireNonCancelableEvent(onChange, { value });
-    const selectedCancelled = fireCancelableEvent(__onOptionClick, option);
+    const selectedCancelled = fireCancelableEvent(onSelect, { value, option: option.option });
     if (!selectedCancelled) {
       closeDropdown();
     } else {
       resetHighlight();
     }
-    fireNonCancelableEvent(onSelect, { value });
   };
   const selectHighlighted = () => {
     if (highlightedOption) {

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -154,26 +154,30 @@ const PropertyFilter = React.forwardRef(
             ...asyncProps,
           }
         : {};
-    const handleSelected: InternalAutosuggestProps['__onOptionClick'] = event => {
+    const handleSelected: InternalAutosuggestProps['onSelect'] = event => {
       // The ignoreKeyDown flag makes sure `createToken` routine runs only once. Autosuggest's `onKeyDown` fires,
       // when an item is selected from the list using "enter" key.
       ignoreKeyDown.current = true;
       setTimeout(() => {
         ignoreKeyDown.current = false;
       }, 0);
-      const { detail: option } = event;
-      const value = option.value || '';
+      const {
+        detail: { value = '', option },
+      } = event;
+
+      // Create a token when property value is selected from the list.
       if ('tokenValue' in option) {
         createToken((option as { tokenValue: string }).tokenValue);
         return;
       }
-      // create a token from the 'use' option
+
+      // Create a token when the 'use' option is selected.
       if (!('keepOpenOnSelect' in option)) {
         createToken(value);
         return;
       }
 
-      // stop dropdown from closing
+      // Prevent autosuggest dropdown from closing.
       event.preventDefault();
       const loadMoreDetail = getLoadMoreDetail(parseText(value, filteringProperties, disableFreeTextFiltering), value);
       fireNonCancelableEvent(onLoadItems, { ...loadMoreDetail, firstPage: true, samePage: false });
@@ -199,12 +203,12 @@ const PropertyFilter = React.forwardRef(
             onKeyDown={handleKeyDown}
             {...autosuggestOptions}
             onChange={event => setFilteringText(event.detail.value)}
+            onSelect={handleSelected}
             empty={filteringEmpty}
             {...asyncAutosuggestProps}
             expandToViewport={expandToViewport}
             __disableShowAll={true}
             __dropdownWidth={300}
-            __onOptionClick={handleSelected}
             __onOpen={e => {
               if (preventFocus.current) {
                 e.preventDefault();


### PR DESCRIPTION
### Description

Make autosuggest onSelect cancellable to remove the need in __onItemClick internal method.

### How has this been tested?

Existing tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

Contains changes to auto-generated documentation.

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
