### PR TITLE
Fix table row scroll

### DIFF
--- a/pages/table/tall-rows.page.tsx
+++ b/pages/table/tall-rows.page.tsx
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { range } from 'lodash';
+import React, { useState } from 'react';
+import Header from '~components/header';
+import Table, { TableProps } from '~components/table';
+import Box from '~components/box';
+import Link from '~components/link';
+import { generateItems, Instance } from './generate-data';
+import { columnsConfig } from './shared-configs';
+
+const items = generateItems(20);
+
+export default function () {
+  const [clicks, setClicks] = useState(0);
+
+  const tallItemsConfig: TableProps.ColumnDefinition<Instance>[] = columnsConfig.map((config, index) => ({
+    ...config,
+    cell: (item: any) =>
+      index === 0 ? (
+        <Link onFollow={() => setClicks(prev => prev + 1)}>{item.id}</Link>
+      ) : (
+        <ul>
+          {range(0, 20).map(index => (
+            <li key={index}>{config.cell(item)}</li>
+          ))}
+        </ul>
+      ),
+  }));
+
+  return (
+    <Box padding="s">
+      <Table
+        header={<Header headingTagOverride="h1">Table with tall rows, clicks: {clicks}</Header>}
+        columnDefinitions={tallItemsConfig}
+        items={items}
+        stickyHeader={true}
+        variant="container"
+      />
+      <div style={{ height: '90vh', padding: 10 }}>Placeholder to allow page scroll beyond table</div>
+    </Box>
+  );
+}

--- a/src/table/__integ__/tall-rows.test.ts
+++ b/src/table/__integ__/tall-rows.test.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+const tableWrapper = createWrapper().findTable();
+const headerSelector = tableWrapper.findHeaderSlot().toSelector();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await page.setWindowSize({ width: 900, height: 800 });
+    await browser.url('#/light/table/tall-rows');
+    await testFn(page);
+  });
+};
+
+test(
+  'row is scrolled to top when focused with keyboard',
+  setupTest(async page => {
+    // Move focus to the last table header.
+    await page.click(headerSelector);
+    await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Tab', 'Tab']);
+    await expect(page.getFocusedElementText()).resolves.toBe('State');
+
+    // Scroll the viewport past the first table row.
+    await page.windowScrollTo({ top: 200 });
+
+    // Focus the link in the first row.
+    await page.keys(['Tab']);
+
+    // Expected the viewport to be scrolled to the top of the first row.
+    const windowScroll = await page.getWindowScroll();
+    expect(windowScroll.top).toBeLessThan(100);
+  })
+);
+
+test(
+  'row is not scrolled to top when focused with mouse click',
+  setupTest(async page => {
+    // Scroll the viewport past the first table row.
+    await page.windowScrollTo({ top: 200 });
+
+    // Click the link in the first row.
+    await page.click(tableWrapper.findBodyCell(1, 1).findLink().toSelector());
+
+    // Expected the viewport scroll to stay unchanged.
+    const windowScroll = await page.getWindowScroll();
+    expect(windowScroll.top).toBe(200);
+
+    // Expected the link to receive the click.
+    await expect(page.getElementsText(headerSelector)).resolves.toEqual(['Table with tall rows, clicks: 1']);
+  })
+);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -157,6 +157,7 @@ const InternalTable = React.forwardRef(
       ? { role: 'region', tabIndex: 0, 'aria-label': ariaLabels?.tableLabel }
       : {};
     const focusVisibleProps = useFocusVisible();
+    const isKyboardFocus = !!focusVisibleProps['data-awsui-focus-visible'];
 
     return (
       <ColumnWidthsProvider
@@ -267,7 +268,14 @@ const InternalTable = React.forwardRef(
                       <tr
                         key={getItemKey(trackBy, item, rowIndex)}
                         className={clsx(styles.row, isSelected && styles['row-selected'])}
-                        onFocus={({ currentTarget }) => stickyHeaderRef.current?.scrollToRow(currentTarget)}
+                        onFocus={({ currentTarget }) => {
+                          // When an element inside table row receives focus we want to adjust the scroll.
+                          // However, that behaviour is unwanted when the focus is received as result of a click
+                          // as it causes the click to never reach the target element.
+                          if (isKyboardFocus) {
+                            stickyHeaderRef.current?.scrollToRow(currentTarget);
+                          }
+                        }}
                         {...focusMarkers.item}
                         onClick={onRowClickHandler && onRowClickHandler.bind(null, rowIndex, item)}
                         onContextMenu={onRowContextMenuHandler && onRowContextMenuHandler.bind(null, rowIndex, item)}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -28,6 +28,7 @@ import StickyScrollbar from './sticky-scrollbar';
 import useFocusVisible from '../internal/hooks/focus-visible';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
+import useMouseDownTarget from './use-mouse-down-target';
 
 type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
@@ -157,7 +158,8 @@ const InternalTable = React.forwardRef(
       ? { role: 'region', tabIndex: 0, 'aria-label': ariaLabels?.tableLabel }
       : {};
     const focusVisibleProps = useFocusVisible();
-    const isKyboardFocus = !!focusVisibleProps['data-awsui-focus-visible'];
+
+    const getMouseDownTarget = useMouseDownTarget();
 
     return (
       <ColumnWidthsProvider
@@ -272,7 +274,7 @@ const InternalTable = React.forwardRef(
                           // When an element inside table row receives focus we want to adjust the scroll.
                           // However, that behaviour is unwanted when the focus is received as result of a click
                           // as it causes the click to never reach the target element.
-                          if (isKyboardFocus) {
+                          if (!currentTarget.contains(getMouseDownTarget())) {
                             stickyHeaderRef.current?.scrollToRow(currentTarget);
                           }
                         }}

--- a/src/table/use-mouse-down-target.ts
+++ b/src/table/use-mouse-down-target.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRef } from 'react';
+import { createSingletonHandler } from '../internal/hooks/use-singleton-handler';
+
+const useEventListenersSingleton = createSingletonHandler<Node | null>(setTarget => {
+  function handleMouseDown(event: MouseEvent) {
+    setTarget(event.target as Node);
+  }
+  function handleKeyDown() {
+    setTarget(null);
+  }
+  window.addEventListener('mousedown', handleMouseDown);
+  window.addEventListener('keydown', handleKeyDown);
+  return () => {
+    window.removeEventListener('mousedown', handleMouseDown);
+    window.removeEventListener('keydown', handleKeyDown);
+  };
+});
+
+/**
+ * Captures last mouse down target and clears it on keydown.
+ * @returns a callback to get the last detected mouse down target.
+ */
+export default function useMouseDownTarget() {
+  const mouseDownTargetRef = useRef<null | Node>(null);
+  useEventListenersSingleton(target => {
+    mouseDownTargetRef.current = target;
+  });
+  return () => mouseDownTargetRef.current;
+}


### PR DESCRIPTION
### Description

When the table row receives focus it scrolls to its top. However, that is not expected when the element inside table's row is clicked as the scroll action prevents element from receiving the click.

### How has this been tested?

Added new integration tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19438

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
