### PR TITLE
fix: Change the error message ID to include the error icon

### DIFF
--- a/src/form-field/__tests__/form-field-context.test.tsx
+++ b/src/form-field/__tests__/form-field-context.test.tsx
@@ -8,6 +8,9 @@ import {
   useFormFieldContext,
   FormFieldValidationControlProps,
 } from '../../../lib/components/internal/context/form-field-context';
+import styles from '../../../lib/components/form-field/styles.css.js';
+
+const errorSelector = `:scope > .${styles.hints} .${styles.error}`;
 
 const TestControl = () => {
   const contextValues = useFormFieldContext({});
@@ -253,11 +256,11 @@ describe('nested form fields', () => {
       </FormField>
     );
 
-    const outerErrorId = outerFormFieldWrapper.findError()?.getElement().id;
+    const outerErrorId = outerFormFieldWrapper.find(errorSelector)?.getElement().id;
     const outerDescriptionId = outerFormFieldWrapper.findDescription()?.getElement().id;
     const outerConstraintId = outerFormFieldWrapper.findConstraint()?.getElement().id;
 
-    const innerErrorId = innerFormFieldWrapper.findError()?.getElement().id;
+    const innerErrorId = innerFormFieldWrapper.find(errorSelector)?.getElement().id;
     const innerDescriptionId = innerFormFieldWrapper.findDescription()?.getElement().id;
     const innerConstraintId = innerFormFieldWrapper.findConstraint()?.getElement().id;
 

--- a/src/form-field/__tests__/form-field-control-id.test.tsx
+++ b/src/form-field/__tests__/form-field-control-id.test.tsx
@@ -5,8 +5,11 @@ import { render } from '@testing-library/react';
 import FormField, { FormFieldProps } from '../../../lib/components/form-field';
 import Input from '../../../lib/components/input';
 import createWrapper from '../../../lib/components/test-utils/dom';
+import styles from '../../../lib/components/form-field/styles.css.js';
 
 const testInput = <Input value="follow me on tiktok" onChange={() => {}} />;
+
+const errorSelector = `:scope > .${styles.hints} .${styles.error}`;
 
 function renderFormField(props: FormFieldProps = {}) {
   const renderResult = render(<FormField {...props} />);
@@ -33,7 +36,7 @@ describe('controlId', () => {
 
     test('renders id for errorText based on controlId', () => {
       const wrapper = renderFormField({ controlId: formFieldControlId, errorText: 'Test error' });
-      expect(wrapper.findError()?.getElement().id).toBe(`${formFieldControlId}-error`);
+      expect(wrapper.find(errorSelector)?.getElement().id).toBe(`${formFieldControlId}-error`);
     });
 
     test('renders id for constraintText based on controlId', () => {
@@ -52,7 +55,7 @@ describe('controlId', () => {
 
       expect(wrapper.findLabel()?.getElement()).toHaveAttribute('for', formFieldControlId);
       expect(wrapper.findDescription()?.getElement().id).toBe(`${formFieldControlId}-description`);
-      expect(wrapper.findError()?.getElement().id).toBe(`${formFieldControlId}-error`);
+      expect(wrapper.find(errorSelector)?.getElement().id).toBe(`${formFieldControlId}-error`);
       expect(wrapper.findConstraint()?.getElement().id).toBe(`${formFieldControlId}-constraint`);
     });
 
@@ -109,7 +112,7 @@ describe('controlId', () => {
 
     test('generates own id and uses it for errorText', () => {
       const wrapper = renderFormField({ errorText: 'Test error' });
-      expect(wrapper.findError()?.getElement()).toHaveAttribute('id');
+      expect(wrapper.find(errorSelector)?.getElement()).toHaveAttribute('id');
     });
 
     test('generates own id and uses it for constraintText', () => {
@@ -129,7 +132,7 @@ describe('controlId', () => {
 
       expect(labelId).not.toBeUndefined();
       expect(wrapper.findDescription()?.getElement().id).toBe(labelId?.replace('label', 'description'));
-      expect(wrapper.findError()?.getElement().id).toBe(labelId?.replace('label', 'error'));
+      expect(wrapper.find(errorSelector)?.getElement().id).toBe(labelId?.replace('label', 'error'));
       expect(wrapper.findConstraint()?.getElement().id).toBe(labelId?.replace('label', 'constraint'));
     });
 

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -23,15 +23,13 @@ interface FormFieldErrorProps {
 }
 
 export const FormFieldError = ({ id, children, errorIconAriaLabel }: FormFieldErrorProps) => (
-  <div className={styles.error}>
+  <div id={id} className={styles.error}>
     <div className={styles['error-icon-shake-wrapper']}>
       <div role="img" aria-label={errorIconAriaLabel} className={styles['error-icon-scale-wrapper']}>
         <InternalIcon name="status-warning" size="small" />
       </div>
     </div>
-    <span id={id} className={styles.error__message}>
-      {children}
-    </span>
+    <span className={styles.error__message}>{children}</span>
   </div>
 );
 

--- a/src/test-utils/dom/form-field/index.ts
+++ b/src/test-utils/dom/form-field/index.ts
@@ -23,7 +23,7 @@ export default class FormFieldWrapper extends ComponentWrapper<HTMLElement> {
   }
 
   findError(): ElementWrapper | null {
-    return this.find(`:scope > .${styles.hints} .${styles.error__message}`);
+    return this.find(`:scope > .${styles.hints} .${styles.error} .${styles.error__message}`);
   }
 
   findDescription(): ElementWrapper | null {


### PR DESCRIPTION
### Description

- include the icon in error id
- change `findError` selector to not break the test util for customers
- update our tests to use a custom selector as the `id` is not on the wrapper div


Related links, issue #, if available: n/a

### How has this been tested?

updated tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
