### PR TITLE
fix: Fix prevent anchor navigation in disabled tabs with `href`

### DIFF
--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -141,6 +141,7 @@ $label-horizontal-spacing: awsui.$space-l;
 .tabs-tab-disabled {
   &,
   &:hover {
+    pointer-events: none;
     cursor: default;
     color: awsui.$color-text-interactive-disabled;
     font-weight: awsui.$font-tabs-disabled-weight;


### PR DESCRIPTION
### Description

When there is a tab with `disabled: true` and `href: '<some-link>` properties the mouse click on the tab routes to that link even when it is disabled.

reference to the issue: https://github.com/cloudscape-design/components/issues/478

### How has this been tested?
Added an integration test for it
[_How did you test to verify your changes?_]
Open the tabs page `pages/tabs/responsive-integ.page.tsx` and add a `href: '/'` to one of the disabled tabs, click on it using mouse and observe. You can verify my fix by pulling this branch -> open the same page and click on the disabled tab and verify nothing happens.

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [-] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [-] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [-] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [-] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
