### PR TITLE
fix(charts): Make legend behave like an ARIA toolbar

### DIFF
--- a/pages/pie-chart/permutations.page.tsx
+++ b/pages/pie-chart/permutations.page.tsx
@@ -57,13 +57,6 @@ const permutations = createPermutations<PieChartProps>([
     legendTitle: ['Legend'],
   },
   {
-    data: [overlappingData],
-    variant: ['pie', 'donut'],
-    size: ['small'],
-    statusType: ['finished'],
-    highlightedSegment: [null, overlappingData[0]],
-  },
-  {
     data: [data1],
     variant: ['pie'],
     size: ['small'],

--- a/src/internal/components/chart-legend/styles.scss
+++ b/src/internal/components/chart-legend/styles.scss
@@ -33,11 +33,17 @@
   align-items: flex-start;
   margin-right: awsui.$space-m;
   padding: 0;
+  border: 0;
+  background-color: transparent;
   cursor: pointer;
   opacity: 1;
 
   &:focus {
     outline: none;
+  }
+
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(2px);
   }
 
   &:last-child {
@@ -50,9 +56,5 @@
 
   &.marker--highlighted {
     /* used in test utils */
-  }
-
-  &.marker--focused {
-    @include styles.focus-highlight(2px);
   }
 }


### PR DESCRIPTION
### Description

Change the role of the legend from a mysterious "application" to a more standard "toolbar". The interactions are actually mostly preserved here, with arrow keys for navigation. The focus is now on individual toolbar buttons, but the hover behavior is unchanged.

Though one choice I made was to detach the hover interactions and the focus interactions. It felt like a bad idea to throw the focus around without any explicit keyboard action from the user or with only a casual hover.

### How has this been tested?

The unit tests have been adapted to match the new behavior, but you're also welcome (and recommended!) to try with a screen reader. It should announce the individual toolbar buttons as you move around. On NVDA, it works with both browse and focus modes (though with browse mode, it only works on activation rather than focus, which is which).

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
