### PR TITLE
Refactor date range picker calendar grid

### DIFF
--- a/src/date-range-picker/calendar/grids/day/index.tsx
+++ b/src/date-range-picker/calendar/grids/day/index.tsx
@@ -36,143 +36,111 @@ interface GridDayProps {
   onlyOneSelected: boolean;
   isRangeStartDate: boolean;
   isRangeEndDate: boolean;
+
+  focusedDateRef: React.RefObject<HTMLDivElement>;
 }
 
-function propsAreEqual(prevProps: GridDayProps, nextProps: GridDayProps): boolean {
+export default function GridDay({
+  locale,
+  baseDate,
+  date,
+  isSelected,
+  isStartDate,
+  isEndDate,
+  onlyOneSelected,
+  isRangeStartDate,
+  isRangeEndDate,
+  isFocusedDate,
+  isDateEnabled,
+  todayAriaLabel,
+  onSelectDate,
+  onFocusDate,
+  isDateInFirstRow,
+  isDateInFirstColumn,
+  isDateInLastColumn,
+  isDateInSelectionStartWeek,
+  isDateInSelectionEndWeek,
+  isInRange,
+  focusedDateRef,
+}: GridDayProps) {
+  const dayLabel = getDateLabel(locale, date);
+
+  const labels = [dayLabel];
+
+  const isEnabled = !isDateEnabled || isDateEnabled(date);
+  const isFocusable = isFocusedDate && isEnabled;
+  const isToday = isTodayFn(date);
+  const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
+
+  const focusVisible = useFocusVisible();
+
+  const baseClasses = {
+    [styles['in-first-row']]: isDateInFirstRow,
+    [styles['in-first-column']]: isDateInFirstColumn,
+  };
+
+  if (!isSameMonth(date, baseDate)) {
+    const classNames = clsx(styles.day, baseClasses, {
+      [styles['in-previous-month']]: isBefore(date, baseDate),
+      [styles['last-day-of-month']]: isLastDayOfMonth(date),
+      [styles['in-next-month']]: isAfter(date, baseDate),
+    });
+    return <div className={classNames} ref={isFocusedDate ? focusedDateRef : undefined}></div>;
+  }
+
+  const classNames = clsx(styles.day, baseClasses, {
+    [styles['in-current-month']]: isSameMonth(date, baseDate),
+    [styles.enabled]: isEnabled,
+    [styles.selected]: isSelected,
+    [styles['start-date']]: isStartDate,
+    [styles['end-date']]: isEndDate,
+    [styles['range-start-date']]: isRangeStartDate,
+    [styles['range-end-date']]: isRangeEndDate,
+    [styles['no-range']]: isSelected && onlyOneSelected,
+    [styles['in-range']]: isInRange,
+    [styles['in-range-border-top']]: isDateInSelectionStartWeek || date.getDate() <= 7,
+    [styles['in-range-border-bottom']]: isDateInSelectionEndWeek || date.getDate() > getDaysInMonth(date) - 7,
+    [styles['in-range-border-left']]: isDateInFirstColumn || date.getDate() === 1 || isRangeStartDate,
+    [styles['in-range-border-right']]: isDateInLastColumn || isLastDayOfMonth(date) || isRangeEndDate,
+    [styles.today]: isToday,
+  });
+
+  computedAttributes['aria-pressed'] = isSelected || isInRange;
+
+  if (isToday) {
+    labels.push(todayAriaLabel);
+    computedAttributes['aria-current'] = 'date';
+  }
+
+  if (isEnabled) {
+    computedAttributes.onClick = () => onSelectDate(date);
+    computedAttributes.onFocus = () => onFocusDate(date);
+    computedAttributes.tabIndex = -1;
+  }
+
+  if (isFocusable) {
+    computedAttributes.tabIndex = 0;
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.keyCode === KeyCode.space) {
+      event.preventDefault();
+      onSelectDate(date);
+    }
+  };
+
   return (
-    prevProps.locale === nextProps.locale &&
-    prevProps.baseDate.getTime() === nextProps.baseDate.getTime() &&
-    prevProps.date.getTime() === nextProps.date.getTime() &&
-    prevProps.isDateInFirstRow === nextProps.isDateInFirstRow &&
-    prevProps.isDateInFirstColumn === nextProps.isDateInFirstColumn &&
-    prevProps.isDateInLastColumn === nextProps.isDateInLastColumn &&
-    prevProps.isDateInSelectionStartWeek === nextProps.isDateInSelectionStartWeek &&
-    prevProps.isDateInSelectionEndWeek === nextProps.isDateInSelectionEndWeek &&
-    prevProps.isFocusedDate === nextProps.isFocusedDate &&
-    prevProps.isDateEnabled === nextProps.isDateEnabled &&
-    prevProps.todayAriaLabel === nextProps.todayAriaLabel &&
-    prevProps.onSelectDate === nextProps.onSelectDate &&
-    prevProps.onFocusDate === nextProps.onFocusDate &&
-    prevProps.isInRange === nextProps.isInRange &&
-    prevProps.isSelected === nextProps.isSelected &&
-    prevProps.isStartDate === nextProps.isStartDate &&
-    prevProps.isEndDate === nextProps.isEndDate &&
-    prevProps.onlyOneSelected === nextProps.onlyOneSelected &&
-    prevProps.isRangeStartDate === nextProps.isRangeStartDate &&
-    prevProps.isRangeEndDate === nextProps.isRangeEndDate
+    <div
+      className={classNames}
+      aria-label={labels.join('. ')}
+      data-date={formatDate(date)}
+      role="button"
+      {...computedAttributes}
+      ref={isFocusedDate ? focusedDateRef : undefined}
+      onKeyDown={onKeyDown}
+      {...focusVisible}
+    >
+      <span className={styles['day-inner']}>{date.getDate()}</span>
+    </div>
   );
 }
