### PR TITLE
feat: Use React's `useId` hook if available

### DIFF
--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -1,16 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 
 let counter = 0;
-export function generateUniqueId(prefix?: string) {
-  return `${prefix ? prefix : ''}${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
+export function generateUniqueId(prefix = '') {
+  return `${prefix}${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
 }
 
-export function useUniqueId(prefix?: string) {
+export function useUniqueId(prefix = '') {
   const idRef = useRef<string | null>(null);
+
+  // useId is only available in React 18+
+  if ((React as ReactWithUseId).useId !== undefined) {
+    return prefix + (React as ReactWithUseId).useId();
+  }
+
   if (!idRef.current) {
     idRef.current = generateUniqueId(prefix);
   }
   return idRef.current;
 }
+
+type ReactWithUseId = typeof React & {
+  // See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cc9a28eb5e1953f8f74ade87d7f16a8db8ab7552/types/react/index.d.ts#L1157
+  useId(): string;
+};


### PR DESCRIPTION
### Description

This updates our `useUniqueId` hook to use [the native `useId` hook provided by React](https://reactjs.org/docs/hooks-reference.html#useid). If the native hook is not available, it falls back to our existing implementation.

The native `useId` hook has the advantage of generating IDs that are stable between server-rendering and client-side hydration, thus preventing hydration errors.

### How has this been tested?

[_How did you test to verify your changes?_]

Upgraded the dev dependency on React and ReactDOM to 18, and inspected the dev pages. They use the new IDs provided by React.

[_How can reviewers test these changes efficiently?_]
see above

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-9561


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
