### PR TITLE
Use correct locale for start of week in calendar

### DIFF
--- a/pages/calendar/integ.page.tsx
+++ b/pages/calendar/integ.page.tsx
@@ -14,7 +14,7 @@ export default function DatePickerEditorScenario() {
       <br />
       <Calendar
         value={value}
-        locale={'en-EN'}
+        locale="en-GB"
         previousMonthAriaLabel={'Previous month'}
         nextMonthAriaLabel={'Next month'}
         todayAriaLabel="Today"

--- a/pages/calendar/simple.page.tsx
+++ b/pages/calendar/simple.page.tsx
@@ -19,7 +19,7 @@ export default function CalendarPage() {
         <Calendar
           value="2021-8-20"
           onChange={() => {}}
-          locale="en-EN"
+          locale="en-GB"
           startOfWeek={1}
           isDateEnabled={date => date.getDay() !== 6 && date.getDay() !== 0}
           nextMonthAriaLabel="Next month"
@@ -29,7 +29,7 @@ export default function CalendarPage() {
         <Calendar
           value=""
           onChange={() => {}}
-          locale="en-EN"
+          locale="en-GB"
           startOfWeek={1}
           isDateEnabled={date => date.getDay() !== 6 && date.getDay() !== 0}
           nextMonthAriaLabel="Next month"

--- a/pages/date-picker/permutations.page.tsx
+++ b/pages/date-picker/permutations.page.tsx
@@ -40,7 +40,7 @@ export default function DatePickerScenario() {
               value={'2020-10-26'}
               name={'date-picker-name'}
               ariaLabel={'date-picker-label'}
-              locale={'en-EN'}
+              locale="en-GB"
               previousMonthAriaLabel={'Previous month'}
               nextMonthAriaLabel={'Next month'}
               todayAriaLabel={'TEST TODAY'}

--- a/pages/date-picker/positioning.page.tsx
+++ b/pages/date-picker/positioning.page.tsx
@@ -18,7 +18,7 @@ export default function DatePickerScenario() {
           value={''}
           name={'date-picker-name'}
           ariaLabel={'date-picker-label'}
-          locale={'en-EN'}
+          locale="en-GB"
           previousMonthAriaLabel={'Previous month'}
           nextMonthAriaLabel={'Next month'}
           todayAriaLabel={'TEST TODAY'}

--- a/pages/date-picker/simple.page.tsx
+++ b/pages/date-picker/simple.page.tsx
@@ -15,7 +15,7 @@ export default function DatePickerScenario() {
         value={value}
         name={'date-picker-name'}
         ariaLabel={'date-picker-label'}
-        locale={'en-EN'}
+        locale="en-GB"
         previousMonthAriaLabel={'Previous month'}
         nextMonthAriaLabel={'Next month'}
         todayAriaLabel={'TEST TODAY'}

--- a/pages/date-picker/with-default-date.page.tsx
+++ b/pages/date-picker/with-default-date.page.tsx
@@ -16,7 +16,7 @@ export default function DatePickerScenario() {
         value={value}
         name={'date-picker-name'}
         ariaLabel={'date-picker-label'}
-        locale={'en-EN'}
+        locale="en-GB"
         previousMonthAriaLabel={'Previous month'}
         nextMonthAriaLabel={'Next month'}
         todayAriaLabel={'TEST TODAY'}

--- a/pages/date-picker/with-event-handlers.page.tsx
+++ b/pages/date-picker/with-event-handlers.page.tsx
@@ -57,7 +57,7 @@ export default function DatePickerScenario() {
         value={value}
         name={'date-picker-name'}
         ariaLabel={'date-picker-label'}
-        locale={'en-EN'}
+        locale="en-GB"
         previousMonthAriaLabel={'Previous month'}
         nextMonthAriaLabel={'Next month'}
         todayAriaLabel={'TEST TODAY'}

--- a/pages/date-range-picker/embedded.page.tsx
+++ b/pages/date-range-picker/embedded.page.tsx
@@ -22,7 +22,7 @@ export default function DatePickerScenario() {
             startOfWeek={0}
             isDateEnabled={() => true}
             value={value}
-            locale={'en-EN'}
+            locale="en-GB"
             i18nStrings={i18nStrings}
             relativeOptions={relativeOptions}
             dateOnly={false}

--- a/pages/date-range-picker/simple.page.tsx
+++ b/pages/date-range-picker/simple.page.tsx
@@ -44,7 +44,7 @@ export default function DatePickerScenario() {
         <FormField label="Date Range Picker field">
           <DateRangePicker
             value={value}
-            locale={'en-EN'}
+            locale="en-GB"
             i18nStrings={dateOnly ? i18nStringsDateOnly : i18nStrings}
             placeholder={'Filter by a date and time range'}
             onChange={e => setValue(e.detail.value)}

--- a/pages/date-range-picker/small-viewport.page.tsx
+++ b/pages/date-range-picker/small-viewport.page.tsx
@@ -27,7 +27,7 @@ export default function DatePickerScenario() {
           <FormField label="Date Range Picker field">
             <DateRangePicker
               value={value}
-              locale="en-EN"
+              locale="en-GB"
               i18nStrings={i18nStrings}
               placeholder="Filter by a date and time range"
               onChange={e => setValue(e.detail.value)}

--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -11,22 +11,52 @@ import CalendarWrapper from '../../../lib/components/test-utils/dom/calendar';
 
 // The calendar is mostly tested here: src/date-picker/__tests__/date-picker-calendar.test.tsx
 
+const defaultProps: CalendarProps = {
+  todayAriaLabel: 'Today',
+  nextMonthAriaLabel: 'next month',
+  previousMonthAriaLabel: 'prev month',
+  value: '',
+};
+
+function renderCalendar(props: CalendarProps = defaultProps) {
+  const { container } = render(<Calendar {...props} />);
+  const wrapper = createWrapper(container) as unknown as CalendarWrapper;
+  return { container, wrapper };
+}
+
+function findCalendarWeekdays(wrapper: CalendarWrapper) {
+  return wrapper.findAll(`.${styles['calendar-day-name']}`).map(day => day.getElement().textContent!.trim());
+}
+
 describe('Calendar', () => {
-  const defaultProps: CalendarProps = {
-    todayAriaLabel: 'Today',
-    nextMonthAriaLabel: 'next month',
-    previousMonthAriaLabel: 'prev month',
-    value: '2018-03-22',
-  };
-
-  function renderCalendar(props: CalendarProps = defaultProps) {
-    const { container, getByTestId } = render(<Calendar {...props} />);
-    const wrapper = createWrapper(container).findComponent(`.${styles.root}`, CalendarWrapper);
-    return { container, wrapper, getByTestId };
-  }
-
   test('check a11y', async () => {
     const { container } = renderCalendar();
     await expect(container).toValidateA11y();
+  });
+});
+
+describe('Calendar locale US', () => {
+  beforeEach(() => {
+    const locale = new Intl.DateTimeFormat('en-US', { timeZone: 'EST' });
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => locale);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  test('start of the week is Sunday', () => {
+    const { wrapper } = renderCalendar();
+    expect(findCalendarWeekdays(wrapper)[0]).toBe('Sun');
+  });
+});
+
+describe('Calendar locale DE', () => {
+  beforeEach(() => {
+    const locale = new Intl.DateTimeFormat('de-DE', { timeZone: 'GMT' });
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => locale);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  test('start of the week is Monday', () => {
+    const { wrapper } = renderCalendar();
+    expect(findCalendarWeekdays(wrapper)[0]).toBe('Mo');
   });
 });

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -31,7 +31,7 @@ export default function Calendar({
   checkControlled('Calendar', 'value', value, 'onChange', onChange);
 
   const normalizedLocale = normalizeLocale('Calendar', locale);
-  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, locale);
+  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, normalizedLocale);
   const elementRef = useRef<HTMLDivElement>(null);
   const gridWrapperRef = useRef<HTMLDivElement>(null);
   const [focusedDate, setFocusedDate] = useState<Date | null>(null);


### PR DESCRIPTION
### Description

Use normalised locale for start of week calculation in calendar.

### How has this been tested?

Manual check with dev-tool sensors and unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
