### PR TITLE
Property filter options filter

### DIFF
--- a/src/property-filter/__tests__/controller.test.ts
+++ b/src/property-filter/__tests__/controller.test.ts
@@ -199,18 +199,18 @@ describe('getAutosuggestOptions', () => {
     {
       label: 'Values',
       options: [
-        { tokenValue: 'string=value1', label: 'value1', __labelPrefix: 'string =' },
-        { tokenValue: 'string-other=value1', label: 'value1', __labelPrefix: 'string-other =' },
-        { tokenValue: 'string=value2', label: 'value2', __labelPrefix: 'string =' },
-        { tokenValue: 'string-other=value2', label: 'value2', __labelPrefix: 'string-other =' },
-        { tokenValue: 'default=value', label: 'value', __labelPrefix: 'default =' },
+        { value: 'string = value1', label: 'value1', __labelPrefix: 'string =' },
+        { value: 'string-other = value1', label: 'value1', __labelPrefix: 'string-other =' },
+        { value: 'string = value2', label: 'value2', __labelPrefix: 'string =' },
+        { value: 'string-other = value2', label: 'value2', __labelPrefix: 'string-other =' },
+        { value: 'default = value', label: 'value', __labelPrefix: 'default =' },
       ],
     },
     {
       label: 'Group values',
       options: [
-        { tokenValue: 'range=1', label: '1', __labelPrefix: 'range =' },
-        { tokenValue: 'range=2', label: '2', __labelPrefix: 'range =' },
+        { value: 'range = 1', label: '1', __labelPrefix: 'range =' },
+        { value: 'range = 2', label: '2', __labelPrefix: 'range =' },
       ],
     },
   ];
@@ -306,8 +306,8 @@ describe('getAutosuggestOptions', () => {
         {
           label: 'String values',
           options: [
-            { tokenValue: 'string!=value1', label: 'value1', __labelPrefix: 'string !=' },
-            { tokenValue: 'string!=value2', label: 'value2', __labelPrefix: 'string !=' },
+            { value: 'string != value1', label: 'value1', __labelPrefix: 'string !=' },
+            { value: 'string != value2', label: 'value2', __labelPrefix: 'string !=' },
           ],
         },
       ],
@@ -334,10 +334,10 @@ describe('getAutosuggestOptions', () => {
         {
           label: 'Values',
           options: [
-            { tokenValue: 'string!:value1', label: 'value1', __labelPrefix: 'string !:' },
-            { tokenValue: 'string-other!:value1', label: 'value1', __labelPrefix: 'string-other !:' },
-            { tokenValue: 'string!:value2', label: 'value2', __labelPrefix: 'string !:' },
-            { tokenValue: 'string-other!:value2', label: 'value2', __labelPrefix: 'string-other !:' },
+            { value: 'string !: value1', label: 'value1', __labelPrefix: 'string !:' },
+            { value: 'string-other !: value1', label: 'value1', __labelPrefix: 'string-other !:' },
+            { value: 'string !: value2', label: 'value2', __labelPrefix: 'string !:' },
+            { value: 'string-other !: value2', label: 'value2', __labelPrefix: 'string-other !:' },
           ],
         },
       ],

--- a/src/property-filter/__tests__/controller.test.ts
+++ b/src/property-filter/__tests__/controller.test.ts
@@ -186,14 +186,14 @@ describe('getAutosuggestOptions', () => {
     {
       label: 'Properties',
       options: [
-        { value: 'string', keepOpenOnSelect: true },
-        { value: 'string-other', keepOpenOnSelect: true },
-        { value: 'default', keepOpenOnSelect: true },
-        { value: 'string!=', keepOpenOnSelect: true },
-        { value: 'custom column', keepOpenOnSelect: true },
+        { label: 'string', value: 'string', keepOpenOnSelect: true },
+        { label: 'string-other', value: 'string-other', keepOpenOnSelect: true },
+        { label: 'default', value: 'default', keepOpenOnSelect: true },
+        { label: 'string!=', value: 'string!=', keepOpenOnSelect: true },
+        { label: 'custom column', value: 'custom column', keepOpenOnSelect: true },
       ],
     },
-    { options: [{ value: 'range', keepOpenOnSelect: true }], label: 'Group properties' },
+    { options: [{ label: 'range', value: 'range', keepOpenOnSelect: true }], label: 'Group properties' },
   ];
   const expectedValueSuggestions = [
     {

--- a/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
+++ b/src/property-filter/__tests__/property-filter-autosuggest.test.tsx
@@ -9,7 +9,10 @@ import { AutosuggestProps } from '../../../lib/components/autosuggest/interfaces
 
 import PropertyFilterAutosuggest from '../../../lib/components/property-filter/property-filter-autosuggest';
 
-const options: AutosuggestProps.Options = [{ value: '123' }, { value: 'abc' }];
+const options: AutosuggestProps.Options = [
+  { value: '123', label: '123' },
+  { value: 'abc', label: 'abc' },
+];
 
 function renderAutosuggest(jsx: React.ReactElement) {
   const { container, rerender } = render(jsx);
@@ -56,7 +59,6 @@ describe('Property filter autosuggest', () => {
           onOptionClick={handleSelectedSpy}
           value=""
           onChange={() => {}}
-          filteringType="auto"
           statusType="finished"
           disableBrowserAutocorrect={false}
         />
@@ -102,7 +104,6 @@ describe('Property filter autosuggest', () => {
         enteredTextLabel={() => ''}
         value="123"
         onChange={() => {}}
-        filteringType="auto"
         statusType="finished"
         disableBrowserAutocorrect={false}
       />
@@ -118,7 +119,6 @@ describe('Property filter autosuggest', () => {
         hideEnteredTextOption={true}
         value="123"
         onChange={() => {}}
-        filteringType="auto"
         statusType="finished"
         disableBrowserAutocorrect={false}
       />

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -371,6 +371,24 @@ describe('property filter parts', () => {
         expect(wrapper.findDropdown()?.findOpenDropdown()).toBeTruthy();
       });
     });
+
+    test('can use selectSuggestionByValue', () => {
+      const onChange = jest.fn();
+      const { propertyFilterWrapper: wrapper } = renderComponent({ onChange });
+      act(() => wrapper.focus());
+      act(() => wrapper.selectSuggestionByValue('string-other'));
+      expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('Use: "string-other"');
+
+      act(() => wrapper.selectSuggestionByValue('string-other != '));
+      expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('Use: "string-other != "');
+
+      act(() => wrapper.selectSuggestionByValue('string-other != value2'));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { operation: 'and', tokens: [{ propertyKey: 'other-string', operator: '!=', value: 'value2' }] },
+        })
+      );
+    });
   });
 
   describe('count text', () => {

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -138,10 +138,6 @@ interface OptionGroup<T> {
   options: T[];
 }
 
-interface ExtendedAutosuggestOption extends AutosuggestProps.Option {
-  tokenValue: string;
-}
-
 export const getAllValueSuggestions = (
   filteringOptions: readonly FilteringOption[],
   filteringProperties: readonly FilteringProperty[],
@@ -149,11 +145,11 @@ export const getAllValueSuggestions = (
   i18nStrings: I18nStrings,
   customGroupsText: readonly GroupText[]
 ) => {
-  const defaultGroup: OptionGroup<ExtendedAutosuggestOption> = {
+  const defaultGroup: OptionGroup<AutosuggestProps.Option> = {
     label: i18nStrings.groupValuesText,
     options: [],
   };
-  const customGroups: { [K in string]: OptionGroup<ExtendedAutosuggestOption> } = {};
+  const customGroups: { [K in string]: OptionGroup<AutosuggestProps.Option> } = {};
   filteringOptions.forEach(filteringOption => {
     const property = getPropertyByKey(filteringProperties, filteringOption.propertyKey);
     // given option refers to a non-existent filtering property
@@ -176,7 +172,7 @@ export const getAllValueSuggestions = (
     }
     const propertyGroup = property.group ? customGroups[property.group] : defaultGroup;
     propertyGroup.options.push({
-      tokenValue: property.propertyLabel + (operator || '=') + filteringOption.value,
+      value: property.propertyLabel + ' ' + (operator || '=') + ' ' + filteringOption.value,
       label: filteringOption.value,
       __labelPrefix: property.propertyLabel + ' ' + (operator || '='),
     });
@@ -293,7 +289,7 @@ export const getAutosuggestOptions = (
         options: [
           {
             options: options.map(({ value }) => ({
-              tokenValue: propertyLabel + parsedText.operator + value,
+              value: propertyLabel + ' ' + parsedText.operator + ' ' + value,
               label: value,
               __labelPrefix: propertyLabel + ' ' + parsedText.operator,
             })),

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -241,6 +241,7 @@ export function createPropertiesCompatibilityMap(
 
 const filteringPropertyToAutosuggestOption = (filteringProperty: FilteringProperty) => ({
   value: filteringProperty.propertyLabel,
+  label: filteringProperty.propertyLabel,
   keepOpenOnSelect: true,
 });
 

--- a/src/property-filter/filter-options.ts
+++ b/src/property-filter/filter-options.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AutosuggestProps } from '../autosuggest/interfaces';
+import { OptionDefinition } from '../internal/components/option/interfaces';
+
+export function filterOptions(
+  options: readonly (AutosuggestProps.Option | AutosuggestProps.OptionGroup)[],
+  searchText = ''
+): readonly (AutosuggestProps.Option | AutosuggestProps.OptionGroup)[] {
+  if (!searchText) {
+    return options;
+  }
+
+  searchText = searchText.toLowerCase();
+  const filtered: (AutosuggestProps.Option | AutosuggestProps.OptionGroup)[] = [];
+  for (const option of options) {
+    if (isGroup(option)) {
+      const childOptions = filterOptions(option.options, searchText);
+      if (childOptions.length > 0) {
+        filtered.push({ ...option, options: filterOptions(option.options, searchText) });
+      }
+    } else if (matchSingleOption(option, searchText)) {
+      filtered.push(option);
+    }
+  }
+  return filtered;
+}
+
+function isGroup(optionOrGroup: AutosuggestProps.Option): optionOrGroup is AutosuggestProps.OptionGroup {
+  return 'options' in optionOrGroup;
+}
+
+function matchSingleOption(option: OptionDefinition, searchText: string): boolean {
+  return (option.label ?? '').toLowerCase().indexOf(searchText) !== -1;
+}

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -168,11 +168,7 @@ const PropertyFilter = React.forwardRef(
       }, 0);
       const { detail: option } = event;
       const value = option.value || '';
-      if ('tokenValue' in option) {
-        createToken((option as { tokenValue: string }).tokenValue);
-        return;
-      }
-      // create a token from the 'use' option
+
       if (!('keepOpenOnSelect' in option)) {
         createToken(value);
         return;

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { Ref, useRef } from 'react';
+import React, { Ref, useMemo, useRef } from 'react';
 
 import { useAutosuggestItems } from '../autosuggest/options-controller';
 import { AutosuggestItem, AutosuggestProps } from '../autosuggest/interfaces';
@@ -28,6 +28,7 @@ import AutosuggestInput, { AutosuggestInputRef } from '../internal/components/au
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import clsx from 'clsx';
 import { getFirstFocusable } from '../internal/components/focus-lock/utils';
+import { filterOptions } from './filter-options';
 
 const DROPDOWN_WIDTH_OPTIONS_LIST = 300;
 const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
@@ -48,7 +49,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
       onBlur,
       onLoadItems,
       options,
-      filteringType = 'auto',
       statusType = 'finished',
       placeholder,
       disabled,
@@ -69,11 +69,12 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const autosuggestInputRef = useRef<AutosuggestInputRef>(null);
     const mergedRef = useMergeRefs(autosuggestInputRef, ref);
 
+    const filteredOptions = useMemo(() => filterOptions(options || [], highlightText), [options, highlightText]);
     const [autosuggestItemsState, autosuggestItemsHandlers] = useAutosuggestItems({
-      options: options || [],
+      options: filteredOptions,
       filterValue: value,
       filterText: highlightText,
-      filteringType,
+      filteringType: 'manual',
       hideEnteredTextLabel: hideEnteredTextOption,
       onSelectItem: (option: AutosuggestItem) => {
         const value = option.value || '';


### PR DESCRIPTION
### Description

Fix property-filter option value not being assign due to use of custom option extension with `tokenValue` instead of `value`.

### How has this been tested?

Added new unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19554

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
