### PR TITLE
Allow internal input to inherit form-field props

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -59,7 +59,7 @@ describe('Date range picker', () => {
       const { container, wrapper } = renderDateRangePicker({
         ...defaultProps,
       });
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
 
       await expect(container).toValidateA11y();
     });
@@ -71,7 +71,7 @@ describe('Date range picker', () => {
         onChange: event => onChangeSpy(event.detail),
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
 
       act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('previous-5-minutes')!.click());
       act(() => wrapper.findDropdown()!.findApplyButton().click());
@@ -95,7 +95,7 @@ describe('Date range picker', () => {
         onChange: event => onChangeSpy(event.detail),
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
       act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click());
 
       act(() => wrapper.findDropdown()!.findCustomRelativeRangeDuration()!.setInputValue('14'));
@@ -116,12 +116,44 @@ describe('Date range picker', () => {
       );
     });
 
+    test('custom unit and duration has correct aria-attributes', () => {
+      const { wrapper } = renderDateRangePicker({
+        ...defaultProps,
+        onChange: () => undefined,
+      });
+
+      act(() => wrapper.findTrigger().click());
+      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click());
+
+      const durationAriaLabelId = wrapper
+        .findDropdown()!
+        .findCustomRelativeRangeDuration()!
+        .findNativeInput()
+        .getElement()
+        .getAttribute('aria-labelledby')!
+        .split(' ')[0];
+      expect(wrapper.find(`#${durationAriaLabelId}`)!.getElement()).toHaveTextContent(
+        i18nStrings.customRelativeRangeDurationLabel
+      );
+
+      const unitAriaLabelId = wrapper
+        .findDropdown()!
+        .findCustomRelativeRangeUnit()!
+        .findTrigger()
+        .getElement()
+        .getAttribute('aria-labelledby')!
+        .split(' ')[0];
+      expect(wrapper.find(`#${unitAriaLabelId}`)!.getElement()).toHaveTextContent(
+        i18nStrings.customRelativeRangeUnitLabel
+      );
+    });
+
     test('remembers the selected option when switching modes', () => {
       const { wrapper } = renderDateRangePicker({
         ...defaultProps,
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
       act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[2].findLabel().click());
 
       changeMode(wrapper, 'absolute');
@@ -141,7 +173,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
 
       const modeSelector = wrapper.findDropdown()!.findSelectionModeSwitch().findModesAsSegments();
       expect(modeSelector.findSelectedSegment()!.getElement().textContent).toBe('Absolute range');
@@ -153,7 +185,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
       changeMode(wrapper, 'relative');
 
       expect(!!wrapper.findDropdown()!.findRelativeRangeRadioGroup()).toBe(false);
@@ -165,7 +197,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
       changeMode(wrapper, 'relative');
 
       expect(wrapper.findDropdown()!.getElement().textContent).toContain('Set a custom range in the past');
@@ -177,7 +209,7 @@ describe('Date range picker', () => {
         rangeSelectorMode: 'relative-only',
         relativeOptions: [],
       });
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
 
       wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual([
@@ -198,7 +230,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
         dateOnly: true,
       });
-      act(() => wrapper.findLabel().click());
+      act(() => wrapper.findTrigger().click());
 
       wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual(['days', 'weeks', 'months', 'years']);

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -147,7 +147,7 @@ function RelativeRangePicker(
                         onChangeRangeSize({ amount, unit: customUnitOfTime, type: 'relative' });
                       }}
                       placeholder={i18nStrings.customRelativeRangeDurationPlaceholder}
-                      __useFormField={true}
+                      __inheritFormFieldProps={true}
                     />
                   </InternalFormField>
                 </div>

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -147,6 +147,7 @@ function RelativeRangePicker(
                         onChangeRangeSize({ amount, unit: customUnitOfTime, type: 'relative' });
                       }}
                       placeholder={i18nStrings.customRelativeRangeDurationPlaceholder}
+                      __useFormField={true}
                     />
                   </InternalFormField>
                 </div>

--- a/src/input/__tests__/internal.test.tsx
+++ b/src/input/__tests__/internal.test.tsx
@@ -38,7 +38,7 @@ test('should call onDelayedInput and onChange handlers respectively', async () =
 test('inherits form-field properties', () => {
   render(
     <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
-      <InternalInput value="" __useFormField={true} />
+      <InternalInput value="" __inheritFormFieldProps={true} />
     </InternalFormField>
   );
   const element = createWrapper().find('input')!.getElement();

--- a/src/input/__tests__/internal.test.tsx
+++ b/src/input/__tests__/internal.test.tsx
@@ -38,7 +38,7 @@ test('should call onDelayedInput and onChange handlers respectively', async () =
 test('inherits form-field properties', () => {
   render(
     <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
-      <InternalInput value="" />
+      <InternalInput value="" __useFormField={true} />
     </InternalFormField>
   );
   const element = createWrapper().find('input')!.getElement();

--- a/src/input/__tests__/internal.test.tsx
+++ b/src/input/__tests__/internal.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper, { InputWrapper } from '../../../lib/components/test-utils/dom';
+import InternalFormField from '../../../lib/components/form-field/internal';
 import InternalInput from '../../../lib/components/input/internal';
 import styles from '../../../lib/components/input/styles.css.js';
 import { DEBOUNCE_DEFAULT_DELAY } from '../../../lib/components/internal/debounce';
@@ -32,4 +33,32 @@ test('should call onDelayedInput and onChange handlers respectively', async () =
   await new Promise(resolve => setTimeout(resolve, DEBOUNCE_DEFAULT_DELAY + 50));
   expect(onDelayedInput).toHaveBeenCalledTimes(1);
   expect(onDelayedInput).toHaveBeenCalledWith({ value: 'second' });
+});
+
+test('inherits form-field properties', () => {
+  render(
+    <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
+      <InternalInput value="" />
+    </InternalFormField>
+  );
+  const element = createWrapper().find('input')!.getElement();
+
+  expect(element).toHaveAttribute('id', 'control-id');
+  expect(element).toHaveAttribute('aria-labelledby', 'control-id-label');
+  expect(element).toHaveAttribute('aria-describedby', 'control-id-error control-id-description');
+  expect(element).toHaveAttribute('aria-invalid', 'true');
+});
+
+test('overrides form-field properties', () => {
+  render(
+    <InternalFormField controlId="control-id" label="Label" description="description" errorText="error">
+      <InternalInput value="" controlId="id" ariaLabelledby="label" ariaDescribedby="description" invalid={false} />
+    </InternalFormField>
+  );
+  const element = createWrapper().find('input')!.getElement();
+
+  expect(element).toHaveAttribute('id', 'id');
+  expect(element).toHaveAttribute('aria-labelledby', 'label');
+  expect(element).toHaveAttribute('aria-describedby', 'description');
+  expect(element).not.toHaveAttribute('aria-invalid');
 });

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -5,7 +5,6 @@ import React, { Ref, useImperativeHandle, useRef } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import InternalInput from './internal';
 import { InputProps } from './interfaces';
-import { useFormFieldContext } from '../internal/context/form-field-context';
 import styles from './styles.css.js';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -33,13 +32,16 @@ const Input = React.forwardRef(
       placeholder,
       autoFocus,
       ariaLabel,
+      ariaLabelledby,
+      ariaDescribedby,
+      invalid,
+      controlId,
       ...rest
     }: InputProps,
     ref: Ref<InputProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Input');
     const baseProps = getBaseProps(rest);
-    const { ariaLabelledby, ariaDescribedby, controlId, invalid } = useFormFieldContext(rest);
 
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -64,14 +66,10 @@ const Input = React.forwardRef(
           ...baseComponentProps,
           autoComplete,
           ariaLabel,
-          ariaDescribedby,
-          ariaLabelledby,
           ariaRequired,
           autoFocus,
-          controlId,
           disabled,
           disableBrowserAutocorrect,
-          invalid,
           name,
           onKeyDown,
           onKeyUp,
@@ -84,6 +82,10 @@ const Input = React.forwardRef(
           step,
           inputMode,
           value,
+          ariaDescribedby,
+          ariaLabelledby,
+          invalid,
+          controlId,
         }}
         className={clsx(styles.root, baseProps.className)}
       />

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -88,7 +88,7 @@ const Input = React.forwardRef(
           controlId,
         }}
         className={clsx(styles.root, baseProps.className)}
-        __useFormField={true}
+        __inheritFormFieldProps={true}
       />
     );
   }

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -88,6 +88,7 @@ const Input = React.forwardRef(
           controlId,
         }}
         className={clsx(styles.root, baseProps.className)}
+        __useFormField={true}
       />
     );
   }

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -36,7 +36,7 @@ export interface InternalInputProps
   __onDelayedInput?: NonCancelableEventHandler<BaseChangeDetail>;
   __onBlurWithDetail?: NonCancelableEventHandler<{ relatedTarget: Node | null }>;
 
