### PR TITLE
chore(link): Move icon overflow permutations to a new page

### DIFF
--- a/pages/link/icon-overflow-permutations.page.tsx
+++ b/pages/link/icon-overflow-permutations.page.tsx
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import Link, { LinkProps } from '~components/link';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+import styles from './styles.scss';
+
+const permutations = createPermutations<LinkProps>([
+  {
+    href: ['#', undefined],
+    children: ['Short', 'Hello world', 'Reallylongstringthatcannotwraptothenextline'],
+  },
+]);
+
+export default function LinkPermutations() {
+  return (
+    <>
+      <h1>Link icon overflow permutations</h1>
+      <ScreenshotArea>
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => (
+            <div className={styles.narrow}>
+              <Link {...permutation} external={true} externalIconAriaLabel={`Opens in a new tab`}>
+                {permutation.children}
+              </Link>
+            </div>
+          )}
+        />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/link/permutations.page.tsx
+++ b/pages/link/permutations.page.tsx
@@ -28,13 +28,6 @@ const permutations = createPermutations<LinkProps>([
   },
 ]);
 
-const narrowIconPermutations = createPermutations<LinkProps>([
-  {
-    href: ['#', undefined],
-    children: ['Short', 'Hello world', 'Reallylongstringthatcannotwraptothenextline'],
-  },
-]);
-
 export default function LinkPermutations() {
   return (
     <>
@@ -45,16 +38,6 @@ export default function LinkPermutations() {
           render={permutation => (
             <div className={clsx(permutation.color === 'inverted' && styles['container-inverted'])}>
               <Link {...permutation} externalIconAriaLabel={`Opens in a new tab`}>
-                {permutation.children}
-              </Link>
-            </div>
-          )}
-        />
-        <PermutationsView
-          permutations={narrowIconPermutations}
-          render={permutation => (
-            <div className={styles.narrow}>
-              <Link {...permutation} external={true} externalIconAriaLabel={`Opens in a new tab`}>
                 {permutation.children}
               </Link>
             </div>


### PR DESCRIPTION
### Description

The link permutation page is getting worryingly long, and the new permutations aren't helping.

### How has this been tested?

They'll be visually tested.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
