### PR TITLE
feat: Add `headerAriaLabel` property to Expandable Section

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -105,6 +105,13 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
     children: ['Navigation content'],
   },
+  {
+    expanded: [true],
+    headerAriaLabel: ['Header with ARIA label (ARIA)'],
+    variant: ['default', 'footer', 'navigation'],
+    header: ['Header with ARIA label'],
+    children: ['Sample content'],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5137,6 +5137,13 @@ manner if you provide a value for this property.",
       "type": "boolean",
     },
     Object {
+      "description": "Adds \`aria-label\` to the header element.
+It should be used to assign unique labels when there are multiple expandable sections with the same header text on one page.",
+      "name": "headerAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
       "optional": true,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5138,7 +5138,7 @@ manner if you provide a value for this property.",
     },
     Object {
       "description": "Adds \`aria-label\` to the header element.
-It should be used to assign unique labels when there are multiple expandable sections with the same header text on one page.",
+Use to assign unique labels when there are multiple expandable sections with the same header text on one page.",
       "name": "headerAriaLabel",
       "optional": true,
       "type": "string",

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -118,5 +118,15 @@ describe('Expandable Section', () => {
       const header = wrapper.findHeader().getElement();
       expect(header).toHaveAttribute('aria-expanded', 'true');
     });
+
+    test('can assign a different label to the header', () => {
+      const wrapper = renderExpandableSection({
+        headerAriaLabel: 'ARIA Label',
+      });
+      const header = wrapper.findHeader().getElement();
+      const content = wrapper.findContent().getElement();
+      expect(header).toHaveAttribute('aria-label', 'ARIA Label');
+      expect(content).toHaveAttribute('aria-label', 'ARIA Label');
+    });
   });
 });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -14,7 +14,8 @@ interface ExpandableSectionHeaderProps {
   children?: ReactNode;
   expanded: boolean;
   ariaControls: string;
-  ariaLabelledBy: string;
+  ariaLabelledBy?: string;
+  ariaLabel?: string;
   onKeyUp: KeyboardEventHandler;
   onKeyDown: KeyboardEventHandler;
   onClick: MouseEventHandler;
@@ -27,6 +28,7 @@ export const ExpandableSectionHeader = ({
   children,
   expanded,
   ariaControls,
+  ariaLabel,
   ariaLabelledBy,
   onKeyUp,
   onKeyDown,
@@ -54,6 +56,7 @@ export const ExpandableSectionHeader = ({
           className={styles['icon-container']}
           type="button"
           aria-labelledby={ariaLabelledBy}
+          aria-label={ariaLabel}
           {...focusVisible}
           {...ariaAttributes}
         >
@@ -73,6 +76,7 @@ export const ExpandableSectionHeader = ({
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
       onClick={onClick}
+      aria-label={ariaLabel}
       {...focusVisible}
       {...ariaAttributes}
     >

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -52,6 +52,12 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   header?: React.ReactNode;
 
   /**
+   * Adds `aria-label` to the header element.
+   * It should be used to assign unique labels when there are multiple expandable sections with the same header text on one page.
+   */
+  headerAriaLabel?: string;
+
+  /**
    * Called when the state changes (that is, when the user expands or collapses the component).
    * The event `detail` contains the current value of the `expanded` property.
    */

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -53,7 +53,7 @@ export interface ExpandableSectionProps extends BaseComponentProps {
 
   /**
    * Adds `aria-label` to the header element.
-   * It should be used to assign unique labels when there are multiple expandable sections with the same header text on one page.
+   * Use to assign unique labels when there are multiple expandable sections with the same header text on one page.
    */
   headerAriaLabel?: string;
 

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -27,6 +27,7 @@ export default function InternalExpandableSection({
   children,
   header,
   disableContentPaddings,
+  headerAriaLabel,
   __internalRootRef,
   ...props
 }: InternalExpandableSectionProps) {
@@ -73,7 +74,8 @@ export default function InternalExpandableSection({
 
   const triggerProps = {
     ariaControls: controlId,
-    ariaLabelledBy: triggerControlId,
+    ariaLabel: headerAriaLabel,
+    ariaLabelledBy: headerAriaLabel ? undefined : triggerControlId,
     onKeyUp,
     onKeyDown,
     onClick,
@@ -105,7 +107,8 @@ export default function InternalExpandableSection({
           ref={ref}
           className={clsx(styles.content, styles[`content-${variant}`], expanded && styles['content-expanded'])}
           role="group"
-          aria-labelledby={triggerControlId}
+          aria-label={triggerProps.ariaLabel}
+          aria-labelledby={triggerProps.ariaLabelledBy}
         >
           {children}
         </div>


### PR DESCRIPTION
### Description

Adds a new `headerAriaLabel` property to Expandable Section that adds an explicit `aria-label` to the header button.

This is useful if you have multiple expandable sections with the same title on one page.

### How has this been tested?

Tested manually. Added unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
