### PR TITLE
fix: Prevent grid blowouts in the Wizard component

### DIFF
--- a/pages/app-layout/with-wizard-and-table.page.tsx
+++ b/pages/app-layout/with-wizard-and-table.page.tsx
@@ -1,21 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import {
-  AppLayout,
-  Box,
-  Button,
-  CollectionPreferences,
-  ColumnLayout,
-  Container,
-  Header,
-  Pagination,
-  SpaceBetween,
-  Table,
-  TextFilter,
-  Wizard,
-} from '~components';
+import { AppLayout, Box, Button, ColumnLayout, Container, Header, SpaceBetween, Table, Wizard } from '~components';
+import { generateItems, Instance } from '../table/generate-data';
+import { columnsConfig } from '../table/shared-configs';
 import ScreenshotArea from '../utils/screenshot-area';
+
+const items = generateItems(20);
 
 export default function () {
   const [activeStepIndex, setActiveStepIndex] = useState(0);
@@ -45,147 +36,18 @@ export default function () {
                 title: 'Add storage',
                 content: (
                   <Box>
-                    <Table
-                      ariaLabels={{
-                        selectionGroupLabel: 'Items selection',
-                        allItemsSelectionLabel: ({ selectedItems }) =>
-                          `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-                        itemSelectionLabel: ({ selectedItems }, item) => {
-                          const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-                          return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-                        },
-                      }}
-                      columnDefinitions={[
-                        {
-                          id: 'variable',
-                          header: 'Variable name',
-                          cell: e => e.name,
-                          sortingField: 'name',
-                        },
-                        {
-                          id: 'value',
-                          header: 'Text value',
-                          cell: e => e.alt,
-                          sortingField: 'alt',
-                        },
-                        { id: 'type', header: 'Type', cell: e => e.type },
-                        {
-                          id: 'description',
-                          header: 'Description',
-                          cell: e => e.description,
-                        },
-                      ]}
-                      items={[
-                        {
-                          name: 'Item 1',
-                          alt: 'First',
-                          description: 'This is the first item',
-                          type: '1A',
-                          size: 'Small',
-                          testing: 'hello',
-                        },
-                        {
-                          name: 'Item 2',
-                          alt: 'Second',
-                          description: 'This is the second item',
-                          type: '1B',
-                          size: 'Large',
-                        },
-                        {
-                          name: 'Item 3',
-                          alt: 'Third',
-                          description: '-',
-                          type: '1A',
-                          size: 'Large',
-                        },
-                        {
-                          name: 'Item 4',
-                          alt: 'Fourth',
-                          description: 'This is the fourth item',
-                          type: '2A',
-                          size: 'Small',
-                        },
-                        {
-                          name: 'Item 5',
-                          alt: '-',
-                          description:
-                            'This is the fifth item with a longer description This is the fifth item with a longer description This is the fifth item with a longer description',
-                          type: '2A',
-                          size: 'Large',
-                        },
-                        {
-                          name: 'Item 6',
-                          alt: 'Sixth',
-                          description: 'This is the sixth item',
-                          type: '1A',
-                          size: 'Small',
-                        },
-                      ]}
-                      loadingText="Loading resources"
-                      selectionType="multi"
-                      trackBy="name"
-                      visibleColumns={['variable', 'value', 'type', 'description']}
-                      empty={
-                        <Box textAlign="center" color="inherit">
-                          <b>No resources</b>
-                          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
-                            No resources to display.
-                          </Box>
-                          <Button>Create resource</Button>
-                        </Box>
+                    <Table<Instance>
+                      header={
+                        <Header
+                          variant="awsui-h1-sticky"
+                          description="Demo page with footer"
+                          actions={<Button variant="primary">Create</Button>}
+                        >
+                          Sticky Scrollbar Example
+                        </Header>
                       }
-                      filter={<TextFilter filteringPlaceholder="Find resources" filteringText="" />}
-                      header={<Header>Table with common features</Header>}
-                      pagination={
-                        <Pagination
-                          currentPageIndex={1}
-                          pagesCount={2}
-                          ariaLabels={{
-                            nextPageLabel: 'Next page',
-                            previousPageLabel: 'Previous page',
-                            pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
-                          }}
-                        />
-                      }
-                      preferences={
-                        <CollectionPreferences
-                          title="Preferences"
-                          confirmLabel="Confirm"
-                          cancelLabel="Cancel"
-                          preferences={{
-                            pageSize: 10,
-                            visibleContent: ['variable', 'value', 'type', 'description'],
-                          }}
-                          pageSizePreference={{
-                            title: 'Select page size',
-                            options: [
-                              { value: 10, label: '10 resources' },
-                              { value: 20, label: '20 resources' },
-                            ],
-                          }}
-                          visibleContentPreference={{
-                            title: 'Select visible content',
-                            options: [
-                              {
-                                label: 'Main distribution properties',
-                                options: [
-                                  {
-                                    id: 'variable',
-                                    label: 'Variable name',
-                                    editable: false,
-                                  },
-                                  { id: 'value', label: 'Text value' },
-                                  { id: 'type', label: 'Type' },
-                                  {
-                                    id: 'description',
-                                    label: 'Description',
-                                  },
-                                ],
-                              },
-                            ],
-                          }}
-                        />
-                      }
+                      columnDefinitions={columnsConfig}
+                      items={items}
                     />
                   </Box>
                 ),

--- a/pages/app-layout/with-wizard-and-table.page.tsx
+++ b/pages/app-layout/with-wizard-and-table.page.tsx
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  AppLayout,
+  Box,
+  Button,
+  CollectionPreferences,
+  ColumnLayout,
+  Container,
+  Header,
+  Pagination,
+  SpaceBetween,
+  Table,
+  TextFilter,
+  Wizard,
+} from '~components';
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        navigationHide={false}
+        content={
+          <Wizard
+            i18nStrings={{
+              stepNumberLabel: stepNumber => `Step ${stepNumber}`,
+              collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
+              skipToButtonLabel: step => `Skip to ${step.title}`,
+              navigationAriaLabel: 'Steps',
+              cancelButton: 'Cancel',
+              previousButton: 'Previous',
+              nextButton: 'Next',
+              submitButton: 'Launch instance',
+              optional: 'optional',
+            }}
+            onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
+            activeStepIndex={activeStepIndex}
+            allowSkipTo={true}
+            steps={[
+              {
+                title: 'Add storage',
+                content: (
+                  <Box>
+                    <Table
+                      ariaLabels={{
+                        selectionGroupLabel: 'Items selection',
+                        allItemsSelectionLabel: ({ selectedItems }) =>
+                          `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+                        itemSelectionLabel: ({ selectedItems }, item) => {
+                          const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
+                          return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
+                        },
+                      }}
+                      columnDefinitions={[
+                        {
+                          id: 'variable',
+                          header: 'Variable name',
+                          cell: e => e.name,
+                          sortingField: 'name',
+                        },
+                        {
+                          id: 'value',
+                          header: 'Text value',
+                          cell: e => e.alt,
+                          sortingField: 'alt',
+                        },
+                        { id: 'type', header: 'Type', cell: e => e.type },
+                        {
+                          id: 'description',
+                          header: 'Description',
+                          cell: e => e.description,
+                        },
+                      ]}
+                      items={[
+                        {
+                          name: 'Item 1',
+                          alt: 'First',
+                          description: 'This is the first item',
+                          type: '1A',
+                          size: 'Small',
+                          testing: 'hello',
+                        },
+                        {
+                          name: 'Item 2',
+                          alt: 'Second',
+                          description: 'This is the second item',
+                          type: '1B',
+                          size: 'Large',
+                        },
+                        {
+                          name: 'Item 3',
+                          alt: 'Third',
+                          description: '-',
+                          type: '1A',
+                          size: 'Large',
+                        },
+                        {
+                          name: 'Item 4',
+                          alt: 'Fourth',
+                          description: 'This is the fourth item',
+                          type: '2A',
+                          size: 'Small',
+                        },
+                        {
+                          name: 'Item 5',
+                          alt: '-',
+                          description:
+                            'This is the fifth item with a longer description This is the fifth item with a longer description This is the fifth item with a longer description',
+                          type: '2A',
+                          size: 'Large',
+                        },
+                        {
+                          name: 'Item 6',
+                          alt: 'Sixth',
+                          description: 'This is the sixth item',
+                          type: '1A',
+                          size: 'Small',
+                        },
+                      ]}
+                      loadingText="Loading resources"
+                      selectionType="multi"
+                      trackBy="name"
+                      visibleColumns={['variable', 'value', 'type', 'description']}
+                      empty={
+                        <Box textAlign="center" color="inherit">
+                          <b>No resources</b>
+                          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                            No resources to display.
+                          </Box>
+                          <Button>Create resource</Button>
+                        </Box>
+                      }
+                      filter={<TextFilter filteringPlaceholder="Find resources" filteringText="" />}
+                      header={<Header>Table with common features</Header>}
+                      pagination={
+                        <Pagination
+                          currentPageIndex={1}
+                          pagesCount={2}
+                          ariaLabels={{
+                            nextPageLabel: 'Next page',
+                            previousPageLabel: 'Previous page',
+                            pageLabel: pageNumber => `Page ${pageNumber} of all pages`,
+                          }}
+                        />
+                      }
+                      preferences={
+                        <CollectionPreferences
+                          title="Preferences"
+                          confirmLabel="Confirm"
+                          cancelLabel="Cancel"
+                          preferences={{
+                            pageSize: 10,
+                            visibleContent: ['variable', 'value', 'type', 'description'],
+                          }}
+                          pageSizePreference={{
+                            title: 'Select page size',
+                            options: [
+                              { value: 10, label: '10 resources' },
+                              { value: 20, label: '20 resources' },
+                            ],
+                          }}
+                          visibleContentPreference={{
+                            title: 'Select visible content',
+                            options: [
+                              {
+                                label: 'Main distribution properties',
+                                options: [
+                                  {
+                                    id: 'variable',
+                                    label: 'Variable name',
+                                    editable: false,
+                                  },
+                                  { id: 'value', label: 'Text value' },
+                                  { id: 'type', label: 'Type' },
+                                  {
+                                    id: 'description',
+                                    label: 'Description',
+                                  },
+                                ],
+                              },
+                            ],
+                          }}
+                        />
+                      }
+                    />
+                  </Box>
+                ),
+                isOptional: true,
+              },
+              {
+                title: 'Review and launch',
+                content: (
+                  <SpaceBetween size="xs">
+                    <Header variant="h3" actions={<Button onClick={() => setActiveStepIndex(0)}>Edit</Button>}>
+                      Step 1: Instance type
+                    </Header>
+                    <Container header={<Header variant="h2">Container title</Header>}>
+                      <ColumnLayout columns={2} variant="text-grid">
+                        <div>
+                          <Box variant="awsui-key-label">First field</Box>
+                          <div>Value</div>
+                        </div>
+                        <div>
+                          <Box variant="awsui-key-label">Second Field</Box>
+                          <div>Value</div>
+                        </div>
+                      </ColumnLayout>
+                    </Container>
+                  </SpaceBetween>
+                ),
+              },
+            ]}
+          />
+        }
+        contentType="wizard"
+      />
+    </ScreenshotArea>
+  );
+}

