### PR TITLE
Range calendar API

### DIFF
--- a/pages/date-range-picker/calendar-permutations.page.tsx
+++ b/pages/date-range-picker/calendar-permutations.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import Box from '~components/box';
-import Calendar, { CalendarProps } from '~components/date-range-picker/calendar';
+import Calendar, { DateRangePickerCalendarProps } from '~components/date-range-picker/calendar';
 import Dropdown from '~components/internal/components/dropdown';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
@@ -21,7 +21,7 @@ const intervals = [
   ['2021-05-10', '2021-05-30'],
 ];
 
-const permutations = createPermutations<CalendarProps>(
+const permutations = createPermutations<DateRangePickerCalendarProps>(
   intervals.map(([startDate, endDate]) => ({
     value: [{ startDate, endDate }],
     locale: ['en-GB'],

--- a/pages/date-range-picker/range-calendar.page.tsx
+++ b/pages/date-range-picker/range-calendar.page.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { Box, Link, Checkbox, SpaceBetween } from '~components';
-import RangeCalendar, { RangeCalendarValue } from '~components/date-range-picker/calendar';
+import RangeCalendar from '~components/date-range-picker/calendar';
+import { RangeCalendarValue } from '~components/date-range-picker/interfaces';
 import { i18nStrings, i18nStringsDateOnly } from './common';
 
 export default function RangeCalendarScenario() {

--- a/pages/date-range-picker/range-calendar.page.tsx
+++ b/pages/date-range-picker/range-calendar.page.tsx
@@ -28,7 +28,6 @@ export default function RangeCalendarScenario() {
           dateOnly={dateOnly}
           timeInputFormat="hh:mm"
           isDateEnabled={date => date.getDate() !== 15}
-          startOfWeek={undefined}
         />
 
         <Link id="focusable-after">Focusable element after the range calendar</Link>

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -14,8 +14,7 @@ import {
   isToday,
 } from 'date-fns';
 import { getCalendarMonth } from 'mnth';
-import { DayIndex } from '../index';
-import { DateRangePickerProps } from '../../interfaces';
+import { DateRangePickerProps, DayIndex } from '../../interfaces';
 import { getDateLabel, renderDayName } from '../../../calendar/utils/intl';
 import clsx from 'clsx';
 import { formatDate } from '../../../internal/utils/date-time';

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { KeyCode } from '../../../internal/keycode';
 import { isSameMonth, isAfter, isBefore, addMonths, min, max } from 'date-fns';
 
-import { DayIndex } from '../index';
-import { DateRangePickerProps } from '../../interfaces';
+import { DateRangePickerProps, DayIndex } from '../../interfaces';
 import InternalSpaceBetween from '../../../space-between/internal';
 import { Grid } from './grid';
 import styles from '../../styles.css.js';

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } f
 import { addMonths, endOfDay, isBefore, startOfDay, startOfMonth, isAfter, isSameMonth } from 'date-fns';
 import styles from '../styles.css.js';
 import { BaseComponentProps } from '../../internal/base-component';
-import { DateRangePickerProps, Focusable } from '../interfaces';
+import { Focusable, RangeCalendarI18nStrings } from '../interfaces';
 import CalendarHeader from './header';
 import { Grids, selectFocusedDate } from './grids';
 import InternalFormField from '../../form-field/internal';
@@ -16,7 +16,7 @@ import clsx from 'clsx';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getDateLabel, renderTimeLabel } from '../../calendar/utils/intl';
 import LiveRegion from '../../internal/components/live-region';
-import { normalizeStartOfWeek } from '../../calendar/utils/locales';
+import { normalizeLocale, normalizeStartOfWeek } from '../../calendar/utils/locales';
 import { formatDate, formatTime, joinDateTime, parseDate } from '../../internal/utils/date-time';
 import { getBaseDate } from '../../calendar/utils/navigation';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
@@ -35,10 +35,10 @@ export interface RangeCalendarValue {
 export interface CalendarProps extends BaseComponentProps {
   value: null | RangeCalendarValue;
   onChange: (value: RangeCalendarValue) => void;
-  locale: string;
-  startOfWeek: number | undefined;
-  isDateEnabled: (date: Date) => boolean;
-  i18nStrings: DateRangePickerProps.I18nStrings;
+  locale?: string;
+  startOfWeek?: number;
+  isDateEnabled?: (date: Date) => boolean;
+  i18nStrings: RangeCalendarI18nStrings;
   dateOnly?: boolean;
   timeInputFormat?: TimeInputProps.Format;
 }
@@ -49,9 +49,9 @@ function RangeCalendar(
   {
     value,
     onChange,
-    locale,
+    locale = '',
     startOfWeek,
-    isDateEnabled,
+    isDateEnabled = () => true,
     i18nStrings,
     dateOnly = false,
     timeInputFormat = 'hh:mm:ss',
@@ -61,7 +61,8 @@ function RangeCalendar(
   const elementRef = useRef<HTMLDivElement>(null);
   const isSingleGrid = useMobile();
 
-  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, locale);
+  const normalizedLocale = normalizeLocale('DateRangePicker', locale);
+  const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, normalizedLocale);
 
   useImperativeHandle(ref, () => ({
     focus() {
@@ -132,11 +133,11 @@ function RangeCalendar(
       return (
         i18nStrings.startDateLabel +
         ', ' +
-        getDateLabel(locale, startDate) +
+        getDateLabel(normalizedLocale, startDate) +
         ', ' +
         i18nStrings.startTimeLabel +
         ', ' +
-        renderTimeLabel(locale, startDate, timeInputFormat) +
+        renderTimeLabel(normalizedLocale, startDate, timeInputFormat) +
         '. '
       );
     };
@@ -145,22 +146,22 @@ function RangeCalendar(
       return (
         i18nStrings.endDateLabel +
         ', ' +
-        getDateLabel(locale, endDate) +
+        getDateLabel(normalizedLocale, endDate) +
         ', ' +
         i18nStrings.endTimeLabel +
         ', ' +
-        renderTimeLabel(locale, endDate, timeInputFormat) +
+        renderTimeLabel(normalizedLocale, endDate, timeInputFormat) +
         '. '
       );
     };
 
     const announceRange = (startDate: Date, endDate: Date) => {
       if (!i18nStrings.renderSelectedAbsoluteRangeAriaLive) {
-        return `${getDateLabel(locale, startDate)} – ${getDateLabel(locale, endDate)}`;
+        return `${getDateLabel(normalizedLocale, startDate)} – ${getDateLabel(normalizedLocale, endDate)}`;
       }
       return i18nStrings.renderSelectedAbsoluteRangeAriaLive(
-        getDateLabel(locale, startDate),
-        getDateLabel(locale, endDate)
+        getDateLabel(normalizedLocale, startDate),
+        getDateLabel(normalizedLocale, endDate)
       );
     };
 
@@ -275,7 +276,7 @@ function RangeCalendar(
         >
           <CalendarHeader
             baseDate={currentMonth}
-            locale={locale}
+            locale={normalizedLocale}
             onChangeMonth={onHeaderChangeMonthHandler}
             previousMonthLabel={i18nStrings.previousMonthAriaLabel}
             nextMonthLabel={i18nStrings.nextMonthAriaLabel}
@@ -285,7 +286,7 @@ function RangeCalendar(
 
           <Grids
             isSingleGrid={isSingleGrid}
-            locale={locale}
+            locale={normalizedLocale}
             baseDate={currentMonth}
             focusedDate={focusedDate}
             onFocusedDateChange={setFocusedDate}

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } f
 import { addMonths, endOfDay, isBefore, startOfDay, startOfMonth, isAfter, isSameMonth } from 'date-fns';
 import styles from '../styles.css.js';
 import { BaseComponentProps } from '../../internal/base-component';
-import { Focusable, RangeCalendarI18nStrings } from '../interfaces';
+import { Focusable, RangeCalendarI18nStrings, RangeCalendarValue } from '../interfaces';
 import CalendarHeader from './header';
 import { Grids, selectFocusedDate } from './grids';
 import { TimeInputProps } from '../../time-input/interfaces';
@@ -18,18 +18,7 @@ import { getBaseDate } from '../../calendar/utils/navigation';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
 import RangeInputs from './range-inputs.js';
 
-export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-
-interface HeaderChangeMonthHandler {
-  (isPreviousButtonClick?: boolean): void;
-}
-
-export interface RangeCalendarValue {
-  startDate: string;
-  endDate: string;
-}
-
-export interface CalendarProps extends BaseComponentProps {
+export interface DateRangePickerCalendarProps extends BaseComponentProps {
   value: null | RangeCalendarValue;
   onChange: (value: RangeCalendarValue) => void;
   locale?: string;
@@ -40,9 +29,9 @@ export interface CalendarProps extends BaseComponentProps {
   timeInputFormat?: TimeInputProps.Format;
 }
 
-export default forwardRef(RangeCalendar);
+export default forwardRef(DateRangePickerCalendar);
 
-function RangeCalendar(
+function DateRangePickerCalendar(
   {
     value,
     onChange,
@@ -52,7 +41,7 @@ function RangeCalendar(
     i18nStrings,
     dateOnly = false,
     timeInputFormat = 'hh:mm:ss',
-  }: CalendarProps,
+  }: DateRangePickerCalendarProps,
   ref: React.Ref<Focusable>
 ) {
   const elementRef = useRef<HTMLDivElement>(null);
@@ -234,7 +223,7 @@ function RangeCalendar(
     // All possible conditions are covered above
   };
 
-  const onHeaderChangeMonthHandler: HeaderChangeMonthHandler = isPrevious => {
+  const onHeaderChangeMonthHandler = (isPrevious?: boolean) => {
     const newCurrentMonth = addMonths(currentMonth, isPrevious ? -1 : 1);
     setCurrentMonth(newCurrentMonth);
 

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -7,11 +7,7 @@ import { BaseComponentProps } from '../../internal/base-component';
 import { Focusable, RangeCalendarI18nStrings } from '../interfaces';
 import CalendarHeader from './header';
 import { Grids, selectFocusedDate } from './grids';
-import InternalFormField from '../../form-field/internal';
-import { InputProps } from '../../input/interfaces';
-import InternalDateInput from '../../date-input/internal';
 import { TimeInputProps } from '../../time-input/interfaces';
-import InternalTimeInput from '../../time-input/internal';
 import clsx from 'clsx';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getDateLabel, renderTimeLabel } from '../../calendar/utils/intl';
@@ -20,6 +16,7 @@ import { normalizeLocale, normalizeStartOfWeek } from '../../calendar/utils/loca
 import { formatDate, formatTime, joinDateTime, parseDate } from '../../internal/utils/date-time';
 import { getBaseDate } from '../../calendar/utils/navigation';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
+import RangeInputs from './range-inputs.js';
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -115,9 +112,8 @@ function RangeCalendar(
     return selectFocusedDate(selectedStartDate, currentMonth, isDateEnabled);
   });
 
+  // This effect "synchronizes" the local state update back up to the parent component.
   useEffect(() => {
-    // This effect "synchronizes" the local state update back up to the overall DateRangePicker component
-
     const startDate = joinDateTime(startDateString, startTimeString);
     const endDate = joinDateTime(endDateString, endTimeString);
 
@@ -247,17 +243,17 @@ function RangeCalendar(
     setFocusedDate(newBaseDate);
   };
 
-  const onChangeStartDate: InputProps['onChange'] = e => {
-    setStartDateString(e.detail.value);
+  const onChangeStartDate = (value: string) => {
+    setStartDateString(value);
 
-    if (e.detail.value.length >= 8) {
-      const newCurrentMonth = startOfMonth(parseDate(e.detail.value));
+    if (value.length >= 8) {
+      const newCurrentMonth = startOfMonth(parseDate(value));
       setCurrentMonth(isSingleGrid ? newCurrentMonth : addMonths(newCurrentMonth, 1));
     }
   };
 
-  const onChangeEndDate: InputProps['onChange'] = e => {
-    setEndDateString(e.detail.value);
+  const onChangeEndDate = (value: string) => {
+    setEndDateString(value);
   };
 
   const headingIdPrefix = useUniqueId('date-range-picker-calendar-heading');
@@ -300,53 +296,20 @@ function RangeCalendar(
             headingIdPrefix={headingIdPrefix}
           />
         </div>
-        <InternalFormField constraintText={i18nStrings.dateTimeConstraintText}>
-          <div className={styles['date-and-time-container']}>
-            <div className={styles['date-and-time-wrapper']}>
-              <InternalFormField label={i18nStrings.startDateLabel} stretch={true}>
-                <InternalDateInput
-                  value={startDateString}
-                  className={styles['start-date-input']}
-                  onChange={onChangeStartDate}
-                  placeholder="YYYY/MM/DD"
-                />
-              </InternalFormField>
-              {!dateOnly && (
-                <InternalFormField label={i18nStrings.startTimeLabel} stretch={true}>
-                  <InternalTimeInput
-                    value={startTimeString}
-                    onChange={e => setStartTimeString(e.detail.value)}
-                    format={timeInputFormat}
-                    placeholder={timeInputFormat}
-                    className={styles['start-time-input']}
-                  />
-                </InternalFormField>
-              )}
-            </div>
 
-            <div className={styles['date-and-time-wrapper']}>
-              <InternalFormField label={i18nStrings.endDateLabel} stretch={true}>
-                <InternalDateInput
-                  value={endDateString}
-                  className={styles['end-date-input']}
-                  onChange={onChangeEndDate}
-                  placeholder="YYYY/MM/DD"
-                />
-              </InternalFormField>
-              {!dateOnly && (
-                <InternalFormField label={i18nStrings.endTimeLabel} stretch={true}>
-                  <InternalTimeInput
-                    value={endTimeString}
-                    onChange={e => setEndTimeString(e.detail.value)}
-                    format={timeInputFormat}
-                    placeholder={timeInputFormat}
-                    className={styles['end-time-input']}
-                  />
-                </InternalFormField>
-              )}
-            </div>
-          </div>
-        </InternalFormField>
+        <RangeInputs
+          startDate={startDateString}
+          onChangeStartDate={onChangeStartDate}
+          startTime={startTimeString}
+          onChangeStartTime={setStartTimeString}
+          endDate={endDateString}
+          onChangeEndDate={onChangeEndDate}
+          endTime={endTimeString}
+          onChangeEndTime={setEndTimeString}
+          i18nStrings={i18nStrings}
+          dateOnly={dateOnly}
+          timeInputFormat={timeInputFormat}
+        />
       </div>
       <LiveRegion className={styles['calendar-aria-live']}>{announcement}</LiveRegion>
     </>

--- a/src/date-range-picker/calendar/range-inputs.tsx
+++ b/src/date-range-picker/calendar/range-inputs.tsx
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import styles from '../styles.css.js';
+import { BaseComponentProps } from '../../internal/base-component';
+import { RangeCalendarI18nStrings } from '../interfaces';
+import InternalFormField from '../../form-field/internal';
+import InternalDateInput from '../../date-input/internal';
+import { TimeInputProps } from '../../time-input/interfaces';
+import InternalTimeInput from '../../time-input/internal';
+
+type I18nStrings = Pick<
+  RangeCalendarI18nStrings,
+  'dateTimeConstraintText' | 'startDateLabel' | 'startTimeLabel' | 'endDateLabel' | 'endTimeLabel'
+>;
+
+export interface RangeInputsProps extends BaseComponentProps {
+  startDate: string;
+  onChangeStartDate: (value: string) => void;
+  startTime: string;
+  onChangeStartTime: (value: string) => void;
+  endDate: string;
+  onChangeEndDate: (value: string) => void;
+  endTime: string;
+  onChangeEndTime: (value: string) => void;
+  i18nStrings: I18nStrings;
+  dateOnly: boolean;
+  timeInputFormat: TimeInputProps.Format;
+}
+
+export default function RangeInputs({
+  startDate,
+  onChangeStartDate,
+  startTime,
+  onChangeStartTime,
+  endDate,
+  onChangeEndDate,
+  endTime,
+  onChangeEndTime,
+  i18nStrings,
+  dateOnly,
+  timeInputFormat,
+}: RangeInputsProps) {
+  return (
+    <InternalFormField constraintText={i18nStrings.dateTimeConstraintText}>
+      <div className={styles['date-and-time-container']}>
+        <div className={styles['date-and-time-wrapper']}>
+          <InternalFormField label={i18nStrings.startDateLabel} stretch={true}>
+            <InternalDateInput
+              value={startDate}
+              className={styles['start-date-input']}
+              onChange={event => onChangeStartDate(event.detail.value)}
+              placeholder="YYYY/MM/DD"
+            />
+          </InternalFormField>
+          {!dateOnly && (
+            <InternalFormField label={i18nStrings.startTimeLabel} stretch={true}>
+              <InternalTimeInput
+                value={startTime}
+                onChange={event => onChangeStartTime(event.detail.value)}
+                format={timeInputFormat}
+                placeholder={timeInputFormat}
+                className={styles['start-time-input']}
+              />
+            </InternalFormField>
+          )}
+        </div>
+
+        <div className={styles['date-and-time-wrapper']}>
+          <InternalFormField label={i18nStrings.endDateLabel} stretch={true}>
+            <InternalDateInput
+              value={endDate}
+              className={styles['end-date-input']}
+              onChange={event => onChangeEndDate(event.detail.value)}
+              placeholder="YYYY/MM/DD"
+            />
+          </InternalFormField>
+          {!dateOnly && (
+            <InternalFormField label={i18nStrings.endTimeLabel} stretch={true}>
+              <InternalTimeInput
+                value={endTime}
+                onChange={event => onChangeEndTime(event.detail.value)}
+                format={timeInputFormat}
+                placeholder={timeInputFormat}
+                className={styles['end-time-input']}
+              />
+            </InternalFormField>
+          )}
+        </div>
+      </div>
+    </InternalFormField>
+  );
+}

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -131,7 +131,7 @@ const DateRangePicker = React.forwardRef(
 
     const [isDropDownOpen, setIsDropDownOpen] = useState<boolean>(false);
 
-    const normalizedLocale = normalizeLocale('DateRangePicker', locale ?? '');
+    const normalizedLocale = normalizeLocale('DateRangePicker', locale);
 
     const closeDropdown = (focusTrigger = false) => {
       setIsDropDownOpen(false);

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -366,6 +366,11 @@ export namespace DateRangePickerProps {
   }
 }
 
+export interface RangeCalendarValue {
+  startDate: string;
+  endDate: string;
+}
+
 export type RangeCalendarI18nStrings = Pick<
   DateRangePickerProps.I18nStrings,
   | 'todayAriaLabel'

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -366,6 +366,8 @@ export namespace DateRangePickerProps {
   }
 }
 
+export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
 export interface RangeCalendarValue {
   startDate: string;
   endDate: string;

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -366,6 +366,19 @@ export namespace DateRangePickerProps {
   }
 }
 
+export type RangeCalendarI18nStrings = Pick<
+  DateRangePickerProps.I18nStrings,
+  | 'todayAriaLabel'
+  | 'nextMonthAriaLabel'
+  | 'previousMonthAriaLabel'
+  | 'startDateLabel'
+  | 'startTimeLabel'
+  | 'endDateLabel'
+  | 'endTimeLabel'
+  | 'dateTimeConstraintText'
+  | 'renderSelectedAbsoluteRangeAriaLive'
+>;
+
 export interface Focusable {
   focus(): void;
 }


### PR DESCRIPTION
### Description

Updated date range picker calendar API to match closely DRP API. Extended calendar's date/time inputs to a separate component. The next step is to extract the range calendar component (w/o date/time inputs).

### How has this been tested?

Existing unit/integ tests, manual tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

* Previous step: https://github.com/cloudscape-design/components/pull/411


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
