### PR TITLE
fix(split-panel): Support touch events for slider

### DIFF
--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -15,9 +15,9 @@ jest.mock('../../../lib/components/split-panel/utils/use-keyboard-events', () =>
   useKeyboardEvents: () => onKeyDown,
 }));
 
-const onSliderMouseDown = jest.fn();
-jest.mock('../../../lib/components/split-panel/utils/use-mouse-events', () => ({
-  useMouseEvents: () => onSliderMouseDown,
+const onSliderPointerDown = jest.fn();
+jest.mock('../../../lib/components/split-panel/utils/use-pointer-events', () => ({
+  usePointerEvents: () => onSliderPointerDown,
 }));
 
 const i18nStrings = {
@@ -159,11 +159,11 @@ describe('Split panel', () => {
         expect(onKeyDown).toHaveBeenCalledTimes(1);
       });
 
-      test('fires mouseDown', () => {
-        onSliderMouseDown.mockClear();
+      test('fires pointerDown', () => {
+        onSliderPointerDown.mockClear();
         const { wrapper } = renderSplitPanel({ contextProps: { position } });
-        fireEvent.mouseDown(wrapper.findSlider()!.getElement());
-        expect(onSliderMouseDown).toHaveBeenCalledTimes(1);
+        fireEvent.pointerDown(wrapper.findSlider()!.getElement());
+        expect(onSliderPointerDown).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -12,7 +12,7 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { SplitPanelProps, SizeControlProps } from './interfaces';
 import ResizeHandler from './icons/resize-handler';
 import PreferencesModal from './preferences-modal';
-import { useMouseEvents } from './utils/use-mouse-events';
+import { usePointerEvents } from './utils/use-pointer-events';
 import { useKeyboardEvents } from './utils/use-keyboard-events';
 
 import styles from './styles.css.js';
@@ -39,7 +39,7 @@ interface TransitionContentProps {
   i18nStrings: SplitPanelProps.I18nStrings;
   relativeSize: number;
   onKeyDown: (event: React.KeyboardEvent<Element>) => void;
-  onSliderMouseDown: () => void;
+  onSliderPointerDown: () => void;
   focusVisible: { 'data-awsui-focus-visible': true } | { 'data-awsui-focus-visible'?: undefined };
   paneHeader: JSX.Element;
   wrappedChildren: JSX.Element;
@@ -62,7 +62,7 @@ const TransitionContentSide = ({
   i18nStrings,
   relativeSize,
   onKeyDown,
-  onSliderMouseDown,
+  onSliderPointerDown,
   focusVisible,
   toggleRef,
   paneHeader,
@@ -101,7 +101,7 @@ const TransitionContentSide = ({
               aria-valuenow={relativeSize}
               className={clsx(styles.slider, styles['slider-side'])}
               onKeyDown={onKeyDown}
-              onMouseDown={onSliderMouseDown}
+              onPointerDown={onSliderPointerDown}
               {...focusVisible}
             >
               <ResizeHandler className={clsx(styles['slider-icon'], styles['slider-icon-side'])} />
@@ -151,7 +151,7 @@ const TransitionContentBottom = ({
   i18nStrings,
   relativeSize,
   onKeyDown,
-  onSliderMouseDown,
+  onSliderPointerDown,
   focusVisible,
   paneHeader,
   wrappedChildren,
@@ -196,7 +196,7 @@ const TransitionContentBottom = ({
             aria-valuenow={relativeSize}
             className={clsx(styles.slider, styles['slider-bottom'])}
             onKeyDown={onKeyDown}
-            onMouseDown={onSliderMouseDown}
+            onPointerDown={onSliderPointerDown}
             {...focusVisible}
           >
             <ResizeHandler className={clsx(styles['slider-icon'], styles['slider-icon-bottom'])} />
@@ -310,7 +310,7 @@ export default function SplitPanel({
     setSidePanelWidth,
     setBottomPanelHeight,
   };
-  const onSliderMouseDown = useMouseEvents(sizeControlProps);
+  const onSliderPointerDown = usePointerEvents(sizeControlProps);
   const onKeyDown = useKeyboardEvents(sizeControlProps);
 
   const toggleRef = useRef<ButtonProps.Ref>(null);
@@ -446,7 +446,7 @@ export default function SplitPanel({
               i18nStrings={i18nStrings}
               relativeSize={relativeSize}
               onKeyDown={onKeyDown}
-              onSliderMouseDown={onSliderMouseDown}
+              onSliderPointerDown={onSliderPointerDown}
               focusVisible={focusVisible}
               toggleRef={toggleRef}
               paneHeader={paneHeader}
@@ -466,7 +466,7 @@ export default function SplitPanel({
               i18nStrings={i18nStrings}
               relativeSize={relativeSize}
               onKeyDown={onKeyDown}
-              onSliderMouseDown={onSliderMouseDown}
+              onSliderPointerDown={onSliderPointerDown}
               focusVisible={focusVisible}
               paneHeader={paneHeader}
               wrappedChildren={wrappedChildren}

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -133,6 +133,9 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   cursor: ns-resize;
   margin: 2px 0 0 0;
   height: $slider-width;
+  // Desktop Safari doesn't support touch events, but Safari on iOS does.
+  // stylelint-disable-next-line plugin/no-unsupported-browser-features
+  touch-action: none;
 
   &:focus {
     outline: none;

--- a/src/split-panel/utils/use-pointer-events.ts
+++ b/src/split-panel/utils/use-pointer-events.ts
@@ -4,14 +4,14 @@ import { useCallback } from 'react';
 import { SizeControlProps } from '../interfaces';
 import styles from '../styles.css.js';
 
-export const useMouseEvents = ({
+export const usePointerEvents = ({
   position,
   splitPanelRef,
   setSidePanelWidth,
   setBottomPanelHeight,
 }: SizeControlProps) => {
-  const onDocumentMouseMove = useCallback(
-    (event: MouseEvent) => {
+  const onDocumentPointerMove = useCallback(
+    (event: PointerEvent) => {
       if (!splitPanelRef || !splitPanelRef.current) {
         return;
       }
@@ -19,31 +19,29 @@ export const useMouseEvents = ({
       if (position === 'side') {
         const mouseClientX = event.clientX;
         const width = splitPanelRef.current.getBoundingClientRect().right - mouseClientX;
-
         setSidePanelWidth(width);
       } else {
         const mouseClientY = event.clientY;
         const height = splitPanelRef.current.getBoundingClientRect().bottom - mouseClientY;
-
         setBottomPanelHeight(height);
       }
     },
     [position, splitPanelRef, setSidePanelWidth, setBottomPanelHeight]
   );
 
-  const onDocumentMouseUp = useCallback(() => {
+  const onDocumentPointerUp = useCallback(() => {
     document.body.classList.remove(styles['resize-active']);
     document.body.classList.remove(styles[`resize-${position}`]);
-    document.removeEventListener('mouseup', onDocumentMouseUp);
-    document.removeEventListener('mousemove', onDocumentMouseMove);
-  }, [onDocumentMouseMove, position]);
+    document.removeEventListener('pointerup', onDocumentPointerUp);
+    document.removeEventListener('pointermove', onDocumentPointerMove);
+  }, [onDocumentPointerMove, position]);
 
-  const onSliderMouseDown = useCallback(() => {
+  const onSliderPointerDown = useCallback(() => {
     document.body.classList.add(styles['resize-active']);
     document.body.classList.add(styles[`resize-${position}`]);
-    document.addEventListener('mouseup', onDocumentMouseUp);
-    document.addEventListener('mousemove', onDocumentMouseMove);
-  }, [onDocumentMouseMove, onDocumentMouseUp, position]);
+    document.addEventListener('pointerup', onDocumentPointerUp);
+    document.addEventListener('pointermove', onDocumentPointerMove);
+  }, [onDocumentPointerMove, onDocumentPointerUp, position]);
 
-  return onSliderMouseDown;
+  return onSliderPointerDown;
 };


### PR DESCRIPTION
### Description

https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events

Basically, renamed all "mouse event" stuff to be "pointer event" stuff.

### How has this been tested?

Locally, with unit tests preserved. I would encourage playing around with this on your phones too, but keep in mind you'll have to pull out your phone for this because desktop browsers don't fire touch events.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
  - https://caniuse.com/pointer
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
