### PR TITLE
Decouple popover and annotation context

### DIFF
--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -96,12 +96,13 @@ export function AnnotationPopover({
       position={direction}
       trackRef={trackRef}
       trackKey={taskLocalStepIndex}
-      variant="annotation"
+      bodyClassName={styles['popover-body']}
       arrow={arrow}
       zIndex={1000}
     >
       <PopoverBody
         dismissButton={true}
+        focusLock={false}
         dismissAriaLabel={i18nStrings.labelDismissAnnotation}
         header={
           <InternalBox color="text-body-secondary" fontSize="body-s" margin={{ top: 'xxxs' }} className={styles.header}>
@@ -110,7 +111,6 @@ export function AnnotationPopover({
         }
         onDismiss={onDismiss}
         className={styles.annotation}
-        variant="annotation"
         overflowVisible="content"
         dismissButtonRef={dismissButtonRefCallback}
       >

--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -20,6 +20,11 @@
   /* used in test-utils */
 }
 
+.popover-body {
+  background-color: awsui.$color-background-status-info;
+  border-color: awsui.$color-border-status-info;
+}
+
 .description {
   overflow: hidden;
   margin-top: awsui.$space-xxs;

--- a/src/popover/__tests__/popover-body.test.tsx
+++ b/src/popover/__tests__/popover-body.test.tsx
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import PopoverBody, { PopoverBodyProps } from '../../../lib/components/popover/body';
+
+import styles from '../../../lib/components/popover/styles.selectors.js';
+
+const defaultProps: PopoverBodyProps = {
+  dismissButton: false,
+  dismissAriaLabel: 'Dismiss',
+  onDismiss: () => undefined,
+  header: 'header',
+  children: 'content',
+};
+
+function renderPopoverBody(props: Partial<PopoverBodyProps>) {
+  const { container } = render(<PopoverBody {...defaultProps} {...props} />);
+  const wrapper = createWrapper(container).findByClassName(styles.body)!;
+  const focusLockWrapper = createWrapper(container).find('[data-focus-lock-disabled]')!;
+  return { wrapper, focusLockWrapper };
+}
+
+test('has aria-modal and focus lock if focusLock=true', () => {
+  const { wrapper, focusLockWrapper } = renderPopoverBody({ focusLock: true });
+  expect(wrapper.getElement()!).toHaveAttribute('aria-modal', 'true');
+  expect(focusLockWrapper.getElement()!).toHaveAttribute('data-focus-lock-disabled', 'false');
+});
+
+test('does not have aria-modal and focus lock if focusLock=false', () => {
+  const { wrapper, focusLockWrapper } = renderPopoverBody({ focusLock: false });
+  expect(wrapper.getElement()!).not.toHaveAttribute('aria-modal');
+  expect(focusLockWrapper.getElement()!).toHaveAttribute('data-focus-lock-disabled', 'disabled');
+});

--- a/src/popover/__tests__/popover-container.test.tsx
+++ b/src/popover/__tests__/popover-container.test.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { createRef } from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import PopoverContainer, { PopoverContainerProps } from '../../../lib/components/popover/container';
+
+import styles from '../../../lib/components/popover/styles.selectors.js';
+
+const defaultProps: PopoverContainerProps = {
+  trackRef: createRef(),
+  position: 'top',
+  arrow: () => null,
+  fixedWidth: false,
+  children: 'content',
+  size: 'medium',
+};
+
+function renderPopoverContainer(props: Partial<PopoverContainerProps>) {
+  const { container } = render(<PopoverContainer {...defaultProps} {...props} />);
+  const containerWrapper = createWrapper(container).findByClassName(styles.container)!;
+  const bodyWrapper = createWrapper(container).findByClassName(styles['container-body'])!;
+  return { containerWrapper, bodyWrapper };
+}
+
+test('renders provided arrow', () => {
+  const arrow = jest.fn();
+  renderPopoverContainer({ arrow });
+  expect(arrow).toHaveBeenCalledTimes(1);
+  expect(arrow).toHaveBeenCalledWith(null);
+});
+
+test('assigns body class name', () => {
+  const { bodyWrapper } = renderPopoverContainer({ bodyClassName: 'body' });
+  expect(bodyWrapper.getElement()!).toHaveClass('body');
+});

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -30,7 +30,7 @@ export interface PopoverBodyProps {
 export default function PopoverBody({
   dismissButton: showDismissButton,
   dismissAriaLabel,
-  focusLock = true,
+  focusLock = showDismissButton,
   header,
   children,
   onDismiss,
@@ -71,10 +71,10 @@ export default function PopoverBody({
       })}
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
-      aria-modal={showDismissButton && focusLock ? true : undefined}
+      aria-modal={focusLock ? true : undefined}
       aria-labelledby={header ? labelledById : undefined}
     >
-      <FocusLock disabled={!focusLock || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
+      <FocusLock disabled={!focusLock} autoFocus={true} returnFocus={returnFocus}>
         {header && (
           <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
             {dismissButton}

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -14,11 +14,11 @@ import styles from './styles.css.js';
 export interface PopoverBodyProps {
   dismissButton: boolean;
   dismissAriaLabel: string | undefined;
+  focusLock?: boolean;
   onDismiss: () => void;
 
   header: React.ReactNode | undefined;
   children: React.ReactNode;
-  variant?: 'annotation';
   returnFocus?: boolean;
   overflowVisible?: 'content' | 'both';
 
@@ -30,10 +30,10 @@ export interface PopoverBodyProps {
 export default function PopoverBody({
   dismissButton: showDismissButton,
   dismissAriaLabel,
+  focusLock = true,
   header,
   children,
   onDismiss,
-  variant,
   returnFocus = true,
   overflowVisible,
   dismissButtonRef,
@@ -71,10 +71,10 @@ export default function PopoverBody({
       })}
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
-      aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}
+      aria-modal={showDismissButton && focusLock ? true : undefined}
       aria-labelledby={header ? labelledById : undefined}
     >
-      <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
+      <FocusLock disabled={!focusLock || !showDismissButton} autoFocus={true} returnFocus={returnFocus}>
         {header && (
           <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
             {dismissButton}

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -24,11 +24,6 @@
   border: awsui.$border-field-width solid awsui.$color-border-popover;
 }
 
-.container-body-variant-annotation {
-  background-color: awsui.$color-background-status-info;
-  border-color: awsui.$color-border-status-info;
-}
-
 .container-body-size-small {
   max-width: 210px;
   &.fixed-width {

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -30,7 +30,7 @@ export interface PopoverContainerProps {
   renderWithPortal?: boolean;
   size: PopoverProps.Size;
   fixedWidth: boolean;
-  variant?: 'annotation';
+  bodyClassName?: string;
 }
 
 const INITIAL_STYLES: CSSProperties = { position: 'absolute', top: -9999, left: -9999 };
@@ -45,7 +45,7 @@ export default function PopoverContainer({
   renderWithPortal,
   size,
   fixedWidth,
-  variant,
+  bodyClassName,
 }: PopoverContainerProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -202,9 +202,8 @@ export default function PopoverContainer({
 
       <div
         ref={bodyRef}
-        className={clsx(styles['container-body'], styles[`container-body-size-${size}`], {
+        className={clsx(styles['container-body'], styles[`container-body-size-${size}`], bodyClassName, {
           [styles['fixed-width']]: fixedWidth,
-          [styles[`container-body-variant-${variant}`]]: variant,
         })}
       >
         <div ref={contentRef}>{children}</div>


### PR DESCRIPTION
### Description

Break tight coupling between popover and annotation context:
* Move annotation-context popover-specific classes to annotation-context;
* Remove "annotation" variant of the popover;

### How has this been tested?

Added more unit tests to popover elements.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
