### PR TITLE
Make root calendar div an application to use correct navigation mode …

### DIFF
--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -114,7 +114,7 @@ export default function Calendar({
   };
 
   return (
-    // The application role is necessary for the screen-readers to allow arrow navigation by default.
+    // The application role is necessary for screen-readers to allow arrow navigation by default.
     <div role="application" className={clsx(styles.root, styles.calendar)} ref={elementRef}>
       <div className={styles['calendar-inner']}>
         <CalendarHeader

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -114,7 +114,8 @@ export default function Calendar({
   };
 
   return (
-    <div className={clsx(styles.root, styles.calendar)} ref={elementRef}>
+    // The application role is necessary for the screen-readers to allow arrow navigation by default.
+    <div role="application" className={clsx(styles.root, styles.calendar)} ref={elementRef}>
       <div className={styles['calendar-inner']}>
         <CalendarHeader
           baseDate={baseDate}

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -282,7 +282,7 @@ function Calendar(
   return (
     <>
       <InternalSpaceBetween size="m">
-        {/* The application role is necessary for the screen-readers to allow arrow navigation by default. */}
+        {/* The application role is necessary for screen-readers to allow arrow navigation by default. */}
         <div
           ref={elementRef}
           role="application"

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -282,12 +282,13 @@ function Calendar(
   return (
     <>
       <InternalSpaceBetween size="m">
+        {/* The application role is necessary for the screen-readers to allow arrow navigation by default. */}
         <div
+          ref={elementRef}
+          role="application"
           className={clsx(styles.calendar, {
             [styles['one-grid']]: isSingleGrid,
           })}
-          role="application"
-          ref={elementRef}
         >
           <CalendarHeader
             baseDate={currentMonth}


### PR DESCRIPTION
…for nvda

### Description

NVDA has browse and focus modes. By wrapping the calendar in role="application" the focus mode is chosen by default which allows arrow-keys navigation.

### How has this been tested?

Manual testing with Chrome/Firefox+NVDA.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
