### PR TITLE
Fix overflow for property filter editor dropdown

### DIFF
--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -149,7 +149,11 @@ const PropertyFilterAutosuggest = React.forwardRef(
 
     let content = null;
     if (customForm) {
-      content = <div ref={customFormRef}>{customForm}</div>;
+      content = (
+        <div ref={customFormRef} className={styles['custom-content-wrapper']}>
+          {customForm}
+        </div>
+      );
     } else if (autosuggestItemsState.items.length > 0) {
       content = (
         <AutosuggestOptionsList

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -79,6 +79,10 @@
   overflow-y: auto;
 }
 
+.custom-content-wrapper {
+  display: contents;
+}
+
 .custom-control {
   margin-right: awsui.$space-s;
 }


### PR DESCRIPTION
### Description

The dropdown content requires an overflow. In property filter editor the top-level DIV element was created to assign a ref. Setting its display to `contents` fixes the problem.

Before:
<img width="508" alt="Before" src="https://user-images.githubusercontent.com/20790937/197714179-c60ffffc-b0e9-44b6-a47b-4b7f6f4150cd.png">

Now:
<img width="508" alt="Now" src="https://user-images.githubusercontent.com/20790937/197714044-6f54f2f5-bb42-40e7-9e16-e0a8139e90ed.png">

### How has this been tested?

Manual check

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

AWSUI-19364

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
