### PR TITLE
Introduce screenreader-only internal component

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -25,6 +25,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import FocusLock from '../internal/components/focus-lock';
 import useFocusVisible from '../internal/hooks/focus-visible/index.js';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 
 export { DatePickerProps };
 
@@ -192,9 +193,9 @@ const DatePicker = React.forwardRef(
                   nextMonthAriaLabel={nextMonthAriaLabel}
                   previousMonthAriaLabel={previousMonthAriaLabel}
                 />
-                <div id={calendarDescriptionId} className={styles['screenreader-only']} aria-live="polite">
+                <ScreenreaderOnly id={calendarDescriptionId} aria-live="polite">
                   {renderMonthAndYear(normalizedLocale, baseDate)}
-                </div>
+                </ScreenreaderOnly>
               </div>
             </FocusLock>
           )}

--- a/src/date-picker/styles.scss
+++ b/src/date-picker/styles.scss
@@ -21,10 +21,6 @@
   }
 }
 
-.screenreader-only {
-  @include styles.awsui-util-hide;
-}
-
 .date-picker-container {
   position: relative;
   max-width: 234px;

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -10,7 +10,12 @@ type ScreenreaderOnlyProps = Exclude<React.HTMLAttributes<HTMLDivElement>, 'clas
  * Makes content now shown on a screen but still announced by screen-reader users.
  * The component is suitable when the aria-label cannot be used, e.g. to avoid elemnts being announced as "blank".
  *
- * To exclude screenreader-only content for testing use `wrapper.find(':not([data-screenreader-only])')`.
+ * To exclude screenreader-only content use `:not([data-screenreader-only])` selector, for example:
+ *
+ * ```
+ * let visibleContent = wrapper.find(`${styles.label}`).find(':not([data-screenreader-only])').getElement().textContent
+ * let screenreaderContent = wrapper.find(`${styles.label}`).find('[data-screenreader-only]').getElement().textContent
+ * ```
  */
 export default function ScreenreaderOnly(props: ScreenreaderOnlyProps) {
   return <div {...props} className={styles.root} data-screenreader-only={true} />;

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -10,13 +10,16 @@ type ScreenreaderOnlyProps = Exclude<React.HTMLAttributes<HTMLDivElement>, 'clas
  * Makes content now shown on a screen but still announced by screen-reader users.
  * The component is suitable when the aria-label cannot be used, e.g. to avoid elemnts being announced as "blank".
  *
- * To exclude screenreader-only content use `:not([data-screenreader-only])` selector, for example:
+ * To exclude screenreader-only content use `:not(.${screenreaderOnlyStyles.root})` selector, for example:
  *
  * ```
- * let visibleContent = wrapper.find(`${styles.label}`).find(':not([data-screenreader-only])').getElement().textContent
- * let screenreaderContent = wrapper.find(`${styles.label}`).find('[data-screenreader-only]').getElement().textContent
+ * import screenreaderOnlyStyles from '~internal/components/screenreader-only/styles.css.js'
+ *
+ * let visibleContent = wrapper.find(`${styles.label}`).find(`:not(.${screenreaderOnlyStyles.root})`).getElement().textContent
+ *
+ * let screenreaderContent = wrapper.find(`${styles.label}`).find(`.${screenreaderOnlyStyles.root}`).getElement().textContent
  * ```
  */
 export default function ScreenreaderOnly(props: ScreenreaderOnlyProps) {
-  return <div {...props} className={styles.root} data-screenreader-only={true} />;
+  return <div {...props} className={styles.root} />;
 }

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import styles from './styles.css.js';
+
+type ScreenreaderOnlyProps = Exclude<React.HTMLAttributes<HTMLDivElement>, 'className'>;
+
+/**
+ * Makes content now shown on a screen but still announced by screen-reader users.
+ * The component is suitable when the aria-label cannot be used, e.g. to avoid elemnts being announced as "blank".
+ *
+ * To exclude screenreader-only content for testing use `wrapper.find(':not([data-screenreader-only])')`.
+ */
+export default function ScreenreaderOnly(props: ScreenreaderOnlyProps) {
+  return <div {...props} className={styles.root} data-screenreader-only={true} />;
+}

--- a/src/internal/components/screenreader-only/styles.scss
+++ b/src/internal/components/screenreader-only/styles.scss
@@ -1,0 +1,10 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../styles' as styles;
+
+.root {
+  @include styles.awsui-util-hide;
+}


### PR DESCRIPTION
### Description

A follow-up for https://github.com/cloudscape-design/components/pull/351.

### How has this been tested?

Manual testing.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
