### PR TITLE
feat: Add .focus() ref method to tiles and radio group

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -9020,7 +9020,14 @@ Object {
       "name": "onChange",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets input focus onto the UI control.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "RadioGroup",
   "properties": Array [
     Object {
@@ -11860,7 +11867,14 @@ Object {
       "name": "onChange",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets input focus onto the UI control.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "Tiles",
   "properties": Array [
     Object {

--- a/src/internal/hooks/forward-focus/radio-group.ts
+++ b/src/internal/hooks/forward-focus/radio-group.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useImperativeHandle, useRef } from 'react';
+
+export interface ForwardFocusRef {
+  focus(): void;
+}
+
+/**
+ * Focus forwarding helper for radio groups where only the first selected
+ * child element should be focused.
+ */
+export default function useRadioGroupForwardFocus(
+  forwardedRef: React.Ref<ForwardFocusRef>,
+  items: ReadonlyArray<{ value: string }> | undefined,
+  value: string | null
+): [React.Ref<HTMLInputElement>, number] {
+  const itemRef = useRef<HTMLInputElement | null>(null);
+  const itemIndex = items && findIndex(items, item => item.value === value);
+  useImperativeHandle(forwardedRef, () => ({
+    focus() {
+      itemRef.current?.focus();
+    },
+  }));
+
+  return [itemRef, itemIndex !== undefined && itemIndex !== -1 ? itemIndex : 0];
+}
+
+function findIndex<T>(items: ReadonlyArray<T>, predicate: (t: T) => any): number {
+  for (let i = 0; i < items.length; i++) {
+    if (predicate(items[i])) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -132,6 +132,26 @@ describe('items', () => {
   });
 });
 
+describe('ref', () => {
+  test('when unselected, focuses the first radio button when .focus() is called', () => {
+    let radioGroupRef: RadioGroupProps.Ref | null = null;
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value={null} items={defaultItems} ref={ref => (radioGroupRef = ref)} />
+    );
+    radioGroupRef!.focus();
+    expect(wrapper.findInputByValue('val1')!.getElement()).toHaveFocus();
+  });
+
+  test('when selected, focuses the checked radio button', () => {
+    let radioGroupRef: RadioGroupProps.Ref | null = null;
+    const { wrapper } = renderRadioGroup(
+      <RadioGroup value="val2" items={defaultItems} ref={ref => (radioGroupRef = ref)} />
+    );
+    radioGroupRef!.focus();
+    expect(wrapper.findInputByValue('val2')!.getElement()).toHaveFocus();
+  });
+});
+
 describe('value', () => {
   test('selects the right button when value changes', () => {
     const { wrapper, rerender } = renderRadioGroup(<RadioGroup value={null} items={defaultItems} />);

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -8,9 +8,10 @@ import InternalRadioGroup from './internal';
 
 export { RadioGroupProps };
 
-export default function RadioGroup(props: RadioGroupProps) {
+const RadioGroup = React.forwardRef((props: RadioGroupProps, ref: React.Ref<RadioGroupProps.Ref>) => {
   const baseComponentProps = useBaseComponent('RadioGroup');
-  return <InternalRadioGroup {...props} {...baseComponentProps} />;
-}
+  return <InternalRadioGroup ref={ref} {...props} {...baseComponentProps} />;
+});
 
 applyDisplayName(RadioGroup, 'RadioGroup');
+export default RadioGroup;

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -64,4 +64,11 @@ export namespace RadioGroupProps {
   export interface ChangeDetail {
     value: string;
   }
+
+  export interface Ref {
+    /**
+     * Sets input focus onto the UI control.
+     */
+    focus(): void;
+  }
 }

--- a/src/radio-group/internal.tsx
+++ b/src/radio-group/internal.tsx
@@ -9,47 +9,59 @@ import styles from './styles.css.js';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import useRadioGroupForwardFocus from '../internal/hooks/forward-focus/radio-group';
 
 type InternalRadioGroupProps = RadioGroupProps & InternalBaseComponentProps;
 
-export default function InternalRadioGroup({
-  name,
-  value,
-  items,
-  ariaLabel,
-  ariaRequired,
-  onChange,
-  __internalRootRef = null,
-  ...props
-}: InternalRadioGroupProps) {
-  const { ariaDescribedby, ariaLabelledby } = useFormFieldContext(props);
-  const baseProps = getBaseProps(props);
-  const generatedName = useUniqueId('awsui-radio-');
-  return (
-    <div
-      role="radiogroup"
-      aria-labelledby={ariaLabelledby}
-      aria-label={ariaLabel}
-      aria-describedby={ariaDescribedby}
-      aria-required={ariaRequired}
-      {...baseProps}
-      className={clsx(baseProps.className, styles.root)}
-      ref={__internalRootRef}
-    >
-      {items &&
-        items.map(item => (
-          <RadioButton
-            key={item.value}
-            checked={item.value === value}
-            name={name || generatedName}
-            value={item.value}
-            label={item.label}
-            description={item.description}
-            disabled={item.disabled}
-            onChange={onChange}
-            controlId={item.controlId}
-          />
-        ))}
-    </div>
-  );
-}
+const InternalRadioGroup = React.forwardRef(
+  (
+    {
+      name,
+      value,
+      items,
+      ariaLabel,
+      ariaRequired,
+      onChange,
+      __internalRootRef = null,
+      ...props
+    }: InternalRadioGroupProps,
+    ref: React.Ref<RadioGroupProps.Ref>
+  ) => {
+    const { ariaDescribedby, ariaLabelledby } = useFormFieldContext(props);
+    const baseProps = getBaseProps(props);
+    const generatedName = useUniqueId('awsui-radio-');
+
+    const [radioButtonRef, radioButtonRefIndex] = useRadioGroupForwardFocus(ref, items, value);
+
+    return (
+      <div
+        role="radiogroup"
+        aria-labelledby={ariaLabelledby}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedby}
+        aria-required={ariaRequired}
+        {...baseProps}
+        className={clsx(baseProps.className, styles.root)}
+        ref={__internalRootRef}
+      >
+        {items &&
+          items.map((item, index) => (
+            <RadioButton
+              key={item.value}
+              ref={index === radioButtonRefIndex ? radioButtonRef : undefined}
+              checked={item.value === value}
+              name={name || generatedName}
+              value={item.value}
+              label={item.label}
+              description={item.description}
+              disabled={item.disabled}
+              onChange={onChange}
+              controlId={item.controlId}
+            />
+          ))}
+      </div>
+    );
+  }
+);
+
+export default InternalRadioGroup;

--- a/src/tiles/__tests__/tiles.test.tsx
+++ b/src/tiles/__tests__/tiles.test.tsx
@@ -61,6 +61,22 @@ test('does not render attributes for assistive technology when not set', functio
   expect(rootElement).not.toHaveAttribute('aria-label');
 });
 
+describe('ref', () => {
+  test('when unselected, focuses the first tile when .focus() is called', () => {
+    let tilesRef: TilesProps.Ref | null = null;
+    const { wrapper } = renderTiles(<Tiles value={null} items={defaultItems} ref={ref => (tilesRef = ref)} />);
+    tilesRef!.focus();
+    expect(wrapper.findInputByValue('val1')!.getElement()).toHaveFocus();
+  });
+
+  test('when selected, focuses the checked tile', () => {
+    let tilesRef: TilesProps.Ref | null = null;
+    const { wrapper } = renderTiles(<Tiles value="val2" items={defaultItems} ref={ref => (tilesRef = ref)} />);
+    tilesRef!.focus();
+    expect(wrapper.findInputByValue('val2')!.getElement()).toHaveFocus();
+  });
+});
+
 describe('items', () => {
   test('renders items', () => {
     const { wrapper } = renderTiles(<Tiles value={null} items={defaultItems} />);

--- a/src/tiles/index.tsx
+++ b/src/tiles/index.tsx
@@ -8,9 +8,10 @@ import InternalTiles from './internal';
 
 export { TilesProps };
 
-export default function Tiles(props: TilesProps) {
+const Tiles = React.forwardRef((props: TilesProps, ref: React.Ref<TilesProps.Ref>) => {
   const baseComponentProps = useBaseComponent('Tiles');
-  return <InternalTiles {...props} {...baseComponentProps} />;
-}
+  return <InternalTiles ref={ref} {...props} {...baseComponentProps} />;
+});
 
 applyDisplayName(Tiles, 'Tiles');
+export default Tiles;

--- a/src/tiles/interfaces.ts
+++ b/src/tiles/interfaces.ts
@@ -64,4 +64,11 @@ export namespace TilesProps {
   export interface ChangeDetail {
     value: string;
   }
+
+  export interface Ref {
+    /**
+     * Sets input focus onto the UI control.
+     */
+    focus(): void;
+  }
 }

--- a/src/tiles/internal.tsx
+++ b/src/tiles/internal.tsx
@@ -13,67 +13,74 @@ import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { Tile } from './tile';
+import useRadioGroupForwardFocus from '../internal/hooks/forward-focus/radio-group';
 
 const COLUMN_TRIGGERS: TilesProps.Breakpoint[] = ['default', 'xxs', 'xs'];
 
 type InternalTilesProps = TilesProps & InternalBaseComponentProps;
 
-export default function InternalTiles({
-  value,
-  items,
-  ariaLabel,
-  ariaRequired,
-  columns,
-  onChange,
-  __internalRootRef = null,
-  ...rest
-}: InternalTilesProps) {
-  const getColumns = () => {
-    if (columns) {
-      return columns;
-    }
+const InternalTiles = React.forwardRef(
+  (
+    { value, items, ariaLabel, ariaRequired, columns, onChange, __internalRootRef = null, ...rest }: InternalTilesProps,
+    ref: React.Ref<TilesProps.Ref>
+  ) => {
+    const baseProps = getBaseProps(rest);
+    const { ariaDescribedby, ariaLabelledby } = useFormFieldContext(rest);
+    const generatedName = useUniqueId('awsui-tiles-');
 
-    const nItems = items ? items.length : 0;
-    const columnsLookup: Record<number, number> = {
-      0: 1,
-      1: 1,
-      2: 2,
-      4: 2,
-      8: 2,
-    };
-    return columnsLookup[nItems] || 3;
-  };
-  const { ariaDescribedby, ariaLabelledby } = useFormFieldContext(rest);
-  const baseProps = getBaseProps(rest);
-  const generatedName = useUniqueId('awsui-tiles-');
-  const nColumns = getColumns();
-  const [breakpoint, ref] = useContainerBreakpoints(COLUMN_TRIGGERS);
-  const mergedRef = useMergeRefs(ref, __internalRootRef);
+    const [tileRef, tileRefIndex] = useRadioGroupForwardFocus(ref, items, value);
+    const [breakpoint, breakpointRef] = useContainerBreakpoints(COLUMN_TRIGGERS);
+    const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
-  return (
-    <div
-      role="radiogroup"
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledby}
-      aria-describedby={ariaDescribedby}
-      aria-required={ariaRequired}
-      {...baseProps}
-      className={clsx(baseProps.className, styles.root)}
-      ref={mergedRef}
-    >
-      <div className={clsx(styles.columns, styles[`column-${nColumns}`])}>
-        {items &&
-          items.map(item => (
-            <Tile
-              key={item.value}
-              item={item}
-              selected={item.value === value}
-              name={generatedName}
-              breakpoint={breakpoint}
-              onChange={onChange}
-            />
-          ))}
+    const columnCount = getColumnCount(items, columns);
+
+    return (
+      <div
+        role="radiogroup"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
+        aria-describedby={ariaDescribedby}
+        aria-required={ariaRequired}
+        {...baseProps}
+        className={clsx(baseProps.className, styles.root)}
+        ref={mergedRef}
+      >
+        <div className={clsx(styles.columns, styles[`column-${columnCount}`])}>
+          {items &&
+            items.map((item, index) => (
+              <Tile
+                ref={index === tileRefIndex ? tileRef : undefined}
+                key={item.value}
+                item={item}
+                selected={item.value === value}
+                name={generatedName}
+                breakpoint={breakpoint}
+                onChange={onChange}
+              />
+            ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+);
+
+function getColumnCount(
+  items: ReadonlyArray<TilesProps.TilesDefinition> | undefined,
+  columns: number | undefined
+): number {
+  if (columns) {
+    return columns;
+  }
+
+  const nItems = items ? items.length : 0;
+  const columnsLookup: Record<number, number> = {
+    0: 1,
+    1: 1,
+    2: 2,
+    4: 2,
+    8: 2,
+  };
+  return columnsLookup[nItems] || 3;
 }
+
+export default InternalTiles;

--- a/src/tiles/tile.tsx
+++ b/src/tiles/tile.tsx
@@ -9,6 +9,7 @@ import styles from './styles.css.js';
 
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { fireNonCancelableEvent } from '../internal/events';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 
 interface TileProps {
   item: TilesProps.TilesDefinition;
@@ -18,43 +19,47 @@ interface TileProps {
   onChange: TilesProps['onChange'];
 }
 
-export function Tile({ item, selected, name, breakpoint, onChange }: TileProps) {
-  const radioButtonRef = useRef<HTMLInputElement>(null);
-  const controlId = item.controlId || `${name}-value-${item.value}`;
+export const Tile = React.forwardRef(
+  ({ item, selected, name, breakpoint, onChange }: TileProps, forwardedRef: React.Ref<HTMLInputElement>) => {
+    const internalRef = useRef<HTMLInputElement>(null);
+    const controlId = item.controlId || `${name}-value-${item.value}`;
 
-  return (
-    <div
-      className={clsx(
-        styles['tile-container'],
-        { [styles['has-metadata']]: item.description || item.image },
-        { [styles.selected]: selected },
-        { [styles.disabled]: !!item.disabled },
-        styles[`breakpoint-${breakpoint}`]
-      )}
-      data-value={item.value}
-      onClick={() => {
-        if (item.disabled) {
-          return;
-        }
-        radioButtonRef.current?.focus();
-        if (!selected) {
-          fireNonCancelableEvent(onChange, { value: item.value });
-        }
-      }}
-    >
-      <div className={clsx(styles.control, { [styles['no-image']]: !item.image })}>
-        <RadioButton
-          checked={selected}
-          ref={radioButtonRef}
-          name={name}
-          value={item.value}
-          label={item.label}
-          description={item.description}
-          disabled={item.disabled}
-          controlId={controlId}
-        />
+    const mergedRef = useMergeRefs(internalRef, forwardedRef);
+
+    return (
+      <div
+        className={clsx(
+          styles['tile-container'],
+          { [styles['has-metadata']]: item.description || item.image },
+          { [styles.selected]: selected },
+          { [styles.disabled]: !!item.disabled },
+          styles[`breakpoint-${breakpoint}`]
+        )}
+        data-value={item.value}
+        onClick={() => {
+          if (item.disabled) {
+            return;
+          }
+          internalRef.current?.focus();
+          if (!selected) {
+            fireNonCancelableEvent(onChange, { value: item.value });
+          }
+        }}
+      >
+        <div className={clsx(styles.control, { [styles['no-image']]: !item.image })}>
+          <RadioButton
+            checked={selected}
+            ref={mergedRef}
+            name={name}
+            value={item.value}
+            label={item.label}
+            description={item.description}
+            disabled={item.disabled}
+            controlId={controlId}
+          />
+        </div>
+        {item.image && <div className={clsx(styles.image, { [styles.disabled]: !!item.disabled })}>{item.image}</div>}
       </div>
-      {item.image && <div className={clsx(styles.image, { [styles.disabled]: !!item.disabled })}>{item.image}</div>}
-    </div>
-  );
-}
+    );
+  }
+);


### PR DESCRIPTION
### Description

Added a shared hook for picking the right radio button in a radio group and moving focus to it.

### How has this been tested?

Added unit tests.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _Yes, this change contains documentation changes._
   - Added docs for ref. Stole the exact string from other components. 

### Related Links

AWSUI-19658

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [x] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
