### PR TITLE
Shift timezone offset correctly when UTC timezone indicator is used

### DIFF
--- a/src/internal/utils/date-time/__tests__/shift-timezone-offset.test.ts
+++ b/src/internal/utils/date-time/__tests__/shift-timezone-offset.test.ts
@@ -15,6 +15,8 @@ const testCases: [args: TestArguments, result: string][] = [
   [{ date: '2020-01-01T09:00:00-01:00', targetOffset: 1 * 60 }, '2020-01-01T11:00:00'],
   [{ date: '2020-01-01T09:00:00+01:00', targetOffset: -1 * 60 }, '2020-01-01T07:00:00'],
   [{ date: '2020-01-01T09:00:00-01:00', targetOffset: -1 * 60 }, '2020-01-01T09:00:00'],
+  [{ date: '2020-01-01T11:22:33Z', targetOffset: 0 }, '2020-01-01T11:22:33'],
+  [{ date: '2020-01-01T11:22:33.444Z', targetOffset: 0 }, '2020-01-01T11:22:33'],
 ];
 
 describe('shiftTimezoneOffset', () => {

--- a/src/internal/utils/date-time/shift-timezone-offset.ts
+++ b/src/internal/utils/date-time/shift-timezone-offset.ts
@@ -19,7 +19,7 @@ import { parseTimezoneOffset } from './parse-timezone-offset';
  */
 export function shiftTimezoneOffset(dateString: string, targetTimezoneOffset: number) {
   const [datePart, timeAndOffsetPart] = dateString.split('T');
-  const [timePart] = timeAndOffsetPart.split(/-|\+/);
+  const [timePart] = timeAndOffsetPart.split(/-|\+|Z/);
   const valueWithoutOffset = joinDateTime(datePart, timePart);
   const originalTimezoneOffset = parseTimezoneOffset(dateString);
 


### PR DESCRIPTION
### Description

Shift timezone offset correctly when UTC timezone indicator is used.

When found an UTC timezone indicator it must be excluded when shifting the offset. The regression was introduced here: https://github.com/cloudscape-design/components/commit/5fb56014a78127fe345c95c8c45d19d03eaf1a2b. See [original implementation](https://github.com/cloudscape-design/components/commit/5fb56014a78127fe345c95c8c45d19d03eaf1a2b#diff-1784082b42c1ceb0d2b5e4faab3708be97eee646281975067cf907c5d662d1b0L132).

### How has this been tested?

Added additional unit test to cover the condition.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
