### PR TITLE
Add custom props test pages for property filter

### DIFF
--- a/pages/property-filter/common-props.ts
+++ b/pages/property-filter/common-props.ts
@@ -21,6 +21,14 @@ export const columnDefinitions = [
     cell: (item: TableItem) => item.state,
   },
   {
+    id: 'stopped',
+    sortingField: 'stopped',
+    header: 'Stopped',
+    type: 'boolean',
+    propertyLabel: 'Stopped',
+    cell: (item: TableItem) => item.state === 'Stopped',
+  },
+  {
     id: 'instancetype',
     sortingField: 'instancetype',
     header: 'Instance type',
@@ -91,6 +99,14 @@ export const columnDefinitions = [
     type: 'range',
     propertyLabel: 'Launch date',
     cell: (item: TableItem) => item.launchdate,
+  },
+  {
+    id: 'lasteventat',
+    sortingField: 'lasteventat',
+    header: 'Last event occurrence',
+    type: 'datetime',
+    propertyLabel: 'Last event occurrence',
+    cell: (item: TableItem) => item.lasteventat,
   },
 ].map((item, ind) => ({ order: ind + 1, ...item }));
 

--- a/pages/property-filter/table.data.ts
+++ b/pages/property-filter/table.data.ts
@@ -14,6 +14,7 @@ export interface TableItem {
   ipv4publicip?: string;
   securitygroup?: string;
   launchdate?: string;
+  lasteventat?: string;
 }
 
 export const allItems: TableItem[] = [
@@ -29,6 +30,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '66.67.16.87',
     securitygroup: 'sec4-71',
     launchdate: '2019-02-03',
+    lasteventat: '2022-07-27T23:39:44',
   },
   {
     instanceid: 'i-d0312e022392efa0',
@@ -42,6 +44,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '22.20.15.84',
     securitygroup: 'sec4-60',
     launchdate: '2020-11-07',
+    lasteventat: '2022-06-28T19:35:56',
   },
   {
     instanceid: 'i-070eef935c1301e6',
@@ -55,6 +58,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '87.54.78.48',
     securitygroup: 'groupsec-6',
     launchdate: '2020-05-28',
+    lasteventat: '2022-02-20T16:15:04',
   },
   {
     instanceid: 'i-0eeaae622e074e21',
@@ -68,6 +72,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '79.44.72.97',
     securitygroup: 'sec4-35',
     launchdate: '2019-06-04',
+    lasteventat: '2022-06-27T13:42:00',
   },
   {
     instanceid: 'i-799860926d39b2a3',
@@ -81,6 +86,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '90.77.83.18',
     securitygroup: 'sec4-77',
     launchdate: '2020-02-24',
+    lasteventat: '2022-01-13T21:49:37',
   },
   {
     instanceid: 'i-f64935677691848b',
@@ -94,6 +100,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '51.66.90.25',
     securitygroup: 'launch-wizard-66',
     launchdate: '2019-10-10',
+    lasteventat: '2022-04-23T23:23:32',
   },
   {
     instanceid: 'i-d5b5e73917af69a8',
@@ -107,6 +114,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '28.79.18.65',
     securitygroup: 'launch-wizard-52',
     launchdate: '2019-03-19',
+    lasteventat: '2022-01-02T09:18:41',
   },
   {
     instanceid: 'i-2a5bdc6c48fa8e5c',
@@ -120,6 +128,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '29.97.74.94',
     securitygroup: 'launch-wizard-75',
     launchdate: '2020-10-10',
+    lasteventat: '2022-02-22T19:00:58',
   },
   {
     instanceid: 'i-393c4d4a25ca3dba',
@@ -133,6 +142,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '75.40.67.11',
     securitygroup: 'launch-wizard-77',
     launchdate: '2020-01-25',
+    lasteventat: '2022-06-06T15:03:01',
   },
   {
     instanceid: 'i-c28fbdbb073ec4de',
@@ -146,6 +156,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '79.72.46.64',
     securitygroup: 'groupsec-39',
     launchdate: '2019-08-24',
+    lasteventat: '2022-02-19T13:20:26',
   },
   {
     instanceid: 'i-e876fb65dc771c53',
@@ -159,6 +170,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '25.16.51.62',
     securitygroup: 'launch-wizard-40',
     launchdate: '2019-07-21',
+    lasteventat: '2022-04-21T22:36:45',
   },
   {
     instanceid: 'i-d92d0e29fa3a0eda',
@@ -172,6 +184,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '28.44.42.82',
     securitygroup: 'sec4-62',
     launchdate: '2020-02-18',
+    lasteventat: '2022-07-07T16:48:49',
   },
   {
     instanceid: 'i-7911f4562405cb04',
@@ -185,6 +198,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '16.82.75.77',
     securitygroup: 'launch-wizard-86',
     launchdate: '2020-01-18',
+    lasteventat: '2022-05-23T12:56:15',
   },
   {
     instanceid: 'i-d3e9e4c068d4df6a',
@@ -198,6 +212,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '54.72.35.67',
     securitygroup: 'groupsec-29',
     launchdate: '2020-09-11',
+    lasteventat: '2022-04-27T14:26:05',
   },
   {
     instanceid: 'i-9966b9f79fc2afac',
@@ -211,6 +226,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '61.87.44.39',
     securitygroup: 'groupsec-27',
     launchdate: '2020-07-16',
+    lasteventat: '2022-05-28T19:43:53',
   },
   {
     instanceid: 'i-f202265d52b3d9b6',
@@ -224,6 +240,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '76.11.47.15',
     securitygroup: 'groupsec-24',
     launchdate: '2019-09-27',
+    lasteventat: '2022-05-16T08:02:08',
   },
   {
     instanceid: 'i-a6b569bc16be3756',
@@ -237,6 +254,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '90.75.30.51',
     securitygroup: 'launch-wizard-31',
     launchdate: '2020-04-19',
+    lasteventat: '2022-02-02T01:46:08',
   },
   {
     instanceid: 'i-f8e3d9fffd82bd62',
@@ -250,6 +268,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '29.83.25.48',
     securitygroup: 'launch-wizard-22',
     launchdate: '2019-08-23',
+    lasteventat: '2022-07-07T07:38:14',
   },
   {
     instanceid: 'i-d1f8d3023c360cb4',
@@ -263,6 +282,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '63.84.45.12',
     securitygroup: 'launch-wizard-56',
     launchdate: '2019-02-20',
+    lasteventat: '2022-02-07T17:05:10',
   },
   {
     instanceid: 'i-64ed85f898d0a950',
@@ -276,6 +296,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '26.56.98.76',
     securitygroup: 'sec4-55',
     launchdate: '2020-01-23',
+    lasteventat: '2022-03-02T06:32:30',
   },
   {
     instanceid: 'i-6afd6b0ebae03bd6',
@@ -289,6 +310,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '76.68.23.89',
     securitygroup: 'launch-wizard-25',
     launchdate: '2020-04-27',
+    lasteventat: '2022-03-01T12:00:40',
   },
   {
     instanceid: 'i-068993f1f76b09e1',
@@ -302,6 +324,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '96.16.87.34',
     securitygroup: 'sec4-16',
     launchdate: '2019-10-09',
+    lasteventat: '2022-07-28T07:33:14',
   },
   {
     instanceid: 'i-1cd4a64fc26a8fe9',
@@ -315,6 +338,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '95.82.62.43',
     securitygroup: 'launch-wizard-28',
     launchdate: '2020-06-08',
+    lasteventat: '2022-04-26T16:17:23',
   },
   {
     instanceid: 'i-835d004c46769aed',
@@ -328,6 +352,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '60.56.86.66',
     securitygroup: 'sec4-57',
     launchdate: '2019-11-14',
+    lasteventat: '2022-06-12T12:09:41',
   },
   {
     instanceid: 'i-5441bf2e91565e24',
@@ -341,6 +366,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '90.44.83.61',
     securitygroup: 'launch-wizard-36',
     launchdate: '2020-10-08',
+    lasteventat: '2022-05-20T06:42:11',
   },
   {
     instanceid: 'i-a57d0a6a6d20d73b',
@@ -354,6 +380,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '20.26.12.31',
     securitygroup: 'groupsec-29',
     launchdate: '2020-08-30',
+    lasteventat: '2022-05-28T00:07:52',
   },
   {
     instanceid: 'i-0b6646fde4598f8d',
@@ -367,6 +394,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '73.16.96.37',
     securitygroup: 'sec4-76',
     launchdate: '2019-02-05',
+    lasteventat: '2022-02-05T23:24:19',
   },
   {
     instanceid: 'i-5313687f75346895',
@@ -380,6 +408,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '55.92.93.35',
     securitygroup: 'sec4-16',
     launchdate: '2019-04-02',
+    lasteventat: '2022-05-06T09:25:22',
   },
   {
     instanceid: 'i-7173f776b4b30c05',
@@ -393,6 +422,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '23.73.49.79',
     securitygroup: 'groupsec-57',
     launchdate: '2019-06-14',
+    lasteventat: '2022-01-04T05:56:57',
   },
   {
     instanceid: 'i-fcfc136cb96b30c4',
@@ -406,6 +436,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '97.12.18.81',
     securitygroup: 'launch-wizard-61',
     launchdate: '2020-08-15',
+    lasteventat: '2022-05-07T05:53:00',
   },
   {
     instanceid: 'i-8c6a328351a438ff',
@@ -419,6 +450,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '88.32.49.28',
     securitygroup: 'launch-wizard-3',
     launchdate: '2020-12-11',
+    lasteventat: '2022-04-24T05:27:40',
   },
   {
     instanceid: 'i-cd323ed6664c7dc5',
@@ -432,6 +464,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '20.15.84.33',
     securitygroup: 'groupsec-10',
     launchdate: '2020-11-20',
+    lasteventat: '2022-03-15T15:27:25',
   },
   {
     instanceid: 'i-a7251b1805f9df3d',
@@ -445,6 +478,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '91.86.20.30',
     securitygroup: 'launch-wizard-89',
     launchdate: '2019-07-28',
+    lasteventat: '2022-02-07T03:56:03',
   },
   {
     instanceid: 'i-9f11e46b6c54a2a1',
@@ -458,6 +492,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '30.56.30.63',
     securitygroup: 'sec4-68',
     launchdate: '2020-12-14',
+    lasteventat: '2022-04-15T21:49:20',
   },
   {
     instanceid: 'i-6f733cc0de79c2cc',
@@ -471,6 +506,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '18.32.43.84',
     securitygroup: 'groupsec-13',
     launchdate: '2020-12-05',
+    lasteventat: '2022-06-25T05:57:54',
   },
   {
     instanceid: 'i-b994cfe3823d78b4',
@@ -484,6 +520,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '16.51.16.73',
     securitygroup: 'launch-wizard-98',
     launchdate: '2019-07-18',
+    lasteventat: '2022-05-01T03:55:40',
   },
   {
     instanceid: 'i-82b8f4ef5d25d17c',
@@ -497,6 +534,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '93.32.37.10',
     securitygroup: 'launch-wizard-39',
     launchdate: '2020-02-08',
+    lasteventat: '2022-06-24T03:58:57',
   },
   {
     instanceid: 'i-1d9468c0fdc6d337',
@@ -510,6 +548,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '38.77.56.31',
     securitygroup: 'launch-wizard-4',
     launchdate: '2020-10-10',
+    lasteventat: '2022-03-27T20:19:30',
   },
   {
     instanceid: 'i-1d56f94cf858be59',
@@ -523,6 +562,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '35.69.39.61',
     securitygroup: 'launch-wizard-79',
     launchdate: '2020-04-13',
+    lasteventat: '2022-06-22T05:46:24',
   },
   {
     instanceid: 'i-59129472a88790c4',
@@ -536,6 +576,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '22.82.77.95',
     securitygroup: 'groupsec-38',
     launchdate: '2020-08-13',
+    lasteventat: '2022-06-15T21:52:28',
   },
   {
     instanceid: 'i-b761d2801b356d89',
@@ -549,6 +590,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '92.34.58.25',
     securitygroup: 'groupsec-23',
     launchdate: '2019-02-02',
+    lasteventat: '2022-07-28T23:57:26',
   },
   {
     instanceid: 'i-9b50eea20c1d2813',
@@ -562,6 +604,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '59.15.18.96',
     securitygroup: 'groupsec-19',
     launchdate: '2020-09-13',
+    lasteventat: '2022-03-10T05:42:59',
   },
   {
     instanceid: 'i-a19a9633e1c5ba8f',
@@ -575,6 +618,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '52.64.43.38',
     securitygroup: 'groupsec-12',
     launchdate: '2020-08-21',
+    lasteventat: '2022-01-22T00:01:25',
   },
   {
     instanceid: 'i-85c31338cf96a6b9',
@@ -588,6 +632,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '47.49.29.40',
     securitygroup: 'sec4-80',
     launchdate: '2020-12-11',
+    lasteventat: '2022-04-18T16:50:36',
   },
   {
     instanceid: 'i-2a63773bd3bbc950',
@@ -601,6 +646,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '84.54.89.41',
     securitygroup: 'sec4-33',
     launchdate: '2020-01-04',
+    lasteventat: '2022-02-27T22:22:09',
   },
   {
     instanceid: 'i-c71adc85f62dc441',
@@ -614,6 +660,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '43.10.70.14',
     securitygroup: 'groupsec-30',
     launchdate: '2020-04-14',
+    lasteventat: '2022-07-23T08:41:35',
   },
   {
     instanceid: 'i-7d78145659f6edf8',
@@ -627,6 +674,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '25.83.24.18',
     securitygroup: 'sec4-7',
     launchdate: '2020-02-22',
+    lasteventat: '2022-07-20T03:35:11',
   },
   {
     instanceid: 'i-d64836cefed723f9',
@@ -640,6 +688,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '88.51.45.75',
     securitygroup: 'sec4-26',
     launchdate: '2020-06-16',
+    lasteventat: '2022-06-29T01:32:12',
   },
   {
     instanceid: 'i-0854aa3ca406d6de',
@@ -653,6 +702,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '31.74.57.97',
     securitygroup: 'sec4-56',
     launchdate: '2020-03-05',
+    lasteventat: '2022-07-16T01:31:42',
   },
   {
     instanceid: 'i-d50d96196e1da02f',
@@ -666,6 +716,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '90.94.90.27',
     securitygroup: 'sec4-44',
     launchdate: '2020-09-18',
+    lasteventat: '2022-06-29T05:41:03',
   },
   {
     instanceid: 'i-bf46a8fa4f894969',
@@ -679,6 +730,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '37.37.10.67',
     securitygroup: 'groupsec-39',
     launchdate: '2020-09-17',
+    lasteventat: '2022-05-20T21:35:06',
   },
   {
     instanceid: 'i-a3358a2493af65da',
@@ -692,6 +744,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '46.11.71.61',
     securitygroup: 'groupsec-80',
     launchdate: '2019-12-31',
+    lasteventat: '2022-04-13T21:35:21',
   },
   {
     instanceid: 'i-1ca6c551cd98b0bc',
@@ -705,6 +758,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '90.91.66.79',
     securitygroup: 'sec4-62',
     launchdate: '2019-09-05',
+    lasteventat: '2022-04-02T01:57:21',
   },
   {
     instanceid: 'i-78363f3b35fe1638',
@@ -718,6 +772,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '65.38.84.34',
     securitygroup: 'sec4-10',
     launchdate: '2020-09-04',
+    lasteventat: '2022-01-29T11:22:17',
   },
   {
     instanceid: 'i-36cb4d638866ef4b',
@@ -731,6 +786,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '51.59.35.67',
     securitygroup: 'launch-wizard-11',
     launchdate: '2019-12-21',
+    lasteventat: '2022-01-24T23:35:13',
   },
   {
     instanceid: 'i-dde47b18e8183070',
@@ -744,6 +800,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '21.93.32.44',
     securitygroup: 'launch-wizard-6',
     launchdate: '2020-11-07',
+    lasteventat: '2022-05-17T10:39:00',
   },
   {
     instanceid: 'i-86f3902256c13e75',
@@ -757,6 +814,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '86.71.93.66',
     securitygroup: 'sec4-20',
     launchdate: '2020-05-02',
+    lasteventat: '2022-06-01T10:49:16',
   },
   {
     instanceid: 'i-64329dd06110114b',
@@ -770,6 +828,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '47.23.76.64',
     securitygroup: 'launch-wizard-49',
     launchdate: '2019-05-10',
+    lasteventat: '2022-05-24T10:08:27',
   },
   {
     instanceid: 'i-36b91360e881739d',
@@ -783,6 +842,7 @@ export const allItems: TableItem[] = [
     ipv4publicip: '38.54.37.89',
     securitygroup: 'groupsec-10',
     launchdate: '2019-02-13',
+    lasteventat: '2022-03-28T03:39:42',
   },
   {
     instanceid: 'i-3b44795b1fea36ac',
@@ -796,5 +856,6 @@ export const allItems: TableItem[] = [
     ipv4publicip: '62.36.39.27',
     securitygroup: 'launch-wizard-26',
     launchdate: '2019-05-10',
+    lasteventat: '2022-02-06T19:58:40',
   },
 ].map((item, indx) => ({ order: indx, ...item }));

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropertyFilter from '~components/property-filter';
 import ScreenshotArea from '../utils/screenshot-area';
 import { PropertyFilterProps } from '~components/property-filter/interfaces';
-import { columnDefinitions, i18nStrings } from './common-props';
+import { columnDefinitions, i18nStrings, filteringProperties as commonFilteringProperties } from './common-props';
 
 const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = columnDefinitions.map(def => ({
   key: def.id,
@@ -48,16 +48,29 @@ export default function () {
           className="property-filter-default"
           query={{
             tokens: [
-              {
-                operator: ':',
-                value: 'filtering token',
-              },
+              { operator: ':', value: 'filtering token' },
               { operator: ':', value: 'second filtering token' },
             ],
             operation: 'and',
           }}
           onChange={() => {}}
           filteringProperties={filteringProperties}
+          filteringOptions={[]}
+          virtualScroll={true}
+          countText="5 matches"
+          i18nStrings={i18nStrings}
+        />
+        <PropertyFilter
+          className="property-filter-custom-props"
+          query={{
+            tokens: [
+              { propertyKey: 'stopped', operator: '=', value: 'true' },
+              { propertyKey: 'lasteventat', operator: '>', value: '2022-01-01T00:00:00' },
+            ],
+            operation: 'and',
+          }}
+          onChange={() => {}}
+          filteringProperties={commonFilteringProperties}
           filteringOptions={[]}
           virtualScroll={true}
           countText="5 matches"


### PR DESCRIPTION
### Description

Extended property filter token editor test page with datetime and boolean props. The new test scenario is to be covered with screenshot tests to expectedly fail when the custom properties support is added (ref: https://github.com/cloudscape-design/components/pull/166).

### How has this been tested?

Screenshot tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* CR-75879700

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
