### PR TITLE
fix(button-dropdown): Focus on first item of dropdown list when it's opened

### DIFF
--- a/src/__integ__/page-objects/button-dropdown-page.ts
+++ b/src/__integ__/page-objects/button-dropdown-page.ts
@@ -47,6 +47,10 @@ export default class ButtonDropdownPage extends BasePageObject {
     return this.getElementsCount(this.findButtonDropdown().findItems().toSelector());
   }
 
+  public getItemText(itemId: string) {
+    return this.getText(this.getItem(itemId));
+  }
+
   public getHighlightedElementText() {
     const element = this.findButtonDropdown().findHighlightedItem();
     return this.getText(element.toSelector());

--- a/src/button-dropdown/__integ__/button-dropdown-disabled-reason.test.ts
+++ b/src/button-dropdown/__integ__/button-dropdown-disabled-reason.test.ts
@@ -32,10 +32,14 @@ class ButtonDropdownDisabledReasonPage extends BasePageObject {
   }
 }
 
-const setupTest = (testFn: (page: ButtonDropdownDisabledReasonPage) => Promise<void>) => {
+const setupTest = (testFn: (page: ButtonDropdownDisabledReasonPage) => Promise<void>, isMobile?: boolean) => {
   return useBrowser(async browser => {
     const page = new ButtonDropdownDisabledReasonPage(browser);
     await browser.url('#/light/button-dropdown/disabled-reason?visualRefresh=false');
+    if (isMobile) {
+      await page.setMobileWindow();
+    }
+
     await page.waitForVisible(page.findButtonDropdown().toSelector());
     await page.openDropdown();
     await testFn(page);
@@ -76,9 +80,6 @@ describe('Button Dropdown - Disabled Reason', () => {
     it(
       `opens and closes on click when mobile=${mobile}`,
       setupTest(async page => {
-        if (mobile) {
-          await page.setMobileWindow();
-        }
         await page.click(page.findButtonDropdown().findItemById('manage-state').toSelector());
         await page.waitForVisible(page.findDisabledReason().toSelector());
         expect(await page.getDisabledReason()).toContain('Instance state must not be pending or stopping.');
@@ -89,7 +90,7 @@ describe('Button Dropdown - Disabled Reason', () => {
         await page.waitForAssertion(async () =>
           expect(await page.isDisplayed(page.findDisabledReason().toSelector())).toBeFalsy()
         );
-      })
+      }, mobile)
     );
   });
   it(

--- a/src/button-dropdown/__integ__/button-dropdown-items.test.ts
+++ b/src/button-dropdown/__integ__/button-dropdown-items.test.ts
@@ -17,3 +17,22 @@ test(
     expect(await browser.getWindowHandles()).toHaveLength(2);
   })
 );
+
+test(
+  'focus on first menu item when dropdown is opened',
+  useBrowser(async browser => {
+    const page = new ButtonDropdownPage('ButtonDropdown1', browser);
+    await browser.url('#/light/button-dropdown/simple');
+
+    await page.waitForVisible(page.getTrigger());
+    await page.openDropdown();
+
+    const firstTabbableMenuItemText = await page.getItemText('id1');
+
+    const focusedElement = await browser.execute(function () {
+      return document.activeElement!.textContent;
+    });
+
+    expect(focusedElement).toEqual(` ${firstTabbableMenuItemText} `);
+  })
+);

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -17,6 +17,7 @@ import useForwardFocus from '../internal/hooks/forward-focus';
 import { usePrevious } from '../internal/hooks/use-previous';
 import InternalBox from '../box/internal';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs/index.js';
 
 const InternalButtonDropdown = React.forwardRef(
   (
@@ -74,6 +75,10 @@ const InternalButtonDropdown = React.forwardRef(
     const baseProps = getBaseProps(props);
 
     const dropdownRef = useRef<HTMLElement>(null);
+
+    const rootRef = useRef<HTMLDivElement>(null);
+    const mergedRootRef = useMergeRefs(rootRef, __internalRootRef);
+
     useForwardFocus(ref, dropdownRef);
 
     const clickHandler = () => {
@@ -93,6 +98,12 @@ const InternalButtonDropdown = React.forwardRef(
         dropdownRef.current.focus();
       }
     }, [isOpen, wasOpen]);
+
+    useEffect(() => {
+      if (isOpen) {
+        (rootRef?.current?.querySelector(`li:first-child [role="menuitem"][tabindex="-1"]`) as HTMLDivElement)?.focus();
+      }
+    }, [isOpen]);
 
     const triggerVariant = variant === 'navigation' ? undefined : variant;
     const iconProps: Partial<ButtonProps & { __iconClass?: string }> =
@@ -140,7 +151,7 @@ const InternalButtonDropdown = React.forwardRef(
         onMouseMove={handleMouseEvent}
         className={clsx(styles['button-dropdown'], styles[`variant-${variant}`], baseProps.className)}
         aria-owns={expandToViewport && isOpen ? dropdownId : undefined}
-        ref={__internalRootRef}
+        ref={mergedRootRef}
       >
         <Dropdown
           open={canBeOpened && isOpen}


### PR DESCRIPTION
### Description

Focus on first menu item of dropdown list when button dropdown is opened so it will be announced in the screen reader

### How has this been tested?

- Added a unit test
- Tested manually, first menu item is announced by screen reader when the dropdown is opened

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

AWSUI-18913

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
