### PR TITLE
fix(date-range-picker): Use heading role for month names

### DIFF
--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -57,6 +57,7 @@ export interface GridProps {
   locale: string;
   startOfWeek: DayIndex;
   todayAriaLabel: string;
+  ariaLabelledby: string;
 
   className?: string;
 }
@@ -80,6 +81,7 @@ export function Grid({
   locale,
   startOfWeek,
   todayAriaLabel,
+  ariaLabelledby,
 
   className,
 }: GridProps) {
@@ -95,7 +97,7 @@ export function Grid({
   const focusVisible = useFocusVisible();
 
   return (
-    <table role="grid" className={clsx(styles.grid, className)}>
+    <table role="grid" aria-labelledby={ariaLabelledby} className={clsx(styles.grid, className)}>
       <thead>
         <tr>
           {weekdays.map(dayIndex => (

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -41,6 +41,7 @@ export interface GridProps {
   locale: string;
   startOfWeek: DayIndex;
   todayAriaLabel: string;
+  headingIdPrefix: string;
 }
 
 export function selectFocusedDate(
@@ -78,6 +79,7 @@ export const Grids = ({
   locale,
   startOfWeek,
   todayAriaLabel,
+  headingIdPrefix,
 }: GridProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [gridHasFocus, setGridHasFocus] = useState(false);
@@ -210,6 +212,7 @@ export const Grids = ({
             locale={locale}
             startOfWeek={startOfWeek}
             todayAriaLabel={todayAriaLabel}
+            ariaLabelledby={`${headingIdPrefix}-prevmonth`}
           />
         )}
         <Grid
@@ -228,6 +231,7 @@ export const Grids = ({
           locale={locale}
           startOfWeek={startOfWeek}
           todayAriaLabel={todayAriaLabel}
+          ariaLabelledby={`${headingIdPrefix}-currentmonth`}
         />
       </InternalSpaceBetween>
     </div>

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -14,6 +14,7 @@ interface CalendarHeaderProps {
   previousMonthLabel: string;
   nextMonthLabel: string;
   isSingleGrid: boolean;
+  headingIdPrefix: string;
 }
 
 export default function CalendarHeader({
@@ -23,6 +24,7 @@ export default function CalendarHeader({
   previousMonthLabel,
   nextMonthLabel,
   isSingleGrid,
+  headingIdPrefix,
 }: CalendarHeaderProps) {
   const prevMonthLabel = renderMonthAndYear(locale, add(baseDate, { months: -1 }));
   const currentMonthLabel = renderMonthAndYear(locale, baseDate);
@@ -31,10 +33,16 @@ export default function CalendarHeader({
     <>
       <div className={styles['calendar-header']}>
         <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
-        <div className={styles['calendar-header-months-wrapper']}>
-          {!isSingleGrid && <div className={styles['calendar-header-month']}>{prevMonthLabel}</div>}
-          <div className={styles['calendar-header-month']}>{currentMonthLabel}</div>
-        </div>
+        <h2 className={styles['calendar-header-months-wrapper']}>
+          {!isSingleGrid && (
+            <span className={styles['calendar-header-month']} id={`${headingIdPrefix}-prevmonth`}>
+              {prevMonthLabel}
+            </span>
+          )}
+          <span className={styles['calendar-header-month']} id={`${headingIdPrefix}-currentmonth`}>
+            {currentMonthLabel}
+          </span>
+        </h2>
         <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
       </div>
       <LiveRegion>{isSingleGrid ? currentMonthLabel : `${prevMonthLabel}, ${currentMonthLabel}`}</LiveRegion>

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -14,6 +14,7 @@ import InternalDateInput from '../../date-input/internal';
 import { TimeInputProps } from '../../time-input/interfaces';
 import InternalTimeInput from '../../time-input/internal';
 import clsx from 'clsx';
+import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getDateLabel, renderTimeLabel } from '../../calendar/utils/intl';
 import LiveRegion from '../../internal/components/live-region';
 import { normalizeStartOfWeek } from '../../calendar/utils/locales';
@@ -274,6 +275,7 @@ function Calendar(
     setEndDateString(e.detail.value);
   };
 
+  const headingIdPrefix = useUniqueId('date-range-picker-calendar-heading');
   return (
     <>
       <InternalSpaceBetween size="s">
@@ -290,6 +292,7 @@ function Calendar(
             previousMonthLabel={i18nStrings.previousMonthAriaLabel}
             nextMonthLabel={i18nStrings.nextMonthAriaLabel}
             isSingleGrid={isSingleGrid}
+            headingIdPrefix={headingIdPrefix}
           />
 
           <Grids
@@ -305,6 +308,7 @@ function Calendar(
             todayAriaLabel={i18nStrings.todayAriaLabel}
             selectedStartDate={selectedStartDate}
             selectedEndDate={selectedEndDate}
+            headingIdPrefix={headingIdPrefix}
           />
         </div>
         <InternalFormField constraintText={i18nStrings.dateTimeConstraintText}>

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -47,6 +47,8 @@ $calendar-header-color: awsui.$color-text-body-default;
     top: 0;
     bottom: 0;
 
+    margin: 0;
+
     display: flex;
     justify-content: space-around;
     align-items: center;


### PR DESCRIPTION
### Description

This change wraps the month names of the absolute range selector in a `heading` role, to improve the announcement in screen readers.

### How has this been tested?

Tested manually with VoiceOver in Chrome & Safari

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-19214


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
