### PR TITLE
fix(container): Allow for correct border radius theming

### DIFF
--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -32,7 +32,9 @@
 
 .header {
   background-color: awsui.$color-background-container-header;
-  border-radius: awsui.$border-radius-container;
+  border-top-left-radius: awsui.$border-radius-container;
+  border-top-right-radius: awsui.$border-radius-container;
+
   // sticky positioning may be disabled (on mobile or if browser does not support it),
   // but some markup still requires a new stacking context
   &-sticky-disabled {
@@ -62,6 +64,9 @@
   }
   &-variant-cards {
     @include shared.borders-and-shadows;
+    border-bottom-left-radius: awsui.$border-radius-container;
+    border-bottom-right-radius: awsui.$border-radius-container;
+
     &:not(:empty) {
       // bottom shadow does not appear in IE11 due to the presence of background color
       // Adding a bottom border


### PR DESCRIPTION
### Description

Allows to set a custom value for the container border radius without impacting the bottom left/right radius of container header. Needed to make container border radius themeable (https://github.com/cloudscape-design/components/pull/221).


### How has this been tested?

[_How did you test to verify your changes?_] Locally

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

https://github.com/cloudscape-design/components/pull/221


_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [N/A] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [N/A] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

Covered by existing internal visual regression tests

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
