### PR TITLE
Fix code editor build

### DIFF
--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -73,11 +73,6 @@
   .ace_gutter {
     background-color: awsui.$color-background-code-editor-gutter-default;
     color: awsui.$color-text-code-editor-gutter-default;
-    border-top-left-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
-  }
-
-  .ace_scroller {
-    border-top-right-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
   }
 
   .ace_fold-widget.ace_open {
@@ -198,6 +193,15 @@
         }
       }
     }
+  }
+}
+
+.code-editor-refresh :global .ace_editor {
+  .ace_gutter {
+    border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  }
+  .ace_scroller {
+    border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
   }
 }
 

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -253,7 +253,11 @@ export default function CodeEditor(props: CodeEditorProps) {
   const onPreferencesDismiss = () => setPreferencesModalVisible(false);
 
   return (
-    <div {...baseProps} className={clsx(styles['code-editor'], baseProps.className)} ref={mergedRef}>
+    <div
+      {...baseProps}
+      className={clsx(styles['code-editor'], baseProps.className, { [styles['code-editor-refresh']]: isRefresh })}
+      ref={mergedRef}
+    >
       {props.loading && <LoadingScreen>{i18nStrings.loadingState}</LoadingScreen>}
 
       {!ace && !props.loading && (

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -52,14 +52,17 @@
   right: 0;
   bottom: 0;
   left: 0;
-  border-top-left-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
-  border-top-right-radius: max(awsui.$border-radius-code-editor - awsui.$border-item-width, 0px);
 
   &:focus {
     @include styles.focus-highlight(3px);
     position: absolute;
     overflow: visible;
   }
+}
+
+.code-editor-refresh > .resizable-box > .editor {
+  border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
 }
 
 .status-bar {

--- a/style-dictionary/visual-refresh/metadata/borders.ts
+++ b/style-dictionary/visual-refresh/metadata/borders.ts
@@ -34,8 +34,6 @@ const metadata: StyleDictionary.MetadataIndex = {
   },
   borderRadiusCodeEditor: {
     description: 'The border radius of code editors.',
-    public: true,
-    themeable: true,
   },
   borderRadiusContainer: {
     description:


### PR DESCRIPTION
### Description

- Reverting a CSS change that caused build issue
- Making `borderRadiusCodeEditor`token private, as its themeability depends on that CSS change.

### How has this been tested?

Locally

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [X] _Yes, this change contains documentation changes._ Removed a public token, although it has been public for less than a day.
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._ Removing public design token. Mitigated by the fact that it has been public for less than a day
- [X] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [N/A] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [N/A] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing
Covered by visual regression tests
- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
