### PR TITLE
Revert "chore(deps): bump d3-color and d3-scale"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,12 +209,6 @@
         "@babel/types": "^7.16.7"
       }
     },
-    "@babel/helper-string-parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-      "dev": true
-    },
     "@babel/helper-validator-identifier": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
@@ -341,18 +335,18 @@
       }
     },
     "@babel/plugin-syntax-decorators": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.19.0.tgz",
-      "integrity": "sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.12.tgz",
+      "integrity": "sha512-D1Hz0qtGTza8K2xGyEdVNCYLdVHukAcbQr4K3/s6r/esadyEriZovpJimQOpu8ju4/jV8dW/1xdaE0UpDroidw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.17.12"
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-          "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
           "dev": true
         }
       }
@@ -448,229 +442,83 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz",
-      "integrity": "sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.12.tgz",
+      "integrity": "sha512-tVPs6MImAJz+DiX8Y1xXEMdTk5Lwxu9jiPjlS+nv5M2A59R7+/d1+9A8C/sbuY0b3QjIxqClkj6KAplEtRvzaA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-module-transforms": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-simple-access": "^7.17.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.18.6"
-          }
-        },
         "@babel/generator": {
-          "version": "7.19.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.3.tgz",
-          "integrity": "sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
+          "integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.19.3",
-            "@jridgewell/gen-mapping": "^0.3.2",
+            "@babel/types": "^7.17.12",
+            "@jridgewell/gen-mapping": "^0.3.0",
             "jsesc": "^2.5.1"
           }
         },
-        "@babel/helper-environment-visitor": {
-          "version": "7.18.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-          "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-          "dev": true
-        },
-        "@babel/helper-function-name": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-          "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.18.10",
-            "@babel/types": "^7.19.0"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-          "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-          "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
         "@babel/helper-module-transforms": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-          "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
+          "integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
           "dev": true,
           "requires": {
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-module-imports": "^7.18.6",
-            "@babel/helper-simple-access": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "@babel/template": "^7.18.10",
-            "@babel/traverse": "^7.19.0",
-            "@babel/types": "^7.19.0"
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-module-imports": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.12",
+            "@babel/types": "^7.17.12"
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-          "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
           "dev": true
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-          "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-          "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.19.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-          "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
         },
         "@babel/parser": {
-          "version": "7.19.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.3.tgz",
-          "integrity": "sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
+          "integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
           "dev": true
         },
