### PR TITLE
expose error icon label on attribute editor

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -3,7 +3,7 @@
 
 import Axe from 'axe-core';
 import { HtmlValidate } from 'html-validate';
-import { uniq } from 'lodash';
+import { uniq, compact } from 'lodash';
 import { runOptions, spec } from './axe';
 
 declare global {
@@ -25,12 +25,15 @@ const htmlValidator = new HtmlValidate({
     'prefer-native-element': ['error', { exclude: ['listbox', 'button'] }],
     //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
     'no-redundant-for': 'off',
+    // innerHTML normalizes attribute values
+    // https://stackoverflow.com/questions/48092293/javascript-innerhtml-messing-with-html-attributes
+    'attribute-boolean-style': 'off',
   },
 });
 
 // Polyfill for Array.prototype.flatMap
-function flatMap<T>(arr: ReadonlyArray<T>, fn: (t: T) => any[]) {
-  return arr.reduce((acc: T[], item: T) => {
+function flatMap<Input, Output>(arr: ReadonlyArray<Input>, fn: (t: Input) => Output[]) {
+  return arr.reduce((acc: Output[], item: Input) => {
     for (const flatItem of fn(item)) {
       acc.push(flatItem);
     }
@@ -38,7 +41,24 @@ function flatMap<T>(arr: ReadonlyArray<T>, fn: (t: T) => any[]) {
   }, []);
 }
 
+function formatMessages(prefix: string, messages: Array<string>) {
+  if (messages.length === 0) {
+    return '';
+  }
+  return (
+    prefix +
+    '\n' +
+    uniq(messages)
+      .map((message, index) => `${index + 1}. ${message}`)
+      .join('\n')
+  );
+}
+
 async function toValidateA11y(this: jest.MatcherUtils, element: HTMLElement) {
+  if (!(element instanceof HTMLElement)) {
+    // Improve default Axe.run parameters check
+    throw new Error('Provided value is not a valid HTMLElement');
+  }
   // Disable color-contrast checks as unavailable in unit test environment.
   const axeResult = await Axe.run(element, { ...runOptions, rules: { 'color-contrast': { enabled: false } } });
 
@@ -58,10 +78,13 @@ async function toValidateA11y(this: jest.MatcherUtils, element: HTMLElement) {
     const flattenAxeViolations = flatMap(axeViolations, violation =>
       violation.nodes.map(node => `${node.failureSummary} [${violation.id}]`)
     );
-    const allViolations = uniq([...htmlViolations, ...flattenAxeViolations]).map(
-      (message, index) => `${index + 1}. ${message}`
-    );
-    return ['Expected HTML to be valid but had the following errors:'].concat(allViolations).join('\n');
+
+    return compact(
+      ['Expected HTML to be valid but had the following errors:'].concat(
+        formatMessages('HTML validation', htmlViolations),
+        formatMessages('Axe checks', flattenAxeViolations)
+      )
+    ).join('\n');
   };
 
   return { pass, message: generateMessage };

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1055,6 +1055,23 @@ A maximum of four fields are supported.
       "type": "boolean",
     },
     Object {
+      "description": "An object containing all the necessary localized strings required by the component.",
+      "inlineType": Object {
+        "name": "AttributeEditorProps.I18nStrings",
+        "properties": Array [
+          Object {
+            "name": "errorIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "AttributeEditorProps.I18nStrings",
+    },
+    Object {
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
       "optional": true,

--- a/src/__tests__/test-a11y-validator.test.tsx
+++ b/src/__tests__/test-a11y-validator.test.tsx
@@ -27,7 +27,7 @@ describe('a11y validator', () => {
     );
     await expect(expect(container).toValidateA11y()).rejects.toThrow(
       new Error(
-        'Expected HTML to be valid but had the following errors:\n1. <label> is associated with multiple controls [multiple-labeled-controls]\n2. <div> element is not permitted as content under <label> [element-permitted-content]'
+        'Expected HTML to be valid but had the following errors:\nHTML validation\n1. <label> is associated with multiple controls [multiple-labeled-controls]\n2. <div> element is not permitted as content under <label> [element-permitted-content]'
       )
     );
   });
@@ -41,7 +41,7 @@ describe('a11y validator', () => {
     );
     await expect(expect(container).toValidateA11y()).rejects.toThrow(
       new Error(
-        'Expected HTML to be valid but had the following errors:\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
+        'Expected HTML to be valid but had the following errors:\nAxe checks\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
       )
     );
   });

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -41,6 +41,9 @@ const defaultProps: AttributeEditorProps<Item> = {
       };
     }),
   empty: 'empty region',
+  i18nStrings: {
+    errorIconAriaLabel: 'Error',
+  },
 };
 
 function renderAttributeEditor(
@@ -245,6 +248,10 @@ describe('Attribute Editor', () => {
       });
 
       test('should display the returned values as error messages', () => {
+        expect(wrapper.findRow(1)!.findFields()[0].find('[role="img"]')!.getElement()).toHaveAttribute(
+          'aria-label',
+          'Error'
+        );
         expectRowErrorTextContent(wrapper, 0, ['Error with key 0']);
         expectRowErrorTextContent(wrapper, 1, ['Error with key 1']);
       });

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -39,6 +39,10 @@ export namespace AttributeEditorProps {
   export interface Ref {
     focusRemoveButton(itemIndex: number): void;
   }
+
+  export interface I18nStrings {
+    errorIconAriaLabel?: string;
+  }
 }
 
 export interface AttributeEditorProps<T> extends BaseComponentProps {
@@ -103,4 +107,9 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
    * The event `detail` contains the index of the corresponding item.
    */
   onRemoveButtonClick?: NonCancelableEventHandler<AttributeEditorProps.RemoveButtonClickDetail>;
+
+  /**
+   * An object containing all the necessary localized strings required by the component.
+   */
+  i18nStrings?: AttributeEditorProps.I18nStrings;
 }

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -32,6 +32,7 @@ const InternalAttributeEditor = React.forwardRef(
       empty,
       addButtonText,
       removeButtonText,
+      i18nStrings,
       onAddButtonClick,
       onRemoveButtonClick,
       __internalRootRef = null,
@@ -64,6 +65,7 @@ const InternalAttributeEditor = React.forwardRef(
               breakpoint={breakpoint}
               item={item}
               definition={definition}
+              i18nStrings={i18nStrings}
               removable={isItemRemovable(item)}
               removeButtonText={removeButtonText}
               removeButtonRefs={removeButtonRefs.current}

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -14,30 +14,24 @@ import clsx from 'clsx';
 
 const Divider = () => <InternalBox className={styles.divider} padding={{ top: 'l' }} />;
 
-interface AttributeProps {
-  info?: React.ReactNode;
-  label?: React.ReactNode;
-  errorText?: React.ReactNode;
-  control?: React.ReactNode;
-  constraintText?: React.ReactNode;
-  hideLabel?: boolean;
-}
-
-const Attribute = ({ control, hideLabel, ...props }: AttributeProps) => (
-  <InternalFormField __hideLabel={hideLabel} {...props} className={styles.field} stretch={true}>
-    {control}
-  </InternalFormField>
-);
-
 export interface RowProps<T> {
   breakpoint: ColumnLayoutBreakpoint | null;
   item: T;
   definition: ReadonlyArray<AttributeEditorProps.FieldDefinition<T>>;
+  i18nStrings: AttributeEditorProps.I18nStrings | undefined;
   index: number;
   removable: boolean;
   removeButtonText: string;
   removeButtonRefs: Array<ButtonProps.Ref | undefined>;
   onRemoveButtonClick?: NonCancelableEventHandler<AttributeEditorProps.RemoveButtonClickDetail>;
+}
+
+function render<T>(
+  item: T,
+  itemIndex: number,
+  slot: AttributeEditorProps.FieldRenderable<T> | React.ReactNode | undefined
+) {
+  return typeof slot === 'function' ? slot(item, itemIndex) : slot;
 }
 
 const GRID_DEFINITION = [{ colspan: { default: 12, xs: 9 } }];
@@ -47,6 +41,7 @@ export const Row = React.memo(
     breakpoint,
     item,
     definition,
+    i18nStrings = {},
     index,
     removable,
     removeButtonText,
@@ -60,9 +55,6 @@ export const Row = React.memo(
       fireNonCancelableEvent(onRemoveButtonClick, { itemIndex: index });
     }, [onRemoveButtonClick, index]);
 
-    const render = (item: T, itemIndex: number, slot: AttributeEditorProps.FieldRenderable<T> | React.ReactNode) =>
-      typeof slot === 'function' ? slot(item, itemIndex) : slot;
-
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>
         <InternalGrid
@@ -71,15 +63,19 @@ export const Row = React.memo(
         >
           <InternalColumnLayout className={styles['row-control']} columns={definition.length} __breakpoint={breakpoint}>
             {definition.map(({ info, label, constraintText, errorText, control }, defIndex) => (
-              <Attribute
+              <InternalFormField
                 key={defIndex}
+                className={styles.field}
                 label={label}
                 info={info}
-                constraintText={constraintText && render(item, index, constraintText)}
-                errorText={errorText && render(item, index, errorText)}
-                control={control && render(item, index, control)}
-                hideLabel={isWideViewport && index > 0}
-              />
+                constraintText={render(item, index, constraintText)}
+                errorText={render(item, index, errorText)}
+                stretch={true}
+                i18nStrings={{ errorIconAriaLabel: i18nStrings.errorIconAriaLabel }}
+                __hideLabel={isWideViewport && index > 0}
+              >
+                {render(item, index, control)}
+              </InternalFormField>
             ))}
           </InternalColumnLayout>
           {removable && (

--- a/src/tag-editor/__tests__/tag-editor-a11y.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor-a11y.test.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import '../../__a11y__/to-validate-a11y';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TagEditor, { TagEditorProps } from '../../../lib/components/tag-editor';
+import { i18nStrings } from './common';
+
+const defaultProps: TagEditorProps = {
+  i18nStrings,
+  tags: [
+    { key: 'a', value: '1', existing: true },
+    { key: 'b', value: '2', existing: true },
+    { key: 'c', value: '3', existing: false },
+  ],
+};
+
+test('simple', async () => {
+  const { container } = render(<TagEditor {...defaultProps} />);
+  await expect(container).toValidateA11y();
+});
+
+test('over limit', async () => {
+  const { container } = render(<TagEditor {...defaultProps} tagLimit={2} />);
+  await expect(container).toValidateA11y();
+});
+
+test('field validation error', async () => {
+  const { container } = render(
+    <TagEditor {...defaultProps} tags={[...defaultProps.tags!, { key: 'aws:', value: '', existing: false }]} />
+  );
+  screen.debug(container.querySelectorAll('.awsui_field_n4qlp_87hqf_145')[6]);
+  await expect(container).toValidateA11y();
+});

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -272,6 +272,7 @@ const TagEditor = React.forwardRef(
           </div>
         }
         definition={definition}
+        i18nStrings={i18nStrings}
       />
     );
   }


### PR DESCRIPTION
### Description

Added new property to attribute editor component

```ts
  /**
   * An object containing all the necessary localized strings required by the component.
   */
  i18nStrings?: AttributeEditorProps.I18nStrings;
```

```ts
interface I18nStrings {
  errorIconAriaLabel?: string;
}
```


### How has this been tested?

Added extra a11y tests, checked that they fail when the labels are missing

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
