### PR TITLE
Make abstract-switch outline definition better encapsulated

### DIFF
--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -52,6 +52,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
         {...baseProps}
         className={clsx(styles.root, baseProps.className)}
         controlClassName={styles['checkbox-control']}
+        outlineClassName={styles.outline}
         controlId={controlId}
         disabled={disabled}
         label={children}
@@ -64,7 +65,6 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
           <input
             {...nativeControlProps}
             ref={checkboxRef}
-            className={styles.input}
             type="checkbox"
             checked={checked}
             name={name}

--- a/src/checkbox/styles.scss
+++ b/src/checkbox/styles.scss
@@ -19,11 +19,6 @@ div.root {
   @include styles.make-control-size($checkbox-size);
 }
 
-.input {
-  @include focus-visible.when-visible {
-    /* stylelint-disable-next-line selector-max-type -- Can't access the outline class from focus-visible */
-    & + span {
-      @include styles.focus-highlight(2px);
-    }
-  }
+.outline {
+  @include styles.focus-highlight(2px);
 }

--- a/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
+++ b/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
@@ -14,6 +14,7 @@ describe('Abstract switch component, aria-labelledby', () => {
   test('should not have a labelId if a label is not provided', () => {
     const wrapper = renderAbstractSwitch({
       controlClassName: '',
+      outlineClassName: '',
       styledControl: <div />,
       controlId: 'custom-id',
       description: 'Description goes here',
@@ -28,6 +29,7 @@ describe('Abstract switch component, aria-labelledby', () => {
   test('should be set to labelId if a label is provided', () => {
     const wrapper = renderAbstractSwitch({
       controlClassName: '',
+      outlineClassName: '',
       styledControl: <div />,
       label: 'Label goes here',
       controlId: 'custom-id',
@@ -47,6 +49,7 @@ describe('Abstract switch component, aria-labelledby', () => {
   test('should include labelId if an ariaLabelledBy id is provided', () => {
     const wrapper = renderAbstractSwitch({
       controlClassName: '',
+      outlineClassName: '',
       styledControl: <div />,
       controlId: 'custom-id',
       ariaLabelledby: 'some-custom-label',

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -10,6 +10,7 @@ import { InternalBaseComponentProps } from '../../hooks/use-base-component/index
 export interface AbstractSwitchProps extends React.HTMLAttributes<HTMLElement>, InternalBaseComponentProps {
   controlId?: string;
   controlClassName: string;
+  outlineClassName: string;
   disabled?: boolean;
   nativeControl: (props: React.InputHTMLAttributes<HTMLInputElement>) => React.ReactElement;
   styledControl: React.ReactElement;
@@ -29,6 +30,7 @@ function joinString(values: (string | undefined)[]) {
 export default function AbstractSwitch({
   controlId,
   controlClassName,
+  outlineClassName,
   disabled,
   nativeControl,
   styledControl,
@@ -86,15 +88,12 @@ export default function AbstractSwitch({
             ...focusVisible,
             id,
             disabled,
+            className: styles['native-input'],
             'aria-describedby': ariaDescriptons.length ? joinString(ariaDescriptons) : undefined,
             'aria-labelledby': ariaLabelledByIds.length ? joinString(ariaLabelledByIds) : undefined,
             'aria-label': ariaLabel,
           })}
-          {/*
-          An empty element to display the outline, because the native control is invisible.
-          Note: There is a CSS selector in src/toggle/styles.scss that relies on a span element selector to show focus.
-          */}
-          <span className={styles.outline} />
+          <span className={clsx(styles.outline, outlineClassName)} />
         </span>
         <span className={clsx(styles.content, !label && !description && styles['empty-content'])}>
           {label && (

--- a/src/internal/components/abstract-switch/styles.scss
+++ b/src/internal/components/abstract-switch/styles.scss
@@ -5,12 +5,25 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
+@use '../../hooks/focus-visible' as focus-visible;
 
 .content,
 .description,
-.label,
-.outline {
+.label {
   display: block;
+}
+
+.outline {
+  display: none;
+}
+
+.native-input {
+  @include focus-visible.when-visible {
+    /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
+    & + .outline {
+      display: block;
+    }
+  }
 }
 
 .wrapper {

--- a/src/radio-group/radio-button.tsx
+++ b/src/radio-group/radio-button.tsx
@@ -31,6 +31,7 @@ export default function RadioButton({
     <AbstractSwitch
       className={clsx(styles.radio, description && styles['radio--has-description'])}
       controlClassName={styles['radio-control']}
+      outlineClassName={styles.outline}
       label={label}
       description={description}
       disabled={disabled}
@@ -38,7 +39,6 @@ export default function RadioButton({
       nativeControl={nativeControlProps => (
         <input
           {...nativeControlProps}
-          className={styles.input}
           type="radio"
           name={name}
           value={value}

--- a/src/radio-group/styles.scss
+++ b/src/radio-group/styles.scss
@@ -30,13 +30,8 @@ $radio-size: awsui.$size-control;
   @include styles.make-control-size($radio-size);
 }
 
-.input {
-  @include focus-visible.when-visible {
-    /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
-    & + span {
-      @include styles.focus-highlight(2px, awsui.$border-radius-control-circular-focus-ring);
-    }
-  }
+.outline {
+  @include styles.focus-highlight(2px, awsui.$border-radius-control-circular-focus-ring);
 }
 
 .styled-circle-border {

--- a/src/toggle/internal.tsx
+++ b/src/toggle/internal.tsx
@@ -43,6 +43,7 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
           [styles['toggle-control-checked']]: checked,
           [styles['toggle-control-disabled']]: disabled,
         })}
+        outlineClassName={styles.outline}
         controlId={controlId}
         disabled={disabled}
         label={children}
@@ -55,7 +56,6 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
           <input
             {...nativeControlProps}
             ref={checkboxRef}
-            className={styles.input}
             type="checkbox"
             checked={checked}
             name={name}

--- a/src/toggle/styles.scss
+++ b/src/toggle/styles.scss
@@ -18,13 +18,8 @@ $shadow-color: rgba(0, 0, 0, 0.25);
   display: flex;
 }
 
-.input {
-  @include focus-visible.when-visible {
-    /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
-    & + span {
-      @include styles.focus-highlight(2px);
-    }
-  }
+.outline {
+  @include styles.focus-highlight(2px);
 }
 
 .toggle-control {


### PR DESCRIPTION
### Description

Refactored abstract-switch to make outline style definition better encapsulated so that consumer components do not rely on the abstract-switch structure.

### How has this been tested?

Existing tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
