### PR TITLE
fix: Allow popovers in charts to be dismissed by pressing Esc

### DIFF
--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -192,6 +192,27 @@ describe('Popover', () => {
       await expect(page.getPopoverTitle()).resolves.toBe('5s');
     })
   );
+
+  test(
+    'popover can be closed when Escape is pressed after hover',
+    setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await expect(page.hasPopover()).resolves.toBe(false);
+      await page.hoverElement(page.chart.toSelector());
+      await expect(page.hasPopover()).resolves.toBe(true);
+      await page.keys(['Escape']);
+      await expect(page.hasPopover()).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'popover can be closed when Escape is pressed after chart plot is focused',
+    setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await page.focusPlot();
+      await expect(page.hasPopover()).resolves.toBe(true);
+      await page.keys(['Escape']);
+      await expect(page.hasPopover()).resolves.toBe(false);
+    })
+  );
 });
 
 describe('Keyboard navigation', () => {

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -114,6 +114,12 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
   const reserveLegendSpace = !showChart && !hideLegend;
   const reserveFilterSpace = !showChart && !isNoMatch && (!hideFilter || additionalFilters);
 
+  useEffect(() => {
+    const onKeyDown = model.handlers.onDocumentKeyDown;
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [model.handlers.onDocumentKeyDown]);
+
   const onBlur = (event: React.FocusEvent) => {
     if (event.relatedTarget && !nodeContains(containerRef.current, event.relatedTarget)) {
       model.handlers.onContainerBlur();

--- a/src/area-chart/model/index.ts
+++ b/src/area-chart/model/index.ts
@@ -26,6 +26,7 @@ export interface ChartModel<T extends AreaChartProps.DataTypes> {
     onLegendHighlight: (series: null | AreaChartProps.Series<T>) => void;
     onPopoverDismiss: (outsideClick?: boolean) => void;
     onContainerBlur: () => void;
+    onDocumentKeyDown: (event: KeyboardEvent) => void;
   };
   interactions: ReadonlyAsyncStore<ChartModel.InteractionsState<T>>;
   refs: {

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -241,6 +241,13 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
       interactions.clearState();
     };
 
+    const onDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        interactions.clearHighlight();
+        interactions.clearHighlightedLegend();
+      }
+    };
+
     return {
       width,
       height,
@@ -260,6 +267,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
         onLegendHighlight,
         onPopoverDismiss,
         onContainerBlur,
+        onDocumentKeyDown,
       },
       refs: {
         plot: plotRef,

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -337,6 +337,35 @@ describe('Details popover', () => {
   );
 
   test(
+    'can be hidden after hover by pressing Escape',
+    setupTest('#/light/mixed-line-bar-chart/test', async page => {
+      // Hover over first group
+      await page.hoverElement(chartWrapper.findBarGroups().get(1).toSelector());
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
+
+      // Pressing escape should hide the popover
+      await page.keys(['Escape']);
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(false);
+      await expect(page.isDisplayed(popoverHeaderSelector())).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'can be hidden after keyboard navigation by pressing Escape',
+    setupTest('#/light/bar-chart/test', async page => {
+      // Navigate first group in the first chart
+      await page.click('#focus-target');
+      await page.keys(['Tab', 'Tab', 'ArrowRight']);
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
+
+      // Pressing Escape should close the popover
+      await page.keys(['Escape']);
+      await expect(page.isDisplayed(popoverHeaderSelector())).resolves.toBe(false);
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(false);
+    })
+  );
+
+  test(
     'can be pinned by clicking on chart background and dismissed by clicking outside chart area in line chart',
     setupTest('#/light/line-chart/test', async page => {
       // Hovers to open popover

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -263,6 +263,22 @@ export default function ChartContainer<T extends ChartDataTypes>({
     return null;
   }, [highlightedPoint, verticalMarkerLeft, highlightedGroupIndex, scaledSeries, barGroups]);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dismissPopover();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [dismissPopover]);
+
+  useLayoutEffect(() => {
+    if (highlightedX !== null || highlightedPoint !== null) {
+      showPopover();
+    }
+  }, [highlightedX, highlightedPoint, showPopover]);
+
   const onPopoverDismiss = (outsideClick?: boolean) => {
     dismissPopover();
 
@@ -277,12 +293,6 @@ export default function ChartContainer<T extends ChartDataTypes>({
       }, 0);
     }
   };
-
-  useLayoutEffect(() => {
-    if (highlightedX !== null) {
-      showPopover();
-    }
-  }, [highlightedX, showPopover]);
 
   const onSVGMouseDown = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
     if (isPopoverOpen) {

--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -299,6 +299,27 @@ describe('Detail popover', () => {
       await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(false);
     })
   );
+
+  test(
+    'can be dismissed after hovering on the segment by pressing Escape',
+    setupTest(async page => {
+      await page.hoverElement(pieWrapper.findSegments().get(1).toSelector());
+      await page.waitForVisible(detailsPopoverSelector);
+      await page.keys(['Escape']);
+      await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'can be dismissed after navigating to the segment with keyboard by pressing Escape',
+    setupTest(async page => {
+      await page.click('#focus-target');
+      await page.keys(['Tab', 'Tab', 'Enter']);
+      await page.waitForVisible(detailsPopoverSelector);
+      await page.keys(['Escape']);
+      await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(false);
+    })
+  );
 });
 
 describe('Focus outline', () => {

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { pie } from 'd3-shape';
 
@@ -164,10 +164,21 @@ export default <T extends PieChartProps.Datum>({
     },
     [highlightedSegment, setTooltipOpen, onHighlightChange]
   );
+
   const clearHighlightedSegment = useCallback(() => {
     setTooltipOpen(false);
     onHighlightChange(null);
   }, [onHighlightChange, setTooltipOpen]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        clearHighlightedSegment();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [clearHighlightedSegment]);
 
   const onMouseDown = useCallback(
     (internalDatum: InternalChartDatum<T>) => {


### PR DESCRIPTION
### Description

The accessibility issue in question is that the details popovers appear on hover or during keyboard navigation, but they obscure content when they appear. Assistive technology users need a way to be able to dismiss these popovers without needing to drag the cursor all the way out of the chart.

Related links, issue #, if available: AWSUI-19204, AWSUI-19231, AWSUI-19238, AWSUI-19254, four issues baby wooo let's goooo

### How has this been tested?

Integration tests, but feel free to test it yourself manually too!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
