### PR TITLE
Update property filter types to prepare for collection hooks changes

### DIFF
--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -66,7 +66,12 @@ export const getAllowedOperators = (
   const { operators, defaultOperator } = property;
   const operatorOrder = ['=', '!=', ':', '!:', '>=', '<=', '<', '>'] as const;
   const operatorSet: { [key: string]: true } = { [defaultOperator ?? '=']: true };
-  operators?.forEach(op => (operatorSet[op] = true));
+  // TODO: remove unknown type annotation once extended operators are supported.
+  operators?.forEach((op: unknown) => {
+    if (typeof op === 'string') {
+      operatorSet[op] = true;
+    }
+  });
   return operatorOrder.filter(op => operatorSet[op]);
 };
 

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -153,8 +153,13 @@ export namespace PropertyFilterProps {
   export type Token = PropertyFilterToken;
   export type JoinOperation = PropertyFilterOperation;
   export type ComparisonOperator = PropertyFilterOperator;
-  export type FilteringProperty = PropertyFilterProperty;
   export type FilteringOption = PropertyFilterOption;
+  export interface FilteringProperty extends PropertyFilterProperty {
+    groupValuesLabel: string;
+    propertyLabel: string;
+    group?: string;
+  }
+
   export interface Query {
     tokens: ReadonlyArray<PropertyFilterProps.Token>;
     operation: PropertyFilterProps.JoinOperation;


### PR DESCRIPTION
### Description

To support new extended operators in collection-hooks the filtering property type has to be generic. Also, the new operator type can be an object. See https://github.com/cloudscape-design/collection-hooks/pull/21, https://github.com/cloudscape-design/collection-hooks/pull/22.

### How has this been tested?

Manual testing

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
