### PR TITLE
feat: Add aria label for pagination group

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7851,6 +7851,8 @@ Object {
   "properties": Array [
     Object {
       "description": "Adds aria-labels to the pagination buttons:
+* \`paginationLabel\` (string) - Label for the entire pagination group. It allows users to distinguish context
+* in cases of multiple pagination components in a page.
 * \`previousPageLabel\` (string) - Previous page button.
 * \`pageLabel\` (number => string) - Individual page button, this function is called for every page number that's rendered.
 * \`nextPageLabel\` (string) - Next page button
@@ -7858,6 +7860,7 @@ Example:
 \`\`\`
 {
   nextPageLabel: 'Next page',
+  paginationLabel: 'Table pagination'
   previousPageLabel: 'Previous page',
   pageLabel: pageNumber => \`Page \${pageNumber}\`
 }
@@ -7875,6 +7878,11 @@ Example:
             "name": "pageLabel",
             "optional": true,
             "type": "(pageNumber: number) => string",
+          },
+          Object {
+            "name": "paginationLabel",
+            "optional": true,
+            "type": "string",
           },
           Object {
             "name": "previousPageLabel",

--- a/src/pagination/__tests__/pagination.test.tsx
+++ b/src/pagination/__tests__/pagination.test.tsx
@@ -230,11 +230,13 @@ describe('aria-labels', () => {
         pagesCount={10}
         ariaLabels={{
           nextPageLabel: 'Next page',
+          paginationLabel: 'Table pagination',
           previousPageLabel: 'Previous page',
           pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
         }}
       />
     );
+    expect(wrapper.getElement()).toHaveAttribute('aria-label', 'Table pagination');
     expect(wrapper.findPreviousPageButton().getElement()).toHaveAttribute('aria-label', 'Previous page');
     expect(wrapper.findNextPageButton().getElement()).toHaveAttribute('aria-label', 'Next page');
     expect(wrapper.findPageNumberByIndex(1)!.getElement()).toHaveAttribute('aria-label', 'Page 1 of all pages');

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -30,6 +30,8 @@ export interface PaginationProps {
 
   /**
    * Adds aria-labels to the pagination buttons:
+   * * `paginationLabel` (string) - Label for the entire pagination group. It allows users to distinguish context
+   * * in cases of multiple pagination components in a page.
    * * `previousPageLabel` (string) - Previous page button.
    * * `pageLabel` (number => string) - Individual page button, this function is called for every page number that's rendered.
    * * `nextPageLabel` (string) - Next page button
@@ -38,6 +40,7 @@ export interface PaginationProps {
    * ```
    * {
    *   nextPageLabel: 'Next page',
+   *   paginationLabel: 'Table pagination'
    *   previousPageLabel: 'Previous page',
    *   pageLabel: pageNumber => `Page ${pageNumber}`
    * }
@@ -69,6 +72,7 @@ export interface PaginationProps {
 export namespace PaginationProps {
   export interface Labels {
     nextPageLabel?: string;
+    paginationLabel?: string;
     previousPageLabel?: string;
     pageLabel?: (pageNumber: number) => string;
   }

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -13,6 +13,7 @@ import { PaginationProps } from './interfaces';
 
 const defaultAriaLabels: Required<PaginationProps.Labels> = {
   nextPageLabel: '',
+  paginationLabel: '',
   previousPageLabel: '',
   pageLabel: pageNumber => `${pageNumber}`,
 };
@@ -111,6 +112,7 @@ export default function InternalPagination({
 
   return (
     <ul
+      aria-label={ariaLabels?.paginationLabel}
       {...baseProps}
       className={clsx(baseProps.className, styles.root, disabled && styles['root-disabled'])}
       ref={__internalRootRef}


### PR DESCRIPTION
### Description

New area-label property for Pagination component.
Allows users to distinguish context in cases of multiple pagination components in a page.

### How has this been tested?

Manually tested using VoiceOver and NVDA.
Unit test updated.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
