### PR TITLE
feat: Add arialabels for download and read more link in tutorial panel

### DIFF
--- a/pages/onboarding/i18n.ts
+++ b/pages/onboarding/i18n.ts
@@ -10,9 +10,11 @@ export const tutorialPanelStrings: TutorialPanelProps.I18nStrings = {
   tutorialListDescription:
     'Use our walk-through tutorials to learn how to achieve your desired objectives within Amazon Transcribe.',
   tutorialListDownloadLinkText: 'Download PDF version',
+  labelTutorialListDownloadLink: 'Download PDF version of this tutorial',
   tutorialCompletedText: 'Tutorial completed',
   labelExitTutorial: 'dismiss tutorial',
   learnMoreLinkText: 'Learn more',
+  labelLearnMoreLink: 'Learn more about transcribe audio (opens new tab)',
   startTutorialButtonText: 'Start tutorial',
   restartTutorialButtonText: 'Restart tutorial',
   completionScreenTitle: 'Congratulations! You completed the tutorial',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12751,9 +12751,19 @@ Object {
             "type": "string",
           },
           Object {
+            "name": "labelLearnMoreLink",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "labelTotalSteps",
             "optional": false,
             "type": "(totalStepCount: number) => string",
+          },
+          Object {
+            "name": "labelTutorialListDownloadLink",
+            "optional": true,
+            "type": "string",
           },
           Object {
             "name": "labelsTaskStatus",

--- a/src/tutorial-panel/__tests__/data.tsx
+++ b/src/tutorial-panel/__tests__/data.tsx
@@ -10,9 +10,11 @@ export const i18nStrings: TutorialPanelProps.I18nStrings = {
   tutorialListTitle: 'TUTORIAL_LIST_TITLE',
   tutorialListDescription: <span>TUTORIAL_LIST_DESCRIPTION</span>,
   tutorialListDownloadLinkText: 'DOWNLOAD_LINK_TEXT',
+  labelTutorialListDownloadLink: 'DOWNLOAD_THIS_TUTORIAL_LINK',
 
   tutorialCompletedText: 'TUTORIAL_COMPLETED',
   learnMoreLinkText: 'LEARN_MORE_LINK_TEXT',
+  labelLearnMoreLink: 'LEARN_MORE_ABOUT_TUTORIA',
 
   startTutorialButtonText: 'START_TUTORIAL',
   restartTutorialButtonText: 'RESTART_TUTORIAL',

--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -265,5 +265,16 @@ describe('URL sanitization', () => {
         'TASK_1_FIRST_TASK_TEST TOTAL_STEPS_1'
       );
     });
+    test('links have correct aria-label', () => {
+      const tutorials = getTutorials();
+      const context = getContext();
+      const { container } = renderTutorialPanelWithContext({ tutorials }, context);
+      const wrapper = createWrapper(container).findTutorialPanel()!;
+      expect(wrapper.findDownloadLink()!.getElement()).toHaveAttribute('aria-label', 'DOWNLOAD_THIS_TUTORIAL_LINK');
+      expect(wrapper.findTutorials()[0].findLearnMoreLink()!.getElement()).toHaveAttribute(
+        'aria-label',
+        'LEARN_MORE_ABOUT_TUTORIA'
+      );
+    });
   });
 });

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -71,6 +71,7 @@ export default function TutorialList({
             target="_blank"
             rel="noopener noreferrer"
             className={styles['download-link']}
+            aria-label={i18nStrings.labelTutorialListDownloadLink}
           >
             <InternalIcon name="download" />
             <InternalBox padding={{ left: 'xs' }} color="inherit" fontWeight="bold" display="inline">
@@ -198,6 +199,7 @@ function Tutorial({
                       href={tutorial.learnMoreUrl}
                       className={styles['learn-more-link']}
                       externalIconAriaLabel={i18nStrings.labelLearnMoreExternalIcon}
+                      ariaLabel={i18nStrings.labelLearnMoreLink}
                       external={true}
                     >
                       {i18nStrings.learnMoreLinkText}

--- a/src/tutorial-panel/interfaces.ts
+++ b/src/tutorial-panel/interfaces.ts
@@ -217,5 +217,8 @@ export namespace TutorialPanelProps {
       'in-progress': string;
       success: string;
     };
+
+    labelTutorialListDownloadLink?: string;
+    labelLearnMoreLink?: string;
   }
 }


### PR DESCRIPTION
### Description

Add `labelTutorialListDownloadLink` and `labelLearnMoreLink` props, to allow aria-label on download link and learn more link.

Related links, issue AWSUI-19243

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
