### PR TITLE
Use h2 for calendar header

### DIFF
--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -41,6 +41,7 @@ export interface GridProps {
   startOfWeek: DayIndex;
   todayAriaLabel: string;
   selectedDate: Date | null;
+  ariaLabelledby: string;
 }
 
 export default function Grid({
@@ -55,6 +56,7 @@ export default function Grid({
   startOfWeek,
   todayAriaLabel,
   selectedDate,
+  ariaLabelledby,
 }: GridProps) {
   const focusedDateRef = useRef<HTMLTableCellElement>(null);
 
@@ -117,7 +119,7 @@ export default function Grid({
   const focusVisible = useFocusVisible();
 
   return (
-    <table role="grid" className={styles['calendar-grid']}>
+    <table role="grid" className={styles['calendar-grid']} aria-labelledby={ariaLabelledby}>
       <thead>
         <tr>
           {weekdays.map(dayIndex => (

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -11,6 +11,7 @@ interface CalendarHeaderProps {
   onChangeMonth: (prev?: boolean) => void;
   previousMonthLabel: string;
   nextMonthLabel: string;
+  headingId: string;
 }
 
 const CalendarHeader = ({
@@ -19,11 +20,14 @@ const CalendarHeader = ({
   onChangeMonth,
   previousMonthLabel,
   nextMonthLabel,
+  headingId,
 }: CalendarHeaderProps) => {
   return (
     <div className={styles['calendar-header']}>
       <HeaderButton ariaLabel={previousMonthLabel} isPrevious={true} onChangeMonth={onChangeMonth} />
-      <div className={styles['calendar-header-month']}>{renderMonthAndYear(locale, baseDate)}</div>
+      <h2 className={styles['calendar-header-month']} id={headingId}>
+        {renderMonthAndYear(locale, baseDate)}
+      </h2>
       <HeaderButton ariaLabel={nextMonthLabel} isPrevious={false} onChangeMonth={onChangeMonth} />
     </div>
   );

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -16,6 +16,7 @@ import { getBaseProps } from '../internal/base-component';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component/index.js';
 import { getBaseDate } from './utils/navigation';
 import { useDateCache } from '../internal/hooks/use-date-cache/index.js';
+import { useUniqueId } from '../internal/hooks/use-unique-id/index.js';
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -50,6 +51,8 @@ export default function Calendar({
   const memoizedValue = parsedValue ? valueDateCache(parsedValue) : null;
   const defaultDisplayedDate = memoizedValue ?? new Date();
   const [displayedDate, setDisplayedDate] = useState(defaultDisplayedDate);
+
+  const headingId = useUniqueId('calendar-heading');
 
   // Update displayed date if value changes.
   useEffect(() => {
@@ -118,6 +121,7 @@ export default function Calendar({
           onChangeMonth={onHeaderChangeMonthHandler}
           previousMonthLabel={previousMonthAriaLabel}
           nextMonthLabel={nextMonthAriaLabel}
+          headingId={headingId}
         />
         <div onBlur={onGridBlur} ref={gridWrapperRef}>
           <Grid
@@ -132,6 +136,7 @@ export default function Calendar({
             startOfWeek={normalizedStartOfWeek}
             todayAriaLabel={todayAriaLabel}
             selectedDate={memoizedValue}
+            ariaLabelledby={headingId}
           />
         </div>
       </div>

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -35,6 +35,7 @@
     @include styles.font-body-m;
     font-weight: typographyConstants.$font-weight-bold;
     color: calendar.$header-color;
+    margin: 0;
   }
 
   &-next-month-btn {


### PR DESCRIPTION
### Description

AWSUI-19188
Use `h2` for calendar header, and label the table with the header. 

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