--- a/pages/app-layout/with-wizard-and-table.page.tsx
+++ b/pages/app-layout/with-wizard-and-table.page.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import { AppLayout, Box, Button, ColumnLayout, Container, Header, SpaceBetween, Table, Wizard } from '~components';
-import { generateItems, Instance } from '../table/generate-data';
 import { columnsConfig } from '../table/shared-configs';
+import { generateItems, Instance } from '../table/generate-data';
+import labels from './utils/labels';
+
 import ScreenshotArea from '../utils/screenshot-area';
 
 const items = generateItems(20);
@@ -14,6 +16,7 @@ export default function () {
   return (
     <ScreenshotArea gutters={false}>
       <AppLayout
+        ariaLabels={labels}
         navigationHide={false}
         content={
           <Wizard

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -15,7 +15,7 @@
 .wizard.refresh {
   column-gap: awsui.$space-xl;
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   grid-template-rows: auto 1fr;
   row-gap: awsui.$space-scaled-xl;
 


### PR DESCRIPTION
### Description

A customer issue was received that used a large `Table` component in the `content` slot of one of the `Wizard` component `steps`. This caused a grid blowout that pushed the content beyond the containing grid definition in the `Wizard` component. The resolution was to wrap the second column definition in a `minmax()` function.

**Before:**
<img width="1298" alt="blowout" src="https://user-images.githubusercontent.com/438181/201753486-f42a6a86-7f02-4e9e-bb7f-e378a3c74993.png">

**After:**
<img width="1299" alt="resolved" src="https://user-images.githubusercontent.com/438181/201753506-64a6a8f1-40da-4c32-aa09-92b2fa1a3c75.png">

### How has this been tested?

The fix was manually tested in all major browsers. In addition, a new test page was added to the `AppLayout` category called `with-wizard-and-table`.

### Documentation changes

*Do the changes include any API documentation changes?*
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [x] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [x] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [x] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [x] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [x] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.