### PR TITLE
feat: Improve tabbing behavior for select, multiselect, and autosuggest with expandToViewport enabled

### DIFF
--- a/pages/dropdown/focus-trap.page.tsx
+++ b/pages/dropdown/focus-trap.page.tsx
@@ -9,7 +9,7 @@ import { Box, SpaceBetween, Button } from '~components';
 type PageContext = React.Context<
   AppContextType<{
     expandToViewport: boolean;
-    trapFocus: boolean;
+    loopFocus: boolean;
     disableHeader: boolean;
     disableContent: boolean;
     disableFooter: boolean;
@@ -20,7 +20,7 @@ export default function DropdownScenario() {
   const {
     urlParams: {
       expandToViewport = true,
-      trapFocus = true,
+      loopFocus = true,
       disableHeader = false,
       disableContent = false,
       disableFooter = false,
@@ -48,10 +48,10 @@ export default function DropdownScenario() {
           <label>
             <input
               type="checkbox"
-              checked={trapFocus}
-              onChange={event => setUrlParams({ trapFocus: event.target.checked })}
+              checked={loopFocus}
+              onChange={event => setUrlParams({ loopFocus: event.target.checked })}
             />
-            trapFocus
+            loopFocus
           </label>
 
           <label>
@@ -103,7 +103,7 @@ export default function DropdownScenario() {
                 </div>
               }
               expandToViewport={expandToViewport}
-              trapFocus={trapFocus}
+              loopFocus={loopFocus}
             >
               <div style={{ padding: 8 }}>
                 <Button disabled={disableContent}>content-1</Button>

--- a/pages/multiselect/multiselect.test.page.tsx
+++ b/pages/multiselect/multiselect.test.page.tsx
@@ -117,6 +117,7 @@ export default function MultiselectPage() {
   const [selectedOptions3, setSelectedOptions3] = React.useState<MultiselectProps.Options>([]);
   const [selectedOptions4, setSelectedOptions4] = React.useState<MultiselectProps.Options>(_selectedOptions1);
   const [selectedOptions5, setSelectedOptions5] = React.useState<MultiselectProps.Options>(_selectedOptions2);
+  const [selectedOptions6, setSelectedOptions6] = React.useState<MultiselectProps.Options>(_selectedOptions1);
 
   return (
     <article>
@@ -204,6 +205,25 @@ export default function MultiselectPage() {
             i18nStrings={i18nStrings}
             onChange={event => {
               setSelectedOptions5(event.detail.selectedOptions);
+            }}
+          />
+        </Box>
+
+        <Box padding="s">
+          <Box variant="h1">Test: Expand to viewport</Box>
+          <Multiselect
+            id="expand_to_viewport"
+            statusType="pending"
+            filteringType="none"
+            options={selectedOptions6}
+            placeholder={'Choose option'}
+            tokenLimit={3}
+            selectedOptions={selectedOptions1}
+            deselectAriaLabel={deselectAriaLabel}
+            i18nStrings={i18nStrings}
+            expandToViewport={true}
+            onChange={event => {
+              setSelectedOptions6(event.detail.selectedOptions);
             }}
           />
         </Box>

--- a/pages/select/select.test.async.page.tsx
+++ b/pages/select/select.test.async.page.tsx
@@ -40,6 +40,7 @@ export default class App extends React.Component {
     showFinishedText: boolean;
     fakeResponses: boolean;
     virtualScroll: boolean;
+    expandToViewport: boolean;
   } = {
     selectedOption: null,
     status: 'pending',
@@ -49,6 +50,7 @@ export default class App extends React.Component {
     showFinishedText: true,
     fakeResponses: false,
     virtualScroll: false,
+    expandToViewport: false,
   };
   pageNumber = 0;
 
@@ -155,6 +157,15 @@ export default class App extends React.Component {
             />
             Enable virtualization
           </label>
+          <label>
+            <input
+              id="expand-to-viewport"
+              type="checkbox"
+              checked={this.state.expandToViewport}
+              onChange={e => this.setState({ expandToViewport: !!e.target.checked })}
+            />
+            Expand to viewport
+          </label>
         </section>
         <Select
           selectedOption={this.state.selectedOption}
@@ -170,6 +181,7 @@ export default class App extends React.Component {
           onLoadItems={this.handleLoadItems}
           ariaLabel="async autosuggest"
           virtualScroll={this.state.virtualScroll}
+          expandToViewport={this.state.expandToViewport}
         />
         <input id="to-blur" aria-label="input to blur to" />
       </div>

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -41,6 +41,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     options,
     filteringType = 'auto',
     statusType = 'finished',
+    recoveryText,
     placeholder,
     name,
     disabled,
@@ -149,7 +150,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const highlightedOptionId = autosuggestItemsState.highlightedOption ? generateUniqueId() : undefined;
 
   const isEmpty = !value && !autosuggestItemsState.items.length;
-  const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });
+  const dropdownStatus = useDropdownStatus({ ...props, isEmpty, recoveryText, onRecoveryClick: handleRecoveryClick });
 
   return (
     <AutosuggestInput
@@ -198,6 +199,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
           <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
         ) : null
       }
+      loopFocus={statusType === 'error' && !!recoveryText}
       onCloseDropdown={handleCloseDropdown}
       onDelayedInput={handleDelayedInput}
       onPressArrowDown={handlePressArrowDown}

--- a/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
+++ b/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render as renderJsx } from '@testing-library/react';
-import { getFocusables } from '../../../../../lib/components/internal/components/focus-lock/utils';
 import AutosuggestInputWrapper from '../../../../../lib/components/test-utils/dom/internal/autosuggest-input';
 import AutosuggestInput, {
   AutosuggestInputRef,
@@ -151,58 +150,6 @@ describe('keyboard interactions', () => {
 
     wrapper.findInput().findNativeInput().keydown(KeyCode.right);
     expect(onKeyDown).toBeCalledTimes(5);
-  });
-});
-
-describe('dropdown focus trap', () => {
-  test('does not trap drodpown focus when content and footer are not interactive', () => {
-    const { wrapper } = render(
-      <AutosuggestInput
-        value="1"
-        onChange={() => undefined}
-        dropdownContent={<div>content</div>}
-        dropdownFooter={<div>footer</div>}
-      />
-    );
-    wrapper.findInput().findNativeInput().keydown(KeyCode.down);
-    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
-    expect(getFocusables(wrapper.getElement()).length).toBe(1);
-  });
-
-  test('traps drodpown focus when content is interactive', () => {
-    const { wrapper } = render(
-      <AutosuggestInput
-        value="1"
-        onChange={() => undefined}
-        dropdownContent={
-          <div>
-            <button>content click</button>
-          </div>
-        }
-        dropdownFooter={<div>footer</div>}
-      />
-    );
-    wrapper.findInput().findNativeInput().keydown(KeyCode.down);
-    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
-    expect(getFocusables(wrapper.getElement()).length).toBeGreaterThan(2);
-  });
-
-  test('traps drodpown focus when footer is interactive', () => {
-    const { wrapper } = render(
-      <AutosuggestInput
-        value="1"
-        onChange={() => undefined}
-        dropdownContent={<div>content</div>}
-        dropdownFooter={
-          <div>
-            <button>footer click</button>
-          </div>
-        }
-      />
-    );
-    wrapper.findInput().findNativeInput().keydown(KeyCode.down);
-    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
-    expect(getFocusables(wrapper.getElement()).length).toBeGreaterThan(2);
   });
 });
 

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -16,7 +16,6 @@ import {
   InputKeyEvents,
   InputProps,
 } from '../../../input/interfaces';
-import { getFocusables } from '../focus-lock/utils';
 import { ExpandToViewport } from '../dropdown/interfaces';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
 import { KeyCode } from '../../keycode';
@@ -39,6 +38,7 @@ export interface AutosuggestInputProps
   dropdownContent?: React.ReactNode;
   dropdownFooter?: React.ReactNode;
   dropdownWidth?: number;
+  loopFocus?: boolean;
   onCloseDropdown?: NonCancelableEventHandler<null>;
   onDelayedInput?: NonCancelableEventHandler<BaseChangeDetail>;
   onPressArrowDown?: () => void;
@@ -82,6 +82,7 @@ const AutosuggestInput = React.forwardRef(
       dropdownContent = null,
       dropdownFooter = null,
       dropdownWidth,
+      loopFocus,
       onCloseDropdown,
       onDelayedInput,
       onPressArrowDown,
@@ -124,14 +125,7 @@ const AutosuggestInput = React.forwardRef(
       close: closeDropdown,
     }));
 
-    const handleBlur: React.FocusEventHandler = event => {
-      if (
-        event.currentTarget.contains(event.relatedTarget) ||
-        dropdownContentRef.current?.contains(event.relatedTarget) ||
-        dropdownFooterRef.current?.contains(event.relatedTarget)
-      ) {
-        return;
-      }
+    const handleBlur = () => {
       if (!preventCloseOnBlurRef.current) {
         closeDropdown();
         fireNonCancelableEvent(onBlur, null);
@@ -225,17 +219,6 @@ const AutosuggestInput = React.forwardRef(
       'aria-activedescendant': ariaActivedescendant,
     };
 
-    const [trapDropdownFocus, setTrapDropdownFocus] = useState(false);
-
-    // Run this effect on every render to determine if necessary to trap focus around input and dropdown.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    useEffect(() => {
-      setTrapDropdownFocus(
-        (dropdownFooterRef.current ? getFocusables(dropdownFooterRef.current).length > 0 : false) ||
-          (dropdownContentRef.current ? getFocusables(dropdownContentRef.current).length > 0 : false)
-      );
-    });
-
     // Closes dropdown when outside click is detected.
     // Similar to the internal dropdown implementation but includes the target as well.
     useEffect(() => {
@@ -263,23 +246,19 @@ const AutosuggestInput = React.forwardRef(
     }, [open]);
 
     return (
-      <div
-        {...baseProps}
-        className={clsx(baseProps.className, styles.root)}
-        ref={__internalRootRef}
-        onBlur={handleBlur}
-      >
+      <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <Dropdown
           minWidth={dropdownWidth}
           stretchWidth={!dropdownWidth}
           contentKey={dropdownContentKey}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           trigger={
             <InternalInput
               type="visualSearch"
               value={value}
               onChange={event => handleChange(event.detail.value)}
               __onDelayedInput={event => handleDelayedInput(event.detail.value)}
-              onFocus={handleFocus}
               onKeyDown={handleKeyDown}
               onKeyUp={onKeyUp}
               disabled={disabled}
@@ -302,7 +281,7 @@ const AutosuggestInput = React.forwardRef(
             )
           }
           expandToViewport={expandToViewport}
-          trapFocus={trapDropdownFocus}
+          loopFocus={loopFocus}
         >
           {open && dropdownContent ? (
             <div ref={dropdownContentRef} className={styles['dropdown-content']}>

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -3,10 +3,10 @@
 import React, { useRef } from 'react';
 import { LinkProps } from '../../../link/interfaces';
 import InternalLink from '../../../link/internal';
-import { RecoveryLinkProp } from '../../../select/utils/use-select';
+import { RecoveryLinkProps } from '../../../select/utils/use-select';
 
 import InternalStatusIndicator from '../../../status-indicator/internal';
-import { NonCancelableEventHandler, fireNonCancelableEvent, fireCancelableEvent } from '../../events';
+import { NonCancelableEventHandler, fireNonCancelableEvent } from '../../events';
 import { usePrevious } from '../../hooks/use-previous';
 
 import { DropdownStatusProps } from './interfaces';
@@ -25,7 +25,7 @@ export interface DropdownStatusPropsExtended extends DropdownStatusProps {
    * to recover from the error.
    */
   onRecoveryClick?: NonCancelableEventHandler;
-  recoveryProps?: RecoveryLinkProp;
+  recoveryProps?: RecoveryLinkProps;
 }
 
 function DropdownStatus({ children }: { children: React.ReactNode }) {
@@ -67,7 +67,6 @@ export const useDropdownStatus: UseDropdownStatus = ({
   isNoMatch,
   noMatch,
   onRecoveryClick,
-  recoveryProps,
 }) => {
   const linkRef = useRef<LinkProps.Ref | null>(null);
   const focusRecoveryLink = () => linkRef.current?.focus();
@@ -78,16 +77,12 @@ export const useDropdownStatus: UseDropdownStatus = ({
     statusResult.content = <InternalStatusIndicator type={'loading'}>{loadingText}</InternalStatusIndicator>;
   } else if (statusType === 'error') {
     statusResult.content = (
-      <span
-        ref={recoveryProps ? recoveryProps.ref : null}
-        onBlur={event => fireCancelableEvent(recoveryProps?.onBlur, { relatedTarget: event.relatedTarget }, event)}
-      >
+      <span>
         <InternalStatusIndicator type="error" __animate={previousStatusType !== 'error'}>
           {errorText}
         </InternalStatusIndicator>{' '}
         {recoveryText && (
           <InternalLink
-            {...recoveryProps}
             ref={linkRef}
             onFollow={() => fireNonCancelableEvent(onRecoveryClick)}
             variant="recovery"

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -221,22 +221,18 @@ const Dropdown = ({
     }
   };
 
+  const isOutsideDropdown = (element: Element) =>
+    (!wrapperRef.current || !wrapperRef.current.contains(element)) &&
+    (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(element));
+
   const focusHandler = (event: React.FocusEvent) => {
-    const previouslyFocusedElement = event.relatedTarget;
-    if (
-      (!wrapperRef.current || !wrapperRef.current.contains(previouslyFocusedElement)) &&
-      (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(previouslyFocusedElement))
-    ) {
+    if (event.relatedTarget && isOutsideDropdown(event.relatedTarget)) {
       fireNonCancelableEvent(onFocus, event);
     }
   };
 
   const blurHandler = (event: React.FocusEvent) => {
-    const nextFocusedElement = event.relatedTarget;
-    if (
-      (!wrapperRef.current || !wrapperRef.current.contains(nextFocusedElement)) &&
-      (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(nextFocusedElement))
-    ) {
+    if (event.relatedTarget && isOutsideDropdown(event.relatedTarget)) {
       fireNonCancelableEvent(onBlur, event);
     }
   };

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -121,11 +121,15 @@ const Dropdown = ({
   interior = false,
   minWidth,
   scrollable = true,
-  trapFocus = false,
+  loopFocus = expandToViewport,
+  onFocus,
+  onBlur,
   contentKey,
 }: DropdownProps) => {
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const dropdownContainerRef = useRef<HTMLDivElement | null>(null);
   // This container is only needed to apply max-height to. We can't move max-height to it's parent
   // because of an IE11 issue with flexbox. https://github.com/philipwalton/flexbugs/issues/216
   const verticalContainerRef = useRef<HTMLDivElement>(null);
@@ -214,6 +218,26 @@ const Dropdown = ({
       setPosition('bottom-left');
     } else {
       setPosition('bottom-right');
+    }
+  };
+
+  const focusHandler = (event: React.FocusEvent) => {
+    const previouslyFocusedElement = event.relatedTarget;
+    if (
+      (!wrapperRef.current || !wrapperRef.current.contains(previouslyFocusedElement)) &&
+      (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(previouslyFocusedElement))
+    ) {
+      fireNonCancelableEvent(onFocus, event);
+    }
+  };
+
+  const blurHandler = (event: React.FocusEvent) => {
+    const nextFocusedElement = event.relatedTarget;
+    if (
+      (!wrapperRef.current || !wrapperRef.current.contains(nextFocusedElement)) &&
+      (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(nextFocusedElement))
+    ) {
+      fireNonCancelableEvent(onBlur, event);
     }
   };
 
@@ -331,6 +355,9 @@ const Dropdown = ({
         interior && styles.interior,
         stretchTriggerHeight && styles['stretch-trigger-height']
       )}
+      ref={wrapperRef}
+      onFocus={focusHandler}
+      onBlur={blurHandler}
     >
       <div className={clsx(stretchTriggerHeight && styles['stretch-trigger-height'])} ref={triggerRef}>
         {trigger}
@@ -338,16 +365,16 @@ const Dropdown = ({
 
       <TabTrap
         focusNextCallback={() => dropdownRef.current && getFirstFocusable(dropdownRef.current)?.focus()}
-        disabled={!open || !trapFocus}
+        disabled={!open || !loopFocus}
       />
 
       <DropdownContainer renderWithPortal={expandToViewport && !interior} id={dropdownId} open={open}>
         <Transition in={open ?? false} exit={false}>
           {(state, ref) => (
-            <div onBlur={event => trapFocus && event.stopPropagation()}>
+            <div ref={dropdownContainerRef}>
               <TabTrap
                 focusNextCallback={() => triggerRef.current && getLastFocusable(triggerRef.current)?.focus()}
-                disabled={!open || !trapFocus}
+                disabled={!open || !loopFocus}
               />
 
               <TransitionContent
@@ -371,7 +398,7 @@ const Dropdown = ({
 
               <TabTrap
                 focusNextCallback={() => triggerRef.current && getFirstFocusable(triggerRef.current)?.focus()}
-                disabled={!open || !trapFocus}
+                disabled={!open || !loopFocus}
               />
             </div>
           )}

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -226,13 +226,13 @@ const Dropdown = ({
     (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(element));
 
   const focusHandler = (event: React.FocusEvent) => {
-    if (event.relatedTarget && isOutsideDropdown(event.relatedTarget)) {
+    if (!event.relatedTarget || isOutsideDropdown(event.relatedTarget)) {
       fireNonCancelableEvent(onFocus, event);
     }
   };
 
   const blurHandler = (event: React.FocusEvent) => {
-    if (event.relatedTarget && isOutsideDropdown(event.relatedTarget)) {
+    if (!event.relatedTarget || isOutsideDropdown(event.relatedTarget)) {
       fireNonCancelableEvent(onBlur, event);
     }
   };

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -117,10 +117,21 @@ export interface DropdownProps extends ExpandToViewport {
    * Whether the dropdown will have a scrollbar or not
    */
   scrollable?: boolean;
+
   /**
    * Whether the dropdown will have a focus trap including trigger, header, content and footer.
    */
-  trapFocus?: boolean;
+  loopFocus?: boolean;
+
+  /**
+   * Called when focus enters the trigger or dropdown content.
+   */
+  onFocus?: NonCancelableEventHandler<Pick<React.FocusEvent, 'target' | 'relatedTarget'>>;
+
+  /**
+   * Called when focus leaves the trigger or dropdown content.
+   */
+  onBlur?: NonCancelableEventHandler<Pick<React.FocusEvent, 'target' | 'relatedTarget'>>;
 }
 
 export interface ExpandToViewport {

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -119,7 +119,7 @@ export interface DropdownProps extends ExpandToViewport {
   scrollable?: boolean;
 
   /**
-   * Whether the dropdown will have a focus trap including trigger, header, content and footer.
+   * Whether the dropdown will have a focus loop including trigger, header, content and footer.
    */
   loopFocus?: boolean;
 

--- a/src/multiselect/__integ__/multiselect.test.ts
+++ b/src/multiselect/__integ__/multiselect.test.ts
@@ -134,6 +134,18 @@ describe('focus handling', () => {
       await expect(page.getSelectedText()).resolves.toEqual('selectme');
     })();
   });
+
+  test('should move focus back to the trigger if expandToViewport=true', () => {
+    const wrapper = createWrapper().findMultiselect('#expand_to_viewport');
+    const setupTest = createSetupTest(wrapper);
+
+    return setupTest(async page => {
+      await page.clickSelect();
+      await page.keys(['Tab']);
+      await page.waitForVisible(wrapper.findDropdown({ expandToViewport: true }).toSelector(), false);
+      await expect(page.isFocused(wrapper.findTrigger().toSelector())).resolves.toBe(true);
+    })();
+  });
 });
 
 describe(`Multiselect with filtering`, () => {

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -136,8 +136,8 @@ const InternalMultiselect = React.forwardRef(
       highlightedOption,
       highlightedIndex,
       getTriggerProps,
+      getDropdownProps,
       getFilterProps,
-      getRecoveryProps,
       getMenuProps,
       getOptionProps,
       highlightOption,
@@ -177,7 +177,6 @@ const InternalMultiselect = React.forwardRef(
       isNoMatch,
       noMatch,
       onRecoveryClick: handleRecoveryClick,
-      recoveryProps: getRecoveryProps(),
     });
 
     const filter = (
@@ -271,6 +270,7 @@ const InternalMultiselect = React.forwardRef(
         onKeyPress={handleNativeSearch}
       >
         <Dropdown
+          {...getDropdownProps()}
           open={isOpen}
           trigger={trigger}
           header={filter}

--- a/src/select/__integ__/events-select.test.ts
+++ b/src/select/__integ__/events-select.test.ts
@@ -128,6 +128,12 @@ describe.each<[boolean, boolean]>([
         await page.keys(['ArrowDown']);
         await page.clearEventList();
 
+        // With expandToViewport, focus is returned back to the trigger.
+        if (expandToViewport) {
+          await page.keys(['Tab']);
+          await page.assertEventsFired([]);
+        }
+
         await page.keys(['Tab']);
         await page.assertEventsFired(['onBlur']);
       },

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -86,7 +86,7 @@ describe('useSelect', () => {
 
     test('should return getTriggerProps that configures the trigger', () => {
       const triggerProps = getTriggerProps();
-      expect(Object.keys(triggerProps)).toEqual(['ref', 'onFocus', 'onBlur', 'onMouseDown', 'onKeyDown']);
+      expect(Object.keys(triggerProps)).toEqual(['ref', 'onFocus', 'onMouseDown', 'onKeyDown']);
       expect(triggerProps.ref).toEqual({ current: null });
     });
 

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -97,8 +97,8 @@ const InternalSelect = React.forwardRef(
       highlightedOption,
       highlightedIndex,
       getTriggerProps,
+      getDropdownProps,
       getFilterProps,
-      getRecoveryProps,
       getMenuProps,
       getOptionProps,
       highlightOption,
@@ -173,7 +173,6 @@ const InternalSelect = React.forwardRef(
       isNoMatch,
       noMatch,
       onRecoveryClick: handleRecoveryClick,
-      recoveryProps: getRecoveryProps(),
     });
 
     const announcement = useAnnouncement({
@@ -205,6 +204,7 @@ const InternalSelect = React.forwardRef(
         onKeyPress={handleNativeSearch}
       >
         <Dropdown
+          {...getDropdownProps()}
           open={isOpen}
           stretchTriggerHeight={__inFilteringToken}
           trigger={trigger}

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -15,8 +15,12 @@ import { OptionsListProps } from '../../internal/components/options-list';
 import { FilterProps } from '../parts/filter';
 import { ItemProps } from '../parts/item';
 import { usePrevious } from '../../internal/hooks/use-previous';
-import { BaseKeyDetail, NonCancelableEventHandler } from '../../internal/events';
-import { CancelableEventHandler, fireNonCancelableEvent } from '../../internal/events/index';
+import {
+  BaseKeyDetail,
+  NonCancelableEventHandler,
+  CancelableEventHandler,
+  fireNonCancelableEvent,
+} from '../../internal/events';
 
 export type MenuProps = Omit<OptionsListProps, 'children'> & { ref: React.RefObject<HTMLUListElement> };
 export type GetOptionProps = (option: DropdownOption, index: number) => ItemProps;

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { RefObject } from 'react';
+import { DropdownProps } from '../../internal/components/dropdown/interfaces';
 import { DropdownOption, OptionDefinition, OptionGroup } from '../../internal/components/option/interfaces';
 import { isInteractive, isGroupInteractive, isGroup } from '../../internal/components/option/utils/filter-options';
-import { useEffect, useRef, MutableRefObject } from 'react';
+import { useEffect, useRef } from 'react';
 import { useHighlightedOption } from '../../internal/components/options-list/utils/use-highlight-option';
 import { useOpenState } from '../../internal/components/options-list/utils/use-open-state';
 import { useMenuKeyboard, useTriggerKeyboard } from '../../internal/components/options-list/utils/use-keyboard';
@@ -14,9 +15,8 @@ import { OptionsListProps } from '../../internal/components/options-list';
 import { FilterProps } from '../parts/filter';
 import { ItemProps } from '../parts/item';
 import { usePrevious } from '../../internal/hooks/use-previous';
-import { BaseKeyDetail } from '../../internal/events';
-import { CancelableEventHandler, fireCancelableEvent, NonCancelableEventHandler } from '../../internal/events/index';
-import { containsOrEqual } from '../../internal/utils/dom';
+import { BaseKeyDetail, NonCancelableEventHandler } from '../../internal/events';
+import { CancelableEventHandler, fireNonCancelableEvent } from '../../internal/events/index';
 
 export type MenuProps = Omit<OptionsListProps, 'children'> & { ref: React.RefObject<HTMLUListElement> };
 export type GetOptionProps = (option: DropdownOption, index: number) => ItemProps;
@@ -27,8 +27,8 @@ interface UseSelectProps {
   options: ReadonlyArray<DropdownOption>;
   filteringType: string;
   keepOpen?: boolean;
-  onBlur?: CancelableEventHandler;
-  onFocus?: CancelableEventHandler;
+  onBlur?: NonCancelableEventHandler;
+  onFocus?: NonCancelableEventHandler;
   externalRef: React.Ref<any>;
   fireLoadItems: (filteringText: string) => void;
   setFilteringValue: (filteringText: string) => void;
@@ -41,10 +41,9 @@ export interface SelectTriggerProps {
   onKeyDown?: (event: CustomEvent<BaseKeyDetail>) => void;
   ariaLabelledby?: string;
   onFocus: NonCancelableEventHandler;
-  onBlur: CancelableEventHandler<{ relatedTarget: Node | null }>;
 }
 
-export interface RecoveryLinkProp {
+export interface RecoveryLinkProps {
   ref: RefObject<HTMLAnchorElement>;
   onBlur: CancelableEventHandler<{ relatedTarget: Node | null }>;
 }
@@ -69,7 +68,6 @@ export function useSelect({
   const filterRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLUListElement>(null);
-  const linkRef = useRef<HTMLAnchorElement>(null);
   const hasFilter = filteringType !== 'none';
   const activeRef = hasFilter ? filterRef : menuRef;
   const isSelectingUsingSpace = useRef<boolean>(false);
@@ -100,32 +98,13 @@ export function useSelect({
     },
   });
 
-  const focused: MutableRefObject<boolean> = useRef<boolean>(false);
   const handleFocus = () => {
-    if (!focused.current) {
-      fireCancelableEvent(onFocus, {});
-      focused.current = true;
-    }
+    fireNonCancelableEvent(onFocus, {});
   };
-  const handleBlur = ({ detail }: { detail: { relatedTarget: Node | null } }) => {
-    const { relatedTarget } = detail;
 
-    const nextFocusedIsTrigger = relatedTarget ? containsOrEqual(triggerRef.current, relatedTarget) : false;
-    const nextFocusedInsideDropdown = relatedTarget
-      ? containsOrEqual(menuRef.current, relatedTarget) ||
-        containsOrEqual(filterRef.current, relatedTarget) ||
-        containsOrEqual(linkRef.current, relatedTarget)
-      : false;
-    const nextFocusedInsideComponent = nextFocusedIsTrigger || nextFocusedInsideDropdown;
-    const focusingOut = focused.current && !nextFocusedInsideComponent;
-
-    if (nextFocusedIsTrigger || focusingOut) {
-      closeDropdown();
-    }
-    if (focusingOut) {
-      fireCancelableEvent(onBlur, {});
-      focused.current = false;
-    }
+  const handleBlur = () => {
+    fireNonCancelableEvent(onBlur, {});
+    closeDropdown();
   };
 
   const hasSelectedOption = __selectedOptions.length > 0;
@@ -160,11 +139,15 @@ export function useSelect({
 
   const triggerKeyDownHandler = useTriggerKeyboard({ openDropdown, goHome: goHomeWithKeyboard });
 
+  const getDropdownProps: () => Pick<DropdownProps, 'onFocus' | 'onBlur'> = () => ({
+    onFocus: handleFocus,
+    onBlur: handleBlur,
+  });
+
   const getTriggerProps = (disabled = false) => {
     const triggerProps: SelectTriggerProps = {
       ref: triggerRef,
-      onFocus: handleFocus,
-      onBlur: handleBlur,
+      onFocus: () => closeDropdown(),
     };
     if (!disabled) {
       triggerProps.onMouseDown = (event: CustomEvent) => {
@@ -190,8 +173,6 @@ export function useSelect({
     return {
       ref: filterRef,
       onKeyDown: activeKeyDownHandler,
-      __onBlurWithDetail: handleBlur,
-      onFocus: handleFocus,
       onChange: event => {
         setFilteringValue(event.detail.value);
         resetHighlightWithKeyboard();
@@ -207,20 +188,11 @@ export function useSelect({
     };
   };
 
-  const getRecoveryProps = () => {
-    return {
-      ref: linkRef,
-      onBlur: handleBlur,
-    };
-  };
-
   const getMenuProps = () => {
     const menuProps: MenuProps = {
       id: menuId,
       ref: menuRef,
       open: isOpen,
-      onFocus: handleFocus,
-      onBlur: handleBlur,
       onMouseUp: itemIndex => {
         if (itemIndex > -1) {
           selectOption(options[itemIndex]);
@@ -234,8 +206,6 @@ export function useSelect({
     };
     if (!hasFilter) {
       menuProps.onKeyDown = activeKeyDownHandler;
-      menuProps.onBlur = handleBlur;
-      menuProps.onFocus = handleFocus;
       menuProps.nativeAttributes = {
         'aria-activedescendant': highlightedOptionId,
       };
@@ -305,9 +275,9 @@ export function useSelect({
     highlightedIndex,
     highlightType,
     getTriggerProps,
+    getDropdownProps,
     getMenuProps,
     getFilterProps,
-    getRecoveryProps,
     getOptionProps,
     highlightOption: highlightOptionWithKeyboard,
     selectOption,


### PR DESCRIPTION
### Description

Hey, look at me. Take a deep breath. We're going to get through this. I'll be overexplaining this but it's not a particularly complicated PR.

So, what's the problem? Basically, when you have `expandToViewport` set to `true`, the dropdown is positioned at the end of the DOM. With select and multiselect, the focus gets moved into the options list inside the dropdown. Then, you hit `Tab`, and you're sent off the page instead of to the element after the select trigger. Not good UX.

```
<!-- We want this! -->
<select>
  <trigger /> [1. start here]
  <dropdown>
    <options-list /> [2. focus automatically moved here]
  <dropdown />
</select>

<some-input /> [3. hitting tab gets you here]
```

```
<!-- But this is what happens -->
<select>
  <trigger /> [1. start here]
</select>

<some-input /> [you skipped me :(]

<portal>
  <dropdown>
    <options-list /> [2. focus automatically moved here]
  <dropdown />
</portal>

</body> [3. hitting tab gets you here, i guess???]
```

Okay, so why not do some browser magic to figure out which element is next after the tab order, detect when we tab out of the dropdown, and then move the focus into the next element transparently? Sounds like fun, but it's strewn with edge cases and potential focus traps (but if you want to try, you're welcome to pick up from where I gave up in #201).

There is an alternate solution. With the autosuggest, the focus stays with the input, but when there's an async error, a `Tab` sends you to the "Retry" link (`recoveryText`). The next `Tab` sends you back to the input in a kind of infinite `Tab` loop, but one that can be broken by just dismissing the suggestions (hitting `Esc`). We want this for select and multiselect too (except when we tab back, the dropdown closes). So let's move this behavior into the shared dropdown component.

```
<!-- And this is the fix! -->
<select>
  <trigger /> [1. start here] [3. tabbing forward gets you here again, but closes the dropdown]
</select>

<some-input /> [4. yay!]

<portal>
  <dropdown>
    <options-list /> [2. focus automatically moved here]
  <dropdown />
</portal>
```

### Changes

One: Add a new property to the dropdown called `loopFocus`, which sends the focus back to the trigger when attempting to tab past the dropdown content. It's enabled by default when `expandToViewport` is enabled.

Two: Let's add focus/blur handlers too to simplify upstream implementations. Check out how much manual focus-tracking complexity that removed in `use-select.ts` and `autosuggest-input/index.tsx`! We shipped a completely new tabbing behavior for select and multiselect, with almost no diff in line count.

### How has this been tested?

A whole day of fighting with integration tests, basically! The dropdown loop flag itself doesn't have any new tests, but it's tested through select, multiselect, and autosuggest. I'd also encourage playing around with the behavior yourself manually.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
