### PR TITLE
Decouple autosuggest items and dropdown controllers

### DIFF
--- a/src/autosuggest/controller.ts
+++ b/src/autosuggest/controller.ts
@@ -36,30 +36,32 @@ export const useHighlightVisibleOption = (
   );
 
 export const useKeyboardHandler = (
-  moveHighlight: (direction: -1 | 1) => void,
-  openDropdown: () => void,
-  selectHighlighted: () => void,
   open: boolean,
+  openDropdown: () => void,
+  closeDropdown: () => void,
+  interceptKeyDown: (e: CustomEvent<BaseKeyDetail>) => boolean,
   onKeyDown?: CancelableEventHandler<BaseKeyDetail>
 ) => {
   return useCallback(
     (e: CustomEvent<BaseKeyDetail>) => {
       switch (e.detail.keyCode) {
         case KeyCode.down: {
-          moveHighlight(1);
+          interceptKeyDown(e);
           openDropdown();
           e.preventDefault();
           break;
         }
         case KeyCode.up: {
-          moveHighlight(-1);
+          interceptKeyDown(e);
           openDropdown();
           e.preventDefault();
           break;
         }
         case KeyCode.enter: {
           if (open) {
-            selectHighlighted();
+            if (!interceptKeyDown(e)) {
+              closeDropdown();
+            }
             e.preventDefault();
           }
           onKeyDown && onKeyDown(e);
@@ -70,6 +72,6 @@ export const useKeyboardHandler = (
         }
       }
     },
-    [moveHighlight, selectHighlighted, onKeyDown, open, openDropdown]
+    [open, openDropdown, closeDropdown, interceptKeyDown, onKeyDown]
   );
 };

--- a/src/autosuggest/dropdown-controller.ts
+++ b/src/autosuggest/dropdown-controller.ts
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 export interface UseAutosuggestDropdownProps {
   readOnly?: boolean;
   onClose?: () => void;
+  onBlur?: () => void;
 }
 
 export interface AutosuggestDropdownState {
@@ -15,13 +16,20 @@ export interface AutosuggestDropdownState {
 export interface AutosuggestDropdownHandlers {
   openDropdown(): void;
   closeDropdown(): void;
+  handleBlur: React.FocusEventHandler;
+}
+
+export interface AutosuggestDropdownRefs {
+  footerRef: React.Ref<HTMLDivElement>;
 }
 
 export const useAutosuggestDropdown = ({
   readOnly,
   onClose,
-}: UseAutosuggestDropdownProps): [AutosuggestDropdownState, AutosuggestDropdownHandlers] => {
+  onBlur,
+}: UseAutosuggestDropdownProps): [AutosuggestDropdownState, AutosuggestDropdownHandlers, AutosuggestDropdownRefs] => {
   const [open, setOpen] = useState(false);
+  const footerRef = useRef<HTMLDivElement>(null);
 
   const openDropdown = () => !readOnly && setOpen(true);
 
@@ -30,5 +38,13 @@ export const useAutosuggestDropdown = ({
     onClose?.();
   };
 
-  return [{ open }, { openDropdown, closeDropdown }];
+  const handleBlur: React.FocusEventHandler = event => {
+    if (event.currentTarget.contains(event.relatedTarget) || footerRef.current?.contains(event.relatedTarget)) {
+      return;
+    }
+    closeDropdown();
+    onBlur?.();
+  };
+
+  return [{ open }, { openDropdown, closeDropdown, handleBlur }, { footerRef }];
 };

--- a/src/autosuggest/dropdown-controller.ts
+++ b/src/autosuggest/dropdown-controller.ts
@@ -17,6 +17,7 @@ export interface AutosuggestDropdownHandlers {
   openDropdown(): void;
   closeDropdown(): void;
   handleBlur: React.FocusEventHandler;
+  handleMouseDown: React.MouseEventHandler;
 }
 
 export interface AutosuggestDropdownRefs {
@@ -46,5 +47,10 @@ export const useAutosuggestDropdown = ({
     onBlur?.();
   };
 
-  return [{ open }, { openDropdown, closeDropdown, handleBlur }, { footerRef }];
+  const handleMouseDown: React.MouseEventHandler = event => {
+    // Prevent currently focused element from losing focus.
+    event.preventDefault();
+  };
+
+  return [{ open }, { openDropdown, closeDropdown, handleBlur, handleMouseDown }, { footerRef }];
 };

--- a/src/autosuggest/dropdown-controller.ts
+++ b/src/autosuggest/dropdown-controller.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+export interface UseAutosuggestDropdownProps {
+  readOnly?: boolean;
+  onClose?: () => void;
+}
+
+export interface AutosuggestDropdownState {
+  open: boolean;
+}
+
+export interface AutosuggestDropdownHandlers {
+  openDropdown(): void;
+  closeDropdown(): void;
+}
+
+export const useAutosuggestDropdown = ({
+  readOnly,
+  onClose,
+}: UseAutosuggestDropdownProps): [AutosuggestDropdownState, AutosuggestDropdownHandlers] => {
+  const [open, setOpen] = useState(false);
+
+  const openDropdown = () => !readOnly && setOpen(true);
+
+  const closeDropdown = () => {
+    setOpen(false);
+    onClose?.();
+  };
+
+  return [{ open }, { openDropdown, closeDropdown }];
+};

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -161,11 +161,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const showRecoveryLink = open && statusType === 'error' && props.recoveryText;
   const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });
 
-  const handleMouseDown = (event: React.MouseEvent) => {
-    // prevent currently focused element from losing it
-    event.preventDefault();
-  };
-
   return (
     <div
       {...baseProps}
@@ -194,7 +189,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
             controlId={controlId}
           />
         }
-        onMouseDown={handleMouseDown}
+        onMouseDown={autosuggestDropdownHandlers.handleMouseDown}
         open={open}
         dropdownId={dropdownId}
         footer={

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -92,18 +92,11 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     hideEnteredTextLabel: false,
     onSelectItem: selectOption,
   });
-  const [{ open }, autosuggestDropdownHandlers] = useAutosuggestDropdown({
+  const [{ open }, autosuggestDropdownHandlers, autosuggestDropdownRefs] = useAutosuggestDropdown({
     readOnly,
     onClose: () => autosuggestItemsHandlers.resetHighlightWithKeyboard(),
+    onBlur: () => fireNonCancelableEvent(onBlur),
   });
-
-  const handleBlur: React.FocusEventHandler = event => {
-    if (event.currentTarget.contains(event.relatedTarget) || dropdownFooterRef.current?.contains(event.relatedTarget)) {
-      return;
-    }
-    autosuggestDropdownHandlers.closeDropdown();
-    fireNonCancelableEvent(onBlur);
-  };
 
   const fireLoadMore = useLoadMoreItems(onLoadItems);
 
@@ -132,7 +125,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const formFieldContext = useFormFieldContext(rest);
   const baseProps = getBaseProps(rest);
   const inputRef = useRef<HTMLInputElement>(null);
-  const dropdownFooterRef = useRef<HTMLDivElement>(null);
   useForwardFocus(ref, inputRef);
 
   const selfControlId = useUniqueId('input');
@@ -175,7 +167,12 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   };
 
   return (
-    <div {...baseProps} className={clsx(styles.root, baseProps.className)} ref={__internalRootRef} onBlur={handleBlur}>
+    <div
+      {...baseProps}
+      className={clsx(styles.root, baseProps.className)}
+      ref={__internalRootRef}
+      onBlur={autosuggestDropdownHandlers.handleBlur}
+    >
       <Dropdown
         trigger={
           <InternalInput
@@ -202,7 +199,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
         dropdownId={dropdownId}
         footer={
           dropdownStatus.isSticky ? (
-            <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>
+            <div ref={autosuggestDropdownRefs.footerRef} className={styles['dropdown-footer']}>
               <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
             </div>
           ) : null

--- a/src/autosuggest/options-controller.ts
+++ b/src/autosuggest/options-controller.ts
@@ -80,11 +80,9 @@ export const useAutosuggestItems = ({
         return true;
       }
       case KeyCode.enter: {
-        if (highlightedOptionState.highlightedOption) {
-          if (isInteractive(highlightedOptionState.highlightedOption)) {
-            onSelectItem(highlightedOptionState.highlightedOption);
-            return true;
-          }
+        if (highlightedOptionState.highlightedOption && isInteractive(highlightedOptionState.highlightedOption)) {
+          onSelectItem(highlightedOptionState.highlightedOption);
+          return true;
         }
         return false;
       }

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -158,11 +158,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const showRecoveryLink = open && statusType === 'error' && props.recoveryText;
     const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });
 
-    const handleMouseDown = (event: React.MouseEvent) => {
-      // prevent currently focused element from losing it
-      event.preventDefault();
-    };
-
     return (
       <div
         {...baseProps}
@@ -188,7 +183,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
               controlId={controlId}
             />
           }
-          onMouseDown={handleMouseDown}
+          onMouseDown={autosuggestDropdownHandlers.handleMouseDown}
           open={open}
           dropdownId={dropdownId}
           footer={

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -93,18 +93,9 @@ const PropertyFilterAutosuggest = React.forwardRef(
       hideEnteredTextLabel: hideEnteredTextOption,
       onSelectItem: selectOption,
     });
-    const [{ open }, autosuggestDropdownHandlers] = useAutosuggestDropdown({
+    const [{ open }, autosuggestDropdownHandlers, autosuggestDropdownRefs] = useAutosuggestDropdown({
       onClose: () => autosuggestItemsHandlers.resetHighlightWithKeyboard(),
     });
-    const handleBlur: React.FocusEventHandler = event => {
-      if (
-        event.currentTarget.contains(event.relatedTarget) ||
-        dropdownFooterRef.current?.contains(event.relatedTarget)
-      ) {
-        return;
-      }
-      autosuggestDropdownHandlers.closeDropdown();
-    };
 
     const fireLoadMore = useLoadMoreItems(onLoadItems);
 
@@ -132,7 +123,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const formFieldContext = useFormFieldContext(rest);
     const baseProps = getBaseProps(rest);
     const inputRef = useRef<HTMLInputElement>(null);
-    const dropdownFooterRef = useRef<HTMLDivElement>(null);
     useForwardFocus(ref, inputRef);
 
     const selfControlId = useUniqueId('input');
@@ -174,7 +164,11 @@ const PropertyFilterAutosuggest = React.forwardRef(
     };
 
     return (
-      <div {...baseProps} className={clsx(styles.root, baseProps.className)} onBlur={handleBlur}>
+      <div
+        {...baseProps}
+        className={clsx(styles.root, baseProps.className)}
+        onBlur={autosuggestDropdownHandlers.handleBlur}
+      >
         <Dropdown
           minWidth={DROPDOWN_WIDTH}
           stretchWidth={false}
@@ -199,7 +193,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
           dropdownId={dropdownId}
           footer={
             dropdownStatus.isSticky ? (
-              <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>
+              <div ref={autosuggestDropdownRefs.footerRef} className={styles['dropdown-footer']}>
                 <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
               </div>
             ) : null


### PR DESCRIPTION
### Description

This refactoring is a step towards creating an abstract autosuggest to be shared between public autosuggest component and property-filter. The autosuggest items and dropdown logic was decoupled as the abstract variant can have any content, not only an options list.

### How has this been tested?

Updated unit tests to cover the changed hooks structure.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
