### PR TITLE
fix(table): Fix incorrect dark mode change in b97589

### DIFF
--- a/src/__integ__/__snapshots__/themes.test.ts.snap
+++ b/src/__integ__/__snapshots__/themes.test.ts.snap
@@ -902,7 +902,7 @@ Object {
   "color-text-code-editor-status-bar-disabled": "#687078",
   "color-text-code-editor-tab-button-error": "#16191f",
   "color-text-column-header": "#95a5a6",
-  "color-text-column-sorting-icon": "#687078",
+  "color-text-column-sorting-icon": "#95a5a6",
   "color-text-control-disabled": "#687078",
   "color-text-counter": "#95a5a6",
   "color-text-disabled": "#687078",

--- a/style-dictionary/classic/colors.ts
+++ b/style-dictionary/classic/colors.ts
@@ -95,7 +95,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorTextCalendarDaySelected: '{colorTextDropdownItemHighlighted}',
   colorTextCalendarMonth: '{colorTextBodySecondary}',
   colorTextColumnHeader: { dark: '{colorGrey450}' },
-  colorTextColumnSortingIcon: '{colorGrey550}',
+  colorTextColumnSortingIcon: { light: '{colorGrey550}', dark: '{colorGrey450}' },
   colorTextGroupLabel: '{colorTextLabel}',
   colorTextExpandableSectionDefault: '{colorTextInteractiveDefault}',
   colorTextExpandableSectionHover: '{colorTextInteractiveHover}',


### PR DESCRIPTION
### Description

The existing color in dark mode looks like it was correct. The original definition was `colorTextIconCaret`, which is defined as `{ light: '{colorGrey500}', dark: '{colorGrey450}' }`.

For the original PR, I tested the colors I got from Chrome devtools, which doesn't always resolve CSS custom properties correctly, so that's on me 🤦 

### How has this been tested?

Reverted to existing known state. Any visual changes in light more are intentional.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