-        "@babel/template": {
-          "version": "7.18.10",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-          "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/parser": "^7.18.10",
-            "@babel/types": "^7.18.10"
-          }
-        },
         "@babel/traverse": {
-          "version": "7.19.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.3.tgz",
-          "integrity": "sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
+          "integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.19.3",
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-function-name": "^7.19.0",
-            "@babel/helper-hoist-variables": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/parser": "^7.19.3",
-            "@babel/types": "^7.19.3",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.12",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.17.9",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.12",
+            "@babel/types": "^7.17.12",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.19.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.3.tgz",
-          "integrity": "sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==",
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
+          "integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
           "dev": true,
           "requires": {
-            "@babel/helper-string-parser": "^7.18.10",
-            "@babel/helper-validator-identifier": "^7.19.1",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        },
-        "@jridgewell/trace-mapping": {
-          "version": "0.3.15",
-          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-          "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/resolve-uri": "^3.0.3",
-            "@jridgewell/sourcemap-codec": "^1.4.10"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
         },
         "debug": {
           "version": "4.3.4",
@@ -681,32 +529,11 @@
             "ms": "2.1.2"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -779,209 +606,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@cloudscape-design/browser-test-tools": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.4.tgz",
-      "integrity": "sha512-yFtliOVnRfug7k7p4b3RpNs8Eg6QljkPuvnvgZgD6sF6sbetW0CWMX4aOKxGnEuL+i/9GIoJzoITQ+cGjuJsmg==",
-      "dev": true,
-      "requires": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1140.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.19.7"
-      },
-      "dependencies": {
-        "@types/retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-          "dev": true
-        },
-        "p-retry": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-          "dev": true,
-          "requires": {
-            "@types/retry": "0.12.0",
-            "retry": "^0.13.1"
-          }
-        }
-      }
-    },
-    "@cloudscape-design/collection-hooks": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/collection-hooks/-/collection-hooks-1.0.9.tgz",
-      "integrity": "sha512-rI+LY1WbRr1RVcItwdbTfL6d8Y4o0jxNUWeT69WdqIqjJwV0WLqMHVFtKKGqWTT6ddaEkpKJX//COquNXFFOjQ=="
-    },
-    "@cloudscape-design/documenter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/documenter/-/documenter-1.0.1.tgz",
-      "integrity": "sha512-GdI2pfIAQGxeVuv4hsOtyjAzdAA1U9y0kTP8CAyndkW8Q5dsTz8HYGWqqe2jpQ+rhNfaTSVINTgTSE2gJHQ4cg==",
-      "dev": true,
-      "requires": {
-        "change-case": "^4.1.1",
-        "micromatch": "^4.0.2",
-        "typedoc": "~0.19.2"
-      }
-    },
-    "@cloudscape-design/eslint-plugin": {
-      "version": "file:build-tools/eslint",
-      "dev": true
-    },
-    "@cloudscape-design/global-styles": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/global-styles/-/global-styles-1.0.1.tgz",
-      "integrity": "sha512-Ofb1bRiZllftEiaIknpO9QSVYPFkdDUMFKownvjAOshDsxZ9GhNatjFTW94PL25YhgQOrotkN8g4vdL02b/umQ==",
-      "dev": true
-    },
-    "@cloudscape-design/jest-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/jest-preset/-/jest-preset-2.0.1.tgz",
-      "integrity": "sha512-CNY//zlWhvlPGYAdocZjZjO1lpCjje9lhCdwyDB9rBTThzXLYP7oL0prmVuq1rr5m96ABTuoZ2XF+R/qbdS7zQ==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-modules-commonjs": "^7.9.0"
-      }
-    },
-    "@cloudscape-design/test-utils-converter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-converter/-/test-utils-converter-1.0.1.tgz",
-      "integrity": "sha512-cq25iVKjTWJ3jGgpeVjMI1sQozKZAHYuof3LSiTu0rYVOy0OOpe+QoVrr1RYjHdR09M6knasvYWauYj8u4SgLA==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.16.0",
-        "@babel/plugin-syntax-decorators": "^7.16.0",
-        "@babel/plugin-syntax-typescript": "^7.16.0"
-      }
-    },
-    "@cloudscape-design/test-utils-core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/test-utils-core/-/test-utils-core-1.0.1.tgz",
-      "integrity": "sha512-w3rDQ2S786YqAmv779AiOJ6l7CaAxSlxHxD9O1en32q0y3VOFsTNHCfu6RYdMy0gI5N8uBsQl4Cp8hbtgH2SXw==",
-      "requires": {
-        "css-selector-tokenizer": "^0.8.0",
-        "css.escape": "^1.5.1"
-      }
-    },
-    "@cloudscape-design/theming-build": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.5.tgz",
-      "integrity": "sha512-x+Bbe0Z4KKXEGowD3HtikQtEo0gjBE4f+VP3tY10208Si8XsM6Js/o7YGlz2zrFxDD8659ElXL/AqdjbhVjKCg==",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "^10.4.8",
-        "glob": "^7.2.3",
-        "loader-utils": "^3.2.0",
-        "lodash": "^4.17.21",
-        "postcss": "^8.4.16",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-initial": "^3.0.4",
-        "postcss-inline-svg": "^5.0.0",
-        "postcss-modules": "^4.3.1",
-        "sass": "^1.49.0",
-        "string-hash": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "autoprefixer": {
-          "version": "10.4.12",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-          "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.21.4",
-            "caniuse-lite": "^1.0.30001407",
-            "fraction.js": "^4.2.0",
-            "normalize-range": "^0.1.2",
-            "picocolors": "^1.0.0",
-            "postcss-value-parser": "^4.2.0"
-          }
-        },
-        "browserslist": {
-          "version": "4.21.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-          "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001400",
-            "electron-to-chromium": "^1.4.251",
-            "node-releases": "^2.0.6",
-            "update-browserslist-db": "^1.0.9"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001415",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
-          "integrity": "sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.271",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.271.tgz",
-          "integrity": "sha512-BCPBtK07xR1/uY2HFDtl3wK2De66AW4MSiPlLrnPNxKC/Qhccxd59W73654S3y6Rb/k3hmuGJOBnhjfoutetXA==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "nanoid": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-          "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "8.4.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.17.tgz",
-          "integrity": "sha512-UNxNOLQydcOFi41yHNMcKRZ39NeXlr8AxGuZJsdub8vIb12fHzcq37DTU/QtbI6WLxNg2gF9Z+8qtRwTj1UI1Q==",
-          "dev": true,
-          "requires": {
-            "nanoid": "^3.3.4",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        }
-      }
-    },
-    "@cloudscape-design/theming-runtime": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.2.tgz",
-      "integrity": "sha512-2MF2NT6hCDXMPash5ZtGI1DZmGXOYx42Xd1T4V14P/+goG1cqe0CZLVLSR6FTQxb4S7KPUDmGfJKzpmLWOuD1g==",
-      "requires": {
-        "tslib": "^2.4.0"
-      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -1999,6 +1623,12 @@
         "@types/tough-cookie": "*"
       }
     },
