### PR TITLE
fix: Ensure that breadcrumb behavior in VR matches classic

### DIFF
--- a/pages/app-layout/with-breadcrumbs.page.tsx
+++ b/pages/app-layout/with-breadcrumbs.page.tsx
@@ -2,10 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import AppLayout from '~components/app-layout';
+import BreadcrumbGroup from '~components/breadcrumb-group';
 import ScreenshotArea from '../utils/screenshot-area';
-import { Breadcrumbs } from './utils/content-blocks';
 import label from './utils/labels';
 import styles from './styles.scss';
+
+function Breadcrumbs() {
+  return (
+    <BreadcrumbGroup
+      items={[
+        { text: 'Home', href: '#' },
+        { text: 'Service with a long long long long long long long long long long long long long title', href: '#' },
+      ]}
+    />
+  );
+}
 
 export default function () {
   return (

--- a/src/app-layout/visual-refresh/app-bar.scss
+++ b/src/app-layout/visual-refresh/app-bar.scss
@@ -13,7 +13,7 @@ section.appbar {
   display: grid;
   grid-column: 3;
   grid-row: 2;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
 
   > .appbar-nav {
     grid-column: 1;


### PR DESCRIPTION
AWSUI-19088

### Description

Ensure that breadcrumb behavior in VR matches classic - truncated with ellipsis rather than overflowing container.

### How has this been tested?

Tested in dev pipeline, inc. visual refression

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

AWSUI-19088


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
