### PR TITLE
Align autosuggest focus behaviour with select

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -89,6 +89,23 @@ test('should display entered text option/label', () => {
   expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('Custom function with 1 placeholder');
 });
 
+test('should not close dropdown when no realted target in blur', () => {
+  const { wrapper, container } = renderAutosuggest(
+    <div>
+      <Autosuggest enteredTextLabel={v => v} value="1" options={defaultOptions} />
+      <button id="focus-target">focus target</button>
+    </div>
+  );
+  wrapper.findNativeInput().focus();
+  expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+
+  document.body.focus();
+  expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+
+  createWrapper(container).find('#focus-target')!.focus();
+  expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+});
+
 describe('onSelect', () => {
   test('should select normal value', () => {
     const onChange = jest.fn();

--- a/src/autosuggest/dropdown-controller.ts
+++ b/src/autosuggest/dropdown-controller.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef, useState } from 'react';
+import { getBlurEventRelatedTarget } from '../internal/events';
 
 export interface UseAutosuggestDropdownProps {
   readOnly?: boolean;
@@ -40,7 +41,8 @@ export const useAutosuggestDropdown = ({
   };
 
   const handleBlur: React.FocusEventHandler = event => {
-    if (event.currentTarget.contains(event.relatedTarget) || footerRef.current?.contains(event.relatedTarget)) {
+    const relatedTarget = getBlurEventRelatedTarget(event.nativeEvent);
+    if (event.currentTarget.contains(relatedTarget) || footerRef.current?.contains(relatedTarget)) {
       return;
     }
     closeDropdown();


### PR DESCRIPTION
### Description

Align autosuggest focus behaviour with select. When browser tab is left - the dropdown stays open.

Select uses the same mechanism, see:
* https://github.com/cloudscape-design/components/blob/main/src/select/utils/use-select.ts#L184
* https://github.com/cloudscape-design/components/blob/main/src/input/internal.tsx#L136

### How has this been tested?

Added a unit test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket AWSUI-19147

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
