### PR TITLE
Introduce getTimeOffset API to date-range picker

### DIFF
--- a/pages/date-range-picker/simple.page.tsx
+++ b/pages/date-range-picker/simple.page.tsx
@@ -54,6 +54,7 @@ export default function DatePickerScenario() {
             timeInputFormat="hh:mm"
             rangeSelectorMode={rangeSelectorMode}
             isDateEnabled={date => date.getDate() !== 15}
+            getTimeOffset={date => -1 * date.getTimezoneOffset()}
           />
         </FormField>
         <Link id="focusable-element-after-date-picker">Focusable element after the date range picker</Link>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4810,7 +4810,7 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
-      "description": "A function from ISO8601 date string to return the desired time offset from UTC in minutes.
+      "description": "A function that receives an ISO8601 date string and returns the desired time offset from UTC in minutes.
 Use it to define time relative to the desired timezone.
 Has no effect when \`dateOnly\` is true.
 
@@ -5115,7 +5115,7 @@ Has no effect when \`dateOnly\` is true.
 
 Default: the user's current time offset as provided by the browser.
 
-This property is deprecated. Use getTimeOffset instead.
+The property is deprecated, use getTimeOffset instead.",
       "name": "timeOffset",
       "optional": true,
       "type": "number",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5115,7 +5115,7 @@ Has no effect when \`dateOnly\` is true.
 
 Default: the user's current time offset as provided by the browser.
 
-The property is deprecated, use getTimeOffset instead.",
+This property is deprecated. Use getTimeOffset instead.
       "name": "timeOffset",
       "optional": true,
       "type": "number",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4810,15 +4810,29 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
-      "description": "A function that receives an ISO8601 date string and returns the desired time offset from UTC in minutes.
+      "description": "A function that defines timezone offset from UTC in minutes for selected dates.
 Use it to define time relative to the desired timezone.
+The function is called for the start date and the end date and takes a UTC date
+corresponding the selected value as an argument.
+
 Has no effect when \`dateOnly\` is true.
 
 Default: the user's current time offset as provided by the browser.
 ",
+      "inlineType": Object {
+        "name": "DateRangePickerProps.GetTimeOffsetFunction",
+        "parameters": Array [
+          Object {
+            "name": "date",
+            "type": "Date",
+          },
+        ],
+        "returnType": "number",
+        "type": "function",
+      },
       "name": "getTimeOffset",
       "optional": true,
-      "type": "(date: string) => number",
+      "type": "DateRangePickerProps.GetTimeOffsetFunction",
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
@@ -5115,7 +5129,7 @@ Has no effect when \`dateOnly\` is true.
 
 Default: the user's current time offset as provided by the browser.
 
-The property is deprecated, use getTimeOffset instead.",
+This property is deprecated. Use getTimeOffset instead.",
       "name": "timeOffset",
       "optional": true,
       "type": "number",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4810,6 +4810,17 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
+      "description": "A function from ISO8601 date string to return the desired time offset from UTC in minutes.
+Use it to define time relative to the desired timezone.
+Has no effect when \`dateOnly\` is true.
+
+Default: the user's current time offset as provided by the browser.
+",
+      "name": "getTimeOffset",
+      "optional": true,
+      "type": "(date: string) => number",
+    },
+    Object {
       "description": "An object containing all the necessary localized strings required by the component.",
       "inlineType": Object {
         "name": "DateRangePickerProps.I18nStrings",
@@ -5103,7 +5114,8 @@ display and produce values.
 Has no effect when \`dateOnly\` is true.
 
 Default: the user's current time offset as provided by the browser.
-",
+
+The property is deprecated, use getTimeOffset instead.",
       "name": "timeOffset",
       "optional": true,
       "type": "number",

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -354,7 +354,7 @@ describe('Date range picker', () => {
 
       test('creates offset as a function from date', () => {
         const onChangeSpy = jest.fn();
-        const getTimeOffset = jest.fn().mockImplementation((date: string) => (date.includes('06') ? 120 : 60));
+        const getTimeOffset = jest.fn().mockImplementation((date: Date) => (date.getUTCMonth() === 5 ? 120 : 60));
         const { wrapper } = renderDateRangePicker({
           ...defaultProps,
           timeOffset: 6.5 * 60, // to be ignored as getTimeOffset is preferred
@@ -380,8 +380,8 @@ describe('Date range picker', () => {
         );
 
         expect(getTimeOffset).toBeCalledTimes(2);
-        expect(getTimeOffset).toBeCalledWith('2018-01-01T00:00:00');
-        expect(getTimeOffset).toBeCalledWith('2018-06-01T23:59:59');
+        expect(getTimeOffset).toBeCalledWith(expect.any(Date));
+        expect(getTimeOffset).toBeCalledWith(expect.any(Date));
       });
     });
 

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -380,8 +380,6 @@ describe('Date range picker', () => {
         );
 
         expect(getTimeOffset).toBeCalledTimes(2);
-        expect(getTimeOffset).toBeCalledWith(expect.any(Date));
-        expect(getTimeOffset).toBeCalledWith(expect.any(Date));
       });
     });
 

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -351,6 +351,38 @@ describe('Date range picker', () => {
           );
         }
       });
+
+      test('creates offset as a function from date', () => {
+        const onChangeSpy = jest.fn();
+        const getTimeOffset = jest.fn().mockImplementation((date: string) => (date.includes('06') ? 120 : 60));
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          timeOffset: 6.5 * 60, // to be ignored as getTimeOffset is preferred
+          getTimeOffset,
+          onChange: event => onChangeSpy(event.detail),
+        });
+
+        act(() => wrapper.findTrigger().click());
+
+        act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/01/01'));
+        act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/06/01'));
+
+        act(() => wrapper.findDropdown()!.findApplyButton().click());
+
+        expect(onChangeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            value: {
+              type: 'absolute',
+              startDate: '2018-01-01T00:00:00+01:00',
+              endDate: '2018-06-01T23:59:59+02:00',
+            },
+          })
+        );
+
+        expect(getTimeOffset).toBeCalledTimes(2);
+        expect(getTimeOffset).toBeCalledWith('2018-01-01T00:00:00');
+        expect(getTimeOffset).toBeCalledWith('2018-06-01T23:59:59');
+      });
     });
 
     describe('date-only', () => {

--- a/src/date-range-picker/__tests__/time-offset.test.ts
+++ b/src/date-range-picker/__tests__/time-offset.test.ts
@@ -7,7 +7,10 @@ describe('Date range picker', () => {
   describe('time offset handling', () => {
     test('setTimeOffset', () => {
       expect(
-        setTimeOffset({ type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' }, 120)
+        setTimeOffset(
+          { type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' },
+          { startDate: 120, endDate: 120 }
+        )
       ).toEqual({
         type: 'absolute',
         startDate: '2020-10-12T01:23:45+02:00',
@@ -15,27 +18,43 @@ describe('Date range picker', () => {
       });
 
       expect(
-        setTimeOffset({ type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' }, -240)
+        setTimeOffset(
+          { type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' },
+          { startDate: -240, endDate: -240 }
+        )
       ).toEqual({
         type: 'absolute',
         startDate: '2020-10-12T01:23:45-04:00',
         endDate: '2020-10-12T01:23:45-04:00',
       });
 
-      expect(setTimeOffset({ type: 'relative', unit: 'second', amount: 5 }, -240)).toEqual({
+      expect(
+        setTimeOffset(
+          { type: 'absolute', startDate: '2020-10-12T01:23:45', endDate: '2020-10-12T01:23:45' },
+          { startDate: 120, endDate: -240 }
+        )
+      ).toEqual({
+        type: 'absolute',
+        startDate: '2020-10-12T01:23:45+02:00',
+        endDate: '2020-10-12T01:23:45-04:00',
+      });
+
+      expect(
+        setTimeOffset({ type: 'relative', unit: 'second', amount: 5 }, { startDate: -240, endDate: -240 })
+      ).toEqual({
         type: 'relative',
         unit: 'second',
         amount: 5,
       });
 
-      expect(setTimeOffset(null, 300)).toBe(null);
+      expect(setTimeOffset(null, { startDate: 300, endDate: 300 })).toBe(null);
     });
 
     test('shiftTimeOffset', () => {
       expect(
         shiftTimeOffset(
           { type: 'absolute', startDate: '2020-10-12T01:23:45+04:00', endDate: '2020-10-12T01:23:45-05:00' },
-          120
+          { startDate: 120, endDate: 120 }
         )
       ).toEqual({
         type: 'absolute',
@@ -46,7 +65,7 @@ describe('Date range picker', () => {
       expect(
         shiftTimeOffset(
           { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45+00:00' },
-          -240
+          { startDate: -240, endDate: -240 }
         )
       ).toEqual({
         type: 'absolute',
@@ -56,8 +75,19 @@ describe('Date range picker', () => {
 
       expect(
         shiftTimeOffset(
+          { type: 'absolute', startDate: '2020-10-12T01:23:45Z', endDate: '2020-10-12T01:23:45+00:00' },
+          { startDate: 120, endDate: -240 }
+        )
+      ).toEqual({
+        type: 'absolute',
+        startDate: '2020-10-12T03:23:45',
+        endDate: '2020-10-11T21:23:45',
+      });
+
+      expect(
+        shiftTimeOffset(
           { type: 'absolute', startDate: '2020-10-12T00:00:00+10:00', endDate: '2020-10-12T10:00:00+10:00' },
-          10 * 60
+          { startDate: 10 * 60, endDate: 10 * 60 }
         )
       ).toEqual({
         type: 'absolute',
@@ -68,7 +98,7 @@ describe('Date range picker', () => {
       expect(
         shiftTimeOffset(
           { type: 'absolute', startDate: '2020-10-12T00:00:00-10:00', endDate: '2020-10-12T10:00:00-10:00' },
-          -10 * 60
+          { startDate: -10 * 60, endDate: -10 * 60 }
         )
       ).toEqual({
         type: 'absolute',
@@ -79,7 +109,7 @@ describe('Date range picker', () => {
       expect(
         shiftTimeOffset(
           { type: 'absolute', startDate: '2020-10-12T00:00:00+10:00', endDate: '2020-10-12T10:00:00+10:00' },
-          0
+          { startDate: 0, endDate: 0 }
         )
       ).toEqual({
         type: 'absolute',

--- a/src/date-range-picker/embedded.tsx
+++ b/src/date-range-picker/embedded.tsx
@@ -13,6 +13,7 @@ import { fireNonCancelableEvent } from '../internal/events/index.js';
 import { DateRangePickerProps, Focusable } from './interfaces';
 import { formatValue } from './use-date-range-picker.js';
 import { useMobile } from '../internal/hooks/use-mobile';
+import { normalizeTimeOffset } from './time-offset';
 
 export interface DateRangePickerEmbeddedProps extends DateRangePickerBaseProps {
   ariaLabelledby?: string;
@@ -31,6 +32,7 @@ export function DateRangePickerEmbedded({
   rangeSelectorMode = 'default',
   onChange,
   timeOffset,
+  getTimeOffset,
 }: DateRangePickerEmbeddedProps) {
   const {
     fillMissingTime,
@@ -50,8 +52,8 @@ export function DateRangePickerEmbedded({
 
   function updateRange(value: DateRangePickerProps.AbsoluteValue | DateRangePickerProps.RelativeValue) {
     const newValue = value.type === 'relative' ? value : fillMissingTime(value);
-
-    fireNonCancelableEvent(onChange, { value: formatValue(newValue, { dateOnly, timeOffset }) });
+    const normalizedTimeOffset = normalizeTimeOffset(newValue, getTimeOffset, timeOffset);
+    fireNonCancelableEvent(onChange, { value: formatValue(newValue, { dateOnly, timeOffset: normalizedTimeOffset }) });
   }
 
   const focusRefs = {

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -18,7 +18,7 @@ import { useMobile } from '../internal/hooks/use-mobile';
 import ButtonTrigger from '../internal/components/button-trigger';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import InternalIcon from '../icon/internal';
-import { shiftTimeOffset } from './time-offset';
+import { normalizeTimeOffset, shiftTimeOffset } from './time-offset';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { fireNonCancelableEvent } from '../internal/events/index.js';
@@ -35,7 +35,7 @@ function renderDateRange(
   range: null | DateRangePickerProps.Value,
   placeholder: string,
   formatRelativeRange: DateRangePickerProps.I18nStrings['formatRelativeRange'],
-  timeOffset?: number
+  timeOffset: { startDate?: number; endDate?: number }
 ) {
   if (!range) {
     return (
@@ -99,6 +99,7 @@ const DateRangePicker = React.forwardRef(
       showClearButton = true,
       dateOnly = false,
       timeOffset,
+      getTimeOffset,
       timeInputFormat = 'hh:mm:ss',
       expandToViewport = false,
       rangeSelectorMode = 'default',
@@ -109,7 +110,8 @@ const DateRangePicker = React.forwardRef(
     const { __internalRootRef } = useBaseComponent('DateRangePicker');
     checkControlled('DateRangePicker', 'value', value, 'onChange', onChange);
 
-    value = isDateOnly(value) ? value : shiftTimeOffset(value, timeOffset);
+    const normalizedTimeOffset = normalizeTimeOffset(value, getTimeOffset, timeOffset);
+    value = isDateOnly(value) ? value : shiftTimeOffset(value, normalizeTimeOffset(value, getTimeOffset, timeOffset));
 
     const baseProps = getBaseProps(rest);
     const { invalid, controlId, ariaDescribedby, ariaLabelledby } = useFormFieldContext({
@@ -166,7 +168,12 @@ const DateRangePicker = React.forwardRef(
           }
         }
       }
-      fireNonCancelableEvent(onChange, { value: formatValue(newValue, { dateOnly, timeOffset }) });
+      fireNonCancelableEvent(onChange, {
+        value: formatValue(newValue, {
+          dateOnly,
+          timeOffset: normalizeTimeOffset(newValue, getTimeOffset, timeOffset),
+        }),
+      });
       return validationResult || { valid: true };
     };
 
@@ -222,7 +229,7 @@ const DateRangePicker = React.forwardRef(
             <span className={styles['icon-wrapper']}>
               <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
             </span>
-            {renderDateRange(value, placeholder ?? '', i18nStrings.formatRelativeRange, timeOffset)}
+            {renderDateRange(value, placeholder ?? '', i18nStrings.formatRelativeRange, normalizedTimeOffset)}
           </span>
         </ButtonTrigger>
       </div>

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -111,7 +111,7 @@ const DateRangePicker = React.forwardRef(
     checkControlled('DateRangePicker', 'value', value, 'onChange', onChange);
 
     const normalizedTimeOffset = normalizeTimeOffset(value, getTimeOffset, timeOffset);
-    value = isDateOnly(value) ? value : shiftTimeOffset(value, normalizeTimeOffset(value, getTimeOffset, timeOffset));
+    value = isDateOnly(value) ? value : shiftTimeOffset(value, normalizedTimeOffset);
 
     const baseProps = getBaseProps(rest);
     const { invalid, controlId, ariaDescribedby, ariaLabelledby } = useFormFieldContext({

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -90,20 +90,23 @@ export interface DateRangePickerBaseProps {
    *
    * Default: the user's current time offset as provided by the browser.
    *
-   * The property is deprecated, use getTimeOffset instead.
+   * This property is deprecated. Use getTimeOffset instead.
    * @deprecated
    */
   timeOffset?: number;
 
   /**
-   * A function that receives an ISO8601 date string and returns the desired time offset from UTC in minutes.
+   * A function that defines timezone offset from UTC in minutes for selected dates.
    * Use it to define time relative to the desired timezone.
+   *
+   * The function is called for the start date and the end date and takes a UTC date
+   * corresponding the selected value as an argument.
    *
    * Has no effect when `dateOnly` is true.
    *
    * Default: the user's current time offset as provided by the browser.
    */
-  getTimeOffset?: (date: string) => number;
+  getTimeOffset?: DateRangePickerProps.GetTimeOffsetFunction;
 }
 export interface DateRangePickerProps
   extends BaseComponentProps,
@@ -209,6 +212,10 @@ export namespace DateRangePickerProps {
 
   export interface IsDateEnabledFunction {
     (date: Date): boolean;
+  }
+
+  export interface GetTimeOffsetFunction {
+    (date: Date): number;
   }
 
   export type RangeSelectorMode = 'default' | 'absolute-only' | 'relative-only';

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -89,8 +89,21 @@ export interface DateRangePickerBaseProps {
    * Has no effect when `dateOnly` is true.
    *
    * Default: the user's current time offset as provided by the browser.
+   *
+   * The property is deprecated, use getTimeOffset instead.
+   * @deprecated
    */
   timeOffset?: number;
+
+  /**
+   * A function from ISO8601 date string to return the desired time offset from UTC in minutes.
+   * Use it to define time relative to the desired timezone.
+   *
+   * Has no effect when `dateOnly` is true.
+   *
+   * Default: the user's current time offset as provided by the browser.
+   */
+  getTimeOffset?: (date: string) => number;
 }
 export interface DateRangePickerProps
   extends BaseComponentProps,

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -96,7 +96,7 @@ export interface DateRangePickerBaseProps {
   timeOffset?: number;
 
   /**
-   * A function from ISO8601 date string to return the desired time offset from UTC in minutes.
+   * A function that receives an ISO8601 date string and returns the desired time offset from UTC in minutes.
    * Use it to define time relative to the desired timezone.
    *
    * Has no effect when `dateOnly` is true.

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -77,6 +77,22 @@ export function normalizeTimeOffset(
   return { startDate: undefined, endDate: undefined };
 }
 
+/*
+  Before the getTimeOffset function is used there is no information on the preferred time offset.
+  
+  Besides, the ISO date string might or might not contain the offset:
+  - 2021-02-03T01:02:03
+  - 2021-02-03T01:02:03Z
+  - 2021-02-03T01:02:03+01:00
+  
+  For every value above the date is converted to UTC and the following is true:
+  date.getUTCFullYear() === 2021
+  date.getUTCMonth() === 1
+  date.getUTCDate() === 3
+  date.getUTCHours() === 1
+  date.getUTCMinutes() === 2
+  date.getUTCSeconds() === 3
+*/
 function parseDateUTC(isoDateString: string): Date {
   const date = new Date(isoDateString);
   return addMinutes(date, parseTimezoneOffset(isoDateString));

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -60,15 +60,24 @@ export function shiftTimeOffset(
 
 export function normalizeTimeOffset(
   value: null | DateRangePickerProps.Value,
-  getTimeOffset?: (date: string) => number,
+  getTimeOffset?: DateRangePickerProps.GetTimeOffsetFunction,
   timeOffset?: number
 ) {
   if (value && value.type === 'absolute') {
     if (getTimeOffset) {
-      return { startDate: getTimeOffset(value.startDate), endDate: getTimeOffset(value.endDate) };
+      return {
+        startDate: getTimeOffset(parseDateUTC(value.startDate)),
+        endDate: getTimeOffset(parseDateUTC(value.endDate)),
+      };
     } else if (timeOffset !== undefined) {
       return { startDate: timeOffset, endDate: timeOffset };
     }
   }
   return { startDate: undefined, endDate: undefined };
+}
+
+function parseDateUTC(isoDateString: string): Date {
+  const date = new Date(isoDateString);
+  date.setMinutes(-1 * date.getTimezoneOffset());
+  return date;
 }

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DateRangePickerProps } from './interfaces';
 import { warnOnce } from '../internal/logging';
-import { formatTimezoneOffset, shiftTimezoneOffset } from '../internal/utils/date-time';
+import { formatTimezoneOffset, parseTimezoneOffset, shiftTimezoneOffset } from '../internal/utils/date-time';
+import { addMinutes } from 'date-fns';
 
 /**
  * Appends a time zone offset to an offset-less date string.
@@ -78,6 +79,5 @@ export function normalizeTimeOffset(
 
 function parseDateUTC(isoDateString: string): Date {
   const date = new Date(isoDateString);
-  date.setMinutes(-1 * date.getTimezoneOffset());
-  return date;
+  return addMinutes(date, parseTimezoneOffset(isoDateString));
 }

--- a/src/date-range-picker/time-offset.ts
+++ b/src/date-range-picker/time-offset.ts
@@ -9,18 +9,15 @@ import { formatTimezoneOffset, shiftTimezoneOffset } from '../internal/utils/dat
  */
 export function setTimeOffset(
   value: DateRangePickerProps.Value | null,
-  timeOffsetInMinutes?: number
+  timeOffset: { startDate?: number; endDate?: number }
 ): DateRangePickerProps.Value | null {
   if (!(value?.type === 'absolute')) {
     return value;
   }
-
-  const { startDate, endDate } = value;
-
   return {
     type: 'absolute',
-    startDate: startDate + formatTimezoneOffset(startDate, timeOffsetInMinutes),
-    endDate: endDate + formatTimezoneOffset(endDate, timeOffsetInMinutes),
+    startDate: value.startDate + formatTimezoneOffset(value.startDate, timeOffset.startDate),
+    endDate: value.endDate + formatTimezoneOffset(value.endDate, timeOffset.endDate),
   };
 }
 
@@ -31,7 +28,7 @@ export function setTimeOffset(
  */
 export function shiftTimeOffset(
   value: null | DateRangePickerProps.Value,
-  timeOffsetInMinutes?: number
+  timeOffset: { startDate?: number; endDate?: number }
 ): DateRangePickerProps.Value | null {
   if (!value || value.type !== 'absolute') {
     return value;
@@ -56,7 +53,22 @@ export function shiftTimeOffset(
 
   return {
     type: 'absolute',
-    startDate: shiftTimezoneOffset(value.startDate, timeOffsetInMinutes),
-    endDate: shiftTimezoneOffset(value.endDate, timeOffsetInMinutes),
+    startDate: shiftTimezoneOffset(value.startDate, timeOffset.startDate),
+    endDate: shiftTimezoneOffset(value.endDate, timeOffset.endDate),
   };
+}
+
+export function normalizeTimeOffset(
+  value: null | DateRangePickerProps.Value,
+  getTimeOffset?: (date: string) => number,
+  timeOffset?: number
+) {
+  if (value && value.type === 'absolute') {
+    if (getTimeOffset) {
+      return { startDate: getTimeOffset(value.startDate), endDate: getTimeOffset(value.endDate) };
+    } else if (timeOffset !== undefined) {
+      return { startDate: timeOffset, endDate: timeOffset };
+    }
+  }
+  return { startDate: undefined, endDate: undefined };
 }

--- a/src/date-range-picker/use-date-range-picker.tsx
+++ b/src/date-range-picker/use-date-range-picker.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { DateRangePickerProps } from './interfaces';
 import { setTimeOffset } from './time-offset';
+
 /**
  * This function fills in a start and end time if they are missing.
  */
@@ -21,7 +22,7 @@ function fillMissingTime(value: DateRangePickerProps.AbsoluteValue | null) {
 
 export function formatValue(
   value: null | DateRangePickerProps.Value,
-  { timeOffset, dateOnly }: { timeOffset?: number; dateOnly: boolean }
+  { timeOffset, dateOnly }: { timeOffset: { startDate?: number; endDate?: number }; dateOnly: boolean }
 ): null | DateRangePickerProps.Value {
   if (!value || value.type === 'relative') {
     return value;

--- a/src/internal/utils/date-time/__tests__/format-date-range.test.ts
+++ b/src/internal/utils/date-time/__tests__/format-date-range.test.ts
@@ -3,12 +3,18 @@
 
 import { formatDateRange } from '../../../../../lib/components/internal/utils/date-time/format-date-range';
 
+const browser = { startDate: undefined, endDate: undefined };
+const berlin = { startDate: 120, endDate: 120 };
+const newYork = { startDate: -240, endDate: -240 };
+const regional = { startDate: 0, endDate: 60 };
+
 describe('formatDateRange', () => {
   test.each([
-    ['2020-01-01', '2020-01-02', undefined, '2020-01-01 — 2020-01-02'],
-    ['2020-01-01', '2020-01-02', 60, '2020-01-01 — 2020-01-02'],
-    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', 60, '2020-01-01T00:00:00+01:00 — 2020-01-01T12:00:00+01:00'],
-    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', -60, '2020-01-01T00:00:00-01:00 — 2020-01-01T12:00:00-01:00'],
+    ['2020-01-01', '2020-01-02', browser, '2020-01-01 — 2020-01-02'],
+    ['2020-01-01', '2020-01-02', berlin, '2020-01-01 — 2020-01-02'],
+    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', berlin, '2020-01-01T00:00:00+02:00 — 2020-01-01T12:00:00+02:00'],
+    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', newYork, '2020-01-01T00:00:00-04:00 — 2020-01-01T12:00:00-04:00'],
+    ['2020-01-01T00:00:00', '2020-01-01T12:00:00', regional, '2020-01-01T00:00:00+00:00 — 2020-01-01T12:00:00+01:00'],
   ])('formats date correctly [%s, %s, %s]', (startDate, endDate, timeOffset, expected) => {
     expect(formatDateRange(startDate, endDate, timeOffset)).toBe(expected);
   });

--- a/src/internal/utils/date-time/format-date-range.ts
+++ b/src/internal/utils/date-time/format-date-range.ts
@@ -4,9 +4,13 @@
 import { formatTimezoneOffset } from './format-timezone-offset';
 import { isIsoDateOnly } from './is-iso-date-only';
 
-export function formatDateRange(startDate: string, endDate: string, timeOffset?: number): string {
+export function formatDateRange(
+  startDate: string,
+  endDate: string,
+  timeOffset: { startDate?: number; endDate?: number }
+): string {
   const isDateOnly = isIsoDateOnly(startDate) && isIsoDateOnly(endDate);
-  const formattedStartOffset = isDateOnly ? '' : formatTimezoneOffset(startDate, timeOffset);
-  const formattedEndOffset = isDateOnly ? '' : formatTimezoneOffset(endDate, timeOffset);
+  const formattedStartOffset = isDateOnly ? '' : formatTimezoneOffset(startDate, timeOffset.startDate);
+  const formattedEndOffset = isDateOnly ? '' : formatTimezoneOffset(endDate, timeOffset.endDate);
   return startDate + formattedStartOffset + ' ' + '—' + ' ' + endDate + formattedEndOffset;
 }


### PR DESCRIPTION
### Description

The new getTimeOffset API allowing time offsets to be provided per date to account for daylight savings if different between start and end dates of the selected range.

Usage examples:

```
// Same as default
<DateRangePicker ... getTimeOffset={date => -1 * new Date(date).getTimezoneOffset()} />

// Parse in a custom timezone
import moment from 'moment-timezone'
<DateRangePicker ... getTimeOffset={date => -1 * moment.tz(date, 'America/Toronto')} />
```

### How has this been tested?

Added unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

* Ticket AWSUI-19513

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
