### PR TITLE
fix: Label highlight in screenshot tests

### DIFF
--- a/pages/checkbox/styles.scss
+++ b/pages/checkbox/styles.scss
@@ -4,7 +4,7 @@
 */
 .highlightLabels {
   /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
-  label {
+  [class*='awsui_label-wrapper'] {
     box-shadow: 0 0 0 1px green;
   }
 }

--- a/pages/radio-group/styles.scss
+++ b/pages/radio-group/styles.scss
@@ -10,7 +10,7 @@
 
 .highlightLabels {
   /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
-  label {
+  [class*='awsui_label-wrapper'] {
     box-shadow: 0 0 0 1px green;
   }
 }

--- a/pages/toggle/styles.scss
+++ b/pages/toggle/styles.scss
@@ -4,7 +4,7 @@
 */
 .highlightLabels {
   /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
-  label {
+  [class*='awsui_label-wrapper'] {
     box-shadow: 0 0 0 1px green;
   }
 }

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -51,8 +51,6 @@ export default function AbstractSwitch({
   const labelId = `${id}-label`;
   const descriptionId = `${id}-description`;
 
-  const wrapperAttributes: Record<string, string | undefined> = {};
-
   const ariaLabelledByIds = [];
   if (label) {
     ariaLabelledByIds.push(labelId);
@@ -72,7 +70,6 @@ export default function AbstractSwitch({
   return (
     <div {...rest} className={clsx(styles.wrapper, rest.className)} ref={__internalRootRef}>
       <div
-        {...wrapperAttributes}
         className={styles['label-wrapper']}
         aria-disabled={disabled ? 'true' : undefined}
         onClick={disabled ? undefined : onClick}


### PR DESCRIPTION
### Description

This updates the selector in the custom styles used in our screenshot test. The test checks that the clickable area does not change.


### How has this been tested?
Manual testing in dev pages (e.g. http://localhost:8080/#/light/checkbox/labels-highlight )


### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
