### PR TITLE
chore: Remove getBlurRelatedEventTarget utility

### DIFF
--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -6,12 +6,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import styles from './styles.css.js';
-import {
-  fireNonCancelableEvent,
-  fireKeyboardEvent,
-  NonCancelableEventHandler,
-  getBlurEventRelatedTarget,
-} from '../internal/events';
+import { fireNonCancelableEvent, fireKeyboardEvent, NonCancelableEventHandler } from '../internal/events';
 import { InputProps, BaseInputProps, InputAutoCorrect, BaseChangeDetail } from './interfaces';
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 import { useSearchProps, convertAutoComplete } from './utils';
@@ -135,8 +130,7 @@ function InternalInput(
     onChange: onChange && (event => handleChange(event.target.value)),
     onBlur: e => {
       onBlur && fireNonCancelableEvent(onBlur);
-      __onBlurWithDetail &&
-        fireNonCancelableEvent(__onBlurWithDetail, { relatedTarget: getBlurEventRelatedTarget(e.nativeEvent) });
+      __onBlurWithDetail && fireNonCancelableEvent(__onBlurWithDetail, { relatedTarget: e.relatedTarget });
     },
     onFocus: onFocus && (() => fireNonCancelableEvent(onFocus)),
     ...__nativeAttributes,

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -7,13 +7,7 @@ import Dropdown from '../dropdown';
 
 import { FormFieldValidationControlProps, useFormFieldContext } from '../../context/form-field-context';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
-import {
-  BaseKeyDetail,
-  fireCancelableEvent,
-  fireNonCancelableEvent,
-  getBlurEventRelatedTarget,
-  NonCancelableEventHandler,
-} from '../../events';
+import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
 import InternalInput from '../../../input/internal';
 import {
   BaseChangeDetail,
@@ -131,11 +125,10 @@ const AutosuggestInput = React.forwardRef(
     }));
 
     const handleBlur: React.FocusEventHandler = event => {
-      const relatedTarget = getBlurEventRelatedTarget(event.nativeEvent);
       if (
-        event.currentTarget.contains(relatedTarget) ||
-        dropdownContentRef.current?.contains(relatedTarget) ||
-        dropdownFooterRef.current?.contains(relatedTarget)
+        event.currentTarget.contains(event.relatedTarget) ||
+        dropdownContentRef.current?.contains(event.relatedTarget) ||
+        dropdownFooterRef.current?.contains(event.relatedTarget)
       ) {
         return;
       }

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -5,13 +5,7 @@ import clsx from 'clsx';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import InternalIcon from '../../../icon/internal';
 import styles from './styles.css.js';
-import {
-  fireKeyboardEvent,
-  fireCancelableEvent,
-  CancelableEventHandler,
-  BaseKeyDetail,
-  getBlurEventRelatedTarget,
-} from '../../events';
+import { fireKeyboardEvent, fireCancelableEvent, CancelableEventHandler, BaseKeyDetail } from '../../events';
 import useFocusVisible from '../../hooks/focus-visible';
 
 export interface ButtonTriggerProps extends BaseComponentProps {
@@ -85,9 +79,7 @@ const ButtonTrigger = (
     onMouseDown: onMouseDown && (event => fireCancelableEvent(onMouseDown, {}, event)),
     onClick: onClick && (event => fireCancelableEvent(onClick, {}, event)),
     onFocus: onFocus && (event => fireCancelableEvent(onFocus, {}, event)),
-    onBlur:
-      onBlur &&
-      (event => fireCancelableEvent(onBlur, { relatedTarget: getBlurEventRelatedTarget(event.nativeEvent) }, event)),
+    onBlur: onBlur && (event => fireCancelableEvent(onBlur, { relatedTarget: event.relatedTarget }, event)),
   };
 
   if (invalid) {

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -6,12 +6,7 @@ import InternalLink from '../../../link/internal';
 import { RecoveryLinkProp } from '../../../select/utils/use-select';
 
 import InternalStatusIndicator from '../../../status-indicator/internal';
-import {
-  NonCancelableEventHandler,
-  fireNonCancelableEvent,
-  fireCancelableEvent,
-  getBlurEventRelatedTarget,
-} from '../../events';
+import { NonCancelableEventHandler, fireNonCancelableEvent, fireCancelableEvent } from '../../events';
 import { usePrevious } from '../../hooks/use-previous';
 
 import { DropdownStatusProps } from './interfaces';
@@ -85,13 +80,7 @@ export const useDropdownStatus: UseDropdownStatus = ({
     statusResult.content = (
       <span
         ref={recoveryProps ? recoveryProps.ref : null}
-        onBlur={event =>
-          fireCancelableEvent(
-            recoveryProps?.onBlur,
-            { relatedTarget: getBlurEventRelatedTarget(event.nativeEvent) },
-            event
-          )
-        }
+        onBlur={event => fireCancelableEvent(recoveryProps?.onBlur, { relatedTarget: event.relatedTarget }, event)}
       >
         <InternalStatusIndicator type="error" __animate={previousStatusType !== 'error'}>
           {errorText}

--- a/src/internal/components/options-list/index.tsx
+++ b/src/internal/components/options-list/index.tsx
@@ -10,7 +10,6 @@ import {
   CancelableEventHandler,
   BaseKeyDetail,
   fireKeyboardEvent,
-  getBlurEventRelatedTarget,
 } from '../../events';
 import { findUpUntil } from '../../utils/dom';
 import styles from './styles.css.js';
@@ -106,7 +105,7 @@ const OptionsList = (
       onKeyDown={event => onKeyDown && fireKeyboardEvent(onKeyDown, event)}
       onMouseMove={event => onMouseMove?.(getItemIndex(menuRef, event))}
       onMouseUp={event => onMouseUp?.(getItemIndex(menuRef, event))}
-      onBlur={event => fireNonCancelableEvent(onBlur, { relatedTarget: getBlurEventRelatedTarget(event.nativeEvent) })}
+      onBlur={event => fireNonCancelableEvent(onBlur, { relatedTarget: event.relatedTarget })}
       onFocus={() => fireNonCancelableEvent(onFocus)}
       tabIndex={-1}
       aria-labelledby={ariaLabelledby}

--- a/src/internal/events/index.ts
+++ b/src/internal/events/index.ts
@@ -107,15 +107,3 @@ export function isPlainLeftClick(event?: React.MouseEvent | React.KeyboardEvent)
     !event.metaKey
   );
 }
-
-/**
- * Returns the element the focus is going to, when a blur event is fired.
- * IE11 does not support `realtedTarget` on blur FocusEvent's. However, it
- * moves the focus before the blur event is fired, so we can get the needed
- * element by accessing `document.activeElement`
- * @param event FocusEvent - native focus event
- * @returns Node | null - the element recieving the focus
- */
-export const getBlurEventRelatedTarget = (event: FocusEvent): Node | null => {
-  return (event.relatedTarget || document.activeElement) as Node | null;
-};


### PR DESCRIPTION
### Description

Pretty light easy fix. This one's a hack needed for React ~16.8 on IE11. The focus implementation was changed in React 17 (facebook/react#3751) anyway. Not a major issue, so this can wait, but it's a nice tiny code delete, and I always love that.

### How has this been tested?

Testing it right here in GitHub actions mostly. I gave the components a quick manual once-over, but our existing tests are the only reliable way here. 

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
