### PR TITLE
Increase a11y test coverage

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -22,7 +22,7 @@ const htmlValidator = new HtmlValidate({
     // set relaxed to exclude error that id does not begin with letter
     'valid-id': ['error', { relaxed: true }],
     'no-inline-style': 'off',
-    'prefer-native-element': ['error', { exclude: ['listbox', 'button'] }],
+    'prefer-native-element': ['error', { exclude: ['listbox', 'button', 'region'] }],
     //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
     'no-redundant-for': 'off',
     // innerHTML normalizes attribute values

--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -22,6 +22,7 @@ const htmlValidator = new HtmlValidate({
     // set relaxed to exclude error that id does not begin with letter
     'valid-id': ['error', { relaxed: true }],
     'no-inline-style': 'off',
+    'attribute-boolean-style': 'off',
     'prefer-native-element': ['error', { exclude: ['listbox', 'button'] }],
     //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
     'no-redundant-for': 'off',

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -6,85 +6,86 @@ import Alert, { AlertProps } from '../../../lib/components/alert';
 import Button from '../../../lib/components/button';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/alert/styles.css.js';
+import '../../__a11y__/to-validate-a11y';
 
 function renderAlert(props: AlertProps = {}) {
   const { container } = render(<Alert {...props} />);
-  return createWrapper(container).findAlert()!;
+  return { wrapper: createWrapper(container).findAlert()!, container };
 }
 
 describe('Alert Component', () => {
   describe('structure', () => {
     it('has no header container when no header is set', () => {
-      const wrapper = renderAlert();
+      const { wrapper } = renderAlert();
       expect(wrapper.findHeader()).toBeNull();
     });
     it('displays header - string', () => {
-      const wrapper = renderAlert({ header: 'Hello' });
+      const { wrapper } = renderAlert({ header: 'Hello' });
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Hello');
     });
     it('displays header - custom html', () => {
       const header = <b>Title</b>;
-      const wrapper = renderAlert({ header });
+      const { wrapper } = renderAlert({ header });
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Title');
     });
     it('displays body', () => {
       const content = <b>Some text</b>;
-      const wrapper = renderAlert({ children: content });
+      const { wrapper } = renderAlert({ children: content });
       expect(wrapper.findContent().getElement()).toHaveTextContent('Some text');
     });
     it('shows a dismiss icon', () => {
-      const wrapper = renderAlert({ dismissible: true });
+      const { wrapper } = renderAlert({ dismissible: true });
       expect(wrapper.findDismissButton()).not.toBe(null);
     });
     it("doesn't show a dismiss icon when dissmisible is not set", () => {
-      const wrapper = renderAlert();
+      const { wrapper } = renderAlert();
       expect(wrapper.findDismissButton()).toBe(null);
     });
     it('shows an action button', () => {
-      const wrapper = renderAlert({ buttonText: 'Button text' });
+      const { wrapper } = renderAlert({ buttonText: 'Button text' });
       expect(wrapper.findActionButton()).not.toBe(null);
     });
     it("doesn't show an action button when buttonText is not set", () => {
-      const wrapper = renderAlert();
+      const { wrapper } = renderAlert();
       expect(wrapper.findActionButton()).toBe(null);
     });
     it('correct button text', () => {
-      const wrapper = renderAlert({ buttonText: 'Button text' });
+      const { wrapper } = renderAlert({ buttonText: 'Button text' });
       expect(wrapper.findActionButton()!.findTextRegion()!.getElement()).toHaveTextContent('Button text');
     });
     it('dismiss button has no default label', () => {
-      const wrapper = renderAlert({ dismissible: true });
+      const { wrapper } = renderAlert({ dismissible: true });
       expect(wrapper.findDismissButton()!.getElement()).not.toHaveAttribute('aria-label');
     });
     it('dismiss button can have specified label', () => {
-      const wrapper = renderAlert({ dismissible: true, dismissAriaLabel: 'close' });
+      const { wrapper } = renderAlert({ dismissible: true, dismissAriaLabel: 'close' });
       expect(wrapper.findDismissButton()!.getElement()).toHaveAttribute('aria-label', 'close');
     });
     it('status icon does not have a label by default', () => {
-      const wrapper = renderAlert({});
+      const { wrapper } = renderAlert({});
       expect(wrapper.find('[role="img"]')!.getElement()).not.toHaveAttribute('aria-label');
     });
     it('status icon can have a label', () => {
-      const wrapper = renderAlert({ statusIconAriaLabel: 'Info' });
+      const { wrapper } = renderAlert({ statusIconAriaLabel: 'Info' });
       expect(wrapper.find('[role="img"]')!.getElement()).toHaveAttribute('aria-label', 'Info');
     });
   });
   describe('visibility', () => {
     it('shows the alert by default', () => {
-      const wrapper = renderAlert();
+      const { wrapper } = renderAlert();
       expect(wrapper.getElement()).toBeVisible();
     });
     it('hides the alert when visible is false', () => {
-      const wrapper = renderAlert({ visible: false });
+      const { wrapper } = renderAlert({ visible: false });
       expect(wrapper.getElement()).toHaveClass(styles.hidden);
     });
     it('shows the alert when visible is true', () => {
-      const wrapper = renderAlert({ visible: true });
+      const { wrapper } = renderAlert({ visible: true });
       expect(wrapper.getElement()).toBeVisible();
     });
     it('displays correct type', () => {
       (['error', 'warning', 'info', 'success'] as AlertProps.Type[]).forEach(alertType => {
-        const wrapper = renderAlert({ type: alertType });
+        const { wrapper } = renderAlert({ type: alertType });
         expect(wrapper.findRootElement().getElement()).toHaveClass(styles[`type-${alertType}`]);
       });
     });
@@ -92,25 +93,25 @@ describe('Alert Component', () => {
   describe('functionality', () => {
     it('action button callback gets called', () => {
       const onButtonClickSpy = jest.fn();
-      const wrapper = renderAlert({ buttonText: 'Button', onButtonClick: onButtonClickSpy });
+      const { wrapper } = renderAlert({ buttonText: 'Button', onButtonClick: onButtonClickSpy });
       wrapper.findActionButton()!.click();
       expect(onButtonClickSpy).toHaveBeenCalled();
     });
     it('fires dismiss callback', () => {
       const onDismissSpy = jest.fn();
-      const wrapper = renderAlert({ dismissible: true, onDismiss: onDismissSpy });
+      const { wrapper } = renderAlert({ dismissible: true, onDismiss: onDismissSpy });
       wrapper.findDismissButton()!.click();
       expect(onDismissSpy).toHaveBeenCalled();
     });
   });
 
   it('renders `action` content', () => {
-    const wrapper = renderAlert({ children: 'Message body', action: <Button>Click</Button> });
+    const { wrapper } = renderAlert({ children: 'Message body', action: <Button>Click</Button> });
     expect(wrapper.findActionSlot()!.findButton()!.getElement()).toHaveTextContent('Click');
   });
 
   it('when both `buttonText` and `action` provided, prefers the latter', () => {
-    const wrapper = renderAlert({
+    const { wrapper } = renderAlert({
       children: 'Message body',
       buttonText: 'buttonText',
       action: <Button>Action</Button>,
@@ -118,5 +119,16 @@ describe('Alert Component', () => {
 
     expect(wrapper.findActionButton()).toBeNull();
     expect(wrapper.findActionSlot()!.findButton()!.getElement()).toHaveTextContent('Action');
+  });
+
+  test('a11y', async () => {
+    const { container } = renderAlert({
+      dismissible: true,
+      header: 'Header',
+      dismissAriaLabel: 'Dismiss',
+      statusIconAriaLabel: 'Icon',
+      action: <button type="button">Action</button>,
+    });
+    await expect(container).toValidateA11y();
   });
 });

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -8,6 +8,7 @@ import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 import mobileStyles from '../../../lib/components/app-layout/mobile-toolbar/styles.css.js';
 import sharedStyles from '../../../lib/components/app-layout/styles.css.js';
+import '../../__a11y__/to-validate-a11y';
 
 jest.mock('../../../lib/components/internal/motion', () => ({
   isMotionDisabled: jest.fn().mockReturnValue(true),
@@ -147,4 +148,29 @@ describe('Content height calculation', () => {
     const { height, minHeight } = contentElement.style;
     expect({ height, minHeight }).toEqual({ height: 'calc(100vh - 0px)', minHeight: '' });
   });
+});
+
+test('a11y', async () => {
+  const { container } = renderComponent(
+    <AppLayout
+      navigationOpen={true}
+      toolsOpen={true}
+      splitPanelOpen={true}
+      navigation={<div></div>}
+      content={<div></div>}
+      notifications={<div></div>}
+      breadcrumbs={<div></div>}
+      splitPanel={<div></div>}
+      ariaLabels={{
+        // notifications?: string;
+        // navigation?: string;
+        navigationToggle: 'Open navigation',
+        navigationClose: 'Close navigation',
+        // tools?: string;
+        toolsToggle: 'Open tools',
+        toolsClose: 'Close tools',
+      }}
+    />
+  );
+  await expect(container).toValidateA11y();
 });

--- a/src/app-layout/__tests__/slots.test.tsx
+++ b/src/app-layout/__tests__/slots.test.tsx
@@ -11,7 +11,7 @@ describeEachAppLayout(() => {
       const notificationsEl = wrapper.findNotifications()!.getElement();
       expect(notificationsEl).toHaveTextContent('abcd');
       expect(notificationsEl).not.toHaveAttribute('aria-live');
-      expect(notificationsEl.tagName.toLowerCase()).toBe('section');
+      expect(notificationsEl).toHaveAttribute('role', 'region');
       expect(notificationsEl).not.toHaveAttribute('aria-label');
     });
 

--- a/src/app-layout/__tests__/slots.test.tsx
+++ b/src/app-layout/__tests__/slots.test.tsx
@@ -11,7 +11,7 @@ describeEachAppLayout(() => {
       const notificationsEl = wrapper.findNotifications()!.getElement();
       expect(notificationsEl).toHaveTextContent('abcd');
       expect(notificationsEl).not.toHaveAttribute('aria-live');
-      expect(notificationsEl).toHaveAttribute('role', 'region');
+      expect(notificationsEl.tagName.toLowerCase()).toBe('section');
       expect(notificationsEl).not.toHaveAttribute('aria-label');
     });
 

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -35,7 +35,7 @@ export function renderComponent(jsx: React.ReactElement) {
     ? wrapper.getElement()
     : wrapper.findByClassName(styles['layout-wrapper'])!.getElement();
 
-  return { wrapper, rerender, isUsingGridLayout, contentElement };
+  return { wrapper, rerender, isUsingGridLayout, contentElement, container };
 }
 
 export function describeDesktopAppLayout(callback: () => void) {

--- a/src/app-layout/notifications/index.tsx
+++ b/src/app-layout/notifications/index.tsx
@@ -23,14 +23,14 @@ export const Notifications = React.forwardRef(
   ({ sticky, ...props }: NotificationWrapperProps, ref: React.Ref<HTMLDivElement>) => {
     return sticky ? (
       <div ref={ref} className={styles['notifications-sticky']} style={{ top: props.topOffset }}>
-        <section className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
+        <div role="region" className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
           {props.children}
-        </section>
+        </div>
       </div>
     ) : (
-      <section ref={ref} className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
+      <div role="region" ref={ref} className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
         {props.children}
-      </section>
+      </div>
     );
   }
 );

--- a/src/app-layout/notifications/index.tsx
+++ b/src/app-layout/notifications/index.tsx
@@ -23,14 +23,14 @@ export const Notifications = React.forwardRef(
   ({ sticky, ...props }: NotificationWrapperProps, ref: React.Ref<HTMLDivElement>) => {
     return sticky ? (
       <div ref={ref} className={styles['notifications-sticky']} style={{ top: props.topOffset }}>
-        <div className={clsx(props.testUtilsClassName)} role="region" aria-label={props.labels?.notifications}>
+        <section className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
           {props.children}
-        </div>
+        </section>
       </div>
     ) : (
-      <div ref={ref} className={clsx(props.testUtilsClassName)} role="region" aria-label={props.labels?.notifications}>
+      <section ref={ref} className={clsx(props.testUtilsClassName)} aria-label={props.labels?.notifications}>
         {props.children}
-      </div>
+      </section>
     );
   }
 );

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -19,7 +19,7 @@ export default function Notifications() {
   }
 
   return (
-    <div
+    <section
       aria-label={ariaLabels?.notifications ?? undefined}
       className={clsx(
         styles.notifications,
@@ -30,10 +30,9 @@ export default function Notifications() {
         testutilStyles.notifications,
         'awsui-context-content-header'
       )}
-      role="region"
       ref={notificationsElement}
     >
       {notifications}
-    </div>
+    </section>
   );
 }

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -19,7 +19,8 @@ export default function Notifications() {
   }
 
   return (
-    <section
+    <div
+      role="region"
       aria-label={ariaLabels?.notifications ?? undefined}
       className={clsx(
         styles.notifications,
@@ -33,6 +34,6 @@ export default function Notifications() {
       ref={notificationsElement}
     >
       {notifications}
-    </section>
+    </div>
   );
 }

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -248,7 +248,7 @@ test('axes labels are assigned', () => {
 });
 
 // TODO: resolve https://dequeuniversity.com/rules/axe/4.4/aria-required-children?application=axeAPI
-test.skip('popover a11y check', async () => {
+test('a11y', async () => {
   const { container, wrapper } = renderAreaChart(
     <AreaChart
       series={[areaSeries1]}

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -247,7 +247,6 @@ test('axes labels are assigned', () => {
   expect(wrapper.find('[aria-roledescription="y-axis"]')).not.toBe(null);
 });
 
-// TODO: resolve https://dequeuniversity.com/rules/axe/4.4/aria-required-children?application=axeAPI
 test('a11y', async () => {
   const { container, wrapper } = renderAreaChart(
     <AreaChart

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -50,8 +50,7 @@ afterEach(() => {
 
 describe('Date range picker', () => {
   describe('absolute mode', () => {
-    // TODO: https://dequeuniversity.com/rules/axe/4.4/aria-required-children?application=axeAPI
-    test.skip('a11y checks with opened dropdown', async () => {
+    test('a11y', async () => {
       const { container } = render(
         <DateRangePicker
           {...defaultProps}

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -30,7 +30,9 @@ function renderDateRangePicker(props: DateRangePickerProps = defaultProps) {
   const ref = React.createRef<HTMLInputElement>();
   const { container, getByTestId } = render(
     <div>
-      <button data-testid={outsideId}>click me</button>
+      <button type="button" data-testid={outsideId}>
+        click me
+      </button>
       <DateRangePicker {...props} ref={ref} />
     </div>
   );
@@ -53,8 +55,7 @@ describe('Date range picker', () => {
     beforeEach(() => Mockdate.set(new Date('2020-10-01T12:30:20')));
     afterEach(() => Mockdate.reset());
 
-    // TODO: resolve https://dequeuniversity.com/rules/axe/4.4/aria-required-children?application=axeAPI
-    test.skip('a11y checks with opened dropdown', async () => {
+    test('a11y', async () => {
       const { container, wrapper } = renderDateRangePicker({
         ...defaultProps,
       });

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -53,7 +53,7 @@ function renderDateRange(
     );
 
   return (
-    <InternalBox fontWeight="normal" display="inline" color="inherit">
+    <InternalBox fontWeight="normal" display="inline" color="inherit" variant="span">
       {formatted}
     </InternalBox>
   );

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -58,7 +58,7 @@ export default function ChartPopover({
   ...restProps
 }: ChartPopoverProps) {
   const baseProps = getBaseProps(restProps);
-  const popoverRef = useRef<HTMLSpanElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const onDocumentClick = (event: MouseEvent) => {
@@ -78,7 +78,7 @@ export default function ChartPopover({
   }, [container, onDismiss]);
 
   return (
-    <span
+    <div
       {...baseProps}
       className={clsx(popoverStyles.root, styles.root, baseProps.className, { [styles.dismissable]: dismissButton })}
       ref={popoverRef}
@@ -106,6 +106,6 @@ export default function ChartPopover({
           {children}
         </PopoverBody>
       </PopoverContainer>
-    </span>
+    </div>
   );
 }

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -85,6 +85,7 @@ const TransitionContent = ({
       ref={contentRef}
       data-open={open}
       data-animating={state !== 'exited'}
+      aria-hidden={!open}
       onMouseDown={onMouseDown}
     >
       <div className={clsx(styles['dropdown-content-wrapper'], isRefresh && styles.refresh)}>

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -53,7 +53,7 @@ function InternalPopover(
   const baseProps = getBaseProps(restProps);
   const focusVisible = useFocusVisible();
   const triggerRef = useRef<HTMLElement | null>(null);
-  const popoverRef = useRef<HTMLSpanElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const clickFrameId = useRef<number | null>(null);
 
   const [visible, setVisible] = useState(false);
@@ -111,7 +111,7 @@ function InternalPopover(
   };
 
   const popoverContent = (
-    <span
+    <div
       aria-live={dismissButton ? undefined : 'polite'}
       aria-atomic={dismissButton ? undefined : true}
       className={popoverClasses}
@@ -137,13 +137,13 @@ function InternalPopover(
           </PopoverBody>
         </PopoverContainer>
       )}
-    </span>
+    </div>
   );
 
   const mergedRef = useMergeRefs(popoverRef, __internalRootRef);
 
   return (
-    <span
+    <div
       {...baseProps}
       className={clsx(styles.root, baseProps.className)}
       ref={mergedRef}
@@ -162,6 +162,6 @@ function InternalPopover(
         <span {...triggerProps}>{children}</span>
       )}
       {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
-    </span>
+    </div>
   );
 }


### PR DESCRIPTION
### Description

Increase a11y coverage in unit tests and fix axe/html-validate reported issues.

### How has this been tested?

New tests

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
