### PR TITLE
feat: Add descriptive aria-label to tutorial pabel task list steps title

### DIFF
--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -244,4 +244,17 @@ describe('URL sanitization', () => {
       );
     });
   });
+  describe('a11y', () => {
+    test('task list expandable section should have aria-label joining task title and total step label', () => {
+      const tutorials = getTutorials();
+      const context = getContext({ currentTutorial: tutorials[0] });
+      const { container } = renderTutorialPanelWithContext({ tutorials }, context);
+      const wrapper = createWrapper(container).findTutorialPanel()!;
+      const taskList = wrapper.findTaskList();
+
+      expect(taskList[0].findStepsTitle().getElement().getAttribute('aria-label')).toBe(
+        'TASK_1_FIRST_TASK_TEST TOTAL_STEPS_1'
+      );
+    });
+  });
 });

--- a/src/tutorial-panel/components/tutorial-detail-view/task.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/task.tsx
@@ -7,6 +7,7 @@ import InternalBox from '../../../box/internal';
 import InternalStatusIndicator from '../../../status-indicator/internal';
 import InternalSpaceBetween from '../../../space-between/internal';
 import InternalExpandableSection from '../../../expandable-section/internal';
+import { joinStrings } from '../../../internal/utils/strings/join-strings.js';
 
 function getStatusIndicatorType(taskIndex: number, currentTaskIndex: number) {
   if (taskIndex < currentTaskIndex) {
@@ -64,6 +65,10 @@ export function Task({ task, taskIndex, currentTaskIndex, expanded, onToggleExpa
             }
             expanded={expanded}
             onChange={onExpandChange}
+            headerAriaLabel={joinStrings(
+              i18nStrings.taskTitle(taskIndex, task.title),
+              i18nStrings.labelTotalSteps(task.steps.length)
+            )}
           >
             <ol className={styles['step-list']}>
               {task.steps.map((step, stepIndex) => (


### PR DESCRIPTION
### Description

Tutorial panel steps titles content is not descriptive and can be the same on one page, like multiple "Total steps: 2". Add more descriptive label by joining the task title with steps title.

Related links, issue **AWSUI-19244**

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
