### PR TITLE
In token editor clear value when property key changes

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -539,22 +539,25 @@ describe('property filter parts', () => {
         const operatorSelectWrapper = findOperatorSelector(contentWrapper);
         const valueSelectWrapper = findValueSelector(contentWrapper);
 
+        // Change operator
+        act(() => operatorSelectWrapper.openDropdown());
+        act(() => operatorSelectWrapper.selectOption(1));
+        expect(propertySelectWrapper.findTrigger().getElement()).toHaveTextContent('string');
+        expect(operatorSelectWrapper.findTrigger().getElement()).toHaveTextContent('=Equals');
+        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', 'first');
+
+        // Change value
+        act(() => valueSelectWrapper.setInputValue('123'));
+        expect(propertySelectWrapper.findTrigger().getElement()).toHaveTextContent('string');
+        expect(operatorSelectWrapper.findTrigger().getElement()).toHaveTextContent('=Equals');
+        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', '123');
+
+        // Change property
         act(() => propertySelectWrapper.openDropdown());
         act(() => propertySelectWrapper.selectOption(2));
         expect(propertySelectWrapper.findTrigger().getElement()).toHaveTextContent('string-other');
-        expect(operatorSelectWrapper.findTrigger().getElement()).toHaveTextContent(':Contains');
-        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', 'first');
-
-        act(() => operatorSelectWrapper.openDropdown());
-        act(() => operatorSelectWrapper.selectOption(1));
-        expect(propertySelectWrapper.findTrigger().getElement()).toHaveTextContent('string-other');
         expect(operatorSelectWrapper.findTrigger().getElement()).toHaveTextContent('=Equals');
-        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', 'first');
-
-        act(() => valueSelectWrapper.setInputValue('123'));
-        expect(propertySelectWrapper.findTrigger().getElement()).toHaveTextContent('string-other');
-        expect(operatorSelectWrapper.findTrigger().getElement()).toHaveTextContent('=Equals');
-        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', '123');
+        expect(valueSelectWrapper.findNativeInput().getElement()).toHaveAttribute('value', '');
       });
       test('might change the operation if the old one is not supported, when switching the property', () => {
         const { propertyFilterWrapper: wrapper } = renderComponent({
@@ -633,14 +636,14 @@ describe('property filter parts', () => {
         );
       });
       test('submit button closes the popover and saves the changes', () => {
-        const valueAutosuggestWrapper = findValueSelector(contentWrapper);
-        act(() => valueAutosuggestWrapper.setInputValue('123'));
         const operatorSelectWrapper = findOperatorSelector(contentWrapper);
         act(() => operatorSelectWrapper.openDropdown());
         act(() => operatorSelectWrapper.selectOption(1));
         const propertySelectWrapper = findPropertySelector(contentWrapper);
         act(() => propertySelectWrapper.openDropdown());
         act(() => propertySelectWrapper.selectOption(1));
+        const valueAutosuggestWrapper = findValueSelector(contentWrapper);
+        act(() => valueAutosuggestWrapper.setInputValue('123'));
 
         act(() => contentWrapper.findButton(`.${styles['token-editor-submit']}`)!.click());
         popoverWrapper = wrapper.findTokens()[0]!.find('*')!.findPopover()!;

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -39,9 +39,6 @@
 
 .token-editor {
   margin: awsui.$space-xxs;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
   &-form {
     margin-bottom: awsui.$space-scaled-l;
   }
@@ -64,8 +61,11 @@
     margin-left: calc(-1 * #{awsui.$space-m} + -1 * #{awsui.$space-xxs});
     margin-right: calc(-1 * #{awsui.$space-m} + -1 * #{awsui.$space-xxs});
   }
-  &-commit {
-    margin-left: awsui.$space-xs;
+  &-cancel {
+    margin-right: awsui.$space-xs;
+  }
+  &-submit {
+    /* used in test-utils */
   }
 }
 
@@ -103,13 +103,8 @@
   @include styles.text-wrapping;
 }
 
-.token-editor-cancel {
-  margin-right: awsui.$space-xs;
-}
-
 .remove-all,
 .token-label,
-.join-operation,
-.token-editor-submit {
+.join-operation {
   /* used in test-utils */
 }

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -219,7 +219,7 @@ export function TokenEditor({
       temporaryToken.operator && allowedOperators.indexOf(temporaryToken.operator) !== -1
         ? temporaryToken.operator
         : allowedOperators[0];
-    setTemporaryToken({ ...temporaryToken, propertyKey: newPropertyKey, operator });
+    setTemporaryToken({ ...temporaryToken, propertyKey: newPropertyKey, operator, value: '' });
   };
 
   const operator = temporaryToken.operator;


### PR DESCRIPTION
### Description

When property key changes the old value is likely to no longer be meaningful. Clear it.

That is even more important for the custom props, see https://github.com/cloudscape-design/components/pull/166. 

### How has this been tested?

Updated existing unit test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
