### PR TITLE
fix: Tutorial panel margin on top of task list

### DIFF
--- a/src/tutorial-panel/components/tutorial-detail-view/index.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/index.tsx
@@ -56,21 +56,23 @@ export default function TutorialDetailView({
             {tutorial.title}
           </InternalBox>
         </div>
-        <div role="status">
-          {tutorial.completed && (
-            <CongratulationScreen onFeedbackClick={onFeedbackClick} i18nStrings={i18nStrings}>
-              {tutorial.completedScreenDescription}
-            </CongratulationScreen>
+        <div>
+          <div role="status">
+            {tutorial.completed && (
+              <CongratulationScreen onFeedbackClick={onFeedbackClick} i18nStrings={i18nStrings}>
+                {tutorial.completedScreenDescription}
+              </CongratulationScreen>
+            )}
+          </div>
+          {!tutorial.completed && (
+            <TaskList
+              tasks={tutorial.tasks}
+              onExitTutorial={onExitTutorial}
+              currentGlobalStepIndex={currentStepIndex}
+              i18nStrings={i18nStrings}
+            />
           )}
         </div>
-        {!tutorial.completed && (
-          <TaskList
-            tasks={tutorial.tasks}
-            onExitTutorial={onExitTutorial}
-            currentGlobalStepIndex={currentStepIndex}
-            i18nStrings={i18nStrings}
-          />
-        )}
       </InternalSpaceBetween>
     </>
   );


### PR DESCRIPTION
### Description

#510 added another child under `SpaceBetween`, introduced extra margin before the task list. This PR is to fix it.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
