### PR TITLE
add statusIconAriaLabel to alert and propagate to other components

### DIFF
--- a/pages/alert/permutations.page.tsx
+++ b/pages/alert/permutations.page.tsx
@@ -58,7 +58,10 @@ export default function AlertScenario() {
     <article>
       <h1>Alert permutations</h1>
       <ScreenshotArea>
-        <PermutationsView permutations={permutations} render={permutation => <Alert {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => <Alert statusIconAriaLabel={permutation.type ?? 'Info'} {...permutation} />}
+        />
       </ScreenshotArea>
     </article>
   );

--- a/pages/alert/simple.page.tsx
+++ b/pages/alert/simple.page.tsx
@@ -18,6 +18,7 @@ export default function AlertScenario() {
             <Alert
               header="This is going to be an extremely long title for an alert not sure whether it makes any sense but whatever"
               visible={visible}
+              statusIconAriaLabel="Warning"
               dismissAriaLabel="Close alert"
               dismissible={true}
               buttonText="Button text"
@@ -31,7 +32,7 @@ export default function AlertScenario() {
               <Link href="#">This is a secondary link</Link>
             </Alert>
           </div>
-          <Alert header="Info">
+          <Alert header="Info" statusIconAriaLabel="Info">
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
             ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat

--- a/pages/app-layout/dark-header-main.page.tsx
+++ b/pages/app-layout/dark-header-main.page.tsx
@@ -30,7 +30,12 @@ export default function () {
               Create distribution
             </Header>
             {alertVisible && (
-              <Alert dismissible={true} dismissAriaLabel="Close alert" onDismiss={() => setVisible(false)}>
+              <Alert
+                statusIconAriaLabel="Info"
+                dismissible={true}
+                dismissAriaLabel="Close alert"
+                onDismiss={() => setVisible(false)}
+              >
                 Demo alert
               </Alert>
             )}

--- a/pages/content-layout/dark-header-main.page.tsx
+++ b/pages/content-layout/dark-header-main.page.tsx
@@ -34,7 +34,12 @@ export default function () {
                   Create distribution
                 </Header>
                 {alertVisible && (
-                  <Alert dismissible={true} dismissAriaLabel="Close alert" onDismiss={() => setVisible(false)}>
+                  <Alert
+                    statusIconAriaLabel="Info"
+                    dismissible={true}
+                    dismissAriaLabel="Close alert"
+                    onDismiss={() => setVisible(false)}
+                  >
                     Demo alert
                   </Alert>
                 )}

--- a/pages/content-layout/standalone.page.tsx
+++ b/pages/content-layout/standalone.page.tsx
@@ -29,7 +29,12 @@ export default function () {
                   Create distribution
                 </Header>
                 {alertVisible && (
-                  <Alert dismissible={true} dismissAriaLabel="Close alert" onDismiss={() => setVisible(false)}>
+                  <Alert
+                    statusIconAriaLabel="Info"
+                    dismissible={true}
+                    dismissAriaLabel="Close alert"
+                    onDismiss={() => setVisible(false)}
+                  >
                     Demo alert
                   </Alert>
                 )}

--- a/pages/content-layout/with-header-toggle.page.tsx
+++ b/pages/content-layout/with-header-toggle.page.tsx
@@ -49,7 +49,12 @@ export default function () {
                     Create distribution
                   </Header>
                   {alertVisible && (
-                    <Alert dismissible={true} dismissAriaLabel="Close alert" onDismiss={() => setVisible(false)}>
+                    <Alert
+                      statusIconAriaLabel="Info"
+                      dismissible={true}
+                      dismissAriaLabel="Close alert"
+                      onDismiss={() => setVisible(false)}
+                    >
                       Demo alert
                     </Alert>
                   )}

--- a/pages/date-range-picker/common.ts
+++ b/pages/date-range-picker/common.ts
@@ -31,6 +31,7 @@ export const i18nStrings: DateRangePickerProps['i18nStrings'] = {
   clearButtonLabel: 'Clear and dismiss',
   cancelButtonLabel: 'Cancel',
   applyButtonLabel: 'Apply',
+  errorIconAriaLabel: 'Error',
   renderSelectedAbsoluteRangeAriaLive: (startDate, endDate) => `Range selected from ${startDate} to ${endDate}`,
 };
 

--- a/pages/form/permutations.page.tsx
+++ b/pages/form/permutations.page.tsx
@@ -55,6 +55,7 @@ const permutations = createPermutations<FormProps>([
       </SpaceBetween>,
     ],
     errorText: ['', 'This is an error!'],
+    errorIconAriaLabel: ['Error'],
     actions: [
       <SpaceBetween direction="horizontal" size="xs">
         <Button variant="link">Cancel</Button>

--- a/pages/form/simple.page.tsx
+++ b/pages/form/simple.page.tsx
@@ -33,6 +33,7 @@ export default function FormScenario() {
             </SpaceBetween>
           }
           errorText="This is an error!"
+          errorIconAriaLabel="Error"
         >
           <SpaceBetween direction="vertical" size="l">
             <Container header={<Header variant="h2">Form section header 1</Header>}>

--- a/pages/s3-resource-selector/permutations.page.tsx
+++ b/pages/s3-resource-selector/permutations.page.tsx
@@ -36,7 +36,7 @@ const permutations: ReadonlyArray<S3ResourceSelectorProps> = [
   {
     ...defaults,
     alert: (
-      <Alert type="error" header="Resource cannot be found">
+      <Alert type="error" statusIconAriaLabel="Error" header="Resource cannot be found">
         The specified path does not exist
       </Alert>
     ),

--- a/pages/s3-resource-selector/with-alert.page.tsx
+++ b/pages/s3-resource-selector/with-alert.page.tsx
@@ -14,7 +14,7 @@ export default function () {
       <ScreenshotArea>
         <S3ResourceSelector
           alert={
-            <Alert type="error" header="Resource cannot be found">
+            <Alert type="error" statusIconAriaLabel="Error" header="Resource cannot be found">
               The specified path does not exist
             </Alert>
           }

--- a/pages/wizard/common.ts
+++ b/pages/wizard/common.ts
@@ -6,6 +6,7 @@ const i18nStrings: WizardProps.I18nStrings = {
   stepNumberLabel: stepNumber => `Step ${stepNumber}`,
   collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
   skipToButtonLabel: step => `Skip to ${step.title}`,
+  errorIconAriaLabel: 'Error',
   cancelButton: 'Cancel',
   previousButton: 'Previous',
   nextButton: 'Next',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -45,6 +45,12 @@ An \`onDismiss\` event is fired when a user clicks the button.",
       "type": "string",
     },
     Object {
+      "description": "Provides a text alternative for the icon.",
+      "name": "statusIconAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "defaultValue": "\\"info\\"",
       "description": "Specifies the type of message you want to display.",
       "inlineType": Object {
@@ -4859,6 +4865,11 @@ in a slight, visible lag when scrolling complex pages.",
             "type": "string",
           },
           Object {
+            "name": "errorIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "formatRelativeRange",
             "optional": false,
             "type": "(value: DateRangePickerProps.RelativeValue) => string",
@@ -5250,6 +5261,12 @@ Object {
     Object {
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Provides a text alternative for the error icon in the error alert.",
+      "name": "errorIconAriaLabel",
       "optional": true,
       "type": "string",
     },
@@ -12749,6 +12766,11 @@ Defaults to \`false\`.
           Object {
             "name": "cancelButton",
             "optional": false,
+            "type": "string",
+          },
+          Object {
+            "name": "errorIconAriaLabel",
+            "optional": true,
             "type": "string",
           },
           Object {

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -60,6 +60,14 @@ describe('Alert Component', () => {
       const wrapper = renderAlert({ dismissible: true, dismissAriaLabel: 'close' });
       expect(wrapper.findDismissButton()!.getElement()).toHaveAttribute('aria-label', 'close');
     });
+    it('status icon does not have a label by default', () => {
+      const wrapper = renderAlert({});
+      expect(wrapper.find('[role="img"]')!.getElement()).not.toHaveAttribute('aria-label');
+    });
+    it('status icon can have a label', () => {
+      const wrapper = renderAlert({ statusIconAriaLabel: 'Info' });
+      expect(wrapper.find('[role="img"]')!.getElement()).toHaveAttribute('aria-label', 'Info');
+    });
   });
   describe('visibility', () => {
     it('shows the alert by default', () => {

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
@@ -12,6 +13,12 @@ export interface AlertProps extends BaseComponentProps {
    * Specifies the type of message you want to display.
    */
   type?: AlertProps.Type;
+
+  /**
+   * Provides a text alternative for the icon.
+   */
+  statusIconAriaLabel?: string;
+
   /**
    * Determines whether the alert is displayed.
    * @deprecated Use conditional rendering in your code instead of this prop

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -27,6 +27,7 @@ type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseCompone
 
 export default function InternalAlert({
   type,
+  statusIconAriaLabel,
   visible = true,
   dismissible,
   dismissAriaLabel,
@@ -73,7 +74,7 @@ export default function InternalAlert({
     >
       <VisualContext contextName="alert">
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
-          <div className={clsx(styles.icon, styles.text)}>
+          <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
             <InternalIcon name={typeToIcon[type]} size={size} />
           </div>
           <div className={styles.body}>

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -205,7 +205,7 @@ export function DateRangePickerDropdown({
                 >
                   {!validationResult.valid && (
                     <>
-                      <InternalAlert type="error">
+                      <InternalAlert type="error" statusIconAriaLabel={i18nStrings.errorIconAriaLabel}>
                         <span className={styles['validation-error']}>{validationResult.errorMessage}</span>
                       </InternalAlert>
                       <LiveRegion>{validationResult.errorMessage}</LiveRegion>

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -335,6 +335,11 @@ export namespace DateRangePickerProps {
     dateTimeConstraintText?: string;
 
     /**
+     * Provides a text alternative for the error icon in the error alert.
+     */
+    errorIconAriaLabel?: string;
+
+    /**
      * When the property is set, screen readers announce the selected range when the absolute range gets selected.
      */
     renderSelectedAbsoluteRangeAriaLive?: (startDate: string, endDate: string) => string;

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
 import { BaseComponentProps } from '../internal/base-component';
 
 export interface FormProps extends BaseComponentProps {
@@ -17,6 +18,11 @@ export interface FormProps extends BaseComponentProps {
    * Specifies a form-level validation message.
    */
   errorText?: React.ReactNode;
+
+  /**
+   * Provides a text alternative for the error icon in the error alert.
+   */
+  errorIconAriaLabel?: string;
 
   /**
    * Specifies actions for the form. You should wrap action buttons in a [space between component](/components/space-between) with `direction="horizontal"` and `size="xs"`.

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -15,6 +15,7 @@ export default function InternalForm({
   children,
   header,
   errorText,
+  errorIconAriaLabel,
   actions,
   secondaryActions,
   __internalRootRef,
@@ -28,7 +29,7 @@ export default function InternalForm({
       <div aria-live="assertive">
         {errorText && (
           <InternalBox margin={{ top: 'l' }}>
-            <InternalAlert type="error">
+            <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
               <div className={styles.error}>{errorText}</div>
             </InternalAlert>
           </InternalBox>

--- a/src/tutorial-panel/interfaces.ts
+++ b/src/tutorial-panel/interfaces.ts
@@ -111,7 +111,7 @@ export namespace TutorialPanelProps {
      * tutorial object), the content of `prerequisitesAlert` will be shown in the
      * tutorial list underneath the tutorial title.
      *
-     * Example: `<><Link>Create a bucket first</Link> to complete this tutorial.</>`
+     * @deprecated Use alert component inside description property directly
      */
     prerequisitesAlert?: React.ReactNode;
 
@@ -172,6 +172,7 @@ export namespace TutorialPanelProps {
     /**
      * If this field is present, a warning alert will be displayed inside
      * the step's popover, showing this field's content. Can be JSX or plain text.
+     * @deprecated Use alert component inside content property directly
      */
     warningAlert?: React.ReactNode;
 

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -114,6 +114,7 @@ export namespace WizardProps {
     stepNumberLabel(stepNumber: number): string;
     collapsedStepsLabel(stepNumber: number, stepsCount: number): string;
     skipToButtonLabel?(targetStep: WizardProps.Step, targetStepNumber: number): string;
+    errorIconAriaLabel?: string;
     cancelButton: string;
     previousButton: string;
     nextButton: string;

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -86,6 +86,7 @@ export default function WizardForm({
         }
         secondaryActions={secondaryActions}
         errorText={errorText}
+        errorIconAriaLabel={i18nStrings.errorIconAriaLabel}
       >
         {content}
       </InternalForm>


### PR DESCRIPTION
### Description

Add new properties to allow annotate status icon in alert and derived components

### How has this been tested?

Dry-run

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
