### PR TITLE
feat: Allow custom languages for code editor

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3821,7 +3821,9 @@ The object should contain, among others:
       "type": "string",
     },
     Object {
-      "description": "Specifies the programming language. You can use any of the programming languages supported by the \`ace\` object that you provide.",
+      "description": "Specifies the programming language. You can use any of the programming languages supported by the \`ace\` object that you provide.
+Alternatively, this can be used to set a language that is not supported by the default \`language\` list. Make sure you've added the highlighting support for this language to the Ace instance.
+For more info on custom languages, see the [Code editor API](/components/code-editor?tabId=api) page.",
       "inlineType": Object {
         "name": "CodeEditorProps.Language",
         "properties": Array [],
@@ -3830,6 +3832,12 @@ The object should contain, among others:
       "name": "language",
       "optional": false,
       "type": "CodeEditorProps.Language",
+    },
+    Object {
+      "description": "Specifies a custom label language. If set, it overrides the default language label.",
+      "name": "languageLabel",
+      "optional": true,
+      "type": "string",
     },
     Object {
       "description": "Renders the code editor in a loading state.",

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -101,6 +101,46 @@ describe('Code editor component', () => {
     expect(wrapper.findStatusBar()!.getElement()).toHaveTextContent('JavaScript');
   });
 
+  it('uses custom language label over the default label', () => {
+    const { wrapper } = renderCodeEditor({ languageLabel: 'PartiQL' });
+    expect(wrapper.findStatusBar()!.getElement()).toHaveTextContent('PartiQL');
+  });
+
+  it('allows providing a custom language', () => {
+    renderCodeEditor({ language: 'partiql' });
+    expect(editorMock.session.setMode).toHaveBeenCalledWith('ace/mode/partiql');
+  });
+
+  it('uses custom language with custom label', () => {
+    const { wrapper } = renderCodeEditor({ languageLabel: 'PartiQL', language: 'partiql' });
+    expect(editorMock.session.setMode).toHaveBeenCalledWith('ace/mode/partiql');
+    expect(wrapper.findStatusBar()!.getElement()).toHaveTextContent('PartiQL');
+  });
+
+  it('falls back to language name if a custom language is used without languageLabel', () => {
+    const { wrapper } = renderCodeEditor({ language: 'partiql' });
+    expect(editorMock.session.setMode).not.toHaveBeenCalledWith('ace/mode/javascript');
+    expect(editorMock.session.setMode).toHaveBeenCalledWith('ace/mode/partiql');
+    expect(wrapper.findStatusBar()!.getElement()).toHaveTextContent('partiql');
+  });
+
+  it("uses custom label even if a language isn't provided", () => {
+    const { wrapper } = renderCodeEditor({ language: undefined, languageLabel: 'PartiQL' });
+    expect(editorMock.session.setMode).toHaveBeenCalledWith('ace/mode/undefined');
+    expect(wrapper.findStatusBar()!.getElement()).toHaveTextContent('PartiQL');
+  });
+
+  /**
+   * Undefined language should run the component anyway even when bypassing language requirements,
+   * When that happens, Ace handles the missing language error
+   * renderCodeEditor uses Partial<CodeEditorProps>, no casting needed here
+   */
+  it('allows unidentified language without breaking', () => {
+    const { wrapper } = renderCodeEditor({ language: undefined });
+    expect(editorMock.session.setMode).toHaveBeenCalledWith('ace/mode/undefined');
+    expect(wrapper.findStatusBar()!.getElement()).not.toHaveTextContent('undefined');
+  });
+
   it('changes value', () => {
     const { rerender } = renderCodeEditor({ value: 'value-initial' });
 

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -20,8 +20,15 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
 
   /**
    * Specifies the programming language. You can use any of the programming languages supported by the `ace` object that you provide.
+   * Alternatively, this can be used to set a language that is not supported by the default `language` list. Make sure you've added the highlighting support for this language to the Ace instance.
+   * For more info on custom languages, see the [Code editor API](/components/code-editor?tabId=api) page.
    */
   language: CodeEditorProps.Language;
+
+  /**
+   * Specifies a custom label language. If set, it overrides the default language label.
+   */
+  languageLabel?: string;
 
   /**
    * An event handler called when the value changes.
@@ -105,8 +112,11 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
   onEditorContentResize?: NonCancelableEventHandler<CodeEditorProps.ResizeDetail>;
 }
 
+type LiteralUnion<LiteralType, BaseType extends string> = LiteralType | (BaseType & { _?: never });
+type BuiltInLanguage = typeof AceModes[number]['value'];
+
 export namespace CodeEditorProps {
-  export type Language = typeof AceModes[number]['value'];
+  export type Language = LiteralUnion<BuiltInLanguage, string>;
   export type Theme = typeof LightThemes[number]['value'] | typeof DarkThemes[number]['value'];
 
   export interface AvailableThemes {

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -112,7 +112,11 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
   onEditorContentResize?: NonCancelableEventHandler<CodeEditorProps.ResizeDetail>;
 }
 
+// Prevents typescript from collapsing a string union type into a string type while still allowing any string.
+// This leads to more helpful editor suggestions for known values.
+// See: https://github.com/microsoft/TypeScript/issues/29729
 type LiteralUnion<LiteralType, BaseType extends string> = LiteralType | (BaseType & { _?: never });
+
 type BuiltInLanguage = typeof AceModes[number]['value'];
 
 export namespace CodeEditorProps {

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -31,5 +31,5 @@ export function getAceTheme(theme: CodeEditorProps.Theme) {
 }
 
 export function getLanguageLabel(language: CodeEditorProps.Language): string {
-  return AceModes.filter((mode: { value: string }) => mode.value === language)[0]?.label || '';
+  return AceModes.filter((mode: { value: string }) => mode.value === language)[0]?.label || language;
 }


### PR DESCRIPTION
### Description

Currently, we support languages from a predefined list of languages. Users can add custom languages globally to the ace library (syntax highlighting, syntax validation, other goodies) before initializing the component, but our component has a fixed list of "display names" for languages that needs to be manually kept up to date. A much more scalable solution is to allow users to define the language being passed into the ace library, and also provide a custom label for unknown languages.

This is mostly not my work - **huge thanks to @andre-araujo** for contributing this internally a while ago. Unfortunately, it ended up getting lost in the backlog pile until we received a similar feature request recently.

The API docs have already been approved.

Related links, issue #, if available: AWSUI-13647, AWSUI-19894

### How has this been tested?

Unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
