### PR TITLE
fix: Prevent empty table from flickering

### DIFF
--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -47,9 +47,6 @@ export const useStickyHeader = (
   }, [theadRef, secondaryTheadRef, secondaryTableRef, tableWrapperRef, tableRef]);
   useLayoutEffect(() => {
     syncColumnHeaderWidths();
-    // Content is not going to be layed out until the next frame in angular,
-    // so we need to sync the column headers again.
-    setTimeout(() => syncColumnHeaderWidths(), 0);
     const secondaryTable = secondaryTableRef.current;
     const primaryTable = tableWrapperRef.current;
     return () => {
@@ -60,7 +57,7 @@ export const useStickyHeader = (
         primaryTable.style.marginTop = '';
       }
     };
-  });
+  }, [secondaryTableRef, tableWrapperRef, syncColumnHeaderWidths]);
   useResizeObserver(theadRef, syncColumnHeaderWidths);
   const scrollToTop = () => {
     if (!isMobile && theadRef.current && secondaryTheadRef.current && tableWrapperRef.current) {


### PR DESCRIPTION
### Description

- Add missing dependancies to `useLayoutEffect`
- Remove code that was specific for angular

Related links, issue #, if available: AWSUI-19844

### How has this been tested?

Reproduced the bug manually and tested locally after the fix. to reproduce the bug: 

1. Go to table demo (classic theme)
2. Ensure that no horizontal scrollbar is present on the table (determined at page load time)
3. Use the text filter to reach the empty state
4. Resize the browser window vertically to a smaller size until the table starts to jump
5. make sure you have scrollbars are always enabled in mac settings 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
