### PR TITLE
refactor: Use css-only solution for container expandable section focu…

### DIFF
--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ExpandableSectionProps } from './interfaces';
-import React, { KeyboardEventHandler, MouseEventHandler, ReactNode, useState } from 'react';
+import React, { KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
 import useFocusVisible from '../internal/hooks/focus-visible';
 import InternalIcon from '../icon/internal';
 import clsx from 'clsx';
@@ -48,7 +48,6 @@ export const ExpandableSectionHeader = ({
   onClick,
 }: ExpandableSectionHeaderProps) => {
   const focusVisible = useFocusVisible();
-  const [focused, setFocus] = useState(false);
   const screenreaderContentId = generateUniqueId('expandable-section-header-content-');
 
   const icon = (
@@ -86,7 +85,7 @@ export const ExpandableSectionHeader = ({
     return (
       <div
         id={id}
-        className={clsx(className, triggerClassName, focused && styles['header-focused'], expanded && styles.expanded)}
+        className={clsx(className, triggerClassName, expanded && styles.expanded)}
         onClick={onClick}
         {...focusVisible}
       >
@@ -102,8 +101,6 @@ export const ExpandableSectionHeader = ({
             tabIndex={0}
             onKeyUp={onKeyUp}
             onKeyDown={onKeyDown}
-            onFocus={() => setFocus(true)}
-            onBlur={() => setFocus(false)}
             aria-label={ariaLabel}
             // Do not use aria-labelledby={id} but ScreenreaderOnly because safari+VO does not read headerText in this case.
             aria-labelledby={ariaLabel ? undefined : screenreaderContentId}

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -90,7 +90,8 @@
 
   &-container {
     width: 100%;
-    &.header-focused[data-awsui-focus-visible='true'] {
+
+    &[data-awsui-focus-visible='true']:focus-within {
       outline: none;
       text-decoration: none;
 


### PR DESCRIPTION
### Description

A refactoring proposal for https://github.com/cloudscape-design/components/pull/473

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
