### PR TITLE
Make autosuggest input support custom content

### DIFF
--- a/pages/autosuggest/autosuggest-input.page.tsx
+++ b/pages/autosuggest/autosuggest-input.page.tsx
@@ -30,6 +30,7 @@ export default function AutosuggestInputPage() {
           </Box>
         }
         dropdownWidth={300}
+        ariaLabel="autosuggest input"
       />
     </Box>
   );

--- a/pages/autosuggest/autosuggest-input.page.tsx
+++ b/pages/autosuggest/autosuggest-input.page.tsx
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Box from '~components/box';
+import AutosuggestInput from '~components/internal/components/autosuggest-input';
+
+const contentOptions = [
+  { key: 'small', content: ContentSmall },
+  { key: 'medium', content: ContentMedium },
+  { key: 'large', content: ContentLarge },
+];
+
+export default function AutosuggestInputPage() {
+  const [value, setValue] = useState('');
+
+  const [matched] = contentOptions.filter(o => o.key.startsWith(value.toLowerCase()));
+  const dropdownContentKey = matched ? matched.key : 'not-matched';
+  const DropdownContent = matched ? matched.content : ContentNoMatch;
+
+  return (
+    <Box margin="m">
+      <h1>Autosuggest input</h1>
+      <AutosuggestInput
+        value={value}
+        onChange={e => setValue(e.detail.value)}
+        dropdownContentKey={dropdownContentKey}
+        dropdownContent={
+          <Box padding="m">
+            <DropdownContent />
+          </Box>
+        }
+        dropdownWidth={300}
+      />
+    </Box>
+  );
+}
+
+function ContentNoMatch() {
+  return <div>Nothing matched</div>;
+}
+
+function ContentSmall() {
+  return <div style={{ width: 200 }}>Small</div>;
+}
+
+function ContentMedium() {
+  return <div style={{ width: 350 }}>Medium</div>;
+}
+
+function ContentLarge() {
+  return <div style={{ width: 500 }}>Large</div>;
+}

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { Ref, useRef } from 'react';
+import React, { Ref, useImperativeHandle, useRef } from 'react';
 
 import { useAutosuggestItems } from './options-controller';
 import { AutosuggestItem, AutosuggestProps } from './interfaces';
@@ -25,7 +25,6 @@ import AutosuggestOptionsList from './options-list';
 import { useAutosuggestLoadMore } from './load-more-controller';
 import { OptionsLoadItemsDetail } from '../internal/components/dropdown/interfaces';
 import AutosuggestInput, { AutosuggestInputRef } from '../internal/components/autosuggest-input';
-import useForwardFocus from '../internal/hooks/forward-focus';
 import { useFormFieldContext } from '../contexts/form-field';
 import clsx from 'clsx';
 
@@ -65,8 +64,14 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   checkOptionValueField('Autosuggest', 'options', options);
 
   const autosuggestInputRef = useRef<AutosuggestInputRef>(null);
-
-  useForwardFocus(ref, autosuggestInputRef);
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => autosuggestInputRef.current?.focus(),
+      select: () => autosuggestInputRef.current?.select(),
+    }),
+    []
+  );
 
   const [autosuggestItemsState, autosuggestItemsHandlers] = useAutosuggestItems({
     options: options || [],
@@ -137,6 +142,11 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     autosuggestInputRef.current?.focus();
   };
 
+  const handleDropdownMouseDown: React.MouseEventHandler = event => {
+    // Prevent currently focused element from losing focus.
+    event.preventDefault();
+  };
+
   const formFieldContext = useFormFieldContext(restProps);
   const selfControlId = useUniqueId('input');
   const controlId = formFieldContext.controlId ?? selfControlId;
@@ -193,6 +203,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
           <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
         ) : null
       }
+      onDropdownMouseDown={handleDropdownMouseDown}
       onCloseDropdown={handleCloseDropdown}
       onDelayedInput={handleDelayedInput}
       onPressArrowDown={handlePressArrowDown}

