### PR TITLE
feat(expandable-section): Add focus ref to expandable header

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5107,7 +5107,14 @@ The event \`detail\` contains the current value of the \`expanded\` property.",
       "name": "onChange",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets the browser focus on the UI control",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "ExpandableSection",
   "properties": Array [
     Object {
@@ -5150,7 +5157,7 @@ Use to assign unique labels when there are multiple expandable sections with the
       "type": "string",
     },
     Object {
-      "defaultValue": "\\"default\\"",
+      "defaultValue": "'default'",
       "description": "The possible variants of an expandable section are as follows:
  * \`default\` - Use this variant in any context.
  * \`footer\` - Use this variant in container footers.

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -129,4 +129,14 @@ describe('Expandable Section', () => {
       expect(content).toHaveAttribute('aria-label', 'ARIA Label');
     });
   });
+
+  describe('focus', () => {
+    test('can be focused through the API', () => {
+      let expandableSection: ExpandableSectionProps.Ref | null = null;
+      const renderResult = render(<ExpandableSection ref={el => (expandableSection = el)} />);
+      const wrapper = createWrapper(renderResult.container);
+      expandableSection!.focus();
+      expect(document.activeElement).toBe(wrapper.findExpandableSection()?.findHeader()!.getElement());
+    });
+  });
 });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -19,69 +19,76 @@ interface ExpandableSectionHeaderProps {
   onKeyUp: KeyboardEventHandler;
   onKeyDown: KeyboardEventHandler;
   onClick: MouseEventHandler;
+  ref: React.Ref<HTMLDivElement>;
 }
 
-export const ExpandableSectionHeader = ({
-  id,
-  className,
-  variant,
-  children,
-  expanded,
-  ariaControls,
-  ariaLabel,
-  ariaLabelledBy,
-  onKeyUp,
-  onKeyDown,
-  onClick,
-}: ExpandableSectionHeaderProps) => {
-  const focusVisible = useFocusVisible();
+export const ExpandableSectionHeader = React.forwardRef(
+  (
+    {
+      id,
+      className,
+      variant,
+      children,
+      expanded,
+      ariaControls,
+      ariaLabel,
+      ariaLabelledBy,
+      onKeyUp,
+      onKeyDown,
+      onClick,
+    }: ExpandableSectionHeaderProps,
+    ref: React.Ref<HTMLDivElement>
+  ) => {
+    const focusVisible = useFocusVisible();
 
-  const icon = (
-    <InternalIcon
-      size={variant === 'container' ? 'medium' : 'normal'}
-      className={clsx(styles.icon, expanded && styles.expanded)}
-      name="caret-down-filled"
-    />
-  );
-  const ariaAttributes = {
-    'aria-controls': ariaControls,
-    'aria-expanded': expanded,
-  };
+    const icon = (
+      <InternalIcon
+        size={variant === 'container' ? 'medium' : 'normal'}
+        className={clsx(styles.icon, expanded && styles.expanded)}
+        name="caret-down-filled"
+      />
+    );
+    const ariaAttributes = {
+      'aria-controls': ariaControls,
+      'aria-expanded': expanded,
+    };
 
-  const triggerClassName = clsx(styles.trigger, styles[`trigger-${variant}`], expanded && styles['trigger-expanded']);
-  if (variant === 'navigation') {
+    const triggerClassName = clsx(styles.trigger, styles[`trigger-${variant}`], expanded && styles['trigger-expanded']);
+    if (variant === 'navigation') {
+      return (
+        <div id={id} className={clsx(className, triggerClassName)} onClick={onClick}>
+          <button
+            className={styles['icon-container']}
+            type="button"
+            aria-labelledby={ariaLabelledBy}
+            aria-label={ariaLabel}
+            {...focusVisible}
+            {...ariaAttributes}
+          >
+            {icon}
+          </button>
+          {children}
+        </div>
+      );
+    }
+
     return (
-      <div id={id} className={clsx(className, triggerClassName)} onClick={onClick}>
-        <button
-          className={styles['icon-container']}
-          type="button"
-          aria-labelledby={ariaLabelledBy}
-          aria-label={ariaLabel}
-          {...focusVisible}
-          {...ariaAttributes}
-        >
-          {icon}
-        </button>
+      <div
+        id={id}
+        role="button"
+        className={clsx(className, triggerClassName, styles.focusable, expanded && styles.expanded)}
+        tabIndex={0}
+        onKeyUp={onKeyUp}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        ref={ref}
+        aria-label={ariaLabel}
+        {...focusVisible}
+        {...ariaAttributes}
+      >
+        <div className={styles['icon-container']}>{icon}</div>
         {children}
       </div>
     );
   }
-
-  return (
-    <div
-      id={id}
-      role="button"
-      className={clsx(className, triggerClassName, styles.focusable, expanded && styles.expanded)}
-      tabIndex={0}
-      onKeyUp={onKeyUp}
-      onKeyDown={onKeyDown}
-      onClick={onClick}
-      aria-label={ariaLabel}
-      {...focusVisible}
-      {...ariaAttributes}
-    >
-      <div className={styles['icon-container']}>{icon}</div>
-      {children}
-    </div>
-  );
-};
+);

--- a/src/expandable-section/index.tsx
+++ b/src/expandable-section/index.tsx
@@ -9,9 +9,12 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 
 export { ExpandableSectionProps };
 
-export default function ExpandableSection({ variant = 'default', ...props }: ExpandableSectionProps) {
-  const baseComponentProps = useBaseComponent('ExpandableSection');
-  return <InternalExpandableSection variant={variant} {...props} {...baseComponentProps} />;
-}
+const ExpandableSection = React.forwardRef(
+  ({ variant = 'default', ...props }: ExpandableSectionProps, ref: React.Ref<ExpandableSectionProps.Ref>) => {
+    const baseComponentProps = useBaseComponent('ExpandableSection');
+    return <InternalExpandableSection ref={ref} variant={variant} {...props} {...baseComponentProps} />;
+  }
+);
 
 applyDisplayName(ExpandableSection, 'ExpandableSection');
+export default ExpandableSection;

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -9,6 +9,13 @@ export namespace ExpandableSectionProps {
   export interface ChangeDetail {
     expanded: boolean;
   }
+
+  export interface Ref {
+    /**
+     * Sets the browser focus on the UI control
+     */
+    focus(): void;
+  }
 }
 
 export interface ExpandableSectionProps extends BaseComponentProps {


### PR DESCRIPTION
### Description

Add focus function to `ExpandableSection` header. 

### How has this been tested?

Added unit tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [* ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

AWSUI-19454

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
