### PR TITLE
AWSUI-19186: proper role for calender dialog and aria-label

### DIFF
--- a/src/date-picker/__tests__/date-picker.test.tsx
+++ b/src/date-picker/__tests__/date-picker.test.tsx
@@ -100,6 +100,12 @@ describe('Date picker - direct date input', () => {
       const { wrapper } = renderDatePicker({ ...defaultProps, ariaLabelledby: 'my-custom-id' });
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-labelledby', 'my-custom-id');
     });
+
+    test('aria-labelledby can be passed to calendar', () => {
+      const { wrapper } = renderDatePicker({ ...defaultProps, ariaLabelledby: 'my-custom-id' });
+      wrapper.findOpenCalendarButton().click();
+      expect(wrapper.findCalendar()?.getElement()).toHaveAttribute('aria-labelledby', 'my-custom-id');
+    });
   });
 
   describe('aria-required', () => {
@@ -123,6 +129,12 @@ describe('Date picker - direct date input', () => {
     test('aria-label is not added if not defined', () => {
       const { wrapper } = renderDatePicker();
       expect(wrapper.findNativeInput().getElement()).not.toHaveAttribute('aria-label');
+    });
+
+    test('aria-label can be passed to calendar', () => {
+      const { wrapper } = renderDatePicker({ ...defaultProps, ariaLabel: 'my-custom-label' });
+      wrapper.findOpenCalendarButton().click();
+      expect(wrapper.findCalendar()?.getElement()).toHaveAttribute('aria-label', 'my-custom-label');
     });
   });
 

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -175,7 +175,8 @@ const DatePicker = React.forwardRef(
                 className={styles.calendar}
                 role="dialog"
                 aria-describedby={calendarDescriptionId}
-                aria-label={'Calendar dialog'}
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledby}
               >
                 <InternalCalendar
                   value={value}

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -173,8 +173,9 @@ const DatePicker = React.forwardRef(
                 {...focusVisible}
                 tabIndex={0}
                 className={styles.calendar}
-                role="application"
+                role="dialog"
                 aria-describedby={calendarDescriptionId}
+                aria-label={'Calendar dialog'}
               >
                 <InternalCalendar
                   value={value}


### PR DESCRIPTION
### Description

- Proper role for calendar-picker dialog
- aria-label for calendar-picker

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
