### PR TITLE
Fix aria label overriden by selected option arialabelledby

### DIFF
--- a/src/__tests__/form-field-controls-integration.test.tsx
+++ b/src/__tests__/form-field-controls-integration.test.tsx
@@ -141,7 +141,9 @@ formFieldControlComponents.forEach(({ componentName, findNativeElement }) => {
           controlId: formFieldControlId,
           label: 'something',
         });
-        expect(findNativeElement(controlWrapper)).toHaveAttribute('aria-labelledby', `${formFieldControlId}-label`);
+        expect(findNativeElement(controlWrapper)?.getAttribute('aria-labelledby')).toMatch(
+          `${formFieldControlId}-label`
+        );
       });
 
       test('overwrites ariaLabelledby from FormField when ariaLabelledby is set on itself', () => {
@@ -152,8 +154,10 @@ formFieldControlComponents.forEach(({ componentName, findNativeElement }) => {
           { ariaLabelledby: controlAriaLabelledby }
         );
 
-        expect(findNativeElement(controlWrapper)).not.toHaveAttribute('aria-labelledby', `${formFieldControlId}-label`);
-        expect(findNativeElement(controlWrapper)).toHaveAttribute('aria-labelledby', controlAriaLabelledby);
+        expect(findNativeElement(controlWrapper)?.getAttribute('aria-labelledby')).not.toMatch(
+          `${formFieldControlId}-label`
+        );
+        expect(findNativeElement(controlWrapper)?.getAttribute('aria-labelledby')).toMatch(controlAriaLabelledby);
       });
 
       test('does not overwrite the value when it is set to undefined', () => {
@@ -163,7 +167,9 @@ formFieldControlComponents.forEach(({ componentName, findNativeElement }) => {
           { ariaLabelledby: undefined }
         );
 
-        expect(findNativeElement(controlWrapper)).toHaveAttribute('aria-labelledby', `${formFieldControlId}-label`);
+        expect(findNativeElement(controlWrapper)?.getAttribute('aria-labelledby')).toMatch(
+          `${formFieldControlId}-label`
+        );
       });
 
       test('applies ariaLabelledby from FormField when other fields are set on itself', () => {
@@ -173,7 +179,9 @@ formFieldControlComponents.forEach(({ componentName, findNativeElement }) => {
         );
 
         const formFieldLabelId = formFieldWrapper.findLabel()?.getElement().id;
-        expect(findNativeElement(controlWrapper)).toHaveAttribute('aria-labelledby', formFieldLabelId);
+        expect(findNativeElement(controlWrapper)?.getAttribute('aria-labelledby')).toMatch(
+          formFieldLabelId!.toString()
+        );
       });
     });
 

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -26,5 +26,5 @@ export interface ScreenreaderOnlyProps {
  * ```
  */
 export default function ScreenreaderOnly(props: ScreenreaderOnlyProps) {
-  return <div {...props} className={clsx(styles.root, props.className)} />;
+  return <span {...props} className={clsx(styles.root, props.className)} />;
 }

--- a/src/select/__tests__/trigger.test.tsx
+++ b/src/select/__tests__/trigger.test.tsx
@@ -56,13 +56,19 @@ describe('Trigger component', () => {
       expect(buttonTriggerEl).toHaveAttribute('aria-expanded', 'false');
     });
 
-    test('should have aria-label attribute', () => {
-      expect(buttonTriggerEl).toHaveAttribute('aria-label', 'aria label');
+    test('should have aria-labelledby attribute consisting of passed aria-labelby aria-label and the internal one pointing at the currently selected option', () => {
+      expect(buttonTriggerEl.getAttribute('aria-labelledby')).toMatch(
+        /aria-labelled-by select-arialabel-.* option-labelled-by/
+      );
+      expect(buttonTriggerEl.querySelector('#option-labelled-by')).toBeTruthy();
     });
 
-    test('should have aria-labelledby attribute consisting of passed aria-labelby and the internal one pointing at the currently selected option', () => {
-      expect(buttonTriggerEl).toHaveAttribute('aria-labelledby', 'aria-labelled-by option-labelled-by');
-      expect(buttonTriggerEl.querySelector('#option-labelled-by')).toBeTruthy();
+    test('should use aria-label value in element referenced by aria-labelledby', () => {
+      const ariaLabelId = buttonTriggerEl
+        .getAttribute('aria-labelledby')
+        ?.match(/select-arialabel-.* /)?.[0]
+        .trim();
+      expect(buttonTriggerEl.querySelector(`#${ariaLabelId}`)).toHaveTextContent('aria label');
     });
 
     test('should have aria-haspopup attribute', () => {

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -9,8 +9,9 @@ import styles from './styles.css.js';
 import { OptionDefinition } from '../../internal/components/option/interfaces';
 import { FormFieldValidationControlProps } from '../../internal/context/form-field-context';
 import Option from '../../internal/components/option';
-import { generateUniqueId } from '../../internal/hooks/use-unique-id';
+import { generateUniqueId, useUniqueId } from '../../internal/hooks/use-unique-id';
 import { SelectTriggerProps } from '../utils/use-select';
+import ScreenreaderOnly from '../../internal/components/screenreader-only';
 
 export interface TriggerProps extends FormFieldValidationControlProps {
   placeholder: string | undefined;
@@ -67,6 +68,7 @@ const Trigger = React.forwardRef(
     }
 
     const mergedRef = useMergeRefs(triggerProps.ref, ref);
+    const calendarDescriptionId = useUniqueId('select-arialabel-');
 
     return (
       <ButtonTrigger
@@ -77,11 +79,13 @@ const Trigger = React.forwardRef(
         disabled={disabled}
         invalid={invalid}
         inFilteringToken={inFilteringToken}
-        ariaLabel={ariaLabel}
         ariaDescribedby={ariaDescribedby}
-        ariaLabelledby={[ariaLabelledby, triggerProps.ariaLabelledby].filter(label => !!label).join(' ')}
+        ariaLabelledby={[ariaLabelledby, calendarDescriptionId, triggerProps.ariaLabelledby]
+          .filter(label => !!label)
+          .join(' ')}
       >
         {triggerContent}
+        <ScreenreaderOnly id={calendarDescriptionId}>{ariaLabel}</ScreenreaderOnly>
       </ButtonTrigger>
     );
   }


### PR DESCRIPTION
### Description

AWSUI-18917
Fix: aira-label has no influence on select with selected option because of aria-labelledby is set too.

### How has this been tested?

[_How did you test to verify your changes?_] 

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_ Add new unit test
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