-  __useFormField?: boolean;
+  __inheritFormFieldProps?: boolean;
 }
 
 const iconClassName = (position: string, hasHandler: boolean) =>
@@ -78,7 +78,7 @@ function InternalInput(
     onFocus,
     __nativeAttributes,
     __internalRootRef,
-    __useFormField,
+    __inheritFormFieldProps,
     ...rest
   }: InternalInputProps,
   ref: Ref<HTMLInputElement>
@@ -98,7 +98,7 @@ function InternalInput(
   __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
 
   const formFieldContext = useFormFieldContext(rest);
-  const { ariaLabelledby, ariaDescribedby, controlId, invalid } = __useFormField ? formFieldContext : rest;
+  const { ariaLabelledby, ariaDescribedby, controlId, invalid } = __inheritFormFieldProps ? formFieldContext : rest;
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -11,7 +11,7 @@ import { InputProps, BaseInputProps, InputAutoCorrect, BaseChangeDetail } from '
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 import { useSearchProps, convertAutoComplete } from './utils';
 import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
-import { FormFieldValidationControlProps } from '../internal/context/form-field-context';
+import { FormFieldValidationControlProps, useFormFieldContext } from '../internal/context/form-field-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 export interface InternalInputProps
@@ -35,6 +35,8 @@ export interface InternalInputProps
 
   __onDelayedInput?: NonCancelableEventHandler<BaseChangeDetail>;
   __onBlurWithDetail?: NonCancelableEventHandler<{ relatedTarget: Node | null }>;
+
+  __useFormField?: boolean;
 }
 
 const iconClassName = (position: string, hasHandler: boolean) =>
