### PR TITLE
Revert "Fix link arialabel overrides externalIconAriaLabel when both …

### DIFF
--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -27,15 +27,6 @@ describe('Link component', () => {
     expect(createWrapper(wrapper.getElement()).find('[aria-label="External link"]')).toBeTruthy();
   });
 
-  test('ariaLabel and externalIconAriaLabel are applied the same time', () => {
-    const wrapper = renderLink({
-      ariaLabel: 'Learn more about S3',
-      externalIconAriaLabel: 'External link',
-      external: true,
-    });
-    expect(wrapper.getElement()).toHaveAttribute('aria-label', 'Learn more about S3, External link');
-  });
-
   describe('"info" variant', () => {
     test('negates fontSize and color', () => {
       const wrapper = renderLink({ variant: 'info', fontSize: 'heading-xl', color: 'inverted' });

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -91,8 +91,7 @@ const InternalLink = React.forwardRef(
         styles[getFontSizeStyle(variant, fontSize)],
         styles[getColorStyle(variant, color)]
       ),
-      'aria-label':
-        ariaLabel && external && externalIconAriaLabel ? ariaLabel + ', ' + externalIconAriaLabel : ariaLabel,
+      'aria-label': ariaLabel,
     };
 
     const content = (


### PR DESCRIPTION
…are set (#279)"

This reverts commit b965962404d9217a5f1ddc88ef5478b1eca82f6c.
> For links that force the customer to leave the current window or tab, explicitly state this action within the externalIconAriaLabel or ariaLabel.


### Description

[_Include a summary of the changes and the related issue._]

[_Also include relevant motivation and context._]

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
