### PR TITLE
Adding ReactNode type to text properties

### DIFF
--- a/src/side-navigation/interfaces.tsx
+++ b/src/side-navigation/interfaces.tsx
@@ -37,7 +37,7 @@ export interface SideNavigationProps extends BaseComponentProps {
    * Object that represents an anchor in the navigation.
    * Links are rendered as `<a>` tags.
    * - `type` - `'link'`.
-   * - `text` (string) - Specifies the link text.
+   * - `text` (string|object) - Specifies the link text.
    * - `href` (string) - Specifies the `href` of the link.
    * - `external` (boolean) - Determines whether to display an external link icon next to the link.
    *      If set to `true`, an external link icon appears next to the link.
@@ -54,7 +54,7 @@ export interface SideNavigationProps extends BaseComponentProps {
    * #### Section
    * Object that represents a section within the navigation.
    * - `type`: `'section'`.
-   * - `text` (string) - Specifies the text to display as a title of the section.
+   * - `text` (string|object) - Specifies the text to display as a title of the section.
    * - `defaultExpanded` (boolean) - Determines whether the section should be expanded by default. Default value is `true`.
    * - `items` (array) - Specifies the content of the section. You can use any valid item from this list.
    *     Although there is no technical limitation to the nesting level,
@@ -63,7 +63,7 @@ export interface SideNavigationProps extends BaseComponentProps {
    * #### LinkGroup
    * Object that represents a group of links.
    * - `type`: `'link-group'`.
-   * - `text` (string) - Specifies the text of the group link.
+   * - `text` (string|object) - Specifies the text of the group link.
    * - `href` (string) - Specifies the `href` of the group link.
    * - `items` (array) - Specifies the content of the section. You can use any valid item from this list.
    *     Although there is no technical limitation to the nesting level,
@@ -73,7 +73,7 @@ export interface SideNavigationProps extends BaseComponentProps {
    *
    * Object that represents an expandable group of links.
    * - `type`: `'expandable-link-group'`.
-   * - `text` (string) - Specifies the text of the group link.
+   * - `text` (string|object) - Specifies the text of the group link.
    * - `href` (string) - Specifies the `href` of the group link.
    * - `defaultExpanded` (boolean) - Specifies whether the group should be expanded by default.
    *    If not explicitly set, the group is collapsed by default, unless one of the nested links is active.
@@ -117,7 +117,7 @@ export namespace SideNavigationProps {
     alt?: string;
   }
   export interface Header {
-    text?: string;
+    text?: string | React.ReactNode;
     href: string;
     logo?: Logo;
   }
@@ -128,7 +128,7 @@ export namespace SideNavigationProps {
 
   export interface Link {
     type: 'link';
-    text: string;
+    text: string | React.ReactNode;
     href: string;
     external?: boolean;
     externalIconAriaLabel?: string;
@@ -137,21 +137,21 @@ export namespace SideNavigationProps {
 
   export interface Section {
     type: 'section';
-    text: string;
+    text: string | React.ReactNode;
     items: ReadonlyArray<Item>;
     defaultExpanded?: boolean;
   }
 
   export interface LinkGroup {
     type: 'link-group';
-    text: string;
+    text: string | React.ReactNode;
     href: string;
     items: ReadonlyArray<Item>;
   }
 
   export interface ExpandableLinkGroup {
     type: 'expandable-link-group';
-    text: string;
+    text: string | React.ReactNode;
     href: string;
     items: ReadonlyArray<Item>;
     defaultExpanded?: boolean;


### PR DESCRIPTION
### Description

A CloudScape sample refers to navigation items text as a ReactNode and this doesn't work with typescript

Following this sample: https://github.com/cloudscape-design/demos/blob/main/src/pages/commons/common-components.jsx

```
export const ec2NavItems: SideNavigationProps.Item[] = [
  { type: 'link', text: 'Instances', href: '#/instances' },
  { type: 'link', text: 'Instance types', href: '#/instance-types' },
  { type: 'link', text: 'Launch templates', href: '#/launch-templates' },
  { type: 'link', text: 'Spot requests', href: '#/spot-requests' },
  { type: 'link', text: 'Saving plans', href: '#/saving-plans' },
  { type: 'link', text: 'Reserved instances', href: '#/reserved-instances' },
  { type: 'divider' },
  {
    type: 'link',
    text: (
      <>
        Notifications <Badge color="red">23</Badge>
      </>
    ),
    href: '#/notifications',
  },
  {
    type: 'link',
    text: (
      <>
        Documentation <Icon name="external" />
      </>
    ),
    href: '#/documentation',
  },
];
```
### How has this been tested?

![image](https://user-images.githubusercontent.com/881117/199515624-f2196328-43bb-42c9-97e0-1822a2d1946d.png)

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [X] _Yes, this change contains documentation changes._
- [ ] _No._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
