### PR TITLE
Revert "AWSUI-18910 : Splitpanel slider made keybaord accessible when position is on side"

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -11,6 +11,7 @@ class AppLayoutSplitViewPage extends BasePageObject {
   async openPanel() {
     await this.click(wrapper.findSplitPanel().findOpenButton().toSelector());
   }
+
   // the argument here is the visible label text
   async switchPosition(position: 'Bottom' | 'Side') {
     await this.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
@@ -76,35 +77,6 @@ function setupTest(
     await testFn(page);
   });
 }
-
-test(
-  'slider is accessible by keyboard in side position',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('Side');
-    await page.keys(['Shift', 'Tab', 'Shift']);
-    await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-
-    const { width } = await page.getSplitPanelSize();
-    await page.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
-    const expectedWidth = width + 30;
-    await expect((await page.getSplitPanelSize()).width).toEqual(expectedWidth);
-  })
-);
-
-test(
-  'slider is accessible by keyboard in bottom position',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.keys(['Shift', 'Tab', 'Shift', 'Shift', 'Tab', 'Shift']);
-    await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-
-    const { height } = await page.getSplitPanelSize();
-    await page.keys(['ArrowUp', 'ArrowUp', 'ArrowUp']);
-    const expectedHeight = height + 30;
-    await expect((await page.getSplitPanelSize()).height).toEqual(expectedHeight);
-  })
-);
 
 test(
   'renders with initial side position',

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -174,7 +174,7 @@ describe('Split panel', () => {
         if (position === 'bottom') {
           return wrapper.findOpenPanelBottom()!.getElement().style.height;
         }
-        return (wrapper.findOpenPanelSide()!.getElement() as HTMLElement).style.width;
+        return (wrapper.findOpenPanelSide()!.getElement().firstElementChild as HTMLElement).style.width;
       }
 
       // layout calculation is delayed by one frame to wait for app-layout to finish its rendering

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -74,15 +74,15 @@ const TransitionContentSide = ({
       className={clsx(baseProps.className, styles.drawer, styles.root, styles['position-side'], {
         [styles['drawer-closed']]: !isOpen,
       })}
-      style={{
-        top: topOffset,
-        bottom: bottomOffset,
-        width: isOpen ? cappedSize : undefined,
-        maxWidth: isRefresh ? '100%' : undefined,
-      }}
       ref={splitPanelRef}
     >
       <aside
+        style={{
+          top: topOffset,
+          bottom: bottomOffset,
+          width: isOpen ? cappedSize : undefined,
+          maxWidth: isRefresh ? '100%' : undefined,
+        }}
         className={clsx(styles['drawer-content-side'], {
           [styles.refresh]: isRefresh,
         })}


### PR DESCRIPTION
Reverts cloudscape-design/components#215

### Why?
This change introduced a visual regression on the split panel inside the app-layout/with-split-panel example page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.