### PR TITLE
Remove the AppLayout contentType dependency for stickyHeader behavior.

### DIFF
--- a/src/app-layout/visual-refresh/app-bar.scss
+++ b/src/app-layout/visual-refresh/app-bar.scss
@@ -89,13 +89,22 @@ section.appbar {
     }
 
     /*
-    If the content type supports a dark sticky header then 
-    minimal bottom padding should be on the breadcrumbs to
+    Table and cards content types implement a custom dark header. 
+    Minimal bottom padding should be on the breadcrumbs to
     reduce the the vertical distance from the main content.
     */
     > .breadcrumbs.content-type-cards,
     > .breadcrumbs.content-type-table {
       padding-bottom: awsui.$space-xxs;
+    }
+
+    /*
+    If a child component tells the AppLayout to have a sticky 
+    background (typically because of a stickyHeader with a 
+    full-page variant) the z-index of the breadcrumbs needs to 
+    be lifted so it doesn't render behind the background element.
+    */
+    > .breadcrumbs.has-sticky-background {
       z-index: 799;
     }
   }

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -22,6 +22,7 @@ export default function AppBar() {
     handleNavigationClick,
     handleToolsClick,
     hasNotificationsContent,
+    hasStickyBackground,
     isMobile,
     navigationHide,
     isNavigationOpen,
@@ -75,6 +76,7 @@ export default function AppBar() {
             [styles['has-dynamic-overlap-height']]: dynamicOverlapHeight > 0,
             [styles['has-header']]: contentHeader,
             [styles['has-notifications-content']]: hasNotificationsContent,
+            [styles['has-sticky-background']]: hasStickyBackground,
           })}
         >
           {breadcrumbs}