+    "@types/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2441,31 +2071,15 @@
       }
     },
     "@wdio/config": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.25.1.tgz",
-      "integrity": "sha512-7I3L+TE75gvh8jiv8cE/Ch9S9erDgrZG9o5587OlNKfpgFciT7DH7/efPXzYwh8YPFV3grFaydxaaoYzDv6PDA==",
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.19.5.tgz",
+      "integrity": "sha512-GyG0SSUjw9RyDgEwculgwiWyQ0eEeFAgaKTAa4RHC6ZgHHTgfyxzkWqBmNLzHfiB6GSR2DyZDcDsPT7ZAHkiEg==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.25.1",
-        "@wdio/utils": "7.25.1",
+        "@wdio/types": "7.19.5",
         "deepmerge": "^4.0.0",
-        "glob": "^8.0.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        }
+        "glob": "^7.1.2"
       }
     },
     "@wdio/logger": {
@@ -2481,46 +2095,46 @@
       }
     },
     "@wdio/protocols": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.22.0.tgz",
-      "integrity": "sha512-8EXRR+Ymdwousm/VGtW3H1hwxZ/1g1H99A1lF0U4GuJ5cFWHCd0IVE5H31Z52i8ZruouW8jueMkGZPSo2IIUSQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.19.0.tgz",
+      "integrity": "sha512-ji74rQag6v+INSNd0J8eAh2rpH5vOXgeiP5Qr32K6PWU6HzYWuAFH2x4srXsH0JawHCdTK2OQAOYrLmMb44hug==",
       "dev": true
     },
     "@wdio/repl": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.25.1.tgz",
-      "integrity": "sha512-3DUtOrLi5thba22IBn/XQ7caFrbXtYOg3750UtXxUuxXU4QHkKq1AN8+WXr4Rq2EnXfB2G9t9pEdqjZSv9oPAw==",
+      "version": "7.19.7",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.19.7.tgz",
+      "integrity": "sha512-6lgzZxSU2yV0YLb4byBASeC42y5rAZk7mOQ41fHTXyC9CfRJubwe47M9KJyAoOrHG2wpwUX92RLTpDrAVDV6Fg==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "7.25.1"
+        "@wdio/utils": "7.19.7"
       }
     },
     "@wdio/types": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.25.1.tgz",
