### PR TITLE
feat: Grow content area if additional vertical space is available

### DIFF
--- a/pages/container/simple.page.tsx
+++ b/pages/container/simple.page.tsx
@@ -97,6 +97,11 @@ export default function SimpleContainers() {
               tortor, mollis vitae molestie sed, malesuada.
             </Container>
           </div>
+          <div style={{ display: 'grid', minHeight: 300 }}>
+            <Container header={<Header variant="h2">Fixed Height Container</Header>} footer="Footer">
+              Content area takes the available vertical space
+            </Container>
+          </div>
         </SpaceBetween>
       </ScreenshotArea>
     </article>

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -9,18 +9,22 @@
 
 .root {
   @include styles.styles-reset;
-  display: block;
+  display: flex;
+  flex-flow: column nowrap;
   word-wrap: break-word;
+
   &.variant {
     &-default,
     &-stacked {
       @include shared.borders-and-shadows;
       background-color: awsui.$color-background-container-content;
     }
+
     &-stacked:not(:last-child) {
       border-bottom-right-radius: 0;
       border-bottom-left-radius: 0;
     }
+
     &-stacked + &-stacked {
       @include shared.divider;
       border-top-left-radius: 0;
@@ -31,6 +35,7 @@
 }
 
 .header {
+  flex: 0 0 auto;
   background-color: awsui.$color-background-container-header;
   border-top-left-radius: awsui.$border-radius-container;
   border-top-right-radius: awsui.$border-radius-container;
@@ -41,31 +46,38 @@
     position: relative;
     z-index: 1;
   }
+
   &-sticky-enabled {
     top: 0;
     /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     position: sticky;
     z-index: 800;
   }
+
   &-stuck {
     box-shadow: awsui.$shadow-sticky-embedded;
     border: 0;
     border-radius: 0;
   }
+
   &-dynamic-height.header-stuck {
     // to prevent the block from changing its height when variant dynamically changes
     margin-bottom: calc(#{awsui.$font-heading-xl-line-height} - #{awsui.$font-heading-l-line-height});
   }
+
   &:not(:empty) {
     border-bottom: awsui.$border-container-sticky-width solid awsui.$color-border-container-divider;
   }
+
   &.with-paddings {
     padding: shared.$header-padding;
   }
+
   &.with-hidden-content {
     border-bottom-left-radius: awsui.$border-radius-container;
     border-bottom-right-radius: awsui.$border-radius-container;
   }
+
   &-variant-cards {
     @include shared.borders-and-shadows;
 
@@ -73,16 +85,19 @@
       // bottom shadow does not appear in IE11 due to the presence of background color
       // Adding a bottom border
       border-bottom: 1px solid #d5dbdb;
+
       /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
       @supports (--css-variable-support-check: #000) {
         border-bottom: 0;
       }
     }
+
     &.header-stuck {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
     }
   }
+
   &-variant-full-page.header-stuck {
     box-shadow: awsui.$shadow-sticky;
   }
@@ -96,17 +111,25 @@ the default white background of the container component.
   background-color: awsui.$color-background-layout-main;
 }
 
-.content.with-paddings {
-  padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
-  .header + & {
-    padding-top: awsui.$space-container-content-top;
+.content {
+  flex: auto;
+
+  &.with-paddings {
+    padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
+
+    .header + & {
+      padding-top: awsui.$space-container-content-top;
+    }
   }
 }
 
 .footer {
+  flex: 0 0 auto;
+
   &.with-paddings {
     padding: shared.$footer-padding;
   }
+
   &.with-divider {
     @include shared.divider;
   }

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -112,7 +112,7 @@ the default white background of the container component.
 }
 
 .content {
-  flex: auto;
+  flex: 1 0 auto;
 
   &.with-paddings {
     padding: awsui.$space-scaled-l awsui.$space-container-horizontal;


### PR DESCRIPTION
### Description

Prior, a fixed height container (for example placed in a 1x1 Grid) would place the footer at the end of the content area and consuming additional vertical space in the footer. This change ensure that the footer sticks to the bottom and gives additional vertical space to the content slot.


### How has this been tested?

Screenshot test

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
