### PR TITLE
Reuse calendar sass variables

### DIFF
--- a/src/calendar/calendar.scss
+++ b/src/calendar/calendar.scss
@@ -1,0 +1,27 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../internal/styles/tokens' as awsui;
+
+// Colors
+$header-color: awsui.$color-text-dropdown-item-default;
+$grid-border-color: awsui.$color-border-calendar-grid;
+$grid-day-color: awsui.$color-text-dropdown-item-default;
+$grid-day-name-color: awsui.$color-text-calendar-month;
+$grid-disabled-day-color: awsui.$color-text-dropdown-item-disabled;
+$grid-nonmonth-day-color: awsui.$color-text-dropdown-item-secondary;
+$grid-hover-background-color: awsui.$color-background-dropdown-item-hover;
+$grid-hover-border-color: awsui.$color-border-dropdown-item-hover;
+$grid-today-background-color: awsui.$color-background-calendar-today;
+$grid-selected-text-color: awsui.$color-background-control-default;
+$grid-selected-background-color: awsui.$color-background-control-checked;
+$grid-selected-border-color: awsui.$color-background-control-checked;
+$grid-in-range-background-color: awsui.$color-background-dropdown-item-selected;
+
+// Shadows
+$grid-selected-focused-box-shadow: 0 0 0 2px awsui.$color-border-calendar-grid-selected-focus-ring;
+
+// Borders
+$grid-border: 1px solid $grid-border-color;

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -9,20 +9,7 @@
 @use '../internal/styles/typography/index' as typographyConstants;
 @use './motion';
 