-      "integrity": "sha512-9Xt2U0YXYxRW4UvMFwjt+44UkfhwrI1gPhW+y56SubpyKaUfdNGberteboQoR/7Os1SVtJry4FohEZNmFzPK6g==",
+      "version": "7.19.5",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.19.5.tgz",
+      "integrity": "sha512-S1lC0pmtEO7NVH/2nM1c7NHbkgxLZH3VVG/z6ym3Bbxdtcqi2LMsEvvawMAU/fmhyiIkMsGZCO8vxG9cRw4z4A==",
       "dev": true,
       "requires": {
-        "@types/node": "^18.0.0",
+        "@types/node": "^17.0.4",
         "got": "^11.8.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.8.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.1.tgz",
-          "integrity": "sha512-vuYaNuEIbOYLTLUAJh50ezEbvxrD43iby+lpUA2aa148Nh5kX/AVO/9m1Ahmbux2iU5uxJTNF9g2Y+31uml7RQ==",
+          "version": "17.0.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+          "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
           "dev": true
         }
       }
     },
     "@wdio/utils": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.25.1.tgz",
-      "integrity": "sha512-DL+nDRVgzruJLhedBUQEMUcojLoGwsjCQCYWram4NfwAIIkxcAX/5Y4vHSut3OoW2bEHl3R8/FQ4B/ivIr2EoQ==",
+      "version": "7.19.7",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.19.7.tgz",
+      "integrity": "sha512-i/fBnEmEGDQ8Sr8H8p9UZ0kUPjSQhoJE2EullSyX+YgyZDtO3JO0M0jiRpbCFr0M+7fi17g+YOzQWmCSRGhPJA==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.25.1",
+        "@wdio/types": "7.19.5",
         "p-iteration": "^1.1.8"
       }
     },
@@ -3290,9 +2904,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "async-done": {
@@ -3361,9 +2975,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1228.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1228.0.tgz",
-      "integrity": "sha512-fc/eQEUiw+rOYl7SoIJBnmigFaET3t1zZiSUlMfnLfmpv2KGuhOoMaBTGQn9KkaFI1sSbeeoUjof7bxItgFDRA==",
+      "version": "2.1178.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1178.0.tgz",
+      "integrity": "sha512-ZsFuVbTp9aakAIZ7lTJspuCzSw5VRIDF0bUmSZmE2tc/X/haTu/TrMeWgwPjyLkQtdhfjChCyI71V+ADqFkjsA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -3734,7 +3348,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal": {
@@ -4022,9 +3636,9 @@
       "dev": true
     },
     "chrome-launcher": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
-      "integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.0.tgz",
+      "integrity": "sha512-ZQqX5kb9H0+jy1OqLnWampfocrtSZaGl7Ny3F9GRha85o4odbL8x55paUzh51UC7cEmZ5obp3H2Mm70uC2PpRA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -4224,9 +3838,9 @@
       }
     },
     "clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
@@ -4363,6 +3977,16 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compress-brotli": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
+      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-buffer": "~3.0.0",
+        "json-buffer": "~3.0.1"
+      }
     },
     "compress-commons": {
       "version": "4.1.1",
@@ -4880,7 +4504,7 @@
     "css-value": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
-      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+      "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
     },
     "css-what": {
@@ -5007,29 +4631,31 @@
       }
     },
     "d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
-      "requires": {
-        "internmap": "1 - 2"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
-        "d3-color": "1 - 3"
+        "d3-color": "1"
       }
     },
     "d3-path": {
@@ -5038,15 +4664,16 @@
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
     },
     "d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
       "requires": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "d3-shape": {
@@ -5058,19 +4685,16 @@
       }
     },
     "d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
