### PR TITLE
fix: Change the highlighted pinned segment on mouse down in Pie Chart

### DIFF
--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -322,6 +322,19 @@ describe('Detail popover', () => {
   );
 });
 
+test(
+  'highlights the clicked segment when there is a pinned segment',
+  setupTest(async page => {
+    // Show and pin the popover by clicking
+    await page.click(pieWrapper.findSegments().get(2).toSelector());
+    await page.waitForVisible(detailsPopoverSelector);
+    await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Chocolate');
+
+    await page.click(pieWrapper.findSegments().get(1).toSelector());
+    await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Potatoes');
+    await expect(page.getText(pieWrapper.findHighlightedSegmentLabel().toSelector())).resolves.toBe('Potatoes');
+  })
+);
 describe('Focus outline', () => {
   const focusOutlineSelector = `.${chartPlotStyles['focus-outline']}`;
 

--- a/src/pie-chart/index.tsx
+++ b/src/pie-chart/index.tsx
@@ -116,14 +116,11 @@ const PieChart = function PieChart<T extends PieChartProps.Datum = PieChartProps
 
   const onHighlightChange = useCallback(
     (segment: T | null) => {
-      if (pinnedSegment !== null) {
-        return;
-      }
       setLegendSegment(segment);
       setHighlightedSegment(segment);
       fireNonCancelableEvent(controlledOnHighlightChange, { highlightedSegment: segment });
     },
-    [pinnedSegment, controlledOnHighlightChange, setHighlightedSegment]
+    [controlledOnHighlightChange, setHighlightedSegment]
   );
 
   const onBlur = (event: React.FocusEvent) => {


### PR DESCRIPTION
### Description

In the pie chart if a user clicks on a segment so it become pinned and tries to click on another segment, the highlight will remain on the first pinned segment, check the video: 

https://user-images.githubusercontent.com/99883674/203754470-43216d09-c9aa-4e65-9988-ff65cd1ff84b.mov



### How has this been tested?
Added an integration test for it

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
