### PR TITLE
Fix autosuggest and property filter dropdown expanded state

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -173,6 +173,13 @@ describe('Dropdown states', () => {
       await expect(container).toValidateA11y();
     });
   });
+
+  it('when no options is matched the dropdown is shown but aria-expanded is false', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} statusType="finished" value="free-text" />);
+    wrapper.setInputValue('free-text');
+    expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
 });
 
 describe('a11y props', () => {

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -302,11 +302,10 @@ const AutosuggestInput = React.forwardRef(
             )
           }
           expandToViewport={expandToViewport}
-          hasContent={!!dropdownContent}
           trapFocus={trapDropdownFocus}
         >
           <div ref={dropdownContentRef} className={styles['dropdown-content']}>
-            {open && dropdownContent}
+            {open ? dropdownContent : null}
           </div>
         </Dropdown>
       </div>

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -75,7 +75,7 @@ const AutosuggestInput = React.forwardRef(
       expandToViewport,
       ariaControls,
       ariaActivedescendant,
-      dropdownExpanded,
+      dropdownExpanded = true,
       dropdownContentKey,
       dropdownContentFocusable = false,
       dropdownContent = null,
@@ -209,7 +209,7 @@ const AutosuggestInput = React.forwardRef(
       }
     };
 
-    const expanded = open && (dropdownExpanded ?? !!dropdownContent);
+    const expanded = open && dropdownExpanded;
     const nativeAttributes = {
       name,
       placeholder,
@@ -302,7 +302,7 @@ const AutosuggestInput = React.forwardRef(
             )
           }
           expandToViewport={expandToViewport}
-          hasContent={expanded}
+          hasContent={!!dropdownContent}
           trapFocus={trapDropdownFocus}
         >
           <div ref={dropdownContentRef} className={styles['dropdown-content']}>

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -304,9 +304,11 @@ const AutosuggestInput = React.forwardRef(
           expandToViewport={expandToViewport}
           trapFocus={trapDropdownFocus}
         >
-          <div ref={dropdownContentRef} className={styles['dropdown-content']}>
-            {open ? dropdownContent : null}
-          </div>
+          {open && dropdownContent ? (
+            <div ref={dropdownContentRef} className={styles['dropdown-content']}>
+              {dropdownContent}
+            </div>
+          ) : null}
         </Dropdown>
       </div>
     );

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -121,7 +121,6 @@ const Dropdown = ({
   preferCenter = false,
   interior = false,
   minWidth,
-  hasContent = true,
   scrollable = true,
   trapFocus = false,
   contentKey,
@@ -360,7 +359,7 @@ const Dropdown = ({
                 stretchWidth={stretchWidth}
                 interior={interior}
                 header={header}
-                hasContent={hasContent}
+                hasContent={!!children}
                 expandToViewport={expandToViewport}
                 footer={footer}
                 onMouseDown={onMouseDown}

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -41,7 +41,6 @@ interface TransitionContentProps {
   dropdownClasses: string;
   stretchWidth: boolean;
   interior: boolean;
-  hasContent: boolean;
   isRefresh: boolean;
   dropdownRef: React.RefObject<HTMLDivElement>;
   verticalContainerRef: React.RefObject<HTMLDivElement>;
@@ -60,7 +59,6 @@ const TransitionContent = ({
   dropdownClasses,
   stretchWidth,
   interior,
-  hasContent,
   isRefresh,
   dropdownRef,
   verticalContainerRef,
@@ -80,7 +78,7 @@ const TransitionContent = ({
         [styles['with-limited-width']]: !stretchWidth,
         [styles['hide-upper-border']]: stretchWidth,
         [styles.interior]: interior,
-        [styles['is-empty']]: !header && !hasContent,
+        [styles['is-empty']]: !header && !children,
         [styles.refresh]: isRefresh,
         [styles['use-portal']]: expandToViewport && !interior,
       })}
@@ -359,7 +357,6 @@ const Dropdown = ({
                 stretchWidth={stretchWidth}
                 interior={interior}
                 header={header}
-                hasContent={!!children}
                 expandToViewport={expandToViewport}
                 footer={footer}
                 onMouseDown={onMouseDown}

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -114,10 +114,6 @@ export interface DropdownProps extends ExpandToViewport {
    */
   minWidth?: number;
   /**
-   * Whether there are items in the dropdown vs. an empty list
-   */
-  hasContent?: boolean;
-  /**
    * Whether the dropdown will have a scrollbar or not
    */
   scrollable?: boolean;

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -746,6 +746,21 @@ describe('property filter parts', () => {
     expect(wrapper.findNativeInput().getElement()).toHaveValue('string != ');
   });
 
+  describe('dropdown states', () => {
+    it('when free text filtering is allowed and no property is matched dropdown is visible but aria-expanded is false', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering: false });
+      wrapper.setInputValue('free-text');
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
+      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Use: "free-text"');
+    });
+    it('when free text filtering is not allowed and no property is matched dropdown is hidden but aria-expanded is false', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering: true });
+      wrapper.setInputValue('free-text');
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
+      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('');
+    });
+  });
+
   test('property filter input can be found with autosuggest selector', () => {
     const { container } = renderComponent();
     expect(createWrapper(container).findAutosuggest()!.getElement()).not.toBe(null);

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -156,21 +156,23 @@ const PropertyFilterAutosuggest = React.forwardRef(
         expandToViewport={expandToViewport}
         ariaControls={listId}
         ariaActivedescendant={highlightedOptionId}
-        dropdownExpanded={autosuggestItemsState.items.length > 1}
+        dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null}
         dropdownContent={
-          <AutosuggestOptionsList
-            autosuggestItemsState={autosuggestItemsState}
-            autosuggestItemsHandlers={autosuggestItemsHandlers}
-            highlightedOptionId={highlightedOptionId}
-            highlightText={highlightText}
-            listId={listId}
-            controlId={controlId}
-            enteredTextLabel={enteredTextLabel}
-            handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
-            hasDropdownStatus={dropdownStatus.content !== null}
-            virtualScroll={virtualScroll}
-            listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
-          />
+          autosuggestItemsState.items.length > 0 ? (
+            <AutosuggestOptionsList
+              autosuggestItemsState={autosuggestItemsState}
+              autosuggestItemsHandlers={autosuggestItemsHandlers}
+              highlightedOptionId={highlightedOptionId}
+              highlightText={highlightText}
+              listId={listId}
+              controlId={controlId}
+              enteredTextLabel={enteredTextLabel}
+              handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
+              hasDropdownStatus={dropdownStatus.content !== null}
+              virtualScroll={virtualScroll}
+              listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+            />
+          ) : null
         }
         dropdownFooter={
           dropdownStatus.isSticky ? (


### PR DESCRIPTION
### Description

When no options found but the empty state or "use" option is present - show the dropdown but set the aria-expanded as "false". In property filter when disableFreeTextFiltering=true it is possible for the dropdown to be hidden completely.

### How has this been tested?

Manual tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
