### PR TITLE
Simpler css for drp date-only input layout

### DIFF
--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -106,13 +106,12 @@ $calendar-grid-width: awsui.$size-calendar-grid-width;
 }
 
 .date-and-time-wrapper {
+  width: $calendar-grid-width;
+}
+.date-and-time-wrapper:not(.date-only) {
   display: grid;
   column-gap: awsui.$space-xs;
   grid-template-columns: 1fr 1fr;
-  width: $calendar-grid-width;
-  &.date-only {
-    grid-template-columns: unset;
-  }
 }
 
 .date-and-time-constrainttext {


### PR DESCRIPTION
### Description

Remove unnecessary grid for date-only drp input layout.

### How has this been tested?

Manual tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