-      "requires": {
-        "d3-array": "2 - 3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
-        "d3-time": "1 - 3"
+        "d3-time": "1"
       }
     },
     "data-urls": {
@@ -5397,44 +5021,44 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "devtools": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.25.1.tgz",
-      "integrity": "sha512-01T8QZeiD92MpI/7rP8kUflN3XcMqv2moa07123OjjENuuOhYxRWmJ7xj94txnF5PJp1Cv8/jvK8EUbnEHf6MQ==",
+      "version": "7.19.7",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.19.7.tgz",
+      "integrity": "sha512-XkIuojwTD0LeCzEeoTozKfAYWZUAw5Sj6CNPUuift3eDD9wnY2AcKLmFw8e9ihVUevJriyV8tMNbDsl97HSYWg==",
       "dev": true,
       "requires": {
-        "@types/node": "^18.0.0",
+        "@types/node": "^17.0.4",
         "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.25.1",
+        "@wdio/config": "7.19.5",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.22.0",
-        "@wdio/types": "7.25.1",
-        "@wdio/utils": "7.25.1",
+        "@wdio/protocols": "7.19.0",
+        "@wdio/types": "7.19.5",
+        "@wdio/utils": "7.19.7",
         "chrome-launcher": "^0.15.0",
         "edge-paths": "^2.1.0",
         "puppeteer-core": "^13.1.3",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.1",
-        "uuid": "^9.0.0"
+        "uuid": "^8.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.8.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.1.tgz",
-          "integrity": "sha512-vuYaNuEIbOYLTLUAJh50ezEbvxrD43iby+lpUA2aa148Nh5kX/AVO/9m1Ahmbux2iU5uxJTNF9g2Y+31uml7RQ==",
+          "version": "17.0.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+          "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
           "dev": true
         },
         "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1049481",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1049481.tgz",
-      "integrity": "sha512-QeoiFUnCNlXusSIfCOov0bn9uGTx7Q+9Cj+vvNFzHym5OcJeXyFxXNtvWtFmDorlEnTJYL5S6wXv+kgAg1s/Zw==",
+      "version": "0.0.998712",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.998712.tgz",
+      "integrity": "sha512-KCl+wJ9RsnDyGSsW7nbkgLFYxcKxZ7nzr6/r/hMOjkS02q2x1p8PbUenzKRMfL0jALhYxkCHrYnPnV3GHVD9EQ==",
       "dev": true
     },
     "diff-sequences": {
@@ -6520,7 +6144,7 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "execa": {
@@ -6911,7 +6535,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-diff": {
@@ -6997,7 +6621,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -8315,7 +7939,7 @@
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
     "icss-utils": {
@@ -8426,11 +8050,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "interpret": {
       "version": "1.4.0",
@@ -8781,57 +8400,35 @@
         "has-tostringtag": "^1.0.0"
       },
       "dependencies": {
-        "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-          "dev": true,
-          "requires": {
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
-          }
-        },
         "es-abstract": {
-          "version": "1.20.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
-          "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "function.prototype.name": "^1.1.5",
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.6",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
             "is-shared-array-buffer": "^1.0.2",
             "is-string": "^1.0.7",
             "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.2",
+            "object-inspect": "^1.12.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
+            "object.assign": "^4.1.2",
             "regexp.prototype.flags": "^1.4.3",
-            "safe-regex-test": "^1.0.0",
             "string.prototype.trimend": "^1.0.5",
             "string.prototype.trimstart": "^1.0.5",
             "unbox-primitive": "^1.0.2"
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.3"
           }
         },
         "has-bigints": {
@@ -8839,30 +8436,6 @@
           "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-          "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.4",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
-          }
         },
         "regexp.prototype.flags": {
           "version": "1.4.3",
@@ -8884,6 +8457,18 @@
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
             "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "string.prototype.trimstart": {
@@ -8895,6 +8480,18 @@
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
             "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "unbox-primitive": {
@@ -10171,11 +9768,12 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.0.tgz",
-      "integrity": "sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
+      "integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
       "dev": true,
       "requires": {
+        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -10516,43 +10114,43 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
       "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.memoize": {
@@ -10576,7 +10174,7 @@
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
     },
     "lodash.uniq": {
@@ -10588,7 +10186,7 @@
     "lodash.zip": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
-      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
     "log-symbols": {
@@ -10768,9 +10366,9 @@
       "dev": true
     },
     "marky": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.4.tgz",
+      "integrity": "sha512-zd2/GiSn6U3/jeFVZ0J9CA1LzQ8RfIVvXkb/U0swFHF/zT+dVohTAWjmo2DcIuofmIIIROlwTbd+shSeXmxr0w==",
       "dev": true
     },
     "matchdep": {
@@ -11968,7 +11566,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "picocolors": {
@@ -12681,7 +12279,7 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
     "puppeteer-core": {
@@ -12745,7 +12343,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "queue-microtask": {
@@ -12988,12 +12586,23 @@
       }
     },
     "readdir-glob": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.2.tgz",
-      "integrity": "sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
       "dev": true,
       "requires": {
-        "minimatch": "^5.1.0"
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "readdirp": {
@@ -13404,9 +13013,9 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
       "dev": true,
       "requires": {
         "lowercase-keys": "^2.0.0"
@@ -13501,30 +13110,6 @@
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
-      }
-    },
-    "safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      },
-      "dependencies": {
-        "get-intrinsic": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.3"
-          }
-        }
       }
     },
     "safer-buffer": {
@@ -13625,7 +13210,7 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
       "dev": true
     },
     "saxes": {
@@ -14313,7 +13898,7 @@
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
       "dev": true
     },
     "string-length": {
@@ -15259,7 +14844,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
     "trim-newlines": {
@@ -15465,9 +15050,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.2.tgz",
-      "integrity": "sha512-bbxglRjsGQMchfvXZNusUcYgiB9Hx2K4AHYXQy2DITZ9Rd+JzhX7+hoocE5Winr7z2oHvPsekkBwXtigvxevXg==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
       "dev": true,
       "optional": true
     },
@@ -15669,7 +15254,7 @@
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
         "punycode": "1.3.2",
@@ -15949,50 +15534,50 @@
       }
     },
     "webdriver": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.25.1.tgz",
-      "integrity": "sha512-BmR5RT37EGNJj/O/GTCqBKXV/Jr9V4oQTTDaurZixVKW0ubG7uyfrhiklzuWUtmES9VualTKgQumhGhchBTC6g==",
+      "version": "7.19.7",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.19.7.tgz",
+      "integrity": "sha512-3gygDpwaCMZlUhh7Wv1SbjTvfdLGbPqRQ3poZ7lKvsVAAmciLziJDeR8LrNTyS9R418MgNbBdWOQrHGS+gp0ZQ==",
       "dev": true,
       "requires": {
-        "@types/node": "^18.0.0",
-        "@wdio/config": "7.25.1",
+        "@types/node": "^17.0.4",
+        "@wdio/config": "7.19.5",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.22.0",
-        "@wdio/types": "7.25.1",
-        "@wdio/utils": "7.25.1",
+        "@wdio/protocols": "7.19.0",
+        "@wdio/types": "7.19.5",
+        "@wdio/utils": "7.19.7",
         "got": "^11.0.2",
-        "ky": "0.30.0",
+        "ky": "^0.30.0",
         "lodash.merge": "^4.6.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.8.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.1.tgz",
-          "integrity": "sha512-vuYaNuEIbOYLTLUAJh50ezEbvxrD43iby+lpUA2aa148Nh5kX/AVO/9m1Ahmbux2iU5uxJTNF9g2Y+31uml7RQ==",
+          "version": "17.0.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+          "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
           "dev": true
         }
       }
     },
     "webdriverio": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.25.1.tgz",
