### PR TITLE
Add charts thresholds examples for time scale

### DIFF
--- a/pages/mixed-line-bar-chart/thresholds.page.tsx
+++ b/pages/mixed-line-bar-chart/thresholds.page.tsx
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import Container from '~components/container';
-import Header from '~components/header';
 import Grid from '~components/grid';
 import Box from '~components/box';
 import MixedLineBarChart from '~components/mixed-line-bar-chart';
+import LineChart from '~components/line-chart';
 import ScreenshotArea from '../utils/screenshot-area';
 import { colorChartsThresholdInfo, colorChartsThresholdPositive, colorChartsThresholdNegative } from '~design-tokens';
 
 import {
+  latencyData,
+  dateTimeFormatter,
   data1,
   data2,
   data3,
@@ -32,183 +33,186 @@ export default function () {
           { colspan: { default: 12, s: 6 } },
           { colspan: { default: 12, s: 6 } },
           { colspan: { default: 12, s: 6 } },
-          { colspan: { default: 12, s: 4 } },
-          { colspan: { default: 12, s: 4 } },
-          { colspan: { default: 12, s: 4 } },
+          { colspan: { default: 12, s: 6 } },
+          { colspan: { default: 12, s: 6 } },
+          { colspan: { default: 12, s: 6 } },
+          { colspan: { default: 12, s: 6 } },
           { colspan: { default: 12, s: 6 } },
         ]}
       >
-        <Container header={<Header variant="h2">Line chart </Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              { title: 'Series 1', type: 'line', data: data1 },
-              { title: 'Series 2', type: 'line', data: data2 },
-              { title: 'Threshold', type: 'threshold', y: 150 },
-              { title: 'Negative', type: 'threshold', x: 7, color: colorChartsThresholdNegative },
-              { title: 'Info', type: 'threshold', x: 8.5, color: colorChartsThresholdInfo },
-              { title: 'Positive', type: 'threshold', x: 9.3, color: colorChartsThresholdPositive },
-            ]}
-            xDomain={[0, data1.length]}
-            yDomain={[-30, 300]}
-            xTitle="Time"
-            yTitle="Latency (ms)"
-            xScaleType="linear"
-            ariaLabel="Line chart"
-            ariaDescription={`Arbitrary line chart about latency. ${lineChartInstructions}`}
-          />
-        </Container>
+        <LineChart
+          {...commonProps}
+          height={250}
+          ariaLabel="Time-based line chart"
+          series={[
+            { title: 'Latency', type: 'line', data: latencyData.map(({ time, p90 }) => ({ x: time, y: p90 })) },
+            { title: 'Event 1', type: 'threshold', x: latencyData[15].time },
+            { title: 'Event 2', type: 'threshold', x: new Date(latencyData[15].time.getTime() + 90 * 60 * 1000) },
+          ]}
+          xDomain={[latencyData[0].time, latencyData[latencyData.length - 1].time]}
+          yDomain={[100, 300]}
+          xScaleType="time"
+          xTitle="X value"
+          yTitle="Y value"
+          i18nStrings={{ ...commonProps.i18nStrings, xTickFormatter: dateTimeFormatter }}
+          ariaDescription={lineChartInstructions}
+        />
 
-        <Container header={<Header variant="h2">Mixed chart</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              { title: 'Calories', type: 'bar', data: data3 },
-              { title: 'Happiness', type: 'line', data: data5 },
-              { title: 'Careful', type: 'threshold', x: 'Chocolate', color: colorChartsThresholdNegative },
-              { title: 'Yellow', type: 'threshold', x: 'Bananas', color: '#eebb01' },
-              { title: 'Threshold', type: 'threshold', y: 300 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Potatoes', 'Bananas', 'Chocolate']}
-            yDomain={[0, 700]}
-            xTitle="Food"
-            yTitle="Calories (kcal)"
-            xScaleType="categorical"
-            ariaLabel="Mixed chart"
-            ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            { title: 'Series 1', type: 'line', data: data1 },
+            { title: 'Series 2', type: 'line', data: data2 },
+            { title: 'Threshold', type: 'threshold', y: 150 },
+            { title: 'Negative', type: 'threshold', x: 7, color: colorChartsThresholdNegative },
+            { title: 'Info', type: 'threshold', x: 8.5, color: colorChartsThresholdInfo },
+            { title: 'Positive', type: 'threshold', x: 9.3, color: colorChartsThresholdPositive },
+          ]}
+          xDomain={[0, data1.length]}
+          yDomain={[-30, 300]}
+          xTitle="Time"
+          yTitle="Latency (ms)"
+          xScaleType="linear"
+          ariaLabel="Line chart"
+          ariaDescription={`Arbitrary line chart about latency. ${lineChartInstructions}`}
+        />
 
