### PR TITLE
chore: Disable code coverage when running locally

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -9,7 +9,7 @@ module.exports = merge({}, tsPreset, cloudscapePreset, {
   verbose: true,
   testEnvironment: 'jsdom',
   reporters: ['default', 'github-actions'],
-  collectCoverage: true,
+  collectCoverage: process.env.CI === 'true',
   coveragePathIgnorePatterns: [
     '__tests__',
     '__integ__',


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Disable code coverage when running locally. Can be overridden, via command line: `npx jest -c jest.unit.config.js --collectCoverage`

Related links, issue #, if available: n/a

### How has this been tested?

* Locally – no coverage by default, faster tests, cleaner console
* CI - See the CodeCov comment below

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
