### PR TITLE
fix: Remove aria-controls and aria-owns when autosuggest dropdown is closed

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -204,6 +204,7 @@ describe('a11y props', () => {
     const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} options={[]} />);
     const input = wrapper.findNativeInput().getElement();
     wrapper.findNativeInput().focus();
+    expect(input).toHaveAttribute('aria-controls', expect.stringContaining('random-'));
     expect(input).toHaveAttribute('aria-owns', expect.stringContaining('random-'));
   });
 

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -194,9 +194,17 @@ describe('a11y props', () => {
     const input = wrapper.findNativeInput().getElement();
     expect(input).toHaveAttribute('aria-autocomplete', 'list');
     expect(input).toHaveAttribute('aria-expanded', 'false');
-    expect(input).toHaveAttribute('aria-controls', expect.stringContaining('random-'));
+    expect(input).not.toHaveAttribute('aria-controls');
+    expect(input).not.toHaveAttribute('aria-owns');
     expect(input).not.toHaveAttribute('aria-label');
     expect(input).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  test('has correct aria property when suggestion dialog is open', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} options={[]} />);
+    const input = wrapper.findNativeInput().getElement();
+    wrapper.findNativeInput().focus();
+    expect(input).toHaveAttribute('aria-owns', expect.stringContaining('random-'));
   });
 
   test('adds correct aria properties to input when expanded', () => {

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -212,6 +212,7 @@ const AutosuggestInput = React.forwardRef(
       role: 'combobox',
       'aria-autocomplete': 'list',
       'aria-expanded': expanded,
+      'aria-controls': open ? ariaControls : undefined,
       // 'aria-owns' needed for safari+vo to announce activedescendant content
       'aria-owns': open ? ariaControls : undefined,
       'aria-label': ariaLabel,

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -212,9 +212,8 @@ const AutosuggestInput = React.forwardRef(
       role: 'combobox',
       'aria-autocomplete': 'list',
       'aria-expanded': expanded,
-      'aria-controls': ariaControls,
       // 'aria-owns' needed for safari+vo to announce activedescendant content
-      'aria-owns': ariaControls,
+      'aria-owns': open ? ariaControls : undefined,
       'aria-label': ariaLabel,
       'aria-activedescendant': ariaActivedescendant,
     };


### PR DESCRIPTION
### Description

When the suggestions are collapsed, the aria-owns/aria-controls attributes on the field refers to a non-existent ID. so 
 removing aria-owns/aria-controls when the dropdown is closed and only show it on open
### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
