### PR TITLE
fix: Use deterministic table items for AppLayout page

### DIFF
--- a/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
+++ b/pages/app-layout/with-sticky-table-and-split-panel.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import AppLayout from '~components/app-layout';
 import Header from '~components/header';
 import Link from '~components/link';
@@ -14,6 +14,9 @@ import { columnsConfig } from '../table/shared-configs';
 import Button from '~components/button';
 import SplitPanel from '~components/split-panel';
 import SpaceBetween from '~components/space-between';
+
+const maxItemCount = 30;
+const defaultItems = generateItems(maxItemCount);
 
 const DEMO_CONTENT = (
   <div>
@@ -31,7 +34,7 @@ const DEMO_CONTENT = (
         </Header>
       }
       columnDefinitions={columnsConfig}
-      items={generateItems(10)}
+      items={defaultItems.slice(0, 10)}
       variant="embedded"
     />
     <p>
@@ -62,18 +65,13 @@ const DEMO_CONTENT = (
 export default function () {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
-  const [itemCount, setItemCount] = useState<number>(30);
-  const [items, setItems] = useState(generateItems(itemCount));
+  const [itemSizeToDisplay, setItemSizeToDisplay] = useState(maxItemCount);
   const [splitPanelOpen, setSplitPanelOpen] = useState(false);
 
   function openHelp(article: keyof typeof toolsContent) {
     setToolsOpen(true);
     setSelectedTool(article);
   }
-
-  useEffect(() => {
-    setItems(generateItems(itemCount));
-  }, [itemCount]);
 
   return (
     <ScreenshotArea gutters={false}>
@@ -99,11 +97,11 @@ export default function () {
                 }
                 actions={
                   <SpaceBetween size="xs" direction="horizontal">
-                    <Button data-testid="set-item-count-to-1" onClick={() => setItemCount(1)}>
+                    <Button data-testid="set-item-count-to-1" onClick={() => setItemSizeToDisplay(1)}>
                       Set item count to 1
                     </Button>
-                    <Button data-testid="set-item-count-to-30" onClick={() => setItemCount(30)}>
-                      Set item count to 30
+                    <Button data-testid="set-item-count-to-30" onClick={() => setItemSizeToDisplay(maxItemCount)}>
+                      Set item count to {maxItemCount}
                     </Button>
                   </SpaceBetween>
                 }
@@ -114,7 +112,7 @@ export default function () {
             stickyHeader={true}
             variant="full-page"
             columnDefinitions={columnsConfig}
-            items={items}
+            items={defaultItems.slice(0, itemSizeToDisplay)}
           />
         }
         splitPanelOpen={splitPanelOpen}


### PR DESCRIPTION
Screenshot tests failed because of non-deterministic
table items. When toggling in between the item count
the items did not stay the same. This commit fixed that
behaviour and the related failing screenshot tests.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
