### PR TITLE
chore: Move split panel side and bottom positions into separate files

### DIFF
--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -331,7 +331,6 @@ const OldAppLayout = React.forwardRef(
       contentWidthStyles: contentMaxWidthStyle,
       isOpen: splitPanelOpen,
       isMobile,
-      isRefresh: false,
       isForcedPosition: isSplitpanelForcedPosition,
       lastInteraction: splitPanelLastInteraction,
       splitPanelRef,

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -58,7 +58,6 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     isForcedPosition: isSplitPanelForcedPosition,
     isMobile,
     isOpen: isSplitPanelOpen,
-    isRefresh: true,
     leftOffset: 0,
     onPreferencesChange: handleSplitPanelPreferencesChange,
     onResize: handleSplitPanelResize,

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -23,7 +23,6 @@ export interface SplitPanelContextProps {
   isCopy?: boolean;
   isOpen?: boolean;
   isMobile: boolean;
-  isRefresh: boolean;
   isForcedPosition: boolean;
   // The lastInteraction property indicates last meaningful state transition used to trigger split-panel effects.
   // We can't observe properties in a regular way because split-panel is being mounted in several places at once.
@@ -51,7 +50,6 @@ export const SplitPanelContext = createContext<SplitPanelContextProps>({
   isCopy: false,
   isOpen: true,
   isMobile: false,
-  isRefresh: false,
   isForcedPosition: false,
   lastInteraction: undefined,
   splitPanelRef: undefined,

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -53,7 +53,6 @@ const defaultContextProps: SplitPanelContextProps = {
   getHeader: () => null,
   isOpen: true,
   isMobile: false,
-  isRefresh: false,
   isForcedPosition: false,
   onResize: jest.fn(),
   onToggle: jest.fn(),

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React from 'react';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import { TransitionStatus } from '../internal/components/transition';
+import { SplitPanelContentProps } from './interfaces';
+import styles from './styles.css.js';
+import { useSplitPanelContext } from '../internal/context/split-panel-context';
+import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+
+interface SplitPanelContentBottomProps extends SplitPanelContentProps {
+  state: TransitionStatus;
+  transitioningElementRef: React.Ref<any>;
+  appLayoutMaxWidth: React.CSSProperties | undefined;
+}
+
+export function SplitPanelContentBottom({
+  baseProps,
+  isOpen,
+  state,
+  transitioningElementRef,
+  splitPanelRef,
+  cappedSize,
+  header,
+  resizeHandle,
+  children,
+  appLayoutMaxWidth,
+  panelHeaderId,
+  onToggle,
+}: SplitPanelContentBottomProps) {
+  const isRefresh = useVisualRefresh();
+  const {
+    bottomOffset,
+    leftOffset,
+    rightOffset,
+    disableContentPaddings,
+    contentWrapperPaddings,
+    isMobile,
+    splitPanelHeaderRef,
+  } = useSplitPanelContext();
+  const transitionContentBottomRef = useMergeRefs(splitPanelRef || null, transitioningElementRef);
+
+  const centeredMaxWidthClasses = clsx({
+    [styles['pane-bottom-center-align']]: isRefresh,
+    [styles['pane-bottom-content-nav-padding']]: contentWrapperPaddings?.closedNav,
+    [styles['pane-bottom-content-tools-padding']]: contentWrapperPaddings?.closedTools,
+  });
+
+  return (
+    <div
+      {...baseProps}
+      className={clsx(baseProps.className, styles.root, styles.drawer, styles['position-bottom'], {
+        [styles['drawer-closed']]: !isOpen,
+        [styles['drawer-mobile']]: isMobile,
+        [styles['drawer-disable-content-paddings']]: disableContentPaddings,
+        [styles.animating]: isRefresh && (state === 'entering' || state === 'exiting'),
+        [styles.refresh]: isRefresh,
+      })}
+      onClick={() => !isOpen && onToggle()}
+      style={{
+        bottom: bottomOffset,
+        left: leftOffset,
+        right: rightOffset,
+        height: isOpen ? cappedSize : undefined,
+      }}
+      ref={transitionContentBottomRef}
+    >
+      {isOpen && <div className={styles['slider-wrapper-bottom']}>{resizeHandle}</div>}
+      <div className={styles['drawer-content-bottom']} aria-labelledby={panelHeaderId} role="region">
+        <div className={clsx(styles['pane-header-wrapper-bottom'], centeredMaxWidthClasses)} ref={splitPanelHeaderRef}>
+          {header}
+        </div>
+        <div className={clsx(styles['content-bottom'], centeredMaxWidthClasses)} aria-hidden={!isOpen}>
+          <div className={clsx({ [styles['content-bottom-max-width']]: isRefresh })} style={appLayoutMaxWidth}>
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
 import { BaseComponentProps } from '../internal/base-component';
 
 export interface SplitPanelProps extends BaseComponentProps {
@@ -49,4 +50,16 @@ export interface SizeControlProps {
   handleRef?: React.RefObject<HTMLDivElement>;
   setSidePanelWidth: (width: number) => void;
   setBottomPanelHeight: (height: number) => void;
+}
+
+export interface SplitPanelContentProps {
+  baseProps: BaseComponentProps;
+  isOpen?: boolean;
+  splitPanelRef?: React.Ref<any>;
+  cappedSize: number;
+  panelHeaderId: string;
+  resizeHandle: React.ReactNode;
+  header: React.ReactNode;
+  children: React.ReactNode;
+  onToggle: () => void;
 }

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+import { ButtonProps } from '../button/interfaces';
+import InternalButton from '../button/internal';
+import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { SplitPanelProps, SplitPanelContentProps } from './interfaces';
+import styles from './styles.css.js';
+import { useSplitPanelContext } from '../internal/context/split-panel-context';
+
+interface SplitPanelContentSideProps extends SplitPanelContentProps {
+  i18nStrings: SplitPanelProps.I18nStrings;
+  toggleRef: React.RefObject<ButtonProps.Ref>;
+}
+
+export function SplitPanelContentSide({
+  baseProps,
+  splitPanelRef,
+  toggleRef,
+  header,
+  children,
+  resizeHandle,
+  isOpen,
+  cappedSize,
+  i18nStrings,
+  panelHeaderId,
+  onToggle,
+}: SplitPanelContentSideProps) {
+  const { topOffset, bottomOffset } = useSplitPanelContext();
+  const isRefresh = useVisualRefresh();
+  return (
+    <div
+      {...baseProps}
+      className={clsx(baseProps.className, styles.drawer, styles.root, styles['position-side'], {
+        [styles['drawer-closed']]: !isOpen,
+      })}
+      style={{
+        width: isOpen ? cappedSize : undefined,
+        maxWidth: isRefresh ? '100%' : undefined,
+      }}
+      ref={splitPanelRef}
+    >
+      <div
+        className={clsx(styles['drawer-content-side'], {
+          [styles.refresh]: isRefresh,
+        })}
+        style={{
+          top: topOffset,
+          bottom: bottomOffset,
+        }}
+        onClick={() => !isOpen && onToggle()}
+        aria-labelledby={panelHeaderId}
+        role="region"
+      >
+        {isOpen ? (
+          <div className={styles['slider-wrapper-side']}>{resizeHandle}</div>
+        ) : (
+          <InternalButton
+            className={clsx(styles['open-button'], styles['open-button-side'])}
+            iconName="angle-left"
+            variant="icon"
+            formAction="none"
+            ariaLabel={i18nStrings.openButtonAriaLabel}
+            ariaExpanded={isOpen}
+            ref={isRefresh ? null : toggleRef}
+          />
+        )}
+        <div className={styles['content-side']} aria-hidden={!isOpen}>
+          <div className={clsx(styles['pane-header-wrapper-side'])}>{header}</div>
+          <hr className={styles['header-divider']} />
+          <div className={clsx(styles['pane-content-wrapper-side'])}>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Description

There already were  separate `TransitionContentBottom` and `TransitionContentSide` components, but cramped into a single file for some reason. Let's finish the refactoring and move them into separate files

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
