### PR TITLE
fix: let line chart highlight all points at a given X coordinate usin…

### DIFF
--- a/pages/line-chart/single-series.page.tsx
+++ b/pages/line-chart/single-series.page.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Container from '~components/container';
+import Header from '~components/header';
+import Box from '~components/box';
+import LineChart from '~components/line-chart';
+import ScreenshotArea from '../utils/screenshot-area';
+
+import { data1, commonProps, lineChartInstructions } from '../mixed-line-bar-chart/common';
+
+export default function () {
+  return (
+    <ScreenshotArea>
+      <h1>Line chart integration tests</h1>
+      <Box padding="l">
+        <Container header={<Header variant="h2">Line Chart</Header>}>
+          <LineChart
+            {...commonProps}
+            id="chart"
+            height={130}
+            series={[{ title: 'Series 1', type: 'line', data: data1 }]}
+            xDomain={[0, 32]}
+            yDomain={[0, 50]}
+            xTitle="Time"
+            yTitle="Latency (ms)"
+            xScaleType="linear"
+            ariaLabel="Line chart"
+            ariaDescription={lineChartInstructions}
+          />
+        </Container>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/internal/components/cartesian-chart/vertical-marker.tsx
+++ b/src/internal/components/cartesian-chart/vertical-marker.tsx
@@ -16,12 +16,13 @@ export interface VerticalMarkerProps {
   showPoints?: boolean;
   showLine?: boolean;
   points: null | readonly SeriesPoint[];
+  ariaLabel?: string;
 }
 
 export default memo(forwardRef(VerticalMarker));
 
 function VerticalMarker(
-  { height, showPoints = true, showLine = true, points }: VerticalMarkerProps,
+  { height, showPoints = true, showLine = true, points, ariaLabel }: VerticalMarkerProps,
   ref: React.Ref<SVGLineElement>
 ) {
   const [firstPoint] = points || [];
@@ -31,6 +32,7 @@ function VerticalMarker(
       <line
         ref={ref}
         aria-hidden="true"
+        aria-label={ariaLabel}
         className={styles['vertical-marker']}
         style={{ visibility: showLine && firstPoint ? 'visible' : 'hidden' }}
         x1={firstPoint?.x}

--- a/src/internal/components/chart-plot/focus-outline.tsx
+++ b/src/internal/components/chart-plot/focus-outline.tsx
@@ -4,11 +4,12 @@ import React, { useEffect, useRef } from 'react';
 
 import styles from './styles.css.js';
 import useFocusVisible from '../../hooks/focus-visible/index';
+import { Offset } from './interfaces';
 
 export interface FocusOutlineProps {
   elementKey?: null | string | number | boolean;
   elementRef?: React.RefObject<SVGSVGElement | SVGGElement>;
-  offset?: number;
+  offset?: Offset;
 }
 
 export default function FocusOutline({ elementKey, elementRef, offset = 0 }: FocusOutlineProps) {
@@ -34,12 +35,14 @@ export default function FocusOutline({ elementKey, elementRef, offset = 0 }: Foc
 function showOutline(
   el: SVGRectElement,
   position: { x: number; y: number; width: number; height: number },
-  offset: number
+  offset: Offset
 ) {
-  el.setAttribute('x', (position.x - offset).toString());
-  el.setAttribute('y', (position.y - offset).toString());
-  el.setAttribute('width', (position.width + 2 * offset).toString());
-  el.setAttribute('height', (position.height + 2 * offset).toString());
+  const offsetX = typeof offset === 'number' ? offset : offset.x;
+  const offsetY = typeof offset === 'number' ? offset : offset.y;
+  el.setAttribute('x', (position.x - offsetX).toString());
+  el.setAttribute('y', (position.y - offsetY).toString());
+  el.setAttribute('width', (position.width + 2 * offsetX).toString());
+  el.setAttribute('height', (position.height + 2 * offsetY).toString());
   el.style.visibility = 'visible';
 }
 

--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -11,6 +11,7 @@ import LiveRegion from '../live-region/index';
 import ApplicationController, { ApplicationRef } from './application-controller';
 import FocusOutline from './focus-outline';
 import focusSvgElement from '../../utils/focus-svg-element';
+import { Offset } from './interfaces';
 
 const DEFAULT_PLOT_FOCUS_OFFSET = 3;
 const DEFAULT_ELEMENT_FOCUS_OFFSET = 3;
@@ -37,7 +38,7 @@ export interface ChartPlotProps {
   ariaRoleDescription?: string;
   activeElementKey?: null | string | number | boolean;
   activeElementRef?: React.RefObject<SVGGElement>;
-  activeElementFocusOffset?: number;
+  activeElementFocusOffset?: Offset;
   ariaLiveRegion?: React.ReactNode;
   isClickable?: boolean;
   isPrecise?: boolean;

--- a/src/internal/components/chart-plot/interfaces.ts
+++ b/src/internal/components/chart-plot/interfaces.ts
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export type Offset = number | { x: number; y: number };

--- a/src/line-chart/__integ__/line-chart.test.ts
+++ b/src/line-chart/__integ__/line-chart.test.ts
@@ -26,47 +26,127 @@ function setupTest(url: string, testFn: (page: LineChartPageObject) => Promise<v
 }
 
 describe('Keyboard navigation', () => {
-  test(
-    'line series are navigable with keyboard',
-    setupTest('#/light/line-chart/test', async page => {
-      await page.click('button');
-      await page.keys(['Escape', 'Tab', 'ArrowRight']);
+  describe('with single series', () => {
+    test(
+      'line series is navigable with keyboard',
+      setupTest('#/light/line-chart/single-series', async page => {
+        await page.click('button');
+        await page.keys(['Escape', 'Tab', 'ArrowRight']);
 
-      // First series is highlighted
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        // First series is highlighted
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
 
-      // Move horizontally to the next point
-      await page.keys(['ArrowRight']);
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('1');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        // Move horizontally to the next point
+        await page.keys(['ArrowRight']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('1');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
 
-      // Move horizontally to the last point
-      await page.keys(['ArrowLeft', 'ArrowLeft']);
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('31');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
-    })
-  );
+        // Move horizontally to the last point
+        await page.keys(['ArrowLeft', 'ArrowLeft']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('31');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+      })
+    );
+  });
 
-  test(
-    'threshold series are navigable with keyboard',
-    setupTest('#/light/line-chart/test', async page => {
-      await page.click('button');
-      await page.keys(['Escape', 'Tab', 'ArrowRight', 'ArrowUp']);
+  describe('wth multiple series', () => {
+    test(
+      'line series are navigable with keyboard',
+      setupTest('#/light/line-chart/test', async page => {
+        await page.click('button');
+        await page.keys(['Escape', 'Tab', 'ArrowRight', 'ArrowDown']);
 
-      // Threshold is highlighted
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+        // First series is highlighted
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Threshold');
 
-      // Move horizontally to the next point
-      await page.keys(['ArrowRight']);
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('1');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+        // Move horizontally to the next point
+        await page.keys(['ArrowRight']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('1');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Threshold');
 
-      // Move horizontally to the last point
-      await page.keys(['ArrowLeft', 'ArrowLeft']);
-      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('31');
-      await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
-    })
-  );
+        // Move horizontally to the last point
+        await page.keys(['ArrowLeft', 'ArrowLeft']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('31');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Threshold');
+      })
+    );
+
+    test(
+      'threshold series are navigable with keyboard',
+      setupTest('#/light/line-chart/test', async page => {
+        await page.click('button');
+        await page.keys(['Escape', 'Tab', 'ArrowRight', 'ArrowUp']);
+
+        // Threshold is highlighted
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+
+        // Move horizontally to the next point
+        await page.keys(['ArrowRight']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+
+        // Move horizontally to the last point
+        await page.keys(['ArrowLeft', 'ArrowLeft']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('31');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+      })
+    );
+
+    test(
+      'cycles through the different series',
+      setupTest('#/light/line-chart/test', async page => {
+        await page.click('button');
+        await page.keys(['Escape', 'Tab', 'ArrowRight']);
+
+        // All series are highlighted
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+
+        // Move vertically to the first series
+        await page.keys(['ArrowDown']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Threshold');
+
+        // Move vertically to the next series
+        await page.keys(['ArrowDown']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Threshold');
+
+        // Move vertically to the next series
+        await page.keys(['ArrowDown']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.not.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+
+        // Circle back to initial state highlighting all series
+        await page.keys(['ArrowDown']);
+        await expect(page.getText(popoverHeaderSelector())).resolves.toContain('0');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 1');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Series 2');
+        await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold');
+      })
+    );
+  });
 });

--- a/src/mixed-line-bar-chart/__tests__/use-navigation.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/use-navigation.test.tsx
@@ -20,6 +20,7 @@ import {
   thresholdSeries,
   xThresholdSeries1,
 } from './common';
+import { VerticalMarkerLeft } from '../interfaces';
 
 const xScale = new ChartScale('linear', [0, 3], [0, 3]);
 const yScale = new NumericChartScale('linear', [0, 15], [0, 15], null);
@@ -27,7 +28,6 @@ const categoricalScale = new ChartScale('categorical', ['Potatoes', 'Chocolate',
 
 const commonProps: Omit<UseNavigationProps<ChartDataTypes>, 'xScale' | 'yScale' | 'barGroups' | 'scaledSeries'> = {
   highlightedSeries: null,
-  legendSeries: null,
   isHandlersDisabled: false,
   series: [],
   visibleSeries: [],
@@ -38,6 +38,7 @@ const commonProps: Omit<UseNavigationProps<ChartDataTypes>, 'xScale' | 'yScale' 
   highlightPoint: jest.fn(),
   highlightGroup: jest.fn(),
   clearHighlightedSeries: jest.fn(),
+  setVerticalMarkerLeft: jest.fn(),
 };
 
 const buildNavigationProps = (
@@ -62,6 +63,7 @@ class UseNavigationWrapper extends ElementWrapper {
     highlightedSeries: 'highlighted-series',
     highlightedPoint: 'highlighted-point',
     highlightedGroupIndex: 'highlighted-group-index',
+    verticalMarker: 'vertical-marker',
   };
 
   findKeyboardArea() {
@@ -79,12 +81,17 @@ class UseNavigationWrapper extends ElementWrapper {
   findHighlightedGroupIndex() {
     return this.findByClassName(UseNavigationWrapper.selectors.highlightedGroupIndex);
   }
+
+  findVerticalMarker() {
+    return this.findByClassName(UseNavigationWrapper.selectors.verticalMarker);
+  }
 }
 
 function RenderedNavigationHook(props: UseNavigationProps<ChartDataTypes>) {
   const [highlightedSeries, setHighlightedSeries] = useState(props.highlightedSeries);
   const [highlightedPoint, setHighlightedPoint] = useState(props.highlightedPoint);
   const [highlightedGroupIndex, setHighlightedGroup] = useState(props.highlightedGroupIndex);
+  const [verticalMarkerLeft, setVerticalMarkerLeft] = useState<VerticalMarkerLeft<any> | null>(null);
 
   const { onFocus, onKeyDown } = useNavigation({
     ...props,
@@ -95,6 +102,7 @@ function RenderedNavigationHook(props: UseNavigationProps<ChartDataTypes>) {
       setHighlightedPoint(null);
       setHighlightedGroup(group);
     },
+    setVerticalMarkerLeft,
     highlightedSeries,
     highlightedPoint,
     highlightedGroupIndex,
@@ -107,6 +115,7 @@ function RenderedNavigationHook(props: UseNavigationProps<ChartDataTypes>) {
       <span className={UseNavigationWrapper.selectors.highlightedPoint}>
         {highlightedPoint?.x},{highlightedPoint?.y}
       </span>
+      <span className={UseNavigationWrapper.selectors.verticalMarker}>{verticalMarkerLeft?.scaledX}</span>
     </div>
   );
 }
@@ -124,72 +133,139 @@ function renderNavigationHook(
 }
 
 describe('Line charts', () => {
-  const series: any[] = [
-    {
-      index: 0,
-      color: 'blue',
-      series: lineSeries1,
-    },
-    {
-      index: 1,
-      color: 'green',
-      series: lineSeries2,
-    },
-    {
-      index: 2,
-      color: 'grey',
-      series: thresholdSeries,
-    },
-    {
-      index: 3,
-      color: 'red',
-      series: xThresholdSeries1,
-    },
-  ];
+  describe('with one single series', () => {
+    const series: any[] = [
+      {
+        index: 0,
+        color: 'blue',
+        series: lineSeries1,
+      },
+    ];
 
-  const lineProps = { xScale, yScale, series };
+    const lineProps = { xScale, yScale, series };
 
-  test('highlights first line series when focused', () => {
-    const { wrapper } = renderNavigationHook(lineProps);
-    act(() => wrapper.focus());
+    test('highlights first point when focused', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
 
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent('Line Series 1');
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries1.title);
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('0,10');
+    });
+
+    test('can navigate horizontally', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
+
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('0,10');
+
+      act(() => wrapper.keydown(KeyCode.right));
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,8');
+
+      // Loop back
+      act(() => wrapper.keydown(KeyCode.left));
+      act(() => wrapper.keydown(KeyCode.left));
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('3,10');
+    });
   });
 
-  test('can navigate vertically through series', () => {
-    const { wrapper } = renderNavigationHook(lineProps);
-    act(() => wrapper.focus());
+  describe('with multiple series', () => {
+    const series: any[] = [
+      {
+        index: 0,
+        color: 'blue',
+        series: lineSeries1,
+      },
+      {
+        index: 1,
+        color: 'green',
+        series: lineSeries2,
+      },
+      {
+        index: 2,
+        color: 'grey',
+        series: thresholdSeries,
+      },
+      {
+        index: 3,
+        color: 'red',
+        series: xThresholdSeries1,
+      },
+    ];
 
-    act(() => wrapper.keydown(KeyCode.down));
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries2.title);
+    const lineProps = { xScale, yScale, series };
 
-    act(() => wrapper.keydown(KeyCode.down));
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(thresholdSeries.title);
+    test('highlights all points from all series at the first X coordinate when focused', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
 
-    act(() => wrapper.keydown(KeyCode.down));
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(xThresholdSeries1.title);
+      expect(wrapper.findHighlightedSeries()?.getElement()).toBeEmptyDOMElement();
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
+    });
 
-    // Loop around to the first series
-    act(() => wrapper.keydown(KeyCode.down));
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries1.title);
+    test('can navigate vertically through series', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
 
-    act(() => wrapper.keydown(KeyCode.up));
-    expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(thresholdSeries.title);
-  });
+      expect(wrapper.findHighlightedSeries()?.getElement()).toBeEmptyDOMElement();
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
 
-  test('can navigate horizontally', () => {
-    const { wrapper } = renderNavigationHook(lineProps);
-    act(() => wrapper.focus());
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries1.title);
 
-    expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('0,10');
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries2.title);
 
-    act(() => wrapper.keydown(KeyCode.right));
-    expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,8');
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(thresholdSeries.title);
 
-    // Loop back
-    act(() => wrapper.keydown(KeyCode.left));
-    act(() => wrapper.keydown(KeyCode.left));
-    expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('3,10');
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(xThresholdSeries1.title);
+
+      // Loop around to show all series again
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toBeEmptyDOMElement();
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
+
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toHaveTextContent(lineSeries1.title);
+
+      act(() => wrapper.keydown(KeyCode.up));
+      expect(wrapper.findHighlightedSeries()?.getElement()).toBeEmptyDOMElement();
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
+    });
+
+    test('can navigate horizontally within all series', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
+
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
+
+      act(() => wrapper.keydown(KeyCode.right));
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('1');
+
+      act(() => wrapper.keydown(KeyCode.left));
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('0');
+
+      // Loop back
+      act(() => wrapper.keydown(KeyCode.left));
+      expect(wrapper.findVerticalMarker()?.getElement()).toHaveTextContent('3');
+    });
+
+    test('can navigate horizontally within one series', () => {
+      const { wrapper } = renderNavigationHook(lineProps);
+      act(() => wrapper.focus());
+
+      act(() => wrapper.keydown(KeyCode.down));
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('0,10');
+
+      act(() => wrapper.keydown(KeyCode.right));
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,8');
+
+      // Loop back
+      act(() => wrapper.keydown(KeyCode.left));
+      act(() => wrapper.keydown(KeyCode.left));
+      expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('3,10');
+    });
   });
 });
 

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useState } from 'react';
 import { nodeContains } from '../../internal/utils/dom';
 
 import { ScaledBarGroup } from '../make-scaled-bar-groups';
@@ -8,7 +7,7 @@ import { ScaledPoint } from '../make-scaled-series';
 
 import styles from '../styles.css.js';
 import { ChartPlotRef } from '../../internal/components/chart-plot';
-import { MixedLineBarChartProps } from '../interfaces';
+import { MixedLineBarChartProps, VerticalMarkerLeft } from '../interfaces';
 import { isYThreshold } from '../utils';
 
 const MAX_HOVER_MARGIN = 6;
@@ -23,6 +22,7 @@ export interface UseMouseHoverProps<T> {
   clearHighlightedSeries: () => void;
   isGroupNavigation: boolean;
   isHandlersDisabled: boolean;
+  setVerticalMarkerLeft: (marker: VerticalMarkerLeft<T> | null) => void;
 }
 
 export function useMouseHover<T>({
@@ -35,9 +35,8 @@ export function useMouseHover<T>({
   clearHighlightedSeries,
   isGroupNavigation,
   isHandlersDisabled,
+  setVerticalMarkerLeft,
 }: UseMouseHoverProps<T>) {
-  const [verticalMarkerLeft, setVerticalMarkerLeft] = useState<number | null>(null);
-
   const onSeriesMouseMove = (event: React.MouseEvent<SVGElement, MouseEvent>) => {
     const svgRect = (event.target as SVGElement).getBoundingClientRect();
     const offsetX = event.clientX - svgRect.left;
@@ -53,7 +52,7 @@ export function useMouseHover<T>({
       .reduce((prev, curr) => (Math.abs(curr - offsetY) < Math.abs(prev - offsetY) ? curr : prev), -Infinity);
 
     if (isFinite(closestX)) {
-      setVerticalMarkerLeft(closestX);
+      setVerticalMarkerLeft({ scaledX: closestX, trigger: 'mouse' });
       if (
         isFinite(closestY) &&
         Math.abs(offsetX - closestX) < MAX_HOVER_MARGIN &&
@@ -62,7 +61,6 @@ export function useMouseHover<T>({
         const [{ color, datum, series }] = scaledSeries.filter(
           s => (s.x === closestX || isYThreshold(s.series)) && s.y === closestY
         );
-        highlightSeries(series);
         highlightPoint({ x: closestX, y: closestY, color, datum, series });
       } else {
         highlightSeries(null);
@@ -117,5 +115,5 @@ export function useMouseHover<T>({
     }
   };
 
-  return { verticalMarkerLeft, onSVGMouseMove, onSVGMouseOut };
+  return { onSVGMouseMove, onSVGMouseOut };
 }

--- a/src/mixed-line-bar-chart/interfaces.ts
+++ b/src/mixed-line-bar-chart/interfaces.ts
@@ -106,3 +106,11 @@ export namespace MixedLineBarChartProps {
 
   export type I18nStrings<T> = CartesianChartProps.I18nStrings<T>;
 }
+
+export type Trigger = 'keyboard' | 'mouse';
+
+export interface VerticalMarkerLeft<T> {
+  scaledX: number;
+  datumX?: T;
+  trigger: Trigger;
+}

--- a/src/mixed-line-bar-chart/internal.tsx
+++ b/src/mixed-line-bar-chart/internal.tsx
@@ -257,7 +257,6 @@ export default function InternalMixedLineBarChart<T extends number | string | Da
             setHighlightedPoint={setHighlightedPoint}
             highlightedGroupIndex={highlightedGroupIndex}
             setHighlightedGroupIndex={setHighlightedGroupIndex}
-            legendSeries={legendSeries}
             detailPopoverSize={detailPopoverSize}
             xTitle={xTitle}
             yTitle={yTitle}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "types": [],
+    "types": ["jest"],
     "module": "esnext",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
…g keyboard navigation

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Issue: AWSUI-19201

Context: mouse hover on line chart allows to highlight not only one single point but also all points (from all series) at a given X coordinate, but this behavior was missing for keyboard users. This PR adds it.

The visual appearance is the same as when the points are highlighted with the mouse, but with the focus indicator around the points and the  vertical marker:
![Screenshot 2022-11-30 at 09 00 09](https://user-images.githubusercontent.com/1257272/204740014-8781c315-a4c0-4e58-b6e1-40d7945ba1a4.png)

### How has this been tested?

<!-- How did you test to verify your changes? -->

- Added unit tests and integration tests
- Manually tested on local server
- Validated new aria-label with VoiceOver

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
