### PR TITLE
fix: Prevent resetting StickyBackground from elements using InternalContainer

### DIFF
--- a/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
+++ b/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
@@ -24,6 +24,16 @@ const DEMO_CONTENT = (
       magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
       Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
     </p>
+    <Table<Instance>
+      header={
+        <Header headingTagOverride="h1" counter="10">
+          Table Example In Split panel
+        </Header>
+      }
+      columnDefinitions={columnsConfig}
+      items={generateItems(10)}
+      variant="embedded"
+    />
     <p>
       Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
       vulputate eu scelerisque felis imperdiet proin fermentum.
@@ -54,6 +64,7 @@ export default function () {
   const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
   const [itemCount, setItemCount] = useState<number>(30);
   const [items, setItems] = useState(generateItems(itemCount));
+  const [splitPanelOpen, setSplitPanelOpen] = useState(false);
 
   function openHelp(article: keyof typeof toolsContent) {
     setToolsOpen(true);
@@ -106,6 +117,10 @@ export default function () {
             items={items}
           />
         }
+        splitPanelOpen={splitPanelOpen}
+        onSplitPanelToggle={({ detail }) => {
+          setSplitPanelOpen(detail.open);
+        }}
         splitPanel={
           <SplitPanel
             header="Split panel header"
@@ -122,7 +137,7 @@ export default function () {
               resizeHandleAriaLabel: 'Slider',
             }}
           >
-            {DEMO_CONTENT}
+            {splitPanelOpen && DEMO_CONTENT}
           </SplitPanel>
         }
       />

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useContext, useLayoutEffect, useRef } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { AppLayoutContext } from '../app-layout/visual-refresh/context';
 import { ContainerProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
@@ -67,14 +67,17 @@ export default function InternalContainer({
    * has a high constrast sticky header. This is to make sure the background element
    * stays in the same vertical position as the header content.
    */
-  useLayoutEffect(
+  useEffect(
     function handleHasStickyBackground() {
-      if (isRefresh && isSticky && variant === 'full-page') {
+      const shouldUpdateStickyBackground = isRefresh && isSticky && variant === 'full-page';
+      if (shouldUpdateStickyBackground) {
         setHasStickyBackground(true);
       }
 
       return function cleanup() {
-        setHasStickyBackground(false);
+        if (shouldUpdateStickyBackground) {
+          setHasStickyBackground(false);
+        }
       };
     },
     [isRefresh, isSticky, setHasStickyBackground, variant]


### PR DESCRIPTION
### Description

Before this change, the sticky background got reset when mounting and unmounting another component which uses the `InternalContainer`. This resulted in a header background which did not had the full width after unmounting. See #505 for details.
 

Related links, issue #, if available: AWSUI-19824, CR-80122674

### How has this been tested?

- manually tested in all browsers we currently support.
- added additional screenshot tests for verification.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
