### PR TITLE
fix: Make loading states displayed again

### DIFF
--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -100,7 +100,7 @@ const Cards = React.forwardRef(function <T = any>(
     status = (
       <div className={styles.loading}>
         <InternalStatusIndicator type="loading">
-          <LiveRegion>{loadingText}</LiveRegion>
+          <LiveRegion visible={true}>{loadingText}</LiveRegion>
         </InternalStatusIndicator>
       </div>
     );

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -261,7 +261,7 @@ export default function CodeEditor(props: CodeEditorProps) {
     >
       {props.loading && (
         <LoadingScreen>
-          <LiveRegion>{i18nStrings.loadingState}</LiveRegion>
+          <LiveRegion visible={true}>{i18nStrings.loadingState}</LiveRegion>
         </LoadingScreen>
       )}
 

--- a/src/help-panel/index.tsx
+++ b/src/help-panel/index.tsx
@@ -22,7 +22,7 @@ export default function HelpPanel({ header, footer, children, loading, loadingTe
   return loading ? (
     <div {...containerProps} ref={__internalRootRef}>
       <InternalStatusIndicator type="loading">
-        <LiveRegion>{loadingText}</LiveRegion>
+        <LiveRegion visible={true}>{loadingText}</LiveRegion>
       </InternalStatusIndicator>
     </div>
   ) : (

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -11,6 +11,7 @@ import styles from './styles.css.js';
 export interface LiveRegionProps extends ScreenreaderOnlyProps {
   assertive?: boolean;
   delay?: number;
+  visible?: boolean;
   children: React.ReactNode;
 }
 
@@ -49,7 +50,7 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
 */
 export default memo(LiveRegion);
 
-function LiveRegion({ assertive = false, delay = 10, children, ...restProps }: LiveRegionProps) {
+function LiveRegion({ assertive = false, delay = 10, visible = false, children, ...restProps }: LiveRegionProps) {
   const sourceRef = useRef<HTMLSpanElement>(null);
   const targetRef = useRef<HTMLSpanElement>(null);
 
@@ -93,13 +94,17 @@ function LiveRegion({ assertive = false, delay = 10, children, ...restProps }: L
   });
 
   return (
-    <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
-      <span aria-hidden="true">
-        <span ref={sourceRef}>{children}</span>
-      </span>
+    <>
+      {visible && children}
 
-      <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>
-    </ScreenreaderOnly>
+      <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
+        <span aria-hidden="true">
+          <span ref={sourceRef}>{children}</span>
+        </span>
+
+        <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>
+      </ScreenreaderOnly>
+    </>
   );
 }
 

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -95,12 +95,14 @@ function LiveRegion({ assertive = false, delay = 10, visible = false, children, 
 
   return (
     <>
-      {visible && children}
+      {visible && <span ref={sourceRef}>{children}</span>}
 
       <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
-        <span aria-hidden="true">
-          <span ref={sourceRef}>{children}</span>
-        </span>
+        {!visible && (
+          <span ref={sourceRef} aria-hidden="true">
+            {children}
+          </span>
+        )}
 
         <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>
       </ScreenreaderOnly>

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -140,7 +140,7 @@ export const S3InContext = React.forwardRef(
           {loading && (
             <InternalBox margin={{ top: 's' }}>
               <InternalStatusIndicator type="loading">
-                <LiveRegion>{i18nStrings?.inContextLoadingText}</LiveRegion>
+                <LiveRegion visible={true}>{i18nStrings?.inContextLoadingText}</LiveRegion>
               </InternalStatusIndicator>
             </InternalBox>
           )}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -263,7 +263,7 @@ const InternalTable = React.forwardRef(
                       >
                         {loading ? (
                           <InternalStatusIndicator type="loading" className={styles.loading} wrapText={true}>
-                            <LiveRegion>{loadingText}</LiveRegion>
+                            <LiveRegion visible={true}>{loadingText}</LiveRegion>
                           </InternalStatusIndicator>
                         ) : (
                           <div className={styles.empty}>{empty}</div>

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -238,7 +238,7 @@ const TagEditor = React.forwardRef(
       return (
         <div className={styles.root} ref={baseComponentProps.__internalRootRef}>
           <InternalStatusIndicator className={styles.loading} type="loading">
-            <LiveRegion>{i18nStrings.loading}</LiveRegion>
+            <LiveRegion visible={true}>{i18nStrings.loading}</LiveRegion>
           </InternalStatusIndicator>
         </div>
       );

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -85,7 +85,7 @@ export default function TutorialList({
         */}
           {loading ? (
             <InternalStatusIndicator type="loading">
-              <LiveRegion>{i18nStrings.loadingText}</LiveRegion>
+              <LiveRegion visible={true}>{i18nStrings.loadingText}</LiveRegion>
             </InternalStatusIndicator>
           ) : (
             <>


### PR DESCRIPTION
### Description

Wrapping something in a live-region makes it invisible. Fixing that for those items that are expected to be displayed.

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

[_Check for unexpected visual regressions, see [`CONTRIBUTING.md`](CONTRIBUTING.md#run-visual-regression-tests) for details._]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
