### PR TITLE
fix: Prevent dropdowns from closing when elements inside self-dismiss

### DIFF
--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -295,18 +295,10 @@ const Dropdown = ({
         fireNonCancelableEvent(onDropdownClose);
       }
     };
-
-    /*
-     * This small delay allows the event that opened the dropdown to
-     * finish bubbling, so that it is not immediately captured here.
-     */
-    const timeout = setTimeout(() => {
-      window.addEventListener('click', clickListener);
-    }, 0);
+    window.addEventListener('click', clickListener, true);
 
     return () => {
-      clearTimeout(timeout);
-      window.removeEventListener('click', clickListener);
+      window.removeEventListener('click', clickListener, true);
     };
   }, [open, onDropdownClose]);
 


### PR DESCRIPTION
### Description

If an element inside dropdown dismisses itself after click, the click away listener detects it as a click outside. To prevent this from happening, moved the listener to capture phase. `setTimeout` are also not needed anymore, because it was only to work around bubbling issues, which are not happening when using capture

Found when integrating feature https://github.com/cloudscape-design/components/pull/531 in the real use case

### How has this been tested?

Added an extra unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
