### PR TITLE
chore: Adjust large popover max-width on smaller viewports

### DIFF
--- a/pages/popover/scenarios.page.tsx
+++ b/pages/popover/scenarios.page.tsx
@@ -81,6 +81,7 @@ export default function () {
               position="bottom"
               size="large"
               fixedWidth={true}
+              id="large-popover"
               header="Network interface eth0"
               content={<KeyValuePair />}
               dismissAriaLabel="Close"

--- a/src/popover/__integ__/popover-placement.test.ts
+++ b/src/popover/__integ__/popover-placement.test.ts
@@ -155,3 +155,25 @@ describe('Fallback to vertical placement in mobile', () => {
     );
   }
 });
+
+test(
+  `Large size popover should fallback to medium size in mobile`,
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/popover/scenarios');
+
+    const wrapper = createWrapper();
+    const largePopover = wrapper.findPopover('#large-popover');
+    const triggerSelector = largePopover.findTrigger().toSelector();
+    const containerSelector = largePopover.findByClassName(styles.container).toSelector();
+    await page.click(triggerSelector);
+    const { width: desktopContainerWidth } = await page.getBoundingBox(containerSelector);
+    expect(desktopContainerWidth).toEqual(480);
+
+    // Set mobile window size
+    const [width, height] = VIEWPORT_MOBILE;
+    await page.setWindowSize({ width, height });
+    const { width: mobileContainerWidth } = await page.getBoundingBox(containerSelector);
+    expect(mobileContainerWidth).toEqual(310);
+  })
+);

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -44,6 +44,10 @@
 
 .body-size-large {
   max-width: 480px;
+  @media (max-width: 480px) {
+    // On viewports smaller than 480px, we default to the body-size-medium width
+    max-width: 310px;
+  }
   &.fixed-width {
     width: 480px;
   }


### PR DESCRIPTION
### Description

Changed the `max-width` of the `large` Popover in smaller viewports.

### How has this been tested?

[_How did you test to verify your changes?_]
Locally, existing tests and new test for the smaller viewport.

[_How can reviewers test these changes efficiently?_]
Use the `Popover` component with `size="large"` and set your viewport width to 400px.


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-19009

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
