### PR TITLE
feat: Screen reader should announce tutorial completion message

### DIFF
--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -177,6 +177,15 @@ describe('tutorial detail view', () => {
     wrapper.findFeedbackLink()!.getElement().click();
     expect(onFeedbackClick).toHaveBeenCalledTimes(1);
   });
+
+  test('completed screen should have role status', () => {
+    const tutorials = getTutorials();
+    const context = getContext({ currentTutorial: tutorials[1] });
+    const { container } = renderTutorialPanelWithContext({ tutorials }, context);
+    const completedScreen = createWrapper(container).findTutorialPanel()!.find('[role="status"]')!.getElement();
+    expect(completedScreen).toHaveTextContent('COMPLETION_SCREEN_TITLE');
+    expect(completedScreen).toHaveTextContent('COMPLETED_SCREEN_DESCRIPTION_TEST');
+  });
 });
 
 describe('URL sanitization', () => {

--- a/src/tutorial-panel/components/tutorial-detail-view/index.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/index.tsx
@@ -56,11 +56,14 @@ export default function TutorialDetailView({
             {tutorial.title}
           </InternalBox>
         </div>
-        {tutorial.completed ? (
-          <CongratulationScreen onFeedbackClick={onFeedbackClick} i18nStrings={i18nStrings}>
-            {tutorial.completedScreenDescription}
-          </CongratulationScreen>
-        ) : (
+        <div role="status">
+          {tutorial.completed && (
+            <CongratulationScreen onFeedbackClick={onFeedbackClick} i18nStrings={i18nStrings}>
+              {tutorial.completedScreenDescription}
+            </CongratulationScreen>
+          )}
+        </div>
+        {!tutorial.completed && (
           <TaskList
             tasks={tutorial.tasks}
             onExitTutorial={onExitTutorial}


### PR DESCRIPTION
### Description

When tutorial is completed, the completion message should be announced.

Related links, issue #AWSUI-19249

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit test.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
