### PR TITLE
feat: Focus stays in the input on opening select or multiselect with filter input

### DIFF
--- a/src/multiselect/__integ__/multiselect.test.ts
+++ b/src/multiselect/__integ__/multiselect.test.ts
@@ -231,7 +231,11 @@ describe(`Multiselect with group selection`, () => {
     'group selection selects all enabled child options',
     setupTest(async page => {
       await page.clickSelect();
-      await page.keys(['ArrowUp']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
       await expect(page.getSelectedOptionLabels()).resolves.toEqual([
         'Second category',
@@ -246,7 +250,11 @@ describe(`Multiselect with group selection`, () => {
     'group selection deselects all enabled child options on double press',
     setupTest(async page => {
       await page.clickSelect();
-      await page.keys(['ArrowUp']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
       await page.keys(['Enter']);
 
@@ -258,7 +266,11 @@ describe(`Multiselect with group selection`, () => {
     'deselecting an element removes the parent from the selected options labels',
     setupTest(async page => {
       await page.clickSelect();
-      await page.keys(['ArrowUp']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
       await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
@@ -270,6 +282,12 @@ describe(`Multiselect with group selection`, () => {
     'selecting elements one by one selects the parent',
     setupTest(async page => {
       await page.clickSelect();
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
       await page.keys(['ArrowDown']);
       await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
@@ -300,8 +318,12 @@ describe(`Multiselect with group selection`, () => {
       await page.clickSelect();
       await page.keys(['ArrowDown']);
       await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
+      await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
       await page.keys(['4']);
+      await page.keys(['ArrowDown']);
       await page.keys(['ArrowDown']);
       await page.keys(['Enter']);
       await expect(page.getSelectedOptionLabels()).resolves.toEqual([]);

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -240,6 +240,34 @@ describe('useSelect', () => {
     expect(updateSelectedOption).not.toHaveBeenCalled();
   });
 
+  test('select without filter should open and navigate to selected option', () => {
+    const hook = renderHook(useSelect, {
+      initialProps: { ...initialProps, filteringType: 'none', selectedOptions: [{ value: 'child1' }] },
+    });
+    const { getTriggerProps } = hook.result.current;
+    const triggerProps = getTriggerProps();
+    act(() => triggerProps.onKeyDown && triggerProps.onKeyDown(createTestEvent(KeyCode.space)));
+    expect(hook.result.current.isOpen).toBe(true);
+    expect(hook.result.current.highlightedOption).toEqual({
+      type: 'child',
+      option: {
+        label: 'Child 1',
+        value: 'child1',
+      },
+    });
+  });
+
+  test('select with filter should open and NOT navigate to selected option', () => {
+    const hook = renderHook(useSelect, {
+      initialProps: { ...initialProps, selectedOptions: [{ value: 'child1' }] },
+    });
+    const { getTriggerProps } = hook.result.current;
+    const triggerProps = getTriggerProps();
+    act(() => triggerProps.onKeyDown && triggerProps.onKeyDown(createTestEvent(KeyCode.space)));
+    expect(hook.result.current.isOpen).toBe(true);
+    expect(hook.result.current.highlightedOption).toBeFalsy();
+  });
+
   describe('calculates if the highlighted option is selected', () => {
     test('highlighted option is selected', () => {
       const hook = renderHook(useSelect, {

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -249,11 +249,12 @@ export function useSelect({
 
   const prevOpen = usePrevious<boolean>(isOpen);
   useEffect(() => {
-    // highlight the first selected option, when opening the Select component
-    if (isOpen && !prevOpen && hasSelectedOption) {
+    // highlight the first selected option, when opening the Select component without filter input
+    // keep the focus in the filter input when opening, so that screenreader can recognize the combobox
+    if (isOpen && !prevOpen && hasSelectedOption && !hasFilter) {
       setHighlightedIndexWithMouse(options.indexOf(__selectedOptions[0]));
     }
-  }, [isOpen, __selectedOptions, hasSelectedOption, setHighlightedIndexWithMouse, options, prevOpen]);
+  }, [isOpen, __selectedOptions, hasSelectedOption, setHighlightedIndexWithMouse, options, prevOpen, hasFilter]);
 
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION

### Description

When open the select with filtering, focus should stays in the input, until up/down arrow key is pressed. So that screen readers can recognise and announce combobox. 
For other select without filtering, focus should go to selected item when it opens, as it is.

Related links, **issue AWSUI-18955**

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit test

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
