### PR TITLE
chore: Add analytics beta hook

### DIFF
--- a/pages/app/index.html
+++ b/pages/app/index.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cloudscape demo pages</title>
 
-<head>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Cloudscape demo pages</title>
+    <script>
+      const isDevelopment = '<%= process.env.NODE_ENV %>' !== 'production';
+      const developmentCsp = "connect-src 'self' ws://" + location.host + ';';
+      const safeCsp = "default-src 'self'; style-src 'self'; font-src data:;" + (isDevelopment ? developmentCsp : '');
+      const themingCsp = "default-src 'self'; style-src 'unsafe-inline' 'self'; font-src data:;";
+      // Custom CSP required for how we load SVGs in CodeEditor component
+      //unsafe-inline is required for the react-resizable box in the code-editor
+      const codeEditorCsp =
+        "default-src 'self'; style-src 'unsafe-inline' 'self'; font-src data:;  img-src 'self' data:;" +
+        (isDevelopment ? developmentCsp : '');
 
-  <script>
-    const isDevelopment = "<%= process.env.NODE_ENV %>" !== "production";
-    const developmentCsp = "connect-src 'self' ws://" + location.host + ";" ;
-    const safeCsp = "default-src 'self'; style-src 'self'; font-src data:;" + (isDevelopment ? developmentCsp : "");
-    const themingCsp = "default-src 'self'; style-src 'unsafe-inline' 'self'; font-src data:;"
-    // Custom CSP required for how we load SVGs in CodeEditor component
-    //unsafe-inline is required for the react-resizable box in the code-editor
-    const codeEditorCsp = "default-src 'self'; style-src 'unsafe-inline' 'self'; font-src data:;  img-src 'self' data:;" + (isDevelopment ? developmentCsp : "");
- 
-    let csp;
-    if (location.hash.indexOf('code-editor') > -1) {
-      csp = codeEditorCsp;
-    } else if (location.hash.indexOf('theming') > -1) {
-      csp = themingCsp;
-    } else {
-      csp = safeCsp;
-    }
-    document.write('<meta http-equiv="Content-Security-Policy" content="' + csp + '" />');
-  </script>
-</head>
+      let csp;
+      if (location.hash.indexOf('code-editor') > -1) {
+        csp = codeEditorCsp;
+      } else if (location.hash.indexOf('theming') > -1) {
+        csp = themingCsp;
+      } else {
+        csp = safeCsp;
+      }
+      document.write('<meta http-equiv="Content-Security-Policy" content="' + csp + '" />');
+    </script>
+  </head>
 
-<body>
-  <!-- #b element should be there for compatibility with global navigation -->
-  <div id="b">
-    <div id="app"></div>
-  </div>
-</body>
-
+  <body class="awsui-analytics-enabled">
+    <!-- #b element should be there for compatibility with global navigation -->
+    <div id="b">
+      <div id="app"></div>
+    </div>
+  </body>
 </html>