-        <Container header={<Header variant="h2">Bar chart horizontal</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              { title: 'Calories', type: 'bar', data: data3 },
-              { title: 'Careful', type: 'threshold', x: 'Chocolate', color: colorChartsThresholdNegative },
-              { title: 'Yellow', type: 'threshold', x: 'Bananas', color: '#eebb01' },
-              { title: 'Threshold', type: 'threshold', y: 300 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Potatoes', 'Bananas', 'Chocolate']}
-            yDomain={[0, 700]}
-            xTitle="Food"
-            yTitle="Calories (kcal)"
-            xScaleType="categorical"
-            ariaLabel="Bar chart horizontal"
-            ariaDescription={`Arbitrary bar chart about food. ${barChartInstructions}`}
-            horizontalBars={true}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            { title: 'Calories', type: 'bar', data: data3 },
+            { title: 'Happiness', type: 'line', data: data5 },
+            { title: 'Careful', type: 'threshold', x: 'Chocolate', color: colorChartsThresholdNegative },
+            { title: 'Yellow', type: 'threshold', x: 'Bananas', color: '#eebb01' },
+            { title: 'Threshold', type: 'threshold', y: 300 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Potatoes', 'Bananas', 'Chocolate']}
+          yDomain={[0, 700]}
+          xTitle="Food"
+          yTitle="Calories (kcal)"
+          xScaleType="categorical"
+          ariaLabel="Mixed chart"
+          ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
+        />
 
-        <Container header={<Header variant="h2">Stacked bar chart</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              ...multipleBarsData,
-              {
-                type: 'line',
-                title: 'foo',
-                data: [
-                  { x: 'Apples', y: 7 },
-                  { x: 'Oranges', y: 5 },
-                ],
-              },
-              { type: 'threshold', title: 'citrus', x: 'Oranges' },
-              { title: 'Threshold', type: 'threshold', y: 6 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
-            yDomain={[0, 12]}
-            xTitle="Food"
-            yTitle="Consumption"
-            xScaleType="categorical"
-            stackedBars={true}
-            ariaLabel="Stacked Bar Chart"
-            ariaDescription={`Arbitrary stacked bar chart. ${barChartInstructions}`}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            { title: 'Calories', type: 'bar', data: data3 },
+            { title: 'Careful', type: 'threshold', x: 'Chocolate', color: colorChartsThresholdNegative },
+            { title: 'Yellow', type: 'threshold', x: 'Bananas', color: '#eebb01' },
+            { title: 'Threshold', type: 'threshold', y: 300 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Potatoes', 'Bananas', 'Chocolate']}
+          yDomain={[0, 700]}
+          xTitle="Food"
+          yTitle="Calories (kcal)"
+          xScaleType="categorical"
+          ariaLabel="Bar chart horizontal"
+          ariaDescription={`Arbitrary bar chart about food. ${barChartInstructions}`}
+          horizontalBars={true}
+        />
 
-        <Container header={<Header variant="h2">Stacked bar chart horizontal</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              ...multipleBarsData,
-              { type: 'threshold', title: 'citrus', x: 'Oranges' },
-              { title: 'Threshold', type: 'threshold', y: 6 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
-            yDomain={[0, 12]}
-            xTitle="Food"
-            yTitle="Consumption"
-            xScaleType="categorical"
-            stackedBars={true}
-            ariaLabel="Stacked bar chart horizontal"
-            ariaDescription={`Arbitrary stacked bar chart. ${barChartInstructions}`}
-            horizontalBars={true}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            ...multipleBarsData,
+            {
+              type: 'line',
+              title: 'foo',
+              data: [
+                { x: 'Apples', y: 7 },
+                { x: 'Oranges', y: 5 },
+              ],
+            },
+            { type: 'threshold', title: 'citrus', x: 'Oranges' },
+            { title: 'Threshold', type: 'threshold', y: 6 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
+          yDomain={[0, 12]}
+          xTitle="Food"
+          yTitle="Consumption"
+          xScaleType="categorical"
+          stackedBars={true}
+          ariaLabel="Stacked Bar Chart"
+          ariaDescription={`Arbitrary stacked bar chart. ${barChartInstructions}`}
+        />
 
-        <Container header={<Header variant="h2">Grouped bar chart</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              ...multipleBarsData,
-              { type: 'threshold', title: 'citrus', x: 'Oranges' },
-              { title: 'Threshold', type: 'threshold', y: 6 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
-            yDomain={[0, 12]}
-            xTitle="Food"
-            yTitle="Consumption"
-            xScaleType="categorical"
-            ariaLabel="Grouped bar chart"
-            ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            ...multipleBarsData,
+            { type: 'threshold', title: 'citrus', x: 'Oranges' },
+            { title: 'Threshold', type: 'threshold', y: 6 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
+          yDomain={[0, 12]}
+          xTitle="Food"
+          yTitle="Consumption"
+          xScaleType="categorical"
+          stackedBars={true}
+          ariaLabel="Stacked bar chart horizontal"
+          ariaDescription={`Arbitrary stacked bar chart. ${barChartInstructions}`}
+          horizontalBars={true}
+        />
 
-        <Container header={<Header variant="h2">Grouped bar chart horizontal</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              ...multipleBarsData,
-              { type: 'threshold', title: 'citrus', x: 'Oranges' },
-              { title: 'Threshold', type: 'threshold', y: 6 },
-            ]}
-            xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
-            yDomain={[0, 12]}
-            xTitle="Food"
-            yTitle="Consumption"
-            xScaleType="categorical"
-            ariaLabel="Grouped bar chart"
-            ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
-            horizontalBars={true}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            ...multipleBarsData,
+            { type: 'threshold', title: 'citrus', x: 'Oranges' },
+            { title: 'Threshold', type: 'threshold', y: 6 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
+          yDomain={[0, 12]}
+          xTitle="Food"
+          yTitle="Consumption"
+          xScaleType="categorical"
+          ariaLabel="Grouped bar chart"
+          ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
+        />
 
-        <Container header={<Header variant="h2">Dense bar chart</Header>}>
-          <MixedLineBarChart
-            {...commonProps}
-            height={250}
-            series={[
-              { title: 'Values', type: 'bar', data: data6 },
-              { title: 'Upper limit', type: 'threshold', y: 150 },
-              { title: 'Left', type: 'threshold', x: 50.5, color: colorChartsThresholdNegative },
-              { title: 'Center', type: 'threshold', x: 52.5, color: colorChartsThresholdInfo },
-              { title: 'Right', type: 'threshold', x: 55, color: colorChartsThresholdNegative },
-            ]}
-            xDomain={[...data6.map(d => d.x), 50.5, 52.5].sort()}
-            xTitle="Index"
-            yTitle="Value"
-            xScaleType="categorical"
-            ariaLabel="Dense bar chart"
-            ariaDescription={`Dense bar chart. ${barChartInstructions}`}
-          />
-        </Container>
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            ...multipleBarsData,
+            { type: 'threshold', title: 'citrus', x: 'Oranges' },
+            { title: 'Threshold', type: 'threshold', y: 6 },
+          ]}
+          xDomain={['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']}
+          yDomain={[0, 12]}
+          xTitle="Food"
+          yTitle="Consumption"
+          xScaleType="categorical"
+          ariaLabel="Grouped bar chart"
+          ariaDescription={`Arbitrary mixed chart about food. ${barChartInstructions}`}
+          horizontalBars={true}
+        />
+
+        <MixedLineBarChart
+          {...commonProps}
+          height={250}
+          series={[
+            { title: 'Values', type: 'bar', data: data6 },
+            { title: 'Upper limit', type: 'threshold', y: 150 },
+            { title: 'Left', type: 'threshold', x: 50.5, color: colorChartsThresholdNegative },
+            { title: 'Center', type: 'threshold', x: 52.5, color: colorChartsThresholdInfo },
+            { title: 'Right', type: 'threshold', x: 55, color: colorChartsThresholdNegative },
+          ]}
+          xDomain={[...data6.map(d => d.x), 50.5, 52.5].sort()}
+          xTitle="Index"
+          yTitle="Value"
+          xScaleType="categorical"
+          ariaLabel="Dense bar chart"
+          ariaDescription={`Dense bar chart. ${barChartInstructions}`}
+        />
       </Grid>
     </ScreenshotArea>
   );


### PR DESCRIPTION
### Description

Add charts thresholds examples for time scale. The time scale is different as the dates are compared by reference.

### How has this been tested?

Manual tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
