### PR TITLE
Remove unnecessary isKeyboard ref from use-highlighted-option

### DIFF
--- a/pages/select/item.permutations.page.tsx
+++ b/pages/select/item.permutations.page.tsx
@@ -93,7 +93,7 @@ const permutations = createPermutations<ItemProps>([
     option: [options.complexOption],
     highlighted: [false, true],
     selected: [false, true],
-    highlightedType: ['keyboard'],
+    highlightType: ['keyboard'],
     hasCheckbox: [true],
   },
   {
@@ -125,7 +125,7 @@ const permutations = createPermutations<ItemProps>([
   {
     option: [options.simpleOption, options.complexOption],
     highlighted: [false, true],
-    highlightedType: ['keyboard'],
+    highlightType: ['keyboard'],
     selected: [true],
     hasCheckbox: [false],
   },

--- a/pages/selectable-item/permutations.page.tsx
+++ b/pages/selectable-item/permutations.page.tsx
@@ -40,7 +40,7 @@ const permutations = createPermutations<SelectableItemProps>([
   {
     selected: [false, true],
     highlighted: [true],
-    highlightedType: ['keyboard'],
+    highlightType: ['keyboard'],
     disabled: [false],
     children: [bigOption],
   },

--- a/src/autosuggest/__tests__/controller.test.ts
+++ b/src/autosuggest/__tests__/controller.test.ts
@@ -20,10 +20,10 @@ describe('Autosuggest controller', () => {
 
     test('"flattens" the list of options, indenting group items', () => {
       const { result } = renderHook(useAutosuggestItems, { initialProps: defaultProps });
-      expect(result.current.items.length).toEqual(4);
-      expect(result.current.items[1].type).toEqual('parent');
-      expect(result.current.items[2].type).toEqual('child');
-      expect(result.current.items[3].type).toEqual('child');
+      expect(result.current[0].items.length).toEqual(4);
+      expect(result.current[0].items[1].type).toEqual('parent');
+      expect(result.current[0].items[2].type).toEqual('child');
+      expect(result.current[0].items[3].type).toEqual('child');
     });
 
     test('disables options inside a disabled group', () => {
@@ -31,9 +31,9 @@ describe('Autosuggest controller', () => {
       const { result } = renderHook(useAutosuggestItems, {
         initialProps: { ...defaultProps, options: withDisabledGroup },
       });
-      expect(result.current.items.length).toEqual(4);
-      expect(result.current.items[2].disabled).toEqual(true);
-      expect(result.current.items[3].disabled).toEqual(true);
+      expect(result.current[0].items.length).toEqual(4);
+      expect(result.current[0].items[2].disabled).toEqual(true);
+      expect(result.current[0].items[3].disabled).toEqual(true);
     });
 
     test('disables group that only contains disabled options', () => {
@@ -50,8 +50,8 @@ describe('Autosuggest controller', () => {
       const { result } = renderHook(useAutosuggestItems, {
         initialProps: { ...defaultProps, options: withDisabledOptions },
       });
-      expect(result.current.items.length).toEqual(4);
-      expect(result.current.items[1].disabled).toEqual(true);
+      expect(result.current[0].items.length).toEqual(4);
+      expect(result.current[0].items[1].disabled).toEqual(true);
     });
 
     test('does not disable group with at least one enabled option', () => {
@@ -67,8 +67,8 @@ describe('Autosuggest controller', () => {
       } = renderHook(useAutosuggestItems, {
         initialProps: { ...defaultProps, options: withDisabledOptions },
       });
-      expect(current.items).toHaveLength(4);
-      expect(current.items[1].disabled).toBeFalsy();
+      expect(current[0].items).toHaveLength(4);
+      expect(current[0].items[1].disabled).toBeFalsy();
     });
 
     test('does not filter again, if called with the same list', () => {
@@ -87,7 +87,7 @@ describe('Autosuggest controller', () => {
         filterText: '',
         filteringType: 'auto',
       });
-      expect(result.current.items).toBe(firstResult.items);
+      expect(result.current[0].items).toBe(firstResult[0].items);
     });
 
     test('filters passed items and generates a "use-entered" item', () => {
@@ -99,8 +99,8 @@ describe('Autosuggest controller', () => {
           filteringType: 'auto',
         },
       });
-      expect(result.current.items.length).toEqual(3);
-      expect(result.current.items[0]).toEqual({ value: '1', type: 'use-entered', option: { value: '1' } });
+      expect(result.current[0].items.length).toEqual(3);
+      expect(result.current[0].items[0]).toEqual({ value: '1', type: 'use-entered', option: { value: '1' } });
     });
 
     test('does not filter items using "filteringType" "manual"', () => {
@@ -112,7 +112,7 @@ describe('Autosuggest controller', () => {
           filteringType: 'manual',
         },
       });
-      expect(result.current.items.length).toEqual(5);
+      expect(result.current[0].items.length).toEqual(5);
     });
 
     test('does not filter items when "showAll" flag is set', () => {
@@ -124,8 +124,8 @@ describe('Autosuggest controller', () => {
           filteringType: 'auto',
         },
       });
-      act(() => result.current.setShowAll(true));
-      expect(result.current.items.length).toEqual(5);
+      act(() => result.current[1].setShowAll(true));
+      expect(result.current[0].items.length).toEqual(5);
     });
 
     test('does not filter again when called with the same parameters', () => {
@@ -144,7 +144,7 @@ describe('Autosuggest controller', () => {
         filterText: '1',
         filteringType: 'auto',
       });
-      expect(firstResult.items).toBe(result.current.items);
+      expect(firstResult[0].items).toBe(result.current[0].items);
     });
   });
 

--- a/src/autosuggest/__tests__/controller.test.ts
+++ b/src/autosuggest/__tests__/controller.test.ts
@@ -6,23 +6,16 @@ import { renderHook, act } from '../../__tests__/render-hook';
 import { AutosuggestItem } from '../interfaces';
 import { CancelableEventHandler, BaseKeyDetail, fireCancelableEvent } from '../../internal/events';
 import { KeyCode } from '../../internal/keycode';
-import { createRef, MutableRefObject } from 'react';
 
 const options = [{ value: 'Option 0' }, { label: 'Group 1', options: [{ value: 'Option 1' }, { value: 'Option 2' }] }];
 
 describe('Autosuggest controller', () => {
-  const isKeyboard = { current: true };
-  beforeEach(() => {
-    isKeyboard.current = true;
-  });
-
   describe('useAutosuggestItems', () => {
     const defaultProps: UseAutosuggestItemsProps = {
       options,
       filterValue: '',
       filterText: '',
       filteringType: 'auto',
-      isKeyboard,
     };
 
     test('"flattens" the list of options, indenting group items', () => {
@@ -85,7 +78,6 @@ describe('Autosuggest controller', () => {
           filterValue: '',
           filterText: '',
           filteringType: 'auto',
-          isKeyboard,
         },
       });
       const firstResult = result.current;
@@ -94,7 +86,6 @@ describe('Autosuggest controller', () => {
         filterValue: '',
         filterText: '',
         filteringType: 'auto',
-        isKeyboard,
       });
       expect(result.current.items).toBe(firstResult.items);
     });
@@ -106,7 +97,6 @@ describe('Autosuggest controller', () => {
           filterValue: '1',
           filterText: '1',
           filteringType: 'auto',
-          isKeyboard,
         },
       });
       expect(result.current.items.length).toEqual(3);
@@ -120,7 +110,6 @@ describe('Autosuggest controller', () => {
           filterValue: '1',
           filterText: '1',
           filteringType: 'manual',
-          isKeyboard,
         },
       });
       expect(result.current.items.length).toEqual(5);
@@ -133,7 +122,6 @@ describe('Autosuggest controller', () => {
           filterValue: '1',
           filterText: '1',
           filteringType: 'auto',
-          isKeyboard,
         },
       });
       act(() => result.current.setShowAll(true));
@@ -147,7 +135,6 @@ describe('Autosuggest controller', () => {
           filterValue: '1',
           filterText: '1',
           filteringType: 'auto',
-          isKeyboard,
         },
       });
       const firstResult = result.current;
@@ -156,7 +143,6 @@ describe('Autosuggest controller', () => {
         filterValue: '1',
         filterText: '1',
         filteringType: 'auto',
-        isKeyboard,
       });
       expect(firstResult.items).toBe(result.current.items);
     });
@@ -220,7 +206,6 @@ describe('Autosuggest controller', () => {
   describe('useKeyboardHandler', () => {
     const moveHighlight: (direction: -1 | 1) => void = jest.fn();
     const selectHighlighted: () => void = jest.fn();
-    const isKeyboard = createRef<boolean>() as MutableRefObject<boolean>;
     const open = true;
     const onKeyDown: CancelableEventHandler<BaseKeyDetail> = jest.fn();
     const openDropdown: () => void = jest.fn();
@@ -234,9 +219,8 @@ describe('Autosuggest controller', () => {
     let handleKeyDown: CancelableEventHandler<BaseKeyDetail>;
     beforeEach(() => {
       jest.resetAllMocks();
-      isKeyboard.current = true;
       const { result } = renderHook((args: Parameters<typeof useKeyboardHandler>) => useKeyboardHandler(...args), {
-        initialProps: [moveHighlight, openDropdown, selectHighlighted, isKeyboard, open, onKeyDown],
+        initialProps: [moveHighlight, openDropdown, selectHighlighted, open, onKeyDown],
       });
       handleKeyDown = result.current;
     });
@@ -246,13 +230,6 @@ describe('Autosuggest controller', () => {
       expect(openDropdown).toBeCalled();
       fireCancelableEvent(handleKeyDown, { keyCode: KeyCode.up, ...keyDetail });
       expect(moveHighlight).toBeCalledWith(-1);
-    });
-    test('unsets isKeyboard ref on arrow keys', () => {
-      fireCancelableEvent(handleKeyDown, { keyCode: KeyCode.down, ...keyDetail });
-      expect(isKeyboard.current).toEqual(true);
-      isKeyboard.current = false;
-      fireCancelableEvent(handleKeyDown, { keyCode: KeyCode.up, ...keyDetail });
-      expect(isKeyboard.current).toEqual(true);
     });
     test('selects highlighted item on "enter" key', () => {
       fireCancelableEvent(handleKeyDown, { keyCode: KeyCode.enter, ...keyDetail });
@@ -283,7 +260,7 @@ describe('Autosuggest controller', () => {
       const event = new KeyboardEvent('keydown', { key: 'Enter' });
       const spy = jest.spyOn(event, 'preventDefault');
       const { result } = renderHook((args: Parameters<typeof useKeyboardHandler>) => useKeyboardHandler(...args), {
-        initialProps: [moveHighlight, openDropdown, selectHighlighted, isKeyboard, false, onKeyDown],
+        initialProps: [moveHighlight, openDropdown, selectHighlighted, false, onKeyDown],
       });
       handleKeyDown = result.current;
 

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -9,13 +9,14 @@ import { getTestOptionIndexes } from '../internal/components/options-list/utils/
 
 import styles from './styles.css.js';
 import { AutosuggestItem } from './interfaces';
+import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
 
 export interface AutosuggestOptionProps extends BaseComponentProps {
   nativeAttributes?: Record<string, any>;
   highlightText: string;
   option: AutosuggestItem;
   highlighted: boolean;
-  highlightedType: 'mouse' | 'keyboard';
+  highlightType: HighlightType;
   enteredTextLabel: (value: string) => string;
   virtualPosition?: number;
   padBottom?: boolean;
@@ -30,7 +31,7 @@ const AutosuggestOption = (
     highlightText,
     option,
     highlighted,
-    highlightedType,
+    highlightType,
     enteredTextLabel,
     virtualPosition,
     padBottom,
@@ -84,7 +85,7 @@ const AutosuggestOption = (
       screenReaderContent={screenReaderContent}
       ariaSetsize={ariaSetsize}
       ariaPosinset={ariaPosinset}
-      highlightedType={highlightedType}
+      highlightType={highlightType}
     >
       {optionContent}
     </SelectableItem>

--- a/src/autosuggest/controller.ts
+++ b/src/autosuggest/controller.ts
@@ -39,7 +39,6 @@ export const useKeyboardHandler = (
   moveHighlight: (direction: -1 | 1) => void,
   openDropdown: () => void,
   selectHighlighted: () => void,
-  isKeyboard: React.MutableRefObject<boolean>,
   open: boolean,
   onKeyDown?: CancelableEventHandler<BaseKeyDetail>
 ) => {
@@ -47,14 +46,12 @@ export const useKeyboardHandler = (
     (e: CustomEvent<BaseKeyDetail>) => {
       switch (e.detail.keyCode) {
         case KeyCode.down: {
-          isKeyboard.current = true;
           moveHighlight(1);
           openDropdown();
           e.preventDefault();
           break;
         }
         case KeyCode.up: {
-          isKeyboard.current = true;
           moveHighlight(-1);
           openDropdown();
           e.preventDefault();
@@ -73,6 +70,6 @@ export const useKeyboardHandler = (
         }
       }
     },
-    [moveHighlight, selectHighlighted, onKeyDown, isKeyboard, open, openDropdown]
+    [moveHighlight, selectHighlighted, onKeyDown, open, openDropdown]
   );
 };

--- a/src/autosuggest/controller.ts
+++ b/src/autosuggest/controller.ts
@@ -6,7 +6,7 @@ import { KeyCode } from '../internal/keycode';
 import { AutosuggestItem } from './interfaces';
 
 export const useSelectVisibleOption = (
-  filteredItems: AutosuggestItem[],
+  filteredItems: readonly AutosuggestItem[],
   selectOption: (option: AutosuggestItem) => void,
   isInteractive: (option: AutosuggestItem) => boolean
 ) =>
@@ -21,7 +21,7 @@ export const useSelectVisibleOption = (
   );
 
 export const useHighlightVisibleOption = (
-  filteredItems: AutosuggestItem[],
+  filteredItems: readonly AutosuggestItem[],
   setHighlightedIndex: (index: number) => void,
   isHighlightable: (option: AutosuggestItem) => boolean
 ) =>

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -80,14 +80,13 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   checkControlled('Autosuggest', 'value', value, 'onChange', onChange);
   checkOptionValueField('Autosuggest', 'options', options);
 
-  const isKeyboard = useRef(false);
   const [open, setOpen] = useState(false);
   const {
     items,
     setShowAll,
     highlightedOption,
     highlightedIndex,
-    highlightedType,
+    highlightType,
     moveHighlight,
     resetHighlight,
     setHighlightedIndex,
@@ -96,7 +95,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     filterValue: value,
     filterText: value,
     filteringType,
-    isKeyboard,
     hideEnteredTextLabel: false,
   });
   const openDropdown = () => !readOnly && setOpen(true);
@@ -136,7 +134,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     onChange && onChange(e);
   };
 
-  const handleKeyDown = useKeyboardHandler(moveHighlight, openDropdown, selectHighlighted, isKeyboard, open, onKeyDown);
+  const handleKeyDown = useKeyboardHandler(moveHighlight, openDropdown, selectHighlighted, open, onKeyDown);
   const handleLoadMore = useCallback(() => {
     options && options.length && statusType === 'pending' && fireLoadMore(false, false);
   }, [fireLoadMore, options, statusType]);
@@ -245,8 +243,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
             selectedAriaLabel={selectedAriaLabel}
             renderHighlightedAriaLive={renderHighlightedAriaLive}
             listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
-            isKeyboard={isKeyboard}
-            highlightedType={highlightedType}
+            highlightType={highlightType}
           />
         )}
       </Dropdown>

--- a/src/autosuggest/options-controller.ts
+++ b/src/autosuggest/options-controller.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState, MutableRefObject } from 'react';
+import { useMemo, useState } from 'react';
 import { filterOptions } from './utils/utils';
 import { generateTestIndexes } from '../internal/components/options-list/utils/test-indexes';
 import { AutosuggestItem, AutosuggestProps } from './interfaces';
@@ -14,7 +14,6 @@ export interface UseAutosuggestItemsProps {
   filterValue: string;
   filterText: string;
   filteringType: AutosuggestProps.FilteringType;
-  isKeyboard: MutableRefObject<boolean>;
   hideEnteredTextLabel?: boolean;
 }
 
@@ -32,7 +31,6 @@ export const useAutosuggestItems = ({
   filterValue,
   filterText,
   filteringType,
-  isKeyboard,
   hideEnteredTextLabel,
 }: UseAutosuggestItemsProps) => {
   const [showAll, setShowAll] = useState(false);
@@ -48,15 +46,15 @@ export const useAutosuggestItems = ({
     return filteredItems;
   }, [items, filterValue, filterText, filteringType, showAll, hideEnteredTextLabel]);
 
-  const { highlightedOption, highlightedIndex, highlightedType, moveHighlight, resetHighlight, setHighlightedIndex } =
-    useHighlightedOption({ options: filteredItems, isKeyboard });
+  const { highlightType, highlightedOption, highlightedIndex, moveHighlight, resetHighlight, setHighlightedIndex } =
+    useHighlightedOption({ options: filteredItems });
 
   return {
     showAll,
     setShowAll,
     items: filteredItems,
     highlightedIndex,
-    highlightedType,
+    highlightType,
     highlightedOption,
     setHighlightedIndex,
     moveHighlight,

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -10,6 +10,7 @@ import PlainList from './plain-list';
 
 import { useAnnouncement } from '../select/utils/use-announcement';
 import { OptionGroup } from '../internal/components/option/interfaces';
+import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
 
 export interface AutosuggestOptionsListProps
   extends Pick<
@@ -28,8 +29,7 @@ export interface AutosuggestOptionsListProps
   handleLoadMore: () => void;
   hasDropdownStatus?: boolean;
   listBottom?: React.ReactNode;
-  isKeyboard: React.MutableRefObject<boolean>;
-  highlightedType: 'mouse' | 'keyboard';
+  highlightType: HighlightType;
 }
 
 const isInteractive = (option?: AutosuggestItem) => {
@@ -40,14 +40,12 @@ const isHighlightable = (option?: AutosuggestItem) => {
   return !!option && option.type !== 'parent';
 };
 
-const createMouseEventHandler =
-  (handler: (index: number) => void, isKeyboard: React.MutableRefObject<boolean>) => (itemIndex: number) => {
-    // prevent mouse events to avoid losing focus from the input
-    isKeyboard.current = false;
-    if (itemIndex > -1) {
-      handler(itemIndex);
-    }
-  };
+const createMouseEventHandler = (handler: (index: number) => void) => (itemIndex: number) => {
+  // prevent mouse events to avoid losing focus from the input
+  if (itemIndex > -1) {
+    handler(itemIndex);
+  }
+};
 
 export default function AutosuggestOptionsList({
   options,
@@ -66,13 +64,12 @@ export default function AutosuggestOptionsList({
   selectedAriaLabel,
   renderHighlightedAriaLive,
   listBottom,
-  isKeyboard,
-  highlightedType,
+  highlightType,
 }: AutosuggestOptionsListProps) {
   const highlightVisibleOption = useHighlightVisibleOption(options, setHighlightedIndex, isHighlightable);
   const selectVisibleOption = useSelectVisibleOption(options, selectOption, isInteractive);
-  const handleMouseUp = createMouseEventHandler(selectVisibleOption, isKeyboard);
-  const handleMouseMove = createMouseEventHandler(highlightVisibleOption, isKeyboard);
+  const handleMouseUp = createMouseEventHandler(selectVisibleOption);
+  const handleMouseMove = createMouseEventHandler(highlightVisibleOption);
 
   const ListComponent = virtualScroll ? VirtualList : PlainList;
 
@@ -97,7 +94,7 @@ export default function AutosuggestOptionsList({
       hasDropdownStatus={hasDropdownStatus}
       menuProps={{ id: listId, ariaLabelledby: controlId, onMouseUp: handleMouseUp, onMouseMove: handleMouseMove }}
       screenReaderContent={announcement}
-      highlightedType={highlightedType}
+      highlightType={highlightType}
     />
   );
 }

--- a/src/autosuggest/plain-list.tsx
+++ b/src/autosuggest/plain-list.tsx
@@ -9,6 +9,7 @@ import { getBaseProps } from '../internal/base-component';
 import AutosuggestOption from './autosuggest-option';
 import { AutosuggestProps, AutosuggestItem } from './interfaces';
 import styles from './styles.css.js';
+import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
 
 export interface ListProps {
   menuProps: Omit<OptionsListProps, 'children'>;
@@ -16,7 +17,7 @@ export interface ListProps {
   filteredItems: AutosuggestItem[];
   highlightedOption?: AutosuggestItem;
   highlightedIndex: number;
-  highlightedType: 'mouse' | 'keyboard';
+  highlightType: HighlightType;
   enteredTextLabel: AutosuggestProps.EnteredTextLabel;
   highlightedA11yProps: Record<string, string | number | boolean>;
   hasDropdownStatus?: boolean;
@@ -48,7 +49,7 @@ const PlainList = ({
   menuProps,
   highlightedOption,
   highlightedIndex,
-  highlightedType,
+  highlightType,
   enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
@@ -59,10 +60,10 @@ const PlainList = ({
   const listRef = useRef<HTMLUListElement>(null);
   useEffect(() => {
     const item = listRef.current?.querySelector(`[data-mouse-target="${highlightedIndex}"]`);
-    if (highlightedType === 'keyboard' && item) {
+    if (highlightType === 'keyboard' && item) {
       scrollUntilVisible(item as HTMLElement);
     }
-  }, [highlightedType, highlightedIndex]);
+  }, [highlightType, highlightedIndex]);
 
   return (
     <OptionsList
@@ -92,7 +93,7 @@ const PlainList = ({
             data-mouse-target={index}
             enteredTextLabel={enteredTextLabel}
             screenReaderContent={screenReaderContent}
-            highlightedType={highlightedType}
+            highlightType={highlightType}
             {...optionProps}
           />
         );

--- a/src/autosuggest/plain-list.tsx
+++ b/src/autosuggest/plain-list.tsx
@@ -9,15 +9,12 @@ import { getBaseProps } from '../internal/base-component';
 import AutosuggestOption from './autosuggest-option';
 import { AutosuggestProps, AutosuggestItem } from './interfaces';
 import styles from './styles.css.js';
-import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
+import { AutosuggestItemsState } from './options-controller';
 
 export interface ListProps {
+  autosuggestItemsState: AutosuggestItemsState;
   menuProps: Omit<OptionsListProps, 'children'>;
   handleLoadMore: () => void;
-  filteredItems: AutosuggestItem[];
-  highlightedOption?: AutosuggestItem;
-  highlightedIndex: number;
-  highlightType: HighlightType;
   enteredTextLabel: AutosuggestProps.EnteredTextLabel;
   highlightedA11yProps: Record<string, string | number | boolean>;
   hasDropdownStatus?: boolean;
@@ -29,9 +26,9 @@ export interface ListProps {
 export const getOptionProps = (
   index: number,
   item: AutosuggestItem,
-  filteredItems: AutosuggestItem[],
+  filteredItems: readonly AutosuggestItem[],
   highlightedA11yProps: ListProps['highlightedA11yProps'],
-  highlightedOption?: ListProps['highlightedOption'],
+  highlightedOption?: AutosuggestItem,
   hasDropdownStatus?: boolean
 ) => {
   const nativeAttributes = item === highlightedOption ? highlightedA11yProps : {};
@@ -44,12 +41,9 @@ export const getOptionProps = (
 };
 
 const PlainList = ({
+  autosuggestItemsState,
   handleLoadMore,
-  filteredItems,
   menuProps,
-  highlightedOption,
-  highlightedIndex,
-  highlightType,
   enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
@@ -59,11 +53,11 @@ const PlainList = ({
 }: ListProps) => {
   const listRef = useRef<HTMLUListElement>(null);
   useEffect(() => {
-    const item = listRef.current?.querySelector(`[data-mouse-target="${highlightedIndex}"]`);
-    if (highlightType === 'keyboard' && item) {
+    const item = listRef.current?.querySelector(`[data-mouse-target="${autosuggestItemsState.highlightedIndex}"]`);
+    if (autosuggestItemsState.highlightType === 'keyboard' && item) {
       scrollUntilVisible(item as HTMLElement);
     }
-  }, [highlightType, highlightedIndex]);
+  }, [autosuggestItemsState.highlightType, autosuggestItemsState.highlightedIndex]);
 
   return (
     <OptionsList
@@ -74,13 +68,13 @@ const PlainList = ({
       // to prevent closing the list when clicking the scrollbar on IE11
       nativeAttributes={{ unselectable: 'on' }}
     >
-      {filteredItems.map((item, index) => {
+      {autosuggestItemsState.items.map((item, index) => {
         const optionProps = getOptionProps(
           index,
           item,
-          filteredItems,
+          autosuggestItemsState.items,
           highlightedA11yProps,
-          highlightedOption,
+          autosuggestItemsState.highlightedOption,
           hasDropdownStatus
         );
 
@@ -88,12 +82,12 @@ const PlainList = ({
           <AutosuggestOption
             highlightText={highlightText}
             option={item}
-            highlighted={item === highlightedOption}
+            highlighted={item === autosuggestItemsState.highlightedOption}
             key={index}
             data-mouse-target={index}
             enteredTextLabel={enteredTextLabel}
             screenReaderContent={screenReaderContent}
-            highlightType={highlightType}
+            highlightType={autosuggestItemsState.highlightType}
             {...optionProps}
           />
         );

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -16,7 +16,7 @@ const VirtualList = ({
   menuProps,
   highlightedOption,
   highlightedIndex,
-  highlightedType,
+  highlightType,
   enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
@@ -41,10 +41,10 @@ const VirtualList = ({
   });
 
   useEffect(() => {
-    if (highlightedType === 'keyboard') {
+    if (highlightType === 'keyboard') {
       rowVirtualizer.scrollToIndex(highlightedIndex);
     }
-  }, [highlightedType, rowVirtualizer, highlightedIndex]);
+  }, [highlightType, rowVirtualizer, highlightedIndex]);
 
   return (
     <OptionsList
@@ -86,7 +86,7 @@ const VirtualList = ({
             screenReaderContent={screenReaderContent}
             ariaSetsize={filteredItems.length}
             ariaPosinset={index + 1}
-            highlightedType={highlightedType}
+            highlightType={highlightType}
             {...optionProps}
           />
         );

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -11,12 +11,9 @@ import { getOptionProps, ListProps } from './plain-list';
 import styles from './styles.css.js';
 
 const VirtualList = ({
+  autosuggestItemsState,
   handleLoadMore,
-  filteredItems,
   menuProps,
-  highlightedOption,
-  highlightedIndex,
-  highlightType,
   enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
@@ -29,7 +26,7 @@ const VirtualList = ({
   const [width, strutRef] = useContainerQuery(rect => rect.width, []);
   useImperativeHandle(strutRef, () => scrollRef.current);
   const rowVirtualizer = useVirtual({
-    size: filteredItems.length,
+    size: autosuggestItemsState.items.length,
     parentRef: scrollRef,
     // estimateSize is a dependency of measurements memo. We update it to force full recalculation
     // when the height of any option could have changed:
@@ -41,10 +38,10 @@ const VirtualList = ({
   });
 
   useEffect(() => {
-    if (highlightType === 'keyboard') {
-      rowVirtualizer.scrollToIndex(highlightedIndex);
+    if (autosuggestItemsState.highlightType === 'keyboard') {
+      rowVirtualizer.scrollToIndex(autosuggestItemsState.highlightedIndex);
     }
-  }, [highlightType, rowVirtualizer, highlightedIndex]);
+  }, [autosuggestItemsState.highlightType, autosuggestItemsState.highlightedIndex, rowVirtualizer]);
 
   return (
     <OptionsList
@@ -59,17 +56,17 @@ const VirtualList = ({
         aria-hidden="true"
         key="total-size"
         className={styles['layout-strut']}
-        style={{ height: rowVirtualizer.totalSize + (filteredItems.length === 1 ? 1 : 0) }}
+        style={{ height: rowVirtualizer.totalSize + (autosuggestItemsState.items.length === 1 ? 1 : 0) }}
       />
       {rowVirtualizer.virtualItems.map(virtualRow => {
         const { index, start, measureRef } = virtualRow;
-        const item = filteredItems[index];
+        const item = autosuggestItemsState.items[index];
         const optionProps = getOptionProps(
           index,
           item,
-          filteredItems,
+          autosuggestItemsState.items,
           highlightedA11yProps,
-          highlightedOption,
+          autosuggestItemsState.highlightedOption,
           hasDropdownStatus
         );
 
@@ -79,14 +76,14 @@ const VirtualList = ({
             ref={measureRef}
             highlightText={highlightText}
             option={item}
-            highlighted={item === highlightedOption}
+            highlighted={item === autosuggestItemsState.highlightedOption}
             data-mouse-target={index}
             enteredTextLabel={enteredTextLabel}
             virtualPosition={start + (index === 0 ? 1 : 0)}
             screenReaderContent={screenReaderContent}
-            ariaSetsize={filteredItems.length}
+            ariaSetsize={autosuggestItemsState.items.length}
             ariaPosinset={index + 1}
-            highlightType={highlightType}
+            highlightType={autosuggestItemsState.highlightType}
             {...optionProps}
           />
         );

--- a/src/internal/components/options-list/__tests__/use-highlight-option.test.ts
+++ b/src/internal/components/options-list/__tests__/use-highlight-option.test.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { renderHook, act } from '../../../../__tests__/render-hook';
 import { flattenOptions } from '../../option/utils/flatten-options';
-import { createHighlightedOptionHook } from '../utils/use-highlight-option';
+import { useHighlightedOption } from '../utils/use-highlight-option';
 import { DropdownOption } from '../../option/interfaces';
 
-const useHighlightedOption = createHighlightedOptionHook({
-  isHighlightable: (option: DropdownOption) => option && option.type !== 'parent',
-});
+const isHighlightable = (option: DropdownOption) => option && option.type !== 'parent';
 
 const options = [
   {
@@ -46,15 +44,15 @@ const optionProp = flattenOptions(options).flatOptions;
 describe('useHighlightedOption', () => {
   test('should move highlight and also highlight disabled options', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    expect(hook.result.current.highlightedOption).toBe(undefined);
-    act(() => hook.result.current.moveHighlight(1));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
-    act(() => hook.result.current.moveHighlight(1));
-    act(() => hook.result.current.moveHighlight(1));
-    act(() => hook.result.current.moveHighlight(1));
-    expect(hook.result.current.highlightedOption).toEqual({
+    expect(hook.result.current[0].highlightedOption).toBe(undefined);
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({
       option: { label: 'Child 1' },
       type: 'child',
       disabled: true,
@@ -63,16 +61,16 @@ describe('useHighlightedOption', () => {
 
   test('should go to the end and do not move further', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    act(() => hook.result.current.goEnd());
-    expect(hook.result.current.highlightedOption).toEqual({
+    act(() => hook.result.current[1].goEndWithKeyboard());
+    expect(hook.result.current[0].highlightedOption).toEqual({
       option: { label: 'Child 2', disabled: true },
       type: 'child',
       disabled: true,
     });
-    act(() => hook.result.current.moveHighlight(1));
-    expect(hook.result.current.highlightedOption).toEqual({
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({
       option: { label: 'Child 2', disabled: true },
       type: 'child',
       disabled: true,
@@ -81,51 +79,51 @@ describe('useHighlightedOption', () => {
 
   test('should move highlight to the beginning to do not go further', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    expect(hook.result.current.highlightedOption).toBe(undefined);
-    act(() => hook.result.current.moveHighlight(1));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
-    act(() => hook.result.current.goHome());
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
-    act(() => hook.result.current.moveHighlight(-1));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    expect(hook.result.current[0].highlightedOption).toBe(undefined);
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].goHomeWithKeyboard());
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(-1));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
   });
 
   test('should reset highlight', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    expect(hook.result.current.highlightedOption).toBe(undefined);
-    act(() => hook.result.current.moveHighlight(1));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
-    act(() => hook.result.current.resetHighlight());
-    expect(hook.result.current.highlightedOption).toEqual(undefined);
+    expect(hook.result.current[0].highlightedOption).toBe(undefined);
+    act(() => hook.result.current[1].moveHighlightWithKeyboard(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].resetHighlightWithKeyboard());
+    expect(hook.result.current[0].highlightedOption).toEqual(undefined);
   });
 
   test('should set highlighted index', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    act(() => hook.result.current.setHighlightedIndex(1));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].setHighlightedIndexWithMouse(1));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
   });
 
   test('should highlight option by value', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    act(() => hook.result.current.highlightOption(optionProp[1]));
-    expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
+    act(() => hook.result.current[1].highlightOptionWithKeyboard(optionProp[1]));
+    expect(hook.result.current[0].highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
   });
 
   test('should update highlightType when highligh option', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp },
+      initialProps: { options: optionProp, isHighlightable },
     });
-    act(() => hook.result.current.setHighlightedIndex(1));
-    expect(hook.result.current.highlightType).toEqual('mouse');
-    act(() => hook.result.current.highlightOption(optionProp[1]));
-    expect(hook.result.current.highlightType).toEqual('keyboard');
+    act(() => hook.result.current[1].setHighlightedIndexWithMouse(1));
+    expect(hook.result.current[0].highlightType).toEqual('mouse');
+    act(() => hook.result.current[1].highlightOptionWithKeyboard(optionProp[1]));
+    expect(hook.result.current[0].highlightType).toEqual('keyboard');
   });
 });

--- a/src/internal/components/options-list/__tests__/use-highlight-option.test.ts
+++ b/src/internal/components/options-list/__tests__/use-highlight-option.test.ts
@@ -4,7 +4,6 @@ import { renderHook, act } from '../../../../__tests__/render-hook';
 import { flattenOptions } from '../../option/utils/flatten-options';
 import { createHighlightedOptionHook } from '../utils/use-highlight-option';
 import { DropdownOption } from '../../option/interfaces';
-import { createRef, MutableRefObject } from 'react';
 
 const useHighlightedOption = createHighlightedOptionHook({
   isHighlightable: (option: DropdownOption) => option && option.type !== 'parent',
@@ -43,12 +42,11 @@ const options = [
 ];
 
 const optionProp = flattenOptions(options).flatOptions;
-const isKeyboard = createRef<boolean>() as MutableRefObject<boolean>;
 
 describe('useHighlightedOption', () => {
   test('should move highlight and also highlight disabled options', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     expect(hook.result.current.highlightedOption).toBe(undefined);
     act(() => hook.result.current.moveHighlight(1));
@@ -65,7 +63,7 @@ describe('useHighlightedOption', () => {
 
   test('should go to the end and do not move further', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     act(() => hook.result.current.goEnd());
     expect(hook.result.current.highlightedOption).toEqual({
@@ -83,7 +81,7 @@ describe('useHighlightedOption', () => {
 
   test('should move highlight to the beginning to do not go further', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     expect(hook.result.current.highlightedOption).toBe(undefined);
     act(() => hook.result.current.moveHighlight(1));
@@ -96,7 +94,7 @@ describe('useHighlightedOption', () => {
 
   test('should reset highlight', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     expect(hook.result.current.highlightedOption).toBe(undefined);
     act(() => hook.result.current.moveHighlight(1));
@@ -107,7 +105,7 @@ describe('useHighlightedOption', () => {
 
   test('should set highlighted index', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     act(() => hook.result.current.setHighlightedIndex(1));
     expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
@@ -115,20 +113,19 @@ describe('useHighlightedOption', () => {
 
   test('should highlight option by value', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
     act(() => hook.result.current.highlightOption(optionProp[1]));
     expect(hook.result.current.highlightedOption).toEqual({ option: { label: 'Child 1' }, type: 'child' });
   });
 
-  test('should update highlightedType when highligh option', () => {
+  test('should update highlightType when highligh option', () => {
     const hook = renderHook(useHighlightedOption, {
-      initialProps: { options: optionProp, isKeyboard },
+      initialProps: { options: optionProp },
     });
+    act(() => hook.result.current.setHighlightedIndex(1));
+    expect(hook.result.current.highlightType).toEqual('mouse');
     act(() => hook.result.current.highlightOption(optionProp[1]));
-    expect(hook.result.current.highlightedType).toEqual('mouse');
-    isKeyboard.current = true;
-    act(() => hook.result.current.highlightOption(optionProp[1]));
-    expect(hook.result.current.highlightedType).toEqual('keyboard');
+    expect(hook.result.current.highlightType).toEqual('keyboard');
   });
 });

--- a/src/internal/components/options-list/__tests__/use-keyboard.test.ts
+++ b/src/internal/components/options-list/__tests__/use-keyboard.test.ts
@@ -32,7 +32,6 @@ const menuInitialProps = {
   goHome: () => {},
   goEnd: () => {},
   closeDropdown: () => {},
-  isKeyboard: { current: false },
 };
 
 describe('useTriggerKeyboard', () => {
@@ -40,18 +39,15 @@ describe('useTriggerKeyboard', () => {
     test(`should call openDropdown and goHome when press ${name}`, () => {
       const openDropdown = jest.fn();
       const goHome = jest.fn();
-      const isKeyboard = { current: false };
       const hook = renderHook(useTriggerKeyboard, {
         initialProps: {
           openDropdown,
           goHome,
-          isKeyboard,
         },
       });
       act(() => hook.result.current(eventDetail as any));
       expect(openDropdown).toHaveBeenCalled();
       expect(goHome).toHaveBeenCalled();
-      expect(isKeyboard.current).toBe(true);
       expect(eventDetail.preventDefault).toHaveBeenCalled();
     });
   });
@@ -60,114 +56,97 @@ describe('useTriggerKeyboard', () => {
 describe('useMenuKeyboard', () => {
   test('should move highlight up when pressing up', () => {
     const moveHighlight = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, moveHighlight, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, moveHighlight, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.up));
     expect(moveHighlight).toHaveBeenCalledWith(-1);
     expect(menuKeys.up.preventDefault).toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should move highlight down when pressing down', () => {
     const moveHighlight = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, moveHighlight, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, moveHighlight, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.down));
     expect(moveHighlight).toHaveBeenCalledWith(1);
     expect(menuKeys.down.preventDefault).toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should go home when pressing home', () => {
     const goHome = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, goHome, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, goHome, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.home));
     expect(goHome).toHaveBeenCalled();
     expect(menuKeys.home.preventDefault).not.toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should go to end when pressing end', () => {
     const goEnd = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, goEnd, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, goEnd, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.end));
     expect(goEnd).toHaveBeenCalled();
     expect(menuKeys.end.preventDefault).not.toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should close the dropdown when pressing escape', () => {
     const closeDropdown = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, closeDropdown, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, closeDropdown, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.escape));
     expect(closeDropdown).toHaveBeenCalled();
     expect(menuKeys.escape.preventDefault).not.toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should select option when pressing enter', () => {
     const selectOption = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, selectOption, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, selectOption, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.enter));
     expect(selectOption).toHaveBeenCalled();
     expect(menuKeys.enter.preventDefault).toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should not select option when pressing space when native space is in action (filtering enabled)', () => {
     const selectOption = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, selectOption, isKeyboard, isSelectingUsingSpace },
+      initialProps: { ...menuInitialProps, selectOption, isSelectingUsingSpace },
     });
     act(() => hook.result.current(menuKeys.space));
     expect(selectOption).not.toHaveBeenCalled();
     expect(menuKeys.space.preventDefault).not.toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should select option when pressing space when preventNativeSpace is enabled', () => {
     const selectOption = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, selectOption, isKeyboard, isSelectingUsingSpace, preventNativeSpace: true },
+      initialProps: { ...menuInitialProps, selectOption, isSelectingUsingSpace, preventNativeSpace: true },
     });
     act(() => hook.result.current(menuKeys.space));
     expect(selectOption).toHaveBeenCalled();
     expect(menuKeys.space.preventDefault).toHaveBeenCalled();
-    expect(isKeyboard.current).toBe(true);
   });
 
   test('should update `isSelectingUsingSpace` when selecting an item with space key', () => {
     const selectOption = jest.fn();
-    const isKeyboard = { current: false };
     const isSelectingUsingSpace = { current: false };
     const hook = renderHook(useMenuKeyboard, {
-      initialProps: { ...menuInitialProps, selectOption, isKeyboard, isSelectingUsingSpace, preventNativeSpace: true },
+      initialProps: { ...menuInitialProps, selectOption, isSelectingUsingSpace, preventNativeSpace: true },
     });
     act(() => hook.result.current(menuKeys.space));
     expect(isSelectingUsingSpace.current).toBe(true);

--- a/src/internal/components/options-list/utils/use-highlight-option.ts
+++ b/src/internal/components/options-list/utils/use-highlight-option.ts
@@ -1,64 +1,58 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { MutableRefObject, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
+
+export type HighlightType = 'keyboard' | 'mouse';
 
 export function createHighlightedOptionHook<OptionType>({
   isHighlightable,
 }: {
   isHighlightable: (option: OptionType) => boolean;
 }) {
-  return function useHighlightedOption({
-    options,
-    isKeyboard,
-  }: {
-    options: ReadonlyArray<OptionType>;
-    isKeyboard: MutableRefObject<boolean>;
-  }) {
+  return function useHighlightedOption({ options }: { options: ReadonlyArray<OptionType> }) {
     const [highlightedIndex, setHighlightedIndexState] = useState(-1);
-    const [highlightedType, setHighlightedType] = useState<'mouse' | 'keyboard'>(
-      isKeyboard.current ? 'keyboard' : 'mouse'
-    );
-    const setHighlightedIndex = useCallback(
-      (index: number) => {
-        setHighlightedIndexState(index);
-        setHighlightedType(isKeyboard.current ? 'keyboard' : 'mouse');
-      },
-      [isKeyboard]
-    );
+    const [highlightType, setHighlightType] = useState<HighlightType>('keyboard');
+    const setHighlightedIndex = useCallback((index: number, highlightType: HighlightType) => {
+      setHighlightedIndexState(index);
+      setHighlightType(highlightType);
+    }, []);
     const highlightedOption =
       options[highlightedIndex] && isHighlightable(options[highlightedIndex]) ? options[highlightedIndex] : undefined;
 
-    const moveHighlightFrom = (direction: -1 | 1, startIndex = highlightedIndex) => {
+    const moveHighlightFrom = (direction: -1 | 1, startIndex = highlightedIndex, highlightType: HighlightType) => {
       let newIndex = startIndex;
       do {
         newIndex += direction;
       } while (options[newIndex] && !isHighlightable(options[newIndex]));
 
       if (options[newIndex]) {
-        setHighlightedIndex(newIndex);
+        setHighlightedIndex(newIndex, highlightType);
       }
     };
 
-    const moveHighlight = (direction: -1 | 1) => moveHighlightFrom(direction);
+    const moveHighlight = (direction: -1 | 1, highlightType: HighlightType) =>
+      moveHighlightFrom(direction, highlightedIndex, highlightType);
 
     const highlightOption = useCallback(
-      (option: OptionType) => {
+      (option: OptionType, highlightType: HighlightType) => {
         const index = options.indexOf(option);
-        setHighlightedIndex(index);
+        setHighlightedIndex(index, highlightType);
       },
       [options, setHighlightedIndex]
     );
 
     return {
-      setHighlightedIndex,
+      highlightType,
       highlightedIndex,
-      highlightedType,
       highlightedOption,
-      moveHighlight,
-      resetHighlight: () => setHighlightedIndex(-1),
-      goHome: () => moveHighlightFrom(1, -1),
-      goEnd: () => moveHighlightFrom(-1, options.length),
-      highlightOption,
+      // Mouse handlers
+      setHighlightedIndex: (index: number) => setHighlightedIndex(index, 'mouse'),
+      // Keyboard handlers
+      moveHighlight: (direction: -1 | 1) => moveHighlight(direction, 'keyboard'),
+      highlightOption: (option: OptionType) => highlightOption(option, 'keyboard'),
+      resetHighlight: () => setHighlightedIndex(-1, 'keyboard'),
+      goHome: () => moveHighlightFrom(1, -1, 'keyboard'),
+      goEnd: () => moveHighlightFrom(-1, options.length, 'keyboard'),
     };
   };
 }

--- a/src/internal/components/options-list/utils/use-highlight-option.ts
+++ b/src/internal/components/options-list/utils/use-highlight-option.ts
@@ -4,55 +4,73 @@ import { useCallback, useState } from 'react';
 
 export type HighlightType = 'keyboard' | 'mouse';
 
-export function createHighlightedOptionHook<OptionType>({
-  isHighlightable,
-}: {
+export interface HighlightedOptionProps<OptionType> {
+  options: readonly OptionType[];
   isHighlightable: (option: OptionType) => boolean;
-}) {
-  return function useHighlightedOption({ options }: { options: ReadonlyArray<OptionType> }) {
-    const [highlightedIndex, setHighlightedIndexState] = useState(-1);
-    const [highlightType, setHighlightType] = useState<HighlightType>('keyboard');
-    const setHighlightedIndex = useCallback((index: number, highlightType: HighlightType) => {
-      setHighlightedIndexState(index);
-      setHighlightType(highlightType);
-    }, []);
-    const highlightedOption =
-      options[highlightedIndex] && isHighlightable(options[highlightedIndex]) ? options[highlightedIndex] : undefined;
+}
 
-    const moveHighlightFrom = (direction: -1 | 1, startIndex = highlightedIndex, highlightType: HighlightType) => {
-      let newIndex = startIndex;
-      do {
-        newIndex += direction;
-      } while (options[newIndex] && !isHighlightable(options[newIndex]));
+export interface HighlightedOptionState<OptionType> {
+  highlightType: HighlightType;
+  highlightedIndex: number;
+  highlightedOption?: OptionType;
+}
 
-      if (options[newIndex]) {
-        setHighlightedIndex(newIndex, highlightType);
-      }
-    };
+export interface HighlightedOptionHandlers<OptionType> {
+  // Mouse handlers
+  setHighlightedIndexWithMouse(index: number): void;
+  // Keyboard handlers
+  moveHighlightWithKeyboard(direction: -1 | 1): void;
+  highlightOptionWithKeyboard(option: OptionType): void;
+  resetHighlightWithKeyboard(): void;
+  goHomeWithKeyboard(): void;
+  goEndWithKeyboard(): void;
+}
 
-    const moveHighlight = (direction: -1 | 1, highlightType: HighlightType) =>
-      moveHighlightFrom(direction, highlightedIndex, highlightType);
+export function useHighlightedOption<OptionType>({
+  options,
+  isHighlightable,
+}: HighlightedOptionProps<OptionType>): [HighlightedOptionState<OptionType>, HighlightedOptionHandlers<OptionType>] {
+  const [highlightedIndex, setHighlightedIndexState] = useState(-1);
+  const [highlightType, setHighlightType] = useState<HighlightType>('keyboard');
+  const setHighlightedIndex = useCallback((index: number, highlightType: HighlightType) => {
+    setHighlightedIndexState(index);
+    setHighlightType(highlightType);
+  }, []);
 
-    const highlightOption = useCallback(
-      (option: OptionType, highlightType: HighlightType) => {
-        const index = options.indexOf(option);
-        setHighlightedIndex(index, highlightType);
-      },
-      [options, setHighlightedIndex]
-    );
+  const highlightedOption =
+    options[highlightedIndex] && isHighlightable(options[highlightedIndex]) ? options[highlightedIndex] : undefined;
 
-    return {
-      highlightType,
-      highlightedIndex,
-      highlightedOption,
-      // Mouse handlers
-      setHighlightedIndex: (index: number) => setHighlightedIndex(index, 'mouse'),
-      // Keyboard handlers
-      moveHighlight: (direction: -1 | 1) => moveHighlight(direction, 'keyboard'),
-      highlightOption: (option: OptionType) => highlightOption(option, 'keyboard'),
-      resetHighlight: () => setHighlightedIndex(-1, 'keyboard'),
-      goHome: () => moveHighlightFrom(1, -1, 'keyboard'),
-      goEnd: () => moveHighlightFrom(-1, options.length, 'keyboard'),
-    };
+  const moveHighlightFrom = (direction: -1 | 1, startIndex = highlightedIndex, highlightType: HighlightType) => {
+    let newIndex = startIndex;
+    do {
+      newIndex += direction;
+    } while (options[newIndex] && !isHighlightable(options[newIndex]));
+
+    if (options[newIndex]) {
+      setHighlightedIndex(newIndex, highlightType);
+    }
   };
+
+  const moveHighlight = (direction: -1 | 1, highlightType: HighlightType) =>
+    moveHighlightFrom(direction, highlightedIndex, highlightType);
+
+  const highlightOption = useCallback(
+    (option: OptionType, highlightType: HighlightType) => {
+      const index = options.indexOf(option);
+      setHighlightedIndex(index, highlightType);
+    },
+    [options, setHighlightedIndex]
+  );
+
+  return [
+    { highlightType, highlightedIndex, highlightedOption },
+    {
+      setHighlightedIndexWithMouse: (index: number) => setHighlightedIndex(index, 'mouse'),
+      moveHighlightWithKeyboard: (direction: -1 | 1) => moveHighlight(direction, 'keyboard'),
+      highlightOptionWithKeyboard: (option: OptionType) => highlightOption(option, 'keyboard'),
+      resetHighlightWithKeyboard: () => setHighlightedIndex(-1, 'keyboard'),
+      goHomeWithKeyboard: () => moveHighlightFrom(1, -1, 'keyboard'),
+      goEndWithKeyboard: () => moveHighlightFrom(-1, options.length, 'keyboard'),
+    },
+  ];
 }

--- a/src/internal/components/options-list/utils/use-keyboard.ts
+++ b/src/internal/components/options-list/utils/use-keyboard.ts
@@ -14,7 +14,6 @@ interface UseMenuKeyboard {
     goHome: () => void;
     goEnd: () => void;
     closeDropdown: () => void;
-    isKeyboard: MutableRefObject<boolean>;
     isSelectingUsingSpace: MutableRefObject<boolean>;
     preventNativeSpace?: boolean;
   }): CancelableEventHandler<BaseKeyDetail>;
@@ -26,13 +25,11 @@ export const useMenuKeyboard: UseMenuKeyboard = ({
   goHome,
   goEnd,
   closeDropdown,
-  isKeyboard,
   isSelectingUsingSpace,
   preventNativeSpace = false,
 }) => {
   return useCallback(
     (e: CustomEvent<BaseKeyDetail>) => {
-      isKeyboard.current = true;
       switch (e.detail.keyCode) {
         case KeyCode.up:
           e.preventDefault();
@@ -63,22 +60,17 @@ export const useMenuKeyboard: UseMenuKeyboard = ({
           }
       }
     },
-    [moveHighlight, selectOption, goHome, goEnd, closeDropdown, isKeyboard, isSelectingUsingSpace, preventNativeSpace]
+    [moveHighlight, selectOption, goHome, goEnd, closeDropdown, isSelectingUsingSpace, preventNativeSpace]
   );
 };
 
 interface UseTriggerKeyboard {
-  (inputProps: {
-    openDropdown: () => void;
-    goHome: () => void;
-    isKeyboard: MutableRefObject<boolean>;
-  }): CancelableEventHandler<BaseKeyDetail>;
+  (inputProps: { openDropdown: () => void; goHome: () => void }): CancelableEventHandler<BaseKeyDetail>;
 }
 
-export const useTriggerKeyboard: UseTriggerKeyboard = ({ openDropdown, goHome, isKeyboard }) => {
+export const useTriggerKeyboard: UseTriggerKeyboard = ({ openDropdown, goHome }) => {
   return useCallback(
     (e: CustomEvent<BaseKeyDetail>) => {
-      isKeyboard.current = true;
       switch (e.detail.keyCode) {
         case KeyCode.up:
         case KeyCode.down:
@@ -92,6 +84,6 @@ export const useTriggerKeyboard: UseTriggerKeyboard = ({ openDropdown, goHome, i
           break;
       }
     },
-    [openDropdown, goHome, isKeyboard]
+    [openDropdown, goHome]
   );
 };

--- a/src/internal/components/selectable-item/index.tsx
+++ b/src/internal/components/selectable-item/index.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useLayoutEffect } from 'react';
 import clsx from 'clsx';
 import styles from './styles.css.js';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
+import { HighlightType } from '../options-list/utils/use-highlight-option.js';
 
 export interface SelectableItemProps extends BaseComponentProps {
   children: React.ReactNode;
@@ -22,7 +23,7 @@ export interface SelectableItemProps extends BaseComponentProps {
   screenReaderContent?: string;
   ariaPosinset?: number;
   ariaSetsize?: number;
-  highlightedType?: 'mouse' | 'keyboard';
+  highlightType?: HighlightType;
 }
 
 const SelectableItem = (
@@ -43,7 +44,7 @@ const SelectableItem = (
     screenReaderContent,
     ariaPosinset,
     ariaSetsize,
-    highlightedType,
+    highlightType,
     ...restProps
   }: SelectableItemProps,
   ref: React.Ref<HTMLDivElement>
@@ -55,7 +56,7 @@ const SelectableItem = (
     [styles['has-background']]: hasBackground,
     [styles.parent]: isParent,
     [styles.child]: isChild,
-    [styles['is-keyboard']]: highlightedType === 'keyboard',
+    [styles['is-keyboard']]: highlightType === 'keyboard',
     [styles.disabled]: disabled,
     [styles.virtual]: virtualPosition !== undefined,
     [styles['pad-bottom']]: padBottom,

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -132,14 +132,13 @@ const InternalMultiselect = React.forwardRef(
     const scrollToIndex = useRef<SelectListProps.SelectListRef>(null);
     const {
       isOpen,
+      highlightType,
       highlightedOption,
       highlightedIndex,
-      highlightedType,
       getTriggerProps,
       getFilterProps,
       getMenuProps,
       getOptionProps,
-      isKeyboard,
       highlightOption,
       announceSelected,
     } = useSelect({
@@ -161,7 +160,6 @@ const InternalMultiselect = React.forwardRef(
       options: filteredOptions,
       highlightOption: highlightOption,
       highlightedOption: highlightedOption?.option,
-      isKeyboard,
       useInteractiveGroups,
     });
 
@@ -289,7 +287,7 @@ const InternalMultiselect = React.forwardRef(
             checkboxes={true}
             useInteractiveGroups={useInteractiveGroups}
             screenReaderContent={announcement}
-            highlightedType={highlightedType}
+            highlightType={highlightType}
           />
         </Dropdown>
         {showTokens && (

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -77,13 +77,12 @@ const PropertyFilterAutosuggest = React.forwardRef(
     } = props;
     const highlightText = filterText === undefined ? value : filterText;
 
-    const isKeyboard = useRef(false);
     const [open, setOpen] = useState(false);
     const {
       items,
       highlightedOption,
       highlightedIndex,
-      highlightedType,
+      highlightType,
       moveHighlight,
       resetHighlight,
       setHighlightedIndex,
@@ -92,7 +91,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
       filterValue: value,
       filterText: highlightText,
       filteringType,
-      isKeyboard,
       hideEnteredTextLabel: hideEnteredTextOption,
     });
     const openDropdown = () => setOpen(true);
@@ -137,14 +135,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
       onChange && onChange(e);
     };
 
-    const handleKeyDown = useKeyboardHandler(
-      moveHighlight,
-      openDropdown,
-      selectHighlighted,
-      isKeyboard,
-      open,
-      onKeyDown
-    );
+    const handleKeyDown = useKeyboardHandler(moveHighlight, openDropdown, selectHighlighted, open, onKeyDown);
     const handleLoadMore = useCallback(() => {
       options && options.length && statusType === 'pending' && fireLoadMore(false, false);
     }, [fireLoadMore, options, statusType]);
@@ -248,8 +239,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
               hasDropdownStatus={dropdownStatus.content !== null}
               virtualScroll={virtualScroll}
               listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
-              isKeyboard={isKeyboard}
-              highlightedType={highlightedType}
+              highlightType={highlightType}
             />
           )}
         </Dropdown>

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -73,15 +73,11 @@ describe('useSelect', () => {
       initialProps,
     });
 
-    const { isOpen, highlightedOption, getTriggerProps, getMenuProps, getFilterProps, getOptionProps, isKeyboard } =
+    const { isOpen, highlightedOption, getTriggerProps, getMenuProps, getFilterProps, getOptionProps } =
       hook.result.current;
 
     test('should return isOpen=false as the initial state', () => {
       expect(isOpen).toBe(false);
-    });
-
-    test('should return isKeyboard=false as the initial state', () => {
-      expect(isKeyboard.current).toBe(false);
     });
 
     test('should return highlightedOption=undefined as the initial state', () => {
@@ -160,7 +156,7 @@ describe('useSelect', () => {
         value: 'child1',
       },
     });
-    expect(hook.result.current.isKeyboard.current).toBe(true);
+    expect(hook.result.current.highlightType).toBe('keyboard');
   });
 
   test('should open and navigate to the first option and select', () => {

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -93,14 +93,13 @@ const InternalSelect = React.forwardRef(
     const scrollToIndex = useRef<SelectListProps.SelectListRef>(null);
     const {
       isOpen,
+      highlightType,
       highlightedOption,
       highlightedIndex,
-      highlightedType,
       getTriggerProps,
       getFilterProps,
       getMenuProps,
       getOptionProps,
-      isKeyboard,
       highlightOption,
       selectOption,
       announceSelected,
@@ -121,7 +120,6 @@ const InternalSelect = React.forwardRef(
       options: filteredOptions,
       highlightOption: !isOpen ? selectOption : highlightOption,
       highlightedOption: !isOpen ? selectedOption : highlightedOption?.option,
-      isKeyboard,
     });
 
     useEffect(() => {
@@ -222,7 +220,7 @@ const InternalSelect = React.forwardRef(
             ref={scrollToIndex}
             hasDropdownStatus={dropdownStatus.content !== null}
             screenReaderContent={announcement}
-            highlightedType={highlightedType}
+            highlightType={highlightType}
           />
         </Dropdown>
       </div>

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -8,6 +8,7 @@ import { getBaseProps } from '../../internal/base-component';
 import { DropdownOption, OptionDefinition } from '../../internal/components/option/interfaces';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
 import InternalIcon from '../../icon/internal.js';
+import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option.js';
 
 export interface ItemProps {
   option: DropdownOption;
@@ -21,7 +22,7 @@ export interface ItemProps {
   screenReaderContent?: string;
   ariaPosinset?: number;
   ariaSetsize?: number;
-  highlightedType?: 'mouse' | 'keyboard';
+  highlightType?: HighlightType;
 }
 
 const Item = (
@@ -37,7 +38,7 @@ const Item = (
     screenReaderContent,
     ariaPosinset,
     ariaSetsize,
-    highlightedType,
+    highlightType,
     ...restProps
   }: ItemProps,
   ref: React.Ref<HTMLDivElement>
@@ -64,7 +65,7 @@ const Item = (
       screenReaderContent={screenReaderContent}
       ariaPosinset={ariaPosinset}
       ariaSetsize={ariaSetsize}
-      highlightedType={highlightedType}
+      highlightType={highlightType}
       {...baseProps}
     >
       <div className={styles.item}>

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -8,6 +8,7 @@ import SelectableItem from '../../internal/components/selectable-item';
 import { getBaseProps } from '../../internal/base-component';
 import { DropdownOption, OptionDefinition } from '../../internal/components/option/interfaces';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
+import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option.js';
 export interface ItemProps {
   option: DropdownOption;
   highlighted?: boolean;
@@ -21,7 +22,7 @@ export interface ItemProps {
   screenReaderContent?: string;
   ariaPosinset?: number;
   ariaSetsize?: number;
-  highlightedType?: 'mouse' | 'keyboard';
+  highlightType?: HighlightType;
 }
 
 const MultiSelectItem = (
@@ -38,7 +39,7 @@ const MultiSelectItem = (
     screenReaderContent,
     ariaPosinset,
     ariaSetsize,
-    highlightedType,
+    highlightType,
     ...restProps
   }: ItemProps,
   ref: React.Ref<HTMLDivElement>
@@ -62,7 +63,7 @@ const MultiSelectItem = (
       disabled={disabled}
       isParent={isParent}
       isChild={isChild}
-      highlightedType={highlightedType}
+      highlightType={highlightType}
       ref={ref}
       virtualPosition={virtualPosition}
       padBottom={padBottom}

--- a/src/select/parts/plain-list.tsx
+++ b/src/select/parts/plain-list.tsx
@@ -8,13 +8,14 @@ import { DropdownOption } from '../../internal/components/option/interfaces';
 import { scrollUntilVisible } from '../../internal/utils/scrollable-containers';
 
 import styles from './styles.css.js';
+import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option';
 
 export interface SelectListProps {
   menuProps: MenuProps;
   getOptionProps: GetOptionProps;
   filteredOptions: ReadonlyArray<DropdownOption>;
   filteringValue: string;
-  highlightedType: 'mouse' | 'keyboard';
+  highlightType: HighlightType;
   checkboxes?: boolean;
   hasDropdownStatus?: boolean;
   listBottom?: React.ReactNode;
@@ -32,7 +33,7 @@ const PlainList = (
     getOptionProps,
     filteredOptions,
     filteringValue,
-    highlightedType,
+    highlightType,
     checkboxes,
     hasDropdownStatus,
     listBottom,
@@ -46,11 +47,11 @@ const PlainList = (
     ref,
     () => (index: number) => {
       const item = menuRef.current?.querySelector(`[data-mouse-target="${index}"]`);
-      if (highlightedType === 'keyboard' && item) {
+      if (highlightType === 'keyboard' && item) {
         scrollUntilVisible(item as HTMLElement);
       }
     },
-    [highlightedType, menuRef]
+    [highlightType, menuRef]
   );
 
   return (
@@ -59,7 +60,7 @@ const PlainList = (
         options: filteredOptions,
         getOptionProps,
         filteringValue,
-        highlightedType,
+        highlightType,
         checkboxes,
         hasDropdownStatus,
         useInteractiveGroups,

--- a/src/select/parts/virtual-list.tsx
+++ b/src/select/parts/virtual-list.tsx
@@ -21,7 +21,7 @@ const VirtualListOpen = forwardRef(
       getOptionProps,
       filteredOptions,
       filteringValue,
-      highlightedType,
+      highlightType,
       checkboxes,
       hasDropdownStatus,
       listBottom,
@@ -49,17 +49,17 @@ const VirtualListOpen = forwardRef(
     useImperativeHandle(
       ref,
       () => (index: number) => {
-        if (highlightedType === 'keyboard') {
+        if (highlightType === 'keyboard') {
           scrollToIndex(index);
         }
       },
-      [highlightedType, scrollToIndex]
+      [highlightType, scrollToIndex]
     );
     const finalOptions = renderOptions({
       options: virtualItems.map(({ index }) => filteredOptions[index]),
       getOptionProps,
       filteringValue,
-      highlightedType,
+      highlightType,
       checkboxes,
       hasDropdownStatus,
       virtualItems,

--- a/src/select/utils/render-options.tsx
+++ b/src/select/utils/render-options.tsx
@@ -6,12 +6,13 @@ import Item from '../parts/item';
 import MutliselectItem from '../parts/multiselect-item';
 import { DropdownOption } from '../../internal/components/option/interfaces';
 import { getItemProps } from './get-item-props';
+import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option';
 
 export interface RenderOptionProps {
   options: ReadonlyArray<DropdownOption>;
   getOptionProps: any;
   filteringValue: string;
-  highlightedType: 'mouse' | 'keyboard';
+  highlightType: HighlightType;
   checkboxes?: boolean;
   hasDropdownStatus?: boolean;
   virtualItems?: VirtualItem[];
@@ -24,7 +25,7 @@ export const renderOptions = ({
   options,
   getOptionProps,
   filteringValue,
-  highlightedType,
+  highlightType,
   checkboxes = false,
   hasDropdownStatus,
   virtualItems,
@@ -57,7 +58,7 @@ export const renderOptions = ({
         screenReaderContent={screenReaderContent}
         ariaPosinset={globalIndex + 1}
         ariaSetsize={ariaSetsize}
-        highlightedType={highlightedType}
+        highlightType={highlightType}
       />
     );
   });

--- a/src/select/utils/use-native-search.ts
+++ b/src/select/utils/use-native-search.ts
@@ -19,7 +19,6 @@ export const isRepeatedChar = (str: string) => str.split('').every(c => c === st
 
 interface UseNativeSearchProps {
   isEnabled: boolean;
-  isKeyboard: React.MutableRefObject<boolean>;
   options: ReadonlyArray<DropdownOption>;
   highlightOption: (option: DropdownOption) => void;
   highlightedOption: OptionDefinition | undefined | null;
@@ -72,7 +71,6 @@ function findMatchingOption(
 export function useNativeSearch({
   isEnabled,
   options,
-  isKeyboard,
   highlightOption,
   highlightedOption,
   useInteractiveGroups,
@@ -82,7 +80,6 @@ export function useNativeSearch({
   const delayedResetValue = useDebounceCallback(() => (value.current = ''), 500);
 
   return (event: React.KeyboardEvent) => {
-    isKeyboard.current = true;
     if (!isEnabled) {
       return;
     }

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -67,7 +67,6 @@ export function useSelect({
   const menuRef = useRef<HTMLUListElement>(null);
   const hasFilter = filteringType !== 'none';
   const activeRef = hasFilter ? filterRef : menuRef;
-  const isKeyboard = useRef<boolean>(false);
   const isSelectingUsingSpace = useRef<boolean>(false);
   const __selectedOptions = connectOptionsByValue(options, selectedOptions);
   const __selectedValuesSet = selectedOptions.reduce((selectedValuesSet: Set<string>, item: OptionDefinition) => {
@@ -77,16 +76,16 @@ export function useSelect({
     return selectedValuesSet;
   }, new Set<string>());
   const {
+    highlightType,
     highlightedOption,
     highlightedIndex,
-    highlightedType,
     moveHighlight,
     resetHighlight,
     setHighlightedIndex,
     highlightOption,
     goHome,
     goEnd,
-  } = useHighlightedOption({ options, isKeyboard });
+  } = useHighlightedOption({ options });
 
   const { isOpen, openDropdown, closeDropdown, toggleDropdown } = useOpenState({
     onOpen: () => fireLoadItems(''),
@@ -147,12 +146,11 @@ export function useSelect({
       triggerRef.current?.focus();
       closeDropdown();
     },
-    isKeyboard,
     isSelectingUsingSpace,
     preventNativeSpace: !hasFilter,
   });
 
-  const triggerKeyDownHandler = useTriggerKeyboard({ openDropdown, goHome, isKeyboard });
+  const triggerKeyDownHandler = useTriggerKeyboard({ openDropdown, goHome });
 
   const getTriggerProps = (disabled = false) => {
     const triggerProps: SelectTriggerProps = {
@@ -209,13 +207,11 @@ export function useSelect({
       onFocus: handleFocus,
       onBlur: handleBlur,
       onMouseUp: itemIndex => {
-        isKeyboard.current = false;
         if (itemIndex > -1) {
           selectOption(options[itemIndex]);
         }
       },
       onMouseMove: itemIndex => {
-        isKeyboard.current = false;
         if (itemIndex > -1) {
           setHighlightedIndex(itemIndex);
         }
@@ -292,12 +288,11 @@ export function useSelect({
     isOpen,
     highlightedOption,
     highlightedIndex,
-    highlightedType,
+    highlightType,
     getTriggerProps,
     getMenuProps,
     getFilterProps,
     getOptionProps,
-    isKeyboard,
     highlightOption,
     selectOption,
     announceSelected,


### PR DESCRIPTION
### Description

The isKeyboard ref was used to alter the following change of highlight based on the type of interaction. Instead, the highlight type now depends on the callback method being used. The `setHighlightedIndex` is used for mouse highlight and all other - for keyboard highlight.

### How has this been tested?

Updated existing tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
