### PR TITLE
chore: Print stack trace in error message

### DIFF
--- a/pages/app/components/error-boundary.tsx
+++ b/pages/app/components/error-boundary.tsx
@@ -10,13 +10,13 @@ export default class ErrorBoundary extends React.Component<any, { errorMessage: 
 
   static getDerivedStateFromError(error: Error) {
     // Update state so the next render will show the fallback UI.
-    return { errorMessage: error.message };
+    return { errorMessage: error.stack || error.message };
   }
 
   render() {
     if (this.state.errorMessage) {
       // You can render any custom fallback UI
-      return <span style={{ color: 'red' }}>{this.state.errorMessage}</span>;
+      return <span style={{ color: 'red', whiteSpace: 'pre' }}>{this.state.errorMessage}</span>;
     }
 
     return this.props.children;


### PR DESCRIPTION
### Description

Print not only the error message, but also a stacktrace

Related links, issue #, if available: n/a

### How has this been tested?

Pr build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
