### PR TITLE
fix(app-layout): Fix scroll anchoring breaking on desktop classic app layout

### DIFF
--- a/src/app-layout/navigation-panel.tsx
+++ b/src/app-layout/navigation-panel.tsx
@@ -47,11 +47,7 @@ export function NavigationPanel({
   toggleRefs,
 }: NavigationPanelProps) {
   return (
-    <div
-      style={{
-        width: navigationDrawerWidth,
-      }}
-    >
+    <div className={styles['navigation-panel']} style={{ width: navigationDrawerWidth }}>
       <div
         className={clsx(styles['panel-wrapper-outer'], {
           [styles.mobile]: isMobile,

--- a/src/app-layout/styles.scss
+++ b/src/app-layout/styles.scss
@@ -55,6 +55,10 @@ $drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{awsui.$space-
   visibility: hidden;
 }
 
+.navigation-panel {
+  overflow-anchor: none;
+}
+
 .drawer {
   flex-shrink: 0;
   position: relative;


### PR DESCRIPTION
### Description

For some text-heavy scenarios, the user may find that the scroll position gets lost as they resize the window.

If you think about it programmatically, it makes sense. The page is scrolled by a fixed `N` pixels, and when you shrink the content, the previous paragraphs reflow and take up more height, so the paragraph you were reading may move down your screen (or vice versa).

Thankfully, browsers have a solution to this, called [scroll anchoring](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring). In short, the browser picks an element to keep fixed in a position relative to the viewport. So if you're reading an article and a huge ad pops up higher in the page, it won't mess with you. Unfortunately, in our case, the browser is picking the left navigation pane as a scroll anchor, and that one doesn't exactly scroll, obviously. So we tell the browser not to pick that element, and it moves on down to some element in the app layout content, which is what we want.

### How has this been tested?

Only manually. I tried to put together an integ test to replicate and test this behavior, but the browser logic for determining scroll anchors is only _kind of_ deterministic and replicable. Since it's a single CSS property, and it makes inherent sense, and the surface area is minimal, I'm willing to make this one happen without tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
