### PR TITLE
fix: Fix split panel height calculations when screen viewport is resized

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -119,7 +119,18 @@ test(
     await expect(page.getPanelPosition()).resolves.toEqual('side');
   })
 );
+test(
+  'switches to bottom position when screen resizes to mobile',
+  setupTest(async page => {
+    await page.openPanel();
+    await page.switchPosition('side');
+    await expect(page.getPanelPosition()).resolves.toEqual('side');
 
+    await page.setWindowSize(viewports.mobile);
+    await expect(page.getPanelPosition()).resolves.toEqual('bottom');
+    await expect(page.getContentMarginBottom()).resolves.toEqual('160px');
+  })
+);
 test(
   'switches to bottom position when screen is too narrow and restores back on resize',
   setupTest(async page => {

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -162,11 +162,15 @@ const OldAppLayout = React.forwardRef(
       footerSelector,
       disableBodyScroll
     );
+    const [isSplitpanelForcedPosition, setIsSplitpanelForcedPosition] = useState(false);
+
     const [notificationsHeight, notificationsRef] = useContainerQuery(rect => rect.height);
     const [splitPanelHeaderHeight, splitPanelHeaderMeasureRef] = useContainerQuery(
       rect => (splitPanel ? rect.height : 0),
-      [splitPanel]
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [splitPanel, isSplitpanelForcedPosition]
     );
+
     const splitPanelHeaderRefObject = useRef(null);
     const splitPanelHeaderRef = useMergeRefs(splitPanelHeaderMeasureRef, splitPanelHeaderRefObject);
     const anyPanelOpen = navigationVisible || toolsVisible;
@@ -188,7 +192,7 @@ const OldAppLayout = React.forwardRef(
     const [splitPanelHeight, splitPanelRef] = useContainerQuery(
       rect => (splitPanel ? rect.height : 0),
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [splitPanel, splitPanelPosition]
+      [splitPanel, splitPanelPosition, isSplitpanelForcedPosition]
     );
 
     const closedDrawerWidth = 40;
@@ -273,8 +277,7 @@ const OldAppLayout = React.forwardRef(
       }
     });
 
-    const [isForcedPosition, setIsForcedPosition] = useState(false);
-    const finalSplitPanePosition = isForcedPosition ? 'bottom' : splitPanelPosition;
+    const finalSplitPanePosition = isSplitpanelForcedPosition ? 'bottom' : splitPanelPosition;
 
     const splitPaneAvailableOnTheSide = Boolean(splitPanel) && finalSplitPanePosition === 'side';
     const splitPanelOpenOnTheSide = splitPaneAvailableOnTheSide && splitPanelOpen;
@@ -293,7 +296,7 @@ const OldAppLayout = React.forwardRef(
 
     useEffect(() => {
       const contentWidth = contentWidthWithSplitPanel - splitPanelSize;
-      setIsForcedPosition(isMobile || (defaults.minContentWidth || 0) > contentWidth);
+      setIsSplitpanelForcedPosition(isMobile || (defaults.minContentWidth || 0) > contentWidth);
       // This is a workaround to avoid a forced position due to splitPanelSize, which is
       // user controlled variable.
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -329,7 +332,7 @@ const OldAppLayout = React.forwardRef(
       isOpen: splitPanelOpen,
       isMobile,
       isRefresh: false,
-      isForcedPosition,
+      isForcedPosition: isSplitpanelForcedPosition,
       lastInteraction: splitPanelLastInteraction,
       splitPanelRef,
       splitPanelHeaderRef,


### PR DESCRIPTION
### Description

This fixes the height calculations of the split panel when the screen is manually resized and the split panel preferences is set to `position: 'side'` 

This problem applies only in classic, to reproduce open the classic split panel demo -> make split panel preferences apply to the side -> resize the screen to mobile viewport -> observe the scroll, you will not be able to scroll to the content's end.


[_How did you test to verify your changes?_]

Added an integration test for that


[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
