### PR TITLE
feat: Make border-radius design tokens public and themeable

### DIFF
--- a/style-dictionary/visual-refresh/metadata/borders.ts
+++ b/style-dictionary/visual-refresh/metadata/borders.ts
@@ -14,58 +14,92 @@ const metadata: StyleDictionary.MetadataIndex = {
   borderPanelTopWidth: { description: 'The split panel top border width.' },
   borderRadiusAlert: {
     description: 'The border radius of alerts.',
+    public: true,
+    themeable: true,
   },
   borderRadiusBadge: {
     description: 'The border radius of badges.',
+    public: true,
+    themeable: true,
   },
   borderRadiusButton: {
     description: "The border radius of buttons and segmented control's segments.",
+    public: true,
+    themeable: true,
   },
   borderRadiusCalendarDayFocusRing: {
     description: 'The border radius of the focused day in date picker and date range picker.',
+    public: true,
+    themeable: true,
   },
   borderRadiusCodeEditor: {
     description: 'The border radius of code editors.',
+    public: true,
+    themeable: true,
   },
   borderRadiusContainer: {
     description:
       'The border radius of containers. Also used in container-based components like table, cards, expandable section, and modal.',
+    public: true,
+    themeable: true,
   },
   borderRadiusControlCircularFocusRing: {
     description: 'The border radius of the focus indicator of circular controls. For example: radio button.',
+    public: true,
+    themeable: true,
   },
   borderRadiusControlDefaultFocusRing: {
     description:
       'The border radius of the focus indicator of interactive elements. For example: button, link, toggle, pagination controls, expandable section header, popover trigger.',
+    public: true,
+    themeable: true,
   },
   borderRadiusDropdown: {
     description:
       'The border radius of dropdown containers. For example: button dropdown, select, multiselect, autosuggest, date picker, date range picker.',
+    public: true,
+    themeable: true,
   },
   borderRadiusFlashbar: {
     description: 'The border radius of flash messages in flashbars.',
+    public: true,
+    themeable: true,
   },
   borderRadiusItem: {
     description:
       'The border radius of items that can be selected from a list. For example: select options, table rows, calendar days.',
+    public: true,
+    themeable: true,
   },
   borderRadiusInput: {
     description: 'The border radius of form controls. For example: input, select.',
+    public: true,
+    themeable: true,
   },
   borderRadiusPopover: {
     description: 'The border radius of popovers.',
+    public: true,
+    themeable: true,
   },
   borderRadiusTabsFocusRing: {
     description: "The border radius of tabs' focus indicator. Used in tabs and in the code editor status bar.",
+    public: true,
+    themeable: true,
   },
   borderRadiusTiles: {
     description: 'The border radius of tiles.',
+    public: true,
+    themeable: true,
   },
   borderRadiusToken: {
     description: 'The border radius of tokens. For example: token groups, multiselect tokens, property filter tokens.',
+    public: true,
+    themeable: true,
   },
   borderRadiusTutorialPanelItem: {
     description: 'The border radius of tutorials inside a tutorial panel.',
+    public: true,
+    themeable: true,
   },
 };
 


### PR DESCRIPTION
### Description

Make border radius design tokens public and themeable


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [X] _Yes, this change contains documentation changes._
- [ ] _No._

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



