### PR TITLE
feat: Add steps information to annotation trigger aria label

### DIFF
--- a/pages/onboarding/i18n.ts
+++ b/pages/onboarding/i18n.ts
@@ -27,7 +27,10 @@ export const tutorialPanelStrings: TutorialPanelProps.I18nStrings = {
 export const annotationContextStrings: AnnotationContextProps.I18nStrings = {
   stepCounterText: (stepIndex, totalStepCount) => `Step ${stepIndex + 1}/${totalStepCount}`,
   taskTitle: (taskIndex, taskTitle) => `Task ${taskIndex + 1}: ${taskTitle}`,
-  labelHotspot: openState => (openState ? 'close annotation' : 'open annotation'),
+  labelHotspot: (openState, stepIndex, totalStepCount) =>
+    openState
+      ? `close annotation for step ${stepIndex + 1}/${totalStepCount}`
+      : `open annotation for step ${stepIndex + 1}/${totalStepCount}`,
   nextButtonText: 'Next',
   previousButtonText: 'Previous',
   finishButtonText: 'Finish',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -207,7 +207,7 @@ the component.",
           Object {
             "name": "labelHotspot",
             "optional": false,
-            "type": "(openState: boolean) => string",
+            "type": "(openState: boolean, stepIndex: number, totalStepCount: number) => string",
           },
           Object {
             "name": "nextButtonText",

--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -238,7 +238,7 @@ test('trigger should have aria-label with steps information', () => {
   );
 
   const hotspot = wrapper.find('#second')!.findHotspot()!;
-  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('OPEN_HOTSPOT_TEST STEP_1_OF_2_TEST');
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('OPEN_HOTSPOT_TEST_FOR_STEP_1_OF_2_TEST');
   hotspot.findTrigger().click();
-  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('CLOSE_HOTSPOT_TEST STEP_1_OF_2_TEST');
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('CLOSE_HOTSPOT_TEST_FOR_STEP_1_OF_2_TEST');
 });

--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -225,3 +225,20 @@ test('does not run into an endless loop in (un)registerHotspot when toggling Hot
   */
   done();
 }, 1000);
+
+test('trigger should have aria-label with steps information', () => {
+  const { wrapper } = renderAnnotationContext(
+    <>
+      <Hotspot hotspotId="first-hotspot" />
+      <div id="second">
+        <Hotspot hotspotId="second-hotspot" />
+      </div>
+      <Hotspot hotspotId="third-hotspot" />
+    </>
+  );
+
+  const hotspot = wrapper.find('#second')!.findHotspot()!;
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('OPEN_HOTSPOT_TEST STEP_1_OF_2_TEST');
+  hotspot.findTrigger().click();
+  expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('CLOSE_HOTSPOT_TEST STEP_1_OF_2_TEST');
+});

--- a/src/annotation-context/__tests__/data.tsx
+++ b/src/annotation-context/__tests__/data.tsx
@@ -9,7 +9,10 @@ export const i18nStrings: AnnotationContextProps.I18nStrings = {
   previousButtonText: 'PREVIOUS_BUTTON_TEST',
   finishButtonText: 'FINISH_BUTTON_TEST',
   labelDismissAnnotation: 'DISMISS_ANNOTATION_TEST',
-  labelHotspot: (openState: boolean) => (openState ? 'CLOSE_HOTSPOT_TEST' : 'OPEN_HOTSPOT_TEST'),
+  labelHotspot: (openState: boolean, stepIndex: number, totalStepCount: number) =>
+    openState
+      ? `CLOSE_HOTSPOT_TEST_FOR_STEP_${stepIndex + 1}_OF_${totalStepCount}_TEST`
+      : `OPEN_HOTSPOT_TEST_FOR_STEP_${stepIndex + 1}_OF_${totalStepCount}_TEST`,
   stepCounterText: (stepIndex: number, totalStepCount: number) => `STEP_${stepIndex + 1}_OF_${totalStepCount}_TEST`,
   taskTitle: (taskIndex: number, taskTitle: string) => `TASK_${taskIndex + 1}_${taskTitle}`,
 };

--- a/src/annotation-context/__tests__/data.tsx
+++ b/src/annotation-context/__tests__/data.tsx
@@ -9,7 +9,7 @@ export const i18nStrings: AnnotationContextProps.I18nStrings = {
   previousButtonText: 'PREVIOUS_BUTTON_TEST',
   finishButtonText: 'FINISH_BUTTON_TEST',
   labelDismissAnnotation: 'DISMISS_ANNOTATION_TEST',
-  labelHotspot: (openState: boolean) => (openState ? 'OPEN_HOTSPOT_TEST' : 'CLOSE_HOTSPOT_TEST'),
+  labelHotspot: (openState: boolean) => (openState ? 'CLOSE_HOTSPOT_TEST' : 'OPEN_HOTSPOT_TEST'),
   stepCounterText: (stepIndex: number, totalStepCount: number) => `STEP_${stepIndex + 1}_OF_${totalStepCount}_TEST`,
   taskTitle: (taskIndex: number, taskTitle: string) => `TASK_${taskIndex + 1}_${taskTitle}`,
 };

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -5,6 +5,7 @@ import styles from './styles.css.js';
 import { AnnotationIcon } from './annotation-icon';
 import useFocusVisible from '../../internal/hooks/focus-visible/index.js';
 import { AnnotationContextProps } from '../interfaces';
+import { joinStrings } from '../../internal/utils/strings/join-strings.js';
 
 export interface AnnotationTriggerProps {
   open: boolean;
@@ -12,10 +13,12 @@ export interface AnnotationTriggerProps {
   onClick: () => void;
 
   i18nStrings: AnnotationContextProps['i18nStrings'];
+  taskLocalStepIndex: number;
+  totalLocalSteps: number;
 }
 
 export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(function AnnotationTrigger(
-  { open, onClick: onClickHandler, i18nStrings }: AnnotationTriggerProps,
+  { open, onClick: onClickHandler, i18nStrings, taskLocalStepIndex, totalLocalSteps }: AnnotationTriggerProps,
   ref
 ) {
   const focusVisible = useFocusVisible();
@@ -33,7 +36,10 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
       ref={ref}
       className={styles.hotspot}
       aria-haspopup="dialog"
-      aria-label={i18nStrings.labelHotspot(open)}
+      aria-label={joinStrings(
+        i18nStrings.labelHotspot(open),
+        i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)
+      )}
       onClick={onClick}
       {...focusVisible}
     >

--- a/src/annotation-context/annotation/annotation-trigger.tsx
+++ b/src/annotation-context/annotation/annotation-trigger.tsx
@@ -5,7 +5,6 @@ import styles from './styles.css.js';
 import { AnnotationIcon } from './annotation-icon';
 import useFocusVisible from '../../internal/hooks/focus-visible/index.js';
 import { AnnotationContextProps } from '../interfaces';
-import { joinStrings } from '../../internal/utils/strings/join-strings.js';
 
 export interface AnnotationTriggerProps {
   open: boolean;
@@ -36,10 +35,7 @@ export default React.forwardRef<HTMLButtonElement, AnnotationTriggerProps>(funct
       ref={ref}
       className={styles.hotspot}
       aria-haspopup="dialog"
-      aria-label={joinStrings(
-        i18nStrings.labelHotspot(open),
-        i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)
-      )}
+      aria-label={i18nStrings.labelHotspot(open, taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
       onClick={onClick}
       {...focusVisible}
     >

--- a/src/annotation-context/annotation/closed-annotation.tsx
+++ b/src/annotation-context/annotation/closed-annotation.tsx
@@ -12,9 +12,18 @@ export interface AnnotationProps {
   i18nStrings: AnnotationContextProps['i18nStrings'];
 
   focusOnRender: boolean;
+  totalLocalSteps: number;
+  taskLocalStepIndex: number;
 }
 
-export function ClosedAnnotation({ globalStepIndex, onOpen, i18nStrings, focusOnRender }: AnnotationProps) {
+export function ClosedAnnotation({
+  globalStepIndex,
+  onOpen,
+  i18nStrings,
+  focusOnRender,
+  totalLocalSteps,
+  taskLocalStepIndex,
+}: AnnotationProps) {
   const [hotspotRef, setHotspotRef] = useState<HTMLButtonElement | null>(null);
   const onClick = useCallback(() => {
     onOpen(globalStepIndex);
@@ -26,5 +35,14 @@ export function ClosedAnnotation({ globalStepIndex, onOpen, i18nStrings, focusOn
     }
   }, [focusOnRender, hotspotRef]);
 
-  return <AnnotationTrigger open={false} onClick={onClick} i18nStrings={i18nStrings} ref={setHotspotRef} />;
+  return (
+    <AnnotationTrigger
+      open={false}
+      onClick={onClick}
+      i18nStrings={i18nStrings}
+      ref={setHotspotRef}
+      totalLocalSteps={totalLocalSteps}
+      taskLocalStepIndex={taskLocalStepIndex}
+    />
+  );
 }

--- a/src/annotation-context/annotation/open-annotation.tsx
+++ b/src/annotation-context/annotation/open-annotation.tsx
@@ -61,7 +61,14 @@ export function OpenAnnotation({
 
   return (
     <>
-      <AnnotationTrigger open={true} onClick={onDismiss} i18nStrings={i18nStrings} ref={trackRef} />
+      <AnnotationTrigger
+        open={true}
+        onClick={onDismiss}
+        i18nStrings={i18nStrings}
+        ref={trackRef}
+        totalLocalSteps={totalLocalSteps}
+        taskLocalStepIndex={taskLocalStepIndex}
+      />
 
       <AnnotationPopover
         trackRef={trackRef}

--- a/src/annotation-context/index.tsx
+++ b/src/annotation-context/index.tsx
@@ -157,12 +157,15 @@ export default function AnnotationContext({
       }
 
       if (!task || !step || !open || id !== currentId) {
+        const { task: currentTask, localIndex: currentStepIndex } = getStepInfo(annotations, globalStepIndex);
         return (
           <ClosedAnnotation
             globalStepIndex={globalStepIndex}
             i18nStrings={i18nStrings}
             onOpen={onOpen}
             focusOnRender={id === currentId}
+            totalLocalSteps={currentTask ? currentTask.steps.length : 0}
+            taskLocalStepIndex={currentStepIndex}
           />
         );
       }
@@ -206,6 +209,7 @@ export default function AnnotationContext({
       openPreviousStep,
       onDismiss,
       onOpen,
+      annotations,
     ]
   );
 

--- a/src/annotation-context/interfaces.ts
+++ b/src/annotation-context/interfaces.ts
@@ -72,7 +72,7 @@ export namespace AnnotationContextProps {
     finishButtonText: string;
 
     labelDismissAnnotation: string;
-    labelHotspot: (openState: boolean) => string;
+    labelHotspot: (openState: boolean, stepIndex: number, totalStepCount: number) => string;
 
     stepCounterText: (stepIndex: number, totalStepCount: number) => string;
     taskTitle: (taskIndex: number, taskTitle: string) => string;


### PR DESCRIPTION
### Description

Current aria-label on annotation trigger has only _open/close_ state, the aria-labels are "open/close annotation". However, one page can have multiple annotations with same accessible name, screenreader users cant distinguish them. The PR is to add steps information to the aria-label, being for example "open annotation Step 3/6".

Related links, issue #AWSUI-19245

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit test. 

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
