### PR TITLE
Use form field internally in property filter token editor

### DIFF
--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -45,40 +45,9 @@
   justify-content: space-between;
   &-form {
     display: grid;
-    grid-template-columns: max-content minmax(awsui.$space-xl, 1fr) minmax(200px, min-content);
+    grid-template-columns: minmax(max-content, 100%);
     grid-row-gap: awsui.$space-scaled-l;
     margin-bottom: awsui.$space-scaled-l;
-  }
-  &-label {
-    max-width: 200px;
-    align-self: center;
-    &-text {
-      @include styles.text-flex-wrapping;
-    }
-  }
-  &-label-property {
-    grid-row: 1;
-    grid-column: 1;
-  }
-  &-label-operator {
-    grid-row: 2;
-    grid-column: 1;
-  }
-  &-label-value {
-    grid-row: 3;
-    grid-column: 1;
-  }
-  &-field-property {
-    grid-row: 1;
-    grid-column: 3;
-  }
-  &-field-operator {
-    grid-row: 2;
-    grid-column: 3;
-  }
-  &-field-value {
-    grid-row: 3;
-    grid-column: 3;
   }
   &-actions {
     display: flex;
@@ -136,6 +105,9 @@
 .remove-all,
 .token-label,
 .join-operation,
+.token-editor-field-property,
+.token-editor-field-operator,
+.token-editor-field-value,
 .token-editor-submit {
   /* used in test-utils */
 }

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -44,10 +44,16 @@
   flex-direction: column;
   justify-content: space-between;
   &-form {
-    display: grid;
-    grid-template-columns: minmax(max-content, 100%);
-    grid-row-gap: awsui.$space-scaled-l;
     margin-bottom: awsui.$space-scaled-l;
+  }
+  &-field-property {
+    /* used in test-utils */
+  }
+  &-field-operator {
+    margin-top: awsui.$space-scaled-l;
+  }
+  &-field-value {
+    margin-top: awsui.$space-scaled-l;
   }
   &-actions {
     display: flex;
@@ -105,9 +111,6 @@
 .remove-all,
 .token-label,
 .join-operation,
-.token-editor-field-property,
-.token-editor-field-operator,
-.token-editor-field-value,
 .token-editor-submit {
   /* used in test-utils */
 }

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -1,14 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState, useRef } from 'react';
-import clsx from 'clsx';
 
 import { SelectProps } from '../select/interfaces';
 import InternalSelect from '../select/internal';
 import InternalAutosuggest from '../autosuggest/internal';
 import InternalPopover, { InternalPopoverRef } from '../popover/internal';
 import { InternalButton } from '../button/internal';
-import { useUniqueId } from '../internal/hooks/use-unique-id/index';
 
 import {
   ComparisonOperator,
@@ -30,31 +28,11 @@ import {
 } from './controller';
 import { NonCancelableEventHandler } from '../internal/events';
 import { DropdownStatusProps } from '../internal/components/dropdown-status/interfaces';
+import InternalFormField from '../form-field/internal';
 
 const freeTextOperators: ComparisonOperator[] = [':', '!:'];
 
-interface TokenEditorFieldProps {
-  label: React.ReactNode;
-  type: 'property' | 'operator' | 'value';
-  children: ({ controlId }: { controlId: string }) => React.ReactNode;
-}
-
-function TokenEditorField({ type, label, children }: TokenEditorFieldProps) {
-  const controlId = useUniqueId();
-  return (
-    <>
-      <label className={clsx(styles['token-editor-label'], styles[`token-editor-label-${type}`])} htmlFor={controlId}>
-        <span className={styles['token-editor-label-text']}>{label}</span>
-      </label>
-      <div className={clsx(styles['token-editor-field'], styles[`token-editor-field-${type}`])}>
-        {children({ controlId })}
-      </div>
-    </>
-  );
-}
-
 interface PropertyInputProps {
-  controlId: string;
   asyncProps: null | DropdownStatusProps;
   customGroupsText: readonly GroupText[];
   disableFreeTextFiltering?: boolean;
@@ -66,7 +44,6 @@ interface PropertyInputProps {
 }
 
 function PropertyInput({
-  controlId,
   propertyKey,
   onChangePropertyKey,
   asyncProps,
@@ -98,7 +75,6 @@ function PropertyInput({
   }
   return (
     <InternalSelect
-      controlId={controlId}
       options={propertyOptions}
       selectedOption={
         property
@@ -115,7 +91,6 @@ function PropertyInput({
 }
 
 interface OperatorInputProps {
-  controlId: string;
   filteringProperties: readonly FilteringProperty[];
   i18nStrings: I18nStrings;
   onChangeOperator: (operator: ComparisonOperator) => void;
@@ -124,7 +99,6 @@ interface OperatorInputProps {
 }
 
 function OperatorInput({
-  controlId,
   propertyKey,
   operator,
   onChangeOperator,
@@ -140,7 +114,6 @@ function OperatorInput({
   }));
   return (
     <InternalSelect
-      controlId={controlId}
       options={operatorOptions}
       triggerVariant="option"
       selectedOption={
@@ -158,7 +131,6 @@ function OperatorInput({
 }
 
 interface ValueInputProps {
-  controlId: string;
   asyncProps: DropdownStatusProps;
   filteringOptions: readonly FilteringOption[];
   filteringProperties: readonly FilteringProperty[];
@@ -171,7 +143,6 @@ interface ValueInputProps {
 }
 
 function ValueInput({
-  controlId,
   propertyKey,
   operator,
   value,
@@ -190,7 +161,6 @@ function ValueInput({
     : { empty: asyncProps.empty };
   return (
     <InternalAutosuggest
-      controlId={controlId}
       enteredTextLabel={i18nStrings.enteredTextLabel}
       value={value ?? ''}
       onChange={e => onChangeValue(e.detail.value)}
@@ -276,51 +246,42 @@ export function TokenEditor({
       content={
         <div className={styles['token-editor']}>
           <div className={styles['token-editor-form']}>
-            <TokenEditorField label={i18nStrings.propertyText} type="property">
-              {({ controlId }) => (
-                <PropertyInput
-                  controlId={controlId}
-                  propertyKey={propertyKey}
-                  onChangePropertyKey={onChangePropertyKey}
-                  asyncProps={asyncProperties ? asyncProps : null}
-                  filteringProperties={filteringProperties}
-                  onLoadItems={onLoadItems}
-                  customGroupsText={customGroupsText}
-                  i18nStrings={i18nStrings}
-                  disableFreeTextFiltering={disableFreeTextFiltering}
-                />
-              )}
-            </TokenEditorField>
+            <InternalFormField label={i18nStrings.propertyText} className={styles['token-editor-field-property']}>
+              <PropertyInput
+                propertyKey={propertyKey}
+                onChangePropertyKey={onChangePropertyKey}
+                asyncProps={asyncProperties ? asyncProps : null}
+                filteringProperties={filteringProperties}
+                onLoadItems={onLoadItems}
+                customGroupsText={customGroupsText}
+                i18nStrings={i18nStrings}
+                disableFreeTextFiltering={disableFreeTextFiltering}
+              />
+            </InternalFormField>
 
-            <TokenEditorField label={i18nStrings.operatorText} type="operator">
-              {({ controlId }) => (
-                <OperatorInput
-                  controlId={controlId}
-                  propertyKey={propertyKey}
-                  operator={operator}
-                  onChangeOperator={onChangeOperator}
-                  filteringProperties={filteringProperties}
-                  i18nStrings={i18nStrings}
-                />
-              )}
-            </TokenEditorField>
+            <InternalFormField label={i18nStrings.operatorText} className={styles['token-editor-field-operator']}>
+              <OperatorInput
+                propertyKey={propertyKey}
+                operator={operator}
+                onChangeOperator={onChangeOperator}
+                filteringProperties={filteringProperties}
+                i18nStrings={i18nStrings}
+              />
+            </InternalFormField>
 
-            <TokenEditorField label={i18nStrings.valueText} type="value">
-              {({ controlId }) => (
-                <ValueInput
-                  controlId={controlId}
-                  propertyKey={propertyKey}
-                  operator={operator}
-                  value={value}
-                  onChangeValue={onChangeValue}
-                  asyncProps={asyncProps}
-                  filteringProperties={filteringProperties}
-                  filteringOptions={filteringOptions}
-                  onLoadItems={onLoadItems}
-                  i18nStrings={i18nStrings}
-                />
-              )}
-            </TokenEditorField>
+            <InternalFormField label={i18nStrings.valueText} className={styles['token-editor-field-value']}>
+              <ValueInput
+                propertyKey={propertyKey}
+                operator={operator}
+                value={value}
+                onChangeValue={onChangeValue}
+                asyncProps={asyncProps}
+                filteringProperties={filteringProperties}
+                filteringOptions={filteringOptions}
+                onLoadItems={onLoadItems}
+                i18nStrings={i18nStrings}
+              />
+            </InternalFormField>
           </div>
 
           <div className={styles['token-editor-actions']}>


### PR DESCRIPTION
### Description

The use of our form field simplifies the existing code and makes adding custom forms easier.

Approved by the design.

### How has this been tested?

Screenshot tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
