### PR TITLE
fix: Remove table round corner under header

### DIFF
--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -61,8 +61,6 @@
   padding-top: awsui.$space-table-content-top;
   padding-bottom: awsui.$space-table-content-bottom;
   overflow-x: auto;
-  border-top-right-radius: awsui.$border-radius-container;
-  border-top-left-radius: awsui.$border-radius-container;
   &.variant-stacked,
   &.variant-container {
     & > .table {
@@ -78,6 +76,10 @@
   }
   &.has-footer {
     padding-bottom: 0px;
+  }
+  &:not(.has-header) {
+    border-top-right-radius: awsui.$border-radius-container;
+    border-top-left-radius: awsui.$border-radius-container;
   }
 
   @include focus-visible.when-visible {


### PR DESCRIPTION
### Description

Table rounded corner causes gap between header. The fix is to remove the border-radius when header exists.  

Related links, issue AWSUI-19854

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
