### PR TITLE
Use iso dates in date input

### DIFF
--- a/pages/date-input/permutations.page.tsx
+++ b/pages/date-input/permutations.page.tsx
@@ -10,7 +10,7 @@ import Box from '~components/box';
 
 const permutations = createPermutations<DateInputProps>([
   {
-    value: ['', '2020/01/01'],
+    value: ['', '2020-01-01'],
     placeholder: ['', 'YYYY/MM/DD'],
     ariaLabel: ['Some label'],
     invalid: [false, true],

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -7,7 +7,7 @@ import { DatePickerProps } from './interfaces';
 import Calendar from './calendar';
 import { normalizeLocale } from './calendar/utils/locales';
 import { getDateLabel } from './calendar/utils/intl';
-import { displayToIso, isoToDisplay, memoizedDate } from './calendar/utils/date';
+import { memoizedDate } from './calendar/utils/date';
 import { InputProps } from '../input/interfaces';
 import { KeyCode } from '../internal/keycode';
 import { fireNonCancelableEvent } from '../internal/events';
@@ -105,8 +105,7 @@ const DatePicker = React.forwardRef(
     };
 
     const onInputChangeHandler: InputProps['onChange'] = event => {
-      const isoDateString = displayToIso(event.detail.value);
-      fireNonCancelableEvent(onChange, { value: isoDateString });
+      fireNonCancelableEvent(onChange, { value: event.detail.value });
     };
 
     const onInputBlurHandler: InputProps['onBlur'] = () => {
@@ -127,7 +126,7 @@ const DatePicker = React.forwardRef(
             ariaDescribedby={ariaDescribedby}
             ariaLabel={ariaLabel}
             ariaRequired={ariaRequired}
-            value={isoToDisplay(value)}
+            value={value}
             autoComplete={false}
             disableBrowserAutocorrect={true}
             disableAutocompleteOnBlur={isDropDownOpen}

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -9,11 +9,9 @@ import CalendarHeader from './header';
 import { Grids, selectFocusedDate } from './grids';
 import moveFocusHandler from '../../date-picker/calendar/utils/move-focus-handler';
 import {
-  displayToIso,
   formatDate,
   formatTime,
   formatISOStringWithoutTimezone,
-  isoToDisplay,
   parseDate,
 } from '../../date-picker/calendar/utils/date';
 import InternalSpaceBetween from '../../space-between/internal';
@@ -271,18 +269,16 @@ function Calendar(
   };
 
   const onChangeStartDate: InputProps['onChange'] = e => {
-    const isoDateString = displayToIso(e.detail.value);
-    setStartDateString(isoDateString);
+    setStartDateString(e.detail.value);
 
-    if (isoDateString.length >= 8) {
-      const newCurrentMonth = startOfMonth(parseDate(isoDateString));
+    if (e.detail.value.length >= 8) {
+      const newCurrentMonth = startOfMonth(parseDate(e.detail.value));
       setCurrentMonth(isSingleGrid ? newCurrentMonth : addMonths(newCurrentMonth, 1));
     }
   };
 
   const onChangeEndDate: InputProps['onChange'] = e => {
-    const isoDateString = displayToIso(e.detail.value);
-    setEndDateString(isoDateString);
+    setEndDateString(e.detail.value);
   };
 
   let constrainttextId = useUniqueId('awsui-area-date-range-picker');
@@ -329,7 +325,7 @@ function Calendar(
               <div className={styles['date-and-time-wrapper__date']}>
                 <InternalFormField label={i18nStrings.startDateLabel} stretch={true}>
                   <DateInput
-                    value={isoToDisplay(startDateString)}
+                    value={startDateString}
                     autoComplete={false}
                     disableBrowserAutocorrect={true}
                     disableAutocompleteOnBlur={false}
@@ -360,7 +356,7 @@ function Calendar(
               <div className={styles['date-and-time-wrapper__date']}>
                 <InternalFormField label={i18nStrings.endDateLabel} stretch={true}>
                   <DateInput
-                    value={isoToDisplay(endDateString)}
+                    value={endDateString}
                     autoComplete={false}
                     disableBrowserAutocorrect={true}
                     disableAutocompleteOnBlur={false}

--- a/src/internal/components/date-input/__tests__/date-input.test.tsx
+++ b/src/internal/components/date-input/__tests__/date-input.test.tsx
@@ -56,12 +56,9 @@ describe('Date Input component', () => {
     expect(inputElement).toHaveAttribute('id', 'custom-id');
   });
 
-  // We expect DatePicker to handle replacing the separator
-  test('does not autoformat dates with / in place of -', () => {
-    const { wrapper } = renderDateInput({
-      value: '2018-01-02',
-    });
-    expect(wrapper.findNativeInput().getElement().value).toBe('2018/');
+  test('does accept values in ISO format', () => {
+    const { wrapper } = renderDateInput({ value: '2018-01-02' });
+    expect(wrapper.findNativeInput().getElement().value).toBe('2018/01/02');
   });
 
   test('should not limit pasted value by the current month', () => {
@@ -76,7 +73,7 @@ describe('Date Input component', () => {
 
     expect(onChangeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        detail: { value: '2019/03/30' },
+        detail: { value: '2019-03-30' },
       })
     );
   });
@@ -115,7 +112,7 @@ describe('Date Input component', () => {
         });
 
         wrapper.findNativeInput().keydown({ key: separatorKey });
-        expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2001/' } }));
+        expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2001-' } }));
       });
     });
 
@@ -125,7 +122,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '3' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/02/03' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-02-03' } }));
     });
 
     test('should correct "2" to "2002/01/01" on enter', () => {
@@ -134,7 +131,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: 'Enter', keyCode: KeyCode.enter });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2002/01/01' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2002-01-01' } }));
     });
 
     test('should correct "21" to "2021/01/01" on enter', () => {
@@ -143,7 +140,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: 'Enter', keyCode: KeyCode.enter });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2021/01/01' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2021-01-01' } }));
     });
   });
 