-      "integrity": "sha512-8O5FgQWZzByen2vivBXa101PwsJT/wOLUSdks80nxbFHVWKI/5kda1zi+m6x01ATtStva4xMQCxW/Df7QVloKA==",
+      "version": "7.19.7",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.19.7.tgz",
+      "integrity": "sha512-GaekRmFN3wokW3VN08hFjTJ3GagJxuKR6AV8kVvlxxMye9nfU3TQPzsrqGrue8uWYvyZ3x0SVkUluwtImZNzPA==",
       "dev": true,
       "requires": {
         "@types/aria-query": "^5.0.0",
-        "@types/node": "^18.0.0",
-        "@wdio/config": "7.25.1",
+        "@types/node": "^17.0.4",
+        "@wdio/config": "7.19.5",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.22.0",
-        "@wdio/repl": "7.25.1",
-        "@wdio/types": "7.25.1",
-        "@wdio/utils": "7.25.1",
+        "@wdio/protocols": "7.19.0",
+        "@wdio/repl": "7.19.7",
+        "@wdio/types": "7.19.5",
+        "@wdio/utils": "7.19.7",
         "archiver": "^5.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.25.1",
-        "devtools-protocol": "^0.0.1049481",
+        "devtools": "7.19.7",
+        "devtools-protocol": "^0.0.998712",
         "fs-extra": "^10.0.0",
         "grapheme-splitter": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
@@ -16005,13 +15590,13 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
-        "webdriver": "7.25.1"
+        "webdriver": "7.19.7"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.8.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.1.tgz",
-          "integrity": "sha512-vuYaNuEIbOYLTLUAJh50ezEbvxrD43iby+lpUA2aa148Nh5kX/AVO/9m1Ahmbux2iU5uxJTNF9g2Y+31uml7RQ==",
+          "version": "17.0.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+          "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
           "dev": true
         }
       }
