### PR TITLE
Use table layout for drp calendar

### DIFF
--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -65,7 +65,7 @@ describe('Date range picker calendar', () => {
   const findDropdownWeekdays = (wrapper: DateRangePickerWrapper) => {
     return wrapper
       .findDropdown()!
-      .findAll(`.${styles['calendar-day-name']}`)
+      .findAll(`.${gridDayStyles['day-header']}`)
       .map(day => day.getElement().textContent!.trim());
   };
 

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useMemo } from 'react';
-import styles from '../../styles.css.js';
-import dayStyles from './styles.css.js';
+import styles from './styles.css.js';
 import {
   isSameMonth,
   isAfter,
@@ -32,7 +31,7 @@ export interface GridProps {
   rangeEndDate: Date | null;
 
   focusedDate: Date | null;
-  focusedDateRef: React.RefObject<HTMLDivElement>;
+  focusedDateRef: React.RefObject<HTMLTableCellElement>;
 
   onSelectDate: DateChangeHandler;
   onGridKeyDownHandler: (e: React.KeyboardEvent) => void;
@@ -80,18 +79,20 @@ export function Grid({
   const focusVisible = useFocusVisible();
 
   return (
-    <div className={clsx(styles.grid, className)}>
-      <div className={styles['calendar-day-names']}>
-        {rotateDayIndexes(startOfWeek).map(dayIndex => (
-          <div key={dayIndex} className={styles['calendar-day-name']}>
-            {renderDayName(locale, dayIndex)}
-          </div>
-        ))}
-      </div>
-      <div className={styles['calendar-dates']} onKeyDown={onGridKeyDownHandler}>
+    <table role="none" className={clsx(styles.grid, className)}>
+      <thead>
+        <tr>
+          {rotateDayIndexes(startOfWeek).map(dayIndex => (
+            <th key={dayIndex} scope="col" className={clsx(styles['grid-cell'], styles['day-header'])}>
+              {renderDayName(locale, dayIndex)}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody onKeyDown={onGridKeyDownHandler}>
         {weeks.map((week, weekIndex) => {
           return (
-            <div key={weekIndex} className={styles['calendar-week']}>
+            <tr key={weekIndex} className={styles.week}>
               {week.map((date, dateIndex) => {
                 const isStartDate = !!selectedStartDate && isSameDay(date, selectedStartDate);
                 const isEndDate = !!selectedEndDate && isSameDay(date, selectedEndDate);
@@ -113,31 +114,32 @@ export function Grid({
 
                 const isEnabled = !isDateEnabled || isDateEnabled(date);
                 const isFocusable = isFocused && isEnabled;
-                const computedAttributes: React.HTMLAttributes<HTMLDivElement> = {};
 
                 const baseClasses = {
-                  [dayStyles.day]: true,
-                  [dayStyles['in-first-row']]: weekIndex === 0,
-                  [dayStyles['in-first-column']]: dateIndex === 0,
+                  [styles.day]: true,
+                  [styles['grid-cell']]: true,
+                  [styles['in-first-row']]: weekIndex === 0,
+                  [styles['in-first-column']]: dateIndex === 0,
                 };
 
                 if (!isSameMonth(date, baseDate)) {
                   return (
-                    <div
+                    <td
                       key={`${weekIndex}:${dateIndex}`}
-                      className={clsx(baseClasses, {
-                        [dayStyles['in-previous-month']]: isBefore(date, baseDate),
-                        [dayStyles['last-day-of-month']]: isLastDayOfMonth(date),
-                        [dayStyles['in-next-month']]: isAfter(date, baseDate),
-                      })}
                       ref={isFocused ? focusedDateRef : undefined}
-                    ></div>
+                      className={clsx(baseClasses, {
+                        [styles['in-previous-month']]: isBefore(date, baseDate),
+                        [styles['last-day-of-month']]: isLastDayOfMonth(date),
+                        [styles['in-next-month']]: isAfter(date, baseDate),
+                      })}
+                    ></td>
                   );
                 }
 
+                const handlers: React.HTMLAttributes<HTMLDivElement> = {};
                 if (isEnabled) {
-                  computedAttributes.onClick = () => onSelectDate(date);
-                  computedAttributes.onFocus = () => onFocusedDateChange(date);
+                  handlers.onClick = () => onSelectDate(date);
+                  handlers.onFocus = () => onFocusedDateChange(date);
                 }
 
                 // Can't be focused.
@@ -157,25 +159,25 @@ export function Grid({
                 }
 
                 return (
-                  <div
+                  <td
+                    ref={isFocused ? focusedDateRef : undefined}
                     key={`${weekIndex}:${dateIndex}`}
                     className={clsx(baseClasses, {
-                      [dayStyles['in-current-month']]: isSameMonth(date, baseDate),
-                      [dayStyles.enabled]: isEnabled,
-                      [dayStyles.selected]: isSelected,
-                      [dayStyles['start-date']]: isStartDate,
-                      [dayStyles['end-date']]: isEndDate,
-                      [dayStyles['range-start-date']]: isRangeStartDate,
-                      [dayStyles['range-end-date']]: isRangeEndDate,
-                      [dayStyles['no-range']]: isSelected && onlyOneSelected,
-                      [dayStyles['in-range']]: dateIsInRange,
-                      [dayStyles['in-range-border-top']]: !!inRangeStartWeek || date.getDate() <= 7,
-                      [dayStyles['in-range-border-bottom']]:
-                        !!inRangeEndWeek || date.getDate() > getDaysInMonth(date) - 7,
-                      [dayStyles['in-range-border-left']]: dateIndex === 0 || date.getDate() === 1 || isRangeStartDate,
-                      [dayStyles['in-range-border-right']]:
+                      [styles['in-current-month']]: isSameMonth(date, baseDate),
+                      [styles.enabled]: isEnabled,
+                      [styles.selected]: isSelected,
+                      [styles['start-date']]: isStartDate,
+                      [styles['end-date']]: isEndDate,
+                      [styles['range-start-date']]: isRangeStartDate,
+                      [styles['range-end-date']]: isRangeEndDate,
+                      [styles['no-range']]: isSelected && onlyOneSelected,
+                      [styles['in-range']]: dateIsInRange,
+                      [styles['in-range-border-top']]: !!inRangeStartWeek || date.getDate() <= 7,
+                      [styles['in-range-border-bottom']]: !!inRangeEndWeek || date.getDate() > getDaysInMonth(date) - 7,
+                      [styles['in-range-border-left']]: dateIndex === 0 || date.getDate() === 1 || isRangeStartDate,
+                      [styles['in-range-border-right']]:
                         dateIndex === week.length - 1 || isLastDayOfMonth(date) || isRangeEndDate,
-                      [dayStyles.today]: isToday(date),
+                      [styles.today]: isToday(date),
                     })}
                     aria-label={dayAnnouncement}
                     aria-pressed={isSelected || dateIsInRange}
@@ -183,19 +185,18 @@ export function Grid({
                     data-date={formatDate(date)}
                     role="button"
                     tabIndex={tabIndex}
-                    {...computedAttributes}
-                    ref={isFocused ? focusedDateRef : undefined}
+                    {...handlers}
                     {...focusVisible}
                   >
-                    <span className={dayStyles['day-inner']}>{date.getDate()}</span>
-                  </div>
+                    <span className={styles['day-inner']}>{date.getDate()}</span>
+                  </td>
                 );
               })}
-            </div>
+            </tr>
           );
         })}
-      </div>
-    </div>
+      </tbody>
+    </table>
   );
 }
 

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -85,7 +85,7 @@ export const Grids = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [gridHasFocus, setGridHasFocus] = useState(false);
 
-  const focusedDateRef = useRef<HTMLDivElement>(null);
+  const focusedDateRef = useRef<HTMLTableCellElement>(null);
 
   const baseDateTime = baseDate?.getTime();
   const focusedDateTime = focusedDate?.getTime();

--- a/src/date-range-picker/calendar/grids/styles.scss
+++ b/src/date-range-picker/calendar/grids/styles.scss
@@ -30,11 +30,27 @@
   }
 }
 
-.day {
-  flex: 1 1 0%;
-  width: 0;
+.grid {
+  width: awsui.$size-calendar-grid-width;
+  border-spacing: 0;
+}
+.grid-cell {
+  width: calc(100% / 7);
   word-break: break-word;
   text-align: center;
+  font-weight: unset;
+}
+.day-header {
+  padding: awsui.$space-s 0 awsui.$space-xxs;
+  color: calendar.$grid-day-name-color;
+  @include styles.font-body-s;
+}
+
+.week {
+  /* used for identifying element */
+}
+
+.day {
   border-bottom: calendar.$grid-border;
   border-right: calendar.$grid-border;
   padding: awsui.$space-xxs 0;

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -7,7 +7,6 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
 @use '../internal/styles/typography/index' as typographyConstants;
-@use '../calendar/calendar' as calendar;
 @use './motion';
 
 $calendar-grid-width: awsui.$size-calendar-grid-width;
@@ -73,35 +72,11 @@ $calendar-header-color: awsui.$color-text-body-default;
   &-prev-month-btn {
     /* used for identifying element */
   }
-
-  &-day-names {
-    display: flex;
-    justify-content: stretch;
-  }
-
-  &-day-name {
-    flex: 1 1 0%;
-    width: 0;
-    word-break: break-word;
-    text-align: center;
-    padding: awsui.$space-s 0 awsui.$space-xxs;
-    color: calendar.$grid-day-name-color;
-    @include styles.font-body-s;
-  }
-
-  &-week {
-    display: flex;
-    justify-content: stretch;
-  }
 }
 
 .first-grid,
 .second-grid {
   /* used in test-utils */
-}
-
-.grid {
-  width: $calendar-grid-width;
 }
 
 .date-and-time-wrapper {

--- a/src/test-utils/dom/date-range-picker/index.ts
+++ b/src/test-utils/dom/date-range-picker/index.ts
@@ -3,7 +3,7 @@
 import { act } from 'react-dom/test-utils';
 import { ComponentWrapper, ElementWrapper, usesDom, createWrapper } from '@cloudscape-design/test-utils-core/dom';
 import styles from '../../../date-range-picker/styles.selectors.js';
-import dayStyles from '../../../date-range-picker/calendar/grids/styles.selectors.js';
+import gridStyles from '../../../date-range-picker/calendar/grids/styles.selectors.js';
 import relativeRangeStyles from '../../../date-range-picker/relative-range/styles.selectors.js';
 import SelectWrapper from '../select';
 import ButtonWrapper from '../button';
@@ -109,18 +109,17 @@ export class DrpDropdownWrapper extends ComponentWrapper {
    */
   findDateAt(grid: 'left' | 'right', row: 1 | 2 | 3 | 4 | 5 | 6, column: 1 | 2 | 3 | 4 | 5 | 6 | 7): ElementWrapper {
     const gridClassName = grid === 'right' ? styles['second-grid'] : styles['first-grid'];
-
     return this.find(
-      `.${gridClassName} .${styles['calendar-week']}:nth-child(${row}) .${dayStyles.day}:nth-child(${column})`
+      `.${gridClassName} .${gridStyles.week}:nth-child(${row}) .${gridStyles.day}:nth-child(${column})`
     )!;
   }
 
   findSelectedStartDate(): ElementWrapper | null {
-    return this.findByClassName(dayStyles['start-date']);
+    return this.findByClassName(gridStyles['start-date']);
   }
 
   findSelectedEndDate(): ElementWrapper | null {
-    return this.findByClassName(dayStyles['end-date']);
+    return this.findByClassName(gridStyles['end-date']);
   }
 
   findStartDateInput(): InputWrapper | null {


### PR DESCRIPTION
### Description

Update drp calendar layout to use table but set role to "none" to temporarily keep the old behaviour.

Similar request for calendar component: https://github.com/cloudscape-design/components/pull/343

### How has this been tested?

Visual regression tests and screenshot tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* AWSUI-19213

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
