### PR TITLE
Use live region in form component

### DIFF
--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -4,63 +4,63 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Form, { FormProps } from '../../../lib/components/form';
+import alertStyles from '../../../lib/components/alert/styles.selectors.js';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.selectors.js';
 
 function renderForm(props: FormProps = {}) {
   const { container } = render(<Form {...props} errorIconAriaLabel="Error icon" />);
-  return { wrapper: createWrapper(container).findForm()!, container };
+  return createWrapper(container).findForm()!;
 }
 
 describe('Form Component', () => {
   describe('structure', () => {
     it('has no header container when no header is set', () => {
-      const { wrapper } = renderForm();
+      const wrapper = renderForm();
       expect(wrapper.findHeader()).toBeNull();
     });
 
     it('displays header - custom html', () => {
-      const { wrapper } = renderForm({ header: <h1>Form header</h1> });
+      const wrapper = renderForm({ header: <h1>Form header</h1> });
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Form header');
     });
 
     it('has no content container when no content is set', () => {
-      const { wrapper } = renderForm();
+      const wrapper = renderForm();
       expect(wrapper.findContent()).toBeNull();
     });
 
     it('displays content - custom html', () => {
-      const { wrapper } = renderForm({ children: <span>Form content</span> });
+      const wrapper = renderForm({ children: <span>Form content</span> });
       expect(wrapper.findContent()!.getElement()).toHaveTextContent('Form content');
     });
 
     it('form contains no error by default', () => {
-      const { wrapper } = renderForm();
+      const wrapper = renderForm();
       expect(wrapper.findError()).toBeNull();
     });
 
     it('form displays the error when set, removes when unset', () => {
-      let { wrapper } = renderForm({ errorText: 'Some error' });
+      let wrapper = renderForm({ errorText: 'Some error' });
       expect(wrapper.findError()!.getElement()).toHaveTextContent('Some error');
 
-      ({ wrapper } = renderForm({ errorText: '' }));
+      wrapper = renderForm({ errorText: '' });
       expect(wrapper.findError()).toBeNull();
     });
 
     it('form error includes alert and live region', () => {
-      const { container } = renderForm({ errorText: 'Some error' });
-      const wrapper = createWrapper(container);
+      const wrapper = renderForm({ errorText: 'Some error' });
 
-      expect(wrapper.findAlert()!.getElement()).toHaveTextContent('Some error');
+      expect(wrapper.findByClassName(alertStyles.root)!.getElement()).toHaveTextContent('Some error');
       expect(wrapper.findByClassName(liveRegionStyles.root)!.getElement()).toHaveTextContent('Error icon, Some error');
     });
 
     it('has no actions container when no actions are set', () => {
-      const { wrapper } = renderForm();
+      const wrapper = renderForm();
       expect(wrapper.findActions()).toBeNull();
     });
 
     it('displays action button', () => {
-      const { wrapper } = renderForm({ actions: <button>Click me!</button> });
+      const wrapper = renderForm({ actions: <button>Click me!</button> });
       expect(wrapper.findActions()!.find('button')!.getElement()).toHaveTextContent('Click me!');
     });
   });

--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -4,54 +4,63 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Form, { FormProps } from '../../../lib/components/form';
+import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.selectors.js';
 
 function renderForm(props: FormProps = {}) {
-  const { container } = render(<Form {...props} />);
-  return createWrapper(container).findForm()!;
+  const { container } = render(<Form {...props} errorIconAriaLabel="Error icon" />);
+  return { wrapper: createWrapper(container).findForm()!, container };
 }
 
 describe('Form Component', () => {
   describe('structure', () => {
     it('has no header container when no header is set', () => {
-      const wrapper = renderForm();
+      const { wrapper } = renderForm();
       expect(wrapper.findHeader()).toBeNull();
     });
 
     it('displays header - custom html', () => {
-      const wrapper = renderForm({ header: <h1>Form header</h1> });
+      const { wrapper } = renderForm({ header: <h1>Form header</h1> });
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Form header');
     });
 
     it('has no content container when no content is set', () => {
-      const wrapper = renderForm();
+      const { wrapper } = renderForm();
       expect(wrapper.findContent()).toBeNull();
     });
 
     it('displays content - custom html', () => {
-      const wrapper = renderForm({ children: <span>Form content</span> });
+      const { wrapper } = renderForm({ children: <span>Form content</span> });
       expect(wrapper.findContent()!.getElement()).toHaveTextContent('Form content');
     });
 
     it('form contains no error by default', () => {
-      const wrapper = renderForm();
+      const { wrapper } = renderForm();
       expect(wrapper.findError()).toBeNull();
     });
 
     it('form displays the error when set, removes when unset', () => {
-      let wrapper = renderForm({ errorText: 'Some error' });
+      let { wrapper } = renderForm({ errorText: 'Some error' });
       expect(wrapper.findError()!.getElement()).toHaveTextContent('Some error');
 
-      wrapper = renderForm({ errorText: '' });
+      ({ wrapper } = renderForm({ errorText: '' }));
       expect(wrapper.findError()).toBeNull();
     });
 
+    it('form error includes alert and live region', () => {
+      const { container } = renderForm({ errorText: 'Some error' });
+      const wrapper = createWrapper(container);
+
+      expect(wrapper.findAlert()!.getElement()).toHaveTextContent('Some error');
+      expect(wrapper.findByClassName(liveRegionStyles.root)!.getElement()).toHaveTextContent('Error icon, Some error');
+    });
+
     it('has no actions container when no actions are set', () => {
-      const wrapper = renderForm();
+      const { wrapper } = renderForm();
       expect(wrapper.findActions()).toBeNull();
     });
 
     it('displays action button', () => {
-      const wrapper = renderForm({ actions: <button>Click me!</button> });
+      const { wrapper } = renderForm({ actions: <button>Click me!</button> });
       expect(wrapper.findActions()!.find('button')!.getElement()).toHaveTextContent('Click me!');
     });
   });

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -8,6 +8,7 @@ import InternalBox from '../box/internal';
 import styles from './styles.css.js';
 import { FormProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import LiveRegion from '../internal/components/live-region';
 
 type InternalFormProps = FormProps & InternalBaseComponentProps;
 
@@ -26,15 +27,13 @@ export default function InternalForm({
     <div {...baseProps} ref={__internalRootRef} className={clsx(styles.root, baseProps.className)}>
       {header && <div className={styles.header}>{header}</div>}
       {children && <div className={styles.content}>{children}</div>}
-      <div aria-live="assertive">
-        {errorText && (
-          <InternalBox margin={{ top: 'l' }}>
-            <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
-              <div className={styles.error}>{errorText}</div>
-            </InternalAlert>
-          </InternalBox>
-        )}
-      </div>
+      {errorText && (
+        <InternalBox margin={{ top: 'l' }}>
+          <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
+            <div className={styles.error}>{errorText}</div>
+          </InternalAlert>
+        </InternalBox>
+      )}
       {(actions || secondaryActions) && (
         <div className={styles.footer}>
           <div className={styles['actions-section']}>
@@ -42,6 +41,11 @@ export default function InternalForm({
             {secondaryActions && <div className={styles['secondary-actions']}>{secondaryActions}</div>}
           </div>
         </div>
+      )}
+      {errorText && (
+        <LiveRegion assertive={true}>
+          {errorIconAriaLabel}, {errorText}
+        </LiveRegion>
       )}
     </div>
   );


### PR DESCRIPTION
### Description

Replace aria-live with live-region component in form.

### How has this been tested?

Added new unit test, manual testing with VO and NVDA.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
