### PR TITLE
Fix modal focus lock auto-focus behaviour

### DIFF
--- a/pages/modal/focus-restoration.page.tsx
+++ b/pages/modal/focus-restoration.page.tsx
@@ -1,10 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { Modal, Button } from '~components';
+import { Modal, Button, SpaceBetween, AttributeEditor, Input } from '~components';
+
+interface Item {
+  key: string;
+  value: string;
+}
+
+function createItems() {
+  return Array(15)
+    .fill(null)
+    .map((_, i) => ({ key: `some-key-${i}`, value: `some-value-${i}` }));
+}
 
 function Destructible() {
   const [visible, setVisible] = useState(false);
+  const [items, setItems] = useState(createItems());
   return (
     <article>
       <Button id="destructible" onClick={() => setVisible(true)}>
@@ -12,7 +24,7 @@ function Destructible() {
       </Button>
       {visible && (
         <Modal visible={true} onDismiss={() => setVisible(false)} closeAriaLabel="Close modal">
-          Demo content #1
+          <ItemsForm items={items} setItems={setItems} />
         </Modal>
       )}
     </article>
@@ -21,15 +33,43 @@ function Destructible() {
 
 function Controlled() {
   const [visible, setVisible] = useState(false);
+  const [items, setItems] = useState(createItems());
   return (
     <article>
       <Button id="controlled" onClick={() => setVisible(true)}>
         Show controlled modal
       </Button>
       <Modal visible={visible} onDismiss={() => setVisible(false)} closeAriaLabel="Close modal">
-        Demo content #2
+        <ItemsForm items={items} setItems={setItems} />
       </Modal>
     </article>
+  );
+}
+
+function ItemsForm({ items, setItems }: { items: Item[]; setItems: (items: Item[]) => void }) {
+  return (
+    <AttributeEditor
+      onAddButtonClick={() => setItems([...items, { key: '', value: '' }])}
+      onRemoveButtonClick={({ detail: { itemIndex } }) => {
+        const tmpItems = [...items];
+        tmpItems.splice(itemIndex, 1);
+        setItems(tmpItems);
+      }}
+      items={items}
+      addButtonText="Add new item"
+      definition={[
+        {
+          label: 'Key',
+          control: item => <Input value={item.key} onChange={() => undefined} placeholder="Enter key" />,
+        },
+        {
+          label: 'Value',
+          control: item => <Input value={item.value} onChange={() => undefined} placeholder="Enter value" />,
+        },
+      ]}
+      removeButtonText="Remove"
+      empty="No items associated with the resource."
+    />
   );
 }
 
@@ -37,8 +77,10 @@ export default function () {
   return (
     <>
       <h1>Destructible modals</h1>
-      <Destructible />
-      <Controlled />
+      <SpaceBetween size="m">
+        <Destructible />
+        <Controlled />
+      </SpaceBetween>
     </>
   );
 }

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -24,3 +24,30 @@ test.each(['destructible', 'controlled'])(`should reset focus to previously acti
     await expect(page.isFocused(`#${name}`)).resolves.toBe(true);
   })()
 );
+
+test(
+  'should not move focus to the modal close button when content focus gets lost',
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/modal/focus-restoration');
+
+    // Open modal
+    await page.click('#destructible');
+
+    // Select 5th "Remove" button
+    await page.keys(['Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab']);
+    await expect(page.getFocusedElementText()).resolves.toBe('Remove');
+
+    // Remove attributes until focus moves away from the "Remove" button.
+    do {
+      await page.keys(['Enter']);
+    } while ((await page.getFocusedElementText()) === 'Remove');
+
+    // Expected the focus to go to the body but not the first focusable element of the modal.
+    await expect(page.isFocused('body')).resolves.toBe(true);
+  })
+);

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -140,6 +140,24 @@ describe('Modal component', () => {
       const wrapper = renderModal({ visible: true });
       expect(document.activeElement).toBe(wrapper.findDismissButton().getElement());
     });
+
+    it('restores focus to previous element on unmount', async () => {
+      const textfield = document.createElement('input');
+      textfield.type = 'text';
+      document.body.appendChild(textfield);
+
+      textfield.focus();
+      expect(document.activeElement).toBe(textfield);
+
+      const { rerender } = render(<Modal onDismiss={() => null} visible={true} />);
+      expect(document.activeElement).not.toBe(textfield);
+
+      rerender(<></>);
+      // react-focus-lock returns focus asyncronousy as Promise.resolve().then(() => element.focus())
+      // so need to wait before checking the active element.
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(document.activeElement).toBe(textfield);
+    });
   });
 
   describe('ESC key behavior', () => {

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -140,21 +140,6 @@ describe('Modal component', () => {
       const wrapper = renderModal({ visible: true });
       expect(document.activeElement).toBe(wrapper.findDismissButton().getElement());
     });
-
-    it('restores focus to previous element on unmount', () => {
-      const textfield = document.createElement('input');
-      textfield.type = 'text';
-      document.body.appendChild(textfield);
-
-      textfield.focus();
-      expect(document.activeElement).toBe(textfield);
-
-      const { rerender } = render(<Modal onDismiss={() => null} visible={true} />);
-      expect(document.activeElement).not.toBe(textfield);
-
-      rerender(<></>);
-      expect(document.activeElement).toBe(textfield);
-    });
   });
 
   describe('ESC key behavior', () => {


### PR DESCRIPTION
### Description

Make modal focus lock only use auto-focus when the modal is opened but not when the focused element inside the modal gets removed to avoid the unexpected focusing to the close button that may cause scroll.

### How has this been tested?

Manual testing + new integration test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket WSUI-19440

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
