### PR TITLE
Introduce property-filter-autosuggest derived from internal autosuggest

### DIFF
--- a/pages/property-filter/property-filter-autosuggest.page.tsx
+++ b/pages/property-filter/property-filter-autosuggest.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import InternalAutosuggest from '~components/autosuggest/internal';
+import PropertyFilterAutosuggest from '~components/property-filter/property-filter-autosuggest';
 
 const options = [
   {
@@ -15,18 +15,15 @@ const options = [
   { value: 'Option', description: 'description2' },
 ];
 const enteredTextLabel = (value: string) => `Use: ${value}`;
-export default function AutosuggestPage() {
+
+export default function PropertyFilterAutosuggestPage() {
   const [value, setValue] = useState('Option 1');
   return (
     <div style={{ padding: 10 }}>
-      <h1>Internal autosuggest features</h1>
-      <InternalAutosuggest
-        __filterText={value.substr(2)}
-        __onOptionClick={e => {
-          e.preventDefault();
-        }}
-        __dropdownWidth={300}
-        __disableShowAll={true}
+      <h1>Property filter autosuggest features</h1>
+      <PropertyFilterAutosuggest
+        filterText={value.substr(2)}
+        onOptionClick={e => e.preventDefault()}
         value={value}
         options={options}
         onChange={event => setValue(event.detail.value)}

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -15,24 +15,16 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 import { getBaseProps } from '../internal/base-component';
 import { generateUniqueId, useUniqueId } from '../internal/hooks/use-unique-id';
 import useForwardFocus from '../internal/hooks/forward-focus';
-import { fireNonCancelableEvent, CancelableEventHandler } from '../internal/events';
+import { fireNonCancelableEvent } from '../internal/events';
 import InternalInput from '../input/internal';
 import { InputProps } from '../input/interfaces';
 import styles from './styles.css.js';
 import { checkOptionValueField } from '../select/utils/check-option-value-field';
 import checkControlled from '../internal/hooks/check-controlled';
-import { fireCancelableEvent } from '../internal/events/index';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import AutosuggestOptionsList from './options-list';
 
-export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {
-  __filterText?: string;
-  __dropdownWidth?: number;
-  __onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
-  __disableShowAll?: boolean;
-  __hideEnteredTextOption?: boolean;
-  __onOpen?: CancelableEventHandler<null>;
-}
+export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {}
 
 const isInteractive = (option?: AutosuggestItem) => {
   return !!option && !option.disabled && option.type !== 'parent';
@@ -81,16 +73,9 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     onSelect,
     selectedAriaLabel,
     renderHighlightedAriaLive,
-    __dropdownWidth,
-    __onOptionClick,
-    __disableShowAll,
-    __hideEnteredTextOption,
-    __onOpen,
     __internalRootRef,
-    __filterText,
     ...rest
   } = props;
-  const filterText = __filterText === undefined ? value : __filterText;
 
   checkControlled('Autosuggest', 'value', value, 'onChange', onChange);
   checkOptionValueField('Autosuggest', 'options', options);
@@ -101,9 +86,9 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     useAutosuggestItems({
       options: options || [],
       filterValue: value,
-      filterText,
+      filterText: value,
       filteringType,
-      hideEnteredTextLabel: __hideEnteredTextOption,
+      hideEnteredTextLabel: false,
     });
   const openDropdown = () => !readOnly && setOpen(true);
   const closeDropdown = () => {
@@ -120,12 +105,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const selectOption = (option: AutosuggestItem) => {
     const value = option.value || '';
     fireNonCancelableEvent(onChange, { value });
-    const selectedCancelled = fireCancelableEvent(__onOptionClick, option);
-    if (!selectedCancelled) {
-      closeDropdown();
-    } else {
-      resetHighlight();
-    }
+    closeDropdown();
     fireNonCancelableEvent(onSelect, { value });
   };
   const selectHighlighted = () => {
@@ -186,12 +166,9 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   };
 
   const handleInputFocus: InputProps['onFocus'] = e => {
-    !__disableShowAll && setShowAll(true);
-    const openPrevented = fireCancelableEvent(__onOpen, null);
-    if (!openPrevented) {
-      openDropdown();
-      fireLoadMore(true, false, '');
-    }
+    setShowAll(true);
+    openDropdown();
+    fireLoadMore(true, false, '');
     onFocus?.(e);
   };
 
@@ -207,8 +184,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   return (
     <div {...baseProps} className={clsx(styles.root, baseProps.className)} ref={__internalRootRef} onBlur={handleBlur}>
       <Dropdown
-        minWidth={__dropdownWidth}
-        stretchWidth={!__dropdownWidth}
         trigger={
           <InternalInput
             type="search"
@@ -251,7 +226,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
             highlightedIndex={highlightedIndex}
             setHighlightedIndex={setHighlightedIndex}
             highlightedOptionId={highlightedOptionId}
-            highlightText={filterText}
+            highlightText={value}
             listId={listId}
             controlId={controlId}
             enteredTextLabel={enteredTextLabel}

--- a/src/property-filter/__tests__/controller.test.ts
+++ b/src/property-filter/__tests__/controller.test.ts
@@ -234,7 +234,7 @@ describe('getAutosuggestOptions', () => {
       value: '',
     };
     const expected = {
-      __filterText: '',
+      filterText: '',
       options: expectedPropertySuggestions,
     };
     const actual = getAutosuggestOptions(
@@ -255,7 +255,7 @@ describe('getAutosuggestOptions', () => {
       value: 'text',
     };
     const expected = {
-      __filterText: 'text',
+      filterText: 'text',
       options: [...expectedPropertySuggestions, ...expectedValueSuggestions],
     };
     const actual = getAutosuggestOptions(
@@ -280,7 +280,7 @@ describe('getAutosuggestOptions', () => {
       property: filteringProperties[0],
     };
     const expected = {
-      __filterText: 'string !',
+      filterText: 'string !',
       options: [...expectedPropertySuggestions, ...expectedOperatorSuggestions],
     };
     const actual = getAutosuggestOptions(
@@ -293,7 +293,7 @@ describe('getAutosuggestOptions', () => {
     // Operator suggestions go after the property suggestions
     // Every operator suggestion has `keepOpenOnSelect` set on it
     // Operator suggestions and their group label are taken form the i18nStrings object
-    // `__filterText` should match `value` property of operator suggestions for autosuggest filtering to work
+    // `filterText` should match `value` property of operator suggestions for autosuggest filtering to work
     expect(actual).toEqual(expected);
   });
   test('returns value suggestions for a given property, when the filteringText starts with this property`s labels followed by a completed operator', () => {
@@ -304,7 +304,7 @@ describe('getAutosuggestOptions', () => {
       property: filteringProperties[0],
     };
     const expected = {
-      __filterText: 'value',
+      filterText: 'value',
       options: [
         {
           label: 'String values',
@@ -322,7 +322,7 @@ describe('getAutosuggestOptions', () => {
       customGroupText,
       i18nStrings
     );
-    // `__filterText` should match `label` property of value suggestions for autosuggest filtering to work
+    // `filterText` should match `label` property of value suggestions for autosuggest filtering to work
     expect(actual).toEqual(expected);
   });
   test('returns value suggestions for the properies that support `!:` operator, when doing a negated free text search', () => {
@@ -332,7 +332,7 @@ describe('getAutosuggestOptions', () => {
       value: 'value',
     };
     const expected = {
-      __filterText: 'value',
+      filterText: 'value',
       options: [
         {
           label: 'Values',

--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -3,10 +3,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
-import InternalAutosuggest from '../../../lib/components/autosuggest/internal';
 import AutosuggestWrapper from '../../../lib/components/test-utils/dom/autosuggest';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import { AutosuggestProps } from '../../../lib/components/autosuggest/interfaces';
+
+import PropertyFilterAutosuggest from '../../../lib/components/property-filter/property-filter-autosuggest';
 
 const options: AutosuggestProps.Options = [{ value: '123' }, { value: 'abc' }];
 
@@ -17,16 +18,16 @@ function renderAutosuggest(jsx: React.ReactElement) {
 }
 
 describe('Internal autosuggest features', () => {
-  describe('`__filterText`', () => {
+  describe('filterText', () => {
     let wrapper: AutosuggestWrapper;
     beforeEach(() => {
       wrapper = renderAutosuggest(
-        <InternalAutosuggest
+        <PropertyFilterAutosuggest
           options={options}
           enteredTextLabel={value => value}
           value={'123'}
           onChange={() => {}}
-          __filterText={'abc'}
+          filterText={'abc'}
         />
       ).wrapper;
       wrapper.focus();
@@ -39,20 +40,20 @@ describe('Internal autosuggest features', () => {
     test('is used for highlighting', () => {
       expect(wrapper.findDropdown().findHighlightedMatches()[0].getElement()).toHaveTextContent('abc');
     });
-    test('is not used for the `enteredText-` option', () => {
+    test('is not used for the enteredText- option', () => {
       expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('123');
     });
   });
-  describe('`__onOptionClick`', () => {
+  describe('onOptionClick', () => {
     const handleSelectedSpy = jest.fn();
     let wrapper: AutosuggestWrapper;
     beforeEach(() => {
       handleSelectedSpy.mockReset();
       wrapper = renderAutosuggest(
-        <InternalAutosuggest
+        <PropertyFilterAutosuggest
           options={options}
           enteredTextLabel={() => ''}
-          __onOptionClick={handleSelectedSpy}
+          onOptionClick={handleSelectedSpy}
           value=""
           onChange={() => {}}
           filteringType="auto"
@@ -94,12 +95,11 @@ describe('Internal autosuggest features', () => {
       expect(wrapper.findDropdown().findHighlightedOption()).toBeNull();
     });
   });
-  test('`__disableShowAll`: forces the list of suggestions to be filtered, when the input is focused', () => {
+  test('the list of suggestions to be filtered, when the input is focused', () => {
     const wrapper: AutosuggestWrapper = renderAutosuggest(
-      <InternalAutosuggest
+      <PropertyFilterAutosuggest
         options={options}
         enteredTextLabel={() => ''}
-        __disableShowAll={true}
         value="123"
         onChange={() => {}}
         filteringType="auto"
@@ -110,12 +110,12 @@ describe('Internal autosuggest features', () => {
     wrapper.focus();
     expect(wrapper.findDropdown().findOptions()).toHaveLength(1);
   });
-  test('`__hideEnteredTextOption`: stops "entered text" option from being created', () => {
+  test('hideEnteredTextOption: stops "entered text" option from being created', () => {
     const wrapper: AutosuggestWrapper = renderAutosuggest(
-      <InternalAutosuggest
+      <PropertyFilterAutosuggest
         options={options}
         enteredTextLabel={() => ''}
-        __hideEnteredTextOption={true}
+        hideEnteredTextOption={true}
         value="123"
         onChange={() => {}}
         filteringType="auto"
@@ -126,14 +126,14 @@ describe('Internal autosuggest features', () => {
     wrapper.focus();
     expect(wrapper.findEnteredTextOption()).toBeNull();
   });
-  describe('`__onOpen`', () => {
+  describe('onOpen', () => {
     let wrapper: AutosuggestWrapper;
     beforeEach(() => {
       wrapper = renderAutosuggest(
-        <InternalAutosuggest
+        <PropertyFilterAutosuggest
           options={options}
           enteredTextLabel={() => ''}
-          __onOpen={e => e.preventDefault()}
+          onOpen={e => e.preventDefault()}
           value="123"
           onChange={() => {}}
           filteringType="auto"
@@ -151,7 +151,7 @@ describe('Internal autosuggest features', () => {
       expect(wrapper.findDropdown().findOpenDropdown()).not.toBeNull();
     });
   });
-  describe('`_disabled option`', () => {
+  describe('disabled option', () => {
     let wrapper: AutosuggestWrapper;
     const handleSelectedSpy = jest.fn();
     const withDisabledOptions = [
@@ -163,7 +163,7 @@ describe('Internal autosuggest features', () => {
     ];
     beforeEach(() => {
       wrapper = renderAutosuggest(
-        <InternalAutosuggest
+        <PropertyFilterAutosuggest
           options={withDisabledOptions}
           enteredTextLabel={() => ''}
           onSelect={handleSelectedSpy}

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -259,7 +259,7 @@ export const getAutosuggestOptions = (
       const { propertyLabel, groupValuesLabel } = parsedText.property;
       const options = getPropertyOptions(parsedText.property, filteringOptions);
       return {
-        __filterText: parsedText.value,
+        filterText: parsedText.value,
         options: [
           {
             options: (options || []).map(({ value }) => ({
@@ -274,7 +274,7 @@ export const getAutosuggestOptions = (
     }
     case 'operator': {
       return {
-        __filterText: parsedText.property.propertyLabel + ' ' + parsedText.operatorPrefix,
+        filterText: parsedText.property.propertyLabel + ' ' + parsedText.operatorPrefix,
         options: [
           ...getPropertySuggestions(
             filteringProperties,
@@ -298,7 +298,7 @@ export const getAutosuggestOptions = (
       const needsValueSuggestions = !!parsedText.value;
       const needsPropertySuggestions = !(parsedText.step === 'free-text' && parsedText.operator === '!:');
       return {
-        __filterText: parsedText.value,
+        filterText: parsedText.value,
         options: [
           ...(needsPropertySuggestions
             ? getPropertySuggestions(

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import React, { useRef, useState, useMemo } from 'react';
 
 import InternalSpaceBetween from '../space-between/internal';
-import InternalAutosuggest, { InternalAutosuggestProps } from '../autosuggest/internal';
 import { InternalButton } from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
 import useForwardFocus from '../internal/hooks/forward-focus';
@@ -20,6 +19,7 @@ import { getQueryActions, parseText, getAutosuggestOptions, ParsedText, getAllow
 import { useLoadItems } from './use-load-items';
 import styles from './styles.css.js';
 import useBaseComponent from '../internal/hooks/use-base-component';
+import PropertyFilterAutosuggest, { PropertyFilterAutosuggestProps } from './property-filter-autosuggest';
 
 export { PropertyFilterProps };
 
@@ -109,7 +109,7 @@ const PropertyFilter = React.forwardRef(
       setFilteringText('');
     };
     const ignoreKeyDown = useRef<boolean>(false);
-    const handleKeyDown: InternalAutosuggestProps['onKeyDown'] = event => {
+    const handleKeyDown: PropertyFilterAutosuggestProps['onKeyDown'] = event => {
       if (filteringText && !ignoreKeyDown.current && event.detail.keyCode === KeyCode.enter) {
         createToken(filteringText);
       }
@@ -154,7 +154,7 @@ const PropertyFilter = React.forwardRef(
             ...asyncProps,
           }
         : {};
-    const handleSelected: InternalAutosuggestProps['__onOptionClick'] = event => {
+    const handleSelected: PropertyFilterAutosuggestProps['onOptionClick'] = event => {
       // The ignoreKeyDown flag makes sure `createToken` routine runs only once. Autosuggest's `onKeyDown` fires,
       // when an item is selected from the list using "enter" key.
       ignoreKeyDown.current = true;
@@ -196,10 +196,10 @@ const PropertyFilter = React.forwardRef(
       <span {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <div className={styles['search-field']}>
           {customControl && <div className={styles['custom-control']}>{customControl}</div>}
-          <InternalAutosuggest
+          <PropertyFilterAutosuggest
+            ref={inputRef}
             virtualScroll={virtualScroll}
             enteredTextLabel={i18nStrings.enteredTextLabel}
-            ref={inputRef}
             className={styles.input}
             ariaLabel={i18nStrings.filteringAriaLabel}
             placeholder={i18nStrings.filteringPlaceholder}
@@ -211,16 +211,14 @@ const PropertyFilter = React.forwardRef(
             empty={filteringEmpty}
             {...asyncAutosuggestProps}
             expandToViewport={expandToViewport}
-            __disableShowAll={true}
-            __dropdownWidth={300}
-            __onOptionClick={handleSelected}
-            __onOpen={e => {
+            onOptionClick={handleSelected}
+            onOpen={e => {
               if (preventFocus.current) {
                 e.preventDefault();
                 preventFocus.current = false;
               }
             }}
-            __hideEnteredTextOption={disableFreeTextFiltering && parsedText.step !== 'property'}
+            hideEnteredTextOption={disableFreeTextFiltering && parsedText.step !== 'property'}
           />
           <span
             aria-live="polite"

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -1,0 +1,253 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React, { Ref, useCallback, useRef, useState } from 'react';
+
+import { useKeyboardHandler } from '../autosuggest/controller';
+import { useAutosuggestItems } from '../autosuggest/options-controller';
+import { AutosuggestItem, AutosuggestProps } from '../autosuggest/interfaces';
+
+import Dropdown from '../internal/components/dropdown';
+import { useDropdownStatus } from '../internal/components/dropdown-status';
+import DropdownFooter from '../internal/components/dropdown-footer';
+
+import { useFormFieldContext } from '../internal/context/form-field-context';
+import { getBaseProps } from '../internal/base-component';
+import { generateUniqueId, useUniqueId } from '../internal/hooks/use-unique-id';
+import useForwardFocus from '../internal/hooks/forward-focus';
+import { fireNonCancelableEvent, CancelableEventHandler } from '../internal/events';
+import InternalInput from '../input/internal';
+import { InputProps } from '../input/interfaces';
+import styles from '../autosuggest/styles.css.js';
+import { fireCancelableEvent } from '../internal/events/index';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import AutosuggestOptionsList from '../autosuggest/options-list';
+
+const DROPDOWN_WIDTH = 300;
+
+export interface PropertyFilterAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {
+  filterText?: string;
+  onOpen?: CancelableEventHandler<null>;
+  onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
+  hideEnteredTextOption?: boolean;
+}
+
+const isInteractive = (option?: AutosuggestItem) => {
+  return !!option && !option.disabled && option.type !== 'parent';
+};
+
+const useLoadMoreItems = (onLoadItems: AutosuggestProps['onLoadItems']) => {
+  const lastFilteringText = useRef<string | null>(null);
+  return useCallback(
+    (firstPage: boolean, samePage: boolean, filteringText?: string) => {
+      if (samePage || !firstPage || filteringText === undefined || lastFilteringText.current !== filteringText) {
+        if (filteringText !== undefined) {
+          lastFilteringText.current = filteringText;
+        }
+        if (lastFilteringText.current !== null && onLoadItems) {
+          fireNonCancelableEvent(onLoadItems, { filteringText: lastFilteringText.current, firstPage, samePage });
+        }
+      }
+    },
+    [onLoadItems]
+  );
+};
+
+const PropertyFilterAutosuggest = React.forwardRef(
+  (props: PropertyFilterAutosuggestProps, ref: Ref<InputProps.Ref>) => {
+    const {
+      value,
+      onChange,
+      onLoadItems,
+      options,
+      filteringType = 'auto',
+      statusType = 'finished',
+      placeholder,
+      disabled,
+      ariaLabel,
+      enteredTextLabel,
+      onKeyDown,
+      virtualScroll,
+      expandToViewport,
+      filterText,
+      onOpen,
+      onOptionClick,
+      hideEnteredTextOption,
+      ...rest
+    } = props;
+    const highlightText = filterText === undefined ? value : filterText;
+
+    const usingMouse = useRef(true);
+    const [open, setOpen] = useState(false);
+    const { items, highlightedOption, highlightedIndex, moveHighlight, resetHighlight, setHighlightedIndex } =
+      useAutosuggestItems({
+        options: options || [],
+        filterValue: value,
+        filterText: highlightText,
+        filteringType,
+        hideEnteredTextLabel: hideEnteredTextOption,
+      });
+    const openDropdown = () => setOpen(true);
+    const closeDropdown = () => {
+      setOpen(false);
+      resetHighlight();
+    };
+    const handleBlur: React.FocusEventHandler = event => {
+      if (
+        event.currentTarget.contains(event.relatedTarget) ||
+        dropdownFooterRef.current?.contains(event.relatedTarget)
+      ) {
+        return;
+      }
+      closeDropdown();
+    };
+    const selectOption = (option: AutosuggestItem) => {
+      const value = option.value || '';
+      fireNonCancelableEvent(onChange, { value });
+      const selectedCancelled = fireCancelableEvent(onOptionClick, option);
+      if (!selectedCancelled) {
+        closeDropdown();
+      } else {
+        resetHighlight();
+      }
+    };
+    const selectHighlighted = () => {
+      if (highlightedOption) {
+        if (isInteractive(highlightedOption)) {
+          selectOption(highlightedOption);
+        }
+      } else {
+        closeDropdown();
+      }
+    };
+
+    const fireLoadMore = useLoadMoreItems(onLoadItems);
+
+    const handleInputChange: InputProps['onChange'] = e => {
+      openDropdown();
+      resetHighlight();
+      onChange && onChange(e);
+    };
+
+    const handleKeyDown = useKeyboardHandler(
+      moveHighlight,
+      openDropdown,
+      selectHighlighted,
+      usingMouse,
+      open,
+      onKeyDown
+    );
+    const handleLoadMore = useCallback(() => {
+      options && options.length && statusType === 'pending' && fireLoadMore(false, false);
+    }, [fireLoadMore, options, statusType]);
+    const handleRecoveryClick = useCallback(() => {
+      fireLoadMore(false, true);
+      inputRef.current?.focus();
+    }, [fireLoadMore]);
+
+    const formFieldContext = useFormFieldContext(rest);
+    const baseProps = getBaseProps(rest);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const dropdownFooterRef = useRef<HTMLDivElement>(null);
+    useForwardFocus(ref, inputRef);
+
+    const selfControlId = useUniqueId('input');
+    const controlId = formFieldContext.controlId ?? selfControlId;
+    const dropdownId = useUniqueId('dropdown');
+    const listId = useUniqueId('list');
+
+    // From an a11y point of view we only count the dropdown as 'expanded' if there are items that a user can dropdown into
+    const expanded = open && items.length > 1;
+    const highlightedOptionId = highlightedOption ? generateUniqueId() : undefined;
+    const nativeAttributes = {
+      name,
+      placeholder,
+      onClick: openDropdown,
+      role: 'combobox',
+      'aria-autocomplete': 'list',
+      'aria-expanded': expanded,
+      'aria-controls': listId,
+      // 'aria-owns' needed for safari+vo to announce activedescendant content
+      'aria-owns': listId,
+      'aria-label': ariaLabel,
+      'aria-activedescendant': highlightedOptionId,
+    };
+
+    const handleInputFocus: InputProps['onFocus'] = () => {
+      const openPrevented = fireCancelableEvent(onOpen, null);
+      if (!openPrevented) {
+        openDropdown();
+        fireLoadMore(true, false, '');
+      }
+    };
+
+    const isEmpty = !value && !items.length;
+    const showRecoveryLink = open && statusType === 'error' && props.recoveryText;
+    const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });
+
+    const handleMouseDown = (event: React.MouseEvent) => {
+      // prevent currently focused element from losing it
+      event.preventDefault();
+    };
+
+    return (
+      <div {...baseProps} className={clsx(styles.root, baseProps.className)} onBlur={handleBlur}>
+        <Dropdown
+          minWidth={DROPDOWN_WIDTH}
+          stretchWidth={false}
+          trigger={
+            <InternalInput
+              type="search"
+              value={value}
+              onChange={handleInputChange}
+              __onDelayedInput={event => fireLoadMore(true, false, event.detail.value)}
+              onFocus={handleInputFocus}
+              onKeyDown={handleKeyDown}
+              disabled={disabled}
+              ref={inputRef}
+              autoComplete={false}
+              __nativeAttributes={nativeAttributes}
+              {...formFieldContext}
+              controlId={controlId}
+            />
+          }
+          onMouseDown={handleMouseDown}
+          open={open}
+          dropdownId={dropdownId}
+          footer={
+            dropdownStatus.isSticky ? (
+              <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>
+                <DropdownFooter content={dropdownStatus.content} hasItems={items.length >= 1} />
+              </div>
+            ) : null
+          }
+          expandToViewport={expandToViewport}
+          hasContent={items.length >= 1 || dropdownStatus.content !== null}
+          trapFocus={!!showRecoveryLink}
+        >
+          {open && (
+            <AutosuggestOptionsList
+              options={items}
+              highlightedOption={highlightedOption}
+              selectOption={selectOption}
+              highlightedIndex={highlightedIndex}
+              setHighlightedIndex={setHighlightedIndex}
+              highlightedOptionId={highlightedOptionId}
+              highlightText={highlightText}
+              listId={listId}
+              controlId={controlId}
+              enteredTextLabel={enteredTextLabel}
+              handleLoadMore={handleLoadMore}
+              hasDropdownStatus={dropdownStatus.content !== null}
+              virtualScroll={virtualScroll}
+              listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+              usingMouse={usingMouse}
+            />
+          )}
+        </Dropdown>
+      </div>
+    );
+  }
+);
+
+export default PropertyFilterAutosuggest;

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -160,7 +160,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const expanded = open && items.length > 1;
     const highlightedOptionId = highlightedOption ? generateUniqueId() : undefined;
     const nativeAttributes = {
-      name,
       placeholder,
       onClick: openDropdown,
       role: 'combobox',


### PR DESCRIPTION
### Description

Property filter uses autosuggest internally but requires more features that the public autosuggest API has to offer. The coming changes to the property filter (see https://github.com/cloudscape-design/components/pull/166) would only worsen this problem.

In this PR a new internal property-filter-autosuggest component is introduced that is similar to autosuggest but includes the property filter-related changes. Those extra properties are removed from the internal autosuggest as no longer required.

### How has this been tested?

Existing tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