--- a/pages/wizard/analytics.page.tsx
+++ b/pages/wizard/analytics.page.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Wizard, { WizardProps } from '~components/wizard';
+import Toggle from '~components/toggle';
+import Button from '~components/button';
+import styles from './styles.scss';
+
+import { i18nStrings } from './common';
+
+const steps: WizardProps.Step[] = [
+  {
+    title: 'Step 1',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 1</div>
+      </div>
+    ),
+  },
+  {
+    title: 'Step 2',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 2</div>
+      </div>
+    ),
+  },
+  {
+    title: 'Step 3',
+    content: (
+      <div className={styles['step-content']}>
+        <div id="content-text">Content 3</div>
+      </div>
+    ),
+  },
+];
+
+export default function WizardPage() {
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const [scrollableContainer, setScrollableContainer] = useState<boolean>(false);
+  return (
+    <div>
+      <Toggle
+        checked={scrollableContainer}
+        ariaLabel={'toggle'}
+        onChange={({ detail }) => setScrollableContainer(detail.checked)}
+      />
+      <input id="focus-reset" aria-label="input" />
+      <div id="scrollable-container" className={scrollableContainer ? styles['scrollable-container'] : ''}>
+        <Wizard
+          data-analytics="Test Wizard"
+          steps={steps}
+          i18nStrings={i18nStrings}
+          activeStepIndex={activeStepIndex}
+          onNavigate={e => setActiveStepIndex(e.detail.requestedStepIndex)}
+          secondaryActions={activeStepIndex === 2 ? <Button>Save as draft</Button> : null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/internal/hooks/use-analytics/__tests__/use-analytics.test.tsx
+++ b/src/internal/hooks/use-analytics/__tests__/use-analytics.test.tsx
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { useAnalytics } from '../index';
+
+describe('useAnalytics', () => {
+  function App() {
+    const analyticsEnabled = useAnalytics();
+    return <div data-testid="root">{analyticsEnabled.toString()}</div>;
+  }
+
+  test('analytics disabled by default', () => {
+    render(<App />);
+    expect(screen.getByTestId('root')).toHaveTextContent('false');
+  });
+});

--- a/src/internal/hooks/use-analytics/index.ts
+++ b/src/internal/hooks/use-analytics/index.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// We expect analytics to be set only once and before the application is rendered.
+let analyticsEnabled: boolean | undefined = undefined;
+
+export function useAnalytics() {
+  if (analyticsEnabled === undefined) {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      analyticsEnabled = false;
+    } else {
+      analyticsEnabled = !!document.querySelector('.awsui-analytics-enabled');
+    }
+  }
+
+  return analyticsEnabled;
+}

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -16,6 +16,8 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 
+import { useAnalytics } from '../internal/hooks/use-analytics';
+
 export { WizardProps };
 
 export default function Wizard({
@@ -31,6 +33,7 @@ export default function Wizard({
   ...rest
 }: WizardProps) {
   const { __internalRootRef } = useBaseComponent('Wizard');
+
   const baseProps = getBaseProps(rest);
 
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
@@ -79,8 +82,11 @@ export default function Wizard({
     );
   }
 
+  const analyticsEnabled = useAnalytics();
+  const analyticsProps = analyticsEnabled ? { ['data-analytics-type']: 'funnel' } : {};
+
   return (
-    <div {...baseProps} className={clsx(styles.root, baseProps.className)} ref={ref}>
+    <div {...analyticsProps} {...baseProps} className={clsx(styles.root, baseProps.className)} ref={ref}>
       <div
         className={clsx(styles.wizard, isVisualRefresh && styles.refresh, smallContainer && styles['small-container'])}
       >

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -11,6 +11,7 @@ import WizardFormHeader from './wizard-form-header';
 import styles from './styles.css.js';
 import useFocusVisible from '../internal/hooks/focus-visible';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
+import { useAnalytics } from '../internal/hooks/use-analytics';
 
 interface WizardFormProps {
   steps: ReadonlyArray<WizardProps.Step>;
@@ -61,6 +62,9 @@ export default function WizardForm({
       ? i18nStrings.skipToButtonLabel(steps[skipToTargetIndex], skipToTargetIndex + 1)
       : undefined;
 
+  const analyticsEnabled = useAnalytics();
+  const analyticsProps = analyticsEnabled ? { ['data-analytics']: title, ['data-analytics-type']: 'eventContext' } : {};
+
   return (
     <>
       <WizardFormHeader isMobile={isMobile || showCollapsedSteps} isVisualRefresh={isVisualRefresh}>
@@ -101,7 +105,7 @@ export default function WizardForm({
         errorText={errorText}
         errorIconAriaLabel={i18nStrings.errorIconAriaLabel}
       >
-        {content}
+        <div {...analyticsProps}>{content}</div>
       </InternalForm>
     </>
   );


### PR DESCRIPTION
### Description

Adds an internal hook that will check for the presence of a beta data attribute to enable auto tagging of the Wizard component for better analytics integration.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Added a simple unit test for the hook
- Manual validation of added tags

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
