### PR TITLE
code-editor: support listing only supported themes

### DIFF
--- a/pages/code-editor/base-props.ts
+++ b/pages/code-editor/base-props.ts
@@ -1,6 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { CodeEditorProps } from '~components';
+import 'ace-builds/css/ace.css';
+import 'ace-builds/css/theme/dawn.css';
+import 'ace-builds/css/theme/tomorrow_night_bright.css';
+
+// supported themes should match imports above
+export const themes = { light: ['dawn'], dark: ['tomorrow_night_bright'] };
 
 export const i18nStrings: CodeEditorProps.I18nStrings = {
   loadingState: 'Loading code editor',

--- a/pages/code-editor/controllable-height.page.tsx
+++ b/pages/code-editor/controllable-height.page.tsx
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import CodeEditor, { CodeEditorProps } from '~components/code-editor';
-import { i18nStrings } from './i18n-strings';
+import { i18nStrings } from './base-props';
 import ScreenshotArea from '../utils/screenshot-area';
-
-import 'ace-builds/css/ace.css';
-import 'ace-builds/css/theme/dawn.css';
-import 'ace-builds/css/theme/tomorrow_night_bright.css';
 
 import { sayHelloSample } from './code-samples';
 

--- a/pages/code-editor/error.page.tsx
+++ b/pages/code-editor/error.page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import CodeEditor from '~components/code-editor';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './i18n-strings';
+import { i18nStrings } from './base-props';
 
 export default function () {
   return (

--- a/pages/code-editor/loading.page.tsx
+++ b/pages/code-editor/loading.page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import CodeEditor from '~components/code-editor';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './i18n-strings';
+import { i18nStrings } from './base-props';
 
 export default function () {
   return (

--- a/pages/code-editor/simple.page.tsx
+++ b/pages/code-editor/simple.page.tsx
@@ -5,11 +5,7 @@ import Button from '~components/button';
 import CodeEditor, { CodeEditorProps } from '~components/code-editor';
 import SpaceBetween from '~components/space-between';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './i18n-strings';
-
-import 'ace-builds/css/ace.css';
-import 'ace-builds/css/theme/dawn.css';
-import 'ace-builds/css/theme/tomorrow_night_bright.css';
+import { i18nStrings, themes } from './base-props';
 
 import { buildSample, awsTemplateSample } from './code-samples';
 
@@ -64,6 +60,7 @@ export default class App extends React.PureComponent<null, IState> {
             onPreferencesChange={e => this.onPreferencesChange(e.detail)}
             loading={this.state.loading}
             i18nStrings={i18nStrings}
+            themes={themes}
           />
         </ScreenshotArea>
 

--- a/pages/code-editor/vertical-scroll.page.tsx
+++ b/pages/code-editor/vertical-scroll.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import CodeEditor, { CodeEditorProps } from '~components/code-editor';
-import { i18nStrings } from './i18n-strings';
+import { i18nStrings } from './base-props';
 
 import 'ace-builds/css/ace.css';
 import 'ace-builds/css/theme/dawn.css';

--- a/pages/code-editor/with-errors-no-warnings.page.tsx
+++ b/pages/code-editor/with-errors-no-warnings.page.tsx
@@ -5,11 +5,7 @@ import Button from '~components/button';
 import CodeEditor, { CodeEditorProps } from '~components/code-editor';
 import SpaceBetween from '~components/space-between';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './i18n-strings';
-
-import 'ace-builds/css/ace.css';
-import 'ace-builds/css/theme/dawn.css';
-import 'ace-builds/css/theme/tomorrow_night_bright.css';
+import { i18nStrings, themes } from './base-props';
 
 import { buildSample, awsTemplateSample } from './code-samples';
 
@@ -74,6 +70,7 @@ sdsdasd
             onPreferencesChange={e => this.onPreferencesChange(e.detail)}
             loading={this.state.loading}
             i18nStrings={i18nStrings}
+            themes={themes}
           />
         </ScreenshotArea>
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3830,6 +3830,29 @@ You can use any theme provided by Ace.
       "type": "Partial<CodeEditorProps.Preferences>",
     },
     Object {
+      "description": "List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
+least one dark theme. If not set explicitly, it will render all Ace themes available for selection.",
+      "inlineType": Object {
+        "name": "CodeEditorProps.AvailableThemes",
+        "properties": Array [
+          Object {
+            "name": "dark",
+            "optional": false,
+            "type": "ReadonlyArray<string>",
+          },
+          Object {
+            "name": "light",
+            "optional": false,
+            "type": "ReadonlyArray<string>",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "themes",
+      "optional": true,
+      "type": "CodeEditorProps.AvailableThemes",
+    },
+    Object {
       "description": "Specifies the content that's displayed in the code editor.",
       "name": "value",
       "optional": false,

--- a/src/code-editor/__tests__/preferences-modal.test.tsx
+++ b/src/code-editor/__tests__/preferences-modal.test.tsx
@@ -63,6 +63,22 @@ test('should change syntax theme preference via modal', () => {
   expect(onPreferencesChange).toHaveBeenCalledWith({ theme: 'chrome', wrapLines: true });
 });
 
+test('renders all themes by default', () => {
+  const { wrapper } = renderCodeEditor();
+  wrapper.findSettingsButton()!.click();
+  const select = createWrapper().findModal()!.findContent().findSelect()!;
+  select.openDropdown();
+  expect(select.findDropdown().findOptions()).toHaveLength(38);
+});
+
+test('should allow limiting themes selection via property', () => {
+  const { wrapper } = renderCodeEditor({ themes: { light: ['chrome'], dark: ['ambiance'] } });
+  wrapper.findSettingsButton()!.click();
+  const select = createWrapper().findModal()!.findContent().findSelect()!;
+  select.openDropdown();
+  expect(select.findDropdown().findOptions()).toHaveLength(2);
+});
+
 test('should reset pending changes when modal dismisses', () => {
   const onPreferencesChange = jest.fn();
   const { wrapper } = renderCodeEditor({ onPreferencesChange: event => onPreferencesChange(event.detail) });

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -328,6 +328,7 @@ export default function CodeEditor(props: CodeEditorProps) {
             <PreferencesModal
               onConfirm={onPreferencesConfirm}
               onDismiss={onPreferencesDismiss}
+              themes={props.themes}
               preferences={props.preferences}
               defaultTheme={defaultTheme}
               i18nStrings={{

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -59,6 +59,12 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
   preferences?: Partial<CodeEditorProps.Preferences>;
 
   /**
+   * List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
+   * least one dark theme. If not set explicitly, it will render all Ace themes available for selection.
+   */
+  themes?: CodeEditorProps.AvailableThemes;
+
+  /**
    * Called when any of the preferences change.
    * The event `detail` contains the value of all the preferences as submitted by the user.
    *
@@ -102,6 +108,11 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
 export namespace CodeEditorProps {
   export type Language = typeof AceModes[number]['value'];
   export type Theme = typeof LightThemes[number]['value'] | typeof DarkThemes[number]['value'];
+
+  export interface AvailableThemes {
+    light: ReadonlyArray<string>;
+    dark: ReadonlyArray<string>;
+  }
 
   export interface Preferences {
     wrapLines: boolean;

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -31,15 +31,33 @@ interface PreferencesModalProps {
 
   i18nStrings: PreferencesModali18nStrings;
 
+  themes: CodeEditorProps['themes'];
   defaultTheme: CodeEditorProps.Theme;
 
   onConfirm: (preferences: CodeEditorProps.Preferences) => void;
   onDismiss: () => void;
 }
 
+function filterThemes(allThemes: ReadonlyArray<SelectProps.Option>, available: ReadonlyArray<string> | undefined) {
+  if (!available) {
+    return allThemes;
+  }
+  return allThemes.filter(theme => available.indexOf(theme.value!) > -1);
+}
+
 export default (props: PreferencesModalProps) => {
   const [wrapLines, setWrapLines] = useState<boolean>(props.preferences?.wrapLines ?? true);
   const [theme, setTheme] = useState<CodeEditorProps.Theme>(props.preferences?.theme ?? props.defaultTheme);
+  const themeOptions = [
+    {
+      label: props.i18nStrings.lightThemes,
+      options: filterThemes(LightThemes, props.themes?.light),
+    },
+    {
+      label: props.i18nStrings.darkThemes,
+      options: filterThemes(DarkThemes, props.themes?.dark),
+    },
+  ];
   const [selectedThemeOption, setSelectedThemeOption] = useState<SelectProps.Option>(
     () => [...LightThemes, ...DarkThemes].filter(t => t.value === theme)[0]
   );
@@ -79,10 +97,7 @@ export default (props: PreferencesModalProps) => {
               <InternalSelect
                 selectedOption={selectedThemeOption}
                 onChange={onThemeSelected}
-                options={[
-                  { label: props.i18nStrings.lightThemes, options: LightThemes },
-                  { label: props.i18nStrings.darkThemes, options: DarkThemes },
-                ]}
+                options={themeOptions}
                 filteringType="auto"
               />
             </InternalFormField>


### PR DESCRIPTION
### Description

Allow to limit what syntax themes are available for selection

```js
import 'ace-builds/css/theme/dawn.css';
import 'ace-builds/css/theme/tomorrow_night_bright.css';

// the list should match imported files
<CodeEditor themes={{light: ['dawn'], dark: ['tomorrow_night_bright']}} />
```

### How has this been tested?

Added a unit test

### Documentation changes

- [x] _Yes, this change contains documentation changes._
- [ ] _No._



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
