### PR TITLE
chore(tabs): Change overflow button navigation formAction to none

### DIFF
--- a/pages/tabs/responsive-integ.page.tsx
+++ b/pages/tabs/responsive-integ.page.tsx
@@ -59,7 +59,9 @@ export default function TabsDemoPage() {
     <div id="container" className={small ? styles.small : ''}>
       <h1>Tabs</h1>
       <input type="text" id="before" aria-label="before" />
-      <Tabs tabs={tabs} activeTabId={selectedTab} onChange={event => setSelectedTab(event.detail.activeTabId)} />
+      <form action="/">
+        <Tabs tabs={tabs} activeTabId={selectedTab} onChange={event => setSelectedTab(event.detail.activeTabId)} />
+      </form>
       <input type="text" id="after" aria-label="after" />
       <button id="size-toggle" onClick={() => setSmall(!small)}>
         Toggle

--- a/src/tabs/__integ__/tabs.test.ts
+++ b/src/tabs/__integ__/tabs.test.ts
@@ -49,6 +49,10 @@ class TabsPage extends BasePageObject {
   async toggleSmallSize() {
     await this.click('#size-toggle');
   }
+
+  getUrl() {
+    return this.browser.getUrl();
+  }
 }
 
 const setupTest = (testFn: (page: TabsPage) => Promise<void>, smallViewport = false) => {
@@ -270,3 +274,15 @@ test(
     }, smallViewport)
   );
 });
+
+test(
+  'header buttons do not trigger form submission',
+  setupTest(async page => {
+    const urlBefore = await page.getUrl();
+    await page.click(wrapper.find(page.paginationButton('left')).toSelector());
+    await page.click(wrapper.find(page.paginationButton('right')).toSelector());
+    const urlAfter = await page.getUrl();
+
+    expect(urlAfter).toEqual(urlBefore);
+  }, true)
+);

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -133,6 +133,7 @@ export function TabHeaderBar({
       {horizontalOverflow && (
         <span ref={leftOverflowButton} className={leftButtonClasses}>
           <InternalButton
+            formAction="none"
             variant="icon"
             iconName="angle-left"
             __nativeAttributes={paginationButtonAttributes}
@@ -154,6 +155,7 @@ export function TabHeaderBar({
       {horizontalOverflow && (
         <span className={rightButtonClasses}>
           <InternalButton
+            formAction="none"
             variant="icon"
             iconName="angle-right"
             __nativeAttributes={paginationButtonAttributes}


### PR DESCRIPTION
### Description

The default behavior of the buttons is a formAction of submit. This changes it to none so that it if used in a form it will not submit the form when scrolling left and right.

[_Include a summary of the changes and the related issue._]

[_Also include relevant motivation and context._]

### How has this been tested?

We currently have a [test for outer from submissions](https://github.com/cloudscape-design/components/blob/main/src/__tests__/outer-form-submit.test.tsx), however these buttons are not visible in wider view ports and we cannot set a viewport for this test as it's executed in jsdom.

[_How did you test to verify your changes?_]
Updated integ test page and added an integ test and validate that no form submission occurs. In this integ test a form submission would trigger a navigation, so we test that no navigation happens when clicking any of the header navigation buttons

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

[*Attach any related links/pull request for this change*]
AWSUI-19106

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
