### PR TITLE
fix: Option should have aira-selected or aria-checked

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -197,3 +197,11 @@ describe('a11y props', () => {
     expect(input).toHaveAttribute('aria-activedescendant', highlightedOption.getAttribute('id'));
   });
 });
+
+test('Option should have aria-selected', () => {
+  const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+  wrapper.focus();
+  expect(wrapper.findDropdown()!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute('aria-selected', 'false');
+  wrapper.findNativeInput().keydown(KeyCode.down);
+  expect(wrapper.findDropdown()!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute('aria-selected', 'true');
+});

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -70,7 +70,7 @@ const AutosuggestOption = (
     <SelectableItem
       {...baseProps}
       className={styles.option}
-      ariaSelected={highlighted || undefined}
+      ariaSelected={highlighted}
       highlighted={highlighted}
       disabled={option.disabled}
       hasBackground={useEntered}

--- a/src/internal/components/selectable-item/index.tsx
+++ b/src/internal/components/selectable-item/index.tsx
@@ -6,10 +6,8 @@ import styles from './styles.css.js';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { HighlightType } from '../options-list/utils/use-highlight-option.js';
 
-export interface SelectableItemProps extends BaseComponentProps {
+export type SelectableItemProps = BaseComponentProps & {
   children: React.ReactNode;
-  ariaSelected?: boolean;
-  ariaChecked?: boolean;
   selected?: boolean;
   highlighted?: boolean;
   disabled?: boolean;
@@ -24,7 +22,7 @@ export interface SelectableItemProps extends BaseComponentProps {
   ariaPosinset?: number;
   ariaSetsize?: number;
   highlightType?: HighlightType;
-}
+} & ({ ariaSelected?: boolean; ariaChecked?: never } | { ariaSelected?: never; ariaChecked?: boolean | 'mixed' });
 
 const SelectableItem = (
   {
@@ -98,12 +96,12 @@ const SelectableItem = (
     a11yProperties['aria-hidden'] = true;
   }
 
-  if (ariaSelected) {
+  if (ariaSelected !== undefined) {
     a11yProperties['aria-selected'] = ariaSelected;
   }
 
   // Safari+VO needs aria-checked for multi-selection. Otherwise it only announces selected option even though another option is highlighted.
-  if (ariaChecked) {
+  if (ariaChecked !== undefined) {
     a11yProperties['aria-checked'] = ariaChecked;
   }
 

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -393,3 +393,19 @@ test('closes dropdown after selecting a group option when keepOpen=false', () =>
   wrapper.selectOptionByValue('group');
   expect(wrapper.findDropdown().findOptionByValue('group')).toBeFalsy();
 });
+
+test('Option should have aria-checked', () => {
+  const { wrapper } = renderMultiselect(
+    <Multiselect selectedOptions={[{ label: 'Second', value: '2' }]} options={groupOptions} />
+  );
+  wrapper.openDropdown();
+  expect(wrapper.findDropdown()!.find('[data-mouse-target="0"]')!.getElement()).toHaveAttribute(
+    'aria-checked',
+    'mixed'
+  );
+  expect(wrapper.findDropdown()!.find('[data-mouse-target="1"]')!.getElement()).toHaveAttribute(
+    'aria-checked',
+    'false'
+  );
+  expect(wrapper.findDropdown()!.find('[data-mouse-target="2"]')!.getElement()).toHaveAttribute('aria-checked', 'true');
+});

--- a/src/select/__tests__/select-a11y.test.tsx
+++ b/src/select/__tests__/select-a11y.test.tsx
@@ -46,4 +46,17 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
 
     await expect(container).toValidateA11y();
   });
+
+  test('Option should have aria-selected', () => {
+    const { wrapper } = renderSelect({ selectedOption: { label: 'First', value: '1' } });
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(wrapper.findDropdown({ expandToViewport })!.find('[data-test-index="2"]')!.getElement()).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+  });
 });

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -52,7 +52,7 @@ const Item = (
 
   return (
     <SelectableItem
-      ariaSelected={selected}
+      ariaSelected={Boolean(selected)}
       selected={selected}
       isNextSelected={isNextSelected}
       highlighted={highlighted}

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -56,7 +56,7 @@ const MultiSelectItem = (
 
   return (
     <SelectableItem
-      ariaChecked={selected}
+      ariaChecked={isParent && indeterminate ? 'mixed' : Boolean(selected)}
       selected={selected}
       isNextSelected={isNextSelected}
       highlighted={highlighted}


### PR DESCRIPTION
### Description

Currently aria-selected is set only when the value is true. However it should be set to true/false when select is possible. Aria-checked needs be set when it is multi-selection.  Aria-selected and aria-checked should not be set at the same time. 

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

AWSUI-18451


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
