### PR TITLE
Make DRP calendar better decoupled from DRP

### DIFF
--- a/pages/date-range-picker/calendar-permutations.page.tsx
+++ b/pages/date-range-picker/calendar-permutations.page.tsx
@@ -10,26 +10,24 @@ import ScreenshotArea from '../utils/screenshot-area';
 import { i18nStrings } from './common';
 
 const intervals = [
-  [['2021-08-01'], ['2021-08-31']],
-  [['2021-08-02'], ['2021-09-01']],
-  [['2021-08-09'], ['2021-08-16']],
-  [['2021-08-30'], ['2021-08-31']],
-  [['2021-08-31'], ['2021-09-22']],
-  [['2021-08-10'], ['2021-08-14']],
-  [['2021-08-03'], ['2021-08-09']],
-  [['2021-05-10'], ['2021-05-31']],
-  [['2021-05-10'], ['2021-05-30']],
+  ['2021-08-01', '2021-08-31'],
+  ['2021-08-02', '2021-09-01'],
+  ['2021-08-09', '2021-08-16'],
+  ['2021-08-30', '2021-08-31'],
+  ['2021-08-31', '2021-09-22'],
+  ['2021-08-10', '2021-08-14'],
+  ['2021-08-03', '2021-08-09'],
+  ['2021-05-10', '2021-05-31'],
+  ['2021-05-10', '2021-05-30'],
 ];
 
 const permutations = createPermutations<CalendarProps>(
-  intervals.map(([initialStartDate, initialEndDate]) => ({
-    isSingleGrid: [false],
-    initialStartDate,
-    initialEndDate,
+  intervals.map(([startDate, endDate]) => ({
+    value: [{ startDate, endDate }],
     locale: ['en-GB'],
     startOfWeek: [1],
     isDateEnabled: [() => true],
-    onSelectDateRange: [() => {}],
+    onChange: [() => {}],
     timeInputFormat: ['hh:mm:ss'],
     i18nStrings: [i18nStrings],
     dateOnly: [false, true],

--- a/pages/date-range-picker/range-calendar.page.tsx
+++ b/pages/date-range-picker/range-calendar.page.tsx
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Box, Link, Checkbox, SpaceBetween } from '~components';
+import RangeCalendar, { RangeCalendarValue } from '~components/date-range-picker/calendar';
+import { i18nStrings, i18nStringsDateOnly } from './common';
+
+export default function RangeCalendarScenario() {
+  const [value, setValue] = useState<null | RangeCalendarValue>({ startDate: '2020-01-25', endDate: '2020-02-02' });
+  const [dateOnly, setDateOnly] = useState(false);
+
+  return (
+    <Box padding="s">
+      <SpaceBetween direction="vertical" size="m">
+        <h1>Range calendar</h1>
+
+        <Checkbox checked={dateOnly} onChange={event => setDateOnly(event.detail.checked)}>
+          Date-only
+        </Checkbox>
+
+        <Link id="focusable-before">Focusable element before the range calendar</Link>
+
+        <RangeCalendar
+          value={value}
+          onChange={setValue}
+          locale="en-GB"
+          i18nStrings={dateOnly ? i18nStringsDateOnly : i18nStrings}
+          dateOnly={dateOnly}
+          timeInputFormat="hh:mm"
+          isDateEnabled={date => date.getDate() !== 15}
+          startOfWeek={undefined}
+        />
+
+        <Link id="focusable-after">Focusable element after the range calendar</Link>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -14,7 +14,7 @@ import {
   isToday,
 } from 'date-fns';
 import { getCalendarMonth } from 'mnth';
-import { DateChangeHandler, DayIndex } from '../index';
+import { DayIndex } from '../index';
 import { DateRangePickerProps } from '../../interfaces';
 import { getDateLabel, renderDayName } from '../../../calendar/utils/intl';
 import clsx from 'clsx';
@@ -48,7 +48,7 @@ export interface GridProps {
   focusedDate: Date | null;
   focusedDateRef: React.RefObject<HTMLTableCellElement>;
 
-  onSelectDate: DateChangeHandler;
+  onSelectDate: (date: Date) => void;
   onGridKeyDownHandler: (e: React.KeyboardEvent) => void;
   onFocusedDateChange: React.Dispatch<React.SetStateAction<Date | null>>;
 

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { KeyCode } from '../../../internal/keycode';
 import { isSameMonth, isAfter, isBefore, addMonths, min, max } from 'date-fns';
 
-import { DateChangeHandler, DayIndex, MonthChangeHandler } from '../index';
+import { DayIndex } from '../index';
 import { DateRangePickerProps } from '../../interfaces';
 import InternalSpaceBetween from '../../../space-between/internal';
 import { Grid } from './grid';
@@ -36,8 +36,8 @@ export interface GridProps {
   isDateEnabled: DateRangePickerProps.IsDateEnabledFunction;
   isSingleGrid: boolean;
 
-  onSelectDate: DateChangeHandler;
-  onChangeMonth: MonthChangeHandler;
+  onSelectDate: (date: Date) => void;
+  onChangeMonth: (date: Date) => void;
 
   locale: string;
   startOfWeek: DayIndex;

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -170,14 +170,12 @@ export function DateRangePickerDropdown({
                   {rangeSelectionMode === 'absolute' && (
                     <Calendar
                       ref={focusRefs['absolute-only']}
-                      isSingleGrid={isSingleGrid}
-                      initialEndDate={selectedAbsoluteRange?.endDate}
-                      initialStartDate={selectedAbsoluteRange?.startDate}
+                      value={selectedAbsoluteRange ? { ...selectedAbsoluteRange } : null}
+                      onChange={value => setSelectedAbsoluteRange({ type: 'absolute', ...value })}
                       locale={locale}
                       startOfWeek={startOfWeek}
                       isDateEnabled={isDateEnabled}
                       i18nStrings={i18nStrings}
-                      onSelectDateRange={setSelectedAbsoluteRange}
                       dateOnly={dateOnly}
                       timeInputFormat={timeInputFormat}
                     />

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -25,13 +25,18 @@ $calendar-header-color: awsui.$color-text-body-default;
   display: flex;
 }
 
-.calendar {
-  display: block;
+.calendar-container {
   width: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs});
 
   &.one-grid {
     width: $calendar-grid-width;
   }
+}
+
+.calendar {
+  display: block;
+  width: 100%;
+  margin-bottom: awsui.$space-scaled-s;
 
   &-header {
     display: flex;


### PR DESCRIPTION
### Description

Similar to Calendar, we want DRP calendar (Range calendar) to become a standalone component. It requires adjustments to the component's API for it to receive similar properties to DRP.

### How has this been tested?

Existing tests including screenshots, manual tests with new page.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
