### PR TITLE
Make popover body scrollable when needed

### DIFF
--- a/build-tools/utils/files.js
+++ b/build-tools/utils/files.js
@@ -36,7 +36,9 @@ function listPublicItems(baseDir) {
         elem !== 'interfaces.ts' &&
         elem !== 'test-utils' &&
         elem !== 'theming' &&
-        elem !== 'contexts'
+        elem !== 'contexts' &&
+        elem !== 'calendar' &&
+        elem !== 'date-input'
     );
 }
 

--- a/build-tools/utils/files.js
+++ b/build-tools/utils/files.js
@@ -36,9 +36,7 @@ function listPublicItems(baseDir) {
         elem !== 'interfaces.ts' &&
         elem !== 'test-utils' &&
         elem !== 'theming' &&
-        elem !== 'contexts' &&
-        elem !== 'calendar' &&
-        elem !== 'date-input'
+        elem !== 'contexts'
     );
 }
 

--- a/pages/popover/container-test.page.tsx
+++ b/pages/popover/container-test.page.tsx
@@ -72,7 +72,11 @@ export default function () {
               </div>
             )}
           >
-            {() => <div id={`content-${hoverId}`}>Content {hoverId}</div>}
+            {(style, contentRef) => (
+              <div ref={contentRef} id={`content-${hoverId}`} style={style}>
+                Content {hoverId}
+              </div>
+            )}
           </PopoverContainer>
         ) : null}
       </ScreenshotArea>

--- a/pages/popover/container-test.page.tsx
+++ b/pages/popover/container-test.page.tsx
@@ -62,6 +62,8 @@ export default function () {
 
         {hoverId ? (
           <PopoverContainer
+            size="small"
+            fixedWidth={false}
             position="bottom"
             trackRef={hoverRef}
             trackKey={hoverId}
@@ -72,11 +74,7 @@ export default function () {
               </div>
             )}
           >
-            {(style, contentRef) => (
-              <div ref={contentRef} id={`content-${hoverId}`} style={style}>
-                Content {hoverId}
-              </div>
-            )}
+            <div id={`content-${hoverId}`}>Content {hoverId}</div>
           </PopoverContainer>
         ) : null}
       </ScreenshotArea>

--- a/pages/popover/container-test.page.tsx
+++ b/pages/popover/container-test.page.tsx
@@ -72,7 +72,7 @@ export default function () {
               </div>
             )}
           >
-            <div id={`content-${hoverId}`}>Content {hoverId}</div>
+            {() => <div id={`content-${hoverId}`}>Content {hoverId}</div>}
           </PopoverContainer>
         ) : null}
       </ScreenshotArea>

