### PR TITLE
fix: Prevent Unicode combining characters from overflowing boundaries

### DIFF
--- a/pages/token-group/simple.page.tsx
+++ b/pages/token-group/simple.page.tsx
@@ -4,9 +4,11 @@ import React, { useState } from 'react';
 import TokenGroup, { TokenGroupProps } from '~components/token-group';
 import Box from '~components/box';
 
+const unicodeCombiningCharactersTestString = 'L̷̡̧͔̖̥̱̲͓̘̳͉̤͍͛͗̋̃̈͐̈͘͘ơ̵̻͔̬̲̠̽̈́̏͊͑͒͘̕r̷̰͇̗̯̠̟̣̗̜̻̙̀̎̾̈͘̕͝ȩ̸͖̻͔͔̀̐̆̀̃m̵̬̗̮͍̙̦̗̮̯̽̕ ̸̟͖̩̼̲̓̇͊̊̓î̷̧̨̳̺̥̻̞̣̽͝p̷̞͊s̸̭̗͉̩̲̈̔̑͊́͆͝u̶͎̥̰̥͒̕m̶̨̛̟͚͖͉͉̘̯͓̜͚̎͂̌̽̄͐̕ͅ';
+
 const generateItems = (numberOfItems: number) => {
   return [...new Array(numberOfItems)].map((_item, index) => ({
-    label: `Item ${index + 1}`,
+    label: index === 5 ? unicodeCombiningCharactersTestString : `Item ${index + 1}`,
     disabled: index === 1,
     dismissLabel: `Remove item ${index + 1}`,
   })) as TokenGroupProps.Item[];
@@ -29,7 +31,7 @@ export default function TokenGroupPage() {
   return (
     <Box padding="xl">
       <h1>Token Group</h1>
-      <TokenGroup items={items} onDismiss={onDismiss} i18nStrings={i18nStrings} limit={5} />
+      <TokenGroup items={items} onDismiss={onDismiss} i18nStrings={i18nStrings} limit={6} />
     </Box>
   );
 }

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -16,6 +16,8 @@
   margin-top: calc(-1 * #{styles.$control-border-width});
   cursor: pointer;
 
+  overflow: hidden;
+
   &.disabled {
     cursor: default;
     color: awsui.$color-text-dropdown-item-disabled;

--- a/src/cards/styles.scss
+++ b/src/cards/styles.scss
@@ -92,6 +92,7 @@
     width: 100%;
     min-width: 0;
     box-sizing: border-box;
+    overflow: hidden;
   }
   &-header {
     @include styles.font-heading-m;

--- a/src/internal/components/filtering-token/styles.scss
+++ b/src/internal/components/filtering-token/styles.scss
@@ -36,6 +36,7 @@
 
 .token-content {
   padding: styles.$control-padding-vertical styles.$control-padding-horizontal;
+  overflow: hidden;
 }
 
 .dismiss-button {

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -14,6 +14,8 @@
   list-style: none;
   z-index: 1;
 
+  overflow: hidden;
+
   border: awsui.$border-divider-list-width solid transparent;
   border-top-color: awsui.$color-border-dropdown-item-default;
   border-bottom-color: awsui.$color-border-dropdown-item-default;

--- a/src/token-group/styles.scss
+++ b/src/token-group/styles.scss
@@ -27,6 +27,7 @@
   color: awsui.$color-text-body-default;
   height: 100%;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .dismiss-button {

--- a/src/top-navigation/styles.scss
+++ b/src/top-navigation/styles.scss
@@ -226,6 +226,8 @@
   padding: awsui.$space-scaled-m;
   border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 
+  overflow: hidden;
+
   &-text {
     @include styles.font-panel-header;
     color: awsui.$color-text-heading-default;
@@ -303,6 +305,8 @@
 .overflow-menu-list-item {
   box-sizing: border-box;
   letter-spacing: awsui.$font-button-letter-spacing;
+
+  overflow: hidden;
 
   &-icon {
     margin-right: awsui.$space-xxs;


### PR DESCRIPTION
### Description

This change prevents stacked [combining characters](https://en.wikipedia.org/wiki/Combining_character) from overflowing the boundaries of their DOM elements. The change is limited to components that are likely to contain user-controlled input where it can not already be wrapped by the developer.
This change applies to the following components:
- Button dropdown
- Cards
- Multiselect
- Property filter
- Select
- Token group
- Top navigation

### How has this been tested?

[_How did you test to verify your changes?_]  
Manual testing in the dev pages


[_How can reviewers test these changes efficiently?_]  
GitHub apparently does not support including the test string in this issue description, so you'll have to generate it yourself:
1. Go to https://lingojam.com/ZalgoText
2. Enter "Lorem ipsum" on the left side
3. Move the slider all the way to the right
4. Copy the result text

Edit the dev pages for any of the components listed above, and copy-paste the test string into properties that you want to test. View them in the browser and verify that the test string does not cover other UI elements.

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-19107


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
