### PR TITLE
fix(date-picker): Fix baseDate handling when navigating through the calendar

### DIFF
--- a/src/date-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-picker/calendar/__tests__/calendar.test.tsx
@@ -39,8 +39,12 @@ describe('Date picker calendar', () => {
     };
   }
 
+  const findFocusedDay = (wrapper: DatePickerWrapper) => {
+    return wrapper.findCalendar()!.find(`.${styles['calendar-day-focusable']}`);
+  };
+
   const findFocusableDateText = (wrapper: DatePickerWrapper) => {
-    const focusedItem = wrapper.findCalendar()!.find(`.${styles['calendar-day-focusable']}`);
+    const focusedItem = findFocusedDay(wrapper);
     return focusedItem ? focusedItem.getElement().textContent!.trim() : null;
   };
 
@@ -337,6 +341,50 @@ describe('Date picker calendar', () => {
         expect(findFocusableDateText(wrapper)).toBe('2');
       });
 
+      test('should focus next available date if available dates are spread across different months in the same year', () => {
+        const isDateEnabled = (date: any) => {
+          return ['2022-01-14', '2022-02-14', '2022-04-14'].includes(date.toISOString().slice(0, 10));
+        };
+        const { wrapper } = renderDatePicker({ ...defaultProps, value: '2022-01-14', isDateEnabled });
+        act(() => wrapper.findOpenCalendarButton().click());
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        // Navigate to future available dates in same year
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2022');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.right));
+        expect(findCalendarHeaderText(wrapper)).toBe('February 2022');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.right));
+        expect(findCalendarHeaderText(wrapper)).toBe('April 2022');
+        // Navigate to past available dates in same year
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.left));
+        expect(findCalendarHeaderText(wrapper)).toBe('February 2022');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.left));
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2022');
+      });
+
+      test('should focus next available date if available dates are spread across different different years', () => {
+        const isDateEnabled = (date: any) => {
+          return ['2022-01-14', '2023-01-14', '2024-01-14'].includes(date.toISOString().slice(0, 10));
+        };
+        const { wrapper } = renderDatePicker({ ...defaultProps, value: '2022-01-14', isDateEnabled });
+        act(() => wrapper.findOpenCalendarButton().click());
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        act(() => wrapper.findCalendar()!.keydown(KeyCode.tab));
+        // Navigate to future available dates in different years
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2022');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.right));
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2023');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.right));
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2024');
+        // Navigate to past available dates in different years
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.left));
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2023');
+        act(() => findFocusedDay(wrapper)!.keydown(KeyCode.left));
+        expect(findCalendarHeaderText(wrapper)).toBe('January 2022');
+      });
+
       test('should jump over the disabled date in future', () => {
         const isDateEnabled = (date: Date) => date.getDate() !== 22;
         const { wrapper } = renderDatePicker({ ...defaultProps, isDateEnabled, value: '2018-03-21' });
@@ -392,14 +440,14 @@ describe('Date picker calendar', () => {
         expect(findCalendarHeaderText(wrapper)).toBe('March 2018');
       });
 
-      test('should display next month if there is no enabled date in the current', () => {
+      test('should display the current month if there is no enabled date in the current', () => {
         const dateLimit = new Date(2018, 3, 10).getTime();
         const isDateEnabled = (date: Date) => date.getTime() > dateLimit;
-        const { wrapper } = renderDatePicker({ ...defaultProps, isDateEnabled });
+        const { wrapper } = renderDatePicker({ ...defaultProps, value: '2018-03-21', isDateEnabled });
         act(() => wrapper.findOpenCalendarButton().click());
-        act(() => wrapper.setInputValue('2018/03/21'));
-        expect(findCalendarHeaderText(wrapper)).toBe('April 2018');
-        expect(findFocusableDateText(wrapper)).toBe('11');
+        expect(findCalendarHeaderText(wrapper)).toBe('March 2018');
+        expect(wrapper.findCalendar()!.findSelectedDate().getElement().textContent).toBe('21');
+        expect(findFocusableDateText(wrapper)).toBeNull();
       });
 
       test('does not focus anything if all dates are disabled', () => {

--- a/src/date-picker/calendar/index.tsx
+++ b/src/date-picker/calendar/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef, useState } from 'react';
-import { addDays, addMonths, isSameMonth, startOfMonth } from 'date-fns';
+import { addDays, addMonths, getDaysInMonth, isSameMonth, startOfMonth } from 'date-fns';
 import styles from '../styles.css.js';
 import { BaseComponentProps } from '../../internal/base-component';
 import useFocusVisible from '../../internal/hooks/focus-visible/index.js';
@@ -76,12 +76,17 @@ const Calendar = ({
     return null;
   };
 
+  // Get the first enabled date of the month. If no day is enabled in the given month, return the first day of the month.
+  // This is needed because `baseDate` is used as the first focusable date, for example when navigating to the calendar area.
   const getBaseDate = (date: Date) => {
     const startDate = startOfMonth(date);
-    if (isDateEnabled(startDate)) {
-      return startDate;
+    for (let i = 0; i < getDaysInMonth(date); i++) {
+      const currentDate = addDays(startDate, i);
+      if (isDateEnabled(currentDate)) {
+        return currentDate;
+      }
     }
-    return moveFocusHandler(startDate, isDateEnabled, (date: Date) => addDays(date, 1));
+    return startDate;
   };
 
   const baseDate: Date = getBaseDate(displayedDate);

--- a/src/date-picker/calendar/utils/move-focus-handler.ts
+++ b/src/date-picker/calendar/utils/move-focus-handler.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { differenceInMonths } from 'date-fns';
+import { differenceInYears } from 'date-fns';
 import { DatePickerProps } from '../../interfaces';
 
 export interface MoveFocusHandler {
@@ -18,7 +18,9 @@ const moveFocusHandler: MoveFocusHandler = (focussed: Date, isDateEnabled, moveC
   }
 
   while (!isDateEnabled(current)) {
-    if (Math.abs(differenceInMonths(focussed, current)) > 1) {
+    // Get the first enabled date within the one year max.
+    // Used when using keyboard navigation on calendar days.
+    if (Math.abs(differenceInYears(focussed, current)) > 1) {
       return focussed;
     }
     current = moveCallback(current);


### PR DESCRIPTION
### Description
This change fixes two issues:

1) Scenario value set to a day in March, all dates <= April are disabled:
When opening the date picker, April was shown as month because and not march as the value stated.
With this change, March is now shown instead of April to reflect the current input value.

2) When attempting to use isDateEnabled given a set of available dates, there was an issue when the list of available dates was not continuous by month. E.g. if the following dates `['2022-04-14', '2022-03-14', '2022-01-14']` are enabled, the component was not allowing to go back to previous months: navigating from March 2022 into the past was not possible (making 2022-01-14 inaccessible).

### How has this been tested?

- tested manually.
- add additional unit tests to cover the fix.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links
AWSUI-19136


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
