### PR TITLE
fix: Prevent app layout from obscuring clicks when disableContentPaddings=true

### DIFF
--- a/pages/app-layout/disable-paddings-edge-controls.page.tsx
+++ b/pages/app-layout/disable-paddings-edge-controls.page.tsx
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import AppLayout from '~components/app-layout';
+import Box from '~components/box';
+import Button from '~components/button';
+import SplitPanel from '~components/split-panel';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { splitPaneli18nStrings } from './utils/strings';
+import labels from './utils/labels';
+
+export default function () {
+  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [events, setEvents] = useState<string[]>([]);
+  const addEvent = (text: string) => setEvents(events => [...events, text]);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        disableContentPaddings={true}
+        notifications={<Box variant="h2">Notifications</Box>}
+        navigationOpen={navigationOpen}
+        onNavigationChange={({ detail }) => setNavigationOpen(detail.open)}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        splitPanelPreferences={{ position: 'side' }}
+        onSplitPanelPreferencesChange={() => {}}
+        navigation={
+          <>
+            <Box variant="h2">Navigation</Box>
+            <Button data-testid="navigation" onClick={() => addEvent('Clicked "Navigation"')}>
+              Navigation
+            </Button>
+          </>
+        }
+        tools={
+          <>
+            <Box variant="h2">Tools</Box>
+            <Button data-testid="tools" onClick={() => addEvent('Clicked "Tools"')}>
+              Tools
+            </Button>
+          </>
+        }
+        splitPanel={
+          <SplitPanel i18nStrings={splitPaneli18nStrings} header="Split panel">
+            <Button data-testid="split-panel" onClick={() => addEvent('Clicked "Split panel"')}>
+              Split panel
+            </Button>
+          </SplitPanel>
+        }
+        content={
+          <>
+            <Box variant="h1">Edge controls test</Box>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Button data-testid="one" onClick={() => addEvent('Clicked "One"')}>
+                One
+              </Button>
+              <Button data-testid="two" onClick={() => addEvent('Clicked "Two"')}>
+                Two
+              </Button>
+            </div>
+            <ul id="events">
+              {events.map((event, i) => (
+                <li key={i}>{event}</li>
+              ))}
+            </ul>
+          </>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/__integ__/app-layout-refresh-edge-controls.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-edge-controls.test.ts
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+import { viewports } from './constants';
+
+const wrapper = createWrapper().findAppLayout();
+
+class AppLayoutRefreshEdgeControlsPage extends BasePageObject {
+  getEvent(index: number) {
+    return this.getText(`#events > li:nth-child(${index + 1})`);
+  }
+}
+
+function setupTest(testFn: (page: AppLayoutRefreshEdgeControlsPage) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new AppLayoutRefreshEdgeControlsPage(browser);
+    await page.setWindowSize(viewports.desktop);
+    await browser.url(`#/light/app-layout/disable-paddings-edge-controls/?visualRefresh=true&motionDisabled=true`);
+    await page.waitForVisible(wrapper.findContentRegion().toSelector());
+    await testFn(page);
+  });
+}
+
+describe('with disableContentPaddings=true', () => {
+  test(
+    'clickable elements below the navigation toggle are clickable',
+    setupTest(async page => {
+      await page.click(`[data-testid="one"]`);
+      return expect(page.getEvent(0)).resolves.toBe(`Clicked "One"`);
+    })
+  );
+
+  test(
+    'clickable elements below the tools toggle are clickable',
+    setupTest(async page => {
+      await page.click(`[data-testid="two"]`);
+      return expect(page.getEvent(0)).resolves.toBe(`Clicked "Two"`);
+    })
+  );
+
+  test(
+    'the navigation toggle is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findNavigationToggle().toSelector());
+      return expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+    })
+  );
+
+  test(
+    'the tools toggle is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findToolsToggle().toSelector());
+      return expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+    })
+  );
+
+  test(
+    'the side split panel toggle is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+      return expect(page.isDisplayed(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toBe(true);
+    })
+  );
+
+  test(
+    'the navigation content is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findNavigationToggle().toSelector());
+      await page.click(`[data-testid="navigation"]`);
+      return expect(page.getEvent(0)).resolves.toBe(`Clicked "Navigation"`);
+    })
+  );
+
+  test(
+    'the tools content is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findToolsToggle().toSelector());
+      await page.click(`[data-testid="tools"]`);
+      return expect(page.getEvent(0)).resolves.toBe(`Clicked "Tools"`);
+    })
+  );
+
+  test(
+    'the side split panel content is clickable',
+    setupTest(async page => {
+      await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+      await page.click(`[data-testid="split-panel"]`);
+      return expect(page.getEvent(0)).resolves.toBe(`Clicked "Split panel"`);
+    })
+  );
+});

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -17,6 +17,18 @@
   top: var(#{custom-props.$offsetTop});
   z-index: 850;
 
+  /*
+  The navigation and tools containers (that contain the toggle buttons)
+  stretch the full height of the app layout. Normally, this wouldn't be an
+  issue because they sit above the app layout's content padding.
+  
+  But if disableContentPaddings is set to true and there are buttons on the
+  left/right edges of the screen, they will be covered by the containers. So
+  we need to disable pointer events in the container and re-enable them in
+  the panels and toggle buttons.
+  */
+  pointer-events: none;
+
   @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
     #{custom-props.$navigationWidth}: 320px;
   }
