### PR TITLE
fix: Set indeterminate property to true if there are selected items

### DIFF
--- a/src/table/__tests__/selection.test.tsx
+++ b/src/table/__tests__/selection.test.tsx
@@ -114,6 +114,17 @@ describe('Select all checkbox', () => {
   test('indeterminate, when some of the items are selected', () => {
     tableWrapper = renderTable({ selectionType: 'multi', selectedItems: [items[1]] }).wrapper;
     expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('indeterminate', true);
+    expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('checked', false);
+  });
+  test('indetermunate, when there are selected items that do not match the items list', () => {
+    tableWrapper = renderTable({ selectionType: 'multi', selectedItems: [{ id: 4, name: 'Apples' }] }).wrapper;
+    expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('indeterminate', true);
+    expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('checked', false);
+  });
+  test('unchecked, when none of the items are selected', () => {
+    tableWrapper = renderTable({ selectionType: 'multi', selectedItems: [] }).wrapper;
+    expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('indeterminate', false);
+    expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('checked', false);
   });
   test('disabled, when every item is disabled', () => {
     tableWrapper = renderTable({ selectionType: 'multi', isItemDisabled: () => true }).wrapper;

--- a/src/table/__tests__/selection.test.tsx
+++ b/src/table/__tests__/selection.test.tsx
@@ -116,7 +116,7 @@ describe('Select all checkbox', () => {
     expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('indeterminate', true);
     expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('checked', false);
   });
-  test('indetermunate, when there are selected items that do not match the items list', () => {
+  test('indeterminate, when there are selected items that do not match the items list', () => {
     tableWrapper = renderTable({ selectionType: 'multi', selectedItems: [{ id: 4, name: 'Apples' }] }).wrapper;
     expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('indeterminate', true);
     expect(getSelectAllInput(tableWrapper)?.getElement()).toHaveProperty('checked', false);

--- a/src/table/use-selection.ts
+++ b/src/table/use-selection.ts
@@ -103,22 +103,23 @@ export function useSelection<T>({
     disabled: isItemDisabled(item),
     selected: isItemSelected(item),
   });
-  const [allDisabled, allEnabledSelected, hasSelected] = selectionType
+  const [allDisabled, allEnabledSelected] = selectionType
     ? items.reduce(
-        ([allDisabled, allEnabledSelected, hasSelected], item) => {
+        ([allDisabled, allEnabledSelected], item) => {
           const { disabled, selected } = getItemState(item);
           return [
             // all items are disabled (or none are present)
             allDisabled && disabled,
             // all enabled items are selected (or none are present)
             allEnabledSelected && (selected || disabled),
-            // the page has at least one selected item
-            hasSelected || selected,
           ];
         },
-        [true, true, false]
+        [true, true]
       )
-    : [true, true, false];
+    : [true, true];
+
+  // the page has at least one selected item
+  const hasSelected = finalSelectedItems.length > 0;
 
   const handleToggleAll = () => {
     const requestedItems = new ItemSet(trackBy, items);


### PR DESCRIPTION

### Description
This solves an issue when the user has a pagination with checkboxes in the table and tries to select an item and then go the next page, in this case the checkbox in the table's header will not be selected and this is not desired.



### How has this been tested?

To test the problem you can go to `light/table/sticky-header-scrollable-container` page and try with/without this change.

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
