### PR TITLE
fix: Table header stays sticky with few itmes and open split panel

### DIFF
--- a/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
+++ b/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import Link from '~components/link';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Breadcrumbs, Navigation, Tools, Footer, Notifications } from './utils/content-blocks';
+import * as toolsContent from './utils/tools-content';
+import labels from './utils/labels';
+import Table from '~components/table';
+import { generateItems, Instance } from '../table/generate-data';
+import { columnsConfig } from '../table/shared-configs';
+import Button from '~components/button';
+import SplitPanel from '~components/split-panel';
+import SpaceBetween from '~components/space-between';
+
+const DEMO_CONTENT = (
+  <div>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec sagittis
+      aliquam malesuada bibendum arcu vitae elementum. Lectus proin nibh nisl condimentum id venenatis. Penatibus et
+      magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
+      Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
+    </p>
+    <p>
+      Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
+      vulputate eu scelerisque felis imperdiet proin fermentum.
+    </p>
+    <p>
+      Orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Varius quam quisque id diam vel.
+      Risus viverra adipiscing at in. Orci sagittis eu volutpat odio facilisis mauris. Mauris vitae ultricies leo
+      integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam pellentesque.
+    </p>
+    <p>Ante in nibh mauris cursus mattis molestie.</p>
+    <p>
+      Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
+      eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi vitae
+      suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu felis bibendum ut
+      tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. In hac habitasse
+      platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean euismod elementum
+      nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras adipiscing enim eu. Id
+      interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi etiam. Sodales neque sodales
+      ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend mi in. Urna condimentum mattis
+      pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id leo in vitae turpis massa sed.
+      Pharetra pharetra massa massa ultricies mi.
+    </p>
+  </div>
+);
+
+export default function () {
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
+  const [itemCount, setItemCount] = useState<number>(30);
+  const [items, setItems] = useState(generateItems(itemCount));
+
+  function openHelp(article: keyof typeof toolsContent) {
+    setToolsOpen(true);
+    setSelectedTool(article);
+  }
+
+  useEffect(() => {
+    setItems(generateItems(itemCount));
+  }, [itemCount]);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        breadcrumbs={<Breadcrumbs />}
+        navigation={<Navigation />}
+        contentType="table"
+        tools={<Tools>{toolsContent[selectedTool]}</Tools>}
+        toolsOpen={toolsOpen}
+        onToolsChange={({ detail }) => setToolsOpen(detail.open)}
+        notifications={<Notifications />}
+        content={
+          <Table<Instance>
+            header={
+              <Header
+                variant="awsui-h1-sticky"
+                description="Demo page with footer"
+                info={
+                  <Link variant="info" onFollow={() => openHelp('long')}>
+                    Long help text
+                  </Link>
+                }
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button data-testid="set-item-count-to-1" onClick={() => setItemCount(1)}>
+                      Set item count to 1
+                    </Button>
+                    <Button data-testid="set-item-count-to-30" onClick={() => setItemCount(30)}>
+                      Set item count to 30
+                    </Button>
+                  </SpaceBetween>
+                }
+              >
+                Sticky scrollbar example
+              </Header>
+            }
+            stickyHeader={true}
+            variant="full-page"
+            columnDefinitions={columnsConfig}
+            items={items}
+          />
+        }
+        splitPanel={
+          <SplitPanel
+            header="Split panel header"
+            i18nStrings={{
+              preferencesTitle: 'Preferences',
+              preferencesPositionLabel: 'Split panel position',
+              preferencesPositionDescription: 'Choose the default split panel position for the service.',
+              preferencesPositionSide: 'Side',
+              preferencesPositionBottom: 'Bottom',
+              preferencesConfirm: 'Confirm',
+              preferencesCancel: 'Cancel',
+              closeButtonAriaLabel: 'Close panel',
+              openButtonAriaLabel: 'Open panel',
+              resizeHandleAriaLabel: 'Slider',
+            }}
+          >
+            {DEMO_CONTENT}
+          </SplitPanel>
+        }
+      />
+      <Footer legacyConsoleNav={false} />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -13,11 +13,11 @@
   padding-bottom: awsui.$space-layout-content-bottom;
 
   &.has-split-panel:not(.is-split-panel-open).split-panel-position-bottom {
-    padding-bottom: var(#{custom-props.$splitPanelReportedHeaderSize});
+    padding-bottom: calc(var(#{custom-props.$splitPanelReportedHeaderSize}) + #{awsui.$space-layout-content-bottom});
   }
 
   &.has-split-panel.is-split-panel-open.split-panel-position-bottom {
-    padding-bottom: var(#{custom-props.$splitPanelReportedSize});
+    padding-bottom: calc(var(#{custom-props.$splitPanelReportedSize}) + #{awsui.$space-layout-content-bottom});
   }
 
   /*

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -13,24 +13,20 @@
   padding-bottom: awsui.$space-layout-content-bottom;
 
   /*
-  If the split panel is in the bottom position additional padding will need to be 
+  If the split panel is in the bottom position additional padding will need to be
   added to the content area. This is to ensure that the user is able to scroll
-  far enough to see all of the content that would otherwise be obscured by the 
+  far enough to see all of the content that would otherwise be obscured by the
   sticky position of the split panel.
   */
-  &.has-split-panel:not(.is-split-panel-open).split-panel-position-bottom {
-    padding-bottom: calc(var(#{custom-props.$splitPanelReportedHeaderSize}) + #{awsui.$space-layout-content-bottom});
-  }
-
-  &.has-split-panel.is-split-panel-open.split-panel-position-bottom {
-    padding-bottom: calc(var(#{custom-props.$splitPanelReportedSize}) + #{awsui.$space-layout-content-bottom});
+  &.has-split-panel.split-panel-position-bottom {
+    padding-bottom: calc(var(#{custom-props.$splitPanelHeight}) + #{awsui.$space-layout-content-bottom});
   }
 
   /*
-  If disableContentPaddings is enabled then the Main content has a different 
-  behavior inside the Layout grid. By default it will render across the entire 
-  grid column span. If the Navigation is open on the left, we increment the 
-  start column by one. If the Tools or Split Panel (in side position) is open 
+  If disableContentPaddings is enabled then the Main content has a different
+  behavior inside the Layout grid. By default it will render across the entire
+  grid column span. If the Navigation is open on the left, we increment the
+  start column by one. If the Tools or Split Panel (in side position) is open
   on the right, we decrement the column end by one.
   */
   &.disable-content-paddings {
@@ -50,14 +46,14 @@
   }
 
   /*
-  If disableContentPaddings is not enabled (the majority of use cases) then 
-  the following code block will compute the padding behavior for the Main 
+  If disableContentPaddings is not enabled (the majority of use cases) then
+  the following code block will compute the padding behavior for the Main
   under various circumstances.
   */
   &:not(.disable-content-paddings) {
     @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
       /*
-      Notifications is the previous adjacent sibling to the Main in 
+      Notifications is the previous adjacent sibling to the Main in
       desktop viewports if there are no Breadcrumbs or Header. Use additional
       to padding on the Main.
       */
@@ -67,7 +63,7 @@
       }
 
       /*
-      Main is the only rendered center content if there are no Notifications, 
+      Main is the only rendered center content if there are no Notifications,
       Breadcrumbs, or Header. Use minimal top padding.
       */
       &.content-type-default:not(.has-notifications-content):not(.has-breadcrumbs):not(.has-header):not(.has-dynamic-overlap-height),
@@ -76,7 +72,7 @@
       }
 
       /*
-      If the Header exists then it is necessarily the previous adjacent 
+      If the Header exists then it is necessarily the previous adjacent
       sibling to the Main which requires no top padding.
       */
       &.has-header,
@@ -87,8 +83,8 @@
 
     @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
       /*
-      If the Notifications exist but the Header does not then the 
-      Notifications is the previous adjacent sibling to the Main 
+      If the Notifications exist but the Header does not then the
+      Notifications is the previous adjacent sibling to the Main
       requiring additional top padding. This is because the Breadcrumbs
       are now rendered first and positioned sticky.
       */
@@ -106,7 +102,7 @@
       }
 
       /*
-      If the Header exists then it is necessarily the previous adjacent 
+      If the Header exists then it is necessarily the previous adjacent
       sibling to the Main which requires no top padding.
       */
       &.has-header,

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -12,6 +12,12 @@
   grid-row: 4 / span 2;
   padding-bottom: awsui.$space-layout-content-bottom;
 
+  /*
+  If the split panel is in the bottom position additional padding will need to be 
+  added to the content area. This is to ensure that the user is able to scroll
+  far enough to see all of the content that would otherwise be obscured by the 
+  sticky position of the split panel.
+  */
   &.has-split-panel:not(.is-split-panel-open).split-panel-position-bottom {
     padding-bottom: calc(var(#{custom-props.$splitPanelReportedHeaderSize}) + #{awsui.$space-layout-content-bottom});
   }

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -5,11 +5,20 @@
 
 @use '../../internal/styles/' as styles;
 @use '../../internal/styles/tokens' as awsui;
+@use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .container {
   grid-column: 3;
   grid-row: 4 / span 2;
   padding-bottom: awsui.$space-layout-content-bottom;
+
+  &.has-split-panel:not(.is-split-panel-open).split-panel-position-bottom {
+    padding-bottom: var(#{custom-props.$splitPanelReportedHeaderSize});
+  }
+
+  &.has-split-panel.is-split-panel-open.split-panel-position-bottom {
+    padding-bottom: var(#{custom-props.$splitPanelReportedSize});
+  }
 
   /*
   If disableContentPaddings is enabled then the Main content has a different 

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -7,7 +7,6 @@ import customCssProps from '../../internal/generated/custom-css-properties';
 import { SplitPanelContext } from '../../internal/context/split-panel-context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
-import { useObservedElement } from '../utils/use-observed-element';
 
 export default function Main() {
   const {
@@ -25,13 +24,14 @@ export default function Main() {
     isAnyPanelOpen,
     mainElement,
     splitPanel,
-    splitPanelReportedSize,
+    offsetBottom,
+    footerHeight,
   } = useContext(AppLayoutContext);
 
-  const { getHeader: getSplitPanelHeader, position: splitPanelPosition } = useContext(SplitPanelContext);
+  const { position: splitPanelPosition } = useContext(SplitPanelContext);
 
-  const splitPanelReportedHeaderSize = useObservedElement(getSplitPanelHeader);
   const isUnfocusable = isMobile && isAnyPanelOpen;
+  const splitPanelHeight = offsetBottom - footerHeight;
 
   return (
     <div
@@ -55,8 +55,7 @@ export default function Main() {
       )}
       ref={mainElement}
       style={{
-        [customCssProps.splitPanelReportedHeaderSize]: `${splitPanelReportedHeaderSize}px`,
-        [customCssProps.splitPanelReportedSize]: `${splitPanelReportedSize}px`,
+        [customCssProps.splitPanelHeight]: `${splitPanelHeight}px`,
       }}
     >
       {content}

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -3,9 +3,11 @@
 import React, { useContext } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
+import customCssProps from '../../internal/generated/custom-css-properties';
 import { SplitPanelContext } from '../../internal/context/split-panel-context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
+import { useObservedElement } from '../utils/use-observed-element';
 
 export default function Main() {
   const {
@@ -22,9 +24,16 @@ export default function Main() {
     isMobile,
     isAnyPanelOpen,
     mainElement,
+    splitPanel,
   } = useContext(AppLayoutContext);
 
-  const { position: splitPanelPosition } = useContext(SplitPanelContext);
+  const {
+    getHeader: getSplitPanelHeader,
+    position: splitPanelPosition,
+    size: splitPanelSize,
+  } = useContext(SplitPanelContext);
+
+  const splitPanelReportedHeaderSize = useObservedElement(getSplitPanelHeader);
   const isUnfocusable = isMobile && isAnyPanelOpen;
 
   return (
@@ -39,6 +48,7 @@ export default function Main() {
           [styles['has-dynamic-overlap-height']]: dynamicOverlapHeight > 0,
           [styles['has-header']]: contentHeader,
           [styles['has-notifications-content']]: hasNotificationsContent,
+          [styles['has-split-panel']]: splitPanel,
           [styles['is-navigation-open']]: isNavigationOpen,
           [styles['is-tools-open']]: isToolsOpen,
           [styles['is-split-panel-open']]: isSplitPanelOpen,
@@ -47,6 +57,10 @@ export default function Main() {
         testutilStyles.content
       )}
       ref={mainElement}
+      style={{
+        [customCssProps.splitPanelReportedHeaderSize]: `${splitPanelReportedHeaderSize}px`,
+        [customCssProps.splitPanelReportedSize]: `${splitPanelSize}px`,
+      }}
     >
       {content}
     </div>

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -25,13 +25,10 @@ export default function Main() {
     isAnyPanelOpen,
     mainElement,
     splitPanel,
+    splitPanelReportedSize,
   } = useContext(AppLayoutContext);
 
-  const {
-    getHeader: getSplitPanelHeader,
-    position: splitPanelPosition,
-    size: splitPanelSize,
-  } = useContext(SplitPanelContext);
+  const { getHeader: getSplitPanelHeader, position: splitPanelPosition } = useContext(SplitPanelContext);
 
   const splitPanelReportedHeaderSize = useObservedElement(getSplitPanelHeader);
   const isUnfocusable = isMobile && isAnyPanelOpen;
@@ -59,7 +56,7 @@ export default function Main() {
       ref={mainElement}
       style={{
         [customCssProps.splitPanelReportedHeaderSize]: `${splitPanelReportedHeaderSize}px`,
-        [customCssProps.splitPanelReportedSize]: `${splitPanelSize}px`,
+        [customCssProps.splitPanelReportedSize]: `${splitPanelReportedSize}px`,
       }}
     >
       {content}

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -8,20 +8,27 @@
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 /*
-When the Split Panel is in the bottom position it will be an additional
-row entry in the grid definition within the Layout component. The state of 
-the Navigation and Tools components will adjust the start and end column
-within. In the bottom position, the Split Panel is simply a direct child 
-of the Tools component flex container and should consume 100% of the 
-parent height.
+When the Split Panel is in the bottom position it was share the same row 
+as the content area. This row is defined as 1 fractional unit which will 
+consume the remaining vertical space in the grid after the notifications 
+and breadcrumbs.
 */
 section.split-panel-bottom {
+  /*
+  The align self property will position the split panel at the bottom of the grid row.
+  This could be off the viewport if the content area has enough content to be scrollable.
+  */
   align-self: end;
   bottom: var(#{custom-props.$footerHeight});
   display: none;
   grid-column: 1 / 6;
   grid-row: 5;
   height: auto;
+  /* 
+  The position sticky will work in conjunction with the align self: end; property.
+  If the grid row scrolls beyond the viewport, the sticky bottom position 
+  will lift it up above the footer so it is always visible.
+  */
   position: sticky;
   z-index: 851;
 

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -16,9 +16,11 @@ of the Tools component flex container and should consume 100% of the
 parent height.
 */
 section.split-panel-bottom {
+  align-self: end;
   bottom: var(#{custom-props.$footerHeight});
   display: none;
   grid-column: 1 / 6;
+  grid-row: 5;
   height: auto;
   position: sticky;
   z-index: 851;

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -24,6 +24,7 @@ const customCssPropertiesList = [
   'navigationWidth',
   'splitPanelReportedHeaderSize',
   'splitPanelReportedSize',
+  'splitPanelHeight',
   'splitPanelMinWidth',
   'splitPanelMaxWidth',
   'toolsMaxWidth',


### PR DESCRIPTION
### Description

This PR fixes the unexpected table header overscroll when the table has few items and split panel gets opened at bottom position.

Steps to reproduce this issue:
1. Open https://cloudscape.design/examples/react/split-panel-multiple.html
2. Set filter to XLOWCQQFJJHM80
3. Open split-panel
4. Scroll down

### How has this been tested?

- tested manually on all supported browsers.
- additional screenshot tests will be added.

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [x] _No._

### Related Links

- AWSUI-19765


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- [ ] _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
