### PR TITLE
fix: Property filter duplicates property name in suggestion when the label is empty

### DIFF
--- a/src/internal/components/option/index.tsx
+++ b/src/internal/components/option/index.tsx
@@ -59,7 +59,7 @@ const Option = ({
 
   return (
     <span
-      title={option.label || option.value}
+      title={option.label ?? option.value}
       data-value={option.value}
       className={className}
       aria-disabled={disabled}
@@ -69,7 +69,7 @@ const Option = ({
       <span className={clsx(styles.content)}>
         <span className={clsx(styles['label-content'])}>
           <Label
-            label={option.label || option.value}
+            label={option.label ?? option.value}
             prefix={option.__labelPrefix}
             highlightText={highlightText}
             triggerVariant={triggerVariant}


### PR DESCRIPTION
### Description
<!-- Include a summary of the changes and the related issue. -->
<!-- Also include relevant motivation and context. -->

When the label of a suggested value in the property filter is empty, it uses the value instead. However, the value contains the property name, so the property name is duplicated. With this change, an empty value of an option is correctly displayed as empty.

Related links, issue #, if available: AWSUI-19878

### How has this been tested?

<!-- How did you test to verify your changes? -->
Manual testing in a dev page

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
