### PR TITLE
deprecate controlid of radiogroup

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -8682,11 +8682,7 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "string",
     },
     Object {
-      "description": "Specifies the ID of the native form element. You can use it to relate
-a label element's \`for\` attribute to this control.
-It defaults to an automatically generated ID that
-is provided by its parent form field component.
-",
+      "description": "Deprecated, has no effect.",
       "name": "controlId",
       "optional": true,
       "type": "string",

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -44,6 +44,12 @@ export interface RadioGroupProps extends BaseComponentProps, FormFieldControlPro
    * Called when the user selects a different radio button. The event `detail` contains the current `value`.
    */
   onChange?: NonCancelableEventHandler<RadioGroupProps.ChangeDetail>;
+
+  /**
+   * Deprecated, has no effect.
+   * @deprecated
+   */
+  controlId?: string;
 }
 
 export namespace RadioGroupProps {


### PR DESCRIPTION
### Description

ControlId of RadioGroup has no effect. There is ControlId of individual RadioButton in RadioGroup (items), which is in use and attach to each RadioButton input. No group form element to attach to the ControlId of RadioGroup.
Decision discussed and made in doc _Checkbox-Toggle-and-Formfield-controlId-association_

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