--- a/src/internal/components/autosuggest-input/__integ__/autosuggest-input.test.ts
+++ b/src/internal/components/autosuggest-input/__integ__/autosuggest-input.test.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import AutosuggestInputWrapper from '../../../../../lib/components/test-utils/selectors/internal/autosuggest-input';
+
+const wrapper = new AutosuggestInputWrapper('*');
+
+function setupTest(testFn: (page: BasePageObject) => Promise<void>, url = '/#/light/autosuggest/autosuggest-input') {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url(url);
+    await testFn(page);
+  });
+}
+
+test(
+  'should replace dropdown content and change its size',
+  setupTest(async page => {
+    await page.click(wrapper.findInput().findNativeInput().toSelector());
+    await page.waitForVisible(wrapper.findDropdown()!.findOpenDropdown().toSelector());
+    const smallDropdownSize = await page.getBoundingBox(wrapper.findDropdown()!.findOpenDropdown().toSelector());
+
+    await page.keys('Medium');
+    await page.waitForVisible(wrapper.findDropdown()!.findOpenDropdown().toSelector());
+    const mediumDropdownSize = await page.getBoundingBox(wrapper.findDropdown()!.findOpenDropdown().toSelector());
+
+    expect(smallDropdownSize).not.toEqual(mediumDropdownSize);
+  })
+);

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -124,6 +124,7 @@ const Dropdown = ({
   hasContent = true,
   scrollable = true,
   trapFocus = false,
+  contentKey,
 }: DropdownProps) => {
   const triggerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -264,7 +265,7 @@ const Dropdown = ({
     }
     // See AWSUI-13040
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, dropdownRef, triggerRef, verticalContainerRef, interior, stretchWidth, isMobile]);
+  }, [open, dropdownRef, triggerRef, verticalContainerRef, interior, stretchWidth, isMobile, contentKey]);
 
   // subscribe to outside click
   useEffect(() => {

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -59,6 +59,10 @@ export interface DropdownProps extends ExpandToViewport {
    */
   children?: React.ReactNode;
   /**
+   * Updating content key triggers dropdown position re-evaluation.
+   */
+  contentKey?: string;
+  /**
    * Open state of the dropdown.
    */
   open?: boolean;

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -26,12 +26,12 @@ export const getQueryActions = (
     const newTokens = tokens.filter((_, i) => i !== index);
     fireOnChange(newTokens, operation);
     preventFocus.current = true;
-    inputRef.current?.focusNoOpen();
+    inputRef.current?.focus({ preventDropdown: true });
   };
   const removeAllTokens = () => {
     fireOnChange([], operation);
     preventFocus.current = true;
-    inputRef.current?.focusNoOpen();
+    inputRef.current?.focus({ preventDropdown: true });
   };
   const addToken = (newToken: PropertyFilterProps.Token) => {
     const newTokens = [...tokens];

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useRef, useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo, useImperativeHandle } from 'react';
 
 import InternalSpaceBetween from '../space-between/internal';
 import { InternalButton } from '../button/internal';
 import { getBaseProps } from '../internal/base-component';
-import useForwardFocus from '../internal/hooks/forward-focus';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { KeyCode } from '../internal/keycode';
 import SelectToggle from '../token-group/toggle';
@@ -57,7 +56,7 @@ const PropertyFilter = React.forwardRef(
     const inputRef = useRef<AutosuggestInputRef>(null);
     const preventFocus = useRef<boolean>(false);
     const baseProps = getBaseProps(rest);
-    useForwardFocus(ref, inputRef);
+    useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
     const { tokens, operation } = query;
     const showResults = tokens?.length && !disabled;
     const { addToken, removeToken, setToken, setOperation, removeAllTokens } = getQueryActions(

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -129,6 +129,11 @@ const PropertyFilterAutosuggest = React.forwardRef(
       autosuggestInputRef.current?.focus();
     };
 
+    const handleDropdownMouseDown: React.MouseEventHandler = event => {
+      // Prevent currently focused element from losing focus.
+      event.preventDefault();
+    };
+
     const selfControlId = useUniqueId('input');
     const controlId = rest.controlId ?? selfControlId;
     const listId = useUniqueId('list');
@@ -175,6 +180,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
           ) : null
         }
         dropdownWidth={DROPDOWN_WIDTH}
+        onDropdownMouseDown={handleDropdownMouseDown}
         onCloseDropdown={handleCloseDropdown}
         onDelayedInput={handleDelayedInput}
         onPressArrowDown={handlePressArrowDown}


### PR DESCRIPTION
### Description

The autosuggest input was extracted out from autosuggest (see https://github.com/cloudscape-design/components/pull/240, https://github.com/cloudscape-design/components/pull/246).

It works well when having a list of options as its content, but requires changes to support different content which might not require click to be muted and can have different size.

This is done in preparation for custom content in property filter (see https://github.com/cloudscape-design/components/pull/166).

### How has this been tested?

Added new unit and integ tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
