### PR TITLE
fix use or ariaLabels and item types on table pages

### DIFF
--- a/pages/table/events.page.tsx
+++ b/pages/table/events.page.tsx
@@ -5,12 +5,9 @@ import Header from '~components/header';
 import Table, { TableProps } from '~components/table';
 import { NonCancelableCustomEvent } from '~components/interfaces';
 import range from 'lodash/range';
-import { ariaLabels } from './shared-configs';
+import { ariaLabels, Item } from './shared-configs';
 const items = createSimpleItems(5);
-interface Item {
-  number: number;
-  text: string;
-}
+
 function createSimpleItems(count: number): Item[] {
   const texts = ['One', 'Two', 'Three', 'Four', 'Five'];
   return range(count).map(number => ({ number, text: texts[number % texts.length] }));

--- a/pages/table/resizable-columns-permutations.page.tsx
+++ b/pages/table/resizable-columns-permutations.page.tsx
@@ -6,30 +6,25 @@ import Table, { TableProps } from '~components/table';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
-import { ariaLabels } from './shared-configs';
-
-interface Item {
-  id: number;
-  text: string;
-}
+import { ariaLabels, Item } from './shared-configs';
 
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<TableProps<Item>>([
   {
     selectionType: ['single', undefined],
     resizableColumns: [true, false],
-    items: [[{ id: 1, text: 'Dummy item' }]],
+    items: [[{ number: 1, text: 'Dummy item' }]],
     columnDefinitions: [
       [
-        { header: 'fixed width', cell: item => <Link>{item.id}</Link>, width: 100, minWidth: 80 },
+        { header: 'fixed width', cell: item => <Link>{item.number}</Link>, width: 100, minWidth: 80 },
         { header: 'auto-grow', cell: () => '-' },
       ],
       [
-        { header: 'fixed width', cell: item => <Link>{item.id}</Link>, width: 800 },
+        { header: 'fixed width', cell: item => <Link>{item.number}</Link>, width: 800 },
         { header: 'with overflow', cell: () => '-', width: 500 },
       ],
       [
-        { header: 'fixed width', cell: item => <Link>{item.id}</Link>, width: 600 },
+        { header: 'fixed width', cell: item => <Link>{item.number}</Link>, width: 600 },
         { header: 'no width', cell: item => item.text },
         { header: 'fixed with', cell: () => '-', width: 600 },
       ],

--- a/pages/table/shared-configs.tsx
+++ b/pages/table/shared-configs.tsx
@@ -95,7 +95,7 @@ export const paginationLabels: PaginationProps.Labels = {
   previousPageLabel: 'Previous page',
 };
 
-export const ariaLabels: Required<TableProps<{ text: string }>>['ariaLabels'] = {
+export const ariaLabels: Required<TableProps<Item>>['ariaLabels'] = {
   selectionGroupLabel: 'group label',
   allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item selected`,
   itemSelectionLabel: ({ selectedItems }, item) =>


### PR DESCRIPTION
### Description

Unify use of shared `ariaLabels` value and item type. The `T` in `TableProps.AriaLabels<T>` and `TableProps<T>` should match. But because we are using a shared `ariaLabels` object on different tables and types did not always match, before this PR.

Typescript currently does not catch this issue, but it will be after I add some more changes in the future PRs

### How has this been tested?

Build passes

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
