### PR TITLE
Enable html validator element-permitted-content rule

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -23,9 +23,8 @@ const htmlValidator = new HtmlValidate({
     'valid-id': ['error', { relaxed: true }],
     'no-inline-style': 'off',
     'prefer-native-element': ['error', { exclude: ['listbox'] }],
-    //TODO: enable 'no-redundant-for' and 'element-permitted-content' after fixing Toggle
+    //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
     'no-redundant-for': 'off',
-    'element-permitted-content': 'off',
   },
 });
 

--- a/src/__tests__/test-a11y-validator.test.tsx
+++ b/src/__tests__/test-a11y-validator.test.tsx
@@ -25,9 +25,10 @@ describe('a11y validator', () => {
         <input id="my-field" type="text" />
       </label>
     );
-    // TODO: add <div> element is not permitted as content under <label> error when element-permitted-content is enabled
     await expect(expect(container).toValidateA11y()).rejects.toThrow(
-      'Expected HTML to be valid but had the following errors:\n1. <label> is associated with multiple controls [multiple-labeled-controls]'
+      new Error(
+        'Expected HTML to be valid but had the following errors:\n1. <label> is associated with multiple controls [multiple-labeled-controls]\n2. <div> element is not permitted as content under <label> [element-permitted-content]'
+      )
     );
   });
 
@@ -39,7 +40,9 @@ describe('a11y validator', () => {
       </label>
     );
     await expect(expect(container).toValidateA11y()).rejects.toThrow(
-      'Expected HTML to be valid but had the following errors:\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
+      new Error(
+        'Expected HTML to be valid but had the following errors:\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
+      )
     );
   });
 });


### PR DESCRIPTION
### Description

Enable html validator element-permitted-content rule
Should have no violation once we merge https://github.com/cloudscape-design/components/pull/109

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
