### PR TITLE
refactor: Join all state changes in a single place

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -200,6 +200,44 @@ describe('Date range picker', () => {
         expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/17');
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('23:59:59');
       });
+
+      test('missing start date can be filled (before end date)', () => {
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
+        });
+
+        act(() => wrapper.findTrigger().click());
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('');
+        act(() => wrapper.findDropdown()!.findDateAt('left', 2, 3).click());
+
+        expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('9');
+        expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/09');
+        expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('00:00:00');
+
+        expect(wrapper.findDropdown()!.findSelectedEndDate()!.getElement()).toHaveTextContent('12');
+        expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/12');
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('13:05:21');
+      });
+
+      test('missing start date can be filled (after end date, requires a flip)', () => {
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
+        });
+
+        act(() => wrapper.findTrigger().click());
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('');
+        act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
+
+        expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('12');
+        expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/12');
+        expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('00:00:00');
+
+        expect(wrapper.findDropdown()!.findSelectedEndDate()!.getElement()).toHaveTextContent('17');
+        expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/17');
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('23:59:59');
+      });
     });
 
     describe('time offset', () => {

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -220,7 +220,7 @@ describe('Date range picker', () => {
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('13:05:21');
       });
 
-      test('missing start date can be filled (after end date, requires a flip)', () => {
+      test('missing start date can be filled (after end date, requires a swap)', () => {
         const { wrapper } = renderDateRangePicker({
           ...defaultProps,
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },

--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -77,6 +77,10 @@ describe('Date range picker calendar', () => {
     return wrapper.findDropdown()!.findByClassName(gridDayStyles.today)!;
   };
 
+  const findLiveAnnouncement = (wrapper: DateRangePickerWrapper) => {
+    return wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])!.getElement();
+  };
+
   beforeEach(() => {
     // Set default locale of the browser to en-US for more consistent tests
     const locale = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' });
@@ -450,40 +454,51 @@ describe('Date range picker calendar', () => {
     test('add aria-live when date is selected', () => {
       const { wrapper } = renderDateRangePicker({
         ...defaultProps,
+        rangeSelectorMode: 'absolute-only',
         value: null,
       });
-      changeMode(wrapper, 'absolute');
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])!.getElement()).toHaveTextContent('');
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent('');
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
       });
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])!.getElement()).toHaveTextContent(
-        new RegExp(i18nStrings.startDateLabel)
-      );
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
       });
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])?.getElement()).toHaveTextContent(
-        new RegExp(i18nStrings.endDateLabel)
-      );
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])?.getElement()).toHaveTextContent(
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings!.renderSelectedAbsoluteRangeAriaLive!('', ''))
       );
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 3, 2).click();
       });
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])!.getElement()).toHaveTextContent(
-        new RegExp(i18nStrings.startDateLabel)
-      );
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 3, 1).click();
       });
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])!.getElement()).toHaveTextContent(
-        new RegExp(i18nStrings.startDateLabel)
-      );
-      expect(wrapper.findDropdown()!.findByClassName(styles['calendar-aria-live'])?.getElement()).toHaveTextContent(
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings.renderSelectedAbsoluteRangeAriaLive!('', ''))
       );
+    });
+
+    test('renders default range announcement when i18n string is not provided', () => {
+      const { wrapper } = renderDateRangePicker({
+        ...defaultProps,
+        i18nStrings: { ...defaultProps.i18nStrings, renderSelectedAbsoluteRangeAriaLive: undefined },
+        rangeSelectorMode: 'absolute-only',
+        value: null,
+      });
+      // select start
+      act(() => {
+        wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
+      });
+      // select end
+      act(() => {
+        wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
+      });
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent('Sunday, September 6, 2020 – Monday, September 7, 2020');
     });
 
     test('should set aria-disabled="true" and unset aria-selected to disabled date', () => {


### PR DESCRIPTION
### Description

Split calculations and side effects into separate places. First, we figure which changes we need to make, then make these changes. Basically, this

```js
// before
if(condition) {
   rangeStart.setDate(foo)
} else {
   rangeStart.setDate(bar)
}

// after
let newValue
if(condition) {
   newValue = foo
} else {
   newValue = bar
}

// all side-effects are below
if(newValue) {
   rangeStart.setDate(newValue)
}
```

In the next PR I am going to change `rangeStart.setDate` signature, so it would be very nice to change 1 line and not 4

Related links, issue #, if available: n/a

### How has this been tested?

PR build + locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
