### PR TITLE
fix(input): Prevent scrolling from changing value of number inputs

### DIFF
--- a/src/input/__tests__/input.test.tsx
+++ b/src/input/__tests__/input.test.tsx
@@ -399,4 +399,13 @@ describe('Input', () => {
       expect(keyUpSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  test('input is blurred when type=number and scrolled over', () => {
+    const blurSpy = jest.fn();
+    const { wrapper, input } = renderInput({ type: 'number', onBlur: blurSpy });
+    wrapper.focus();
+    expect(blurSpy).not.toHaveBeenCalled();
+    fireEvent.wheel(input);
+    expect(blurSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -141,6 +141,14 @@ function InternalInput(
     ...__nativeAttributes,
   };
 
+  if (type === 'number') {
+    // Chrome and Safari have a weird built-in behavior of letting focused
+    // number inputs be controlled by scrolling on them. However, they don't
+    // lock the browser's scroll, so it's very easy to accidentally increment
+    // the input while scrolling down the page.
+    attributes.onWheel = event => event.currentTarget.blur();
+  }
+
   if (disableBrowserAutocorrect) {
     attributes.autoCorrect = 'off';
     attributes.autoCapitalize = 'off';


### PR DESCRIPTION
### Description

Comment in the code explains it all.

    // Chrome and Safari have a weird built-in behavior of letting focused
    // number inputs be controlled by scrolling on them. However, they don't
    // lock the browser's scroll, so it's very easy to accidentally increment
    // the input while scrolling down the page.

Limiting the scope of this to number inputs because Firefox also fires wheel events as the mouse goes past the input, and not just starting a scroll on it like it does with Safari and Chrome. So if this starts happening everywhere, it would get annoying.

### How has this been tested?

Couldn't really figure my way around emulating "real" scroll with webdriverio, so I just went with the unit test route.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-19371


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._
  - Don't know enough about "scrolling" with accessibility software, but this is only an issue with pointing devices.

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
