### PR TITLE
Fix link arialabel overrides externalIconAriaLabel when both are set

### DIFF
--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -27,6 +27,15 @@ describe('Link component', () => {
     expect(createWrapper(wrapper.getElement()).find('[aria-label="External link"]')).toBeTruthy();
   });
 
+  test('ariaLabel and externalIconAriaLabel are applied the same time', () => {
+    const wrapper = renderLink({
+      ariaLabel: 'Learn more about S3',
+      externalIconAriaLabel: 'External link',
+      external: true,
+    });
+    expect(wrapper.getElement()).toHaveAttribute('aria-label', 'Learn more about S3, External link');
+  });
+
   describe('"info" variant', () => {
     test('negates fontSize and color', () => {
       const wrapper = renderLink({ variant: 'info', fontSize: 'heading-xl', color: 'inverted' });

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -91,7 +91,8 @@ const InternalLink = React.forwardRef(
         styles[getFontSizeStyle(variant, fontSize)],
         styles[getColorStyle(variant, color)]
       ),
-      'aria-label': ariaLabel,
+      'aria-label':
+        ariaLabel && external && externalIconAriaLabel ? ariaLabel + ', ' + externalIconAriaLabel : ariaLabel,
     };
 
     const content = (


### PR DESCRIPTION
### Description

When link has only externalIconAriaLabel, focus on link announces [link content] + [externalIconAriaLabel] 
But when arialabel and externalIconAriaLabel both set, it only announces [arialabel]
**AWSUI-19310**

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
