### PR TITLE
fix: Ensure split panel resizes content area correctly when repositioned

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -57,6 +57,12 @@ class AppLayoutSplitViewPage extends BasePageObject {
   getSplitPanelSize() {
     return this.getBoundingBox(wrapper.findSplitPanel().toSelector());
   }
+
+  getContentMarginBottom() {
+    return this.browser.execute(contentRegion => {
+      return document.querySelector(contentRegion)?.parentElement?.parentElement?.style.marginBottom;
+    }, wrapper.findContentRegion().toSelector());
+  }
 }
 
 function setupTest(
@@ -185,4 +191,23 @@ test(
     await page.dragResizerTo({ x: 0, y: height });
     await expect(page.getPanelPosition()).resolves.toEqual('bottom');
   })
+);
+
+test(
+  'should resize main content area when switching to side',
+  setupTest(async page => {
+    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
+    await page.switchPosition('Side');
+    await expect(page.getContentMarginBottom()).resolves.toEqual('');
+  }, '#/light/app-layout/with-full-page-table-and-split-panel')
+);
+
+test(
+  'should resize main content area when switching to side then back to bottom',
+  setupTest(async page => {
+    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
+    await page.switchPosition('Side');
+    await page.switchPosition('Bottom');
+    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
+  }, '#/light/app-layout/with-full-page-table-and-split-panel')
 );

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -165,7 +165,6 @@ const OldAppLayout = React.forwardRef(
       disableBodyScroll
     );
     const [notificationsHeight, notificationsRef] = useContainerQuery(rect => rect.height);
-    const [splitPanelHeight, splitPanelRef] = useContainerQuery(rect => (splitPanel ? rect.height : 0), [splitPanel]);
     const [splitPanelHeaderHeight, splitPanelHeaderMeasureRef] = useContainerQuery(
       rect => (splitPanel ? rect.height : 0),
       [splitPanel]
@@ -187,6 +186,12 @@ const OldAppLayout = React.forwardRef(
       }
     );
     const splitPanelPosition = splitPanelPreferences?.position || 'bottom';
+
+    const [splitPanelHeight, splitPanelRef] = useContainerQuery(
+      rect => (splitPanel ? rect.height : 0),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [splitPanel, splitPanelPosition]
+    );
 
     const closedDrawerWidth = 40;
     const effectiveNavigationWidth = navigationHide ? 0 : navigationOpen ? navigationWidth : closedDrawerWidth;


### PR DESCRIPTION
### Description

Fix bug (AWSUI-19070) where AppLayout content would be hidden by split panel when it's repositioned

### How has this been tested?

[_How did you test to verify your changes?_]

Tested locally & new integ test

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
