### PR TITLE
fix(code-editor): Allow for correct border radius theming

### DIFF
--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -73,6 +73,11 @@
   .ace_gutter {
     background-color: awsui.$color-background-code-editor-gutter-default;
     color: awsui.$color-text-code-editor-gutter-default;
+    border-top-left-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
+  }
+
+  .ace_scroller {
+    border-top-right-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
   }
 
   .ace_fold-widget.ace_open {
@@ -193,15 +198,6 @@
         }
       }
     }
-  }
-}
-
-.code-editor-refresh :global .ace_editor {
-  .ace_gutter {
-    border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
-  }
-  .ace_scroller {
-    border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
   }
 }
 

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -253,11 +253,7 @@ export default function CodeEditor(props: CodeEditorProps) {
   const onPreferencesDismiss = () => setPreferencesModalVisible(false);
 
   return (
-    <div
-      {...baseProps}
-      className={clsx(styles['code-editor'], baseProps.className, { [styles['code-editor-refresh']]: isRefresh })}
-      ref={mergedRef}
-    >
+    <div {...baseProps} className={clsx(styles['code-editor'], baseProps.className)} ref={mergedRef}>
       {props.loading && <LoadingScreen>{i18nStrings.loadingState}</LoadingScreen>}
 
       {!ace && !props.loading && (

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -52,17 +52,14 @@
   right: 0;
   bottom: 0;
   left: 0;
+  border-top-left-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
+  border-top-right-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
 
   &:focus {
     @include styles.focus-highlight(3px);
     position: absolute;
     overflow: visible;
   }
-}
-
-.code-editor-refresh > .resizable-box > .editor {
-  border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
-  border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
 }
 
 .status-bar {


### PR DESCRIPTION
### Description

Allows to set a custom value for code editor border radius. The fix is needed before making the border radius themeable (https://github.com/cloudscape-design/components/pull/221)


### How has this been tested?

[_How did you test to verify your changes?_] Locally

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

https://github.com/cloudscape-design/components/pull/221


_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._ `max` CSS function is supported in all browsers that Cloudscape supports: https://developer.mozilla.org/en-US/docs/Web/CSS/max
- [N/A] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [N/A] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

Covered by internal visual regression tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
