### PR TITLE
Change color of focus indicator of actionable elements in flashbar

### DIFF
--- a/pages/flashbar/dismissal.page.tsx
+++ b/pages/flashbar/dismissal.page.tsx
@@ -28,6 +28,12 @@ export default function FlashbarPermutations() {
   return (
     <>
       <h1>Flashbar dismissal test</h1>
+      <p>
+        Click here to focus so we can tab to the content below{' '}
+        <button type="button" id="focus-target">
+          focus
+        </button>
+      </p>
       <ScreenshotArea disableAnimations={true}>
         <Flashbar items={items} />
       </ScreenshotArea>

--- a/style-dictionary/classic/contexts/flashbar.ts
+++ b/style-dictionary/classic/contexts/flashbar.ts
@@ -5,16 +5,7 @@ import { tokens as parentTokens } from '../colors';
 import merge from 'lodash/merge';
 import { expandColorDictionary } from '../../utils';
 
-const tokens: StyleDictionary.ColorsDictionary = {
-  colorTextButtonNormalDefault: '{colorGrey100}',
-  colorBorderButtonNormalDefault: '{colorGrey100}',
-  colorBackgroundButtonNormalDefault: 'transparent',
-  colorTextButtonNormalHover: '{colorWhite}',
-  colorBorderButtonNormalHover: '{colorWhite}',
-  colorBackgroundButtonNormalHover: 'rgba(0, 7, 22, 0.15)',
-  colorTextButtonNormalActive: '{colorWhite}',
-  colorBorderButtonNormalActive: '{colorWhite}',
-  colorBackgroundButtonNormalActive: 'rgba(0, 7, 22, 0.2)',
+const tokens = {
   colorBorderItemFocused: '{colorGrey100}',
 };
 

--- a/style-dictionary/classic/index.ts
+++ b/style-dictionary/classic/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ThemeBuilder } from '@cloudscape-design/theming-build';
 import { createColorMode, createDensityMode, createMotionMode } from '../utils/modes';
-import { createTopNavigationContext } from '../utils/contexts';
+import { createTopNavigationContext, createFlashbarContext } from '../utils/contexts';
 
 const modes = [
   createColorMode('.awsui-dark-mode'),
@@ -30,6 +30,8 @@ export function buildClassicOpenSource(builder: ThemeBuilder) {
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   builder.addContext(createTopNavigationContext(require('./contexts/top-navigation').tokens));
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  builder.addContext(createFlashbarContext(require('./contexts/flashbar').tokens));
 
   return builder.build();
 }

--- a/style-dictionary/visual-refresh/index.ts
+++ b/style-dictionary/visual-refresh/index.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ThemeBuilder } from '@cloudscape-design/theming-build';
 import { createColorMode, createDensityMode, createMotionMode } from '../utils/modes';
-import { createTopNavigationContext, createHeaderContext } from '../utils/contexts';
-import flashbarContextTokens from './contexts/flashbar';
+import { createTopNavigationContext, createHeaderContext, createFlashbarContext } from '../utils/contexts';
 import alertContextTokens from './contexts/alert';
 
 const modes = [
@@ -35,11 +34,7 @@ export function buildVisualRefresh(builder: ThemeBuilder) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   builder.addContext(createHeaderContext(require('./contexts/header').tokens));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  builder.addContext({
-    id: 'flashbar',
-    selector: '.awsui-context-flashbar',
-    tokens: flashbarContextTokens,
-  });
+  builder.addContext(createFlashbarContext(require('./contexts/flashbar').tokens));
   builder.addContext({
     id: 'alert',
     selector: '.awsui-context-alert',


### PR DESCRIPTION
### Description

AWSUI-18907
Blue focus indicator in flashbar (info error) in classic has a contrast ratio of less than 3:1 
Change the focus indicator color to grey-100 as VR
Added screenshot test  CR-75687450

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
