### PR TITLE
Fix property filter on-load-items arguments when operator is inserted

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -764,6 +764,60 @@ describe('property filter parts', () => {
     });
   });
 
+  describe('async loading', () => {
+    test('calls onLoadItems with parsed property and operator when operator is selected', () => {
+      const onLoadItems = jest.fn();
+      const { propertyFilterWrapper: wrapper } = renderComponent({ onLoadItems });
+
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+      expect(wrapper.findNativeInput().getElement()).toHaveValue('string');
+      expect(onLoadItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            filteringText: 'string',
+            filteringProperty: undefined,
+            filteringOperator: undefined,
+          }),
+        })
+      );
+
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+      expect(wrapper.findNativeInput().getElement()).toHaveValue('string = ');
+      expect(onLoadItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            filteringText: '',
+            filteringProperty: expect.objectContaining({ key: 'string' }),
+            filteringOperator: '=',
+          }),
+        })
+      );
+    });
+
+    test('calls onLoadItems with parsed property and operator when operator is inserted', () => {
+      const onLoadItems = jest.fn();
+      const { propertyFilterWrapper: wrapper } = renderComponent({ onLoadItems });
+
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.down));
+      act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+      expect(wrapper.findNativeInput().getElement()).toHaveValue('default = ');
+      expect(onLoadItems).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            filteringText: '',
+            filteringProperty: expect.objectContaining({ key: 'default-operator' }),
+            filteringOperator: '=',
+          }),
+        })
+      );
+    });
+  });
+
   test('property filter input can be found with autosuggest selector', () => {
     const { container } = renderComponent();
     expect(createWrapper(container).findAutosuggest()!.getElement()).not.toBe(null);

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -173,17 +173,22 @@ const PropertyFilter = React.forwardRef(
 
       // stop dropdown from closing
       event.preventDefault();
+
       const parsedText = parseText(value, filteringProperties, disableFreeTextFiltering);
       const loadMoreDetail = getLoadMoreDetail(parsedText, value);
-      fireNonCancelableEvent(onLoadItems, { ...loadMoreDetail, firstPage: true, samePage: false });
 
       // Insert operator automatically if only one operator is defined for the given property.
       if (parsedText.step === 'operator') {
         const operators = getAllowedOperators(parsedText.property);
         if (value.trim() === parsedText.property.propertyLabel && operators.length === 1) {
+          loadMoreDetail.filteringProperty = parsedText.property;
+          loadMoreDetail.filteringOperator = operators[0];
+          loadMoreDetail.filteringText = '';
           setFilteringText(parsedText.property.propertyLabel + ' ' + operators[0] + ' ');
         }
       }
+
+      fireNonCancelableEvent(onLoadItems, { ...loadMoreDetail, firstPage: true, samePage: false });
     };
     const [tokensExpanded, setTokensExpanded] = useState(false);
     const toggleExpandedTokens = () => setTokensExpanded(!tokensExpanded);


### PR DESCRIPTION
### Description

When operator is automatically inserted the load details need to be adjusted accordingly.

### How has this been tested?

New unit tests added.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19150

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
