### PR TITLE
fix(split-panel): Align resize handle with cursor

### DIFF
--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -32,6 +32,7 @@ interface TransitionContentProps {
   baseProps: BaseComponentProps;
   isOpen?: boolean;
   splitPanelRef?: React.Ref<any>;
+  handleRef: React.RefObject<HTMLDivElement>;
   bottomOffset: number;
   cappedSize: number;
   isRefresh: boolean;
@@ -54,6 +55,7 @@ const TransitionContentSide = ({
   baseProps,
   isOpen,
   splitPanelRef,
+  handleRef,
   topOffset,
   bottomOffset,
   cappedSize,
@@ -102,6 +104,7 @@ const TransitionContentSide = ({
               className={clsx(styles.slider, styles['slider-side'])}
               onKeyDown={onKeyDown}
               onPointerDown={onSliderPointerDown}
+              ref={handleRef}
               {...focusVisible}
             >
               <ResizeHandler className={clsx(styles['slider-icon'], styles['slider-icon-side'])} />
@@ -144,6 +147,7 @@ const TransitionContentBottom = ({
   baseProps,
   isOpen,
   splitPanelRef,
+  handleRef,
   bottomOffset,
   cappedSize,
   isRefresh,
@@ -197,6 +201,7 @@ const TransitionContentBottom = ({
             className={clsx(styles.slider, styles['slider-bottom'])}
             onKeyDown={onKeyDown}
             onPointerDown={onSliderPointerDown}
+            ref={handleRef}
             {...focusVisible}
           >
             <ResizeHandler className={clsx(styles['slider-icon'], styles['slider-icon-bottom'])} />
@@ -303,10 +308,13 @@ export default function SplitPanel({
     }
   };
 
-  const splitPanelRefObject = useRef(null);
+  const splitPanelRefObject = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<HTMLDivElement>(null);
+
   const sizeControlProps: SizeControlProps = {
     position,
     splitPanelRef: splitPanelRefObject,
+    handleRef,
     setSidePanelWidth,
     setBottomPanelHeight,
   };
@@ -438,6 +446,7 @@ export default function SplitPanel({
               baseProps={baseProps}
               isOpen={isOpen}
               splitPanelRef={mergedRef}
+              handleRef={handleRef}
               topOffset={topOffset}
               bottomOffset={bottomOffset}
               cappedSize={cappedSize}
@@ -459,6 +468,7 @@ export default function SplitPanel({
               baseProps={baseProps}
               isOpen={isOpen}
               splitPanelRef={mergedRef}
+              handleRef={handleRef}
               bottomOffset={bottomOffset}
               cappedSize={cappedSize}
               isRefresh={isRefresh}

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -46,6 +46,7 @@ export namespace SplitPanelProps {
 export interface SizeControlProps {
   position: 'side' | 'bottom';
   splitPanelRef?: React.RefObject<HTMLDivElement>;
+  handleRef?: React.RefObject<HTMLDivElement>;
   setSidePanelWidth: (width: number) => void;
   setBottomPanelHeight: (height: number) => void;
 }

--- a/src/split-panel/utils/use-pointer-events.ts
+++ b/src/split-panel/utils/use-pointer-events.ts
@@ -7,26 +7,35 @@ import styles from '../styles.css.js';
 export const usePointerEvents = ({
   position,
   splitPanelRef,
+  handleRef,
   setSidePanelWidth,
   setBottomPanelHeight,
 }: SizeControlProps) => {
   const onDocumentPointerMove = useCallback(
     (event: PointerEvent) => {
-      if (!splitPanelRef || !splitPanelRef.current) {
+      if (!splitPanelRef || !splitPanelRef.current || !handleRef || !handleRef.current) {
         return;
       }
 
       if (position === 'side') {
         const mouseClientX = event.clientX;
-        const width = splitPanelRef.current.getBoundingClientRect().right - mouseClientX;
+
+        // The handle offset aligns the cursor with the middle of the resize handle.
+        const handleOffset = handleRef.current.getBoundingClientRect().width / 2;
+        const width = splitPanelRef.current.getBoundingClientRect().right - mouseClientX + handleOffset;
+
         setSidePanelWidth(width);
       } else {
         const mouseClientY = event.clientY;
-        const height = splitPanelRef.current.getBoundingClientRect().bottom - mouseClientY;
+
+        // The handle offset aligns the cursor with the middle of the resize handle.
+        const handleOffset = handleRef.current.getBoundingClientRect().height / 2;
+        const height = splitPanelRef.current.getBoundingClientRect().bottom - mouseClientY + handleOffset;
+
         setBottomPanelHeight(height);
       }
     },
-    [position, splitPanelRef, setSidePanelWidth, setBottomPanelHeight]
+    [position, splitPanelRef, handleRef, setSidePanelWidth, setBottomPanelHeight]
   );
 
   const onDocumentPointerUp = useCallback(() => {


### PR DESCRIPTION
### Description

This change updates the calculation of the size of the split panel so that the resize handle is always centered on the cursor while dragging.


_Before: the resize handle is slightly lower than the cursor_
![Screenshot of the resize handle of a split panel, with a misaligned mouse cursor on it.](https://user-images.githubusercontent.com/9086585/191950951-bc7c7395-60da-4e65-a032-acfbcc93316e.jpg)


_After: the resize handle is centered on the cursor_
![Screenshot of the resize handle of a split panel, with a centered mouse cursor on it.](https://user-images.githubusercontent.com/9086585/191950944-4e3f22a8-5153-44b9-bfd7-d143a9763479.jpg)

### How has this been tested?

Manual testing in dev pages (http://localhost:8080/#/light/app-layout/with-split-panel), in both bottom and side position.

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
