### PR TITLE
fix: Make sure Tiles always have a solid background color

### DIFF
--- a/src/tiles/styles.scss
+++ b/src/tiles/styles.scss
@@ -32,6 +32,7 @@ $gutter: awsui.$space-grid-gutter;
   box-sizing: border-box;
   border: styles.$control-border-width solid awsui.$color-border-input-default;
   border-radius: awsui.$border-radius-tiles;
+  background: awsui.$color-background-input-default;
   padding: awsui.$space-xs awsui.$space-scaled-m;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Description

Unlike other form elements, the Tiles component currently does not have a background color set (unless the tile is selected or disabled). Example: https://codesandbox.io/s/vigilant-ritchie-tgtb0h.

This change makes sure that the Tiles always have a solid background color set.

### How has this been tested?

Tested locally.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links
https://codesandbox.io/s/vigilant-ritchie-tgtb0h


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
