### PR TITLE
fix(card): add aria label support and role for cards

### DIFF
--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -66,6 +66,15 @@ describe('Cards', () => {
       expect(wrapper.findItems()).toHaveLength(defaultItems.length);
     });
 
+    it('uses correct role for cards list based on selectionType', () => {
+      wrapper = renderCards(
+        <Cards<Item> cardDefinition={cardDefinition} items={defaultItems} selectionType="single" />
+      ).wrapper;
+
+      const cardsOrderedList = getCard(0).getElement().parentElement;
+      expect(cardsOrderedList).toHaveAttribute('role', 'group');
+    });
+
     it('correctly renders card header', () => {
       defaultItems.forEach((item, idx) => {
         wrapper = renderCards(<Cards<Item> cardDefinition={cardDefinition} items={defaultItems} />).wrapper;
@@ -158,6 +167,15 @@ describe('Cards', () => {
     it('is displayed', () => {
       wrapper = renderCards(<Cards<Item> cardDefinition={{}} items={defaultItems} header="abcedefg" />).wrapper;
       expect(wrapper.findHeader()?.getElement()).toHaveTextContent('abcedefg');
+    });
+
+    it('maintains logical relationship between header and cards', () => {
+      wrapper = renderCards(<Cards<Item> cardDefinition={{}} items={defaultItems} header="abcedefg" />).wrapper;
+      const headerElement = wrapper.findHeader()!.getElement();
+      expect(headerElement).toHaveAttribute('id');
+      const cardsOrderedList = getCard(0).getElement().parentElement;
+      expect(cardsOrderedList).toHaveAttribute('aria-labelledby', headerElement!.getAttribute('id'));
+      expect(cardsOrderedList).toHaveAttribute('aria-describedby', headerElement!.getAttribute('id'));
     });
   });
 

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -18,6 +18,7 @@ export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>,
   __disableFooterPaddings?: boolean;
   __hiddenContent?: boolean;
   __headerRef?: React.RefObject<HTMLDivElement>;
+  __headerId?: string;
   /**
    * Additional internal variant:
    * * `embedded` - Use this variant within a parent container (such as a modal,
@@ -41,6 +42,7 @@ export default function InternalContainer({
   __disableFooterPaddings = false,
   __hiddenContent = false,
   __headerRef,
+  __headerId,
   ...restProps
 }: InternalContainerProps) {
   const baseProps = getBaseProps(restProps);
@@ -53,6 +55,8 @@ export default function InternalContainer({
 
   const mergedRef = useMergeRefs(rootRef, __internalRootRef);
   const headerMergedRef = useMergeRefs(headerRef, overlapElement, __headerRef);
+
+  const headerIdProp = __headerId ? { id: __headerId } : {};
 
   return (
     <div
@@ -71,6 +75,7 @@ export default function InternalContainer({
               [styles['with-paddings']]: !disableHeaderPaddings,
               [styles['with-hidden-content']]: __hiddenContent,
             })}
+            {...headerIdProp}
             {...stickyStyles}
             ref={headerMergedRef}
           >


### PR DESCRIPTION
### Description

This PR adds aria label relation between cards header and cards. It also adds the `role` attribute on cards list.

Related Ticket: **AWSUI-19077**
### How has this been tested?
I've added some unit tests.
[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