@@ -73,6 +85,7 @@ nav.navigation {
   overscroll-behavior-y: contain;
   position: relative;
   word-wrap: break-word;
+  pointer-events: auto;
 
   // Animation for the Navigation opacity and width when it is added to the DOM
   @keyframes openNavigation {

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -84,6 +84,7 @@ section.split-panel-bottom {
 section.split-panel-side {
   height: 100%;
   overflow-x: hidden;
+  pointer-events: auto;
 
   // Animation for opacity and width when pening the Split Panel
   @keyframes openSplitPanelSide {

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -33,6 +33,8 @@ viewport size and state of the Tools drawer.
   top: var(#{custom-props.$offsetTop});
   z-index: 850;
 
+  pointer-events: none;
+
   @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
     #{custom-props.$toolsWidth}: 360px;
   }
@@ -57,6 +59,8 @@ viewport size and state of the Tools drawer.
   overscroll-behavior-y: contain;
   position: relative;
   word-wrap: break-word;
+
+  pointer-events: auto;
 
   // Animation for the Tools opacity and width when it is added to the DOM
   @keyframes openTools {

--- a/src/app-layout/visual-refresh/trigger-button.scss
+++ b/src/app-layout/visual-refresh/trigger-button.scss
@@ -23,6 +23,8 @@ handleSplitPanelMaxWidth function in the context.
   padding: 0 awsui.$space-s;
   width: awsui.$space-layout-toggle-diameter;
 
+  pointer-events: auto;
+
   @include focus-visible.when-visible {
     @include styles.focus-highlight(3px);
   }


### PR DESCRIPTION
### Description

<details>
   <summary><strong>Demo recording</strong></summary>

https://user-images.githubusercontent.com/983897/200972832-efdfda31-85bf-4ea0-8972-24828b83e48b.mov

</details>

The refresh app layout has scaffolding that blocks mouse clicks from passing through it to the content below. Normally, that wouldn't be a problem, because the only thing under that area are content paddings. But... if you disable content paddings and want to have interactive controls from edge to edge, then you're going have issues.

To resolve those without tweaking around the app layout structure and breaking a million other things, I just set `pointer-events: none` on the wrapper elements, and reactivate pointer events on the child elements (i.e. the panels and toggle buttons).

### How has this been tested?

Check out that dev page! Check out those integration tests! So cool!

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [x] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._
  - Keyboard behavior is unchanged

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
