### PR TITLE
feat: Add test-util for split panel header

### DIFF
--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -96,7 +96,7 @@ describe('Split panel', () => {
   describe.each(['bottom', 'side'] as const)('Position %s', position => {
     test('displays header, content and aria-label', () => {
       const { wrapper } = renderSplitPanel({ contextProps: { position } });
-      expect(wrapper.getElement()).toHaveTextContent('Split panel header');
+      expect(wrapper.findHeader().getElement()).toHaveTextContent('Split panel header');
       expect(wrapper.getElement()).toHaveTextContent('Split panel content');
       expect(wrapper.findSlider()!.getElement()).toHaveAttribute('aria-label', 'resizeHandleAriaLabel');
     });

--- a/src/test-utils/dom/split-panel/index.ts
+++ b/src/test-utils/dom/split-panel/index.ts
@@ -7,6 +7,10 @@ import styles from '../../../split-panel/styles.selectors.js';
 export default class SplitPanelWrapper extends ComponentWrapper {
   static rootSelector: string = styles.root;
 
+  findHeader(): ElementWrapper {
+    return this.find(`.${styles['header-text']}`)!;
+  }
+
   findPreferencesButton(): ButtonWrapper | null {
     return this.findComponent(`.${styles['preferences-button']}`, ButtonWrapper);
   }


### PR DESCRIPTION
### Description

Added a test-utility to asset split panel header content

### How has this been tested?

Updated existing unit test to cover this feature

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
