### PR TITLE
Make vendor files bundling scoped to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ src/index.ts
 src/test-utils/dom/index.ts
 src/test-utils/selectors
 src/internal/generated/custom-css-properties/index.*
-src/internal/vendor/generated-third-party-licenses.txt
+vendor/generated-third-party-licenses.txt

--- a/build-tools/tasks/bundle-vendor-files.js
+++ b/build-tools/tasks/bundle-vendor-files.js
@@ -3,6 +3,6 @@
 const execa = require('execa');
 const { task } = require('../utils/gulp-utils');
 
-module.exports = task('bundleVendorFiles', () => {
-  return execa('rollup', ['-c', 'src/internal/vendor/rollup.config.mjs'], { stdio: 'inherit' });
+module.exports = task('bundle-vendor-files', () => {
+  return execa('rollup', ['-c', 'vendor/rollup.config.mjs'], { stdio: 'inherit' });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,13 +28,12 @@ const {
 const quickBuild = series(
   clean,
   parallel(packageJSON, generateEnvironment, generateIcons, generateIndexFile, licenses),
-  parallel(generateCustomCssPropertiesMap, styles, typescript, testUtils),
-  bundleVendorFiles
+  parallel(generateCustomCssPropertiesMap, styles, typescript, testUtils)
 );
 
 exports.clean = clean;
 exports['quick-build'] = quickBuild;
-exports.build = series(quickBuild, parallel(buildPages, themeableSource, docs));
+exports.build = series(quickBuild, bundleVendorFiles, parallel(buildPages, themeableSource, docs));
 exports.test = series(unit, integ, a11y);
 exports['test:unit'] = unit;
 exports['test:integ'] = integ;
@@ -54,5 +53,4 @@ exports.watch = () => {
   );
   watch(['src/test-utils/dom/**/*.ts', '!src/test-utils/dom/index.ts'], testUtils);
   watch(['style-dictionary/**/*.ts', 'src/**/*.scss'], styles);
-  watch(['src/internal/vendor/**/*.ts', '!src/internal/vendor/**/__tests__/**'], series(typescript, bundleVendorFiles));
 };

--- a/src/internal/vendor/__tests__/d3-scale-third-party-licences.test.ts
+++ b/src/internal/vendor/__tests__/d3-scale-third-party-licences.test.ts
@@ -6,7 +6,10 @@ import fs from 'fs';
 describe('d3-scale-third-party-licenses.txt content', () => {
   test('stays unchanged without any d3-scale version changes', () => {
     // The file we assert against gets generated during building the project.
-    const content = fs.readFileSync(path.resolve(__dirname, '../../../../generated-third-party-licenses.txt'), 'utf8');
+    const content = fs.readFileSync(
+      path.resolve(__dirname, '../../../../vendor/generated-third-party-licenses.txt'),
+      'utf8'
+    );
     expect(content).toMatchSnapshot();
   });
 });

--- a/src/internal/vendor/__tests__/d3-scale-third-party-licences.test.ts
+++ b/src/internal/vendor/__tests__/d3-scale-third-party-licences.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 describe('d3-scale-third-party-licenses.txt content', () => {
   test('stays unchanged without any d3-scale version changes', () => {
     // The file we assert against gets generated during building the project.
-    const content = fs.readFileSync(path.resolve(__dirname, '../generated-third-party-licenses.txt'), 'utf8');
+    const content = fs.readFileSync(path.resolve(__dirname, '../../../../generated-third-party-licenses.txt'), 'utf8');
     expect(content).toMatchSnapshot();
   });
 });

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,6 +1,6 @@
-### What is the src/internal/vendor folder about?
+### What is the vendor folder about?
 
-This folder references dependencies which we ship as bundled dependencies.
+This folder contains setup for dependencies which we ship as bundled dependencies.
 Bundling the files is handled by rollup as part of the build process (run TS compile, run rollup which takes the compiled
 artifact as input and bundles its dependencies).
 


### PR DESCRIPTION
### Description

Make vendor files bundling scoped to build for it to not affect quick-build.

Moved vendor deps setup to the root for better visibility.

### How has this been tested?

Tested quick-build and build

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
