### PR TITLE
feat(container): `clipOverflow` property

### DIFF
--- a/pages/container/simple.page.tsx
+++ b/pages/container/simple.page.tsx
@@ -97,6 +97,18 @@ export default function SimpleContainers() {
               tortor, mollis vitae molestie sed, malesuada.
             </Container>
           </div>
+          <Container
+            disableContentPaddings={true}
+            disableHeaderPaddings={true}
+            clipOverflow={true}
+            header={<div style={{ background: 'rgba(255, 0, 0, 0.1)', width: '100%' }}>Header Area</div>}
+            footer="Footer"
+          >
+            <div style={{ background: 'rgba(0, 0, 255, 0.1)', width: '100%' }}>Content Area</div>
+          </Container>
+          <Container disableContentPaddings={true} clipOverflow={true}>
+            <div style={{ background: 'rgba(0, 0, 255, 0.1)', width: '100%' }}>Content Area</div>
+          </Container>
         </SpaceBetween>
       </ScreenshotArea>
     </article>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4036,6 +4036,12 @@ Object {
       "type": "string",
     },
     Object {
+      "description": "Specifies if overflowing content should be clipped at the element edges. This is especially important when paddings are disabled.",
+      "name": "clipOverflow",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "defaultValue": "false",
       "description": "Determines whether the container content has padding. If \`true\`, removes the default padding from the content area.",
       "name": "disableContentPaddings",

--- a/src/container/interfaces.ts
+++ b/src/container/interfaces.ts
@@ -37,4 +37,9 @@ export interface ContainerProps extends BaseComponentProps {
    * @visualrefresh `stacked` variant
    */
   variant?: 'default' | 'stacked';
+
+  /**
+   * Specifies if overflowing content should be clipped at the element edges. This is especially important when paddings are disabled.
+   */
+  clipOverflow?: boolean;
 }

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -33,6 +33,7 @@ export default function InternalContainer({
   variant = 'default',
   disableHeaderPaddings = false,
   disableContentPaddings = false,
+  clipOverflow = false,
   __stickyOffset,
   __stickyHeader = false,
   __internalRootRef = null,
@@ -55,7 +56,9 @@ export default function InternalContainer({
   return (
     <div
       {...baseProps}
-      className={clsx(baseProps.className, styles.root, styles[`variant-${variant}`])}
+      className={clsx(baseProps.className, styles.root, styles[`variant-${variant}`], {
+        [styles['clip-overflow-with-fallback']]: clipOverflow,
+      })}
       ref={mergedRef}
     >
       {header && (

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -11,7 +11,6 @@
   @include styles.styles-reset;
   display: block;
   word-wrap: break-word;
-  overflow: clip;
   &.variant {
     &-default,
     &-stacked {

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -11,6 +11,7 @@
   @include styles.styles-reset;
   display: block;
   word-wrap: break-word;
+  overflow: clip;
   &.variant {
     &-default,
     &-stacked {
@@ -27,6 +28,14 @@
       border-top-right-radius: 0;
       box-shadow: awsui.$shadow-container-stacked;
     }
+  }
+  &.clip-overflow-with-fallback {
+    /**
+     * Fallback value for Safari, which does not support overflow:clip. However, this creates a new 
+     * block formatting context, which could break existing layouts.
+     */
+    overflow: hidden;
+    overflow: clip;
   }
 }
 

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -12,7 +12,11 @@ export const getOverflowParents = (element: HTMLElement): HTMLElement[] => {
   let node: HTMLElement | null = element;
 
   while ((node = node.parentElement) && node !== document.body) {
-    getComputedStyle(node).overflow !== 'visible' && parents.push(node);
+    const styles = getComputedStyle(node);
+
+    if (['visible', 'clip'].indexOf(styles.overflow) < 0) {
+      parents.push(node);
+    }
   }
   return parents;
 };


### PR DESCRIPTION
Allows to clip container content by the edges of the container.

### Description

[_Include a summary of the changes and the related issue._]

[_Also include relevant motivation and context._]

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
