### PR TITLE
Add property filter token editor actions separator

### DIFF
--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -56,10 +56,18 @@
     flex-shrink: 0;
     margin-left: awsui.$space-xl;
   }
+  &-form {
+    margin-bottom: awsui.$space-scaled-l;
+  }
   &-actions {
     display: flex;
     justify-content: flex-end;
-    margin-top: awsui.$space-scaled-xl;
+    padding-top: awsui.$space-s;
+    border-top: 1px solid #{awsui.$color-border-dropdown-item-default};
+    // The below code cancels horizontal padding of the popover and horizontal margin of the token-editor.
+    padding-right: calc(#{awsui.$space-m} + #{awsui.$space-xxs});
+    margin-left: calc(-1 * #{awsui.$space-m} + -1 * #{awsui.$space-xxs});
+    margin-right: calc(-1 * #{awsui.$space-m} + -1 * #{awsui.$space-xxs});
   }
   &-commit {
     margin-left: awsui.$space-xs;

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -211,7 +211,7 @@ interface TokenEditorFormProps {
 function TokenEditorForm({ i18nStrings, onCancel, onSubmit, children }: TokenEditorFormProps) {
   return (
     <div className={styles['token-editor']}>
-      {children}
+      <div className={styles['token-editor-form']}>{children}</div>
 
       <div className={styles['token-editor-actions']}>
         <InternalButton variant="link" className={styles['token-editor-cancel']} onClick={onCancel}>


### PR DESCRIPTION
### Description

Add separator to the property filter token editor between editor form and actions, same as in the date range picker.

### How has this been tested?

Manual testing, screenshot testing.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
