### PR TITLE
fix: Focus resize handler when split panel is opened

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -26,13 +26,13 @@ function setupTest(
 [false, true].forEach(visualRefresh =>
   describe(`visualRefresh=${visualRefresh}`, () => {
     test(
-      'split panel focus toggles between open and close buttons',
+      'split panel focus moves to slider on open and open button on close',
       setupTest(
         async page => {
           await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
           await page.keys('Enter');
-          await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
-          await page.keys('Enter');
+          await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+          await page.keys(['Tab', 'Tab']);
           await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
           await page.keys('Enter');
           await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
@@ -79,8 +79,7 @@ function setupTest(
         async page => {
           await page.setWindowSize({ width: 1000, height: 800 });
           await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-          await page.keys('Tab');
-          await page.keys('Enter');
+          await page.keys(['Tab', 'Tab', 'Tab', 'Enter']);
           await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
         },
         { pageName: 'with-split-panel', visualRefresh, splitPanelPosition: 'side' }

--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -98,7 +98,6 @@ test(
   'slider is accessible by keyboard in bottom position',
   setupTest(async page => {
     await page.openPanel();
-    await page.keys(['Shift', 'Tab', 'Shift', 'Shift', 'Tab', 'Shift']);
     await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
 
     const { height } = await page.getSplitPanelSize();

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -110,8 +110,8 @@ for (const theme of ['refresh', 'classic']) {
       })
     );
 
-    (['bottom', 'side'] as const).forEach(position =>
-      test(`Moves focus between open and close buttons in ${position} position`, () => {
+    (['bottom', 'side'] as const).forEach(position => {
+      test(`Moves focus to slider when opened in ${position} position`, () => {
         const { wrapper } = renderComponent(
           <AppLayout
             splitPanel={defaultSplitPanel}
@@ -120,13 +120,22 @@ for (const theme of ['refresh', 'classic']) {
           />
         );
         act(() => wrapper.findSplitPanel()!.findOpenButton()!.click());
-        expect(wrapper.findSplitPanel()!.findCloseButton()!.getElement()).toHaveFocus();
+        expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
+      });
+
+      test(`Moves focus to open button when closed in ${position} position`, () => {
+        const { wrapper } = renderComponent(
+          <AppLayout
+            splitPanel={defaultSplitPanel}
+            splitPanelPreferences={{ position }}
+            onSplitPanelPreferencesChange={noop}
+          />
+        );
+        act(() => wrapper.findSplitPanel()!.findOpenButton()!.click());
         act(() => wrapper.findSplitPanel()!.findCloseButton()!.click());
         expect(wrapper.findSplitPanel()!.findOpenButton()!.getElement()).toHaveFocus();
-        act(() => wrapper.findSplitPanel()!.findOpenButton()!.click());
-        expect(wrapper.findSplitPanel()!.findCloseButton()!.getElement()).toHaveFocus();
-      })
-    );
+      });
+    });
   });
 }
 

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -328,7 +328,7 @@ export default function SplitPanel({
   useEffectOnUpdate(() => {
     switch (lastInteraction?.type) {
       case 'open':
-        return closeRef.current?.focus();
+        return handleRef.current?.focus();
       case 'close':
         return toggleRef.current?.focus();
       case 'position':


### PR DESCRIPTION
### Description

When the split panel is opened, we previously moved focus to the close button. But this isn't great because it's the third (and often last) item in the tab order, after the resizer and the preferences button. While it would be nice to keep this, making the close button the first thing in the tab order (without changing the visuals) is unintuitive, especially because it's the right-most item in the header area. So we just move focus to the resize handler, which seems like the most sensible thing for the time being. And we're probably going to revisit focus moves at some point.

Related links, issue #, if available: AWSUI-19409

### How has this been tested?

~~Too lazy to run all the tests. If a test yells at me, I'll update it. Or else, I'll write a test.~~ Updated unit and integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
