### PR TITLE
fix: Hotspot events inside a checkbox label unexpectedly toggle the checkbox

### DIFF
--- a/pages/annotation-context/with-hotspot-inside-switch.page.tsx
+++ b/pages/annotation-context/with-hotspot-inside-switch.page.tsx
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import AnnotationContext from '~components/annotation-context';
+import Checkbox from '~components/checkbox';
+import Hotspot from '~components/hotspot';
+import RadioGroup from '~components/radio-group';
+import SpaceBetween from '~components/space-between';
+import Tiles from '~components/tiles';
+import Toggle from '~components/toggle';
+import tutorials from '../onboarding/tutorials';
+import { annotationContextStrings } from '../onboarding/i18n';
+
+const tutorial = tutorials(() => {})[0];
+const noop = () => {};
+
+export default function AnnotationScroll() {
+  const [checkboxIsChecked, setCheckboxIsChecked] = useState(false);
+  const [toggleIsChecked, setToggleIsChecked] = useState(false);
+  const [radiogroupValue, setRadiogroupValue] = useState('first');
+  const [tilesValue, setTilesValue] = useState('item1');
+
+  return (
+    <>
+      <h1>Annotation Context: with Hotspots inside components using AbstractSwitch</h1>
+      <AnnotationContext
+        currentTutorial={tutorial}
+        i18nStrings={annotationContextStrings}
+        onStartTutorial={noop}
+        onExitTutorial={noop}
+      >
+        <div style={{ padding: 20 }}>
+          <SpaceBetween size="l">
+            <Checkbox
+              checked={checkboxIsChecked}
+              onChange={e => {
+                console.log('Checkbox toggled');
+                setCheckboxIsChecked(e.detail.checked);
+              }}
+              description="This is a description"
+            >
+              This is the checkbox label
+              <Hotspot hotspotId={tutorial.tasks[0].steps[0].hotspotId} />
+            </Checkbox>
+
+            <Toggle
+              checked={toggleIsChecked}
+              onChange={e => {
+                console.log('Toggle toggled');
+                setToggleIsChecked(e.detail.checked);
+              }}
+              description="This is a description"
+            >
+              This is the toggle label
+              <Hotspot hotspotId={tutorial.tasks[0].steps[2].hotspotId}></Hotspot>
+            </Toggle>
+
+            <RadioGroup
+              onChange={({ detail }) => {
+                console.log('Radio button selected');
+                setRadiogroupValue(detail.value);
+              }}
+              value={radiogroupValue}
+              items={[
+                { value: 'first', label: 'First choice', description: 'This is a description' },
+                {
+                  value: 'second',
+                  label: (
+                    <>
+                      Second choice <Hotspot hotspotId={tutorial.tasks[0].steps[3].hotspotId} />
+                    </>
+                  ),
+                  description: 'This is a description',
+                },
+                { value: 'third', label: 'Third choice', description: 'This is a description' },
+              ]}
+            />
+
+            <Tiles
+              onChange={({ detail }) => {
+                console.log('Tile selected');
+                setTilesValue(detail.value);
+              }}
+              value={tilesValue}
+              items={[
+                { label: 'Item 1 label', value: 'item1' },
+                {
+                  label: (
+                    <>
+                      Item 2 label <Hotspot hotspotId={tutorial.tasks[0].steps[5].hotspotId} />
+                    </>
+                  ),
+                  value: 'item2',
+                },
+                { label: 'Item 3 label', value: 'item3' },
+              ]}
+            />
+          </SpaceBetween>
+        </div>
+      </AnnotationContext>
+    </>
+  );
+}