--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -21,8 +21,7 @@ div.background {
     behind the notifications above the content dark header.
     */
     @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
-      &.content-type-cards.has-notifications-content.sticky-notifications,
-      &.content-type-table.has-notifications-content.sticky-notifications {
+      &.has-sticky-background.has-notifications-content.sticky-notifications {
         position: sticky;
         top: var(#{custom-props.$offsetTop});
         z-index: 799;
@@ -42,7 +41,7 @@ div.background {
     the high contrast header background only in the content area.
     */
     @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
-      &.has-sticky-overlap {
+      &.has-sticky-background {
         position: sticky;
         top: var(#{custom-props.$offsetTopWithNotifications});
         z-index: 799;

--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -36,15 +36,13 @@ div.background {
     grid-row: 4;
 
     /*
-    The cards and table content types have sticky header content that 
-    will retain position on viewport scroll. They are setting the 
-    dynamicOverlapHeight property in the AppLayout context with a container query 
-    that observes the content height. The background needs to be sticky in 
-    desktop viewports without overlapping notification content if it exists.
+    The cards and table content types can have sticky header content that 
+    will retain position on viewport scroll. The overlap background needs to 
+    be sticky in desktop viewports to prevent light background gutters with 
+    the high contrast header background only in the content area.
     */
     @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
-      &.content-type-cards,
-      &.content-type-table {
+      &.has-sticky-overlap {
         position: sticky;
         top: var(#{custom-props.$offsetTopWithNotifications});
         z-index: 799;

--- a/src/app-layout/visual-refresh/background.tsx
+++ b/src/app-layout/visual-refresh/background.tsx
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Background() {
-  const { contentType, hasNotificationsContent, stickyNotifications } = useContext(AppLayoutContext);
+  const { contentType, hasNotificationsContent, stickyNotifications, hasStickyOverlap } = useContext(AppLayoutContext);
 
   return (
     <div className={clsx(styles.background, 'awsui-context-content-header')}>
@@ -21,7 +21,11 @@ export default function Background() {
         })}
       />
 
-      <div className={clsx(styles.overlap, styles[`content-type-${contentType}`])} />
+      <div
+        className={clsx(styles.overlap, styles[`content-type-${contentType}`], {
+          [styles['has-sticky-overlap']]: hasStickyOverlap,
+        })}
+      />
     </div>
   );
 }

--- a/src/app-layout/visual-refresh/background.tsx
+++ b/src/app-layout/visual-refresh/background.tsx
@@ -10,20 +10,21 @@ import styles from './styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Background() {
-  const { contentType, hasNotificationsContent, stickyNotifications, hasStickyOverlap } = useContext(AppLayoutContext);
+  const { hasNotificationsContent, hasStickyBackground, stickyNotifications } = useContext(AppLayoutContext);
 
   return (
     <div className={clsx(styles.background, 'awsui-context-content-header')}>
       <div
-        className={clsx(styles['notifications-appbar-header'], styles[`content-type-${contentType}`], {
+        className={clsx(styles['notifications-appbar-header'], {
           [styles['has-notifications-content']]: hasNotificationsContent,
+          [styles['has-sticky-background']]: hasStickyBackground,
           [styles['sticky-notifications']]: stickyNotifications,
         })}
       />
 
       <div
-        className={clsx(styles.overlap, styles[`content-type-${contentType}`], {
-          [styles['has-sticky-overlap']]: hasStickyOverlap,
+        className={clsx(styles.overlap, {
+          [styles['has-sticky-background']]: hasStickyBackground,
         })}
       />
     </div>

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -32,7 +32,7 @@ interface AppLayoutContextProps extends AppLayoutProps {
   handleToolsClick: (value: boolean) => void;
   hasDefaultToolsWidth: boolean;
   hasNotificationsContent: boolean;
-  hasStickyOverlap: boolean;
+  hasStickyBackground: boolean;
   isAnyPanelOpen: boolean;
   isMobile: boolean;
   isNavigationOpen: boolean;
@@ -47,7 +47,7 @@ interface AppLayoutContextProps extends AppLayoutProps {
   notificationsHeight: number;
   offsetBottom: number;
   setDynamicOverlapHeight: (value: number) => void;
-  setHasStickyOverlap: (value: boolean) => void;
+  setHasStickyBackground: (value: boolean) => void;
   setIsNavigationOpen: (value: boolean) => void;
   setIsToolsOpen: (value: boolean) => void;
   setOffsetBottom: (value: number) => void;
@@ -80,7 +80,7 @@ const defaults: AppLayoutContextProps = {
   handleToolsClick: (value: boolean) => value,
   hasDefaultToolsWidth: true,
   hasNotificationsContent: false,
-  hasStickyOverlap: false,
+  hasStickyBackground: false,
   isAnyPanelOpen: false,
   isMobile: false,
   isNavigationOpen: false,
@@ -106,7 +106,7 @@ const defaults: AppLayoutContextProps = {
   onSplitPanelToggle: () => {},
   onSplitPanelPreferencesChange: () => {},
   setDynamicOverlapHeight: (value: number) => void value,
-  setHasStickyOverlap: (value: boolean) => value,
+  setHasStickyBackground: (value: boolean) => value,
   setIsNavigationOpen: (value: boolean) => value,
   setIsToolsOpen: (value: boolean) => value,
   setOffsetBottom: (value: number) => void value,
@@ -163,11 +163,11 @@ export const AppLayoutProvider = React.forwardRef(
     /**
      * The overlap height has a default set in CSS but can also be dynamically overridden
      * for content types (such as Table and Wizard) that have variable size content in the overlap.
-     * If a child component utilizes a sticky header the hasStickyOverlap property will determine
-     * if the overlap remains in the same vertical position.
+     * If a child component utilizes a sticky header the hasStickyBackground property will determine
+     * if the background remains in the same vertical position.
      */
     const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState(0);
-    const [hasStickyOverlap, setHasStickyOverlap] = useState(false);
+    const [hasStickyBackground, setHasStickyBackground] = useState(false);
 
     /**
      * Set the default values for minimum and maximum content width.
@@ -529,7 +529,7 @@ export const AppLayoutProvider = React.forwardRef(
           handleSplitPanelResize,
           handleToolsClick,
           hasNotificationsContent,
-          hasStickyOverlap,
+          hasStickyBackground,
           isAnyPanelOpen,
           isMobile,
           isNavigationOpen: isNavigationOpen ?? false,
@@ -547,7 +547,7 @@ export const AppLayoutProvider = React.forwardRef(
           notificationsHeight,
           offsetBottom,
           setDynamicOverlapHeight,
-          setHasStickyOverlap,
+          setHasStickyBackground,
           setOffsetBottom,
           setSplitPanelReportedSize,
           splitPanelMaxWidth,

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -32,6 +32,7 @@ interface AppLayoutContextProps extends AppLayoutProps {
   handleToolsClick: (value: boolean) => void;
   hasDefaultToolsWidth: boolean;
   hasNotificationsContent: boolean;
+  hasStickyOverlap: boolean;
   isAnyPanelOpen: boolean;
   isMobile: boolean;
   isNavigationOpen: boolean;
@@ -46,6 +47,7 @@ interface AppLayoutContextProps extends AppLayoutProps {
   notificationsHeight: number;
   offsetBottom: number;
   setDynamicOverlapHeight: (value: number) => void;
+  setHasStickyOverlap: (value: boolean) => void;
   setIsNavigationOpen: (value: boolean) => void;
   setIsToolsOpen: (value: boolean) => void;
   setOffsetBottom: (value: number) => void;
@@ -78,6 +80,7 @@ const defaults: AppLayoutContextProps = {
   handleToolsClick: (value: boolean) => value,
   hasDefaultToolsWidth: true,
   hasNotificationsContent: false,
+  hasStickyOverlap: false,
   isAnyPanelOpen: false,
   isMobile: false,
   isNavigationOpen: false,
@@ -103,6 +106,7 @@ const defaults: AppLayoutContextProps = {
   onSplitPanelToggle: () => {},
   onSplitPanelPreferencesChange: () => {},
   setDynamicOverlapHeight: (value: number) => void value,
+  setHasStickyOverlap: (value: boolean) => value,
   setIsNavigationOpen: (value: boolean) => value,
   setIsToolsOpen: (value: boolean) => value,
   setOffsetBottom: (value: number) => void value,
@@ -159,8 +163,11 @@ export const AppLayoutProvider = React.forwardRef(
     /**
      * The overlap height has a default set in CSS but can also be dynamically overridden
      * for content types (such as Table and Wizard) that have variable size content in the overlap.
+     * If a child component utilizes a sticky header the hasStickyOverlap property will determine
+     * if the overlap remains in the same vertical position.
      */
     const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState(0);
+    const [hasStickyOverlap, setHasStickyOverlap] = useState(false);
 
     /**
      * Set the default values for minimum and maximum content width.
@@ -522,6 +529,7 @@ export const AppLayoutProvider = React.forwardRef(
           handleSplitPanelResize,
           handleToolsClick,
           hasNotificationsContent,
+          hasStickyOverlap,
           isAnyPanelOpen,
           isMobile,
           isNavigationOpen: isNavigationOpen ?? false,
@@ -539,6 +547,7 @@ export const AppLayoutProvider = React.forwardRef(
           notificationsHeight,
           offsetBottom,
           setDynamicOverlapHeight,
+          setHasStickyOverlap,
           setOffsetBottom,
           setSplitPanelReportedSize,
           splitPanelMaxWidth,

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -50,7 +50,7 @@ export default function InternalContainer({
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
-  const { setHasStickyOverlap } = useContext(AppLayoutContext);
+  const { setHasStickyBackground } = useContext(AppLayoutContext);
   const isRefresh = useVisualRefresh();
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
@@ -62,21 +62,20 @@ export default function InternalContainer({
 
   /**
    * The visual refresh AppLayout component needs to know if a child component
-   * has a high constrast sticky header. This is to make sure the overlap element
-   * determined by the dynamicOverlapHeight property stays in the same vertical
-   * position as the header content.
+   * has a high constrast sticky header. This is to make sure the background element
+   * stays in the same vertical position as the header content.
    */
   useLayoutEffect(
-    function handleHasStickyOverlap() {
+    function handleHasStickyBackground() {
       if (isRefresh && isSticky && variant === 'full-page') {
-        setHasStickyOverlap(true);
+        setHasStickyBackground(true);
       }
 
       return function cleanup() {
-        setHasStickyOverlap(false);
+        setHasStickyBackground(false);
       };
     },
-    [isRefresh, isSticky, setHasStickyOverlap, variant]
+    [isRefresh, isSticky, setHasStickyBackground, variant]
   );
 
   return (


### PR DESCRIPTION
Currently the `AppLayout` component is using the `contentType` property to determine whether or not a child component is implementing `stickyHeader` behavior. The assumption was that the `cards` and `table` content types would always be accompanied by the use of a sticky header. This was not the case in classic thus creating a feature dependency in visual refresh that is considered a regression.

This PR adds a new property to the visual refresh `AppLayout` component called `hasStickyBackground`. A child component will communicate up via the `AppLayout` context to determine whether or not a sticky header is implemented independent of the `contentType` property.