### PR TITLE
fix(form-field): Restore findError() selector to keep backwards compatibility

### DIFF
--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -23,13 +23,15 @@ interface FormFieldErrorProps {
 }
 
 export const FormFieldError = ({ id, children, errorIconAriaLabel }: FormFieldErrorProps) => (
-  <div id={id} className={styles.error}>
+  <div className={styles.error}>
     <div className={styles['error-icon-shake-wrapper']}>
       <div role="img" aria-label={errorIconAriaLabel} className={styles['error-icon-scale-wrapper']}>
         <InternalIcon name="status-warning" size="small" />
       </div>
     </div>
-    <span className={styles.error__message}>{children}</span>
+    <span id={id} className={styles.error__message}>
+      {children}
+    </span>
   </div>
 );
 

--- a/src/test-utils/dom/form-field/index.ts
+++ b/src/test-utils/dom/form-field/index.ts
@@ -23,7 +23,7 @@ export default class FormFieldWrapper extends ComponentWrapper<HTMLElement> {
   }
 
   findError(): ElementWrapper | null {
-    return this.find(`:scope > .${styles.hints} .${styles.error}`);
+    return this.find(`:scope > .${styles.hints} .${styles.error__message}`);
   }
 
   findDescription(): ElementWrapper | null {


### PR DESCRIPTION
### Description

#202 changed the test util to contain both the error icon and the error message, where it previously contained just the error message text. Unfortunately, this is a breaking change, so it's best to revert for now.

### How has this been tested?

No visual changes, just a "revert". This mostly only affects tests that check DOM structure instead of text, so our own tests don't fail. And I'm not inclined to write a test to assert a DOM structure.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