-$calendar-header-color: awsui.$color-text-dropdown-item-default;
-$calendar-grid-border-color: awsui.$color-border-calendar-grid;
-$calendar-grid-day-color: awsui.$color-text-dropdown-item-default;
-$calendar-grid-day-name-color: awsui.$color-text-calendar-month;
-$calendar-grid-disabled-day-color: awsui.$color-text-dropdown-item-disabled;
-$calendar-grid-nonmonth-day-color: awsui.$color-text-dropdown-item-secondary;
-$calendar-grid-hover-background-color: awsui.$color-background-dropdown-item-hover;
-$calendar-grid-hover-border-color: awsui.$color-border-dropdown-item-hover;
-$calendar-grid-today-background-color: awsui.$color-background-calendar-today;
-$calendar-grid-selected-text-color: awsui.$color-background-control-default;
-$calendar-grid-selected-background-color: awsui.$color-background-control-checked;
-$calendar-grid-selected-border-color: awsui.$color-background-control-checked;
-$calendar-grid-selected-focused-box-shadow: 0 0 0 2px awsui.$color-border-calendar-grid-selected-focus-ring;
-$calendar-grid-border: 1px solid $calendar-grid-border-color;
+@use './calendar' as calendar;
 
 .root {
   /* used in test-utils */
@@ -31,7 +18,7 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
 .calendar {
   display: block;
   // IE11 does not calculate the height correctly when in nested flex containers (@see https://github.com/philipwalton/flexbugs#flexbug-3)
-  width: 234px;
+  width: awsui.$size-calendar-grid-width;
   overflow: auto;
 
   &-inner {
@@ -47,7 +34,7 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
   &-header-month {
     @include styles.font-body-m;
     font-weight: typographyConstants.$font-weight-bold;
-    color: $calendar-header-color;
+    color: calendar.$header-color;
   }
 
   &-next-month-btn {
@@ -69,12 +56,12 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
     word-break: break-word;
     text-align: center;
     padding: awsui.$space-s 0 awsui.$space-xxs;
-    color: $calendar-grid-day-name-color;
+    color: calendar.$grid-day-name-color;
     @include styles.font-body-s;
   }
 
   &-dates {
-    border: $calendar-grid-border;
+    border: calendar.$grid-border;
   }
   &-week {
     display: flex;
@@ -86,10 +73,10 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
     width: 0;
     word-break: break-word;
     text-align: center;
-    border-bottom: $calendar-grid-border;
-    border-right: $calendar-grid-border;
+    border-bottom: calendar.$grid-border;
+    border-right: calendar.$grid-border;
     padding: awsui.$space-xxs 0;
-    color: $calendar-grid-disabled-day-color;
+    color: calendar.$grid-disabled-day-color;
     position: relative;
 
     &:last-child {
@@ -106,18 +93,18 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
 
     &-enabled {
       cursor: pointer;
-      color: $calendar-grid-nonmonth-day-color;
+      color: calendar.$grid-nonmonth-day-color;
       &::after {
         border-radius: awsui.$border-radius-item;
       }
       &.calendar-day-current-month {
-        color: $calendar-grid-day-color;
+        color: calendar.$grid-day-color;
         &:hover {
           color: awsui.$color-text-calendar-day-hover;
-          background-color: $calendar-grid-hover-background-color;
+          background-color: calendar.$grid-hover-background-color;
           &:not(.calendar-day-selected) {
             &::after {
-              border: awsui.$border-item-width solid $calendar-grid-hover-border-color;
+              border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
             }
           }
         }
@@ -125,7 +112,7 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
     }
 
     &-today {
-      background-color: $calendar-grid-today-background-color;
+      background-color: calendar.$grid-today-background-color;
       border-radius: awsui.$border-radius-item;
     }
 
@@ -166,7 +153,7 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
           @include styles.focus-highlight(
             awsui.$space-calendar-grid-focus-outline-gutter,
             awsui.$border-radius-calendar-day-focus-ring,
-            $calendar-grid-selected-focused-box-shadow
+            calendar.$grid-selected-focused-box-shadow
           );
           &::before {
             z-index: 2;
@@ -174,13 +161,13 @@ $calendar-grid-border: 1px solid $calendar-grid-border-color;
         }
       }
       &::after {
-        background-color: $calendar-grid-selected-background-color;
-        border: awsui.$border-item-width solid $calendar-grid-selected-border-color;
+        background-color: calendar.$grid-selected-background-color;
+        border: awsui.$border-item-width solid calendar.$grid-selected-border-color;
         border-radius: awsui.$border-radius-item;
       }
       > .day-inner {
         z-index: 2;
-        color: $calendar-grid-selected-text-color;
+        color: calendar.$grid-selected-text-color;
         position: relative;
       }
     }

--- a/src/date-range-picker/calendar/grids/day/styles.scss
+++ b/src/date-range-picker/calendar/grids/day/styles.scss
@@ -6,27 +6,7 @@
 @use '../../../../internal/styles/index' as styles;
 @use '../../../../internal/styles/tokens' as awsui;
 @use '../../../../internal/hooks/focus-visible' as focus-visible;
-
-$calendar-grid-border-color: awsui.$color-border-calendar-grid;
-
-$calendar-grid-day-color: awsui.$color-text-dropdown-item-default;
-$calendar-grid-disabled-day-color: awsui.$color-text-dropdown-item-disabled;
-
-$calendar-grid-hover-background-color: awsui.$color-background-dropdown-item-hover;
-$calendar-grid-hover-border-color: awsui.$color-border-dropdown-item-hover;
-
-$calendar-grid-today-background-color: awsui.$color-background-calendar-today;
-
-$calendar-grid-selected-background-color: awsui.$color-background-control-checked;
-$calendar-grid-selected-text-color: awsui.$color-background-control-default;
-$calendar-grid-selected-border-color: awsui.$color-background-control-checked;
-$calendar-grid-in-range-background-color: awsui.$color-background-dropdown-item-selected;
-
-$calendar-grid-selected-focused-box-shadow: 0 0 0 2px awsui.$color-border-calendar-grid-selected-focus-ring;
-
-$calendar-grid-border: 1px solid $calendar-grid-border-color;
-
-$calendar-grid-width: 234px;
+@use '../../../../calendar/calendar' as calendar;
 
 @mixin border-radius($horizontal, $vertical) {
   &,
@@ -39,7 +19,7 @@ $calendar-grid-width: 234px;
   $sides: top, right, bottom, left;
   @each $side in $sides {
     &.in-range-border-#{$side}::after {
-      border-#{$side}: awsui.$border-item-width solid $calendar-grid-selected-border-color;
+      border-#{$side}: awsui.$border-item-width solid calendar.$grid-selected-border-color;
     }
   }
 }
@@ -55,10 +35,10 @@ $calendar-grid-width: 234px;
   width: 0;
   word-break: break-word;
   text-align: center;
-  border-bottom: $calendar-grid-border;
-  border-right: $calendar-grid-border;
+  border-bottom: calendar.$grid-border;
+  border-right: calendar.$grid-border;
   padding: awsui.$space-xxs 0;
-  color: $calendar-grid-disabled-day-color;
+  color: calendar.$grid-disabled-day-color;
   position: relative;
 
   &:focus {
@@ -91,7 +71,7 @@ $calendar-grid-width: 234px;
 }
 
 .in-first-row:not(.in-previous-month) {
-  border-top: $calendar-grid-border;
+  border-top: calendar.$grid-border;
 }
 
 .in-previous-month:not(.last-day-of-month) {
@@ -106,7 +86,7 @@ $calendar-grid-width: 234px;
   border-left: 1px solid transparent;
 
   &.in-current-month {
-    border-left: $calendar-grid-border;
+    border-left: calendar.$grid-border;
   }
 }
 
@@ -114,7 +94,7 @@ $calendar-grid-width: 234px;
   cursor: pointer;
 
   &.in-current-month {
-    color: $calendar-grid-day-color;
+    color: calendar.$grid-day-color;
     &:not(.in-range),
     &.end-date.start-date,
     &.no-range {
@@ -125,10 +105,10 @@ $calendar-grid-width: 234px;
     }
     &:hover {
       color: awsui.$color-text-calendar-day-hover;
-      background-color: $calendar-grid-hover-background-color;
+      background-color: calendar.$grid-hover-background-color;
       &:not(.selected) {
         &::after {
-          border: awsui.$border-item-width solid $calendar-grid-hover-border-color;
+          border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
         }
       }
     }
@@ -136,7 +116,7 @@ $calendar-grid-width: 234px;
 }
 
 .today:not(.in-range) {
-  background-color: $calendar-grid-today-background-color;
+  background-color: calendar.$grid-today-background-color;
   border-radius: awsui.$border-radius-item;
 }
 
@@ -149,7 +129,7 @@ $calendar-grid-width: 234px;
     @include styles.focus-highlight(
       awsui.$space-calendar-grid-selected-focus-outline-gutter,
       awsui.$border-radius-calendar-day-focus-ring,
-      $calendar-grid-selected-focused-box-shadow
+      calendar.$grid-selected-focused-box-shadow
     );
     &::before {
       z-index: 1;
@@ -157,8 +137,8 @@ $calendar-grid-width: 234px;
   }
 
   &::after {
-    background-color: $calendar-grid-selected-background-color;
-    border: awsui.$border-item-width solid $calendar-grid-selected-border-color;
+    background-color: calendar.$grid-selected-background-color;
+    border: awsui.$border-item-width solid calendar.$grid-selected-border-color;
     z-index: 0;
   }
 
@@ -179,14 +159,14 @@ $calendar-grid-width: 234px;
   }
 
   > .day-inner {
-    color: $calendar-grid-selected-text-color;
+    color: calendar.$grid-selected-text-color;
     position: relative;
     z-index: 2;
   }
 }
 
 .in-range {
-  background-color: $calendar-grid-in-range-background-color;
+  background-color: calendar.$grid-in-range-background-color;
 
   @include in-range-borders;
 


### PR DESCRIPTION
### Description

A step towards reusing calendar and date-range picker calendar styles.

### How has this been tested?

Manual tests, visual checks.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
