### PR TITLE
Use table layout for calendar

### DIFF
--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -24,7 +24,7 @@ function renderCalendar(props: CalendarProps = defaultProps) {
 }
 
 function findCalendarWeekdays(wrapper: CalendarWrapper) {
-  return wrapper.findAll(`.${styles['calendar-day-name']}`).map(day => day.getElement().textContent!.trim());
+  return wrapper.findAll(`.${styles['calendar-day-header']}`).map(day => day.getElement().textContent!.trim());
 }
 
 describe('Calendar', () => {

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -103,11 +103,10 @@ export default function Grid({
           ))}
         </tr>
       </thead>
-      <tbody className={styles['calendar-grid-body']} onKeyDown={onGridKeyDownHandler}>
+      <tbody onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => (
           <tr key={weekIndex} className={clsx(styles['calendar-grid-row'], styles['calendar-week'])}>
             {week.map((date, dateIndex) => {
-              const isDateInLastWeek = weeks.length - 1 === weekIndex;
               const isFocusable = !!focusedDate && isSameDay(date, focusedDate);
               const isSelected = !!selectedDate && isSameDay(date, selectedDate);
               const isEnabled = !isDateEnabled || isDateEnabled(date);
@@ -140,7 +139,6 @@ export default function Grid({
                   role="button"
                   aria-label={dayAnnouncement}
                   className={clsx(styles['calendar-grid-cell'], styles['calendar-day'], {
-                    [styles['calendar-day-in-last-week']]: isDateInLastWeek,
                     [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
                     [styles['calendar-day-enabled']]: isEnabled,
                     [styles['calendar-day-selected']]: isSelected,

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -93,7 +93,11 @@ export default function Grid({
       <thead>
         <tr className={styles['calendar-grid-row']}>
           {rotateDayIndexes(startOfWeek).map(dayIndex => (
-            <th key={dayIndex} className={clsx(styles['calendar-grid-cell'], styles['calendar-day-header'])}>
+            <th
+              key={dayIndex}
+              scope="col"
+              className={clsx(styles['calendar-grid-cell'], styles['calendar-day-header'])}
+            >
               {renderDayName(locale, dayIndex)}
             </th>
           ))}
@@ -101,7 +105,7 @@ export default function Grid({
       </thead>
       <tbody className={styles['calendar-grid-body']} onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => (
-          <tr key={weekIndex} className={styles['calendar-grid-row']}>
+          <tr key={weekIndex} className={clsx(styles['calendar-grid-row'], styles['calendar-week'])}>
             {week.map((date, dateIndex) => {
               const isDateInLastWeek = weeks.length - 1 === weekIndex;
               const isFocusable = !!focusedDate && isSameDay(date, focusedDate);

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -125,40 +125,44 @@ export default function Grid({
               const isEnabled = !isDateEnabled || isDateEnabled(date);
               const isDateOnSameDay = isSameDay(date, new Date());
 
-              const dayAnnouncement = isDateOnSameDay
-                ? `${getDateLabel(locale, date)}. ${todayAriaLabel}`
-                : getDateLabel(locale, date);
-
-              const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
-
-              if (isSelected) {
-                computedAttributes['aria-current'] = 'date';
-              }
-
-              if (isEnabled) {
-                computedAttributes.onClick = () => onSelectDate(date);
-                computedAttributes.tabIndex = -1;
-              } else {
-                computedAttributes['aria-disabled'] = true;
-              }
-
+              // Can't be focused.
+              let tabIndex = undefined;
               if (isFocusable && isEnabled) {
-                computedAttributes.tabIndex = 0;
+                // Next focus target.
+                tabIndex = 0;
+              } else if (isEnabled) {
+                // Can be focused programmatically.
+                tabIndex = -1;
               }
+
+              // Screen-reader announcement for the focused day.
+              let dayAnnouncement = getDateLabel(locale, date);
+              if (isDateOnSameDay) {
+                dayAnnouncement += '. ' + todayAriaLabel;
+              }
+
+              const onClick = () => {
+                if (isEnabled) {
+                  onSelectDate(date);
+                }
+              };
 
               return (
                 <td
                   key={`${weekIndex}:${dateIndex}`}
-                  ref={computedAttributes.tabIndex === 0 ? focusedDateRef : undefined}
+                  ref={tabIndex === 0 ? focusedDateRef : undefined}
                   role="button"
+                  tabIndex={tabIndex}
                   aria-label={dayAnnouncement}
+                  aria-current={isSelected ? 'date' : undefined}
+                  aria-disabled={!isEnabled}
+                  onClick={onClick}
                   className={clsx(styles['calendar-grid-cell'], styles['calendar-day'], {
                     [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
                     [styles['calendar-day-enabled']]: isEnabled,
                     [styles['calendar-day-selected']]: isSelected,
                     [styles['calendar-day-today']]: isDateOnSameDay,
                   })}
-                  {...computedAttributes}
                   {...focusVisible}
                 >
                   <span className={styles['day-inner']} aria-hidden="true">

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -104,7 +104,7 @@ export default function Grid({
   return (
     <table role="none" className={styles['calendar-grid']}>
       <thead>
-        <tr className={styles['calendar-grid-row']}>
+        <tr>
           {rotateDayIndexes(startOfWeek).map(dayIndex => (
             <th
               key={dayIndex}
@@ -118,7 +118,7 @@ export default function Grid({
       </thead>
       <tbody onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => (
-          <tr key={weekIndex} className={clsx(styles['calendar-grid-row'], styles['calendar-week'])}>
+          <tr key={weekIndex} className={styles['calendar-week']}>
             {week.map((date, dateIndex) => {
               const isFocusable = !!focusableDate && isSameDay(date, focusableDate);
               const isSelected = !!selectedDate && isSameDay(date, selectedDate);

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -89,19 +89,21 @@ export default function Grid({
   const focusVisible = useFocusVisible();
 
   return (
-    <div>
-      <div className={styles['calendar-day-names']}>
-        {rotateDayIndexes(startOfWeek).map(i => (
-          <div key={`day-name-${i}`} className={styles['calendar-day-name']}>
-            {renderDayName(locale, i)}
-          </div>
-        ))}
-      </div>
-      <div className={styles['calendar-dates']} onKeyDown={onGridKeyDownHandler}>
+    <table role="grid" className={styles['calendar-grid']}>
+      <thead>
+        <tr className={styles['calendar-grid-row']}>
+          {rotateDayIndexes(startOfWeek).map(dayIndex => (
+            <th key={dayIndex} className={clsx(styles['calendar-grid-cell'], styles['calendar-day-header'])}>
+              {renderDayName(locale, dayIndex)}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className={styles['calendar-grid-body']} onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => {
           const isDateInLastWeek = weeks.length - 1 === weekIndex;
           return (
-            <div key={`week-${weekIndex}`} className={styles['calendar-week']}>
+            <tr key={weekIndex} className={styles['calendar-grid-row']}>
               {week.map((date, dateIndex) => {
                 const isFocusable = !!focusedDate && isSameDay(date, focusedDate);
                 const isSelected = !!selectedDate && isSameDay(date, selectedDate);
@@ -130,11 +132,9 @@ export default function Grid({
                 }
 
                 return (
-                  <div
+                  <td
                     key={`${weekIndex}:${dateIndex}`}
-                    role="button"
-                    aria-label={ariaLabel}
-                    className={clsx(styles['calendar-day'], {
+                    className={clsx(styles['calendar-grid-cell'], styles['calendar-day'], {
                       [styles['calendar-day-in-last-week']]: isDateInLastWeek,
                       [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
                       [styles['calendar-day-enabled']]: isEnabled,
@@ -144,14 +144,17 @@ export default function Grid({
                     {...computedAttributes}
                     {...focusVisible}
                   >
-                    <span className={styles['day-inner']}>{date.getDate()}</span>
-                  </div>
+                    <span className={styles['day-inner']} aria-hidden="true">
+                      {date.getDate()}
+                    </span>
+                    <span className={styles['visually-hidden']}>{ariaLabel}</span>
+                  </td>
                 );
               })}
-            </div>
+            </tr>
           );
         })}
-      </div>
-    </div>
+      </tbody>
+    </table>
   );
 }

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -89,7 +89,7 @@ export default function Grid({
   const focusVisible = useFocusVisible();
 
   return (
-    <table role="grid" className={styles['calendar-grid']}>
+    <table role="none" className={styles['calendar-grid']}>
       <thead>
         <tr className={styles['calendar-grid-row']}>
           {rotateDayIndexes(startOfWeek).map(dayIndex => (
@@ -100,60 +100,59 @@ export default function Grid({
         </tr>
       </thead>
       <tbody className={styles['calendar-grid-body']} onKeyDown={onGridKeyDownHandler}>
-        {weeks.map((week, weekIndex) => {
-          const isDateInLastWeek = weeks.length - 1 === weekIndex;
-          return (
-            <tr key={weekIndex} className={styles['calendar-grid-row']}>
-              {week.map((date, dateIndex) => {
-                const isFocusable = !!focusedDate && isSameDay(date, focusedDate);
-                const isSelected = !!selectedDate && isSameDay(date, selectedDate);
-                const isEnabled = !isDateEnabled || isDateEnabled(date);
-                const isDateOnSameDay = isSameDay(date, new Date());
+        {weeks.map((week, weekIndex) => (
+          <tr key={weekIndex} className={styles['calendar-grid-row']}>
+            {week.map((date, dateIndex) => {
+              const isDateInLastWeek = weeks.length - 1 === weekIndex;
+              const isFocusable = !!focusedDate && isSameDay(date, focusedDate);
+              const isSelected = !!selectedDate && isSameDay(date, selectedDate);
+              const isEnabled = !isDateEnabled || isDateEnabled(date);
+              const isDateOnSameDay = isSameDay(date, new Date());
 
-                const ariaLabel = isDateOnSameDay
-                  ? `${getDateLabel(locale, date)}. ${todayAriaLabel}`
-                  : getDateLabel(locale, date);
+              const dayAnnouncement = isDateOnSameDay
+                ? `${getDateLabel(locale, date)}. ${todayAriaLabel}`
+                : getDateLabel(locale, date);
 
-                const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
+              const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
 
-                if (isSelected) {
-                  computedAttributes['aria-current'] = 'date';
-                }
+              if (isSelected) {
+                computedAttributes['aria-current'] = 'date';
+              }
 
-                if (isEnabled) {
-                  computedAttributes.onClick = () => onSelectDate(date);
-                  computedAttributes.tabIndex = -1;
-                } else {
-                  computedAttributes['aria-disabled'] = true;
-                }
+              if (isEnabled) {
+                computedAttributes.onClick = () => onSelectDate(date);
+                computedAttributes.tabIndex = -1;
+              } else {
+                computedAttributes['aria-disabled'] = true;
+              }
 
-                if (isFocusable && isEnabled) {
-                  computedAttributes.tabIndex = 0;
-                }
+              if (isFocusable && isEnabled) {
+                computedAttributes.tabIndex = 0;
+              }
 
-                return (
-                  <td
-                    key={`${weekIndex}:${dateIndex}`}
-                    className={clsx(styles['calendar-grid-cell'], styles['calendar-day'], {
-                      [styles['calendar-day-in-last-week']]: isDateInLastWeek,
-                      [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
-                      [styles['calendar-day-enabled']]: isEnabled,
-                      [styles['calendar-day-selected']]: isSelected,
-                      [styles['calendar-day-today']]: isDateOnSameDay,
-                    })}
-                    {...computedAttributes}
-                    {...focusVisible}
-                  >
-                    <span className={styles['day-inner']} aria-hidden="true">
-                      {date.getDate()}
-                    </span>
-                    <span className={styles['visually-hidden']}>{ariaLabel}</span>
-                  </td>
-                );
-              })}
-            </tr>
-          );
-        })}
+              return (
+                <td
+                  key={`${weekIndex}:${dateIndex}`}
+                  role="button"
+                  aria-label={dayAnnouncement}
+                  className={clsx(styles['calendar-grid-cell'], styles['calendar-day'], {
+                    [styles['calendar-day-in-last-week']]: isDateInLastWeek,
+                    [styles['calendar-day-current-month']]: isSameMonth(date, baseDate),
+                    [styles['calendar-day-enabled']]: isEnabled,
+                    [styles['calendar-day-selected']]: isSelected,
+                    [styles['calendar-day-today']]: isDateOnSameDay,
+                  })}
+                  {...computedAttributes}
+                  {...focusVisible}
+                >
+                  <span className={styles['day-inner']} aria-hidden="true">
+                    {date.getDate()}
+                  </span>
+                </td>
+              );
+            })}
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -49,26 +49,24 @@
     width: 100%;
     border-spacing: 0;
   }
-  &-grid-body {
-    border: calendar.$grid-border;
-  }
+
   &-grid-row {
     display: flex;
   }
-  &-week {
-    /* used in test-utils */
-  }
+
   &-grid-cell {
     width: 100%;
     word-break: break-word;
     text-align: center;
     font-weight: unset;
   }
+
   &-day-header {
     padding: awsui.$space-s 0 awsui.$space-xxs;
     color: calendar.$grid-day-name-color;
     @include styles.font-body-s;
   }
+
   &-day {
     border-bottom: calendar.$grid-border;
     border-right: calendar.$grid-border;
@@ -76,12 +74,8 @@
     color: calendar.$grid-disabled-day-color;
     position: relative;
 
-    &:last-child {
-      border-right: none;
-    }
-
-    &-in-last-week {
-      border-bottom: none;
+    &:first-child {
+      border-left: calendar.$grid-border;
     }
 
     &-enabled {
@@ -162,6 +156,14 @@
         z-index: 2;
         color: calendar.$grid-selected-text-color;
         position: relative;
+      }
+    }
+  }
+
+  &-week {
+    &:first-child {
+      > .calendar-day {
+        border-top: calendar.$grid-border;
       }
     }
   }

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -50,12 +50,8 @@
     border-spacing: 0;
   }
 
-  &-grid-row {
-    display: flex;
-  }
-
   &-grid-cell {
-    width: 100%;
+    width: calc(100% / 7);
     word-break: break-word;
     text-align: center;
     font-weight: unset;

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -55,6 +55,9 @@
   &-grid-row {
     display: flex;
   }
+  &-week {
+    /* used in test-utils */
+  }
   &-grid-cell {
     width: 100%;
     word-break: break-word;

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -45,34 +45,28 @@
     /* used for identifying element */
   }
 
-  &-day-names {
-    display: flex;
-    justify-content: stretch;
+  &-grid {
+    width: 100%;
+    border-spacing: 0;
   }
-
-  &-day-name {
-    flex: 1 1 0%;
-    width: 0;
+  &-grid-body {
+    border: calendar.$grid-border;
+  }
+  &-grid-row {
+    display: flex;
+  }
+  &-grid-cell {
+    width: 100%;
     word-break: break-word;
     text-align: center;
+    font-weight: unset;
+  }
+  &-day-header {
     padding: awsui.$space-s 0 awsui.$space-xxs;
     color: calendar.$grid-day-name-color;
     @include styles.font-body-s;
   }
-
-  &-dates {
-    border: calendar.$grid-border;
-  }
-  &-week {
-    display: flex;
-    justify-content: stretch;
-  }
-
   &-day {
-    flex: 1 1 0%;
-    width: 0;
-    word-break: break-word;
-    text-align: center;
     border-bottom: calendar.$grid-border;
     border-right: calendar.$grid-border;
     padding: awsui.$space-xxs 0;
@@ -170,4 +164,8 @@
   }
 
   @include styles.styles-reset;
+}
+
+.visually-hidden {
+  @include styles.awsui-util-hide;
 }

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -165,7 +165,3 @@
 
   @include styles.styles-reset;
 }
-
-.visually-hidden {
-  @include styles.awsui-util-hide;
-}

--- a/src/date-picker/__tests__/date-picker-calendar.test.tsx
+++ b/src/date-picker/__tests__/date-picker-calendar.test.tsx
@@ -55,7 +55,7 @@ describe('Date picker calendar', () => {
   const findCalendarWeekdays = (wrapper: DatePickerWrapper) => {
     return wrapper
       .findCalendar()!
-      .findAll(`.${calendarStyles['calendar-day-name']}`)
+      .findAll(`.${calendarStyles['calendar-day-header']}`)
       .map(day => day.getElement().textContent!.trim());
   };
 


### PR DESCRIPTION
### Description

Although the table layout is used the actual behaviour for screen-readers remains unchanged so far due to table's role set to "none" and cell's role set to "button". The next step would be to change the behaviour accordingly.

### How has this been tested?

Visual regression tests, screenshot tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* AWSUI-19185

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
