### PR TITLE
fix: Ensure switches don't fire onChange when disabled

### DIFF
--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import Button, { ButtonProps } from '../../../lib/components/button';
 import createWrapper, { ButtonWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/button/styles.css.js';
@@ -291,9 +291,12 @@ describe('Button Component', () => {
 
   describe('Loading property', () => {
     test("should disable the button when in 'loading' status", () => {
-      const wrapper = renderButton({ loading: true });
+      const onClickSpy = jest.fn();
+      const wrapper = renderButton({ onClick: onClickSpy, loading: true });
       expect(wrapper.findLoadingIndicator()).not.toBeNull();
       expect(wrapper.getElement()).toHaveAttribute('disabled');
+      act(() => wrapper.click());
+      expect(onClickSpy).not.toHaveBeenCalled();
     });
 
     test('gives loading precendence over disabled', () => {
@@ -386,6 +389,13 @@ describe('Button Component', () => {
     test('does not call onClick on link buttons when button is disabled', () => {
       const onClickSpy = jest.fn();
       const wrapper = renderButton({ onClick: onClickSpy, disabled: true, href: 'https://amazon.com' });
+      wrapper.click();
+      expect(onClickSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not call onClick on regular buttons when button is disabled', () => {
+      const onClickSpy = jest.fn();
+      const wrapper = renderButton({ onClick: onClickSpy, disabled: true });
       wrapper.click();
       expect(onClickSpy).not.toHaveBeenCalled();
     });

--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import RadioGroup, { RadioGroupProps } from '../../../lib/components/radio-group';
 import RadioButtonWrapper from '../../../lib/components/test-utils/dom/radio-group/radio-button';
@@ -93,6 +93,16 @@ describe('items', () => {
 
     expect(items[0].findNativeInput().getElement()).toBeEnabled();
     expect(items[1].findNativeInput().getElement()).toBeEnabled();
+  });
+
+  test('does not trigger change handler if disabled', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={[defaultItems[0], { ...defaultItems[1], disabled: true }]} onChange={onChange} />
+    );
+
+    act(() => wrapper.findButtons()[1].findLabel().click());
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('displays the proper label', () => {

--- a/src/tiles/__tests__/tiles.test.tsx
+++ b/src/tiles/__tests__/tiles.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import createWrapper, { ElementWrapper, TilesWrapper } from '../../../lib/components/test-utils/dom';
 import TileWrapper from '../../../lib/components/test-utils/dom/tiles/tile';
 import Tiles, { TilesProps } from '../../../lib/components/tiles';
@@ -79,6 +79,16 @@ describe('items', () => {
     rerender(<Tiles value={null} items={defaultItems} onChange={onChange} />);
     expect(items[0].findNativeInput().getElement()).toBeEnabled();
     expect(items[1].findNativeInput().getElement()).toBeEnabled();
+  });
+
+  test('does not trigger change handler if disabled', () => {
+    const onChange = jest.fn();
+    const { wrapper } = renderTiles(
+      <Tiles value={null} items={[defaultItems[0], { ...defaultItems[1], disabled: true }]} onChange={onChange} />
+    );
+
+    act(() => wrapper.findItems()[1].findLabel().click());
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   test('displays the proper label', () => {

--- a/src/tiles/internal.tsx
+++ b/src/tiles/internal.tsx
@@ -77,7 +77,9 @@ export default function InternalTiles({
                 )}
                 key={item.value}
                 data-value={item.value}
-                onClick={() => item.value !== value && fireNonCancelableEvent(onChange, { value: item.value })}
+                onClick={() =>
+                  !item.disabled && item.value !== value && fireNonCancelableEvent(onChange, { value: item.value })
+                }
               >
                 <div className={clsx(styles.control, { [styles['no-image']]: !item.image })}>
                   <RadioButton

--- a/src/toggle/__tests__/toggle.test.tsx
+++ b/src/toggle/__tests__/toggle.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import createWrapper, { ToggleWrapper } from '../../../lib/components/test-utils/dom';
 import Toggle, { ToggleProps } from '../../../lib/components/toggle';
 import FormField from '../../../lib/components/form-field';
@@ -73,7 +73,7 @@ test('does not trigger change handler if disabled', () => {
   const onChange = jest.fn();
   const { wrapper } = renderToggle(<Toggle checked={false} disabled={true} onChange={onChange} />);
 
-  wrapper.findLabel().click();
+  act(() => wrapper.findLabel().click());
 
   expect(wrapper.findNativeInput().getElement()).not.toBeChecked();
   expect(onChange).not.toHaveBeenCalled();


### PR DESCRIPTION
### Description

This fixes a regression in the Tiles component (being clickable when disabled) and adds tests for all components that use the AbstractSwitch internal component, as well as for the Button component.


### How has this been tested?

[_How did you test to verify your changes?_]
Manual testing in dev pages and added unit tests


[_How can reviewers test these changes efficiently?_]
Visit http://localhost:8080/#/light/tiles/simple and click on the disabled Tile.

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
