### PR TITLE
Improve focus indicator on buttondropdown

### DIFF
--- a/pages/button-dropdown/item-element.permutations.page.tsx
+++ b/pages/button-dropdown/item-element.permutations.page.tsx
@@ -128,7 +128,7 @@ const permutations = createPermutations<ItemProps>([
     hasCategoryHeader: [false],
     onItemActivate: [() => {}],
     highlightItem: [() => {}],
-    focused: [true],
+    isKeyboardHighlighted: [true],
   },
 ]);
 

--- a/pages/button-dropdown/item-element.permutations.page.tsx
+++ b/pages/button-dropdown/item-element.permutations.page.tsx
@@ -119,6 +119,17 @@ const permutations = createPermutations<ItemProps>([
     onItemActivate: [() => {}],
     highlightItem: [() => {}],
   },
+  // keyboard nav
+  {
+    item: [{ id: '1', text: 'keyboard nav' }],
+    disabled: [false, true],
+    highlighted: [false, true],
+    last: [false],
+    hasCategoryHeader: [false],
+    onItemActivate: [() => {}],
+    highlightItem: [() => {}],
+    focused: [true],
+  },
 ]);
 
 export default function () {

--- a/src/button-dropdown/__tests__/button-dropdown-navigation.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-navigation.test.tsx
@@ -76,10 +76,17 @@ describe('Button dropdown navigate with mouse or keyboard', () => {
     act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
     expect(wrapper.findHighlightedItem()!.getElement()).toHaveClass(itemStyles['is-focused']);
 
-    // mouse move on the dropdown to update isKeyboard ref
     fireEvent.mouseMove(wrapper.findItemById('i4')!.getElement());
-    // mouse enter item to update the style on the item
-    fireEvent.mouseEnter(wrapper.findItemById('i4')!.getElement());
+    expect(wrapper.findHighlightedItem()!.getElement()).not.toHaveClass(itemStyles['is-focused']);
+  });
+
+  it('should add class is-focused if highligted with keyboard and remove when mouse move on the same item', () => {
+    const wrapper = renderButtonDropdown({ items });
+    wrapper.openDropdown();
+    act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+    expect(wrapper.findHighlightedItem()!.getElement()).toHaveClass(itemStyles['is-focused']);
+
+    fireEvent.mouseMove(wrapper.findItemById('i1')!.getElement());
     expect(wrapper.findHighlightedItem()!.getElement()).not.toHaveClass(itemStyles['is-focused']);
   });
 

--- a/src/button-dropdown/__tests__/button-dropdown-navigation.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-navigation.test.tsx
@@ -1,12 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 
 import { ButtonDropdownProps, InternalButtonDropdownProps } from '../../../lib/components/button-dropdown/interfaces';
 import InternalButtonDropdown from '../../../lib/components/button-dropdown/internal';
-import { ButtonDropdownWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
+import createWrapper, { ButtonDropdownWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/button-dropdown/styles.css.js';
+import itemStyles from '../../../lib/components/button-dropdown/item-element/styles.css.js';
+import categoryElementStyles from '../../../lib/components/button-dropdown/category-elements/styles.css.js';
+import { KeyCode } from '../../internal/keycode';
+import ButtonDropdown from '../../../lib/components/button-dropdown';
 
 const items: ButtonDropdownProps.Items = [
   { id: 'i1', text: 'item1', description: 'Item 1 description' },
@@ -23,6 +27,11 @@ const items: ButtonDropdownProps.Items = [
 const renderInternalButtonDropdown = (props: InternalButtonDropdownProps) => {
   const { baseElement } = render(<InternalButtonDropdown {...props} />);
   return new ButtonDropdownWrapper(baseElement as HTMLElement);
+};
+
+const renderButtonDropdown = (props: ButtonDropdownProps) => {
+  const renderResult = render(<ButtonDropdown {...props} />);
+  return createWrapper(renderResult.container).findButtonDropdown()!;
 };
 
 function findHeader(wrapper: ButtonDropdownWrapper): ElementWrapper<HTMLElement> {
@@ -57,5 +66,35 @@ describe('Button dropdown header', () => {
 
     wrapper.openDropdown();
     expect(findHeader(wrapper).getElement()).toHaveTextContent('Description');
+  });
+});
+
+describe('Button dropdown navigate with mouse or keyboard', () => {
+  it('should add class is-focused if highligted with keyboard and remove when using mouse', () => {
+    const wrapper = renderButtonDropdown({ items });
+    wrapper.openDropdown();
+    act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+    expect(wrapper.findHighlightedItem()!.getElement()).toHaveClass(itemStyles['is-focused']);
+
+    // mouse move on the dropdown to update isKeyboard ref
+    fireEvent.mouseMove(wrapper.findItemById('i4')!.getElement());
+    // mouse enter item to update the style on the item
+    fireEvent.mouseEnter(wrapper.findItemById('i4')!.getElement());
+    expect(wrapper.findHighlightedItem()!.getElement()).not.toHaveClass(itemStyles['is-focused']);
+  });
+
+  it('should remove class is-focused from parent item when move focus from parent item to child item', () => {
+    const wrapper = renderButtonDropdown({ items, expandableGroups: true });
+    wrapper.openDropdown();
+    act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+    act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.down));
+    expect(wrapper.findByClassName(categoryElementStyles['expandable-header'])!.getElement()).toHaveClass(
+      categoryElementStyles['is-focused']
+    );
+    act(() => wrapper.findOpenDropdown()!.keydown(KeyCode.right));
+    expect(wrapper.findByClassName(categoryElementStyles['expandable-header'])!.getElement()).not.toHaveClass(
+      categoryElementStyles['is-focused']
+    );
+    expect(wrapper.findHighlightedItem()!.getElement()).toHaveClass(itemStyles['is-focused']);
   });
 });

--- a/src/button-dropdown/__tests__/use-highlighted-menu.test.ts
+++ b/src/button-dropdown/__tests__/use-highlighted-menu.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { createRef, MutableRefObject } from 'react';
 import { ButtonDropdownProps } from '../interfaces';
 import { renderHook, act } from '../../__tests__/render-hook';
 import useHighlightedMenu from '../utils/use-highlighted-menu';
@@ -32,10 +31,9 @@ const testItems2: ButtonDropdownProps.Items = [
   { id: 'i4', text: 'item4' },
 ];
 
-const usingMouse = createRef<boolean>() as MutableRefObject<boolean>;
 function render({ items = testItems, hasExpandableGroups = false, isInRestrictedView = false }) {
   return renderHook(useHighlightedMenu, {
-    initialProps: { items, hasExpandableGroups, isInRestrictedView, usingMouse },
+    initialProps: { items, hasExpandableGroups, isInRestrictedView },
   });
 }
 

--- a/src/button-dropdown/__tests__/use-highlighted-menu.test.ts
+++ b/src/button-dropdown/__tests__/use-highlighted-menu.test.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { createRef, MutableRefObject } from 'react';
 import { ButtonDropdownProps } from '../interfaces';
 import { renderHook, act } from '../../__tests__/render-hook';
 import useHighlightedMenu from '../utils/use-highlighted-menu';
@@ -31,9 +32,10 @@ const testItems2: ButtonDropdownProps.Items = [
   { id: 'i4', text: 'item4' },
 ];
 
+const usingMouse = createRef<boolean>() as MutableRefObject<boolean>;
 function render({ items = testItems, hasExpandableGroups = false, isInRestrictedView = false }) {
   return renderHook(useHighlightedMenu, {
-    initialProps: { items, hasExpandableGroups, isInRestrictedView },
+    initialProps: { items, hasExpandableGroups, isInRestrictedView, usingMouse },
   });
 }
 

--- a/src/button-dropdown/category-elements/category-element.tsx
+++ b/src/button-dropdown/category-elements/category-element.tsx
@@ -12,6 +12,7 @@ const CategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
+  isFocused,
   isExpanded,
   highlightItem,
   disabled,
@@ -38,6 +39,7 @@ const CategoryElement = ({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
+            isFocused={isFocused}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             categoryDisabled={disabled}

--- a/src/button-dropdown/category-elements/category-element.tsx
+++ b/src/button-dropdown/category-elements/category-element.tsx
@@ -12,7 +12,7 @@ const CategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
-  isFocused,
+  isKeyboardHighlight,
   isExpanded,
   highlightItem,
   disabled,
@@ -39,7 +39,7 @@ const CategoryElement = ({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
-            isFocused={isFocused}
+            isKeyboardHighlight={isKeyboardHighlight}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             categoryDisabled={disabled}

--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -45,7 +45,7 @@ const ExpandableCategoryElement = ({
     }
   };
 
-  const makeHighlight = (event: React.SyntheticEvent) => {
+  const onHover = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -125,8 +125,8 @@ const ExpandableCategoryElement = ({
       data-testid={item.id}
       ref={ref}
       onClick={onClick}
-      onMouseMove={makeHighlight}
-      onTouchStart={makeHighlight}
+      onMouseEnter={onHover}
+      onTouchStart={onHover}
     >
       {content}
     </li>

--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -18,6 +18,7 @@ const ExpandableCategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
+  isFocused,
   isExpanded,
   highlightItem,
   disabled,
@@ -26,6 +27,7 @@ const ExpandableCategoryElement = ({
 }: CategoryProps) => {
   const highlighted = isHighlighted(item);
   const expanded = isExpanded(item);
+  const focused = isFocused(item);
   const triggerRef = React.useRef<HTMLSpanElement>(null);
   const ref = useRef<HTMLLIElement>(null);
 
@@ -55,6 +57,7 @@ const ExpandableCategoryElement = ({
       className={clsx(styles.header, styles['expandable-header'], styles[`variant-${variant}`], {
         [styles.disabled]: disabled,
         [styles.highlighted]: highlighted,
+        [styles['is-focused']]: focused,
       })}
       // We are using the roving tabindex technique to manage the focus state of the dropdown.
       // The current element will always have tabindex=0 which means that it can be tabbed to,
@@ -100,6 +103,7 @@ const ExpandableCategoryElement = ({
               onGroupToggle={onGroupToggle}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
+              isFocused={isFocused}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               variant={variant}

--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -18,7 +18,7 @@ const ExpandableCategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
-  isFocused,
+  isKeyboardHighlight,
   isExpanded,
   highlightItem,
   disabled,
@@ -27,7 +27,7 @@ const ExpandableCategoryElement = ({
 }: CategoryProps) => {
   const highlighted = isHighlighted(item);
   const expanded = isExpanded(item);
-  const focused = isFocused(item);
+  const isKeyboardHighlighted = isKeyboardHighlight(item);
   const triggerRef = React.useRef<HTMLSpanElement>(null);
   const ref = useRef<HTMLLIElement>(null);
 
@@ -57,7 +57,7 @@ const ExpandableCategoryElement = ({
       className={clsx(styles.header, styles['expandable-header'], styles[`variant-${variant}`], {
         [styles.disabled]: disabled,
         [styles.highlighted]: highlighted,
-        [styles['is-focused']]: focused,
+        [styles['is-focused']]: isKeyboardHighlighted,
       })}
       // We are using the roving tabindex technique to manage the focus state of the dropdown.
       // The current element will always have tabindex=0 which means that it can be tabbed to,
@@ -103,7 +103,7 @@ const ExpandableCategoryElement = ({
               onGroupToggle={onGroupToggle}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
-              isFocused={isFocused}
+              isKeyboardHighlight={isKeyboardHighlight}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               variant={variant}

--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -45,7 +45,7 @@ const ExpandableCategoryElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
+  const makeHighlight = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -125,8 +125,8 @@ const ExpandableCategoryElement = ({
       data-testid={item.id}
       ref={ref}
       onClick={onClick}
-      onMouseEnter={onHover}
-      onTouchStart={onHover}
+      onMouseMove={makeHighlight}
+      onTouchStart={makeHighlight}
     >
       {content}
     </li>

--- a/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
@@ -18,7 +18,7 @@ const MobileExpandableCategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
-  isFocused,
+  isKeyboardHighlight,
   isExpanded,
   highlightItem,
   disabled,
@@ -26,7 +26,7 @@ const MobileExpandableCategoryElement = ({
 }: CategoryProps) => {
   const highlighted = isHighlighted(item);
   const expanded = isExpanded(item);
-  const focused = isFocused(item);
+  const isKeyboardHighlighted = isKeyboardHighlight(item);
   const triggerRef = React.useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
@@ -55,7 +55,7 @@ const MobileExpandableCategoryElement = ({
         [styles.highlighted]: highlighted,
         [styles['rolled-down']]: expanded,
         [styles.disabled]: disabled,
-        [styles['is-focused']]: focused,
+        [styles['is-focused']]: isKeyboardHighlighted,
       })}
       // We are using the roving tabindex technique to manage the focus state of the dropdown.
       // The current element will always have tabindex=0 which means that it can be tabbed to,
@@ -98,7 +98,7 @@ const MobileExpandableCategoryElement = ({
               onGroupToggle={onGroupToggle}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
-              isFocused={isFocused}
+              isKeyboardHighlight={isKeyboardHighlight}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               hasCategoryHeader={true}

--- a/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
@@ -18,6 +18,7 @@ const MobileExpandableCategoryElement = ({
   onGroupToggle,
   targetItem,
   isHighlighted,
+  isFocused,
   isExpanded,
   highlightItem,
   disabled,
@@ -25,6 +26,7 @@ const MobileExpandableCategoryElement = ({
 }: CategoryProps) => {
   const highlighted = isHighlighted(item);
   const expanded = isExpanded(item);
+  const focused = isFocused(item);
   const triggerRef = React.useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
@@ -53,6 +55,7 @@ const MobileExpandableCategoryElement = ({
         [styles.highlighted]: highlighted,
         [styles['rolled-down']]: expanded,
         [styles.disabled]: disabled,
+        [styles['is-focused']]: focused,
       })}
       // We are using the roving tabindex technique to manage the focus state of the dropdown.
       // The current element will always have tabindex=0 which means that it can be tabbed to,
@@ -95,6 +98,7 @@ const MobileExpandableCategoryElement = ({
               onGroupToggle={onGroupToggle}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
+              isFocused={isFocused}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               hasCategoryHeader={true}

--- a/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
@@ -42,7 +42,7 @@ const MobileExpandableCategoryElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
+  const makeHighlight = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -120,8 +120,8 @@ const MobileExpandableCategoryElement = ({
       })}
       role="presentation"
       onClick={onClick}
-      onMouseEnter={onHover}
-      onTouchStart={onHover}
+      onMouseMove={makeHighlight}
+      onTouchStart={makeHighlight}
       data-testid={item.id}
     >
       {content}

--- a/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
@@ -42,7 +42,7 @@ const MobileExpandableCategoryElement = ({
     }
   };
 
-  const makeHighlight = (event: React.SyntheticEvent) => {
+  const onHover = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -120,8 +120,8 @@ const MobileExpandableCategoryElement = ({
       })}
       role="presentation"
       onClick={onClick}
-      onMouseMove={makeHighlight}
-      onTouchStart={makeHighlight}
+      onMouseEnter={onHover}
+      onTouchStart={onHover}
       data-testid={item.id}
     >
       {content}

--- a/src/button-dropdown/category-elements/styles.scss
+++ b/src/button-dropdown/category-elements/styles.scss
@@ -55,6 +55,10 @@ $option-padding-horizontal: awsui.$space-l;
         border-color: awsui.$color-border-dropdown-item-dimmed-hover;
         color: awsui.$color-text-dropdown-item-dimmed;
       }
+      &.is-focused {
+        border-color: awsui.$color-border-item-focused;
+        box-shadow: inset 0 0 0 awsui.$border-control-focus-ring-shadow-spread awsui.$color-border-item-focused;
+      }
     }
 
     &.variant-navigation {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -144,6 +144,7 @@ export interface ButtonDropdownSettings {
 export interface HighlightProps {
   targetItem: ButtonDropdownProps.ItemOrGroup | null;
   isHighlighted: (item: ButtonDropdownProps.ItemOrGroup) => boolean;
+  isFocused: (item: ButtonDropdownProps.ItemOrGroup) => boolean;
   isExpanded: (group: ButtonDropdownProps.ItemGroup) => boolean;
   highlightItem: (item: ButtonDropdownProps.ItemOrGroup) => void;
 }
@@ -184,6 +185,7 @@ export interface ItemProps {
   first?: boolean;
   last: boolean;
   hasCategoryHeader: boolean;
+  focused?: boolean;
   variant?: ItemListProps['variant'];
 }
 

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -144,7 +144,7 @@ export interface ButtonDropdownSettings {
 export interface HighlightProps {
   targetItem: ButtonDropdownProps.ItemOrGroup | null;
   isHighlighted: (item: ButtonDropdownProps.ItemOrGroup) => boolean;
-  isFocused: (item: ButtonDropdownProps.ItemOrGroup) => boolean;
+  isKeyboardHighlight: (item: ButtonDropdownProps.ItemOrGroup) => boolean;
   isExpanded: (group: ButtonDropdownProps.ItemGroup) => boolean;
   highlightItem: (item: ButtonDropdownProps.ItemOrGroup) => void;
 }
@@ -185,7 +185,7 @@ export interface ItemProps {
   first?: boolean;
   last: boolean;
   hasCategoryHeader: boolean;
-  focused?: boolean;
+  isKeyboardHighlighted?: boolean;
   variant?: ItemListProps['variant'];
 }
 

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -51,6 +51,7 @@ const InternalButtonDropdown = React.forwardRef(
       isOpen,
       targetItem,
       isHighlighted,
+      isFocused,
       isExpanded,
       highlightItem,
       onKeyDown,
@@ -77,9 +78,6 @@ const InternalButtonDropdown = React.forwardRef(
     useForwardFocus(ref, dropdownRef);
 
     const clickHandler = () => {
-      if (!usingMouse.current) {
-        return;
-      }
       if (!loading && !disabled) {
         toggleDropdown();
         if (dropdownRef.current) {
@@ -140,6 +138,7 @@ const InternalButtonDropdown = React.forwardRef(
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
         onMouseDown={handleMouseEvent}
+        onMouseMove={handleMouseEvent}
         className={clsx(styles['button-dropdown'], styles[`variant-${variant}`], baseProps.className)}
         aria-owns={expandToViewport && isOpen ? dropdownId : undefined}
         ref={__internalRootRef}
@@ -184,6 +183,7 @@ const InternalButtonDropdown = React.forwardRef(
               hasExpandableGroups={expandableGroups}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
+              isFocused={isFocused}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               expandToViewport={expandToViewport}

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -41,7 +41,6 @@ const InternalButtonDropdown = React.forwardRef(
     ref: React.Ref<ButtonDropdownProps.Ref>
   ) => {
     const isInRestrictedView = useMobile();
-    const usingMouse = useRef(true);
     const dropdownId = useUniqueId('dropdown');
     for (const item of items) {
       checkSafeUrl('ButtonDropdown', item.href);
@@ -59,17 +58,17 @@ const InternalButtonDropdown = React.forwardRef(
       onItemActivate,
       onGroupToggle,
       toggleDropdown,
+      setIsUsingMouse,
     } = useButtonDropdown({
       items,
       onItemClick,
       onItemFollow,
       hasExpandableGroups: expandableGroups,
       isInRestrictedView,
-      usingMouse,
     });
 
     const handleMouseEvent = () => {
-      usingMouse.current = true;
+      setIsUsingMouse(true);
     };
 
     const baseProps = getBaseProps(props);

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -50,7 +50,7 @@ const InternalButtonDropdown = React.forwardRef(
       isOpen,
       targetItem,
       isHighlighted,
-      isFocused,
+      isKeyboardHighlight,
       isExpanded,
       highlightItem,
       onKeyDown,
@@ -182,7 +182,7 @@ const InternalButtonDropdown = React.forwardRef(
               hasExpandableGroups={expandableGroups}
               targetItem={targetItem}
               isHighlighted={isHighlighted}
-              isFocused={isFocused}
+              isKeyboardHighlight={isKeyboardHighlight}
               isExpanded={isExpanded}
               highlightItem={highlightItem}
               expandToViewport={expandToViewport}

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -23,6 +23,7 @@ const ItemElement = ({
   first = false,
   last,
   hasCategoryHeader,
+  focused = false,
   variant = 'normal',
 }: ItemProps) => {
   const isLink = isLinkItem(item);
@@ -51,6 +52,7 @@ const ItemElement = ({
         [styles.first]: first,
         [styles.last]: last,
         [styles['has-category-header']]: hasCategoryHeader,
+        [styles['is-focused']]: focused,
       })}
       role="presentation"
       data-testid={item.id}

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -23,7 +23,7 @@ const ItemElement = ({
   first = false,
   last,
   hasCategoryHeader,
-  focused = false,
+  isKeyboardHighlighted = false,
   variant = 'normal',
 }: ItemProps) => {
   const isLink = isLinkItem(item);
@@ -52,7 +52,7 @@ const ItemElement = ({
         [styles.first]: first,
         [styles.last]: last,
         [styles['has-category-header']]: hasCategoryHeader,
-        [styles['is-focused']]: focused,
+        [styles['is-focused']]: isKeyboardHighlighted,
       })}
       role="presentation"
       data-testid={item.id}

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -39,7 +39,7 @@ const ItemElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
+  const makeHighlight = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -58,8 +58,8 @@ const ItemElement = ({
       data-testid={item.id}
       data-description={item.description}
       onClick={onClick}
-      onMouseEnter={onHover}
-      onTouchStart={onHover}
+      onMouseMove={makeHighlight}
+      onTouchStart={makeHighlight}
     >
       <MenuItem item={item} disabled={disabled} highlighted={highlighted} />
     </li>

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -39,7 +39,7 @@ const ItemElement = ({
     }
   };
 
-  const makeHighlight = (event: React.SyntheticEvent) => {
+  const onHover = (event: React.SyntheticEvent) => {
     event.preventDefault();
     highlightItem(item);
   };
@@ -58,8 +58,8 @@ const ItemElement = ({
       data-testid={item.id}
       data-description={item.description}
       onClick={onClick}
-      onMouseMove={makeHighlight}
-      onTouchStart={makeHighlight}
+      onMouseEnter={onHover}
+      onTouchStart={onHover}
     >
       <MenuItem item={item} disabled={disabled} highlighted={highlighted} />
     </li>

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -42,6 +42,11 @@
         border-color: awsui.$color-border-dropdown-item-dimmed-hover;
         background-color: awsui.$color-background-dropdown-item-dimmed;
       }
+
+      &.is-focused {
+        border-color: awsui.$color-border-item-focused;
+        box-shadow: inset 0 0 0 awsui.$border-control-focus-ring-shadow-spread awsui.$color-border-item-focused;
+      }
     }
   }
 

--- a/src/button-dropdown/items-list.tsx
+++ b/src/button-dropdown/items-list.tsx
@@ -15,7 +15,7 @@ export default function ItemsList({
   onGroupToggle,
   targetItem,
   isHighlighted,
-  isFocused,
+  isKeyboardHighlight,
   isExpanded,
   highlightItem,
   categoryDisabled = false,
@@ -35,7 +35,7 @@ export default function ItemsList({
           onItemActivate={onItemActivate}
           disabled={item.disabled ?? categoryDisabled}
           highlighted={isHighlighted(item)}
-          focused={isFocused(item)}
+          isKeyboardHighlighted={isKeyboardHighlight(item)}
           highlightItem={highlightItem}
           first={index === 0 || isItemGroup(items[index - 1])}
           last={index === items.length - 1 || isItemGroup(items[index + 1])}
@@ -54,7 +54,7 @@ export default function ItemsList({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
-            isFocused={isFocused}
+            isKeyboardHighlight={isKeyboardHighlight}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             disabled={item.disabled ?? false}
@@ -68,7 +68,7 @@ export default function ItemsList({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
-            isFocused={isFocused}
+            isKeyboardHighlight={isKeyboardHighlight}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             disabled={item.disabled ?? false}
@@ -86,7 +86,7 @@ export default function ItemsList({
         onGroupToggle={onGroupToggle}
         targetItem={targetItem}
         isHighlighted={isHighlighted}
-        isFocused={isFocused}
+        isKeyboardHighlight={isKeyboardHighlight}
         isExpanded={isExpanded}
         highlightItem={highlightItem}
         disabled={item.disabled ?? false}

--- a/src/button-dropdown/items-list.tsx
+++ b/src/button-dropdown/items-list.tsx
@@ -15,6 +15,7 @@ export default function ItemsList({
   onGroupToggle,
   targetItem,
   isHighlighted,
+  isFocused,
   isExpanded,
   highlightItem,
   categoryDisabled = false,
@@ -34,6 +35,7 @@ export default function ItemsList({
           onItemActivate={onItemActivate}
           disabled={item.disabled ?? categoryDisabled}
           highlighted={isHighlighted(item)}
+          focused={isFocused(item)}
           highlightItem={highlightItem}
           first={index === 0 || isItemGroup(items[index - 1])}
           last={index === items.length - 1 || isItemGroup(items[index + 1])}
@@ -52,6 +54,7 @@ export default function ItemsList({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
+            isFocused={isFocused}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             disabled={item.disabled ?? false}
@@ -65,6 +68,7 @@ export default function ItemsList({
             onGroupToggle={onGroupToggle}
             targetItem={targetItem}
             isHighlighted={isHighlighted}
+            isFocused={isFocused}
             isExpanded={isExpanded}
             highlightItem={highlightItem}
             disabled={item.disabled ?? false}
@@ -82,6 +86,7 @@ export default function ItemsList({
         onGroupToggle={onGroupToggle}
         targetItem={targetItem}
         isHighlighted={isHighlighted}
+        isFocused={isFocused}
         isExpanded={isExpanded}
         highlightItem={highlightItem}
         disabled={item.disabled ?? false}

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -33,12 +33,22 @@ export function useButtonDropdown({
   isInRestrictedView = false,
   usingMouse,
 }: UseButtonDropdownOptions): UseButtonDropdownApi {
-  const { targetItem, isHighlighted, isExpanded, highlightItem, moveHighlight, expandGroup, collapseGroup, reset } =
-    useHighlightedMenu({
-      items,
-      hasExpandableGroups,
-      isInRestrictedView,
-    });
+  const {
+    targetItem,
+    isHighlighted,
+    isFocused,
+    isExpanded,
+    highlightItem,
+    moveHighlight,
+    expandGroup,
+    collapseGroup,
+    reset,
+  } = useHighlightedMenu({
+    items,
+    hasExpandableGroups,
+    isInRestrictedView,
+    usingMouse,
+  });
 
   const { isOpen, closeDropdown, toggleDropdown } = useOpenState({ onClose: reset });
 
@@ -102,6 +112,7 @@ export function useButtonDropdown({
   };
 
   const onKeyDown = (event: React.KeyboardEvent) => {
+    usingMouse.current = false;
     switch (event.keyCode) {
       case KeyCode.down: {
         doVerticalNavigation(1);
@@ -115,7 +126,6 @@ export function useButtonDropdown({
       }
       case KeyCode.space: {
         // Prevent scrolling the list of items and highlighting the trigger
-        usingMouse.current = false;
         event.preventDefault();
         break;
       }
@@ -160,6 +170,7 @@ export function useButtonDropdown({
     isOpen,
     targetItem,
     isHighlighted,
+    isFocused,
     isExpanded,
     highlightItem,
     onKeyDown,

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -13,7 +13,6 @@ interface UseButtonDropdownOptions extends ButtonDropdownSettings {
   items: ButtonDropdownProps.Items;
   onItemClick?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   onItemFollow?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
-  usingMouse: React.MutableRefObject<boolean>;
 }
 
 interface UseButtonDropdownApi extends HighlightProps {
@@ -23,6 +22,7 @@ interface UseButtonDropdownApi extends HighlightProps {
   onItemActivate: ItemActivate;
   onGroupToggle: GroupToggle;
   toggleDropdown: () => void;
+  setIsUsingMouse: (isUsingMouse: boolean) => void;
 }
 
 export function useButtonDropdown({
@@ -31,7 +31,6 @@ export function useButtonDropdown({
   onItemFollow,
   hasExpandableGroups,
   isInRestrictedView = false,
-  usingMouse,
 }: UseButtonDropdownOptions): UseButtonDropdownApi {
   const {
     targetItem,
@@ -43,11 +42,11 @@ export function useButtonDropdown({
     expandGroup,
     collapseGroup,
     reset,
+    setIsUsingMouse,
   } = useHighlightedMenu({
     items,
     hasExpandableGroups,
     isInRestrictedView,
-    usingMouse,
   });
 
   const { isOpen, closeDropdown, toggleDropdown } = useOpenState({ onClose: reset });
@@ -100,7 +99,7 @@ export function useButtonDropdown({
   };
 
   const activate = (event: React.KeyboardEvent, isEnter?: boolean) => {
-    usingMouse.current = false;
+    setIsUsingMouse(false);
 
     // if item is a link we rely on default behavior of an anchor, no need to prevent
     if (targetItem && isLinkItem(targetItem) && isEnter) {
@@ -112,7 +111,7 @@ export function useButtonDropdown({
   };
 
   const onKeyDown = (event: React.KeyboardEvent) => {
-    usingMouse.current = false;
+    setIsUsingMouse(false);
     switch (event.keyCode) {
       case KeyCode.down: {
         doVerticalNavigation(1);
@@ -178,5 +177,6 @@ export function useButtonDropdown({
     onItemActivate,
     onGroupToggle,
     toggleDropdown,
+    setIsUsingMouse,
   };
 }

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -35,7 +35,7 @@ export function useButtonDropdown({
   const {
     targetItem,
     isHighlighted,
-    isFocused,
+    isKeyboardHighlight,
     isExpanded,
     highlightItem,
     moveHighlight,
@@ -169,7 +169,7 @@ export function useButtonDropdown({
     isOpen,
     targetItem,
     isHighlighted,
-    isFocused,
+    isKeyboardHighlight,
     isExpanded,
     highlightItem,
     onKeyDown,

--- a/src/button-dropdown/utils/use-highlighted-menu.ts
+++ b/src/button-dropdown/utils/use-highlighted-menu.ts
@@ -11,7 +11,6 @@ interface UseHighlightedMenuOptions {
   items: ButtonDropdownProps.Items;
   hasExpandableGroups: boolean;
   isInRestrictedView?: boolean;
-  usingMouse: React.MutableRefObject<boolean>;
 }
 
 interface UseHighlightedMenuApi extends HighlightProps {
@@ -19,27 +18,17 @@ interface UseHighlightedMenuApi extends HighlightProps {
   expandGroup: (group?: ButtonDropdownProps.ItemGroup) => void;
   collapseGroup: () => void;
   reset: () => void;
+  setIsUsingMouse: (isUsingMouse: boolean) => void;
 }
 
 export default function useHighlightedMenu({
   items,
   hasExpandableGroups,
   isInRestrictedView = false,
-  usingMouse,
 }: UseHighlightedMenuOptions): UseHighlightedMenuApi {
-  const [targetIndex, setTargetIndexState] = useState<TreeIndex>([]);
+  const [targetIndex, setTargetIndex] = useState<TreeIndex>([]);
   const [expandedIndex, setExpandedIndex] = useState<TreeIndex>([]);
-  const [isUsingMouse, setIsUsingMouse] = useState<boolean>(usingMouse.current);
-
-  const setTargetIndex = useCallback(
-    (index: TreeIndex) => {
-      if (!indexEquals(index, targetIndex)) {
-        setTargetIndexState(index);
-      }
-      setIsUsingMouse(usingMouse.current);
-    },
-    [usingMouse, targetIndex]
-  );
+  const [isUsingMouse, setIsUsingMouse] = useState<boolean>(true);
 
   const { getItem, getItemIndex, getSequentialIndex, getParentIndex } = useMemo(() => createItemsTree(items), [items]);
 
@@ -98,23 +87,14 @@ export default function useHighlightedMenu({
         setTargetIndex(nextIndex);
       }
     },
-    [
-      targetIndex,
-      expandedIndex,
-      getItem,
-      getSequentialIndex,
-      getParentIndex,
-      hasExpandableGroups,
-      isInRestrictedView,
-      setTargetIndex,
-    ]
+    [targetIndex, expandedIndex, getItem, getSequentialIndex, getParentIndex, hasExpandableGroups, isInRestrictedView]
   );
 
   const highlightItem = useCallback(
     (item: ButtonDropdownProps.ItemOrGroup) => {
       setTargetIndex(getItemIndex(item));
     },
-    [getItemIndex, setTargetIndex]
+    [getItemIndex]
   );
 
   const expandGroup = useCallback(
@@ -126,7 +106,7 @@ export default function useHighlightedMenu({
       setTargetIndex(isInRestrictedView ? groupIndex : firstChildIndex);
       setExpandedIndex(groupIndex);
     },
-    [targetIndex, getItemIndex, isInRestrictedView, setTargetIndex]
+    [targetIndex, getItemIndex, isInRestrictedView]
   );
 
   const collapseGroup = useCallback(() => {
@@ -134,12 +114,12 @@ export default function useHighlightedMenu({
       setTargetIndex(expandedIndex);
       setExpandedIndex(expandedIndex.slice(0, -1));
     }
-  }, [expandedIndex, setTargetIndex]);
+  }, [expandedIndex]);
 
   const reset = useCallback(() => {
     setTargetIndex([]);
     setExpandedIndex([]);
-  }, [setTargetIndex]);
+  }, []);
 
   return {
     targetItem,
@@ -151,5 +131,6 @@ export default function useHighlightedMenu({
     expandGroup,
     collapseGroup,
     reset,
+    setIsUsingMouse,
   };
 }

--- a/src/button-dropdown/utils/use-highlighted-menu.ts
+++ b/src/button-dropdown/utils/use-highlighted-menu.ts
@@ -42,7 +42,8 @@ export default function useHighlightedMenu({
     [targetIndex, getItemIndex]
   );
 
-  const isFocused = useCallback(
+  // check if keyboard focus is on the element
+  const isKeyboardHighlight = useCallback(
     (item: ButtonDropdownProps.ItemOrGroup) => {
       const index = getItemIndex(item);
       return !isUsingMouse && indexEquals(index, targetIndex);
@@ -124,7 +125,7 @@ export default function useHighlightedMenu({
   return {
     targetItem,
     isHighlighted,
-    isFocused,
+    isKeyboardHighlight,
     isExpanded,
     moveHighlight,
     highlightItem,

--- a/src/button-dropdown/utils/use-highlighted-menu.ts
+++ b/src/button-dropdown/utils/use-highlighted-menu.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useMemo, useCallback } from 'react';
 
-import { indexIncludes } from './utils';
+import { indexIncludes, indexEquals } from './utils';
 import { ButtonDropdownProps, HighlightProps } from '../interfaces';
 import createItemsTree, { TreeIndex } from './create-items-tree';
 import moveHighlightOneStep from './move-highlight';
@@ -11,6 +11,7 @@ interface UseHighlightedMenuOptions {
   items: ButtonDropdownProps.Items;
   hasExpandableGroups: boolean;
   isInRestrictedView?: boolean;
+  usingMouse: React.MutableRefObject<boolean>;
 }
 
 interface UseHighlightedMenuApi extends HighlightProps {
@@ -24,6 +25,7 @@ export default function useHighlightedMenu({
   items,
   hasExpandableGroups,
   isInRestrictedView = false,
+  usingMouse,
 }: UseHighlightedMenuOptions): UseHighlightedMenuApi {
   const [targetIndex, setTargetIndex] = useState<TreeIndex>([]);
   const [expandedIndex, setExpandedIndex] = useState<TreeIndex>([]);
@@ -35,10 +37,17 @@ export default function useHighlightedMenu({
   const isHighlighted = useCallback(
     (item: ButtonDropdownProps.ItemOrGroup) => {
       const index = getItemIndex(item);
-
       return indexIncludes(index, targetIndex);
     },
     [targetIndex, getItemIndex]
+  );
+
+  const isFocused = useCallback(
+    (item: ButtonDropdownProps.ItemOrGroup) => {
+      const index = getItemIndex(item);
+      return !usingMouse.current && indexEquals(index, targetIndex);
+    },
+    [targetIndex, getItemIndex, usingMouse]
   );
 
   const isExpanded = useCallback(
@@ -115,6 +124,7 @@ export default function useHighlightedMenu({
   return {
     targetItem,
     isHighlighted,
+    isFocused,
     isExpanded,
     moveHighlight,
     highlightItem,


### PR DESCRIPTION
### Description
Split https://github.com/cloudscape-design/components/pull/56 into buttondropdown and select/multiselect/autosuggest. This is buttondropdown part.

Changes:

1. change to blue border on focused items
2. add more content for screenshot test
3. add unit test 

Why:

to meet a11y color contrast criteria
consistent with other focus indicator in the system
indicate hover focus and select state with more noticeable different style

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

AWSUI-15375


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
