### PR TITLE
Move format date range util from DRP to internal date-time utils

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -26,12 +26,12 @@ import { isDevelopment } from '../internal/is-development.js';
 import { warnOnce } from '../internal/logging.js';
 import { usePrevious } from '../internal/hooks/use-previous/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { formatTimezoneOffset, isIsoDateOnly } from '../internal/utils/date-time';
+import { formatDateRange, isIsoDateOnly } from '../internal/utils/date-time';
 import { formatValue } from './use-date-range-picker.js';
 
 export { DateRangePickerProps };
 
-function formatDateRange(
+function renderDateRange(
   range: null | DateRangePickerProps.Value,
   placeholder: string,
   formatRelativeRange: DateRangePickerProps.I18nStrings['formatRelativeRange'],
@@ -49,7 +49,7 @@ function formatDateRange(
     range.type === 'relative' ? (
       formatRelativeRange(range)
     ) : (
-      <BreakSpaces text={formatAbsoluteRange(range, timeOffset)} />
+      <BreakSpaces text={formatDateRange(range.startDate, range.endDate, timeOffset)} />
     );
 
   return (
@@ -71,12 +71,6 @@ function BreakSpaces({ text }: { text: string }) {
       ))}
     </div>
   );
-}
-
-function formatAbsoluteRange(value: DateRangePickerProps.AbsoluteValue, timeOffset?: number): string {
-  const formattedStartOffset = isDateOnly(value) ? '' : formatTimezoneOffset(value.startDate, timeOffset);
-  const formattedEndOffset = isDateOnly(value) ? '' : formatTimezoneOffset(value.endDate, timeOffset);
-  return value.startDate + formattedStartOffset + ' ' + '—' + ' ' + value.endDate + formattedEndOffset;
 }
 
 function isDateOnly(value: null | DateRangePickerProps.Value) {
@@ -228,7 +222,7 @@ const DateRangePicker = React.forwardRef(
             <span className={styles['icon-wrapper']}>
               <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
             </span>
-            {formatDateRange(value, placeholder ?? '', i18nStrings.formatRelativeRange, timeOffset)}
+            {renderDateRange(value, placeholder ?? '', i18nStrings.formatRelativeRange, timeOffset)}
           </span>
         </ButtonTrigger>
       </div>

--- a/src/internal/utils/date-time/__tests__/format-date-range.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-range.test.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { formatDateRange } from '../../../../../lib/components/internal/utils/date-time/format-date-range';
+
+describe('formatDateRange', () => {
+  test.each([
+    ['2020-01-01', '2020-01-02', undefined, '2020-01-01 — 2020-01-02'],
+    ['2020-01-01', '2020-01-02', 60, '2020-01-01 — 2020-01-02'],
+    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', 60, '2020-01-01T00:00:00+01:00 — 2020-01-01T12:00:00+01:00'],
+    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', -60, '2020-01-01T00:00:00-01:00 — 2020-01-01T12:00:00-01:00'],
+  ])('formats date correctly [%s, %s, %s]', (startDate, endDate, timeOffset, expected) => {
+    expect(formatDateRange(startDate, endDate, timeOffset)).toBe(expected);
+  });
+});

--- a/src/internal/utils/date-time/format-date-range.ts
+++ b/src/internal/utils/date-time/format-date-range.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { formatTimezoneOffset } from './format-timezone-offset';
+import { isIsoDateOnly } from './is-iso-date-only';
+
+export function formatDateRange(startDate: string, endDate: string, timeOffset?: number): string {
+  const isDateOnly = isIsoDateOnly(startDate) && isIsoDateOnly(endDate);
+  const formattedStartOffset = isDateOnly ? '' : formatTimezoneOffset(startDate, timeOffset);
+  const formattedEndOffset = isDateOnly ? '' : formatTimezoneOffset(endDate, timeOffset);
+  return startDate + formattedStartOffset + ' ' + '—' + ' ' + endDate + formattedEndOffset;
+}

--- a/src/internal/utils/date-time/index.ts
+++ b/src/internal/utils/date-time/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { isoToDisplay, displayToIso } from './display-format';
+export { formatDateRange } from './format-date-range';
 export { formatDate } from './format-date';
 export { formatTime } from './format-time';
 export { formatTimezoneOffset } from './format-timezone-offset';


### PR DESCRIPTION
### Description

Extract formatDateRange util from date range picker and add tests for it.

### How has this been tested?

New unit test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
