### PR TITLE
feat: Add ability to add aria-label to View button in S3 Resource Selector

### DIFF
--- a/pages/s3-resource-selector/data/i18n-strings.ts
+++ b/pages/s3-resource-selector/data/i18n-strings.ts
@@ -7,6 +7,7 @@ export const i18nStrings: S3ResourceSelectorProps.I18nStrings = {
   inContextSelectPlaceholder: 'Choose a version',
   inContextBrowseButton: 'Browse S3',
   inContextViewButton: 'View',
+  inContextViewButtonAriaLabel: 'View (opens a new tab)',
   inContextLoadingText: 'Loading resource',
   inContextUriLabel: 'Resource URI',
   inContextVersionSelectLabel: 'Object version',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -9183,6 +9183,11 @@ The return type of the function should be a promise that resolves to a list of v
             "type": "string",
           },
           Object {
+            "name": "inContextViewButtonAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "labelBreadcrumbs",
             "optional": false,
             "type": "string",

--- a/src/s3-resource-selector/__tests__/fixtures.ts
+++ b/src/s3-resource-selector/__tests__/fixtures.ts
@@ -13,6 +13,7 @@ export const i18nStrings: S3ResourceSelectorProps.I18nStrings = {
   inContextSelectPlaceholder: 'Choose a version',
   inContextBrowseButton: 'Browse S3',
   inContextViewButton: 'View',
+  inContextViewButtonAriaLabel: 'View (opens a new tab)',
   inContextLoadingText: 'Loading resource',
   inContextUriLabel: 'Resource URI',
   inContextVersionSelectLabel: 'Object version',

--- a/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
+++ b/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
@@ -132,6 +132,7 @@ test('has view button with href and target', () => {
   const viewButton = wrapper.findViewButton().getElement();
   expect(viewButton).toHaveAttribute('href', 'https://s3.console.aws.amazon.com/');
   expect(viewButton).toHaveAttribute('target', '_blank');
+  expect(viewButton).toHaveAttribute('aria-label', 'View (opens a new tab)');
 });
 
 describe('fetchVersions', () => {

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -169,6 +169,7 @@ export namespace S3ResourceSelectorProps {
     inContextSelectPlaceholder: string;
     inContextBrowseButton: string;
     inContextViewButton: string;
+    inContextViewButtonAriaLabel?: string;
     inContextLoadingText: string;
     inContextUriLabel: string;
     inContextVersionSelectLabel: string;

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -122,6 +122,7 @@ export const S3InContext = React.forwardRef(
               iconName="external"
               iconAlign="right"
               formAction="none"
+              ariaLabel={i18nStrings?.inContextViewButtonAriaLabel}
             >
               {i18nStrings?.inContextViewButton}
             </InternalButton>


### PR DESCRIPTION
### Description

Adds a new key `inContextViewButtonAriaLabel` to the `i18nStrings` of S3 Resource Selector to assign an `aria-label` to the View button.

### How has this been tested?

Tested manually. Adjusted unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-19209


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
