### PR TITLE
fix: Annotation focus on the start of the popover on clicking next

### DIFF
--- a/src/annotation-context/__tests__/annotation-context.test.tsx
+++ b/src/annotation-context/__tests__/annotation-context.test.tsx
@@ -242,3 +242,21 @@ test('trigger should have aria-label with steps information', () => {
   hotspot.findTrigger().click();
   expect(hotspot.findTrigger().getElement().getAttribute('aria-label')).toBe('CLOSE_HOTSPOT_TEST_FOR_STEP_1_OF_2_TEST');
 });
+
+test('annotation should have be labeled by header and step counter', () => {
+  const { wrapper } = renderAnnotationContext(
+    <>
+      <Hotspot hotspotId="first-hotspot" />
+      <Hotspot hotspotId="second-hotspot" />
+      <Hotspot hotspotId="third-hotspot" />
+    </>
+  );
+
+  const annotation = wrapper.findAnnotation()!;
+  const labelIds = annotation.getElement().getAttribute('aria-labelledby');
+  const label = labelIds!
+    .split(' ')
+    .map(label => annotation.find(`#${label}`)!.getElement().textContent)
+    .join(' ');
+  expect(label).toBe('TASK_1_FIRST_TASK_TEST STEP_1_OF_1_TEST');
+});

--- a/src/annotation-context/annotation/annotation-popover.tsx
+++ b/src/annotation-context/annotation/annotation-popover.tsx
@@ -13,6 +13,8 @@ import { AnnotationContextProps } from '../interfaces';
 import InternalAlert from '../../alert/internal';
 import { InternalPosition } from '../../popover/interfaces';
 import { scrollElementIntoView } from '../../internal/utils/scrollable-containers';
+import { useUniqueId } from '../../internal/hooks/use-unique-id/index.js';
+import { joinStrings } from '../../internal/utils/strings/join-strings.js';
 
 export interface AnnotationPopoverProps {
   title: string;
@@ -81,6 +83,9 @@ export function AnnotationPopover({
     scrollElementIntoView(trackRef.current ?? undefined);
   }, [trackRef]);
 
+  const popoverHeaderId = useUniqueId('poppver-header-');
+  const stepCounterId = useUniqueId('step-counter-');
+
   return (
     <PopoverContainer
       size="medium"
@@ -96,7 +101,13 @@ export function AnnotationPopover({
         dismissButton={true}
         dismissAriaLabel={i18nStrings.labelDismissAnnotation}
         header={
-          <InternalBox color="text-body-secondary" fontSize="body-s" margin={{ top: 'xxxs' }} className={styles.header}>
+          <InternalBox
+            id={popoverHeaderId}
+            color="text-body-secondary"
+            fontSize="body-s"
+            margin={{ top: 'xxxs' }}
+            className={styles.header}
+          >
             {title}
           </InternalBox>
         }
@@ -104,6 +115,9 @@ export function AnnotationPopover({
         className={styles.annotation}
         variant="annotation"
         overflowVisible="content"
+        // create new dialog to have the native dialog behavior of the screen readers
+        key={taskLocalStepIndex}
+        ariaLabelledby={joinStrings(popoverHeaderId, stepCounterId)}
       >
         <InternalSpaceBetween size="s">
           <div className={styles.description}>
@@ -117,7 +131,12 @@ export function AnnotationPopover({
 
             <div className={styles.actionBar}>
               <div className={styles.stepCounter}>
-                <InternalBox className={styles['step-counter-content']} color="text-body-secondary" fontSize="body-s">
+                <InternalBox
+                  id={stepCounterId}
+                  className={styles['step-counter-content']}
+                  color="text-body-secondary"
+                  fontSize="body-s"
+                >
                   {i18nStrings.stepCounterText(taskLocalStepIndex ?? 0, totalLocalSteps ?? 0)}
                 </InternalBox>
               </div>

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -22,6 +22,7 @@ export interface PopoverBodyProps {
   overflowVisible?: 'content' | 'both';
 
   className?: string;
+  ariaLabelledby?: string;
 }
 
 export default function PopoverBody({
@@ -33,6 +34,7 @@ export default function PopoverBody({
   variant,
   overflowVisible,
   className,
+  ariaLabelledby,
 }: PopoverBodyProps) {
   const labelledById = useUniqueId('awsui-popover-');
   const dismissButtonFocused = useRef(false);
@@ -79,7 +81,7 @@ export default function PopoverBody({
       role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
       aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}
-      aria-labelledby={header ? labelledById : undefined}
+      aria-labelledby={ariaLabelledby ?? (header ? labelledById : undefined)}
     >
       <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={false}>
         {header && (


### PR DESCRIPTION
### Description

**Current problem**: when clicking the "next" button, the focus does not move to the "x" button, but stays on the "next" button. It only happens when two steps pointing to the same the trigger/hotspot. In this case, the popover only updates, not recreate. It works as expected when trigger/hotspot changes. 
**Solution:** Giving popover body a key, to always create new dialog instead of updating the current one, when step changes. Because screen reader has native behavior to announce dialog content when it shows and with focus on the start of the dialog, for example, NVDA announces content inside one by one, VO announces e.g "with 7 items" in the dialog. Always creating new dialog no matter hotspot changes, keeps consistent expected behavior from screenreader.

**Another update in this PR**: giving aria-labelledby referring to not only title of the popover, but also the step counter. Because the title of steps can be the same. Screenreader users may not know which step it actually is. 

Related links, issue **AWSUI-19246**

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
