### PR TITLE
auto-fill flashbar labels on permutation page

### DIFF
--- a/pages/flashbar/permutations.page.tsx
+++ b/pages/flashbar/permutations.page.tsx
@@ -19,7 +19,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
     dismissible: [true],
     onDismiss: [noop],
     dismissLabel: ['Dismiss'],
-    statusIconAriaLabel: ['success'],
     header: [<span>Simple span content. The &apos;H&apos; in HTML stands for Pizza</span>],
     content: [<span>Simple span content</span>],
   },
@@ -28,7 +27,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
     dismissible: [true, false],
     onDismiss: [noop],
     dismissLabel: ['Dismiss'],
-    statusIconAriaLabel: ['info'],
     header: [
       '',
       <>
@@ -67,7 +65,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
   },
   {
     type: ['success', 'error', 'warning', 'info'],
-    statusIconAriaLabel: ['info'],
     header: ['Flash header'],
     action: [
       <Button iconName="external" iconAlign="right">
@@ -77,7 +74,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
   },
   {
     type: ['success', 'warning', 'error'],
-    statusIconAriaLabel: ['info'],
     loading: [true, false],
     header: [
       <Link color="inverted" href="#" variant="primary">
@@ -94,7 +90,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
   },
   {
     type: ['success', 'error', 'warning', 'info'],
-    statusIconAriaLabel: ['info'],
     header: [
       <span>
         Header with a button{' '}
@@ -116,7 +111,6 @@ const permutations = createPermutations<FlashbarProps.MessageDefinition>([
     buttonText: ['Go for it!'],
     header: ['header'],
     content: ['content'],
-    statusIconAriaLabel: ['info'],
   },
 ]);
 /* eslint-enable react/jsx-key */
@@ -126,7 +120,12 @@ export default function FlashbarPermutations() {
     <>
       <h1>Flashbar permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView permutations={permutations} render={permutation => <Flashbar items={[permutation]} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => (
+            <Flashbar items={[{ ...permutation, statusIconAriaLabel: permutation.type ?? 'info' }]} />
+          )}
+        />
       </ScreenshotArea>
     </>
   );


### PR DESCRIPTION
### Description

Replace custom label definitions with a generic function

### How has this been tested?

A11y tests in the PR build

### Documentation changes


- [ ] _Yes, this change contains documentation changes._
- [x] _No._


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
