### PR TITLE
Make date-input and calendar public

### DIFF
--- a/build-tools/utils/files.js
+++ b/build-tools/utils/files.js
@@ -36,9 +36,7 @@ function listPublicItems(baseDir) {
         elem !== 'interfaces.ts' &&
         elem !== 'test-utils' &&
         elem !== 'theming' &&
-        elem !== 'contexts' &&
-        elem !== 'calendar' &&
-        elem !== 'date-input'
+        elem !== 'contexts'
     );
 }
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4349,17 +4349,6 @@ is provided by its parent form field component.
       "type": "string",
     },
     Object {
-      "defaultValue": "true",
-      "description": "Specifies whether to disable browser autocorrect and related features.
-If you set this to \`true\`, it disables any native browser capabilities
-that automatically correct user input, such as \`autocorrect\` and
-\`autocapitalize\`. If you don't set it, the behavior follows the default behavior
-of the user's browser.",
-      "name": "disableBrowserAutocorrect",
-      "optional": true,
-      "type": "boolean",
-    },
-    Object {
       "description": "Specifies if the control is disabled, which prevents the
 user from modifying the value and prevents the value from
 being included in a form submission. A disabled control can't

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2943,6 +2943,18 @@ The event \`detail\` contains the current value of the field.",
   "name": "Calendar",
   "properties": Array [
     Object {
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Defines whether a particular date is enabled in the calendar or not.
 If you disable a date in the calendar, users can still enter this date using a keyboard.
 We recommend that you also validate these constraints on the client-side and server-side

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2917,6 +2917,98 @@ It prevents clicks.",
 }
 `;
 
+exports[`Documenter definition for calendar matches the snapshot: calendar 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "cancelable": false,
+      "description": "Called whenever a user changes the input value (by typing, pasting, or selecting a value).
+The event \`detail\` contains the current value of the field.",
+      "detailInlineType": Object {
+        "name": "CalendarProps.ChangeDetail",
+        "properties": Array [
+          Object {
+            "name": "value",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "CalendarProps.ChangeDetail",
+      "name": "onChange",
+    },
+  ],
+  "functions": Array [],
+  "name": "Calendar",
+  "properties": Array [
+    Object {
+      "description": "Defines whether a particular date is enabled in the calendar or not.
+If you disable a date in the calendar, users can still enter this date using a keyboard.
+We recommend that you also validate these constraints on the client-side and server-side
+as you would for other form elements.",
+      "inlineType": Object {
+        "name": "CalendarProps.IsDateEnabledFunction",
+        "parameters": Array [
+          Object {
+            "name": "date",
+            "type": "Date",
+          },
+        ],
+        "returnType": "boolean",
+        "type": "function",
+      },
+      "name": "isDateEnabled",
+      "optional": true,
+      "type": "CalendarProps.IsDateEnabledFunction",
+    },
+    Object {
+      "defaultValue": "\\"\\"",
+      "description": "Specifies the locale to use to render month names and determine the starting day of the week.
+If you don't provide this, the locale is determined by the page and browser locales.
+Supported values and formats are listed in the
+[JavaScript Intl API specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation).",
+      "name": "locale",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies an \`aria-label\` for the 'next month' button.",
+      "name": "nextMonthAriaLabel",
+      "optional": false,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies an \`aria-label\` for the 'previous month' button.",
+      "name": "previousMonthAriaLabel",
+      "optional": false,
+      "type": "string",
+    },
+    Object {
+      "description": "Determines the starting day of the week. The values 0-6 map to Sunday-Saturday.
+By default the starting day of the week is defined by the locale, but you can use this property to override it.",
+      "name": "startOfWeek",
+      "optional": true,
+      "type": "number",
+    },
+    Object {
+      "description": "Used as part of the \`aria-label\` for today's date in the calendar.",
+      "name": "todayAriaLabel",
+      "optional": false,
+      "type": "string",
+    },
+    Object {
+      "description": "The current input value, in YYYY-MM-DD format.",
+      "name": "value",
+      "optional": false,
+      "type": "string",
+    },
+  ],
+  "regions": Array [],
+  "releaseStatus": "stable",
+}
+`;
+
 exports[`Documenter definition for cards matches the snapshot: cards 1`] = `
 Object {
   "events": Array [
@@ -4138,6 +4230,178 @@ If true, the overlap will be removed.",
       "name": "header",
     },
   ],
+  "releaseStatus": "stable",
+}
+`;
+
+exports[`Documenter definition for date-input matches the snapshot: date-input 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "cancelable": false,
+      "description": "Called when input focus is removed from the UI control.",
+      "detailType": "null",
+      "name": "onBlur",
+    },
+    Object {
+      "cancelable": false,
+      "description": "Called whenever a user changes the input value (by typing or pasting).
+The event \`detail\` contains the current value of the field.",
+      "detailInlineType": Object {
+        "name": "InputProps.ChangeDetail",
+        "properties": Array [
+          Object {
+            "name": "value",
+            "optional": false,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "InputProps.ChangeDetail",
+      "name": "onChange",
+    },
+    Object {
+      "cancelable": false,
+      "description": "Called when input focus is moved to the UI control.",
+      "detailType": "null",
+      "name": "onFocus",
+    },
+  ],
+  "functions": Array [],
+  "name": "DateInput",
+  "properties": Array [
+    Object {
+      "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for each element that you want to use as a description
+and set the property to a string of each ID separated by spaces (for example, \`\\"id1 id2 id3\\"\`).
+",
+      "name": "ariaDescribedby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds an \`aria-label\` to the native control.
+Use this if you don't have a visible label for this control.
+",
+      "name": "ariaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
+      "name": "ariaLabelledby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies whether to add \`aria-required\` to the native control.",
+      "name": "ariaRequired",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Indicates whether the control should be focused as
+soon as the page loads, which enables the user to
+start typing without having to manually focus the control. Don't
+use this option on pages where the control may be
+scrolled out of the viewport.",
+      "name": "autoFocus",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Adds the specified classes to the root element of the component.",
+      "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies the ID of the native form element. You can use it to relate
+a label element's \`for\` attribute to this control.
+It defaults to an automatically generated ID that
+is provided by its parent form field component.
+",
+      "name": "controlId",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "defaultValue": "true",
+      "description": "Specifies whether to disable browser autocorrect and related features.
+If you set this to \`true\`, it disables any native browser capabilities
+that automatically correct user input, such as \`autocorrect\` and
+\`autocapitalize\`. If you don't set it, the behavior follows the default behavior
+of the user's browser.",
+      "name": "disableBrowserAutocorrect",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Specifies if the control is disabled, which prevents the
+user from modifying the value and prevents the value from
+being included in a form submission. A disabled control can't
+receive focus.",
+      "name": "disabled",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Adds the specified ID to the root element of the component.",
+      "name": "id",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Overrides the invalidation state. Usually the invalid state
+comes from the parent \`FormField\`component,
+however sometimes you need to override its
+state when you have more than one input within a
+single form field.",
+      "name": "invalid",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Specifies the name of the control used in HTML forms.",
+      "name": "name",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies the placeholder text rendered when the value is an empty string.",
+      "name": "placeholder",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies if the control is read only, which prevents the
+user from modifying the value but includes it in a form
+submission. A read-only control can receive focus.
+Don't use read-only inputs outside a form.
+",
+      "name": "readOnly",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Specifies the text entered into the form element.",
+      "name": "value",
+      "optional": false,
+      "type": "string",
+    },
+  ],
+  "regions": Array [],
   "releaseStatus": "stable",
 }
 `;

--- a/src/__tests__/form-field-controls-integration.test.tsx
+++ b/src/__tests__/form-field-controls-integration.test.tsx
@@ -23,6 +23,10 @@ const formFieldControlComponents = [
     findNativeElement: (wrapper: ElementWrapper) => wrapper.findRadioGroup()?.getElement(),
   },
   {
+    componentName: 'date-input',
+    findNativeElement: (wrapper: ElementWrapper) => wrapper.findDateInput()?.findNativeInput()?.getElement(),
+  },
+  {
     componentName: 'time-input',
     findNativeElement: (wrapper: ElementWrapper) => wrapper.findTimeInput()?.findNativeInput()?.getElement(),
   },

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -17,8 +17,6 @@ export function getAllComponents(): string[] {
         name !== 'test-utils' &&
         name !== 'theming' &&
         name !== 'contexts' &&
-        name !== 'calendar' &&
-        name !== 'date-input' &&
         !name.includes('.') &&
         !name.includes('LICENSE')
     );

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -10,12 +10,13 @@ import {
   OptionsFilteringType,
 } from '../internal/components/dropdown/interfaces';
 import { DropdownStatusProps } from '../internal/components/dropdown-status';
-import { BaseInputProps, InputKeyEvents, InputProps } from '../input/interfaces';
+import { BaseInputProps, InputAutoCorrect, InputKeyEvents, InputProps } from '../input/interfaces';
 import { NonCancelableEventHandler } from '../internal/events';
 
 export interface AutosuggestProps
   extends BaseComponentProps,
     BaseInputProps,
+    InputAutoCorrect,
     BaseDropdownHostProps,
     InputKeyEvents,
     FormFieldValidationControlProps,

--- a/src/calendar/__integ__/calendar.test.ts
+++ b/src/calendar/__integ__/calendar.test.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
-import CalendarWrapper from '../../../lib/components/test-utils/selectors/calendar';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
-const calendarWrapper = createWrapper().findComponent('', CalendarWrapper);
+const calendarWrapper = createWrapper().findCalendar();
 
 describe('Date picker calendar interactions', () => {
   const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {

--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -6,8 +6,6 @@ import { render } from '@testing-library/react';
 import Calendar, { CalendarProps } from '../../../lib/components/calendar';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import '../../__a11y__/to-validate-a11y';
-import styles from '../../../lib/components/calendar/styles.selectors.js';
-import CalendarWrapper from '../../../lib/components/test-utils/dom/calendar';
 
 // The calendar is mostly tested here: src/date-picker/__tests__/date-picker-calendar.test.tsx
 
@@ -21,7 +19,7 @@ describe('Calendar', () => {
 
   function renderCalendar(props: CalendarProps = defaultProps) {
     const { container, getByTestId } = render(<Calendar {...props} />);
-    const wrapper = createWrapper(container).findComponent(`.${styles.root}`, CalendarWrapper);
+    const wrapper = createWrapper(container).findCalendar();
     return { container, wrapper, getByTestId };
   }
 

--- a/src/calendar/interfaces.ts
+++ b/src/calendar/interfaces.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
-export interface CalendarProps {
+export interface CalendarProps extends BaseComponentProps {
   /**
    * The current input value, in YYYY-MM-DD format.
    */

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -15,6 +15,9 @@ import { fireNonCancelableEvent } from '../internal/events/index.js';
 import checkControlled from '../internal/hooks/check-controlled/index.js';
 import clsx from 'clsx';
 import { CalendarProps } from './interfaces.js';
+import { getBaseProps } from '../internal/base-component';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs/index.js';
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -27,14 +30,18 @@ export default function Calendar({
   nextMonthAriaLabel,
   previousMonthAriaLabel,
   onChange,
-}: CalendarProps) {
+  __internalRootRef,
+  ...rest
+}: CalendarProps & InternalBaseComponentProps) {
   checkControlled('Calendar', 'value', value, 'onChange', onChange);
 
+  const baseProps = getBaseProps(rest);
   const normalizedLocale = normalizeLocale('Calendar', locale);
   const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, locale);
   const elementRef = useRef<HTMLDivElement>(null);
   const gridWrapperRef = useRef<HTMLDivElement>(null);
   const [focusedDate, setFocusedDate] = useState<Date | null>(null);
+  const ref = useMergeRefs(elementRef, __internalRootRef);
 
   // Set displayed date to value if defined or to current date otherwise.
   const memoizedValue = memoizedDate('value', value);
@@ -114,7 +121,7 @@ export default function Calendar({
   };
 
   return (
-    <div className={clsx(styles.root, styles.calendar)} ref={elementRef}>
+    <div ref={ref} {...baseProps} className={clsx(styles.root, styles.calendar, baseProps.className)}>
       <div className={styles['calendar-inner']}>
         <CalendarHeader
           baseDate={baseDate}

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -121,7 +121,12 @@ export default function Calendar({
   };
 
   return (
-    <div ref={ref} role="application" {...baseProps} className={clsx(styles.root, styles.calendar, baseProps.className)}>
+    <div
+      ref={ref}
+      role="application"
+      {...baseProps}
+      className={clsx(styles.root, styles.calendar, baseProps.className)}
+    >
       <div className={styles['calendar-inner']}>
         <CalendarHeader
           baseDate={baseDate}

--- a/src/date-input/__integ__/date-input.test.ts
+++ b/src/date-input/__integ__/date-input.test.ts
@@ -3,10 +3,9 @@
 
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
-import DateInputWrapper from '../../../lib/components/test-utils/selectors/date-input';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 
-const dateInputWrapper = createWrapper().findComponent('.testing-date-input', DateInputWrapper);
+const dateInputWrapper = createWrapper().findDateInput()!;
 const defaultSelector = dateInputWrapper.findNativeInput().toSelector();
 
 class DateInputPage extends BasePageObject {

--- a/src/date-input/__tests__/date-input.test.tsx
+++ b/src/date-input/__tests__/date-input.test.tsx
@@ -4,13 +4,12 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 import DateInput, { DateInputProps } from '../../../lib/components/date-input';
-import DateInputWrapper from '../../../lib/components/test-utils/dom/date-input';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 function renderDateInput(props: DateInputProps) {
   const onChangeSpy = jest.fn();
-  const { container } = render(<DateInput className="testing-date-input" onChange={onChangeSpy} {...props} />);
-  const wrapper = createWrapper(container).findComponent('.testing-date-input', DateInputWrapper)!;
+  const { container } = render(<DateInput onChange={onChangeSpy} {...props} />);
+  const wrapper = createWrapper(container).findDateInput()!;
   return { wrapper, onChangeSpy };
 }
 

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -10,19 +10,10 @@ import InternalDateInput from './internal';
 
 export { DateInputProps };
 
-const DateInput = React.forwardRef(
-  ({ disableBrowserAutocorrect = true, ...props }: DateInputProps, ref: Ref<HTMLInputElement>) => {
-    const baseComponentProps = useBaseComponent('DateInput');
-    return (
-      <InternalDateInput
-        {...props}
-        {...baseComponentProps}
-        disableBrowserAutocorrect={disableBrowserAutocorrect}
-        ref={ref}
-      />
-    );
-  }
-);
+const DateInput = React.forwardRef((props: DateInputProps, ref: Ref<HTMLInputElement>) => {
+  const baseComponentProps = useBaseComponent('DateInput');
+  return <InternalDateInput {...props} {...baseComponentProps} ref={ref} />;
+});
 
 applyDisplayName(DateInput, 'DateInput');
 

--- a/src/date-input/internal.tsx
+++ b/src/date-input/internal.tsx
@@ -33,10 +33,7 @@ const maskArgs: MaskArgs = {
 };
 
 const InternalDateInput = React.forwardRef(
-  (
-    { value, onChange, disableBrowserAutocorrect = true, __internalRootRef = null, ...props }: InternalDateInputProps,
-    ref: Ref<HTMLInputElement>
-  ) => {
+  ({ value, onChange, __internalRootRef = null, ...props }: InternalDateInputProps, ref: Ref<HTMLInputElement>) => {
     return (
       <MaskedInput
         ref={ref}
@@ -48,7 +45,7 @@ const InternalDateInput = React.forwardRef(
         autofix={true}
         autoComplete={false}
         disableAutocompleteOnBlur={false}
-        disableBrowserAutocorrect={disableBrowserAutocorrect}
+        disableBrowserAutocorrect={true}
         __internalRootRef={__internalRootRef}
       />
     );

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -47,15 +47,6 @@ export interface BaseInputProps {
   autoFocus?: boolean;
 
   /**
-   * Specifies whether to disable browser autocorrect and related features.
-   * If you set this to `true`, it disables any native browser capabilities
-   * that automatically correct user input, such as `autocorrect` and
-   * `autocapitalize`. If you don't set it, the behavior follows the default behavior
-   * of the user's browser.
-   */
-  disableBrowserAutocorrect?: boolean;
-
-  /**
    * Adds an `aria-label` to the native control.
    *
    * Use this if you don't have a visible label for this control.
@@ -83,6 +74,18 @@ export interface BaseInputProps {
    */
   onChange?: NonCancelableEventHandler<InputProps.ChangeDetail>;
 }
+
+export interface InputAutoCorrect {
+  /**
+   * Specifies whether to disable browser autocorrect and related features.
+   * If you set this to `true`, it disables any native browser capabilities
+   * that automatically correct user input, such as `autocorrect` and
+   * `autocapitalize`. If you don't set it, the behavior follows the default behavior
+   * of the user's browser.
+   */
+  disableBrowserAutocorrect?: boolean;
+}
+
 export interface InputAutoComplete {
   /**
    * Specifies whether to enable a browser's autocomplete functionality for this input.
@@ -114,6 +117,7 @@ export interface InputProps
   extends BaseComponentProps,
     BaseInputProps,
     InputKeyEvents,
+    InputAutoCorrect,
     InputAutoComplete,
     FormFieldValidationControlProps {
   /**

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -12,7 +12,7 @@ import {
   NonCancelableEventHandler,
   getBlurEventRelatedTarget,
 } from '../internal/events';
-import { InputProps, BaseInputProps, BaseChangeDetail } from './interfaces';
+import { InputProps, BaseInputProps, InputAutoCorrect, BaseChangeDetail } from './interfaces';
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 import { useSearchProps, convertAutoComplete } from './utils';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
@@ -22,6 +22,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 export interface InternalInputProps
   extends BaseComponentProps,
     BaseInputProps,
+    InputAutoCorrect,
     InputProps,
     FormFieldValidationControlProps,
     InternalBaseComponentProps {

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -15,7 +15,13 @@ import {
   NonCancelableEventHandler,
 } from '../../events';
 import InternalInput from '../../../input/internal';
-import { BaseChangeDetail, BaseInputProps, InputKeyEvents, InputProps } from '../../../input/interfaces';
+import {
+  BaseChangeDetail,
+  BaseInputProps,
+  InputAutoCorrect,
+  InputKeyEvents,
+  InputProps,
+} from '../../../input/interfaces';
 import { getFocusables } from '../focus-lock/utils';
 import { ExpandToViewport } from '../dropdown/interfaces';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
@@ -26,6 +32,7 @@ import clsx from 'clsx';
 export interface AutosuggestInputProps
   extends BaseComponentProps,
     BaseInputProps,
+    InputAutoCorrect,
     InputKeyEvents,
     FormFieldValidationControlProps,
     ExpandToViewport,

--- a/src/textarea/interfaces.ts
+++ b/src/textarea/interfaces.ts
@@ -3,11 +3,12 @@
 import { BaseComponentProps } from '../internal/base-component';
 import { BaseKeyDetail } from '../internal/events';
 import { FormFieldValidationControlProps } from '../internal/context/form-field-context';
-import { BaseInputProps, InputAutoComplete, InputKeyEvents } from '../input/interfaces';
+import { BaseInputProps, InputAutoCorrect, InputAutoComplete, InputKeyEvents } from '../input/interfaces';
 
 export interface TextareaProps
   extends BaseInputProps,
     InputKeyEvents,
+    InputAutoCorrect,
     InputAutoComplete,
     BaseComponentProps,
     FormFieldValidationControlProps {

--- a/src/time-input/interfaces.ts
+++ b/src/time-input/interfaces.ts
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BaseChangeDetail, BaseInputProps } from '../input/interfaces';
+import { BaseChangeDetail, BaseInputProps, InputAutoCorrect } from '../input/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { FormFieldValidationControlProps } from '../internal/context/form-field-context';
 
-export interface TimeInputProps extends BaseInputProps, FormFieldValidationControlProps, BaseComponentProps {
+export interface TimeInputProps
+  extends BaseInputProps,
+    InputAutoCorrect,
+    FormFieldValidationControlProps,
+    BaseComponentProps {
   /**
    * Specifies the format of the time input.
    *


### PR DESCRIPTION
### Description

Release date input and calendar.

### How has this been tested?

Manual check of the build outputs, documenter test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

The API docs were reviewed separately in the website integration.

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
