### PR TITLE
fix: Attribute editor form controls need to be programmatically grouped

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
+import Input from '../../../lib/components/input';
 
 interface Item {
   key: string;
@@ -320,6 +321,37 @@ describe('Attribute Editor', () => {
       for (const row of [1, 2, 3]) {
         expect(wrapper.findRow(row)!.findRemoveButton()!.getElement()).not.toHaveFocus();
       }
+    });
+  });
+
+  describe('a11y', () => {
+    test('row has role group and aria-labelledby referring to first control label and content', () => {
+      const wrapper = renderAttributeEditor({
+        ...defaultProps,
+        definition: [
+          {
+            label: 'Key label',
+            info: 'Key info',
+            control: item => <Input value={item.key} />,
+          },
+          {
+            label: 'Value label',
+            info: 'Value info',
+            control: item => <Input value={item.value} />,
+          },
+        ],
+      });
+      const [labelId, inputId] = wrapper
+        .findRow(1)!
+        .find('[role="group"]')!
+        .getElement()
+        .getAttribute('aria-labelledby')!
+        .split(' ');
+      const label =
+        wrapper.getElement().querySelector(`#${labelId}`)!.textContent +
+        ' ' +
+        wrapper.getElement().querySelector(`#${inputId}`)!.getAttribute('value');
+      expect(label).toBe('Key label k1');
     });
   });
 });

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -11,6 +11,7 @@ import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/e
 import InternalGrid from '../grid/internal';
 import { InternalButton } from '../button/internal';
 import clsx from 'clsx';
+import { generateUniqueId } from '../internal/hooks/use-unique-id';
 
 const Divider = () => <InternalBox className={styles.divider} padding={{ top: 'l' }} />;
 
@@ -55,44 +56,53 @@ export const Row = React.memo(
       fireNonCancelableEvent(onRemoveButtonClick, { itemIndex: index });
     }, [onRemoveButtonClick, index]);
 
+    const firstControlId = generateUniqueId('first-control-id-');
+
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>
-        <InternalGrid
-          __breakpoint={breakpoint}
-          gridDefinition={removable ? REMOVABLE_GRID_DEFINITION : GRID_DEFINITION}
-        >
-          <InternalColumnLayout className={styles['row-control']} columns={definition.length} __breakpoint={breakpoint}>
-            {definition.map(({ info, label, constraintText, errorText, control }, defIndex) => (
-              <InternalFormField
-                key={defIndex}
-                className={styles.field}
-                label={label}
-                info={info}
-                constraintText={render(item, index, constraintText)}
-                errorText={render(item, index, errorText)}
-                stretch={true}
-                i18nStrings={{ errorIconAriaLabel: i18nStrings.errorIconAriaLabel }}
-                __hideLabel={isWideViewport && index > 0}
-              >
-                {render(item, index, control)}
-              </InternalFormField>
-            ))}
-          </InternalColumnLayout>
-          {removable && (
-            <ButtonContainer index={index} isNarrowViewport={isNarrowViewport}>
-              <InternalButton
-                className={styles['remove-button']}
-                formAction="none"
-                ref={ref => {
-                  removeButtonRefs[index] = ref ?? undefined;
-                }}
-                onClick={handleRemoveClick}
-              >
-                {removeButtonText}
-              </InternalButton>
-            </ButtonContainer>
-          )}
-        </InternalGrid>
+        <div role="group" aria-labelledby={`${firstControlId}-label ${firstControlId}`}>
+          <InternalGrid
+            __breakpoint={breakpoint}
+            gridDefinition={removable ? REMOVABLE_GRID_DEFINITION : GRID_DEFINITION}
+          >
+            <InternalColumnLayout
+              className={styles['row-control']}
+              columns={definition.length}
+              __breakpoint={breakpoint}
+            >
+              {definition.map(({ info, label, constraintText, errorText, control }, defIndex) => (
+                <InternalFormField
+                  key={defIndex}
+                  className={styles.field}
+                  label={label}
+                  info={info}
+                  constraintText={render(item, index, constraintText)}
+                  errorText={render(item, index, errorText)}
+                  stretch={true}
+                  i18nStrings={{ errorIconAriaLabel: i18nStrings.errorIconAriaLabel }}
+                  __hideLabel={isWideViewport && index > 0}
+                  controlId={defIndex === 0 ? firstControlId : undefined}
+                >
+                  {render(item, index, control)}
+                </InternalFormField>
+              ))}
+            </InternalColumnLayout>
+            {removable && (
+              <ButtonContainer index={index} isNarrowViewport={isNarrowViewport}>
+                <InternalButton
+                  className={styles['remove-button']}
+                  formAction="none"
+                  ref={ref => {
+                    removeButtonRefs[index] = ref ?? undefined;
+                  }}
+                  onClick={handleRemoveClick}
+                >
+                  {removeButtonText}
+                </InternalButton>
+              </ButtonContainer>
+            )}
+          </InternalGrid>
+        </div>
         {isNarrowViewport && <Divider />}
       </InternalBox>
     );


### PR DESCRIPTION
### Description

1. Add role="group" to visually grouped controls in attribute editor.
2. Using first control label and value as the accessible name of the grouped control. 

Related links, issue **AWSUI-19064**

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit test, manually test on NVDA+chrome/ff, VO+safari.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
