### PR TITLE
fix(property-filter): Include option prefix in the aria announcement

### DIFF
--- a/src/internal/components/option/option-announcer.ts
+++ b/src/internal/components/option/option-announcer.ts
@@ -3,7 +3,13 @@
 import { OptionDefinition, OptionGroup } from './interfaces';
 
 function defaultOptionDescription(option: OptionDefinition, parentGroup: OptionGroup | undefined) {
-  return [parentGroup && parentGroup.label, option.label || option.value, option.description, option.labelTag]
+  return [
+    parentGroup && parentGroup.label,
+    option.__labelPrefix,
+    option.label || option.value,
+    option.description,
+    option.labelTag,
+  ]
     .concat(option.tags)
     .filter(el => !!el)
     .join(' ');

--- a/src/select/utils/use-announcement.ts
+++ b/src/select/utils/use-announcement.ts
@@ -57,5 +57,5 @@ export function useAnnouncement<Option extends OptionHolder>({
   // Use default renderer with selected ARIA label if defined and relevant.
   const selectedAnnouncement = announceSelected && selectedAriaLabel ? selectedAriaLabel : '';
   const defaultDescription = defaultOptionDescription(option, group);
-  return [selectedAnnouncement, defaultDescription].join(' ');
+  return [selectedAnnouncement, defaultDescription].filter(Boolean).join(' ');
 }

--- a/src/select/utils/use-announcement.ts
+++ b/src/select/utils/use-announcement.ts
@@ -55,7 +55,7 @@ export function useAnnouncement<Option extends OptionHolder>({
   }
 
   // Use default renderer with selected ARIA label if defined and relevant.
-  const selectedPrefix = announceSelected && selectedAriaLabel ? selectedAriaLabel : '';
+  const selectedAnnouncement = announceSelected && selectedAriaLabel ? selectedAriaLabel : '';
   const defaultDescription = defaultOptionDescription(option, group);
-  return [selectedPrefix, defaultDescription].filter(Boolean).join(' ');
+  return [selectedAnnouncement, defaultDescription].join(' ');
 }


### PR DESCRIPTION
### Description

The property filter uses label prefixes in the operator and value selection. But these labels don't get announced. Going back through commit/version history, it looks like it's something we accidentally missed.

### How has this been tested?

Manually on VoiceOver/NVDA.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
  - We've noticed that people test things by their "accessible names", so this might break tests. But I don't think this should count.
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.