### PR TITLE
Fix drp calendar header nvda announcement

### DIFF
--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -58,7 +58,7 @@ describe('Date range picker calendar', () => {
     return focusableItem ? focusableItem.getElement().textContent!.trim() : null;
   };
 
-  const findDropdownHeaderText = (wrapper: DateRangePickerWrapper) => {
+  const findCalendarHeaderText = (wrapper: DateRangePickerWrapper) => {
     return wrapper.findDropdown()!.findHeader()!.getElement().textContent!.trim();
   };
 
@@ -83,7 +83,7 @@ describe('Date range picker calendar', () => {
   describe('localization', () => {
     test('should render calendar with the default locale', () => {
       const { wrapper } = renderDateRangePicker();
-      expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+      expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       expect(findDropdownWeekdays(wrapper)).toEqual([
         'Sun',
         'Mon',
@@ -104,7 +104,7 @@ describe('Date range picker calendar', () => {
 
     test('should allow country override', () => {
       const { wrapper } = renderDateRangePicker({ ...defaultProps, locale: 'en-GB' });
-      expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+      expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       expect(findDropdownWeekdays(wrapper)).toEqual([
         'Mon',
         'Tue',
@@ -130,7 +130,7 @@ describe('Date range picker calendar', () => {
       window.Date.prototype.toLocaleDateString = localStringMock;
       try {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, locale });
-        expect(findDropdownHeaderText(wrapper)).toBe('März 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('März 2018');
       } finally {
         window.Date.prototype.toLocaleDateString = oldImpl;
       }
@@ -138,7 +138,7 @@ describe('Date range picker calendar', () => {
 
     test('should override start day of week', () => {
       const { wrapper } = renderDateRangePicker({ ...defaultProps, startOfWeek: 4 });
-      expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+      expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       expect(findDropdownWeekdays(wrapper)).toEqual([
         'Thu',
         'Fri',
@@ -216,7 +216,7 @@ describe('Date range picker calendar', () => {
         changeMode(wrapper, 'absolute');
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.up));
         expect(findFocusableDateText(wrapper)).toBe('24');
-        expect(findDropdownHeaderText(wrapper)).toBe('February 2018March 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('February 2018March 2018');
       });
 
       test('should go to the next month', () => {
@@ -228,7 +228,7 @@ describe('Date range picker calendar', () => {
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.down));
 
         expect(findFocusableDateText(wrapper)).toBe('5');
-        expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
 
       test('should allow first date to be focussed after moving dates then navigating between months', () => {
@@ -290,7 +290,7 @@ describe('Date range picker calendar', () => {
         changeMode(wrapper, 'absolute');
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
         expect(findFocusableDateText(wrapper)).toBe('1');
-        expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
 
       test('should jump to the previous month when the date is disabled', () => {
@@ -303,7 +303,7 @@ describe('Date range picker calendar', () => {
         changeMode(wrapper, 'absolute');
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
         expect(findFocusableDateText(wrapper)).toBe('28');
-        expect(findDropdownHeaderText(wrapper)).toBe('February 2018March 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('February 2018March 2018');
       });
 
       test('should not switch if there are no enabled dates in future', () => {
@@ -317,7 +317,7 @@ describe('Date range picker calendar', () => {
         changeMode(wrapper, 'absolute');
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
         expect(findFocusableDateText(wrapper)).toBe('21');
-        expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
 
       test('should not switch if there are no enabled dates in past', () => {
@@ -331,7 +331,7 @@ describe('Date range picker calendar', () => {
         changeMode(wrapper, 'absolute');
         act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
         expect(findFocusableDateText(wrapper)).toBe('21');
-        expect(findDropdownHeaderText(wrapper)).toBe('March 2018April 2018');
+        expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
 
       test('does not focus anything if all dates are disabled', () => {

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styles from '../../styles.css.js';
 import { renderMonthAndYear } from '../../../calendar/utils/intl';
 import HeaderButton from './button';
+import LiveRegion from '../../../internal/components/live-region';
 
 interface CalendarHeaderProps {
   baseDate: Date;
@@ -15,28 +16,29 @@ interface CalendarHeaderProps {
   isSingleGrid: boolean;
 }
 
-const CalendarHeader = ({
+export default function CalendarHeader({
   baseDate,
   locale,
   onChangeMonth,
   previousMonthLabel,
   nextMonthLabel,
   isSingleGrid,
-}: CalendarHeaderProps) => {
+}: CalendarHeaderProps) {
+  const prevMonthLabel = renderMonthAndYear(locale, add(baseDate, { months: -1 }));
+  const currentMonthLabel = renderMonthAndYear(locale, baseDate);
+
   return (
     <div className={styles['calendar-header']}>
       <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
-      <div aria-live="polite" className={styles['calendar-header-months-wrapper']}>
-        {!isSingleGrid && (
-          <div className={styles['calendar-header-month']}>
-            {renderMonthAndYear(locale, add(baseDate, { months: -1 }))}
-          </div>
-        )}
-        <div className={styles['calendar-header-month']}>{renderMonthAndYear(locale, baseDate)}</div>
+      <div className={styles['calendar-header-months-wrapper']}>
+        {!isSingleGrid && <div className={styles['calendar-header-month']}>{prevMonthLabel}</div>}
+        <div className={styles['calendar-header-month']}>{currentMonthLabel}</div>
       </div>
       <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
+
+      <LiveRegion assertive={true}>
+        {isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`}
+      </LiveRegion>
     </div>
   );
-};
-
-export default CalendarHeader;
+}

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -28,17 +28,16 @@ export default function CalendarHeader({
   const currentMonthLabel = renderMonthAndYear(locale, baseDate);
 
   return (
-    <div className={styles['calendar-header']}>
-      <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
-      <div className={styles['calendar-header-months-wrapper']}>
-        {!isSingleGrid && <div className={styles['calendar-header-month']}>{prevMonthLabel}</div>}
-        <div className={styles['calendar-header-month']}>{currentMonthLabel}</div>
+    <>
+      <div className={styles['calendar-header']}>
+        <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
+        <div className={styles['calendar-header-months-wrapper']}>
+          {!isSingleGrid && <div className={styles['calendar-header-month']}>{prevMonthLabel}</div>}
+          <div className={styles['calendar-header-month']}>{currentMonthLabel}</div>
+        </div>
+        <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
       </div>
-      <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
-
-      <LiveRegion assertive={true}>
-        {isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`}
-      </LiveRegion>
-    </div>
+      <LiveRegion>{isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`}</LiveRegion>
+    </>
   );
 }


### PR DESCRIPTION
### Description

When DRP calendar header live region is polite the NVDA does not really announce it or announce partially. Making it assertive fixes the problem. The VO behaviour does not change.

<img width="1434" alt="Screenshot 2022-10-12 at 17 37 32" src="https://user-images.githubusercontent.com/20790937/195390926-705ac05f-ef35-488e-ad10-4b56fb982e64.png">

### How has this been tested?

Manual testing with Safari/Chrome+VO and Firefox/Chrome+NVDA

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19507

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
