### PR TITLE
fix(header): Export HeaderProps namespace

### DIFF
--- a/src/header/interfaces.ts
+++ b/src/header/interfaces.ts
@@ -43,7 +43,7 @@ export interface HeaderProps extends BaseComponentProps {
   info?: React.ReactNode;
 }
 
-namespace HeaderProps {
+export namespace HeaderProps {
   export type Variant = 'h1' | 'h2' | 'h3' | 'awsui-h1-sticky';
   export type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 }


### PR DESCRIPTION
closes #241 

### Description
`HeaderProps` namespace wasn't exported so consumers of the library couldn't import it's properties like`Varinat` and `HeadingTag`

### How has this been tested?

manually by importing `HeaderProps.Variant` in one of the pages files


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

https://github.com/cloudscape-design/components/issues/241

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
