### PR TITLE
Refactor calendar day styles

### DIFF
--- a/src/calendar/grid/day/index.tsx
+++ b/src/calendar/grid/day/index.tsx
@@ -5,7 +5,6 @@ import styles from '../../styles.css.js';
 import { DatePickerProps } from '../../../date-picker/interfaces';
 import { isSameDay, isSameMonth } from 'date-fns';
 import { getDateLabel } from '../../utils/intl';
-import clsx from 'clsx';
 import useFocusVisible from '../../../internal/hooks/focus-visible/index.js';
 
 interface GridDayProps {
@@ -37,14 +36,6 @@ export default function GridDay({
   const isEnabled = !isDateEnabled || isDateEnabled(date);
   const isDateOnSameDay = isSameDay(date, new Date());
   const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
-  const classNames = clsx(styles['calendar-day'], {
-    [styles['calendar-day-in-last-week']]: isDateInLastWeek,
-    [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
-    [styles['calendar-day-enabled']]: isEnabled,
-    [styles['calendar-day-selected']]: isSelected,
-    [styles['calendar-day-today']]: isDateOnSameDay,
-    [styles['calendar-day-focusable']]: isFocusable && isEnabled,
-  });
   const focusVisible = useFocusVisible();
 
   if (isSelected) {
@@ -67,7 +58,16 @@ export default function GridDay({
   }
 
   return (
-    <div className={classNames} aria-label={labels.join('. ')} role="button" {...computedAttributes} {...focusVisible}>
+    <div
+      role="button"
+      className={styles['calendar-day']}
+      data-current-day={isDateOnSameDay}
+      data-current-month={isSameMonth(date, baseDate)}
+      data-last-week={isDateInLastWeek}
+      aria-label={labels.join('. ')}
+      {...computedAttributes}
+      {...focusVisible}
+    >
       <span className={styles['day-inner']}>{date.getDate()}</span>
     </div>
   );

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -109,7 +109,7 @@ export default function Calendar({
   // Once changed, the corresponding day button needs to receive the actual focus.
   useEffectOnUpdate(() => {
     if (focusedDate) {
-      (elementRef.current?.querySelector(`.${styles['calendar-day-focusable']}`) as HTMLDivElement)?.focus();
+      (elementRef.current?.querySelector(`.${styles['calendar-day']}[tabindex="0"]`) as HTMLDivElement)?.focus();
     }
   }, [focusedDate]);
 

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -83,37 +83,8 @@
       border-right: none;
     }
 
-    &-in-last-week {
+    &[data-last-week='true'] {
       border-bottom: none;
-    }
-
-    &-focusable {
-      /* used for identifying element */
-    }
-
-    &-enabled {
-      cursor: pointer;
-      color: calendar.$grid-nonmonth-day-color;
-      &::after {
-        border-radius: awsui.$border-radius-item;
-      }
-      &.calendar-day-current-month {
-        color: calendar.$grid-day-color;
-        &:hover {
-          color: awsui.$color-text-calendar-day-hover;
-          background-color: calendar.$grid-hover-background-color;
-          &:not(.calendar-day-selected) {
-            &::after {
-              border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
-            }
-          }
-        }
-      }
-    }
-
-    &-today {
-      background-color: calendar.$grid-today-background-color;
-      border-radius: awsui.$border-radius-item;
     }
 
     &::after {
@@ -126,6 +97,32 @@
       right: calc(-1 * #{awsui.$border-item-width});
       background-color: transparent;
     }
+
+    &:not([aria-disabled='true']) {
+      cursor: pointer;
+      color: calendar.$grid-nonmonth-day-color;
+      &::after {
+        border-radius: awsui.$border-radius-item;
+      }
+      &[data-current-month='true'] {
+        color: calendar.$grid-day-color;
+        &:hover {
+          color: awsui.$color-text-calendar-day-hover;
+          background-color: calendar.$grid-hover-background-color;
+          &:not([aria-current]) {
+            &::after {
+              border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
+            }
+          }
+        }
+      }
+    }
+
+    &[data-current-day='true'] {
+      background-color: calendar.$grid-today-background-color;
+      border-radius: awsui.$border-radius-item;
+    }
+
     > .day-inner {
       position: relative;
       z-index: 1;
@@ -144,7 +141,7 @@
       }
     }
 
-    &-selected {
+    &[aria-current] {
       border-color: transparent;
       position: relative;
       z-index: 2;

--- a/src/date-picker/__tests__/date-picker-calendar.test.tsx
+++ b/src/date-picker/__tests__/date-picker-calendar.test.tsx
@@ -40,7 +40,7 @@ describe('Date picker calendar', () => {
   }
 
   const findFocusedDay = (wrapper: DatePickerWrapper) => {
-    return wrapper.findCalendar()!.find(`.${calendarStyles['calendar-day-focusable']}`);
+    return wrapper.findCalendar()!.find(`.${calendarStyles['calendar-day']}[tabIndex="0"]`);
   };
 
   const findFocusableDateText = (wrapper: DatePickerWrapper) => {
@@ -60,7 +60,7 @@ describe('Date picker calendar', () => {
   };
 
   const findToday = (wrapper: DatePickerWrapper): ElementWrapper<HTMLElement> => {
-    return wrapper.findCalendar()!.find(`.${calendarStyles['calendar-day-today']}`)!;
+    return wrapper.findCalendar()!.find(`.${calendarStyles['calendar-day']}[data-current-day="true"]`)!;
   };
 
   beforeEach(() => {

--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -70,7 +70,7 @@ describe('Date range picker calendar', () => {
   };
 
   const findToday = (wrapper: DateRangePickerWrapper): ElementWrapper<HTMLElement> => {
-    return wrapper.findDropdown()!.findByClassName(gridDayStyles.today)!;
+    return wrapper.findDropdown()!.find(`.${gridDayStyles.day}[data-current-day="true"]`)!;
   };
 
   beforeEach(() => {

--- a/src/date-range-picker/calendar/grids/day/index.tsx
+++ b/src/date-range-picker/calendar/grids/day/index.tsx
@@ -116,20 +116,13 @@ const GridDay = React.memo(
       }
 
       const classNames = clsx(styles.day, baseClasses, {
-        [styles['in-current-month']]: isSameMonth(date, baseDate),
         [styles.enabled]: isEnabled,
         [styles.selected]: isSelected,
-        [styles['start-date']]: isStartDate,
-        [styles['end-date']]: isEndDate,
-        [styles['range-start-date']]: isRangeStartDate,
-        [styles['range-end-date']]: isRangeEndDate,
         [styles['no-range']]: isSelected && onlyOneSelected,
-        [styles['in-range']]: isInRange,
         [styles['in-range-border-top']]: isDateInSelectionStartWeek || date.getDate() <= 7,
         [styles['in-range-border-bottom']]: isDateInSelectionEndWeek || date.getDate() > getDaysInMonth(date) - 7,
         [styles['in-range-border-left']]: isDateInFirstColumn || date.getDate() === 1 || isRangeStartDate,
         [styles['in-range-border-right']]: isDateInLastColumn || isLastDayOfMonth(date) || isRangeEndDate,
-        [styles.today]: isToday,
       });
 
       computedAttributes['aria-pressed'] = isSelected || isInRange;
@@ -158,10 +151,17 @@ const GridDay = React.memo(
 
       return (
         <div
+          role="button"
           className={classNames}
           aria-label={labels.join('. ')}
           data-date={formatDate(date)}
-          role="button"
+          data-current-day={isToday}
+          data-current-month={isSameMonth(date, baseDate)}
+          data-in-range={isInRange}
+          data-start-date={isStartDate}
+          data-end-date={isEndDate}
+          data-range-start-date={isRangeStartDate}
+          data-range-end-date={isRangeEndDate}
           {...computedAttributes}
           ref={ref}
           onKeyDown={onKeyDown}

--- a/src/date-range-picker/calendar/grids/day/styles.scss
+++ b/src/date-range-picker/calendar/grids/day/styles.scss
@@ -68,6 +68,22 @@
     position: relative;
     z-index: 1;
   }
+
+  &[data-current-day='true']:not([data-in-range='true']) {
+    background-color: calendar.$grid-today-background-color;
+    border-radius: awsui.$border-radius-item;
+  }
+
+  &[data-in-range='true'] {
+    background-color: calendar.$grid-in-range-background-color;
+
+    @include in-range-borders;
+
+    @include in-range-border-radius(top, right);
+    @include in-range-border-radius(bottom, right);
+    @include in-range-border-radius(bottom, left);
+    @include in-range-border-radius(top, left);
+  }
 }
 
 .in-first-row:not(.in-previous-month) {
@@ -85,7 +101,7 @@
 .in-first-column {
   border-left: 1px solid transparent;
 
-  &.in-current-month {
+  &[data-current-month='true'] {
     border-left: calendar.$grid-border;
   }
 }
@@ -93,10 +109,10 @@
 .enabled {
   cursor: pointer;
 
-  &.in-current-month {
+  &[data-current-month='true'] {
     color: calendar.$grid-day-color;
-    &:not(.in-range),
-    &.end-date.start-date,
+    &:not([data-in-range='true']),
+    &[data-start-date='true'][data-end-date='true'],
     &.no-range {
       &,
       &::after {
@@ -113,11 +129,6 @@
       }
     }
   }
-}
-
-.today:not(.in-range) {
-  background-color: calendar.$grid-today-background-color;
-  border-radius: awsui.$border-radius-item;
 }
 
 .selected {
@@ -142,16 +153,16 @@
     z-index: 0;
   }
 
-  &.start-date,
-  &.range-start-date {
+  &[data-start-date='true'],
+  &[data-range-start-date='true'] {
     @include border-radius(top, left);
     &.in-range-border-bottom {
       @include border-radius(bottom, left);
     }
   }
 
-  &.end-date,
-  &.range-end-date {
+  &[data-end-date='true'],
+  &[data-range-end-date='true'] {
     @include border-radius(bottom, right);
     &.in-range-border-top {
       @include border-radius(top, right);
@@ -163,15 +174,4 @@
     position: relative;
     z-index: 2;
   }
-}
-
-.in-range {
-  background-color: calendar.$grid-in-range-background-color;
-
-  @include in-range-borders;
-
-  @include in-range-border-radius(top, right);
-  @include in-range-border-radius(bottom, right);
-  @include in-range-border-radius(bottom, left);
-  @include in-range-border-radius(top, left);
 }

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -7,12 +7,11 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
 @use '../internal/styles/typography/index' as typographyConstants;
+@use '../calendar/calendar' as calendar;
 @use './motion';
 
-$calendar-header-color: awsui.$color-text-body-default;
-$calendar-grid-day-name-color: awsui.$color-text-calendar-month;
-
 $calendar-grid-width: awsui.$size-calendar-grid-width;
+$calendar-header-color: awsui.$color-text-body-default;
 
 .root {
   @include styles.styles-reset;
@@ -86,7 +85,7 @@ $calendar-grid-width: awsui.$size-calendar-grid-width;
     word-break: break-word;
     text-align: center;
     padding: awsui.$space-s 0 awsui.$space-xxs;
-    color: $calendar-grid-day-name-color;
+    color: calendar.$grid-day-name-color;
     @include styles.font-body-s;
   }
 

--- a/src/test-utils/dom/calendar/index.ts
+++ b/src/test-utils/dom/calendar/index.ts
@@ -29,6 +29,6 @@ export default class CalendarWrapper extends ComponentWrapper {
   }
 
   findSelectedDate(): ElementWrapper {
-    return this.find(`.${styles['calendar-day-selected']}`)!;
+    return this.find(`.${styles['calendar-day']}[aria-current]`)!;
   }
 }

--- a/src/test-utils/dom/date-range-picker/index.ts
+++ b/src/test-utils/dom/date-range-picker/index.ts
@@ -116,11 +116,11 @@ export class DrpDropdownWrapper extends ComponentWrapper {
   }
 
   findSelectedStartDate(): ElementWrapper | null {
-    return this.findByClassName(dayStyles['start-date']);
+    return this.find(`.${dayStyles.day}[data-start-date="true"]`);
   }
 
   findSelectedEndDate(): ElementWrapper | null {
-    return this.findByClassName(dayStyles['end-date']);
+    return this.find(`.${dayStyles.day}[data-end-date="true"]`);
   }
 
   findStartDateInput(): InputWrapper | null {


### PR DESCRIPTION
### Description

Make calendar and date-range picker calendar (partially) day styles rely on the attributes rather than additional class names. That reduces complexity as in some cases the styles can reuse the existing attributes (aria-current, aria-disabled, tab-index) and also allows for the easier reuse of styles between the two calendar implementation as it becomes possible to extract the calendar-day as a mixin w/o the need to support the additional classes.

The refactoring is done as a step towards reusing calendar and date-range picker calendar styles and updating the components to use the table layout.

### How has this been tested?

Manual testing, visual regression tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
