### PR TITLE
Fix property filter input classes assignment

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -82,6 +82,7 @@ const renderComponent = (props?: Partial<PropertyFilterProps & { ref: React.Ref<
   );
   const pageWrapper = createWrapper(container);
   return {
+    container,
     propertyFilterWrapper: pageWrapper.findPropertyFilter()!,
     pageWrapper,
   };
@@ -743,5 +744,14 @@ describe('property filter parts', () => {
     expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('error');
     wrapper.selectSuggestion(2, { expandToViewport: true });
     expect(wrapper.findNativeInput().getElement()).toHaveValue('string != ');
+  });
+
+  test('property filter input can be found with autosuggest selector', () => {
+    const { container } = renderComponent();
+    expect(createWrapper(container).findAutosuggest()!.getElement()).not.toBe(null);
+  });
+  test('property filter input can be found with styles.input', () => {
+    const { container } = renderComponent();
+    expect(createWrapper(container).findByClassName(styles.input)!.getElement()).not.toBe(null);
   });
 });

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -198,7 +198,6 @@ const PropertyFilter = React.forwardRef(
             ref={inputRef}
             virtualScroll={virtualScroll}
             enteredTextLabel={i18nStrings.enteredTextLabel}
-            className={styles.input}
             ariaLabel={i18nStrings.filteringAriaLabel}
             placeholder={i18nStrings.filteringPlaceholder}
             value={filteringText}

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -17,7 +17,8 @@ import {
   BaseKeyDetail,
 } from '../internal/events';
 import { BaseChangeDetail } from '../input/interfaces';
-import styles from '../autosuggest/styles.css.js';
+import autosuggestStyles from '../autosuggest/styles.css.js';
+import styles from './styles.css.js';
 import { fireCancelableEvent } from '../internal/events/index';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import AutosuggestOptionsList from '../autosuggest/options-list';
@@ -25,6 +26,7 @@ import { useAutosuggestLoadMore } from '../autosuggest/load-more-controller';
 import { OptionsLoadItemsDetail } from '../internal/components/dropdown/interfaces';
 import AutosuggestInput, { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import clsx from 'clsx';
 
 const DROPDOWN_WIDTH = 300;
 
@@ -145,7 +147,8 @@ const PropertyFilterAutosuggest = React.forwardRef(
     return (
       <AutosuggestInput
         ref={mergedRef}
-        className={styles.root}
+        {...rest}
+        className={clsx(autosuggestStyles.root, styles.input)}
         value={value}
         onChange={handleChange}
         onFocus={handleFocus}
@@ -186,7 +189,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
         onPressArrowDown={handlePressArrowDown}
         onPressArrowUp={handlePressArrowUp}
         onPressEnter={handlePressEnter}
-        {...rest}
       />
     );
   }


### PR DESCRIPTION
### Description

Property filter autosuggest component requires both autosuggest.root and property-filter.input classes.

### How has this been tested?

Added new unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
