### PR TITLE
chore: Add content write permissions to release notes workflow

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -11,6 +11,10 @@ on:
         required: true
         description: 'npm package of the release repo'
         type: string
+
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: cloudscape-design/.github/.github/workflows/release-gh-notes.yml@main


### PR DESCRIPTION
### Description

Add content write permissions to release notes workflow, the current repository settings needs explicit permissions for github actions to create release notes in the repository 

### How has this been tested?

in my forked repo I've replicated this repo's settings and tested the change

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