-
-const GridDay = React.memo(
-  React.forwardRef<HTMLDivElement, GridDayProps>(
-    (
-      {
-        locale,
-        baseDate,
-        date,
-        isSelected,
-        isStartDate,
-        isEndDate,
-        onlyOneSelected,
-        isRangeStartDate,
-        isRangeEndDate,
-        isFocusedDate,
-        isDateEnabled,
-        todayAriaLabel,
-        onSelectDate,
-        onFocusDate,
-        isDateInFirstRow,
-        isDateInFirstColumn,
-        isDateInLastColumn,
-        isDateInSelectionStartWeek,
-        isDateInSelectionEndWeek,
-        isInRange,
-      }: GridDayProps,
-      ref
-    ) => {
-      const dayLabel = getDateLabel(locale, date);
-
-      const labels = [dayLabel];
-
-      const isEnabled = !isDateEnabled || isDateEnabled(date);
-      const isFocusable = isFocusedDate && isEnabled;
-      const isToday = isTodayFn(date);
-      const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
-
-      const focusVisible = useFocusVisible();
-
-      const baseClasses = {
-        [styles['in-first-row']]: isDateInFirstRow,
-        [styles['in-first-column']]: isDateInFirstColumn,
-      };
-
-      if (!isSameMonth(date, baseDate)) {
-        const classNames = clsx(styles.day, baseClasses, {
-          [styles['in-previous-month']]: isBefore(date, baseDate),
-          [styles['last-day-of-month']]: isLastDayOfMonth(date),
-          [styles['in-next-month']]: isAfter(date, baseDate),
-        });
-        return <div className={classNames} ref={ref}></div>;
-      }
-
-      const classNames = clsx(styles.day, baseClasses, {
-        [styles['in-current-month']]: isSameMonth(date, baseDate),
-        [styles.enabled]: isEnabled,
-        [styles.selected]: isSelected,
-        [styles['start-date']]: isStartDate,
-        [styles['end-date']]: isEndDate,
-        [styles['range-start-date']]: isRangeStartDate,
-        [styles['range-end-date']]: isRangeEndDate,
-        [styles['no-range']]: isSelected && onlyOneSelected,
-        [styles['in-range']]: isInRange,
-        [styles['in-range-border-top']]: isDateInSelectionStartWeek || date.getDate() <= 7,
-        [styles['in-range-border-bottom']]: isDateInSelectionEndWeek || date.getDate() > getDaysInMonth(date) - 7,
-        [styles['in-range-border-left']]: isDateInFirstColumn || date.getDate() === 1 || isRangeStartDate,
-        [styles['in-range-border-right']]: isDateInLastColumn || isLastDayOfMonth(date) || isRangeEndDate,
-        [styles.today]: isToday,
-      });
-
-      computedAttributes['aria-pressed'] = isSelected || isInRange;
-
-      if (isToday) {
-        labels.push(todayAriaLabel);
-        computedAttributes['aria-current'] = 'date';
-      }
-
-      if (isEnabled) {
-        computedAttributes.onClick = () => onSelectDate(date);
-        computedAttributes.onFocus = () => onFocusDate(date);
-        computedAttributes.tabIndex = -1;
-      }
-
-      if (isFocusable) {
-        computedAttributes.tabIndex = 0;
-      }
-
-      const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-        if (event.keyCode === KeyCode.space) {
-          event.preventDefault();
-          onSelectDate(date);
-        }
-      };
-
-      return (
-        <div
-          className={classNames}
-          aria-label={labels.join('. ')}
-          data-date={formatDate(date)}
-          role="button"
-          {...computedAttributes}
-          ref={ref}
-          onKeyDown={onKeyDown}
-          {...focusVisible}
-        >
-          <span className={styles['day-inner']}>{date.getDate()}</span>
-        </div>
-      );
-    }
-  ),
-  propsAreEqual
-);
-
-export default GridDay;

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -68,16 +68,16 @@ export function Grid({
   return (
     <div className={clsx(styles.grid, className)}>
       <div className={styles['calendar-day-names']}>
-        {rotateDayIndexes(startOfWeek).map(i => (
-          <div key={`day-name-${i}`} className={styles['calendar-day-name']}>
-            {renderDayName(locale, i)}
+        {rotateDayIndexes(startOfWeek).map(dayIndex => (
+          <div key={dayIndex} className={styles['calendar-day-name']}>
+            {renderDayName(locale, dayIndex)}
           </div>
         ))}
       </div>
       <div className={styles['calendar-dates']} onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => {
           return (
-            <div key={`week-${weekIndex}`} className={styles['calendar-week']}>
+            <div key={weekIndex} className={styles['calendar-week']}>
               {week.map((date, dateIndex) => {
                 const isStartDate = !!selectedStartDate && isSameDay(date, selectedStartDate);
                 const isEndDate = !!selectedEndDate && isSameDay(date, selectedEndDate);
@@ -99,8 +99,9 @@ export function Grid({
 
                 return (
                   <GridDay
-                    key={`date-${weekIndex}-${dateIndex}`}
+                    key={`${weekIndex}:${dateIndex}`}
                     locale={locale}
+                    date={date}
                     baseDate={baseDate}
                     isSelected={isSelected}
                     isStartDate={isStartDate}
@@ -108,9 +109,8 @@ export function Grid({
                     onlyOneSelected={onlyOneSelected}
                     isRangeStartDate={isRangeStartDate}
                     isRangeEndDate={isRangeEndDate}
-                    date={date}
                     isFocusedDate={isFocused}
-                    ref={isFocused ? focusedDateRef : undefined}
+                    focusedDateRef={focusedDateRef}
                     todayAriaLabel={todayAriaLabel}
                     onSelectDate={onSelectDate}
                     onFocusDate={onFocusedDateChange}


### PR DESCRIPTION
### Description

Removed React.memo and React.ref wrappers from date range picker calendar day.

The memo was irrelevant because the onSelectDay handlers created in the calendar wasn't memoized anyway causing all days to re-render whenever selection changes. The memoization can be added back if needed with a more elegant solution e.g. the date objects can be memoized in the parent:

```
const cache = {}
function memoizeDate(date) {
  // ...
}

// function Grid
return <GridDay date={memoizeDate(date)} baseDate={memoizeDate(baseDate)} ... />

function GridDay() {...}
export default memo(GridDay) // no need to provide a comparator function
```

### How has this been tested?

No additional tests needed.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
