### PR TITLE
Make live-region use screenreader-only

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -25,7 +25,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import FocusLock from '../internal/components/focus-lock';
 import useFocusVisible from '../internal/hooks/focus-visible/index.js';
-import ScreenreaderOnly from '../internal/components/screenreader-only';
+import LiveRegion from '../internal/components/live-region';
 
 export { DatePickerProps };
 
@@ -193,9 +193,7 @@ const DatePicker = React.forwardRef(
                   nextMonthAriaLabel={nextMonthAriaLabel}
                   previousMonthAriaLabel={previousMonthAriaLabel}
                 />
-                <ScreenreaderOnly id={calendarDescriptionId} aria-live="polite">
-                  {renderMonthAndYear(normalizedLocale, baseDate)}
-                </ScreenreaderOnly>
+                <LiveRegion id={calendarDescriptionId}>{renderMonthAndYear(normalizedLocale, baseDate)}</LiveRegion>
               </div>
             </FocusLock>
           )}

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -372,9 +372,7 @@ function Calendar(
           )}
         </InternalSpaceBetween>
       </InternalSpaceBetween>
-      <LiveRegion>
-        <span className={styles['calendar-aria-live']}>{announcement}</span>
-      </LiveRegion>
+      <LiveRegion className={styles['calendar-aria-live']}>{announcement}</LiveRegion>
     </>
   );
 }

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -3,10 +3,12 @@
 
 /* eslint-disable @cloudscape-design/prefer-live-region */
 
+import clsx from 'clsx';
 import React, { memo, useEffect, useRef } from 'react';
+import ScreenreaderOnly, { ScreenreaderOnlyProps } from '../screenreader-only/index.js';
 import styles from './styles.css.js';
 
-export interface LiveRegionProps {
+export interface LiveRegionProps extends ScreenreaderOnlyProps {
   assertive?: boolean;
   delay?: number;
   children: React.ReactNode;
@@ -47,7 +49,7 @@ export interface LiveRegionProps {
 */
 export default memo(LiveRegion);
 
-function LiveRegion({ assertive = false, delay = 10, children }: LiveRegionProps) {
+function LiveRegion({ assertive = false, delay = 10, children, ...restProps }: LiveRegionProps) {
   const sourceRef = useRef<HTMLSpanElement>(null);
   const targetRef = useRef<HTMLSpanElement>(null);
 
@@ -91,13 +93,13 @@ function LiveRegion({ assertive = false, delay = 10, children }: LiveRegionProps
   });
 
   return (
-    <div className={styles.root}>
+    <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
       <span aria-hidden="true">
         <span ref={sourceRef}>{children}</span>
       </span>
 
       <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>
-    </div>
+    </ScreenreaderOnly>
   );
 }
 

--- a/src/internal/components/live-region/styles.scss
+++ b/src/internal/components/live-region/styles.scss
@@ -3,8 +3,6 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-@use '../../styles' as styles;
-
 .root {
-  @include styles.awsui-util-hide;
+  /* used in test-utils */
 }

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -1,10 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import clsx from 'clsx';
 import React from 'react';
 import styles from './styles.css.js';
 
-type ScreenreaderOnlyProps = Exclude<React.HTMLAttributes<HTMLDivElement>, 'className'>;
+export interface ScreenreaderOnlyProps {
+  id?: string;
+  className?: string;
+  children: React.ReactNode;
+}
 
 /**
  * Makes content now shown on a screen but still announced by screen-reader users.
@@ -21,5 +26,5 @@ type ScreenreaderOnlyProps = Exclude<React.HTMLAttributes<HTMLDivElement>, 'clas
  * ```
  */
 export default function ScreenreaderOnly(props: ScreenreaderOnlyProps) {
-  return <div {...props} className={styles.root} />;
+  return <div {...props} className={clsx(styles.root, props.className)} />;
 }


### PR DESCRIPTION
### Description

Use screenreadaer-only by live-region and live-region by date-picker.

### How has this been tested?

Manual check.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