@@ -16019,7 +15604,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
       "dev": true
     },
     "webpack": {
@@ -16405,7 +15990,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dev": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -16454,57 +16039,35 @@
         "is-typed-array": "^1.1.9"
       },
       "dependencies": {
-        "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-          "dev": true,
-          "requires": {
-            "has-property-descriptors": "^1.0.0",
-            "object-keys": "^1.1.1"
-          }
-        },
         "es-abstract": {
-          "version": "1.20.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.3.tgz",
-          "integrity": "sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==",
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+          "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "function.prototype.name": "^1.1.5",
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.1.1",
             "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-property-descriptors": "^1.0.0",
             "has-symbols": "^1.0.3",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.6",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
             "is-shared-array-buffer": "^1.0.2",
             "is-string": "^1.0.7",
             "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.2",
+            "object-inspect": "^1.12.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.4",
+            "object.assign": "^4.1.2",
             "regexp.prototype.flags": "^1.4.3",
-            "safe-regex-test": "^1.0.0",
             "string.prototype.trimend": "^1.0.5",
             "string.prototype.trimstart": "^1.0.5",
             "unbox-primitive": "^1.0.2"
-          }
-        },
-        "get-intrinsic": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.3"
           }
         },
         "has-bigints": {
@@ -16512,30 +16075,6 @@
           "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
           "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
           "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-          "dev": true
-        },
-        "object-inspect": {
-          "version": "1.12.2",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-          "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-          "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.4",
-            "has-symbols": "^1.0.3",
-            "object-keys": "^1.1.1"
-          }
         },
         "regexp.prototype.flags": {
           "version": "1.4.3",
@@ -16557,6 +16096,18 @@
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
             "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "string.prototype.trimstart": {
@@ -16568,6 +16119,18 @@
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
             "es-abstract": "^1.19.5"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+              "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+              "dev": true,
+              "requires": {
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+              }
+            }
           }
         },
         "unbox-primitive": {
@@ -16599,7 +16162,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
@@ -16670,7 +16233,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
     "xmlchars": {
@@ -16737,7 +16300,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ace-builds": "^1.4.13",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
-    "d3-scale": "^4.0.2",
+    "d3-scale": "^2.2.2",
     "d3-shape": "^1.3.7",
     "date-fns": "^2.25.0",
     "mnth": "^2.0.0",


### PR DESCRIPTION
### Description

Revert "chore(deps): bump d3-color and d3-scale" because it blocks multiple consumers. There's a need to review those, and agree on the next steps.

### How has this been tested?

- existing unit and integ tests run green after the revert.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

- N/A


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
