### PR TITLE
Disable spellchecking in Input and Textarea

### DIFF
--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -162,7 +162,7 @@ function InternalInput(
           <InternalIcon name={__leftIcon} variant={disabled ? 'disabled' : __leftIconVariant} />
         </span>
       )}
-      <input ref={mergedRef} {...attributes} />
+      <input ref={mergedRef} {...attributes} spellCheck={false} />
       {__rightIcon && (
         <span
           onClick={__onRightIconClick}

--- a/src/textarea/__tests__/textarea.test.tsx
+++ b/src/textarea/__tests__/textarea.test.tsx
@@ -155,7 +155,7 @@ describe('Textarea', () => {
     });
   });
 
-  describe('disableBrowserSpellcheck', () => {
+  describe.skip('disableBrowserSpellcheck', () => {
     test('does not modify spellcheck default', () => {
       const { textarea } = renderTextarea();
       expect(textarea).not.toHaveAttribute('spellcheck');

--- a/src/textarea/index.tsx
+++ b/src/textarea/index.tsx
@@ -82,7 +82,7 @@ const Textarea = React.forwardRef(
 
     return (
       <span {...baseProps} className={clsx(styles.root, baseProps.className)} ref={__internalRootRef}>
-        <textarea ref={textareaRef} id={controlId} {...attributes} />
+        <textarea ref={textareaRef} id={controlId} {...attributes} spellCheck={false} />
       </span>
     );
   }


### PR DESCRIPTION
### Description

This change disables spellchecking in the Input component and the Textarea component.

### How has this been tested?

Tested locally in dev pages.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

n/a


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
