### PR TITLE
chore: set `"sideEffects": false` flag to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "homepage": "https://cloudscape.design",
   "files": [],
+  "sideEffects": false,
   "scripts": {
     "quick-build": "gulp quick-build",
     "build": "NODE_ENV=production gulp build",


### PR DESCRIPTION
## Description

This PR adds the "sideEffects" flag to package.json so that webpack >= v4 will skip bundling unused modules/files. Because this library uses index.ts to mass export directory modules, this change should reduce bundle size dramatically.

See: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
