### PR TITLE
revert: Show popover for truncated Breadcrumb text on hover or focus (#492)

### DIFF
--- a/pages/breadcrumb-group/scenarios.page.tsx
+++ b/pages/breadcrumb-group/scenarios.page.tsx
@@ -23,14 +23,8 @@ const testCases = [
 
 export default function ButtonDropdownPage() {
   return (
-    <article>
-      <ScreenshotArea
-        disableAnimations={true}
-        style={{
-          // extra space to include popover in the screenshot area
-          paddingBottom: 200,
-        }}
-      >
+    <ScreenshotArea disableAnimations={true}>
+      <article>
         <h1>BreadcrumbGroup variations</h1>
         {testCases.map((testcase, index) => (
           <BreadcrumbGroup
@@ -40,10 +34,7 @@ export default function ButtonDropdownPage() {
             items={testcase.map((text, i) => ({ text, href: `#item-${index}-${i}` }))}
           />
         ))}
-      </ScreenshotArea>
-      <button type="button" id="focus-target">
-        focus
-      </button>
-    </article>
+      </article>
+    </ScreenshotArea>
   );
 }

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -56,7 +56,6 @@ export namespace BreadcrumbGroupProps {
 export interface BreadcrumbItemProps<T extends BreadcrumbGroupProps.Item> {
   item: T;
   isLast?: boolean;
-  isFirst?: boolean;
   isCompressed?: boolean;
   onClick?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;
   onFollow?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;

--- a/src/breadcrumb-group/internal.tsx
+++ b/src/breadcrumb-group/internal.tsx
@@ -101,7 +101,6 @@ export default function InternalBreadcrumbGroup<T extends BreadcrumbGroupProps.I
           onFollow={onFollow}
           isCompressed={isMobile}
           isLast={index === items.length - 1}
-          isFirst={index === 0}
         />
       </li>
     );

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { BreadcrumbGroupProps, BreadcrumbItemProps } from '../interfaces';
 import InternalIcon from '../../icon/internal';
 import styles from './styles.css.js';
@@ -8,25 +8,15 @@ import clsx from 'clsx';
 import useFocusVisible from '../../internal/hooks/focus-visible';
 import { fireCancelableEvent, isPlainLeftClick } from '../../internal/events';
 import { getEventDetail } from '../internal';
-import { Transition } from '../../internal/components/transition';
-import PopoverContainer from '../../popover/container';
-import PopoverBody from '../../popover/body';
-import Portal from '../../internal/components/portal';
-import popoverStyles from '../../popover/styles.css.js';
-import { useContainerQuery } from '../../internal/hooks/container-queries';
-import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 
 export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
   item,
   onClick,
   onFollow,
   isLast = false,
-  isFirst = false,
   isCompressed = false,
 }: BreadcrumbItemProps<T>) {
   const focusVisible = useFocusVisible();
-  const [textTruncated, setTextTruncated] = useState(false);
-  const [openPopover, setOpenPopover] = useState(false);
   const preventDefault = (event: React.MouseEvent) => event.preventDefault();
   const onClickHandler = (event: React.MouseEvent) => {
     if (isPlainLeftClick(event)) {
@@ -34,76 +24,24 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
     }
     fireCancelableEvent(onClick, getEventDetail(item), event);
   };
-  const trackRef = useRef<HTMLElement>(null);
-  const [textWidth, textRef] = useContainerQuery(rect => rect.width);
-  const mergedRef = useMergeRefs(trackRef, textRef);
-  const virtualTextRef = useRef<HTMLElement>(null);
-
-  const popoverContent = (
-    <Transition in={openPopover}>
-      {() => (
-        <PopoverContainer
-          trackRef={trackRef}
-          size="small"
-          fixedWidth={false}
-          position="bottom"
-          arrow={position => (
-            <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
-              <div className={popoverStyles['arrow-outer']} />
-              <div className={popoverStyles['arrow-inner']} />
-            </div>
-          )}
-        >
-          <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
-            {item.text}
-          </PopoverBody>
-        </PopoverContainer>
-      )}
-    </Transition>
-  );
-
-  useEffect(() => {
-    if (isCompressed && textWidth && virtualTextRef && virtualTextRef.current) {
-      if (Math.round(virtualTextRef.current.clientWidth) > Math.round(textWidth)) {
-        setTextTruncated(true);
-      }
-    } else {
-      setTextTruncated(false);
-    }
-  }, [isCompressed, textWidth, virtualTextRef]);
-
   return (
-    <>
-      <div className={clsx(styles.breadcrumb, isLast && styles.last)}>
-        <a
-          {...focusVisible}
-          href={isLast ? undefined : item.href || '#'}
-          className={clsx(styles.anchor, { [styles.compressed]: isCompressed })}
-          aria-current={isLast ? 'page' : undefined} // Active breadcrumb item is implemented according to WAI-ARIA 1.1
-          aria-disabled={isLast && 'true'}
-          onClick={isLast ? preventDefault : onClickHandler}
-          tabIndex={isLast ? 0 : undefined} // tabIndex is added to the last crumb to keep it in the index without an href
-          onFocus={() => textTruncated && setOpenPopover(true)}
-          onBlur={() => textTruncated && setOpenPopover(false)}
-          onMouseEnter={() => textTruncated && setOpenPopover(true)}
-          onMouseLeave={() => textTruncated && setOpenPopover(false)}
-        >
-          <span className={styles.text} ref={mergedRef}>
-            {item.text}
-          </span>
-          {(isLast || isFirst) && isCompressed && (
-            <span className={styles['virtual-item']} ref={virtualTextRef}>
-              {item.text}
-            </span>
-          )}
-        </a>
-        {!isLast ? (
-          <span className={styles.icon}>
-            <InternalIcon name="angle-right" />
-          </span>
-        ) : null}
-      </div>
-      {openPopover && <Portal>{popoverContent}</Portal>}
-    </>
+    <div className={clsx(styles.breadcrumb, isLast && styles.last)}>
+      <a
+        {...focusVisible}
+        href={isLast ? undefined : item.href || '#'}
+        className={clsx(styles.anchor, { [styles.compressed]: isCompressed })}
+        aria-current={isLast ? 'page' : undefined} // Active breadcrumb item is implemented according to WAI-ARIA 1.1
+        aria-disabled={isLast && 'true'}
+        onClick={isLast ? preventDefault : onClickHandler}
+        tabIndex={isLast ? 0 : undefined} // tabIndex is added to the last crumb to keep it in the index without an href
+      >
+        <span className={styles.text}>{item.text}</span>
+      </a>
+      {!isLast ? (
+        <span className={styles.icon}>
+          <InternalIcon name="angle-right" />
+        </span>
+      ) : null}
+    </div>
   );
 }

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -36,6 +36,7 @@
       font-weight: styles.$font-weight-bold;
       text-decoration: none;
       cursor: default;
+      pointer-events: none;
     }
   }
 }
@@ -48,8 +49,4 @@
     white-space: nowrap;
     display: block;
   }
-}
-.virtual-item {
-  @include styles.awsui-util-hide;
-  visibility: hidden;
 }


### PR DESCRIPTION
revert #492  

### Description

This reverts commit 916caba64c9bbe6a94e0d52c8dcfd843396398a5.
Because of performance regression. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
