### PR TITLE
feat: Add slot for custom controls in absolute range date picker

### DIFF
--- a/pages/date-range-picker/calendar-permutations.page.tsx
+++ b/pages/date-range-picker/calendar-permutations.page.tsx
@@ -21,19 +21,26 @@ const intervals = [
   ['2021-05-10', '2021-05-30'],
 ];
 
-const permutations = createPermutations<DateRangePickerCalendarProps>(
-  intervals.map(([startDate, endDate]) => ({
+const permutations = createPermutations<DateRangePickerCalendarProps>([
+  ...intervals.map(([startDate, endDate]) => ({
     value: [{ start: { date: startDate, time: '' }, end: { date: endDate, time: '' } }],
     setValue: [() => {}],
     locale: ['en-GB'],
     startOfWeek: [1],
     isDateEnabled: [() => true],
     onChange: [() => {}],
-    timeInputFormat: ['hh:mm:ss'],
+    timeInputFormat: ['hh:mm:ss'] as const,
     i18nStrings: [i18nStrings],
     dateOnly: [false, true],
-  }))
-);
+    customAbsoluteRangeControl: [undefined],
+  })),
+  {
+    value: [{ start: { date: '', time: '' }, end: { date: '', time: '' } }],
+    setValue: [() => {}],
+    i18nStrings: [i18nStrings],
+    customAbsoluteRangeControl: [() => 'Custom control'],
+  },
+]);
 
 export default function DateRangePickerCalendarPage() {
   let i = -1;

--- a/pages/date-range-picker/custom-control.page.tsx
+++ b/pages/date-range-picker/custom-control.page.tsx
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import startOfWeek from 'date-fns/startOfWeek';
+import endOfWeek from 'date-fns/endOfWeek';
+import startOfMonth from 'date-fns/startOfMonth';
+import endOfMonth from 'date-fns/endOfMonth';
+import enLocale from 'date-fns/locale/en-GB';
+import { Box, DateRangePicker, DateRangePickerProps, Link, FormField } from '~components';
+import { i18nStrings, isValid } from './common';
+import { formatDate } from '~components/internal/utils/date-time';
+
+export default function DatePickerScenario() {
+  const [value, setValue] = useState<DateRangePickerProps['value']>(null);
+
+  return (
+    <Box padding="s">
+      <h1>Date range picker with custom control</h1>
+      <FormField label="Date Range Picker field">
+        <DateRangePicker
+          value={value}
+          onChange={e => setValue(e.detail.value)}
+          locale={enLocale.code}
+          i18nStrings={i18nStrings}
+          relativeOptions={[]}
+          placeholder="Filter by a date and time range"
+          isValidRange={isValid}
+          rangeSelectorMode="absolute-only"
+          customAbsoluteRangeControl={(selectedDate, setSelectedDate) => (
+            <>
+              Auto-select:{' '}
+              <Link
+                onFollow={() => {
+                  const today = formatDate(new Date());
+                  return setSelectedDate({
+                    start: { date: today, time: '' },
+                    end: { date: today, time: '' },
+                  });
+                }}
+              >
+                1D
+              </Link>{' '}
+              <Link
+                variant="secondary"
+                onFollow={() =>
+                  setSelectedDate({
+                    start: {
+                      date: formatDate(startOfWeek(new Date(), { locale: enLocale })),
+                      time: '',
+                    },
+                    end: {
+                      date: formatDate(endOfWeek(new Date(), { locale: enLocale })),
+                      time: '',
+                    },
+                  })
+                }
+              >
+                7D
+              </Link>{' '}
+              <Link
+                onFollow={() =>
+                  setSelectedDate({
+                    start: { date: formatDate(startOfMonth(new Date())), time: '' },
+                    end: { date: formatDate(endOfMonth(new Date())), time: '' },
+                  })
+                }
+              >
+                1M
+              </Link>{' '}
+              <Link
+                onFollow={() =>
+                  setSelectedDate({
+                    start: { date: '', time: '' },
+                    end: { date: '', time: '' },
+                  })
+                }
+              >
+                None
+              </Link>
+            </>
+          )}
+        />
+      </FormField>
+    </Box>
+  );
+}

--- a/pages/date-range-picker/range-calendar.page.tsx
+++ b/pages/date-range-picker/range-calendar.page.tsx
@@ -31,6 +31,7 @@ export default function RangeCalendarScenario() {
           dateOnly={dateOnly}
           timeInputFormat="hh:mm"
           isDateEnabled={date => date.getDate() !== 15}
+          customAbsoluteRangeControl={undefined}
         />
 
         <Link id="focusable-after">Focusable element after the range calendar</Link>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4844,6 +4844,27 @@ is provided by its parent form field component.
       "type": "string",
     },
     Object {
+      "description": "Specifies an additional control displayed in the dropdown, located below the range calendar.",
+      "inlineType": Object {
+        "name": "DateRangePickerProps.AbsoluteRangeControl",
+        "parameters": Array [
+          Object {
+            "name": "selectedRange",
+            "type": "DateRangePickerProps.PendingAbsoluteValue",
+          },
+          Object {
+            "name": "setSelectedRange",
+            "type": "React.Dispatch<React.SetStateAction<DateRangePickerProps.PendingAbsoluteValue>>",
+          },
+        ],
+        "returnType": "React.ReactNode",
+        "type": "function",
+      },
+      "name": "customAbsoluteRangeControl",
+      "optional": true,
+      "type": "DateRangePickerProps.AbsoluteRangeControl",
+    },
+    Object {
       "defaultValue": "false",
       "description": "Hides time inputs and changes the input format to date-only, e.g. 2021-04-06.
 Do not use \`dateOnly\` flag conditionally. The component does not trigger the value update

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -469,5 +469,72 @@ describe('Date range picker', () => {
         );
       });
     });
+
+    describe('custom control', () => {
+      const customControl: DateRangePickerProps.AbsoluteRangeControl = (value, setValue) => (
+        <>
+          <div data-testid="display">{JSON.stringify(value)}</div>
+          <button
+            data-testid="set-date"
+            onClick={() =>
+              setValue({
+                start: { date: '2022-01-02', time: '00:00:00' },
+                end: { date: '2022-02-06', time: '12:34:56' },
+              })
+            }
+          ></button>
+          <button
+            data-testid="clear-date"
+            onClick={() => setValue({ start: { date: '', time: '' }, end: { date: '', time: '' } })}
+          ></button>
+        </>
+      );
+      test('renders current value from calendar', () => {
+        const { wrapper, getByTestId } = renderDateRangePicker({
+          ...defaultProps,
+          value: { type: 'absolute', startDate: '2022-11-24T12:55:00', endDate: '2022-11-28T11:14:00' },
+          customAbsoluteRangeControl: customControl,
+        });
+        act(() => wrapper.findTrigger().click());
+        expect(getByTestId('display')).toHaveTextContent(
+          '{"start":{"date":"2022-11-24","time":"12:55:00"},"end":{"date":"2022-11-28","time":"11:14:00"}}'
+        );
+      });
+
+      test('can update value in calendar', () => {
+        const { wrapper, getByTestId } = renderDateRangePicker({
+          ...defaultProps,
+          customAbsoluteRangeControl: customControl,
+        });
+        act(() => wrapper.findTrigger().click());
+        getByTestId('set-date').click();
+        expect(getByTestId('display')).toHaveTextContent(
+          '{"start":{"date":"2022-01-02","time":"00:00:00"},"end":{"date":"2022-02-06","time":"12:34:56"}}'
+        );
+        expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('2');
+        expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2022/01/02');
+        expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('00:00:00');
+        expect(wrapper.findDropdown()!.findSelectedEndDate()!.getElement()).toHaveTextContent('6');
+        expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2022/02/06');
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('12:34:56');
+      });
+
+      test('can clear value in calendar', () => {
+        const { wrapper, getByTestId } = renderDateRangePicker({
+          ...defaultProps,
+          value: { type: 'absolute', startDate: '2022-11-24T12:55:00', endDate: '2022-11-28T11:14:00' },
+          customAbsoluteRangeControl: customControl,
+        });
+        act(() => wrapper.findTrigger().click());
+        getByTestId('clear-date').click();
+        expect(getByTestId('display')).toHaveTextContent('{"start":{"date":"","time":""},"end":{"date":"","time":""}}');
+        expect(wrapper.findDropdown()!.findSelectedStartDate()).toBeNull();
+        expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('');
+        expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('');
+        expect(wrapper.findDropdown()!.findSelectedEndDate()).toBeNull();
+        expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('');
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('');
+      });
+    });
   });
 });

--- a/src/date-range-picker/calendar/utils.ts
+++ b/src/date-range-picker/calendar/utils.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { addMonths, isSameMonth, startOfMonth } from 'date-fns';
-import { DateRangePickerProps, PendingAbsoluteValue } from '../interfaces';
+import { DateRangePickerProps } from '../interfaces';
 import { parseDate } from '../../internal/utils/date-time';
 
 export function findDateToFocus(
@@ -22,7 +22,7 @@ export function findDateToFocus(
   return null;
 }
 
-export function findMonthToDisplay(value: PendingAbsoluteValue, isSingleGrid: boolean) {
+export function findMonthToDisplay(value: DateRangePickerProps.PendingAbsoluteValue, isSingleGrid: boolean) {
   if (value.start.date) {
     const startDate = parseDate(value.start.date);
     if (isSingleGrid) {

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useRef, useState } from 'react';
-import { DateRangePickerProps, PendingAbsoluteValue } from './interfaces';
+import { DateRangePickerProps } from './interfaces';
 import Calendar from './calendar';
 import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
@@ -43,6 +43,7 @@ export interface DateRangePickerDropdownProps
 
   ariaLabelledby?: string;
   ariaDescribedby?: string;
+  customAbsoluteRangeControl: DateRangePickerProps.AbsoluteRangeControl | undefined;
 }
 
 export function DateRangePickerDropdown({
@@ -63,12 +64,13 @@ export function DateRangePickerDropdown({
   rangeSelectorMode,
   ariaLabelledby,
   ariaDescribedby,
+  customAbsoluteRangeControl,
 }: DateRangePickerDropdownProps) {
   const [rangeSelectionMode, setRangeSelectionMode] = useState<'absolute' | 'relative'>(
     getDefaultMode(value, relativeOptions, rangeSelectorMode)
   );
 
-  const [selectedAbsoluteRange, setSelectedAbsoluteRange] = useState<PendingAbsoluteValue>(() =>
+  const [selectedAbsoluteRange, setSelectedAbsoluteRange] = useState<DateRangePickerProps.PendingAbsoluteValue>(() =>
     splitAbsoluteValue(value?.type === 'absolute' ? value : null)
   );
 
@@ -172,6 +174,7 @@ export function DateRangePickerDropdown({
                       i18nStrings={i18nStrings}
                       dateOnly={dateOnly}
                       timeInputFormat={timeInputFormat}
+                      customAbsoluteRangeControl={customAbsoluteRangeControl}
                     />
                   )}
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -103,6 +103,7 @@ const DateRangePicker = React.forwardRef(
       timeInputFormat = 'hh:mm:ss',
       expandToViewport = false,
       rangeSelectorMode = 'default',
+      customAbsoluteRangeControl,
       ...rest
     }: DateRangePickerProps,
     ref: Ref<DateRangePickerProps.Ref>
@@ -273,6 +274,7 @@ const DateRangePicker = React.forwardRef(
               rangeSelectorMode={rangeSelectorMode}
               ariaLabelledby={ariaLabelledby}
               ariaDescribedby={ariaDescribedby}
+              customAbsoluteRangeControl={customAbsoluteRangeControl}
             />
           )}
         </Dropdown>

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -5,6 +5,7 @@ import { FormFieldValidationControlProps } from '../internal/context/form-field-
 import { NonCancelableEventHandler } from '../internal/events';
 import { TimeInputProps } from '../time-input/interfaces';
 import { ExpandToViewport } from '../internal/components/dropdown/interfaces';
+import React from 'react';
 
 export interface DateRangePickerBaseProps {
   /**
@@ -152,6 +153,11 @@ export interface DateRangePickerProps
    * allows the user to clear the selected value.
    */
   showClearButton?: boolean;
+
+  /**
+   * Specifies an additional control displayed in the dropdown, located below the range calendar.
+   */
+  customAbsoluteRangeControl?: DateRangePickerProps.AbsoluteRangeControl;
 }
 
 export namespace DateRangePickerProps {
@@ -217,6 +223,21 @@ export namespace DateRangePickerProps {
   export interface GetTimeOffsetFunction {
     (date: Date): number;
   }
+
+  export interface DateTimeStrings {
+    date: string;
+    time: string;
+  }
+
+  export interface PendingAbsoluteValue {
+    start: DateTimeStrings;
+    end: DateTimeStrings;
+  }
+
+  export type AbsoluteRangeControl = (
+    selectedRange: PendingAbsoluteValue,
+    setSelectedRange: React.Dispatch<React.SetStateAction<PendingAbsoluteValue>>
+  ) => React.ReactNode;
 
   export type RangeSelectorMode = 'default' | 'absolute-only' | 'relative-only';
 
@@ -367,16 +388,6 @@ export namespace DateRangePickerProps {
 }
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-
-export interface DateTimeStrings {
-  date: string;
-  time: string;
-}
-
-export interface PendingAbsoluteValue {
-  start: DateTimeStrings;
-  end: DateTimeStrings;
-}
 
 export type RangeCalendarI18nStrings = Pick<
   DateRangePickerProps.I18nStrings,

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -38,10 +38,6 @@ $calendar-header-color: awsui.$color-text-body-default;
 }
 
 .calendar {
-  display: block;
-  width: 100%;
-  margin-bottom: awsui.$space-scaled-s;
-
   &-header {
     display: flex;
     justify-content: space-between;

--- a/src/date-range-picker/utils.tsx
+++ b/src/date-range-picker/utils.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DateRangePickerProps, PendingAbsoluteValue } from './interfaces';
+import { DateRangePickerProps } from './interfaces';
 import { setTimeOffset } from './time-offset';
 import { joinDateTime, splitDateTime } from '../internal/utils/date-time';
 
@@ -38,7 +38,9 @@ export function getDefaultMode(
   return relativeOptions.length > 0 ? 'relative' : 'absolute';
 }
 
-export function splitAbsoluteValue(value: null | DateRangePickerProps.AbsoluteValue): PendingAbsoluteValue {
+export function splitAbsoluteValue(
+  value: null | DateRangePickerProps.AbsoluteValue
+): DateRangePickerProps.PendingAbsoluteValue {
   if (!value) {
     return {
       start: { date: '', time: '' },
@@ -48,7 +50,9 @@ export function splitAbsoluteValue(value: null | DateRangePickerProps.AbsoluteVa
   return { start: splitDateTime(value.startDate), end: splitDateTime(value.endDate) };
 }
 
-export function joinAbsoluteValue(value: PendingAbsoluteValue): DateRangePickerProps.AbsoluteValue {
+export function joinAbsoluteValue(
+  value: DateRangePickerProps.PendingAbsoluteValue
+): DateRangePickerProps.AbsoluteValue {
   return {
     type: 'absolute',
     startDate: joinDateTime(value.start.date, value.start.time || '00:00:00'),


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Allow to render a custom control in absolute selection mode. Check the new `custom-control.page.tsx` demo for usage example.

Related links, issue #, if available: n/a

### How has this been tested?

Locally, build in my dev-pipeline (link in DM)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
