### PR TITLE
fix: Rounded corners in container variant of expandable section

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -16,6 +16,7 @@ export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>,
   __stickyOffset?: number;
   __disableFooterDivider?: boolean;
   __disableFooterPaddings?: boolean;
+  __hiddenContent?: boolean;
   __headerRef?: React.RefObject<HTMLDivElement>;
   /**
    * Additional internal variant:
@@ -38,6 +39,7 @@ export default function InternalContainer({
   __internalRootRef = null,
   __disableFooterDivider = false,
   __disableFooterPaddings = false,
+  __hiddenContent = false,
   __headerRef,
   ...restProps
 }: InternalContainerProps) {
@@ -67,6 +69,7 @@ export default function InternalContainer({
               [styles['header-dynamic-height']]: hasDynamicHeight,
               [styles['header-stuck']]: isStuck,
               [styles['with-paddings']]: !disableHeaderPaddings,
+              [styles['with-hidden-content']]: __hiddenContent,
             })}
             {...stickyStyles}
             ref={headerMergedRef}

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -62,10 +62,12 @@
   &.with-paddings {
     padding: shared.$header-padding;
   }
-  &-variant-cards {
-    @include shared.borders-and-shadows;
+  &.with-hidden-content {
     border-bottom-left-radius: awsui.$border-radius-container;
     border-bottom-right-radius: awsui.$border-radius-container;
+  }
+  &-variant-cards {
+    @include shared.borders-and-shadows;
 
     &:not(:empty) {
       // bottom shadow does not appear in IE11 due to the presence of background color

--- a/src/expandable-section/expandable-section-container.tsx
+++ b/src/expandable-section/expandable-section-container.tsx
@@ -33,6 +33,7 @@ export const ExpandableSectionContainer = ({
         variant="default"
         disableContentPaddings={disableContentPaddings || !expanded}
         disableHeaderPaddings={true}
+        __hiddenContent={!expanded}
         __internalRootRef={__internalRootRef}
       >
         {children}


### PR DESCRIPTION
### Description

https://github.com/cloudscape-design/components/pull/243 introduced a regression in bottom border radius of expandable section with `variant=container`. This change addressed the regression.


### How has this been tested?

[_How did you test to verify your changes?_] Locally

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

https://github.com/cloudscape-design/components/pull/243

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [X] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [N/A] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [N/A] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing
Covered by existing visual regression tests
- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
