### PR TITLE
feat: Use ellipsis for clipped chart x categorical label

### DIFF
--- a/pages/bar-chart/permutations.page.tsx
+++ b/pages/bar-chart/permutations.page.tsx
@@ -20,7 +20,7 @@ import {
   multipleNegativeBarsDataWithThreshold,
 } from '../mixed-line-bar-chart/common';
 
-const timeLatencyData = latencyData.map(({ time, p90 }) => ({ x: time, y: p90 }));
+const timeLatencyData = latencyData.slice(0, 6).map(({ time, p90 }) => ({ x: time, y: p90 }));
 
 /* eslint-disable react/jsx-key */
 const stringPermutations = createPermutations<BarChartProps<string>>([

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -51,6 +51,7 @@ function BottomLabels({
       return cacheRef.current[label];
     }
     if (virtualTextRef.current && virtualTextRef.current.getComputedTextLength) {
+      virtualTextRef.current.classList.add(styles.ticks__text);
       virtualTextRef.current.textContent = label;
       cacheRef.current[label] = virtualTextRef.current.getComputedTextLength();
       return cacheRef.current[label];
@@ -110,14 +111,14 @@ function BottomLabels({
                 <foreignObject
                   x={-x}
                   y={TICK_LENGTH + TICK_MARGIN}
-                  width={space}
+                  width={maxWidth}
                   height={TICK_LINE_HEIGHT * lines.length}
                 >
                   {lines.map((line, lineIndex) => (
                     <span
                       key={lineIndex}
                       className={styles.ticks__text__bottom}
-                      style={{ maxWidth: maxWidth + 'px', lineHeight: TICK_LINE_HEIGHT + 'px' }}
+                      style={{ maxWidth: maxWidth + 'px', height: TICK_LINE_HEIGHT + 'px' }}
                     >
                       {line}
                     </span>

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -89,7 +89,7 @@ function BottomLabels({
       aria-roledescription={ariaRoleDescription}
       aria-hidden={true}
     >
-      {visibleTicks.map(({ position, lines, space }, index) => {
+      {visibleTicks.map(({ position, lines }, index) => {
         // calculate the max space the last label can have
         let maxWidth = width + offsetRight - position;
         // calculate the max space other labels can have
@@ -100,7 +100,6 @@ function BottomLabels({
         if (maxWidth < 10) {
           maxWidth = 10;
         }
-        const textAnchor = maxWidth > space ? space / 2 : maxWidth / 2;
         return (
           isFinite(position) && (
             <g
@@ -116,12 +115,12 @@ function BottomLabels({
               <line className={styles.ticks__line} x1={0} x2={0} y1={0} y2={TICK_LENGTH} aria-hidden="true" />
               {isCategorical ? (
                 <foreignObject
-                  x={-textAnchor}
+                  x={-maxWidth / 2}
                   y={TICK_LENGTH + TICK_MARGIN}
                   width={maxWidth}
                   height={TICK_LINE_HEIGHT * lines.length}
                 >
-                  <div className={styles.ticks__text__group}>
+                  <div style={{ width: maxWidth + 'px' }} className={styles.ticks__text__group}>
                     {lines.map((line, lineIndex) => (
                       <span
                         key={lineIndex}

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -68,6 +68,7 @@ function BottomLabels({
   const from = 0 - offsetLeft - xOffset;
   const until = width + offsetRight - xOffset;
   const balanceLabels = axis === 'x' && scale.scaleType !== 'log';
+  // for categorical type, show ellipsis for clipped text instead of hiding labels
   const visibleTicks = isCategorical ? formattedTicks : getVisibleTicks(formattedTicks, from, until, balanceLabels);
   let maxHeight = TICK_LENGTH + TICK_MARGIN;
   for (const { lines } of formattedTicks) {
@@ -89,11 +90,17 @@ function BottomLabels({
       aria-hidden={true}
     >
       {visibleTicks.map(({ position, lines, space }, index) => {
+        // calculate the max space the last label can have
         let maxWidth = width + offsetRight - position;
+        // calculate the max space other labels can have
         if (visibleTicks[index + 1]) {
           maxWidth = visibleTicks[index + 1].position - position - 10;
         }
-        const x = maxWidth > space ? space / 2 : maxWidth / 2;
+        // at least show some content, not hide everything
+        if (maxWidth < 10) {
+          maxWidth = 10;
+        }
+        const textAnchor = maxWidth > space ? space / 2 : maxWidth / 2;
         return (
           isFinite(position) && (
             <g
@@ -107,9 +114,9 @@ function BottomLabels({
               aria-label={lines.join('\n')}
             >
               <line className={styles.ticks__line} x1={0} x2={0} y1={0} y2={TICK_LENGTH} aria-hidden="true" />
-              {scale.isCategorical() ? (
+              {isCategorical ? (
                 <foreignObject
-                  x={-x}
+                  x={-textAnchor}
                   y={TICK_LENGTH + TICK_MARGIN}
                   width={maxWidth}
                   height={TICK_LINE_HEIGHT * lines.length}

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -124,7 +124,7 @@ function BottomLabels({
                     {lines.map((line, lineIndex) => (
                       <span
                         key={lineIndex}
-                        className={styles.ticks__text__bottom}
+                        className={styles.ticks__text__categorical}
                         style={{ maxWidth: maxWidth + 'px', height: TICK_LINE_HEIGHT + 'px' }}
                       >
                         {line}

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -121,15 +121,17 @@ function BottomLabels({
                   width={maxWidth}
                   height={TICK_LINE_HEIGHT * lines.length}
                 >
-                  {lines.map((line, lineIndex) => (
-                    <span
-                      key={lineIndex}
-                      className={styles.ticks__text__bottom}
-                      style={{ maxWidth: maxWidth + 'px', height: TICK_LINE_HEIGHT + 'px' }}
-                    >
-                      {line}
-                    </span>
-                  ))}
+                  <div className={styles.ticks__text__group}>
+                    {lines.map((line, lineIndex) => (
+                      <span
+                        key={lineIndex}
+                        className={styles.ticks__text__bottom}
+                        style={{ maxWidth: maxWidth + 'px', height: TICK_LINE_HEIGHT + 'px' }}
+                      >
+                        {line}
+                      </span>
+                    ))}
+                  </div>
                 </foreignObject>
               ) : (
                 lines.map((line, lineIndex) => (

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -41,7 +41,6 @@
 }
 
 .ticks__text__group {
-  width: max-content;
   text-align: center;
 }
 

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -40,6 +40,15 @@
   fill: awsui.$color-text-body-secondary;
 }
 
+.ticks__text__bottom {
+  font-size: awsui.$font-chart-detail-size;
+  color: awsui.$color-text-body-secondary;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: block;
+  white-space: nowrap;
+}
+
 .ticks--y,
 .ticks--x {
   /* used in test-utils */

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -44,7 +44,7 @@
   text-align: center;
 }
 
-.ticks__text__bottom {
+.ticks__text__categorical {
   font-size: awsui.$font-chart-detail-size;
   line-height: awsui.$font-chart-detail-size;
   color: awsui.$color-text-body-secondary;

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -42,6 +42,7 @@
 
 .ticks__text__bottom {
   font-size: awsui.$font-chart-detail-size;
+  line-height: awsui.$font-chart-detail-size;
   color: awsui.$color-text-body-secondary;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -40,6 +40,11 @@
   fill: awsui.$color-text-body-secondary;
 }
 
+.ticks__text__group {
+  width: max-content;
+  text-align: center;
+}
+
 .ticks__text__bottom {
   font-size: awsui.$font-chart-detail-size;
   line-height: awsui.$font-chart-detail-size;


### PR DESCRIPTION
### Description

AWSUI-19242
Use ellipsis for clipped chart x categorical label instead of hiding labels.
Added unit test.
Screenshot test will also catch the change.  

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
