### PR TITLE
Update icon alt description

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5413,7 +5413,7 @@ Object {
   "name": "Icon",
   "properties": Array [
     Object {
-      "description": "Specifies alternate text for a custom icon (using the url attribute). We recommend that you provide this for accessibility.
+      "description": "Specifies alternate text for a custom icon (using the \`url\` attribute). We recommend that you provide this for accessibility.
 This property is ignored if you use a predefined icon or if you set your custom icon using the \`svg\` slot.",
       "name": "alt",
       "optional": true,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5413,7 +5413,7 @@ Object {
   "name": "Icon",
   "properties": Array [
     Object {
-      "description": "Specifies alternate text for a custom icon. We recommend that you provide this for accessibility.
+      "description": "Specifies alternate text for a custom icon (using the url attribute). We recommend that you provide this for accessibility.
 This property is ignored if you use a predefined icon or if you set your custom icon using the \`svg\` slot.",
       "name": "alt",
       "optional": true,

--- a/src/icon/interfaces.ts
+++ b/src/icon/interfaces.ts
@@ -32,7 +32,7 @@ export interface IconProps extends BaseComponentProps {
    */
   url?: string;
   /**
-   * Specifies alternate text for a custom icon (using the url attribute). We recommend that you provide this for accessibility.
+   * Specifies alternate text for a custom icon (using the `url` attribute). We recommend that you provide this for accessibility.
    * This property is ignored if you use a predefined icon or if you set your custom icon using the `svg` slot.
    */
   alt?: string;

--- a/src/icon/interfaces.ts
+++ b/src/icon/interfaces.ts
@@ -32,7 +32,7 @@ export interface IconProps extends BaseComponentProps {
    */
   url?: string;
   /**
-   * Specifies alternate text for a custom icon. We recommend that you provide this for accessibility.
+   * Specifies alternate text for a custom icon (using the url attribute). We recommend that you provide this for accessibility.
    * This property is ignored if you use a predefined icon or if you set your custom icon using the `svg` slot.
    */
   alt?: string;


### PR DESCRIPTION
### Description

Update API description of alt to specify url instead of "custom icon", because alt only applies when url is set (see [code](https://github.com/cloudscape-design/components/blob/main/src/icon/internal.tsx#L99)), also being more consistent with [guideline writing](https://polaris.a2z.com/components/icon/?tabId=usage&props=N4IgdghgtgpiBcIDOMAuqCWYDmSQBpkMAvORMAewCcoIAbAkANwiowjFQXGtocICuVBohABfIA#:~:text=For%20custom%20icons%20(using%20the%20url%20attribute)%2C%20use%20the%20alt%20attribute%3A)

**AWSUI-18904**

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
