### PR TITLE
fix: Properly set `aria-expanded` on breadcrumb group ellipsis

### DIFF
--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import styles from '../../../lib/components/breadcrumb-group/styles.css.js';
 import itemStyles from '../../../lib/components/breadcrumb-group/item/styles.css.js';
 
@@ -88,6 +88,14 @@ describe('BreadcrumbGroup Component', () => {
         'aria-label',
         'Custom Show path label'
       );
+    });
+
+    test('has proper aria-expanded state on ellipsis button', () => {
+      const button = wrapper.findDropdown()?.findNativeButton();
+
+      expect(button?.getElement()).toHaveAttribute('aria-expanded', 'false');
+      act(() => button?.click());
+      expect(button?.getElement()).toHaveAttribute('aria-expanded', 'true');
     });
 
     test('test-utils findBreadcrumbLink selector properly skip ellipsis item', () => {

--- a/src/breadcrumb-group/internal.tsx
+++ b/src/breadcrumb-group/internal.tsx
@@ -32,8 +32,7 @@ const DropdownTrigger = (
         clickHandler();
       }}
       ref={ref}
-      aria-expanded={isExpanded ? true : undefined}
-      aria-haspopup={true}
+      ariaExpanded={isExpanded}
       ariaLabel={ariaLabel}
       variant="breadcrumb-group"
       formAction="none"


### PR DESCRIPTION
### Description
The ellipsis in the breadcrumb groups is a custom trigger for a button dropdown. As per recommendation, we now set `aria-expanded` to true or false depending on the state.

### How has this been tested?
Tested manually with VoiceOver. Also added another unit test for coverage.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-18956


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
