### PR TITLE
fix(link): Prevent external icon from wrapping to the next line

### DIFF
--- a/pages/link/permutations.page.tsx
+++ b/pages/link/permutations.page.tsx
@@ -28,6 +28,13 @@ const permutations = createPermutations<LinkProps>([
   },
 ]);
 
+const narrowIconPermutations = createPermutations<LinkProps>([
+  {
+    href: ['#', undefined],
+    children: ['Short', 'Hello world', 'Reallylongstringthatcannotwraptothenextline'],
+  },
+]);
+
 export default function LinkPermutations() {
   return (
     <>
@@ -38,6 +45,16 @@ export default function LinkPermutations() {
           render={permutation => (
             <div className={clsx(permutation.color === 'inverted' && styles['container-inverted'])}>
               <Link {...permutation} externalIconAriaLabel={`Opens in a new tab`}>
+                {permutation.children}
+              </Link>
+            </div>
+          )}
+        />
+        <PermutationsView
+          permutations={narrowIconPermutations}
+          render={permutation => (
+            <div className={styles.narrow}>
+              <Link {...permutation} external={true} externalIconAriaLabel={`Opens in a new tab`}>
                 {permutation.children}
               </Link>
             </div>

--- a/pages/link/styles.scss
+++ b/pages/link/styles.scss
@@ -10,3 +10,8 @@
   padding: 5px;
   background-color: tokens.$color-background-notification-blue;
 }
+
+.narrow {
+  border: 1px solid red;
+  max-width: 12ch;
+}

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -98,8 +98,8 @@ const InternalLink = React.forwardRef(
       <>
         {children}
         {external && (
-          <>
-            {' '}
+          <span className={styles['icon-wrapper']}>
+            &nbsp;
             <span
               className={styles.icon}
               aria-label={externalIconAriaLabel}
@@ -107,7 +107,7 @@ const InternalLink = React.forwardRef(
             >
               <InternalIcon name="external" size="inherit" />
             </span>
-          </>
+          </span>
         )}
       </>
     );

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -50,6 +50,10 @@ $font-sizes: ('body-s', 'body-m', 'heading-xs', 'heading-s', 'heading-m', 'headi
   }
 }
 
+.icon-wrapper {
+  white-space: nowrap;
+}
+
 .icon {
   display: inline-block;
 }


### PR DESCRIPTION
### Description

Add a whitespace: nowrap wrapper around the space between the text and the external icon.

Because having an external icon on its own line is a little unsightly.

### How has this been tested?

Added permutations to the link permutation page.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

- AWSUI-19054

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
