### PR TITLE
Use grid layout for property filter token editor

### DIFF
--- a/src/property-filter/__integ__/async-loading.test.ts
+++ b/src/property-filter/__integ__/async-loading.test.ts
@@ -16,8 +16,14 @@ declare let window: ExtendedWindow;
 const wrapper = createWrapper().findPropertyFilter();
 const inputSelector = wrapper.findNativeInput().toSelector();
 const popoverWrapper = createWrapper(wrapper.findTokens().get(1).toSelector()).findPopover();
-const propertyEditWrapper = popoverWrapper.findContent().findByClassName(styles['property-selector']).findSelect();
-const valueEditWrapper = popoverWrapper.findContent().findByClassName(styles['value-selector']).findAutosuggest();
+const propertyEditWrapper = popoverWrapper
+  .findContent()
+  .findByClassName(styles['token-editor-field-property'])
+  .findSelect();
+const valueEditWrapper = popoverWrapper
+  .findContent()
+  .findByClassName(styles['token-editor-field-value'])
+  .findAutosuggest();
 
 class AsyncPropertyFilterPage extends BasePageObject {
   expectLoadItemsEvents = async (expected: PropertyFilterProps.LoadItemsDetail[]) => {

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -89,13 +89,13 @@ const renderComponent = (props?: Partial<PropertyFilterProps & { ref: React.Ref<
 };
 
 function findPropertySelector(wrapper: ElementWrapper) {
-  return wrapper.findByClassName(styles['property-selector'])!.findSelect()!;
+  return wrapper.findByClassName(styles['token-editor-field-property'])!.findSelect()!;
 }
 function findOperatorSelector(wrapper: ElementWrapper) {
-  return wrapper.findByClassName(styles['operator-selector'])!.findSelect()!;
+  return wrapper.findByClassName(styles['token-editor-field-operator'])!.findSelect()!;
 }
 function findValueSelector(wrapper: ElementWrapper) {
-  return wrapper.findByClassName(styles['value-selector'])!.findAutosuggest()!;
+  return wrapper.findByClassName(styles['token-editor-field-value'])!.findAutosuggest()!;
 }
 
 describe('property filter parts', () => {

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -45,14 +45,16 @@
   justify-content: space-between;
   &-form {
     display: grid;
-    grid-template-columns: max-content minmax(awsui.$space-xl, auto) minmax(200px, min-content);
+    grid-template-columns: max-content minmax(awsui.$space-xl, 1fr) minmax(200px, min-content);
     grid-row-gap: awsui.$space-scaled-l;
     margin-bottom: awsui.$space-scaled-l;
   }
   &-label {
-    display: flex;
-    align-items: center;
-    @include styles.text-flex-wrapping;
+    max-width: 200px;
+    align-self: center;
+    &-text {
+      @include styles.text-flex-wrapping;
+    }
   }
   &-label-property {
     grid-row: 1;

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -45,8 +45,7 @@
   justify-content: space-between;
   &-form {
     display: grid;
-    grid-template-columns: 1fr minmax(200px, auto);
-    grid-column-gap: awsui.$space-xl;
+    grid-template-columns: max-content minmax(awsui.$space-xl, auto) minmax(200px, min-content);
     grid-row-gap: awsui.$space-scaled-l;
     margin-bottom: awsui.$space-scaled-l;
   }
@@ -69,15 +68,15 @@
   }
   &-field-property {
     grid-row: 1;
-    grid-column: 2;
+    grid-column: 3;
   }
   &-field-operator {
     grid-row: 2;
-    grid-column: 2;
+    grid-column: 3;
   }
   &-field-value {
     grid-row: 3;
-    grid-column: 2;
+    grid-column: 3;
   }
   &-actions {
     display: flex;

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -43,21 +43,41 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  &-line {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  &-form {
+    display: grid;
+    grid-template-columns: 1fr minmax(200px, auto);
+    grid-column-gap: awsui.$space-xl;
+    grid-row-gap: awsui.$space-scaled-l;
+    margin-bottom: awsui.$space-scaled-l;
   }
   &-label {
+    display: flex;
+    align-items: center;
     @include styles.text-flex-wrapping;
   }
-  &-field {
-    width: 200px;
-    flex-shrink: 0;
-    margin-left: awsui.$space-xl;
+  &-label-property {
+    grid-row: 1;
+    grid-column: 1;
   }
-  &-form {
-    margin-bottom: awsui.$space-scaled-l;
+  &-label-operator {
+    grid-row: 2;
+    grid-column: 1;
+  }
+  &-label-value {
+    grid-row: 3;
+    grid-column: 1;
+  }
+  &-field-property {
+    grid-row: 1;
+    grid-column: 2;
+  }
+  &-field-operator {
+    grid-row: 2;
+    grid-column: 2;
+  }
+  &-field-value {
+    grid-row: 3;
+    grid-column: 2;
   }
   &-actions {
     display: flex;
@@ -115,9 +135,6 @@
 .remove-all,
 .token-label,
 .join-operation,
-.property-selector,
-.operator-selector,
-.value-selector,
 .token-editor-submit {
   /* used in test-utils */
 }

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -330,7 +330,7 @@ export function TokenEditor({
             <InternalButton
               className={styles['token-editor-submit']}
               onClick={() => {
-                setToken(temporaryToken as Token);
+                setToken(temporaryToken);
                 closePopover();
               }}
             >

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -44,7 +44,7 @@ function TokenEditorField({ type, label, children }: TokenEditorFieldProps) {
   return (
     <>
       <label className={clsx(styles['token-editor-label'], styles[`token-editor-label-${type}`])} htmlFor={controlId}>
-        {label}
+        <span className={styles['token-editor-label-text']}>{label}</span>
       </label>
       <div className={clsx(styles['token-editor-field'], styles[`token-editor-field-${type}`])}>
         {children({ controlId })}

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 
 import { SelectProps } from '../select/interfaces';
 import InternalSelect from '../select/internal';
-import InternalSpaceBetween from '../space-between/internal';
 import InternalAutosuggest from '../autosuggest/internal';
 import InternalPopover, { InternalPopoverRef } from '../popover/internal';
 import { InternalButton } from '../button/internal';
@@ -36,19 +35,21 @@ const freeTextOperators: ComparisonOperator[] = [':', '!:'];
 
 interface TokenEditorFieldProps {
   label: React.ReactNode;
-  className: string;
+  type: 'property' | 'operator' | 'value';
   children: ({ controlId }: { controlId: string }) => React.ReactNode;
 }
 
-function TokenEditorField({ className, label, children }: TokenEditorFieldProps) {
+function TokenEditorField({ type, label, children }: TokenEditorFieldProps) {
   const controlId = useUniqueId();
   return (
-    <div className={clsx(styles['token-editor-line'], className)}>
-      <label className={styles['token-editor-label']} htmlFor={controlId}>
+    <>
+      <label className={clsx(styles['token-editor-label'], styles[`token-editor-label-${type}`])} htmlFor={controlId}>
         {label}
       </label>
-      <div className={styles['token-editor-field']}>{children({ controlId })}</div>
-    </div>
+      <div className={clsx(styles['token-editor-field'], styles[`token-editor-field-${type}`])}>
+        {children({ controlId })}
+      </div>
+    </>
   );
 }
 
@@ -201,30 +202,6 @@ function ValueInput({
   );
 }
 
-interface TokenEditorFormProps {
-  i18nStrings: I18nStrings;
-  onCancel(): void;
-  onSubmit(): void;
-  children: React.ReactNode;
-}
-
-function TokenEditorForm({ i18nStrings, onCancel, onSubmit, children }: TokenEditorFormProps) {
-  return (
-    <div className={styles['token-editor']}>
-      <div className={styles['token-editor-form']}>{children}</div>
-
-      <div className={styles['token-editor-actions']}>
-        <InternalButton variant="link" className={styles['token-editor-cancel']} onClick={onCancel}>
-          {i18nStrings.cancelActionText}
-        </InternalButton>
-        <InternalButton className={styles['token-editor-submit']} onClick={onSubmit}>
-          {i18nStrings.applyActionText}
-        </InternalButton>
-      </div>
-    </div>
-  );
-}
-
 interface TokenEditorProps {
   asyncProperties?: boolean;
   asyncProps: DropdownStatusProps;
@@ -297,16 +274,9 @@ export function TokenEditor({
       __onOpen={() => setTemporaryToken(token)}
       renderWithPortal={expandToViewport}
       content={
-        <TokenEditorForm
-          i18nStrings={i18nStrings}
-          onCancel={closePopover}
-          onSubmit={() => {
-            setToken(temporaryToken as Token);
-            closePopover();
-          }}
-        >
-          <InternalSpaceBetween size="l">
-            <TokenEditorField label={i18nStrings.propertyText} className={styles['property-selector']}>
+        <div className={styles['token-editor']}>
+          <div className={styles['token-editor-form']}>
+            <TokenEditorField label={i18nStrings.propertyText} type="property">
               {({ controlId }) => (
                 <PropertyInput
                   controlId={controlId}
@@ -322,7 +292,7 @@ export function TokenEditor({
               )}
             </TokenEditorField>
 
-            <TokenEditorField label={i18nStrings.operatorText} className={styles['operator-selector']}>
+            <TokenEditorField label={i18nStrings.operatorText} type="operator">
               {({ controlId }) => (
                 <OperatorInput
                   controlId={controlId}
@@ -335,7 +305,7 @@ export function TokenEditor({
               )}
             </TokenEditorField>
 
-            <TokenEditorField label={i18nStrings.valueText} className={styles['value-selector']}>
+            <TokenEditorField label={i18nStrings.valueText} type="value">
               {({ controlId }) => (
                 <ValueInput
                   controlId={controlId}
@@ -351,8 +321,23 @@ export function TokenEditor({
                 />
               )}
             </TokenEditorField>
-          </InternalSpaceBetween>
-        </TokenEditorForm>
+          </div>
+
+          <div className={styles['token-editor-actions']}>
+            <InternalButton variant="link" className={styles['token-editor-cancel']} onClick={closePopover}>
+              {i18nStrings.cancelActionText}
+            </InternalButton>
+            <InternalButton
+              className={styles['token-editor-submit']}
+              onClick={() => {
+                setToken(temporaryToken as Token);
+                closePopover();
+              }}
+            >
+              {i18nStrings.applyActionText}
+            </InternalButton>
+          </div>
+        </div>
       }
     >
       {triggerComponent}


### PR DESCRIPTION
### Description

Use grid layout for property filter token editor to prepare for non-select (custom) fields that can be wider than 200px.

Reference: https://github.com/cloudscape-design/components/pull/166

### How has this been tested?

Screenshot tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
