### PR TITLE
Revert "Move formFieldContext to internal Input component (#396)"

### DIFF
--- a/src/input/__tests__/internal.test.tsx
+++ b/src/input/__tests__/internal.test.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper, { InputWrapper } from '../../../lib/components/test-utils/dom';
-import InternalFormField from '../../../lib/components/form-field/internal';
 import InternalInput from '../../../lib/components/input/internal';
 import styles from '../../../lib/components/input/styles.css.js';
 import { DEBOUNCE_DEFAULT_DELAY } from '../../../lib/components/internal/debounce';
@@ -33,32 +32,4 @@ test('should call onDelayedInput and onChange handlers respectively', async () =
   await new Promise(resolve => setTimeout(resolve, DEBOUNCE_DEFAULT_DELAY + 50));
   expect(onDelayedInput).toHaveBeenCalledTimes(1);
   expect(onDelayedInput).toHaveBeenCalledWith({ value: 'second' });
-});
-
-test('inherits form-field properties', () => {
-  render(
-    <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
-      <InternalInput value="" />
-    </InternalFormField>
-  );
-  const element = createWrapper().find('input')!.getElement();
-
-  expect(element).toHaveAttribute('id', 'control-id');
-  expect(element).toHaveAttribute('aria-labelledby', 'control-id-label');
-  expect(element).toHaveAttribute('aria-describedby', 'control-id-error control-id-description');
-  expect(element).toHaveAttribute('aria-invalid', 'true');
-});
-
-test('overrides form-field properties', () => {
-  render(
-    <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
-      <InternalInput value="" controlId="id" ariaLabelledby="label" ariaDescribedby="description" invalid={false} />
-    </InternalFormField>
-  );
-  const element = createWrapper().find('input')!.getElement();
-
-  expect(element).toHaveAttribute('id', 'id');
-  expect(element).toHaveAttribute('aria-labelledby', 'label');
-  expect(element).toHaveAttribute('aria-describedby', 'description');
-  expect(element).not.toHaveAttribute('aria-invalid');
 });

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -5,6 +5,7 @@ import React, { Ref, useImperativeHandle, useRef } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import InternalInput from './internal';
 import { InputProps } from './interfaces';
+import { useFormFieldContext } from '../internal/context/form-field-context';
 import styles from './styles.css.js';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -32,16 +33,13 @@ const Input = React.forwardRef(
       placeholder,
       autoFocus,
       ariaLabel,
-      ariaLabelledby,
-      ariaDescribedby,
-      invalid,
-      controlId,
       ...rest
     }: InputProps,
     ref: Ref<InputProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Input');
     const baseProps = getBaseProps(rest);
+    const { ariaLabelledby, ariaDescribedby, controlId, invalid } = useFormFieldContext(rest);
 
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -66,10 +64,14 @@ const Input = React.forwardRef(
           ...baseComponentProps,
           autoComplete,
           ariaLabel,
+          ariaDescribedby,
+          ariaLabelledby,
           ariaRequired,
           autoFocus,
+          controlId,
           disabled,
           disableBrowserAutocorrect,
+          invalid,
           name,
           onKeyDown,
           onKeyUp,
@@ -82,10 +84,6 @@ const Input = React.forwardRef(
           step,
           inputMode,
           value,
-          ariaDescribedby,
-          ariaLabelledby,
-          invalid,
-          controlId,
         }}
         className={clsx(styles.root, baseProps.className)}
       />

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -11,7 +11,7 @@ import { InputProps, BaseInputProps, InputAutoCorrect, BaseChangeDetail } from '
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 import { useSearchProps, convertAutoComplete } from './utils';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
-import { FormFieldValidationControlProps, useFormFieldContext } from '../internal/context/form-field-context';
+import { FormFieldValidationControlProps } from '../internal/context/form-field-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 export interface InternalInputProps
@@ -48,8 +48,11 @@ function InternalInput(
     inputMode,
     autoComplete = true,
     ariaLabel,
+    ariaLabelledby,
+    ariaDescribedby,
     name,
     value,
+    controlId,
     placeholder,
     autoFocus,
     disabled,
@@ -61,6 +64,7 @@ function InternalInput(
     __leftIconVariant = 'subtle',
     __onLeftIconClick,
 
+    invalid,
     ariaRequired,
 
     __rightIcon,
@@ -93,8 +97,6 @@ function InternalInput(
   __leftIcon = __leftIcon ?? searchProps.__leftIcon;
   __rightIcon = __rightIcon ?? searchProps.__rightIcon;
   __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
-
-  const { ariaDescribedby, ariaLabelledby, controlId, invalid } = useFormFieldContext(rest);
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,


### PR DESCRIPTION
This reverts commit a42106952cf883d5c44529476316a2205959f1f4.

### Description

The fix that is being reverted did bring aria-labelledby and aria-describedby to the internal input which made it available for the select and multiselect search input. However, the search input need to be labelled separately instead.

### How has this been tested?

No tests required for revert.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19125


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
