### PR TITLE
Fix dropdown overflow

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -164,7 +164,6 @@ const DatePicker = React.forwardRef(
           onMouseDown={handleMouseDown}
           trigger={DateInputElement}
           expandToViewport={expandToViewport}
-          scrollable={false}
           dropdownId={dropdownId}
         >
           {isDropDownOpen && (

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -161,11 +161,6 @@ $calendar-grid-width: awsui.$size-calendar-grid-width;
 }
 
 .dropdown {
-  // There needs to be an outer container because we set a fixed width on the
-  // actual dropdown and calendar grid, so the scrollbar would mess up the
-  // widths.
-  overflow: auto;
-
   border-top: 1px solid #{awsui.$color-border-container-top};
   border-bottom: 1px solid #{awsui.$color-border-container-top};
   border-radius: awsui.$border-radius-dropdown;

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -88,14 +88,12 @@ const TransitionContent = ({
       onMouseDown={onMouseDown}
     >
       <div className={clsx(styles['dropdown-content-wrapper'], isRefresh && styles.refresh)}>
-        <div className={styles['ie11-wrapper']}>
-          <div ref={verticalContainerRef} className={styles['dropdown-content']}>
-            <DropdownContextProvider position={position}>
-              {header}
-              {children}
-              {footer}
-            </DropdownContextProvider>
-          </div>
+        <div ref={verticalContainerRef} className={styles['dropdown-content']}>
+          <DropdownContextProvider position={position}>
+            {header}
+            {children}
+            {footer}
+          </DropdownContextProvider>
         </div>
       </div>
     </div>
@@ -119,7 +117,6 @@ const Dropdown = ({
   preferCenter = false,
   interior = false,
   minWidth,
-  scrollable = true,
   trapFocus = false,
   contentKey,
 }: DropdownProps) => {
@@ -220,9 +217,7 @@ const Dropdown = ({
     const onDropdownOpen = () => {
       if (open && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
         // calculate scroll width only for dropdowns that has a scrollbar and ignore it for date picker components
-        if (scrollable) {
-          dropdownRef.current.classList.add(styles.nowrap);
-        }
+        dropdownRef.current.classList.add(styles.nowrap);
         setDropdownPosition(
           ...calculatePosition(
             dropdownRef.current,
@@ -239,9 +234,7 @@ const Dropdown = ({
           dropdownRef.current,
           verticalContainerRef.current
         );
-        if (scrollable) {
-          dropdownRef.current.classList.remove(styles.nowrap);
-        }
+        dropdownRef.current.classList.remove(styles.nowrap);
       }
     };
     onDropdownOpen();

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -114,10 +114,6 @@ export interface DropdownProps extends ExpandToViewport {
    */
   minWidth?: number;
   /**
-   * Whether the dropdown will have a scrollbar or not
-   */
-  scrollable?: boolean;
-  /**
    * Whether the dropdown will have a focus trap including trigger, header, content and footer.
    */
   trapFocus?: boolean;

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -100,16 +100,10 @@
 }
 
 .dropdown-content {
+  overflow: auto;
   display: flex;
   flex-direction: column;
   width: 100%;
-}
-
-// Child flex wrapper used because when combining an absolute position
-// and flexbox, IE11 will incorrectly size the container according to its parent
-// and not its content.
-.ie11-wrapper {
-  display: flex;
 }
 
 .stretch-trigger-height {


### PR DESCRIPTION
### Description

Allow dropdown content to scroll unconditionally. That actually fixes the date-range-picker overflow on mobiles.

Main:
<img width="402" alt="Screenshot 2022-09-20 at 20 03 29" src="https://user-images.githubusercontent.com/20790937/191331528-c8768a05-79c5-4f71-ba8c-4a40fd4259e4.png">

PR:
<img width="402" alt="Screenshot 2022-09-20 at 20 04 04" src="https://user-images.githubusercontent.com/20790937/191331583-98aae68c-1488-4ae6-8cb5-62c726d36544.png">

### How has this been tested?

Manual tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
