### PR TITLE
fix(expandable-section): Reduce activation area

### DIFF
--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -9,7 +9,6 @@ import styles from './styles.css.js';
 
 interface ExpandableSectionHeaderProps {
   id: string;
-  className?: string;
   variant: ExpandableSectionProps.Variant;
   children?: ReactNode;
   expanded: boolean;
@@ -23,7 +22,6 @@ interface ExpandableSectionHeaderProps {
 
 export const ExpandableSectionHeader = ({
   id,
-  className,
   variant,
   children,
   expanded,
@@ -35,53 +33,62 @@ export const ExpandableSectionHeader = ({
   onClick,
 }: ExpandableSectionHeaderProps) => {
   const focusVisible = useFocusVisible();
+  const isNavigation = variant === 'navigation';
 
-  const icon = (
+  const ariaAttributes = {
+    'aria-controls': ariaControls,
+    'aria-expanded': expanded,
+    'aria-label': ariaLabel,
+    'aria-labelledby': isNavigation ? ariaLabelledBy : undefined,
+  };
+  const className = clsx(
+    styles.header,
+    styles[`header-${variant}`],
+    styles.trigger,
+    styles[`trigger-${variant}`],
+    expanded && styles['trigger-expanded']
+  );
+  if (isNavigation) {
+    return (
+      <div>
+        <div id={id} className={className} onClick={onClick}>
+          <button className={styles['icon-container']} type="button" {...focusVisible} {...ariaAttributes}>
+            <ExpandIcon variant={variant} expanded={expanded} />
+          </button>
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        id={id}
+        role="button"
+        className={clsx(className, styles.focusable, expanded && styles.expanded)}
+        tabIndex={0}
+        onKeyUp={onKeyUp}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        {...focusVisible}
+        {...ariaAttributes}
+      >
+        <div className={styles['icon-container']}>
+          <ExpandIcon variant={variant} expanded={expanded} />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+function ExpandIcon({ variant, expanded }: { variant: ExpandableSectionProps.Variant; expanded: boolean }) {
+  return (
     <InternalIcon
       size={variant === 'container' ? 'medium' : 'normal'}
       className={clsx(styles.icon, expanded && styles.expanded)}
       name="caret-down-filled"
     />
   );
-  const ariaAttributes = {
-    'aria-controls': ariaControls,
-    'aria-expanded': expanded,
-  };
-
-  const triggerClassName = clsx(styles.trigger, styles[`trigger-${variant}`], expanded && styles['trigger-expanded']);
-  if (variant === 'navigation') {
-    return (
-      <div id={id} className={clsx(className, triggerClassName)} onClick={onClick}>
-        <button
-          className={styles['icon-container']}
-          type="button"
-          aria-labelledby={ariaLabelledBy}
-          aria-label={ariaLabel}
-          {...focusVisible}
-          {...ariaAttributes}
-        >
-          {icon}
-        </button>
-        {children}
-      </div>
-    );
-  }
-
-  return (
-    <div
-      id={id}
-      role="button"
-      className={clsx(className, triggerClassName, styles.focusable, expanded && styles.expanded)}
-      tabIndex={0}
-      onKeyUp={onKeyUp}
-      onKeyDown={onKeyDown}
-      onClick={onClick}
-      aria-label={ariaLabel}
-      {...focusVisible}
-      {...ariaAttributes}
-    >
-      <div className={styles['icon-container']}>{icon}</div>
-      {children}
-    </div>
-  );
-};
+}

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -89,13 +89,7 @@ export default function InternalExpandableSection({
       variant={variant}
       disableContentPaddings={disableContentPaddings}
       header={
-        <ExpandableSectionHeader
-          id={triggerControlId}
-          className={clsx(styles.header, styles[`header-${variant}`])}
-          variant={variant}
-          expanded={!!expanded}
-          {...triggerProps}
-        >
+        <ExpandableSectionHeader id={triggerControlId} variant={variant} expanded={!!expanded} {...triggerProps}>
           {header}
         </ExpandableSectionHeader>
       }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -34,9 +34,8 @@
 .trigger {
   cursor: pointer;
   box-sizing: border-box;
-  display: flex;
+  display: inline-flex;
   border: none;
-  width: 100%;
   line-height: awsui.$font-body-m-line-height;
   text-align: left;
 
@@ -53,6 +52,7 @@
   &-footer {
     border: awsui.$border-divider-section-width solid transparent;
   }
+
   &-navigation {
     // not needed for focus ring compensation, but to keep this variant vertically aligned with other variants when used together
     border-left: awsui.$border-divider-section-width solid transparent;
@@ -79,17 +79,14 @@
       padding: container.$header-focus-visible-padding;
     }
   }
-
-  &-default.trigger-expanded {
-    border-bottom-color: awsui.$color-border-divider-default;
-  }
 }
 
 .header {
-  display: flex;
+  display: inline-flex;
 
   &-container {
     width: 100%;
+
     > .icon-container {
       margin-top: awsui.$space-expandable-section-icon-offset-top;
       margin-right: awsui.$space-xs;
@@ -124,6 +121,7 @@
 
   &-default {
     padding: awsui.$space-scaled-xs 0;
+    border-top: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
   }
 
   &-footer {


### PR DESCRIPTION
### Description

Reduces activation area of expandable section to icon + text. This also moves the conditional header `border-bottom` to the content. It is only disabled if there is content.  

### How has this been tested?

Screenshots

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
