### PR TITLE
Fix focus return logic when dropdown is closed

### DIFF
--- a/src/button-dropdown/__integ__/button-dropdown-items.test.ts
+++ b/src/button-dropdown/__integ__/button-dropdown-items.test.ts
@@ -17,3 +17,18 @@ test(
     expect(await browser.getWindowHandles()).toHaveLength(2);
   })
 );
+
+test(
+  'focuses on correct button-dropdown when the two are opened one after another',
+  useBrowser(async browser => {
+    const page1 = new ButtonDropdownPage('ButtonDropdown3', browser);
+    const page2 = new ButtonDropdownPage('ButtonDropdown1', browser);
+    await browser.url('#/light/button-dropdown/simple');
+
+    await page1.waitForVisible(page1.getTrigger());
+    await page1.openDropdown();
+    await page2.openDropdown();
+
+    await expect(page2.getFocusedElementText()).resolves.toBe('Two');
+  })
+);

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -63,6 +63,7 @@ const InternalButtonDropdown = React.forwardRef(
       onItemClick,
       onItemFollow,
       onReturnFocus: () => dropdownRef.current?.focus(),
+      expandToViewport,
       hasExpandableGroups: expandableGroups,
       isInRestrictedView,
     });

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 import styles from './styles.css.js';
 import { ButtonDropdownProps, InternalButtonDropdownProps } from './interfaces';
@@ -14,7 +14,6 @@ import { InternalButton } from '../button/internal';
 import { ButtonProps } from '../button/interfaces';
 import { useMobile } from '../internal/hooks/use-mobile';
 import useForwardFocus from '../internal/hooks/forward-focus';
-import { usePrevious } from '../internal/hooks/use-previous';
 import InternalBox from '../box/internal';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 
@@ -63,6 +62,7 @@ const InternalButtonDropdown = React.forwardRef(
       items,
       onItemClick,
       onItemFollow,
+      onReturnFocus: () => dropdownRef.current?.focus(),
       hasExpandableGroups: expandableGroups,
       isInRestrictedView,
     });
@@ -86,13 +86,6 @@ const InternalButtonDropdown = React.forwardRef(
     };
 
     const canBeOpened = !loading && !disabled;
-    const wasOpen = usePrevious(isOpen);
-
-    useEffect(() => {
-      if (!isOpen && dropdownRef.current && wasOpen) {
-        dropdownRef.current.focus();
-      }
-    }, [isOpen, wasOpen]);
 
     const triggerVariant = variant === 'navigation' ? undefined : variant;
     const iconProps: Partial<ButtonProps & { __iconClass?: string }> =

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -14,6 +14,7 @@ interface UseButtonDropdownOptions extends ButtonDropdownSettings {
   onItemClick?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   onItemFollow?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   onReturnFocus: () => void;
+  expandToViewport?: boolean;
 }
 
 interface UseButtonDropdownApi extends HighlightProps {
@@ -33,6 +34,7 @@ export function useButtonDropdown({
   onReturnFocus,
   hasExpandableGroups,
   isInRestrictedView = false,
+  expandToViewport = false,
 }: UseButtonDropdownOptions): UseButtonDropdownApi {
   const {
     targetItem,
@@ -155,6 +157,11 @@ export function useButtonDropdown({
         break;
       }
       case KeyCode.tab: {
+        // When expanded to viewport the focus can't move naturally to the next element.
+        // Returning the focus to the trigger instead.
+        if (expandToViewport) {
+          onReturnFocus();
+        }
         closeDropdown();
         break;
       }

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -13,6 +13,7 @@ interface UseButtonDropdownOptions extends ButtonDropdownSettings {
   items: ButtonDropdownProps.Items;
   onItemClick?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   onItemFollow?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
+  onReturnFocus: () => void;
 }
 
 interface UseButtonDropdownApi extends HighlightProps {
@@ -29,6 +30,7 @@ export function useButtonDropdown({
   items,
   onItemClick,
   onItemFollow,
+  onReturnFocus,
   hasExpandableGroups,
   isInRestrictedView = false,
 }: UseButtonDropdownOptions): UseButtonDropdownApi {
@@ -66,6 +68,7 @@ export function useButtonDropdown({
     if (onItemClick) {
       fireCancelableEvent(onItemClick, details, event);
     }
+    onReturnFocus();
     closeDropdown();
   };
 
@@ -146,6 +149,7 @@ export function useButtonDropdown({
         break;
       }
       case KeyCode.escape: {
+        onReturnFocus();
         closeDropdown();
         event.preventDefault();
         break;


### PR DESCRIPTION
### Description

When dropdown is closed the focus returns back to the trigger but only when an item was activated or Escape was pressed. When closing with a TAB or a mouse click the focus should transition to another element instead.

### How has this been tested?

Added new integration test.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

A pre-requisite for: https://github.com/cloudscape-design/components/pull/378

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
