### PR TITLE
feat: Add autosuggest ref functions in api

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1314,7 +1314,20 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
       "name": "onSelect",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets input focus onto the UI control.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+    Object {
+      "description": "Selects all text in the input control.",
+      "name": "select",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "Autosuggest",
   "properties": Array [
     Object {

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -285,3 +285,31 @@ describe('keyboard interactions', () => {
     expect(onChange).toBeCalledTimes(1);
   });
 });
+
+describe('Ref', () => {
+  test('can be used to focus the component', () => {
+    const ref = React.createRef<AutosuggestProps.Ref>();
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="1" ref={ref} />);
+    const input = wrapper.findNativeInput().getElement();
+    expect(document.activeElement).not.toBe(input);
+    ref.current!.focus();
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('can be used to select all text', () => {
+    const ref = React.createRef<AutosuggestProps.Ref>();
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="te" ref={ref} />);
+    const input = wrapper.findNativeInput().getElement();
+
+    // Make sure no text is selected
+    input.selectionStart = input.selectionEnd = 0;
+    input.blur();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+
+    // Select all text
+    ref.current!.select();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(2);
+  });
+});

--- a/src/autosuggest/index.tsx
+++ b/src/autosuggest/index.tsx
@@ -5,7 +5,6 @@ import { AutosuggestProps } from './interfaces';
 import InternalAutosuggest from './internal';
 import { getExternalProps } from '../internal/utils/external-props';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
-import { InputProps } from '../input/interfaces';
 import useBaseComponent from '../internal/hooks/use-base-component';
 
 export { AutosuggestProps };
@@ -13,7 +12,7 @@ export { AutosuggestProps };
 const Autosuggest = React.forwardRef(
   (
     { filteringType = 'auto', statusType = 'finished', disableBrowserAutocorrect = false, ...props }: AutosuggestProps,
-    ref: React.Ref<InputProps.Ref>
+    ref: React.Ref<AutosuggestProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Autosuggest');
     const externalProps = getExternalProps(props);

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -127,6 +127,18 @@ export namespace AutosuggestProps {
   export interface ContainingOptionAndGroupString {
     (option: Option, group?: OptionGroup): string;
   }
+
+  export interface Ref {
+    /**
+     * Sets input focus onto the UI control.
+     */
+    focus(): void;
+
+    /**
+     * Selects all text in the input control.
+     */
+    select(): void;
+  }
 }
 
 // TODO: use DropdownOption type same as in select and multiselect

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -16,7 +16,7 @@ import {
   fireNonCancelableEvent,
   NonCancelableCustomEvent,
 } from '../internal/events';
-import { BaseChangeDetail, InputProps } from '../input/interfaces';
+import { BaseChangeDetail } from '../input/interfaces';
 import styles from './styles.css.js';
 import { checkOptionValueField } from '../select/utils/check-option-value-field';
 import checkControlled from '../internal/hooks/check-controlled';
@@ -30,7 +30,7 @@ import clsx from 'clsx';
 
 export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {}
 
-const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, ref: Ref<InputProps.Ref>) => {
+const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, ref: Ref<AutosuggestProps.Ref>) => {
   const {
     value,
     onChange,

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -9,13 +9,8 @@ import { FormFieldValidationControlProps, useFormFieldContext } from '../../cont
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
 import InternalInput from '../../../input/internal';
-import {
-  BaseChangeDetail,
-  BaseInputProps,
-  InputAutoCorrect,
-  InputKeyEvents,
-  InputProps,
-} from '../../../input/interfaces';
+import { BaseChangeDetail, BaseInputProps, InputAutoCorrect, InputKeyEvents } from '../../../input/interfaces';
+import { AutosuggestProps } from '../../../autosuggest/interfaces';
 import { ExpandToViewport } from '../dropdown/interfaces';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
 import { KeyCode } from '../../keycode';
@@ -50,7 +45,7 @@ export interface AutosuggestInputFocusOptions {
   preventDropdown?: boolean;
 }
 
-export interface AutosuggestInputRef extends InputProps.Ref {
+export interface AutosuggestInputRef extends AutosuggestProps.Ref {
   focus(options?: AutosuggestInputFocusOptions): void;
   open(): void;
   close(): void;


### PR DESCRIPTION
### Description

AWSUI-19732
show focus() and select() functions in api
add tests for focus() and select()

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