--- a/pages/popover/scrollable.page.tsx
+++ b/pages/popover/scrollable.page.tsx
@@ -13,7 +13,7 @@ export default function () {
   useEffect(() => {
     const interval = setInterval(() => setLoading(prev => !prev), 3000);
     return () => clearInterval(interval);
-  });
+  }, []);
 
   return (
     <>

--- a/pages/popover/scrollable.page.tsx
+++ b/pages/popover/scrollable.page.tsx
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState, useEffect } from 'react';
+import Popover from '~components/popover';
+
+const content =
+  'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui.';
+
+export default function () {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const interval = setInterval(() => setLoading(prev => !prev), 3000);
+    return () => clearInterval(interval);
+  });
+
+  return (
+    <>
+      <h1>Popover scrollable test</h1>
+
+      <div style={{ height: 600, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Popover
+          size="medium"
+          header="Lorem ipsum"
+          content={<div>{loading ? content.slice(0, 200) + '...' : content}</div>}
+          dismissAriaLabel="Close"
+          renderWithPortal={true}
+        >
+          Click!
+        </Popover>
+      </div>
+    </>
+  );
+}

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -37,7 +37,7 @@ const permutations = createPermutations<PopoverBodyProps & { size: PopoverProps.
     // Required internal properties
     dismissAriaLabel: ['Close'],
     onDismiss: [noop],
-    overflowVisible: [true],
+    overflowVisible: ['both'],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -4,12 +4,19 @@ import React from 'react';
 import ScreenshotArea from '../utils/screenshot-area';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
+import { PopoverProps } from '~components/popover';
 import PopoverBody, { PopoverBodyProps } from '~components/popover/body';
 
 const noop = () => {};
 
+const sizeMap: Record<PopoverProps.Size, number> = {
+  small: 210,
+  medium: 310,
+  large: 480,
+};
+
 /* eslint-disable react/jsx-key */
-const permutations = createPermutations<PopoverBodyProps>([
+const permutations = createPermutations<PopoverBodyProps & { size: PopoverProps.Size }>([
   {
     size: ['small', 'medium', 'large'],
     header: [
@@ -28,11 +35,9 @@ const permutations = createPermutations<PopoverBodyProps>([
     // to lock focus and break navigation and a11y checks.
     dismissButton: [false],
     // Required internal properties
-    fixedWidth: [true],
     dismissAriaLabel: ['Close'],
     onDismiss: [noop],
-    overflowVisible: ['both'],
-    contentRef: [React.createRef()],
+    overflowVisible: [true],
   },
 ]);
 /* eslint-enable react/jsx-key */
@@ -42,7 +47,19 @@ export default function () {
     <article>
       <h1>Popover text wrapping</h1>
       <ScreenshotArea>
-        <PermutationsView permutations={permutations} render={permutation => <PopoverBody {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => (
+            <div
+              style={{
+                width: sizeMap[permutation.size],
+                maxWidth: sizeMap[permutation.size],
+              }}
+            >
+              <PopoverBody {...permutation} />
+            </div>
+          )}
+        />
       </ScreenshotArea>
     </article>
   );

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -49,11 +49,11 @@ export default function () {
       <ScreenshotArea>
         <PermutationsView
           permutations={permutations}
-          render={({size, ...permutation }) => (
+          render={({ size, ...permutation }) => (
             <div
               style={{
-                width: sizeMap[permutation.size],
-                maxWidth: sizeMap[permutation.size],
+                width: sizeMap[size],
+                maxWidth: sizeMap[size],
               }}
             >
               <PopoverBody {...permutation} />

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -49,7 +49,7 @@ export default function () {
       <ScreenshotArea>
         <PermutationsView
           permutations={permutations}
-          render={permutation => (
+          render={({size, ...permutation }) => (
             <div
               style={{
                 width: sizeMap[permutation.size],

--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -32,6 +32,7 @@ const permutations = createPermutations<PopoverBodyProps>([
     dismissAriaLabel: ['Close'],
     onDismiss: [noop],
     overflowVisible: ['both'],
+    contentRef: [React.createRef()],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -117,7 +117,7 @@ export function AnnotationPopover({
           onDismiss={onDismiss}
           className={styles.annotation}
           variant="annotation"
-          overflowVisible={true}
+          overflowVisible="content"
           dismissButtonRef={dismissButtonRefCallback}
         >
           <InternalSpaceBetween size="s">

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -98,7 +98,7 @@ export function AnnotationPopover({
         arrow={arrow}
         zIndex={1000}
       >
-        {style => (
+        {(style, contentRef) => (
           <PopoverBody
             size="medium"
             fixedWidth={false}
@@ -119,6 +119,7 @@ export function AnnotationPopover({
             variant="annotation"
             overflowVisible="content"
             dismissButtonRef={dismissButtonRefCallback}
+            contentRef={contentRef}
             style={style}
           >
             <InternalSpaceBetween size="s">

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -98,82 +98,89 @@ export function AnnotationPopover({
         arrow={arrow}
         zIndex={1000}
       >
-        <PopoverBody
-          size="medium"
-          fixedWidth={false}
-          dismissButton={true}
-          dismissAriaLabel={i18nStrings.labelDismissAnnotation}
-          header={
-            <InternalBox
-              color="text-body-secondary"
-              fontSize="body-s"
-              margin={{ top: 'xxxs' }}
-              className={styles.header}
-            >
-              {title}
-            </InternalBox>
-          }
-          onDismiss={onDismiss}
-          className={styles.annotation}
-          variant="annotation"
-          overflowVisible="content"
-          dismissButtonRef={dismissButtonRefCallback}
-        >
-          <InternalSpaceBetween size="s">
-            <div className={styles.description}>
-              <InternalBox className={styles.content}>{content}</InternalBox>
-            </div>
-
-            {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
-
+        {style => (
+          <PopoverBody
+            size="medium"
+            fixedWidth={false}
+            dismissButton={true}
+            dismissAriaLabel={i18nStrings.labelDismissAnnotation}
+            header={
+              <InternalBox
+                color="text-body-secondary"
+                fontSize="body-s"
+                margin={{ top: 'xxxs' }}
+                className={styles.header}
+              >
+                {title}
+              </InternalBox>
+            }
+            onDismiss={onDismiss}
+            className={styles.annotation}
+            variant="annotation"
+            overflowVisible="content"
+            dismissButtonRef={dismissButtonRefCallback}
+            style={style}
+          >
             <InternalSpaceBetween size="s">
-              <div className={styles.divider} />
-
-              <div className={styles.actionBar}>
-                <div className={styles.stepCounter}>
-                  <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
-                    {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
-                  </InternalBox>
-                </div>
-                <InternalSpaceBetween size="xs" direction="horizontal">
-                  {showPreviousButton && (
-                    <InternalButton
-                      variant="link"
-                      onClick={onPreviousButtonClick}
-                      disabled={!previousButtonEnabled}
-                      formAction="none"
-                      ariaLabel={i18nStrings.previousButtonText}
-                      className={styles['previous-button']}
-                    >
-                      {i18nStrings.previousButtonText}
-                    </InternalButton>
-                  )}
-
-                  {showFinishButton ? (
-                    <InternalButton
-                      onClick={onFinish}
-                      formAction="none"
-                      ariaLabel={i18nStrings.finishButtonText}
-                      className={styles['finish-button']}
-                    >
-                      {i18nStrings.finishButtonText}
-                    </InternalButton>
-                  ) : (
-                    <InternalButton
-                      onClick={onNextButtonClick}
-                      disabled={!nextButtonEnabled}
-                      formAction="none"
-                      ariaLabel={i18nStrings.nextButtonText}
-                      className={styles['next-button']}
-                    >
-                      {i18nStrings.nextButtonText}
-                    </InternalButton>
-                  )}
-                </InternalSpaceBetween>
+              <div className={styles.description}>
+                <InternalBox className={styles.content}>{content}</InternalBox>
               </div>
+
+              {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
+
+              <InternalSpaceBetween size="s">
+                <div className={styles.divider} />
+
+                <div className={styles.actionBar}>
+                  <div className={styles.stepCounter}>
+                    <InternalBox
+                      className={styles['step-counter-content']}
+                      color="text-body-secondary"
+                      fontSize="body-s"
+                    >
+                      {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
+                    </InternalBox>
+                  </div>
+                  <InternalSpaceBetween size="xs" direction="horizontal">
+                    {showPreviousButton && (
+                      <InternalButton
+                        variant="link"
+                        onClick={onPreviousButtonClick}
+                        disabled={!previousButtonEnabled}
+                        formAction="none"
+                        ariaLabel={i18nStrings.previousButtonText}
+                        className={styles['previous-button']}
+                      >
+                        {i18nStrings.previousButtonText}
+                      </InternalButton>
+                    )}
+
+                    {showFinishButton ? (
+                      <InternalButton
+                        onClick={onFinish}
+                        formAction="none"
+                        ariaLabel={i18nStrings.finishButtonText}
+                        className={styles['finish-button']}
+                      >
+                        {i18nStrings.finishButtonText}
+                      </InternalButton>
+                    ) : (
+                      <InternalButton
+                        onClick={onNextButtonClick}
+                        disabled={!nextButtonEnabled}
+                        formAction="none"
+                        ariaLabel={i18nStrings.nextButtonText}
+                        className={styles['next-button']}
+                      >
+                        {i18nStrings.nextButtonText}
+                      </InternalButton>
+                    )}
+                  </InternalSpaceBetween>
+                </div>
+              </InternalSpaceBetween>
             </InternalSpaceBetween>
-          </InternalSpaceBetween>
-        </PopoverBody>
+          </PopoverBody>
+        )}
       </PopoverContainer>
     </div>
   );

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -97,6 +97,7 @@ export function AnnotationPopover({
         position={direction}
         trackRef={trackRef}
         trackKey={taskLocalStepIndex}
+        variant="annotation"
         arrow={arrow}
         zIndex={1000}
       >

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -92,96 +92,88 @@ export function AnnotationPopover({
   return (
     <div onClick={e => e.stopPropagation()}>
       <PopoverContainer
+        size="medium"
+        fixedWidth={false}
         position={direction}
         trackRef={trackRef}
         trackKey={taskLocalStepIndex}
         arrow={arrow}
         zIndex={1000}
       >
-        {(style, contentRef) => (
-          <PopoverBody
-            size="medium"
-            fixedWidth={false}
-            dismissButton={true}
-            dismissAriaLabel={i18nStrings.labelDismissAnnotation}
-            header={
-              <InternalBox
-                color="text-body-secondary"
-                fontSize="body-s"
-                margin={{ top: 'xxxs' }}
-                className={styles.header}
-              >
-                {title}
-              </InternalBox>
-            }
-            onDismiss={onDismiss}
-            className={styles.annotation}
-            variant="annotation"
-            overflowVisible="content"
-            dismissButtonRef={dismissButtonRefCallback}
-            contentRef={contentRef}
-            style={style}
-          >
+        <PopoverBody
+          dismissButton={true}
+          dismissAriaLabel={i18nStrings.labelDismissAnnotation}
+          header={
+            <InternalBox
+              color="text-body-secondary"
+              fontSize="body-s"
+              margin={{ top: 'xxxs' }}
+              className={styles.header}
+            >
+              {title}
+            </InternalBox>
+          }
+          onDismiss={onDismiss}
+          className={styles.annotation}
+          variant="annotation"
+          overflowVisible={true}
+          dismissButtonRef={dismissButtonRefCallback}
+        >
+          <InternalSpaceBetween size="s">
+            <div className={styles.description}>
+              <InternalBox className={styles.content}>{content}</InternalBox>
+            </div>
+
+            {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
+
             <InternalSpaceBetween size="s">
-              <div className={styles.description}>
-                <InternalBox className={styles.content}>{content}</InternalBox>
-              </div>
+              <div className={styles.divider} />
 
-              {alert && <InternalAlert type="warning">{alert}</InternalAlert>}
-
-              <InternalSpaceBetween size="s">
-                <div className={styles.divider} />
-
-                <div className={styles.actionBar}>
-                  <div className={styles.stepCounter}>
-                    <InternalBox
-                      className={styles['step-counter-content']}
-                      color="text-body-secondary"
-                      fontSize="body-s"
-                    >
-                      {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
-                    </InternalBox>
-                  </div>
-                  <InternalSpaceBetween size="xs" direction="horizontal">
-                    {showPreviousButton && (
-                      <InternalButton
-                        variant="link"
-                        onClick={onPreviousButtonClick}
-                        disabled={!previousButtonEnabled}
-                        formAction="none"
-                        ariaLabel={i18nStrings.previousButtonText}
-                        className={styles['previous-button']}
-                      >
-                        {i18nStrings.previousButtonText}
-                      </InternalButton>
-                    )}
-
-                    {showFinishButton ? (
-                      <InternalButton
-                        onClick={onFinish}
-                        formAction="none"
-                        ariaLabel={i18nStrings.finishButtonText}
-                        className={styles['finish-button']}
-                      >
-                        {i18nStrings.finishButtonText}
-                      </InternalButton>
-                    ) : (
-                      <InternalButton
-                        onClick={onNextButtonClick}
-                        disabled={!nextButtonEnabled}
-                        formAction="none"
-                        ariaLabel={i18nStrings.nextButtonText}
-                        className={styles['next-button']}
-                      >
-                        {i18nStrings.nextButtonText}
-                      </InternalButton>
-                    )}
-                  </InternalSpaceBetween>
+              <div className={styles.actionBar}>
+                <div className={styles.stepCounter}>
+                  <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
+                    {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
+                  </InternalBox>
                 </div>
-              </InternalSpaceBetween>
+                <InternalSpaceBetween size="xs" direction="horizontal">
+                  {showPreviousButton && (
+                    <InternalButton
+                      variant="link"
+                      onClick={onPreviousButtonClick}
+                      disabled={!previousButtonEnabled}
+                      formAction="none"
+                      ariaLabel={i18nStrings.previousButtonText}
+                      className={styles['previous-button']}
+                    >
+                      {i18nStrings.previousButtonText}
+                    </InternalButton>
+                  )}
+
+                  {showFinishButton ? (
+                    <InternalButton
+                      onClick={onFinish}
+                      formAction="none"
+                      ariaLabel={i18nStrings.finishButtonText}
+                      className={styles['finish-button']}
+                    >
+                      {i18nStrings.finishButtonText}
+                    </InternalButton>
+                  ) : (
+                    <InternalButton
+                      onClick={onNextButtonClick}
+                      disabled={!nextButtonEnabled}
+                      formAction="none"
+                      ariaLabel={i18nStrings.nextButtonText}
+                      className={styles['next-button']}
+                    >
+                      {i18nStrings.nextButtonText}
+                    </InternalButton>
+                  )}
+                </InternalSpaceBetween>
+              </div>
             </InternalSpaceBetween>
-          </PopoverBody>
-        )}
+          </InternalSpaceBetween>
+        </PopoverBody>
       </PopoverContainer>
     </div>
   );

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -305,7 +305,7 @@ test('popover size is assigned', () => {
     // Show popover for the first data point.
     wrapper.findApplication()!.focus();
 
-    expect(wrapper.findByClassName(popoverStyles[`body-size-${size}`])).not.toBe(null);
+    expect(wrapper.findByClassName(popoverStyles[`container-body-size-${size}`])).not.toBe(null);
   }
 });
 

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -36,19 +36,22 @@ export default function Tooltip({ children, content, position = 'right' }: Toolt
               renderWithPortal={true}
               zIndex={7000}
             >
-              <PopoverBody
-                size="small"
-                fixedWidth={false}
-                dismissButton={false}
-                dismissAriaLabel={undefined}
-                header={null}
-                onDismiss={() => {}}
-                overflowVisible="both"
-              >
-                <span data-testid="button-dropdown-disabled-reason" role="tooltip">
-                  {content}
-                </span>
-              </PopoverBody>
+              {style => (
+                <PopoverBody
+                  size="small"
+                  fixedWidth={false}
+                  dismissButton={false}
+                  dismissAriaLabel={undefined}
+                  header={null}
+                  onDismiss={() => {}}
+                  overflowVisible="both"
+                  style={style}
+                >
+                  <span data-testid="button-dropdown-disabled-reason" role="tooltip">
+                    {content}
+                  </span>
+                </PopoverBody>
+              )}
             </PopoverContainer>
           </span>
         </Portal>

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -30,29 +30,26 @@ export default function Tooltip({ children, content, position = 'right' }: Toolt
         <Portal>
           <span className={portalClasses}>
             <PopoverContainer
+              size="small"
+              fixedWidth={false}
               position={position}
               trackRef={ref}
               arrow={position => <Arrow position={position} />}
               renderWithPortal={true}
               zIndex={7000}
+              overflowVisible={true}
             >
-              {(style, contentRef) => (
-                <PopoverBody
-                  size="small"
-                  fixedWidth={false}
-                  dismissButton={false}
-                  dismissAriaLabel={undefined}
-                  header={null}
-                  onDismiss={() => {}}
-                  overflowVisible="both"
-                  style={style}
-                  contentRef={contentRef}
-                >
-                  <span data-testid="button-dropdown-disabled-reason" role="tooltip">
-                    {content}
-                  </span>
-                </PopoverBody>
-              )}
+              <PopoverBody
+                dismissButton={false}
+                dismissAriaLabel={undefined}
+                header={null}
+                onDismiss={() => {}}
+                overflowVisible={true}
+              >
+                <span data-testid="button-dropdown-disabled-reason" role="tooltip">
+                  {content}
+                </span>
+              </PopoverBody>
             </PopoverContainer>
           </span>
         </Portal>

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -37,14 +37,13 @@ export default function Tooltip({ children, content, position = 'right' }: Toolt
               arrow={position => <Arrow position={position} />}
               renderWithPortal={true}
               zIndex={7000}
-              overflowVisible={true}
             >
               <PopoverBody
                 dismissButton={false}
                 dismissAriaLabel={undefined}
                 header={null}
                 onDismiss={() => {}}
-                overflowVisible={true}
+                overflowVisible="both"
               >
                 <span data-testid="button-dropdown-disabled-reason" role="tooltip">
                   {content}

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -36,7 +36,7 @@ export default function Tooltip({ children, content, position = 'right' }: Toolt
               renderWithPortal={true}
               zIndex={7000}
             >
-              {style => (
+              {(style, contentRef) => (
                 <PopoverBody
                   size="small"
                   fixedWidth={false}
@@ -46,6 +46,7 @@ export default function Tooltip({ children, content, position = 'right' }: Toolt
                   onDismiss={() => {}}
                   overflowVisible="both"
                   style={style}
+                  contentRef={contentRef}
                 >
                   <span data-testid="button-dropdown-disabled-reason" role="tooltip">
                     {content}

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -94,7 +94,7 @@ export default function ChartPopover({
           </div>
         )}
       >
-        {style => (
+        {(style, contentRef) => (
           <PopoverBody
             size={size}
             fixedWidth={fixedWidth}
@@ -104,6 +104,7 @@ export default function ChartPopover({
             header={title}
             onDismiss={onDismiss}
             style={style}
+            contentRef={contentRef}
           >
             {children}
           </PopoverBody>

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -84,6 +84,8 @@ export default function ChartPopover({
       ref={popoverRef}
     >
       <PopoverContainer
+        size={size}
+        fixedWidth={fixedWidth}
         position={position}
         trackRef={trackRef}
         trackKey={trackKey}
@@ -94,21 +96,15 @@ export default function ChartPopover({
           </div>
         )}
       >
-        {(style, contentRef) => (
-          <PopoverBody
-            size={size}
-            fixedWidth={fixedWidth}
-            dismissButton={dismissButton}
-            dismissAriaLabel={dismissAriaLabel}
-            returnFocus={false}
-            header={title}
-            onDismiss={onDismiss}
-            style={style}
-            contentRef={contentRef}
-          >
-            {children}
-          </PopoverBody>
-        )}
+        <PopoverBody
+          dismissButton={dismissButton}
+          dismissAriaLabel={dismissAriaLabel}
+          returnFocus={false}
+          header={title}
+          onDismiss={onDismiss}
+        >
+          {children}
+        </PopoverBody>
       </PopoverContainer>
     </span>
   );

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -94,17 +94,20 @@ export default function ChartPopover({
           </div>
         )}
       >
-        <PopoverBody
-          size={size}
-          fixedWidth={fixedWidth}
-          dismissButton={dismissButton}
-          dismissAriaLabel={dismissAriaLabel}
-          returnFocus={false}
-          header={title}
-          onDismiss={onDismiss}
-        >
-          {children}
-        </PopoverBody>
+        {style => (
+          <PopoverBody
+            size={size}
+            fixedWidth={fixedWidth}
+            dismissButton={dismissButton}
+            dismissAriaLabel={dismissAriaLabel}
+            returnFocus={false}
+            header={title}
+            onDismiss={onDismiss}
+            style={style}
+          >
+            {children}
+          </PopoverBody>
+        )}
       </PopoverContainer>
     </span>
   );

--- a/src/popover/__tests__/positions.test.ts
+++ b/src/popover/__tests__/positions.test.ts
@@ -96,11 +96,23 @@ describe('calculatePosition', () => {
     ] as const
   ).forEach(([trigger, body], index) => {
     test(`index=${index} returns scrollable=true if can't fit popover into viewport`, () => {
-      const position = calculatePosition('top', trigger, arrow, body, viewport, viewport);
+      const container = { ...viewport, height: viewport.height * 2 };
+      const position = calculatePosition('top', trigger, arrow, body, container, viewport, true);
       expect(position.scrollable).toBe(true);
       expect(position.boundingOffset.width).toBe(250);
-      expect(position.boundingOffset.height).toBeLessThan(1000);
+      expect(position.boundingOffset.height).toBeLessThan(900);
     });
+  });
+
+  test('Prefers container over viewport when fitting the body if it is larger and renderWithPortal = false', () => {
+    const container = { ...viewport, height: viewport.height + 100 };
+    const trigger = { left: 200, top: 200, height: 25, width: 25 };
+    const body = { width: 250, height: 1000 };
+    const position = calculatePosition('top', trigger, arrow, body, container, viewport);
+    expect(position.scrollable).toBe(true);
+    expect(position.boundingOffset.width).toBe(250);
+    expect(position.boundingOffset.height).toBeGreaterThan(900);
+    expect(position.boundingOffset.height).toBeLessThan(1000);
   });
 });
 

--- a/src/popover/__tests__/positions.test.ts
+++ b/src/popover/__tests__/positions.test.ts
@@ -70,6 +70,38 @@ describe('calculatePosition', () => {
     const position = calculatePosition('bottom', trigger, arrow, body, container, viewport, true);
     expect(position.internalPosition).toBe('bottom-center');
   });
+
+  (
+    [
+      // bottom-right
+      [
+        { left: 200, top: 200, height: 25, width: 25 },
+        { width: 250, height: 1000 },
+      ],
+      // bottom-left
+      [
+        { left: 800, top: 200, height: 25, width: 25 },
+        { width: 250, height: 1000 },
+      ],
+      // top-right
+      [
+        { left: 200, top: 800, height: 25, width: 25 },
+        { width: 250, height: 1000 },
+      ],
+      // top-left
+      [
+        { left: 800, top: 800, height: 25, width: 25 },
+        { width: 250, height: 1000 },
+      ],
+    ] as const
+  ).forEach(([trigger, body], index) => {
+    test(`index=${index} returns scrollable=true if can't fit popover into viewport`, () => {
+      const position = calculatePosition('top', trigger, arrow, body, viewport, viewport);
+      expect(position.scrollable).toBe(true);
+      expect(position.boundingOffset.width).toBe(250);
+      expect(position.boundingOffset.height).toBeLessThan(1000);
+    });
+  });
 });
 
 describe('intersectRectangles', () => {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -7,24 +7,29 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
 
+$body-offset-vertical: calc(#{awsui.$space-s} + #{awsui.$border-field-width});
+$body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
+
 .body {
   @include styles.styles-reset;
   @include styles.text-flex-wrapping;
 
   border-radius: awsui.$border-radius-popover;
+  padding: awsui.$space-s awsui.$space-m;
+
+  background-color: awsui.$color-background-popover;
   box-shadow: awsui.$shadow-popover;
+  border: awsui.$border-field-width solid awsui.$color-border-popover;
 
   &-overflow-visible {
     overflow: visible;
   }
 }
 
+// The content border box needs to be the same as body border box for correct placement computation.
 .body-content {
-  border-radius: awsui.$border-radius-popover;
-  padding: awsui.$space-s awsui.$space-m;
-
-  background-color: awsui.$color-background-popover;
-  border: awsui.$border-field-width solid awsui.$color-border-popover;
+  padding: calc(#{$body-offset-vertical}) calc(#{$body-offset-horizontal});
+  margin: calc(-1 * #{$body-offset-vertical}) calc(-1 * #{$body-offset-horizontal});
 }
 
 .variant-annotation {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -9,6 +9,12 @@
 .body {
   @include styles.styles-reset;
   @include styles.text-flex-wrapping;
+
+  padding: awsui.$space-s awsui.$space-m;
+
+  &-overflow-visible {
+    overflow: visible;
+  }
 }
 
 .has-dismiss {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -5,61 +5,9 @@
 
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
-@use '../internal/hooks/focus-visible' as focus-visible;
-
-$body-offset-vertical: calc(#{awsui.$space-s} + #{awsui.$border-field-width});
-$body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
 
 .body {
-  @include styles.styles-reset;
-  @include styles.text-flex-wrapping;
-
-  border-radius: awsui.$border-radius-popover;
-  padding: awsui.$space-s awsui.$space-m;
-
-  background-color: awsui.$color-background-popover;
-  box-shadow: awsui.$shadow-popover;
-  border: awsui.$border-field-width solid awsui.$color-border-popover;
-
-  &-overflow-visible {
-    overflow: visible;
-  }
-}
-
-// The content border box needs to be the same as body border box for correct placement computation.
-.body-content {
-  padding: calc(#{$body-offset-vertical}) calc(#{$body-offset-horizontal});
-  margin: calc(-1 * #{$body-offset-vertical}) calc(-1 * #{$body-offset-horizontal});
-}
-
-.variant-annotation {
-  background-color: awsui.$color-background-status-info;
-  border-color: awsui.$color-border-status-info;
-}
-
-.body-size-small {
-  max-width: 210px;
-  &.fixed-width {
-    width: 210px;
-  }
-}
-
-.body-size-medium {
-  max-width: 310px;
-  &.fixed-width {
-    width: 310px;
-  }
-}
-
-.body-size-large {
-  max-width: 480px;
-  @media (max-width: 480px) {
-    // On viewports smaller than 480px, we default to the body-size-medium width
-    max-width: 310px;
-  }
-  &.fixed-width {
-    width: 480px;
-  }
+  /* used in test-utils */
 }
 
 .has-dismiss {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -11,19 +11,18 @@
   @include styles.styles-reset;
   @include styles.text-flex-wrapping;
 
-  box-sizing: border-box;
-  border-radius: awsui.$border-radius-popover;
-
-  background-color: awsui.$color-background-popover;
-  box-shadow: awsui.$shadow-popover;
-  border: awsui.$border-field-width solid awsui.$color-border-popover;
   &-overflow-visible {
     overflow: visible;
   }
 }
 
 .body-content {
+  border-radius: awsui.$border-radius-popover;
   padding: awsui.$space-s awsui.$space-m;
+
+  background-color: awsui.$color-background-popover;
+  box-shadow: awsui.$shadow-popover;
+  border: awsui.$border-field-width solid awsui.$color-border-popover;
 }
 
 .variant-annotation {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -7,7 +7,8 @@
 @use '../internal/styles/tokens' as awsui;
 
 .body {
-  /* used in test-utils */
+  @include styles.styles-reset;
+  @include styles.text-flex-wrapping;
 }
 
 .has-dismiss {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -13,7 +13,6 @@
 
   box-sizing: border-box;
   border-radius: awsui.$border-radius-popover;
-  padding: awsui.$space-s awsui.$space-m;
 
   background-color: awsui.$color-background-popover;
   box-shadow: awsui.$shadow-popover;
@@ -21,6 +20,10 @@
   &-overflow-visible {
     overflow: visible;
   }
+}
+
+.body-content {
+  padding: awsui.$space-s awsui.$space-m;
 }
 
 .variant-annotation {

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -11,6 +11,9 @@
   @include styles.styles-reset;
   @include styles.text-flex-wrapping;
 
+  border-radius: awsui.$border-radius-popover;
+  box-shadow: awsui.$shadow-popover;
+
   &-overflow-visible {
     overflow: visible;
   }
@@ -21,7 +24,6 @@
   padding: awsui.$space-s awsui.$space-m;
 
   background-color: awsui.$color-background-popover;
-  box-shadow: awsui.$shadow-popover;
   border: awsui.$border-field-width solid awsui.$color-border-popover;
 }
 

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -20,7 +20,7 @@ export interface PopoverBodyProps {
   children: React.ReactNode;
   variant?: 'annotation';
   returnFocus?: boolean;
-  overflowVisible?: boolean;
+  overflowVisible?: 'content' | 'both';
 
   dismissButtonRef?: React.Ref<ButtonProps.Ref>;
 
@@ -66,7 +66,9 @@ export default function PopoverBody({
 
   return (
     <div
-      className={clsx(styles.body, className)}
+      className={clsx(styles.body, className, {
+        [styles['body-overflow-visible']]: overflowVisible === 'both',
+      })}
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
       aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -9,44 +9,34 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 
-import { PopoverProps } from './interfaces';
 import styles from './styles.css.js';
 
 export interface PopoverBodyProps {
-  size: PopoverProps.Size;
-  fixedWidth: boolean;
   dismissButton: boolean;
   dismissAriaLabel: string | undefined;
   onDismiss: () => void;
 
   header: React.ReactNode | undefined;
   children: React.ReactNode;
-  variant?: 'annotation';
   returnFocus?: boolean;
-  overflowVisible?: 'content' | 'both';
-
-  contentRef: React.Ref<HTMLDivElement>;
-  dismissButtonRef?: React.Ref<ButtonProps.Ref>;
-
+  variant?: 'annotation';
   className?: string;
-  style?: React.CSSProperties;
+  overflowVisible?: boolean;
+
+  dismissButtonRef?: React.Ref<ButtonProps.Ref>;
 }
 
 export default function PopoverBody({
-  size,
-  fixedWidth,
   dismissButton: showDismissButton,
   dismissAriaLabel,
   header,
   children,
   onDismiss,
-  variant,
   returnFocus = true,
-  overflowVisible,
-  contentRef,
-  dismissButtonRef,
+  variant,
   className,
-  style,
+  overflowVisible,
+  dismissButtonRef,
 }: PopoverBodyProps) {
   const labelledById = useUniqueId('awsui-popover-');
 
@@ -75,35 +65,28 @@ export default function PopoverBody({
 
   return (
     <div
-      className={clsx(styles.body, className, styles[`body-size-${size}`], {
-        [styles['fixed-width']]: fixedWidth,
-        [styles[`variant-${variant}`]]: variant,
-        [styles['body-overflow-visible']]: overflowVisible === 'both',
-      })}
-      style={style}
+      className={clsx(styles.body, className)}
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
       aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}
       aria-labelledby={header ? labelledById : undefined}
     >
-      <div ref={contentRef} className={styles['body-content']}>
-        <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
-          {header && (
-            <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
-              {dismissButton}
-              <div className={styles.header} id={labelledById}>
-                <h2>{header}</h2>
-              </div>
-            </div>
-          )}
-          <div className={!header && showDismissButton ? styles['has-dismiss'] : undefined}>
-            {!header && dismissButton}
-            <div className={clsx(styles.content, { [styles['content-overflow-visible']]: !!overflowVisible })}>
-              {children}
+      <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
+        {header && (
+          <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
+            {dismissButton}
+            <div className={styles.header} id={labelledById}>
+              <h2>{header}</h2>
             </div>
           </div>
-        </FocusLock>
-      </div>
+        )}
+        <div className={!header && showDismissButton ? styles['has-dismiss'] : undefined}>
+          {!header && dismissButton}
+          <div className={clsx(styles.content, { [styles['content-overflow-visible']]: !!overflowVisible })}>
+            {children}
+          </div>
+        </div>
+      </FocusLock>
     </div>
   );
 }

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -28,6 +28,7 @@ export interface PopoverBodyProps {
   dismissButtonRef?: React.Ref<ButtonProps.Ref>;
 
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export default function PopoverBody({
@@ -43,6 +44,7 @@ export default function PopoverBody({
   overflowVisible,
   dismissButtonRef,
   className,
+  style,
 }: PopoverBodyProps) {
   const labelledById = useUniqueId('awsui-popover-');
 
@@ -76,6 +78,7 @@ export default function PopoverBody({
         [styles[`variant-${variant}`]]: variant,
         [styles['body-overflow-visible']]: overflowVisible === 'both',
       })}
+      style={style}
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
       aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -18,12 +18,13 @@ export interface PopoverBodyProps {
 
   header: React.ReactNode | undefined;
   children: React.ReactNode;
-  returnFocus?: boolean;
   variant?: 'annotation';
-  className?: string;
+  returnFocus?: boolean;
   overflowVisible?: boolean;
 
   dismissButtonRef?: React.Ref<ButtonProps.Ref>;
+
+  className?: string;
 }
 
 export default function PopoverBody({
@@ -32,11 +33,11 @@ export default function PopoverBody({
   header,
   children,
   onDismiss,
-  returnFocus = true,
   variant,
-  className,
+  returnFocus = true,
   overflowVisible,
   dismissButtonRef,
+  className,
 }: PopoverBodyProps) {
   const labelledById = useUniqueId('awsui-popover-');
 

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -25,6 +25,7 @@ export interface PopoverBodyProps {
   returnFocus?: boolean;
   overflowVisible?: 'content' | 'both';
 
+  contentRef: React.Ref<HTMLDivElement>;
   dismissButtonRef?: React.Ref<ButtonProps.Ref>;
 
   className?: string;
@@ -42,6 +43,7 @@ export default function PopoverBody({
   variant,
   returnFocus = true,
   overflowVisible,
+  contentRef,
   dismissButtonRef,
   className,
   style,
@@ -84,22 +86,24 @@ export default function PopoverBody({
       aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}
       aria-labelledby={header ? labelledById : undefined}
     >
-      <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
-        {header && (
-          <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
-            {dismissButton}
-            <div className={styles.header} id={labelledById}>
-              <h2>{header}</h2>
+      <div ref={contentRef} className={styles['body-content']}>
+        <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
+          {header && (
+            <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
+              {dismissButton}
+              <div className={styles.header} id={labelledById}>
+                <h2>{header}</h2>
+              </div>
+            </div>
+          )}
+          <div className={!header && showDismissButton ? styles['has-dismiss'] : undefined}>
+            {!header && dismissButton}
+            <div className={clsx(styles.content, { [styles['content-overflow-visible']]: !!overflowVisible })}>
+              {children}
             </div>
           </div>
-        )}
-        <div className={!header && showDismissButton ? styles['has-dismiss'] : undefined}>
-          {!header && dismissButton}
-          <div className={clsx(styles.content, { [styles['content-overflow-visible']]: !!overflowVisible })}>
-            {children}
-          </div>
-        </div>
-      </FocusLock>
+        </FocusLock>
+      </div>
     </div>
   );
 }

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -3,8 +3,6 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-@use '../internal/styles/tokens' as awsui;
-
 .container {
   display: inline-block;
   position: fixed;

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -3,12 +3,70 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
+@use '../internal/styles' as styles;
+@use '../internal/styles/tokens' as awsui;
+
+$body-offset-vertical: calc(#{awsui.$space-s} + #{awsui.$border-field-width});
+$body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
+
 .container {
   display: inline-block;
   position: fixed;
   top: -9999px;
   left: -9999px;
   z-index: 2000;
+}
+
+.container-body {
+  @include styles.styles-reset;
+  @include styles.text-flex-wrapping;
+
+  border-radius: awsui.$border-radius-popover;
+  padding: awsui.$space-s awsui.$space-m;
+
+  background-color: awsui.$color-background-popover;
+  box-shadow: awsui.$shadow-popover;
+  border: awsui.$border-field-width solid awsui.$color-border-popover;
+
+  &-overflow-visible {
+    overflow: visible;
+  }
+}
+
+// The content border box needs to be the same as body border box for correct placement computation.
+.container-body-content {
+  padding: $body-offset-vertical $body-offset-horizontal;
+  margin: calc(-1 * #{$body-offset-vertical}) calc(-1 * #{$body-offset-horizontal});
+}
+
+.container-body-variant-annotation {
+  background-color: awsui.$color-background-status-info;
+  border-color: awsui.$color-border-status-info;
+}
+
+.container-body-size-small {
+  max-width: 210px;
+  &.fixed-width {
+    width: 210px;
+  }
+}
+
+.container-body-size-medium {
+  max-width: 310px;
+  &.fixed-width {
+    width: 310px;
+  }
+}
+
+.container-body-size-large {
+  max-width: 480px;
+  @media (max-width: 480px) {
+    // On viewports smaller than 480px, we default to the body-size-medium width
+    max-width: 310px;
+  }
+  &.fixed-width {
+    width: 480px;
+  }
 }
 
 .container-arrow {

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -19,7 +19,6 @@ $body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
 
 .container-body {
   @include styles.styles-reset;
-  @include styles.text-flex-wrapping;
 
   border-radius: awsui.$border-radius-popover;
   padding: awsui.$space-s awsui.$space-m;

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -6,9 +6,6 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 
-$body-offset-vertical: calc(#{awsui.$space-s} + #{awsui.$border-field-width});
-$body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
-
 .container {
   display: inline-block;
   position: fixed;
@@ -21,21 +18,10 @@ $body-offset-horizontal: calc(#{awsui.$space-m} + #{awsui.$border-field-width});
   @include styles.styles-reset;
 
   border-radius: awsui.$border-radius-popover;
-  padding: awsui.$space-s awsui.$space-m;
 
   background-color: awsui.$color-background-popover;
   box-shadow: awsui.$shadow-popover;
   border: awsui.$border-field-width solid awsui.$color-border-popover;
-
-  &-overflow-visible {
-    overflow: visible;
-  }
-}
-
-// The content border box needs to be the same as body border box for correct placement computation.
-.container-body-content {
-  padding: $body-offset-vertical $body-offset-horizontal;
-  margin: calc(-1 * #{$body-offset-vertical}) calc(-1 * #{$body-offset-horizontal});
 }
 
 .container-body-variant-annotation {

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -143,8 +143,6 @@ export default function PopoverContainer({
     setInternalPosition(newInternalPosition);
     setPopoverStyle({ top: popoverOffset.top, left: popoverOffset.left });
 
-    // setBodyStyle(scrollable ? { maxHeight: boundingOffset.height + 'px', overflowY: 'auto', overflowX: 'hidden' } : {});
-
     positionHandlerRef.current = () => {
       const newTrackOffset = toRelativePosition(
         track.getBoundingClientRect(),

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -27,8 +27,12 @@ export interface PopoverContainerProps {
   position: PopoverProps.Position;
   zIndex?: React.CSSProperties['zIndex'];
   arrow: (position: InternalPosition | null) => React.ReactNode;
-  children: (style: React.CSSProperties, contentRef: React.Ref<HTMLDivElement>) => React.ReactNode;
+  children: React.ReactNode;
   renderWithPortal?: boolean;
+  size: PopoverProps.Size;
+  fixedWidth: boolean;
+  variant?: 'annotation';
+  overflowVisible?: boolean;
 }
 
 const INITIAL_STYLES: CSSProperties = { position: 'absolute', top: -9999, left: -9999 };
@@ -41,6 +45,10 @@ export default function PopoverContainer({
   children,
   zIndex,
   renderWithPortal,
+  size,
+  fixedWidth,
+  variant,
+  overflowVisible,
 }: PopoverContainerProps) {
   const [popoverRect, ref] = useContainerQuery((rect, prev) => {
     const roundedRect = { width: Math.round(rect.width), height: Math.round(rect.height) };
@@ -186,7 +194,18 @@ export default function PopoverContainer({
         {arrow(internalPosition)}
       </div>
 
-      {children(bodyStyle, contentRef)}
+      <div
+        className={clsx(styles['container-body'], styles[`container-body-size-${size}`], {
+          [styles['fixed-width']]: fixedWidth,
+          [styles[`container-variant-${variant}`]]: variant,
+          [styles['container-body-overflow-visible']]: overflowVisible,
+        })}
+        style={bodyStyle}
+      >
+        <div ref={contentRef} className={styles['container-body-content']}>
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -130,7 +130,7 @@ export default function PopoverContainer({
     // Position the popover
     setInternalPosition(newInternalPosition);
     setPopoverStyle({ top: popoverOffset.top, left: popoverOffset.left });
-    setBodyStyle(scrollable ? { maxHeight: boundingOffset.height + 'px', overflowY: 'auto' } : {});
+    setBodyStyle(scrollable ? { maxHeight: boundingOffset.height + 'px', overflowY: 'auto', overflowX: 'hidden' } : {});
 
     positionHandlerRef.current = () => {
       const newTrackOffset = toRelativePosition(

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -197,7 +197,7 @@ export default function PopoverContainer({
       <div
         className={clsx(styles['container-body'], styles[`container-body-size-${size}`], {
           [styles['fixed-width']]: fixedWidth,
-          [styles[`container-variant-${variant}`]]: variant,
+          [styles[`container-body-variant-${variant}`]]: variant,
           [styles['container-body-overflow-visible']]: overflowVisible,
         })}
         style={bodyStyle}

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -31,7 +31,6 @@ export interface PopoverContainerProps {
   size: PopoverProps.Size;
   fixedWidth: boolean;
   variant?: 'annotation';
-  overflowVisible?: boolean;
 }
 
 const INITIAL_STYLES: CSSProperties = { position: 'absolute', top: -9999, left: -9999 };
@@ -47,7 +46,6 @@ export default function PopoverContainer({
   size,
   fixedWidth,
   variant,
-  overflowVisible,
 }: PopoverContainerProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -103,8 +101,12 @@ export default function PopoverContainer({
     const containingBlock = getContainingBlock(popover);
     const containingBlockRect = containingBlock ? containingBlock.getBoundingClientRect() : viewportRect;
 
+    const bodyBorderWidth = getBorderWidth(body);
     const contentRect = contentRef.current.getBoundingClientRect();
-    const contentBoundingBox = { width: contentRect.width, height: contentRect.height };
+    const contentBoundingBox = {
+      width: contentRect.width + 2 * bodyBorderWidth,
+      height: contentRect.height + 2 * bodyBorderWidth,
+    };
 
     // Calculate the arrow direction and viewport-relative position of the popover.
     const {
@@ -203,15 +205,16 @@ export default function PopoverContainer({
         className={clsx(styles['container-body'], styles[`container-body-size-${size}`], {
           [styles['fixed-width']]: fixedWidth,
           [styles[`container-body-variant-${variant}`]]: variant,
-          [styles['container-body-overflow-visible']]: overflowVisible,
         })}
       >
-        <div ref={contentRef} className={styles['container-body-content']}>
-          {children}
-        </div>
+        <div ref={contentRef}>{children}</div>
       </div>
     </div>
   );
+}
+
+function getBorderWidth(element: HTMLElement) {
+  return parseInt(getComputedStyle(element).borderWidth) || 0;
 }
 
 /**

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -124,7 +124,7 @@ function InternalPopover(
           renderWithPortal={renderWithPortal}
           zIndex={renderWithPortal ? 7000 : undefined}
         >
-          {style => (
+          {(style, contentRef) => (
             <PopoverBody
               size={size}
               fixedWidth={fixedWidth}
@@ -134,6 +134,7 @@ function InternalPopover(
               onDismiss={onDismiss}
               overflowVisible="both"
               style={style}
+              contentRef={contentRef}
             >
               {content}
             </PopoverBody>

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -125,14 +125,13 @@ function InternalPopover(
           arrow={position => <Arrow position={position} />}
           renderWithPortal={renderWithPortal}
           zIndex={renderWithPortal ? 7000 : undefined}
-          overflowVisible={true}
         >
           <PopoverBody
             dismissButton={dismissButton}
             dismissAriaLabel={dismissAriaLabel}
             header={header}
             onDismiss={onDismiss}
-            overflowVisible={true}
+            overflowVisible="both"
           >
             {content}
           </PopoverBody>

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -124,17 +124,20 @@ function InternalPopover(
           renderWithPortal={renderWithPortal}
           zIndex={renderWithPortal ? 7000 : undefined}
         >
-          <PopoverBody
-            size={size}
-            fixedWidth={fixedWidth}
-            dismissButton={dismissButton}
-            dismissAriaLabel={dismissAriaLabel}
-            header={header}
-            onDismiss={onDismiss}
-            overflowVisible="both"
-          >
-            {content}
-          </PopoverBody>
+          {style => (
+            <PopoverBody
+              size={size}
+              fixedWidth={fixedWidth}
+              dismissButton={dismissButton}
+              dismissAriaLabel={dismissAriaLabel}
+              header={header}
+              onDismiss={onDismiss}
+              overflowVisible="both"
+              style={style}
+            >
+              {content}
+            </PopoverBody>
+          )}
         </PopoverContainer>
       )}
     </span>

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -118,27 +118,24 @@ function InternalPopover(
     >
       {visible && (
         <PopoverContainer
+          size={size}
+          fixedWidth={fixedWidth}
           position={position}
           trackRef={triggerRef}
           arrow={position => <Arrow position={position} />}
           renderWithPortal={renderWithPortal}
           zIndex={renderWithPortal ? 7000 : undefined}
+          overflowVisible={true}
         >
-          {(style, contentRef) => (
-            <PopoverBody
-              size={size}
-              fixedWidth={fixedWidth}
-              dismissButton={dismissButton}
-              dismissAriaLabel={dismissAriaLabel}
-              header={header}
-              onDismiss={onDismiss}
-              overflowVisible="both"
-              style={style}
-              contentRef={contentRef}
-            >
-              {content}
-            </PopoverBody>
-          )}
+          <PopoverBody
+            dismissButton={dismissButton}
+            dismissAriaLabel={dismissAriaLabel}
+            header={header}
+            onDismiss={onDismiss}
+            overflowVisible={true}
+          >
+            {content}
+          </PopoverBody>
         </PopoverContainer>
       )}
     </span>

--- a/src/popover/utils/positions.ts
+++ b/src/popover/utils/positions.ts
@@ -4,6 +4,7 @@ import { PopoverProps, InternalPosition, BoundingOffset, BoundingBox } from '../
 
 // A structure describing how the popover should be positioned
 export interface CalculatePosition {
+  scrollable?: boolean;
   internalPosition: InternalPosition;
   boundingOffset: BoundingOffset;
 }
@@ -162,6 +163,31 @@ function canRectFit(inner: BoundingOffset, outer: BoundingOffset): boolean {
   );
 }
 
+function fitIntoContainer(inner: BoundingOffset, outer: BoundingOffset): BoundingOffset {
+  let { left, width, top, height } = inner;
+
+  // Adjust left boundary.
+  if (left < outer.left) {
+    width = left + width - outer.left;
+    left = outer.left;
+  }
+  // Adjust right boundary.
+  else if (left + width > outer.left + outer.width) {
+    width = outer.left + outer.width - left;
+  }
+  // Adjust top boundary.
+  if (top < outer.top) {
+    height = top + height - outer.top;
+    top = outer.top;
+  }
+  // Adjust bottom boundary.
+  else if (top + height > outer.top + outer.height) {
+    height = outer.top + outer.height - top;
+  }
+
+  return { left, width, top, height };
+}
+
 /**
  * Returns the area of the intersection of passed in rectangles or a null, if there is no intersection
  */
@@ -225,15 +251,14 @@ export function calculatePosition(
     }
   }
 
-  // Position it in the best position outside the viewport. The user will need to scroll to view
-  // the contents, but at least it's accessible once they do.
-  if (bestPositionOutsideViewport !== null) {
-    return bestPositionOutsideViewport;
-  }
+  // Use best possible placement.
+  const internalPosition = bestPositionOutsideViewport?.internalPosition || 'right-top';
+  // Get default rect for that placement.
+  const defaultOffset = RECTANGLE_CALCULATIONS[internalPosition]({ body, trigger, arrow });
+  // Get largest possible rect that fits into viewport.
+  const optimisedOffset = fitIntoContainer(defaultOffset, viewport);
+  // If largest possible rect is smaller than original - set body scroll.
+  const scrollable = optimisedOffset.height < defaultOffset.height;
 
-  // Resort to right-top
-  return {
-    internalPosition: 'right-top',
-    boundingOffset: RECTANGLE_CALCULATIONS['right-top']({ body, trigger, arrow }),
-  };
+  return { internalPosition, boundingOffset: optimisedOffset, scrollable };
 }

--- a/src/popover/utils/positions.ts
+++ b/src/popover/utils/positions.ts
@@ -188,6 +188,12 @@ function fitIntoContainer(inner: BoundingOffset, outer: BoundingOffset): Boundin
   return { left, width, top, height };
 }
 
+function getLargestRect(rect1: BoundingOffset, rect2: BoundingOffset): BoundingOffset {
+  const area1 = rect1.height * rect1.width;
+  const area2 = rect2.height * rect2.width;
+  return area1 >= area2 ? rect1 : rect2;
+}
+
 /**
  * Returns the area of the intersection of passed in rectangles or a null, if there is no intersection
  */
@@ -255,8 +261,11 @@ export function calculatePosition(
   const internalPosition = bestPositionOutsideViewport?.internalPosition || 'right-top';
   // Get default rect for that placement.
   const defaultOffset = RECTANGLE_CALCULATIONS[internalPosition]({ body, trigger, arrow });
-  // Get largest possible rect that fits into viewport.
-  const optimisedOffset = fitIntoContainer(defaultOffset, viewport);
+  // Get largest possible rect that fits into viewport or container.
+  const optimisedOffset = fitIntoContainer(
+    defaultOffset,
+    renderWithPortal ? viewport : getLargestRect(container, viewport)
+  );
   // If largest possible rect is smaller than original - set body scroll.
   const scrollable = optimisedOffset.height < defaultOffset.height;
 


### PR DESCRIPTION
### Description

When popover content is tall sometimes it can be cut by the viewport. The fix allows the content to become scrollable when necessary.

<img width="531" alt="Screenshot 2022-09-18 at 11 25 57" src="https://user-images.githubusercontent.com/20790937/190895406-caf1d481-f29b-4644-b2c9-fd8fa06086e3.png">

### How has this been tested?

* Manual tests for overflow using new test page;
* Screenshot tests;
* Existing placement integration tests;
* New unit tests for updated positioning logic.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
