### PR TITLE
fix(select,autosuggest): Stop polyfilling Element.scrollIntoView

### DIFF
--- a/src/autosuggest/plain-list.tsx
+++ b/src/autosuggest/plain-list.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 
 import OptionsList, { OptionsListProps } from '../internal/components/options-list';
-import { scrollUntilVisible } from '../internal/utils/scrollable-containers';
+import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { getBaseProps } from '../internal/base-component';
 
 import AutosuggestOption from './autosuggest-option';
@@ -53,9 +53,11 @@ const PlainList = ({
 }: ListProps) => {
   const listRef = useRef<HTMLUListElement>(null);
   useEffect(() => {
-    const item = listRef.current?.querySelector(`[data-mouse-target="${autosuggestItemsState.highlightedIndex}"]`);
+    const item = listRef.current?.querySelector<HTMLElement>(
+      `[data-mouse-target="${autosuggestItemsState.highlightedIndex}"]`
+    );
     if (autosuggestItemsState.highlightType === 'keyboard' && item) {
-      scrollUntilVisible(item as HTMLElement);
+      scrollElementIntoView(item);
     }
   }, [autosuggestItemsState.highlightType, autosuggestItemsState.highlightedIndex]);
 

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -61,24 +61,6 @@ export const getOverflowParentDimensions = (
   return parents;
 };
 
-/**
- * If the element is out of view, scrolls the scroll parent until
- * the element is visible.
- *
- * Basically an IE11/Safari polyfill for `elem.scrollIntoView({ block: 'nearest' })`
- */
-export function scrollUntilVisible(element: HTMLElement): void {
-  const parent = element.offsetParent ?? document.documentElement;
-  // Anchor to top of scroll parent.
-  if (element.offsetTop < parent.scrollTop) {
-    parent.scrollTop = element.offsetTop;
-  }
-  // Anchor to bottom of scroll parent.
-  if (element.offsetTop + element.clientHeight > parent.scrollTop + parent.clientHeight) {
-    parent.scrollTop = element.offsetTop + element.clientHeight - parent.clientHeight;
-  }
-}
-
 type ScrollIntoViewOptions = Parameters<HTMLElement['scrollIntoView']>[0];
 
 /**

--- a/src/select/parts/plain-list.tsx
+++ b/src/select/parts/plain-list.tsx
@@ -5,7 +5,7 @@ import React, { forwardRef, useImperativeHandle } from 'react';
 import { renderOptions } from '../utils/render-options';
 import { MenuProps, GetOptionProps } from '../utils/use-select';
 import { DropdownOption } from '../../internal/components/option/interfaces';
-import { scrollUntilVisible } from '../../internal/utils/scrollable-containers';
+import { scrollElementIntoView } from '../../internal/utils/scrollable-containers';
 
 import styles from './styles.css.js';
 import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option';
@@ -46,9 +46,9 @@ const PlainList = (
   useImperativeHandle(
     ref,
     () => (index: number) => {
-      const item = menuRef.current?.querySelector(`[data-mouse-target="${index}"]`);
+      const item = menuRef.current?.querySelector<HTMLElement>(`[data-mouse-target="${index}"]`);
       if (highlightType === 'keyboard' && item) {
-        scrollUntilVisible(item as HTMLElement);
+        scrollElementIntoView(item);
       }
     },
     [highlightType, menuRef]


### PR DESCRIPTION
### Description

No reason to polyfill this anymore; every browser we support has this method ([caniuse](https://caniuse.com/scrollintoview)). We still have to use a wrapper for it though, cause JSDOM doesn't support it.

Can I use and MDN are lying to you; Safari supports the `options` parameter just fine going all the way down to Safari 12.1 (tested manually), but only added `smooth` in Safari 15.4, so the manual smooth scrolling implementation in the tabs component will have to stay for... just over two more years.

Notably, this fixes an issue in VR where scrolling with arrow keys in a select causes it to be misaligned (AWSUI-18701).

### How has this been tested?

You can test this manually by opening up a select with a scrollbar (try the one in the `select.test` page) and scrolling with the arrow keys. I'm feeling a little lazy so I'll have Github actions check unit and integ tests for me.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