@@ -48,11 +50,8 @@ function InternalInput(
     inputMode,
     autoComplete = true,
     ariaLabel,
-    ariaLabelledby,
-    ariaDescribedby,
     name,
     value,
-    controlId,
     placeholder,
     autoFocus,
     disabled,
@@ -64,7 +63,6 @@ function InternalInput(
     __leftIconVariant = 'subtle',
     __onLeftIconClick,
 
-    invalid,
     ariaRequired,
 
     __rightIcon,
@@ -80,6 +78,7 @@ function InternalInput(
     onFocus,
     __nativeAttributes,
     __internalRootRef,
+    __useFormField,
     ...rest
   }: InternalInputProps,
   ref: Ref<HTMLInputElement>
@@ -97,6 +96,9 @@ function InternalInput(
   __leftIcon = __leftIcon ?? searchProps.__leftIcon;
   __rightIcon = __rightIcon ?? searchProps.__rightIcon;
   __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
+
+  const formFieldContext = useFormFieldContext(rest);
+  const { ariaLabelledby, ariaDescribedby, controlId, invalid } = __useFormField ? formFieldContext : rest;
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,


### PR DESCRIPTION
### Description

A second attempt for: https://github.com/cloudscape-design/components/pull/396

The new internal input behaviour is now under flag to not cause regression in select/multiselect.

### How has this been tested?

Added new tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Ticket: AWSUI-19215

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
