### PR TITLE
fix(table): add scope attribute on column headers

### DIFF
--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -125,6 +125,14 @@ test('should render table with primitive content', () => {
   expect(wrapper.findBodyCell(2, 2)!.getElement()).toContainHTML('Oranges');
 });
 
+test('should render table with accessible headers', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={defaultColumns} items={defaultItems} />);
+  const columnHeaders = wrapper.findColumnHeaders();
+  columnHeaders.forEach(header => {
+    expect(header.getElement()).toHaveAttribute('scope', 'col');
+  });
+});
+
 test('should render table with react content', () => {
   const columns: TableProps.ColumnDefinition<Item>[] = [
     ...defaultColumns,

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -72,6 +72,7 @@ export function TableHeaderCell({
       })}
       aria-sort={sortingStatus && getAriaSort(sortingStatus)}
       style={style}
+      scope="col"
     >
       <div
         className={clsx(styles['header-cell-content'], {


### PR DESCRIPTION
### Description

This PR adds the `scope` attribute to column headers in the Table component.

Motivation:
Most a11y guidelines recommend adding `scope='col'` to `th` elements. Example [[ref]](https://www.a11yproject.com/posts/accessible-data-tables/#row-and-column-headings:~:text=Column%20headers%20should,should%20be%20unique.)

### How has this been tested?

[_How did you test to verify your changes?_]
I've added a unit test to confirm that the attribute is rendered.

[_How can reviewers test these changes efficiently?_]
Run the unit test, and check in browser.

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]
No visual regressions
<img width="196" alt="image" src="https://user-images.githubusercontent.com/7447677/189309590-2c416e47-ad24-4ed5-bcf2-f14f1a84f88f.png">


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
