### PR TITLE
feat(table): New header visuals for full-page table columns

### DIFF
--- a/pages/app-layout/with-cards.page.tsx
+++ b/pages/app-layout/with-cards.page.tsx
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import Link from '~components/link';
+import Cards, { CardsProps } from '~components/cards';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Breadcrumbs, Navigation, Tools, Footer, Notifications } from './utils/content-blocks';
+import * as toolsContent from './utils/tools-content';
+import labels from './utils/labels';
+import Button from '~components/button';
+import range from 'lodash/range';
+
+interface Item {
+  number: number;
+  text: string;
+}
+
+function createSimpleItems(count: number) {
+  const texts = ['One', 'Two', 'Three', 'Four', 'Five'];
+  return range(count).map(number => ({ number, text: texts[number % texts.length] }));
+}
+
+const cardDefinition: CardsProps.CardDefinition<Item> = {
+  header: item => item.text,
+  sections: [
+    {
+      id: 'description',
+      header: 'Number',
+      content: item => item.number,
+    },
+    {
+      id: 'type',
+      header: 'Text',
+      content: item => item.text,
+    },
+  ],
+};
+
+const config: CardsProps['cardsPerRow'] = [
+  {
+    cards: 1,
+  },
+  {
+    minWidth: 400,
+    cards: 2,
+  },
+  {
+    cards: 3,
+    minWidth: 700,
+  },
+  {
+    cards: 4,
+    minWidth: 1000,
+  },
+];
+
+const items = createSimpleItems(16);
+
+export default function () {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
+
+  function openHelp(article: keyof typeof toolsContent) {
+    setToolsOpen(true);
+    setSelectedTool(article);
+  }
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        breadcrumbs={<Breadcrumbs />}
+        navigation={<Navigation />}
+        contentType="table"
+        tools={<Tools>{toolsContent[selectedTool]}</Tools>}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+        content={
+          <Cards<Item>
+            items={items}
+            cardDefinition={cardDefinition}
+            stickyHeader={true}
+            variant="full-page"
+            header={
+              <Header
+                variant="awsui-h1-sticky"
+                description="Demo page with footer"
+                info={
+                  <Link variant="info" onFollow={() => openHelp('long')}>
+                    Long help text
+                  </Link>
+                }
+                actions={<Button variant="primary">Create</Button>}
+              >
+                Sticky Scrollbar Example
+              </Header>
+            }
+            cardsPerRow={config}
+          />
+        }
+      />
+      <Footer legacyConsoleNav={false} />
+    </ScreenshotArea>
+  );
+}

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -128,6 +128,7 @@ const Cards = React.forwardRef(function <T = any>(
         __stickyOffset={stickyHeaderVerticalOffset}
         __headerRef={headerRef}
         __headerId={cardsHeaderId}
+        __darkHeader={computedVariant === 'full-page'}
       >
         <div className={clsx(hasToolsHeader && styles['has-header'])}>
           {status ?? (

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -19,6 +19,7 @@ export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>,
   __hiddenContent?: boolean;
   __headerRef?: React.RefObject<HTMLDivElement>;
   __headerId?: string;
+  __darkHeader?: boolean;
   /**
    * Additional internal variant:
    * * `embedded` - Use this variant within a parent container (such as a modal,
@@ -43,6 +44,7 @@ export default function InternalContainer({
   __hiddenContent = false,
   __headerRef,
   __headerId,
+  __darkHeader = false,
   ...restProps
 }: InternalContainerProps) {
   const baseProps = getBaseProps(restProps);
@@ -51,7 +53,7 @@ export default function InternalContainer({
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
   const isRefresh = useVisualRefresh();
   const hasDynamicHeight = isRefresh && variant === 'full-page';
-  const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
+  const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight || !__darkHeader });
 
   const mergedRef = useMergeRefs(rootRef, __internalRootRef);
   const headerMergedRef = useMergeRefs(headerRef, overlapElement, __headerRef);
@@ -79,7 +81,7 @@ export default function InternalContainer({
             {...stickyStyles}
             ref={headerMergedRef}
           >
-            {hasDynamicHeight ? (
+            {__darkHeader ? (
               <div className={clsx(styles['dark-header'], 'awsui-context-content-header')}>{header}</div>
             ) : (
               header

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -99,7 +99,21 @@
   }
 
   &-variant-full-page.header-stuck {
-    box-shadow: awsui.$shadow-sticky;
+    box-shadow: none;
+
+    &::after {
+      content: '';
+
+      position: absolute;
+      right: 0;
+      left: 0;
+      bottom: 0;
+      top: 0;
+
+      box-shadow: awsui.$shadow-sticky;
+      // This polygon only shows the part of the shadow that is lower than the element itself.
+      clip-path: polygon(-999% 100%, 999% 100%, 999% 999%, -999% 999%);
+    }
   }
 }
 

--- a/src/split-panel/icons/bottom-icon-refresh.tsx
+++ b/src/split-panel/icons/bottom-icon-refresh.tsx
@@ -3,13 +3,16 @@
 import React from 'react';
 import { getClassName, SVGTableRowProps } from './side-position-refresh';
 
-const TableRow = ({ offset }: SVGTableRowProps) => {
+const TableRow = ({ offset, isHeader }: SVGTableRowProps) => {
   const offsetTop = 0.4482;
   const offsetBottom = 3.4482;
   return (
-    <g transform={`translate(0, ${offset})`} className={getClassName('disabled')}>
+    <g transform={`translate(0, ${offset})`} className={getClassName(isHeader ? 'column-header' : 'disabled')}>
       <path d={`M31 ${offsetTop}H34V${offsetBottom}H31V${offsetTop}Z`} />
-      <path d={`M39 ${offsetTop}H63V${offsetBottom}H39V${offsetTop}Z`} className={getClassName('secondary')} />
+      <path
+        d={`M39 ${offsetTop}H63V${offsetBottom}H39V${offsetTop}Z`}
+        className={!isHeader ? getClassName('secondary') : undefined}
+      />
       <path d={`M135 ${offsetTop}H155V${offsetBottom}H135V${offsetTop}Z`} />
       <path d={`M158 ${offsetTop}H202V${offsetBottom}H158V${offsetTop}Z`} />
       <path d="M26 8H204.388" className={getClassName('separator')} strokeLinecap="square" />
@@ -46,7 +49,7 @@ const bottomPositionIcon = (
       <rect x="2" y="2" width="226" height="6" className={getClassName('layout-top')} />
     </g>
     <g className="awsui-context-content-header">
-      <path d="M0 8H230V33H0V8Z" className={getClassName('layout-main')} />
+      <path d="M0 8H230V23H0V8Z" className={getClassName('layout-main')} />
       <g className={getClassName('default')}>
         <path
           d="M9 15.5C9 16.8807 7.88071 18 6.5 18C5.11929 18 4 16.8807 4 15.5C4 14.1193 5.11929 13 6.5 13C7.88071 13 9 14.1193 9 15.5Z"
@@ -60,12 +63,9 @@ const bottomPositionIcon = (
           className={getClassName('primary')}
         />
         <circle cx="223.5" cy="15.5" r="2.5" className={getClassName('disabled')} />
-        <path d="M31 25.4482H34V28.4482H31V25.4482Z" />
-        <path d="M39 25.4482H63V28.4482H39V25.4482Z" />
-        <path d="M135 25.4482H155V28.4482H135V25.4482Z" />
-        <path d="M158 25.4482H202V28.4482H158V25.4482Z" />
       </g>
     </g>
+    <TableRow offset={27} isHeader={true} />
     <TableRow offset={39} />
     <TableRow offset={51} />
     <TableRow offset={63} />

--- a/src/split-panel/icons/icons-styles.scss
+++ b/src/split-panel/icons/icons-styles.scss
@@ -54,6 +54,9 @@
   &--disabled {
     fill: awsui.$color-background-control-disabled;
   }
+  &--column-header {
+    fill: awsui.$color-text-input-disabled;
+  }
   &--window {
     stroke: awsui.$color-background-home-header;
     fill: awsui.$color-background-container-content;
@@ -65,7 +68,7 @@
     fill: awsui.$color-text-body-default;
   }
   &--separator {
-    stroke: awsui.$color-border-button-primary-disabled;
+    stroke: awsui.$color-border-divider-default;
   }
   &--input-default {
     fill: awsui.$color-border-input-default;

--- a/src/split-panel/icons/side-position-refresh.tsx
+++ b/src/split-panel/icons/side-position-refresh.tsx
@@ -6,17 +6,21 @@ import styles from '../styles.css.js';
 export interface SVGTableRowProps {
   offset: number;
   separator?: boolean;
+  isHeader?: boolean;
 }
 
 export const getClassName = (suffix: string) => styles[`preference-icon-refresh--${suffix}`];
 
-const TableRow = ({ offset, separator = true }: SVGTableRowProps) => {
+const TableRow = ({ offset, separator = true, isHeader }: SVGTableRowProps) => {
   const offsetTop = 0.4482;
   const offsetBottom = 3.4482;
   return (
-    <g transform={`translate(0, ${offset})`} className={getClassName('disabled')}>
+    <g transform={`translate(0, ${offset})`} className={getClassName(isHeader ? 'column-header' : 'disabled')}>
       <path d={`M19 ${offsetTop}2H22V${offsetBottom}H19V${offsetTop}Z`} />
-      <path d={`M27 ${offsetTop}H51V${offsetBottom}H27V${offsetTop}Z`} className={getClassName('secondary')} />
+      <path
+        d={`M27 ${offsetTop}H51V${offsetBottom}H27V${offsetTop}Z`}
+        className={!isHeader ? getClassName('secondary') : undefined}
+      />
       <path d={`M90 ${offsetTop}H110V${offsetBottom}H90V${offsetTop}Z`} />
       <path d={`M113 ${offsetTop}H157V${offsetBottom}H113V${offsetTop}Z`} />
       {separator && <path d="M14 8H159.387" className={getClassName('separator')} strokeLinecap="square" />}
@@ -51,7 +55,7 @@ const bottomPositionIcon = (
       <rect x="2" y="2" width="212" height="6" className={getClassName('layout-top')} />
     </g>
     <g className="awsui-context-content-header">
-      <path d="M2 8H214V33H2V8Z" className={getClassName('layout-main')} />
+      <path d="M2 8H214V23H2V8Z" className={getClassName('layout-main')} />
       <g className={getClassName('default')}>
         <path
           d="M9 15.5C9 16.8807 7.88071 18 6.5 18C5.11929 18 4 16.8807 4 15.5C4 14.1193 5.11929 13 6.5 13C7.88071 13 9 14.1193 9 15.5Z"
@@ -64,12 +68,9 @@ const bottomPositionIcon = (
           d="M139 15.5C139 13.567 140.567 12 142.5 12H155.86C157.793 12 159.36 13.567 159.36 15.5C159.36 17.433 157.793 19 155.86 19H142.5C140.567 19 139 17.433 139 15.5Z"
           className={getClassName('primary')}
         />
-        <path d="M113 25.4482H157V28.4482H113V25.4482Z" />
-        <path d="M90 25.4482H110V28.4482H90V25.4482Z" />
-        <path d="M27 25.4482H51V28.4482H27V25.4482Z" />
-        <path d="M19 25.4482H22V28.4482H19V25.4482Z" />
       </g>
     </g>
+    <TableRow offset={27} isHeader={true} />
     <TableRow offset={39} />
     <TableRow offset={51} />
     <TableRow offset={63} />

--- a/src/table/__integ__/table.test.ts
+++ b/src/table/__integ__/table.test.ts
@@ -38,10 +38,10 @@ test(
     const header = createWrapper().findContainer().findHeader().toSelector();
     await browser.url('#/light/table/full-page-variant?visualRefresh=true');
     const page = new BasePageObject(browser);
-    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '117px', marginBottom: '0px' });
+    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '115px', marginBottom: '0px' });
     await page.windowScrollTo({ top: 100 });
     await page.waitForJsTimers();
-    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '107px', marginBottom: '10px' });
+    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '105px', marginBottom: '10px' });
   })
 );
 

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -21,6 +21,7 @@ interface TableHeaderCellProps {
   sortingDisabled: boolean | undefined;
   wrapLines: boolean | undefined;
   showFocusRing: boolean;
+  hidden?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
   onResizeFinish: () => void;
   colIndex: number;
@@ -40,6 +41,7 @@ export function TableHeaderCell({
   sortingDisabled,
   wrapLines,
   showFocusRing,
+  hidden,
   onClick,
   colIndex,
   onFocus,
@@ -80,6 +82,7 @@ export function TableHeaderCell({
         [styles['header-cell-disabled']]: sortingDisabled,
         [styles['header-cell-ascending']]: sortingStatus === 'ascending',
         [styles['header-cell-descending']]: sortingStatus === 'descending',
+        [styles['header-cell-hidden']]: hidden,
       })}
       aria-sort={sortingStatus && getAriaSort(sortingStatus)}
       style={style}

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -19,11 +19,11 @@
   &-sticky {
     border-bottom: awsui.$border-table-sticky-width solid awsui.$color-border-divider-default;
   }
-  &-stuck {
+  &-stuck:not(.header-cell-variant-full-page) {
     border-bottom-color: transparent;
   }
-  &-variant-full-page {
-    border-bottom: awsui.$space-scaled-xxs solid transparent;
+  &-variant-full-page.header-cell-hidden {
+    border-bottom-color: transparent;
   }
   &:first-child {
     padding-left: awsui.$space-xs;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -29,6 +29,7 @@ import useFocusVisible from '../internal/hooks/focus-visible';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
 import useMouseDownTarget from './use-mouse-down-target';
+import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap';
 
 type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
@@ -162,6 +163,9 @@ const InternalTable = React.forwardRef(
 
     const getMouseDownTarget = useMouseDownTarget();
 
+    const hasDynamicHeight = computedVariant === 'full-page';
+    const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
+
     return (
       <ColumnWidthsProvider
         tableRef={tableRefObject}
@@ -176,8 +180,13 @@ const InternalTable = React.forwardRef(
           header={
             <>
               {hasHeader && (
-                <div className={clsx(styles['header-controls'], styles[`variant-${computedVariant}`])}>
-                  <ToolsHeader header={header} filter={filter} pagination={pagination} preferences={preferences} />
+                <div
+                  ref={overlapElement}
+                  className={clsx(hasDynamicHeight && [styles['dark-header'], 'awsui-context-content-header'])}
+                >
+                  <div className={clsx(styles['header-controls'], styles[`variant-${computedVariant}`])}>
+                    <ToolsHeader header={header} filter={filter} pagination={pagination} preferences={preferences} />
+                  </div>
                 </div>
               )}
               {stickyHeader && (
@@ -190,6 +199,7 @@ const InternalTable = React.forwardRef(
                   secondaryWrapperRef={secondaryWrapperRef}
                   tableRef={tableRefObject}
                   onScroll={handleScroll}
+                  tableHasHeader={hasHeader}
                 />
               )}
             </>

--- a/src/table/sticky-header.tsx
+++ b/src/table/sticky-header.tsx
@@ -22,12 +22,22 @@ interface StickyHeaderProps {
   secondaryWrapperRef: React.RefObject<HTMLDivElement>;
   tableRef: React.RefObject<HTMLTableElement>;
   onScroll?: React.UIEventHandler<HTMLDivElement>;
+  tableHasHeader?: boolean;
 }
 
 export default forwardRef(StickyHeader);
 
 function StickyHeader(
-  { variant, theadProps, wrapperRef, theadRef, secondaryWrapperRef, onScroll, tableRef }: StickyHeaderProps,
+  {
+    variant,
+    theadProps,
+    wrapperRef,
+    theadRef,
+    secondaryWrapperRef,
+    onScroll,
+    tableRef,
+    tableHasHeader,
+  }: StickyHeaderProps,
   ref: React.Ref<StickyHeaderRef>
 ) {
   const secondaryTheadRef = useRef<HTMLTableRowElement>(null);
@@ -49,6 +59,7 @@ function StickyHeader(
     <div
       className={clsx(styles['header-secondary'], styles[`variant-${variant}`], {
         [styles.stuck]: isStuck,
+        [styles['table-has-header']]: tableHasHeader,
       })}
       aria-hidden={true}
       // Prevents receiving focus in Firefox. Focus on the overflowing table is sufficient

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -141,6 +141,14 @@
   }
 }
 
+/*
+The dynamic height dark header needs a background that will cover
+the default white background of the container component.
+*/
+.dark-header {
+  background-color: awsui.$color-background-layout-main;
+}
+
 .header-secondary {
   overflow: auto;
   -ms-overflow-style: none; /* Internet Explorer 10+ */
@@ -159,6 +167,9 @@
   &::-webkit-scrollbar {
     display: none; /* Safari and Chrome */
   }
+  &.table-has-header {
+    border-top: awsui.$border-divider-list-width solid awsui.$color-border-container-divider;
+  }
 }
 
 .header-controls {
@@ -173,9 +184,6 @@
     padding-left: awsui.$space-table-header-horizontal;
     padding-right: awsui.$space-table-header-horizontal;
     padding-top: awsui.$space-table-embedded-header-top;
-  }
-  & + .header-secondary {
-    border-top: awsui.$border-divider-list-width solid awsui.$color-border-container-divider;
   }
 }
 

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -75,7 +75,10 @@ const Thead = React.forwardRef(
       <thead className={clsx(!hidden && styles['thead-active'])}>
         <tr {...focusMarkers.all} ref={outerRef}>
           {selectionType === 'multi' && (
-            <th className={clsx(headerCellClass, selectionCellClass)} scope="col">
+            <th
+              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
+              scope="col"
+            >
               <SelectionControl
                 onFocusDown={event => onFocusMove!(event.target as HTMLElement, -1, +1)}
                 {...selectAllProps}
@@ -84,7 +87,10 @@ const Thead = React.forwardRef(
             </th>
           )}
           {selectionType === 'single' && (
-            <th className={clsx(headerCellClass, selectionCellClass)} scope="col">
+            <th
+              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
+              scope="col"
+            >
               <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>
             </th>
           )}
@@ -116,6 +122,7 @@ const Thead = React.forwardRef(
                 sortingDescending={sortingDescending}
                 sortingDisabled={sortingDisabled}
                 wrapLines={wrapLines}
+                hidden={hidden}
                 colIndex={colIndex}
                 updateColumn={updateColumn}
                 onResizeFinish={() => onResizeFinish(columnWidths)}


### PR DESCRIPTION
### Description

This change updates the column headers of the full-page variant of the Table component. They are now using the same colour scheme as the body of the table, instead of being part of the dark page header.

![Screenshot of the full-page table after this proposed change](https://user-images.githubusercontent.com/9086585/199226603-5de19879-f897-435a-b39a-1d3c40f08aaa.png)


### How has this been tested?

Local testing in the dev pages

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [X] _No._

### Related Links

- AWSUI-19627


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
