### PR TITLE
fix(header): Reset h2 line-height

### DIFF
--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -165,9 +165,11 @@
   }
   &-variant-h2 {
     font-weight: awsui.$font-heading-l-weight;
+    line-height: awsui.$font-heading-l-line-height;
   }
   &-variant-h3 {
     font-weight: awsui.$font-heading-m-weight;
+    line-height: awsui.$font-heading-m-line-height;
   }
 }
 


### PR DESCRIPTION
### Description

`awsui-h1-sticky` renders a `h1` element with `h2` styles, which means if there is any global styling for h1 it will override the line height of headers using `awsui-h1-sticky`. these global styles could come from previous versions of the system. 

### How has this been tested?

tested locally, no visual difference

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x ] _No._

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
