### PR TITLE
fix(date-range-picker): Get consistent label word breaks on narrow screens

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -62,14 +62,14 @@ function renderDateRange(
 function BreakSpaces({ text }: { text: string }) {
   const tokens = text.split(/( )/);
   return (
-    <div style={{ whiteSpace: 'nowrap' }}>
+    <>
       {tokens.map((token, index) => (
         <React.Fragment key={index}>
-          {token}
+          {token.length > 1 ? <span className={styles['label-token-nowrap']}>{token}</span> : token}
           {token === ' ' && <wbr />}
         </React.Fragment>
       ))}
-    </div>
+    </>
   );
 }
 

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -155,6 +155,10 @@ $calendar-header-color: awsui.$color-text-body-default;
   @include styles.form-placeholder;
 }
 
+.label-token-nowrap {
+  white-space: nowrap;
+}
+
 .mode-switch {
   /* used in test-utils */
 }


### PR DESCRIPTION
### Description

Before this change, the word beak worked differently on Chrome,
FF and Safari on narrow screens (Safari and FF did not break the
label into two rows at all, Chrome did).

This change adds a work break right after the start or before the end time range throughout all browsers:

<img width="440" alt="Screenshot 2022-10-07 at 16 07 29" src="https://user-images.githubusercontent.com/569011/194575809-72da7db8-ce7f-4de3-8531-a26917ea0e7b.png">


### How has this been tested?

- I'm adopting existing screenshot tests to cover the narrow case.

- Checkout this PR, open the `/#/light/date-range-picker/with-default-date` example in Chrome, FF and Safari
 - When doing so, set the viewport width to 450px to test the narrow case.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links
- AWSUI-19387


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