--- a/pages/tiles/permutations.page.tsx
+++ b/pages/tiles/permutations.page.tsx
@@ -51,7 +51,7 @@ const permutations = createPermutations<TilesProps>([
       ],
       [
         { value: 'seventh', description: 'Short Description', label: 'First Button', disabled: true },
-        { value: 'second', description: 'Short description', label: '' },
+        { value: 'second', description: 'Short description', label: 'Second Button' },
         { value: 'ninth', description: '', label: 'Label' },
         {
           value: 'first',

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -90,84 +90,91 @@ export function AnnotationPopover({
   );
 
   return (
-    <PopoverContainer
-      position={direction}
-      trackRef={trackRef}
-      trackKey={taskLocalStepIndex}
-      arrow={arrow}
-      zIndex={1000}
-    >
-      <PopoverBody
-        size="medium"
-        fixedWidth={false}
-        dismissButton={true}
-        dismissAriaLabel={i18nStrings.labelDismissAnnotation}
-        header={
-          <InternalBox color="text-body-secondary" fontSize="body-s" margin={{ top: 'xxxs' }} className={styles.header}>
-            {title}
-          </InternalBox>
-        }
-        onDismiss={onDismiss}
-        className={styles.annotation}
-        variant="annotation"
-        overflowVisible="content"
-        dismissButtonRef={dismissButtonRefCallback}
+    <div onClick={e => e.stopPropagation()}>
+      <PopoverContainer
+        position={direction}
+        trackRef={trackRef}
+        trackKey={taskLocalStepIndex}
+        arrow={arrow}
+        zIndex={1000}
       >
-        <InternalSpaceBetween size="s">
-          <div className={styles.description}>
-            <InternalBox className={styles.content}>{content}</InternalBox>
-          </div>
-
-          {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
-
+        <PopoverBody
+          size="medium"
+          fixedWidth={false}
+          dismissButton={true}
+          dismissAriaLabel={i18nStrings.labelDismissAnnotation}
+          header={
+            <InternalBox
+              color="text-body-secondary"
+              fontSize="body-s"
+              margin={{ top: 'xxxs' }}
+              className={styles.header}
+            >
+              {title}
+            </InternalBox>
+          }
+          onDismiss={onDismiss}
+          className={styles.annotation}
+          variant="annotation"
+          overflowVisible="content"
+          dismissButtonRef={dismissButtonRefCallback}
+        >
           <InternalSpaceBetween size="s">
-            <div className={styles.divider} />
-
-            <div className={styles.actionBar}>
-              <div className={styles.stepCounter}>
-                <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
-                  {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
-                </InternalBox>
-              </div>
-              <InternalSpaceBetween size="xs" direction="horizontal">
-                {showPreviousButton && (
-                  <InternalButton
-                    variant="link"
-                    onClick={onPreviousButtonClick}
-                    disabled={!previousButtonEnabled}
-                    formAction="none"
-                    ariaLabel={i18nStrings.previousButtonText}
-                    className={styles['previous-button']}
-                  >
-                    {i18nStrings.previousButtonText}
-                  </InternalButton>
-                )}
-
-                {showFinishButton ? (
-                  <InternalButton
-                    onClick={onFinish}
-                    formAction="none"
-                    ariaLabel={i18nStrings.finishButtonText}
-                    className={styles['finish-button']}
-                  >
-                    {i18nStrings.finishButtonText}
-                  </InternalButton>
-                ) : (
-                  <InternalButton
-                    onClick={onNextButtonClick}
-                    disabled={!nextButtonEnabled}
-                    formAction="none"
-                    ariaLabel={i18nStrings.nextButtonText}
-                    className={styles['next-button']}
-                  >
-                    {i18nStrings.nextButtonText}
-                  </InternalButton>
-                )}
-              </InternalSpaceBetween>
+            <div className={styles.description}>
+              <InternalBox className={styles.content}>{content}</InternalBox>
             </div>
+
+            {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
+
+            <InternalSpaceBetween size="s">
+              <div className={styles.divider} />
+
+              <div className={styles.actionBar}>
+                <div className={styles.stepCounter}>
+                  <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
+                    {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
+                  </InternalBox>
+                </div>
+                <InternalSpaceBetween size="xs" direction="horizontal">
+                  {showPreviousButton && (
+                    <InternalButton
+                      variant="link"
+                      onClick={onPreviousButtonClick}
+                      disabled={!previousButtonEnabled}
+                      formAction="none"
+                      ariaLabel={i18nStrings.previousButtonText}
+                      className={styles['previous-button']}
+                    >
+                      {i18nStrings.previousButtonText}
+                    </InternalButton>
+                  )}
+
+                  {showFinishButton ? (
+                    <InternalButton
+                      onClick={onFinish}
+                      formAction="none"
+                      ariaLabel={i18nStrings.finishButtonText}
+                      className={styles['finish-button']}
+                    >
+                      {i18nStrings.finishButtonText}
+                    </InternalButton>
+                  ) : (
+                    <InternalButton
+                      onClick={onNextButtonClick}
+                      disabled={!nextButtonEnabled}
+                      formAction="none"
+                      ariaLabel={i18nStrings.nextButtonText}
+                      className={styles['next-button']}
+                    >
+                      {i18nStrings.nextButtonText}
+                    </InternalButton>
+                  )}
+                </InternalSpaceBetween>
+              </div>
+            </InternalSpaceBetween>
           </InternalSpaceBetween>
-        </InternalSpaceBetween>
-      </PopoverBody>
-    </PopoverContainer>
+        </PopoverBody>
+      </PopoverContainer>
+    </div>
   );
 }

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -23,6 +23,7 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
   const onClick = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault();
+      event.stopPropagation();
       onClickHandler();
     },
     [onClickHandler]

--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -11,10 +11,12 @@ class AppLayoutSplitViewPage extends BasePageObject {
   async openPanel() {
     await this.click(wrapper.findSplitPanel().findOpenButton().toSelector());
   }
-  // the argument here is the visible label text
-  async switchPosition(position: 'Bottom' | 'Side') {
+
+  // the argument here is the position value
+  async switchPosition(position: 'bottom' | 'side') {
     await this.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-    await this.click(`label=${position}`);
+    const tile = createWrapper().findModal().findContent().findTiles().findItemByValue(position);
+    await this.click(tile.toSelector());
     await this.click('button=Confirm');
   }
 
@@ -81,7 +83,7 @@ test(
   'slider is accessible by keyboard in side position',
   setupTest(async page => {
     await page.openPanel();
-    await page.switchPosition('Side');
+    await page.switchPosition('side');
     await page.keys(['Shift', 'Tab', 'Shift']);
     await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
 
@@ -122,7 +124,7 @@ test(
   'switches to bottom position when screen is too narrow and restores back on resize',
   setupTest(async page => {
     await page.openPanel();
-    await page.switchPosition('Side');
+    await page.switchPosition('side');
     await expect(page.getPanelPosition()).resolves.toEqual('side');
 
     // narrow enough to force bottom position, but still not mobile
@@ -139,7 +141,7 @@ test(
   'switches to bottom position when when tools panel opens and available space is too small',
   setupTest(async page => {
     await page.openPanel();
-    await page.switchPosition('Side');
+    await page.switchPosition('side');
     await page.click(wrapper.findToolsToggle().toSelector());
     await expect(page.getPanelPosition()).resolves.toEqual('bottom');
 
@@ -170,7 +172,7 @@ test(
     `should not allow resize split panel beyond min and max limits (side position) (${name})}`,
     setupTest(async page => {
       await page.openPanel();
-      await page.switchPosition('Side');
+      await page.switchPosition('side');
       const { width } = await page.getWindowSize();
       await page.dragResizerTo({ x: width, y: 0 });
       expect((await page.getSplitPanelSize()).width).toEqual(280);
@@ -212,7 +214,7 @@ test(
   'should keep split panel position during drag',
   setupTest(async page => {
     await page.openPanel();
-    await page.switchPosition('Side');
+    await page.switchPosition('side');
     await page.dragResizerTo({ x: 0, y: 0 });
     await page.setWindowSize({ ...viewports.desktop, width: 820 });
     const { height } = await page.getWindowSize();
@@ -225,7 +227,7 @@ test(
   'should resize main content area when switching to side',
   setupTest(async page => {
     await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
-    await page.switchPosition('Side');
+    await page.switchPosition('side');
     await expect(page.getContentMarginBottom()).resolves.toEqual('');
   }, '#/light/app-layout/with-full-page-table-and-split-panel')
 );
@@ -234,8 +236,8 @@ test(
   'should resize main content area when switching to side then back to bottom',
   setupTest(async page => {
     await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
-    await page.switchPosition('Side');
-    await page.switchPosition('Bottom');
+    await page.switchPosition('side');
+    await page.switchPosition('bottom');
     await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
   }, '#/light/app-layout/with-full-page-table-and-split-panel')
 );

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -100,7 +100,6 @@ describe('Button Component', () => {
   describe('ariaExpanded property', () => {
     test('adds aria-expanded property to button', () => {
       const wrapper = renderButton({ ariaExpanded: true });
-      console.log(wrapper.getElement());
       expect(wrapper.getElement()).toHaveAttribute('aria-expanded', 'true');
     });
   });

--- a/src/checkbox/__tests__/checkbox.test.tsx
+++ b/src/checkbox/__tests__/checkbox.test.tsx
@@ -92,10 +92,19 @@ describe('native and styled control synchronization', () => {
   });
 });
 
-test('fires onChange event on label click', () => {
+test('fires a single onChange event on label click', () => {
   const onChange = jest.fn();
   const { wrapper } = renderCheckbox(<Checkbox checked={false} onChange={onChange} />);
   wrapper.findLabel().click();
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { checked: true, indeterminate: false } }));
+});
+
+test('fires a single onChange event on input click', () => {
+  const onChange = jest.fn();
+  const { wrapper } = renderCheckbox(<Checkbox checked={false} onChange={onChange} />);
+  wrapper.findNativeInput().click();
+  expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { checked: true, indeterminate: false } }));
 });
 

--- a/src/checkbox/__tests__/common-tests.tsx
+++ b/src/checkbox/__tests__/common-tests.tsx
@@ -29,9 +29,13 @@ export function createCommonTests(Component: React.ComponentType<BaseCheckboxPro
     });
 
     test('renders component this controlId', () => {
-      const { wrapper } = renderComponent(<Component checked={false} controlId="something-specific" />);
+      const { wrapper } = renderComponent(
+        <Component checked={false} controlId="something-specific">
+          Label
+        </Component>
+      );
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('id', 'something-specific');
-      expect(wrapper.findLabel().getElement()).toHaveAttribute('for', 'something-specific');
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-labelledby', 'something-specific-label');
     });
 
     test('name is being rendered only if provided', () => {

--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -12,7 +12,6 @@ import CheckboxIcon from '../internal/components/checkbox-icon';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 interface InternalProps extends CheckboxProps, InternalBaseComponentProps {
-  withoutLabel?: boolean;
   tabIndex?: -1;
 }
 
@@ -32,7 +31,6 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
       onFocus,
       onBlur,
       onChange,
-      withoutLabel,
       tabIndex,
       __internalRootRef,
       ...rest
@@ -47,6 +45,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
         checkboxRef.current.indeterminate = Boolean(indeterminate);
       }
     });
+
     return (
       <AbstractSwitch
         {...baseProps}
@@ -69,25 +68,20 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
             checked={checked}
             name={name}
             tabIndex={tabIndex}
-            onFocus={onFocus && (() => fireNonCancelableEvent(onFocus))}
-            onBlur={onBlur && (() => fireNonCancelableEvent(onBlur))}
+            onFocus={() => fireNonCancelableEvent(onFocus)}
+            onBlur={() => fireNonCancelableEvent(onBlur)}
             // empty handler to suppress React controllability warning
             onChange={() => {}}
-            onClick={
-              // Using onClick because onChange does not fire in indeterminate state in Internet Explorer and Legacy Edge
-              // https://stackoverflow.com/questions/33523130/ie-does-not-fire-change-event-on-indeterminate-checkbox-when-you-click-on-it
-              onChange &&
-              (() =>
-                fireNonCancelableEvent(
-                  onChange,
-                  // for deterministic transitions "indeterminate" -> "checked" -> "unchecked"
-                  indeterminate ? { checked: true, indeterminate: false } : { checked: !checked, indeterminate: false }
-                ))
-            }
           />
         )}
+        onClick={() =>
+          fireNonCancelableEvent(
+            onChange,
+            // for deterministic transitions "indeterminate" -> "checked" -> "unchecked"
+            indeterminate ? { checked: true, indeterminate: false } : { checked: !checked, indeterminate: false }
+          )
+        }
         styledControl={<CheckboxIcon checked={checked} indeterminate={indeterminate} disabled={disabled} />}
-        withoutLabel={withoutLabel}
         __internalRootRef={__internalRootRef}
       />
     );

--- a/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
+++ b/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
@@ -9,6 +9,7 @@ function renderAbstractSwitch(props: AbstractSwitchProps) {
   const { container } = render(<AbstractSwitch {...props} />);
   return createWrapper(container);
 }
+const noop = () => {};
 
 describe('Abstract switch component, aria-labelledby', () => {
   test('should not have a labelId if a label is not provided', () => {
@@ -19,6 +20,7 @@ describe('Abstract switch component, aria-labelledby', () => {
       controlId: 'custom-id',
       description: 'Description goes here',
       nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+      onClick: noop,
     });
 
     const nativeControl = wrapper.find('.switch-element')!.getElement();
@@ -35,6 +37,7 @@ describe('Abstract switch component, aria-labelledby', () => {
       controlId: 'custom-id',
       description: 'Description goes here',
       nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+      onClick: noop,
     });
 
     const nativeControl = wrapper.find('.switch-element')!.getElement();
@@ -57,6 +60,7 @@ describe('Abstract switch component, aria-labelledby', () => {
       label: 'label',
       description: 'description',
       nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+      onClick: noop,
     });
 
     const nativeControl = wrapper.find('.switch-element')!.getElement();

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -20,7 +20,7 @@ export interface AbstractSwitchProps extends React.HTMLAttributes<HTMLElement>, 
   ariaLabel?: string;
   ariaLabelledby?: string;
   ariaDescribedby?: string;
-  withoutLabel?: boolean;
+  onClick: () => void;
 }
 
 function joinString(values: (string | undefined)[]) {
@@ -40,7 +40,7 @@ export default function AbstractSwitch({
   ariaLabel,
   ariaLabelledby,
   ariaDescribedby,
-  withoutLabel,
+  onClick,
   __internalRootRef,
   ...rest
 }: AbstractSwitchProps) {
@@ -48,16 +48,10 @@ export default function AbstractSwitch({
   const id = controlId || uniqueId;
 
   const focusVisible = useFocusVisible();
-  const wrapperId = `${id}-wrapper`;
   const labelId = `${id}-label`;
   const descriptionId = `${id}-description`;
 
-  const WrapperElement = withoutLabel ? 'div' : 'label';
   const wrapperAttributes: Record<string, string | undefined> = {};
-  if (!withoutLabel) {
-    wrapperAttributes.id = wrapperId;
-    wrapperAttributes.htmlFor = id;
-  }
 
   const ariaLabelledByIds = [];
   if (label) {
@@ -77,10 +71,11 @@ export default function AbstractSwitch({
 
   return (
     <div {...rest} className={clsx(styles.wrapper, rest.className)} ref={__internalRootRef}>
-      <WrapperElement
+      <div
         {...wrapperAttributes}
         className={styles['label-wrapper']}
         aria-disabled={disabled ? 'true' : undefined}
+        onClick={disabled ? undefined : onClick}
       >
         <span className={clsx(styles.control, controlClassName)}>
           {styledControl}
@@ -113,7 +108,7 @@ export default function AbstractSwitch({
             </span>
           )}
         </span>
-      </WrapperElement>
+      </div>
     </div>
   );
 }

--- a/src/radio-group/__integ__/label-styling.test.ts
+++ b/src/radio-group/__integ__/label-styling.test.ts
@@ -22,7 +22,7 @@ test(
   setupTest(async page => {
     const radioButtonWrapper = radioGroupWrapper.findButtons().get(1);
     const { width: elementWidth } = await page.getBoundingBox(radioButtonWrapper.toSelector());
-    const { width: labelWidth } = await page.getBoundingBox(radioButtonWrapper.find('label').toSelector());
+    const { width: labelWidth } = await page.getBoundingBox(radioButtonWrapper.findLabel().toSelector());
     expect(labelWidth).toBeLessThan(elementWidth);
   })
 );

--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -197,9 +197,8 @@ describe('value', () => {
 
   describe('radiobutton controlId', () => {
     function check(radioButton: RadioButtonWrapper, controlId: string) {
-      expect(radioButton.findLabel().getElement()).toHaveAttribute('for', controlId);
-      expect(radioButton.findLabel().getElement()).toHaveAttribute('id', `${controlId}-wrapper`);
       expect(radioButton.findNativeInput().getElement()).toHaveAttribute('id', controlId);
+      expect(radioButton.findNativeInput().getElement()).toHaveAttribute('aria-labelledby', `${controlId}-label`);
     }
 
     test('uses controlId for setting up label relations when set', () => {

--- a/src/radio-group/radio-button.tsx
+++ b/src/radio-group/radio-button.tsx
@@ -11,7 +11,6 @@ import styles from './styles.css.js';
 interface RadioButtonProps extends RadioGroupProps.RadioButtonDefinition {
   name: string;
   checked: boolean;
-  withoutLabel?: boolean;
   onChange?: NonCancelableEventHandler<RadioGroupProps.ChangeDetail>;
 }
 
@@ -20,7 +19,6 @@ export default function RadioButton({
   label,
   value,
   checked,
-  withoutLabel,
   description,
   disabled,
   controlId,
@@ -43,9 +41,11 @@ export default function RadioButton({
           name={name}
           value={value}
           checked={checked}
-          onChange={onChange && (() => fireNonCancelableEvent(onChange, { value }))}
+          // empty handler to suppress React controllability warning
+          onChange={() => {}}
         />
       )}
+      onClick={() => !checked && fireNonCancelableEvent(onChange, { value })}
       styledControl={
         <svg viewBox="0 0 100 100" focusable="false" aria-hidden="true">
           <circle
@@ -67,7 +67,6 @@ export default function RadioButton({
           />
         </svg>
       }
-      withoutLabel={withoutLabel}
     />
   );
 }

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -23,11 +23,11 @@ class TablePage extends BasePageObject {
   }
 
   async toggleStickyHeader() {
-    await this.click('#sticky-header-toggle label');
+    await this.click(wrapper.findCheckbox('#sticky-header-toggle').findLabel().toSelector());
   }
 
   async toggleResizableColumns() {
-    await this.click('#resizable-columns-toggle label');
+    await this.click(wrapper.findCheckbox('#resizable-columns-toggle').findLabel().toSelector());
   }
 
   async getHeaderTopOffset() {

--- a/src/table/selection-control/index.tsx
+++ b/src/table/selection-control/index.tsx
@@ -76,9 +76,9 @@ export default function SelectionControl({
   };
 
   const selector = isMultiSelection ? (
-    <InternalCheckbox {...sharedProps} controlId={controlId} withoutLabel={true} indeterminate={indeterminate} />
+    <InternalCheckbox {...sharedProps} controlId={controlId} indeterminate={indeterminate} />
   ) : (
-    <RadioButton {...sharedProps} controlId={controlId} withoutLabel={true} name={name} value={''} label={''} />
+    <RadioButton {...sharedProps} controlId={controlId} name={name} value={''} label={''} />
   );
 
   return (

--- a/src/tiles/__tests__/tiles.test.tsx
+++ b/src/tiles/__tests__/tiles.test.tsx
@@ -223,9 +223,8 @@ describe('value', () => {
 
   describe('tile controlId', () => {
     function check(tile: TileWrapper, controlId: string) {
-      expect(tile.getElement()).toHaveAttribute('for', controlId);
-      expect(tile.getElement()).toHaveAttribute('id', `${controlId}-wrapper`);
       expect(tile.findNativeInput().getElement()).toHaveAttribute('id', controlId);
+      expect(tile.findNativeInput().getElement()).toHaveAttribute('aria-labelledby', `${controlId}-label`);
     }
 
     test('uses controlId for setting up label relations when set', () => {

--- a/src/tiles/internal.tsx
+++ b/src/tiles/internal.tsx
@@ -13,6 +13,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import { fireNonCancelableEvent } from '../internal/events';
 
 const COLUMN_TRIGGERS: TilesProps.Breakpoint[] = ['default', 'xxs', 'xs'];
 
@@ -66,7 +67,7 @@ export default function InternalTiles({
           items.map(item => {
             const controlId = item.controlId || `${generatedName}-value-${item.value}`;
             return (
-              <label
+              <div
                 className={clsx(
                   styles['tile-container'],
                   { [styles['has-metadata']]: item.description || item.image },
@@ -76,26 +77,23 @@ export default function InternalTiles({
                 )}
                 key={item.value}
                 data-value={item.value}
-                htmlFor={controlId}
-                id={`${controlId}-wrapper`}
+                onClick={() => item.value !== value && fireNonCancelableEvent(onChange, { value: item.value })}
               >
                 <div className={clsx(styles.control, { [styles['no-image']]: !item.image })}>
                   <RadioButton
                     checked={item.value === value}
                     name={generatedName}
-                    withoutLabel={true}
                     value={item.value}
                     label={item.label}
                     description={item.description}
                     disabled={item.disabled}
-                    onChange={onChange}
                     controlId={controlId}
                   />
                 </div>
                 {item.image && (
                   <div className={clsx(styles.image, { [styles.disabled]: !!item.disabled })}>{item.image}</div>
                 )}
-              </label>
+              </div>
             );
           })}
       </div>

--- a/src/toggle/__tests__/toggle.test.tsx
+++ b/src/toggle/__tests__/toggle.test.tsx
@@ -36,10 +36,19 @@ test('synchronizes native and styled controls', () => {
   expect(findStyledElement(wrapper)).toHaveClass(styles['toggle-handle-checked']);
 });
 
-test('fires onChange event on label click', () => {
+test('fires a single onChange event on label click', () => {
   const onChange = jest.fn();
   const { wrapper } = renderToggle(<Toggle checked={false} onChange={onChange} />);
   wrapper.findLabel().click();
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { checked: true } }));
+});
+
+test('fires a single onChange event on input click', () => {
+  const onChange = jest.fn();
+  const { wrapper } = renderToggle(<Toggle checked={false} onChange={onChange} />);
+  wrapper.findNativeInput().click();
+  expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: { checked: true } }));
 });
 

--- a/src/toggle/internal.tsx
+++ b/src/toggle/internal.tsx
@@ -35,6 +35,7 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
     const baseProps = getBaseProps(rest);
     const checkboxRef = useRef<HTMLInputElement>(null);
     useForwardFocus(ref, checkboxRef);
+
     return (
       <AbstractSwitch
         {...baseProps}
@@ -59,11 +60,13 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
             type="checkbox"
             checked={checked}
             name={name}
-            onFocus={onFocus && (() => fireNonCancelableEvent(onFocus))}
-            onBlur={onBlur && (() => fireNonCancelableEvent(onBlur))}
-            onChange={onChange && (event => fireNonCancelableEvent(onChange, { checked: event.target.checked }))}
+            onFocus={() => fireNonCancelableEvent(onFocus)}
+            onBlur={() => fireNonCancelableEvent(onBlur)}
+            // empty handler to suppress React controllability warning
+            onChange={() => {}}
           />
         )}
+        onClick={() => fireNonCancelableEvent(onChange, { checked: !checked })}
         styledControl={
           /*Using span, not div for HTML validity*/
           <span


### PR DESCRIPTION
### Description

#### The issue:
when a Hotspot is placed inside a checkbox label (or the label of a Toggle, Radio Button or Tile) and the user clicks on an element inside the Hotspot's Annotation popover, this click event also bubbles up to the checkbox's `<label>` element. This then triggers a duplicated/redirected event on the native `<input>` element.

While the bubbling of the first click event can be prevented with `e.stopPropagation`, this does not prevent the dispatching of the second event. According to [this StackOverflow answer](https://stackoverflow.com/a/67613046), this is known _"legacy-pre-activation behavior"_ and cannot be prevented since it is part of the WHATWG specification - the label->input event duplication/redirection happens before the actual event dispatching.

#### The change:

This change deactivates the legacy behaviour by replacing the `<label>` element with a `<div>`. To match the existing screenreader behaviour, it uses ARIA properties to connect the label to the checkbox. Event listeners are added to match the existing behaviour (but now the bubbling can be stopped with `e.stopPropagation()`).

The Hotspot component now has an additional event handler that prevents events from bubbling into the surrounding component.

### How has this been tested?

[_How did you test to verify your changes?_]
- Added a dev page where I performed manual testing
- Updated unit tests

[_How can reviewers test these changes efficiently?_]
- View the dev page locally and test its announcements and interactions with a screenreader

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-19101


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [X] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [X] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