@@ -154,7 +151,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '/' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2001/' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2001-' } }));
     });
 
     test('should correct "2018/1/" to "2018/01/"', () => {
@@ -163,7 +160,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '/' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/01/' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-01-' } }));
     });
 
     test('should correct "2018/0/" to "2018/01/"', () => {
@@ -172,7 +169,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '/' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/01/' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-01-' } }));
     });
 
     test('should correct "2018/1/2" to "2018/01/02"', () => {
@@ -181,7 +178,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '/' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/01/02' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-01-02' } }));
     });
 
     test('should allow entry of day 31 in January', () => {
@@ -190,7 +187,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '1' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/01/31' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-01-31' } }));
     });
 
     test('should allow entry of day 30 in March', () => {
@@ -199,7 +196,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '0' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/03/30' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-03-30' } }));
     });
 
     test('should disallow entry of day 31 in April', () => {
@@ -207,7 +204,7 @@ describe('Date Input component', () => {
         value: '2018/04/3',
       });
       wrapper.findNativeInput().keydown({ key: '1' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/04/30' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-04-30' } }));
     });
 
     test('should disallow entry of day 29 in february', () => {
@@ -216,7 +213,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '9' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/02/28' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-02-28' } }));
     });
 
     test('should allow entry of day 29 in february, in a leap year', () => {
@@ -225,7 +222,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '9' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2020/02/29' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2020-02-29' } }));
     });
   }); // End limiting range
 
@@ -236,7 +233,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '8' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-' } }));
     });
 
     test('should automatically append colon after 6 digits entered', () => {
@@ -245,7 +242,7 @@ describe('Date Input component', () => {
       });
 
       wrapper.findNativeInput().keydown({ key: '1' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/11/' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-11-' } }));
     });
   }); // End appending separator
 
@@ -257,7 +254,7 @@ describe('Date Input component', () => {
 
       wrapper.findNativeInput().getElement().setSelectionRange(3, 3);
       wrapper.findNativeInput().keydown({ key: '9' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019/01/02' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019-01-02' } }));
     });
 
     test('should autocorrect if value is over limit', () => {
@@ -267,7 +264,7 @@ describe('Date Input component', () => {
 
       wrapper.findNativeInput().getElement().setSelectionRange(5, 5);
       wrapper.findNativeInput().keydown({ key: '5' });
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018/12/02' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2018-12-02' } }));
     });
 
     test('should swallow keys at separator - /', () => {
@@ -302,7 +299,7 @@ describe('Date Input component', () => {
       wrapper.findNativeInput().getElement().setSelectionRange(3, 7);
       wrapper.findNativeInput().keydown({ key: '9' });
 
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019/01/02' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019-01-02' } }));
     });
 
     test('should autocorrect day if month is changed to one with fewer days - 30', () => {
@@ -313,7 +310,7 @@ describe('Date Input component', () => {
       wrapper.findNativeInput().getElement().setSelectionRange(6, 6);
       wrapper.findNativeInput().keydown({ key: '4' });
 
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019/04/30' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019-04-30' } }));
     });
 
     test('should autocorrect day if month is changed to one with fewer days - 28', () => {
@@ -323,7 +320,7 @@ describe('Date Input component', () => {
       wrapper.findNativeInput().getElement().setSelectionRange(6, 6);
       wrapper.findNativeInput().keydown({ key: '2' });
 
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019/02/28' } }));
+      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { value: '2019-02-28' } }));
     });
   }); // end entering value in middle of input
 });

--- a/src/internal/components/date-input/index.tsx
+++ b/src/internal/components/date-input/index.tsx
@@ -1,13 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { Ref } from 'react';
+import { fireNonCancelableEvent } from '../../events';
 
 import MaskedInput from '../masked-input';
 import { MaskArgs } from '../masked-input/utils/mask-format';
 
 import { DateInputProps } from './interfaces';
 
-import { daysInMonth, parseDate, displayToIso } from './utils/date';
+import { daysInMonth, parseDate, displayToIso, isoToDisplay } from './utils/date';
+
+export { DateInputProps };
 
 function daysMax(value: string): number {
   // force to first day in month, as new Date('2018-02-30') -> March 2nd 2018
@@ -26,9 +29,11 @@ const maskArgs: MaskArgs = {
 };
 
 const DateInput = React.forwardRef(
-  ({ __internalRootRef = null, ...props }: DateInputProps, ref: Ref<DateInputProps.Ref>) => {
+  ({ __internalRootRef = null, value, onChange, ...props }: DateInputProps, ref: Ref<DateInputProps.Ref>) => {
     return (
       <MaskedInput
+        value={isoToDisplay(value)}
+        onChange={event => fireNonCancelableEvent(onChange, { value: displayToIso(event.detail.value) })}
         {...props}
         ref={ref}
         disableBrowserAutocorrect={true}
@@ -40,5 +45,4 @@ const DateInput = React.forwardRef(
   }
 );
 
-export { DateInputProps };
 export default DateInput;


### PR DESCRIPTION
### Description

Use iso dates in date input to avoid conversion on the consumer side. Necessary to make different date components compatible, (see [example](https://github.com/cloudscape-design/components/pull/166/files#diff-4d9ae9648adfb58e4bcf4f9f26729adc8aef14f7491b76f79981f43f56ef8e7aR1106)).

### How has this been tested?

Updated existing unit tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
