### PR TITLE
fix: Prevent grid blowout on Firefox with table in wizard

### DIFF
--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -20,6 +20,7 @@
   row-gap: awsui.$space-scaled-xl;
 
   &.small-container {
+    grid-template-columns: minmax(0, 1fr) 0;
     row-gap: awsui.$space-scaled-l;
   }
 }


### PR DESCRIPTION
### Description

Does what it says on the tin. When the refresh wizard collapses to a 1-column view in responsive situations, everything gets shifted to the first column. This changes the column widths so that the the contents are always rendered in a `minmax(0, 1fr)`.

Related links, issue #, if available: AWSUI-19794

### How has this been tested?

Visual tests, and manual checks on all browsers. We have screenshots for this but it looks like this issue was missed.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
