### PR TITLE
feat: Allow mouse to enter popover in charts

### DIFF
--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -128,6 +128,20 @@ describe('Popover', () => {
   );
 
   test(
+    'popover is shown when mouse is over popover',
+    setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await page.setWindowSize({ width: 2000, height: 800 });
+      await expect(page.hasPopover()).resolves.toBe(false);
+
+      await page.focusPlot();
+      await expect(page.getPopoverTitle()).resolves.toBe('1s');
+
+      await page.hoverElement(page.chart.findDetailPopover().findHeader().toSelector());
+      await expect(page.getPopoverTitle()).resolves.toBe('1s');
+    })
+  );
+
+  test(
     'popover can be pinned/unpinned by clicking on the plot',
     setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
       await page.focusPlot();
@@ -219,6 +233,7 @@ describe('Keyboard navigation', () => {
   test(
     'can navigate between data points within series',
     setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await page.setWindowSize({ width: 2000, height: 800 });
       await page.focusPlot();
 
       await expect(page.getPopoverTitle()).resolves.toBe('1s');
@@ -331,6 +346,7 @@ describe('Focus delegation', () => {
   test(
     'preserves series highlight when focused away from plot',
     setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await page.setWindowSize({ width: 2000, height: 800 });
       await page.focusPlot();
 
       await page.keys(['ArrowDown', 'ArrowRight']);

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useState, useImperativeHandle, useRef } from 'react';
 
 import useChartModel, { UseChartModelProps } from '../model/use-chart-model';
 import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import { ChartDataTypes } from '../../internal/components/cartesian-chart/interfaces';
-import { act, render } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import { AreaChartProps } from '../interfaces';
 import { KeyCode } from '../../internal/keycode';
 import { useReaction } from '../model/async-store';
@@ -14,9 +14,11 @@ import PlotPoint = ChartModel.PlotPoint;
 
 class UseChartModelWrapper extends ElementWrapper {
   static selectors = {
-    highlightedPoint: 'highlighted-point',
+    highlightedPoint: 'fhighlighted-point',
     highlightedSeries: 'highlighted-series',
     highlightedX: 'highlighted-x',
+    plot: 'plot',
+    popover: 'popover',
   };
 
   findHighlightedPoint() {
@@ -30,6 +32,14 @@ class UseChartModelWrapper extends ElementWrapper {
   findHighlightedX() {
     return this.findByClassName(UseChartModelWrapper.selectors.highlightedX);
   }
+
+  findPlot() {
+    return this.findByClassName(UseChartModelWrapper.selectors.plot);
+  }
+
+  findDetailPopover() {
+    return this.findByClassName(UseChartModelWrapper.selectors.popover);
+  }
 }
 
 function RenderChartModelHook(props: UseChartModelProps<ChartDataTypes>) {
@@ -37,17 +47,26 @@ function RenderChartModelHook(props: UseChartModelProps<ChartDataTypes>) {
   const [visibleSeries, setVisibleSeries] = useState(props.visibleSeries);
   const [highlightedPoint, setHighlightedPoint] = useState<PlotPoint<ChartDataTypes> | null>(null);
   const [highlightedX, setHighlightedX] = useState<readonly PlotPoint<ChartDataTypes>[] | null>(null);
+  const svgRef = useRef(null);
+  const popoverRef = useRef(null);
 
-  const { computed, handlers, interactions } = useChartModel({
+  const { computed, handlers, interactions, refs } = useChartModel({
     ...props,
     highlightedSeries,
     setHighlightedSeries,
     visibleSeries,
     setVisibleSeries,
+    popoverRef,
   });
 
   useReaction(interactions, state => state.highlightedPoint, setHighlightedPoint);
   useReaction(interactions, state => state.highlightedX, setHighlightedX);
+
+  useImperativeHandle(refs.plot, () => ({
+    svg: svgRef.current!,
+    focusPlot: jest.fn(),
+    focusApplication: jest.fn(),
+  }));
 
   return (
     <div
@@ -65,6 +84,17 @@ function RenderChartModelHook(props: UseChartModelProps<ChartDataTypes>) {
       <span className={UseChartModelWrapper.selectors.highlightedX}>
         {highlightedX === null ? null : highlightedX[0].x}
       </span>
+      <svg
+        onMouseMove={handlers.onSVGMouseMove}
+        onMouseOut={handlers.onSVGMouseOut}
+        className={UseChartModelWrapper.selectors.plot}
+        ref={svgRef}
+      >
+        area plot
+      </svg>
+      <div className={UseChartModelWrapper.selectors.popover} ref={popoverRef} onMouseLeave={handlers.onPopoverLeave}>
+        <div>Popover</div>
+      </div>
       <span>{visibleSeries[0].title}</span>
     </div>
   );
@@ -179,6 +209,147 @@ describe('useChartModel', () => {
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('0');
 
         act(() => wrapper.keydown(KeyCode.right));
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+      });
+    });
+
+    describe('Detail Popover', () => {
+      test('does not clear highlighted X on mouseOut if moving within popover', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+
+        const mouseMoveEvent = {
+          relatedTarget: wrapper.findPlot()?.getElement(),
+          clientX: 100,
+          clientY: 100,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseMove(wrapper.findPlot()!.getElement(), mouseMoveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+
+        const mouseOutEvent = {
+          relatedTarget: wrapper.findDetailPopover()?.getElement(),
+          clientX: 0,
+          clientY: 0,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseOut(wrapper.findPlot()!.getElement(), mouseOutEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+      });
+
+      test('clear highlighted X when mouse leaves popover', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+
+        const mouseMoveEvent = {
+          relatedTarget: wrapper.findPlot()?.getElement(),
+          clientX: 100,
+          clientY: 100,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseMove(wrapper.findPlot()!.getElement(), mouseMoveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+
+        const mouseOutEvent = {
+          relatedTarget: wrapper.findDetailPopover()?.getElement(),
+          clientX: 0,
+          clientY: 0,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseOut(wrapper.findPlot()!.getElement(), mouseOutEvent);
+        });
+
+        const mouseLeaveEvent = {
+          relatedTarget: wrapper.getElement(),
+          clientX: 400,
+          clientY: 400,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseLeave(wrapper.findDetailPopover()!.getElement(), mouseLeaveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('');
+      });
+      test('keep highlighted X when mouse leaves popover but in plot', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+
+        const mouseMoveEvent = {
+          relatedTarget: wrapper.findPlot()?.getElement(),
+          clientX: 100,
+          clientY: 100,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseMove(wrapper.findPlot()!.getElement(), mouseMoveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+
+        const mouseOutEvent = {
+          relatedTarget: wrapper.findDetailPopover()?.getElement(),
+          clientX: 0,
+          clientY: 0,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseOut(wrapper.findPlot()!.getElement(), mouseOutEvent);
+        });
+
+        const mouseLeaveEvent = {
+          relatedTarget: wrapper.findPlot()!.getElement(),
+          clientX: 100,
+          clientY: 100,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseLeave(wrapper.findDetailPopover()!.getElement(), mouseLeaveEvent);
+        });
+
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
       });
     });

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -115,6 +115,7 @@ describe('useChartModel', () => {
         yScaleType: 'linear',
         externalSeries: series,
         visibleSeries: series,
+        popoverRef: { current: null },
       });
       act(() => wrapper.focus());
 
@@ -149,6 +150,7 @@ describe('useChartModel', () => {
           yScaleType: 'linear',
           externalSeries: series,
           visibleSeries: series,
+          popoverRef: { current: null },
         });
         act(() => wrapper.focus());
 
@@ -171,6 +173,7 @@ describe('useChartModel', () => {
           yScaleType: 'linear',
           externalSeries: series,
           visibleSeries: series,
+          popoverRef: { current: null },
         });
         act(() => wrapper.focus());
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('0');

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -14,7 +14,7 @@ import PlotPoint = ChartModel.PlotPoint;
 
 class UseChartModelWrapper extends ElementWrapper {
   static selectors = {
-    highlightedPoint: 'fhighlighted-point',
+    highlightedPoint: 'highlighted-point',
     highlightedSeries: 'highlighted-series',
     highlightedX: 'highlighted-x',
     plot: 'plot',

--- a/src/area-chart/elements/chart-popover.tsx
+++ b/src/area-chart/elements/chart-popover.tsx
@@ -31,6 +31,8 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
     trackKey: highlightDetails.highlightIndex,
     dismissButton: highlightDetails.isPopoverPinned,
     onDismiss: model.handlers.onPopoverDismiss,
+    onMouseLeave: model.handlers.onPopoverLeave,
+    ref: model.refs.popoverRef,
   };
 
   return (

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -65,6 +65,7 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
 }: InternalAreaChartProps<T>) {
   const baseProps = getBaseProps(props);
   const containerRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
 
   if (isDevelopment) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -102,6 +103,7 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
     yScaleType,
     height,
     width,
+    popoverRef,
   });
 
   const { isEmpty, isNoMatch, showChart } = getChartStatus({

--- a/src/area-chart/model/index.ts
+++ b/src/area-chart/model/index.ts
@@ -16,8 +16,8 @@ export interface ChartModel<T extends AreaChartProps.DataTypes> {
   getInternalSeries(series: AreaChartProps.Series<T>): ChartModel.InternalSeries<T>;
   computed: ChartModel.ComputedProps<T>;
   handlers: {
-    onSVGMouseMove: (event: React.MouseEvent<SVGElement, MouseEvent>) => void;
-    onSVGMouseOut: (event: React.MouseEvent<SVGElement, MouseEvent>) => void;
+    onSVGMouseMove: (event: React.MouseEvent<SVGElement>) => void;
+    onSVGMouseOut: (event: React.MouseEvent<SVGElement>) => void;
     onSVGMouseDown: (event: React.MouseEvent<SVGSVGElement>) => void;
     onSVGKeyDown: (event: React.KeyboardEvent) => void;
     onSVGFocus: (event: React.FocusEvent<Element>, trigger: 'mouse' | 'keyboard') => void;
@@ -27,12 +27,14 @@ export interface ChartModel<T extends AreaChartProps.DataTypes> {
     onPopoverDismiss: (outsideClick?: boolean) => void;
     onContainerBlur: () => void;
     onDocumentKeyDown: (event: KeyboardEvent) => void;
+    onPopoverLeave: (event: React.MouseEvent) => void;
   };
   interactions: ReadonlyAsyncStore<ChartModel.InteractionsState<T>>;
   refs: {
     plot: React.RefObject<ChartPlotRef>;
     container: React.RefObject<HTMLDivElement>;
     verticalMarker: React.RefObject<SVGLineElement>;
+    popoverRef: React.RefObject<HTMLElement>;
   };
 }
 

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -15,10 +15,10 @@ import { useStableEventHandler } from '../../internal/hooks/use-stable-event-han
 import { ChartModel } from './index';
 import { ChartPlotRef } from '../../internal/components/chart-plot';
 import { throttle } from '../../internal/utils/throttle';
-import { POPOVER_DEADZONE } from '../../internal/components/chart-popover';
 
 const MAX_HOVER_MARGIN = 6;
 const SVG_HOVER_THROTTLE = 25;
+const POPOVER_DEADZONE = 12;
 
 export interface UseChartModelProps<T extends AreaChartProps.DataTypes> {
   externalSeries: readonly AreaChartProps.Series<T>[];

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -15,10 +15,10 @@ import { useStableEventHandler } from '../../internal/hooks/use-stable-event-han
 import { ChartModel } from './index';
 import { ChartPlotRef } from '../../internal/components/chart-plot';
 import { throttle } from '../../internal/utils/throttle';
+import { POPOVER_DEADZONE } from '../../internal/components/chart-popover';
 
 const MAX_HOVER_MARGIN = 6;
 const SVG_HOVER_THROTTLE = 25;
-const POPOVER_DEADZONE = 12;
 
 export interface UseChartModelProps<T extends AreaChartProps.DataTypes> {
   externalSeries: readonly AreaChartProps.Series<T>[];

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -14,6 +14,8 @@ import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import styles from './styles.css.js';
 
+export const POPOVER_DEADZONE = 12;
+
 export interface ChartPopoverProps extends PopoverProps {
   /** Title of the popover */
   title?: React.ReactNode;

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -14,8 +14,6 @@ import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import styles from './styles.css.js';
 
-export const POPOVER_DEADZONE = 12;
-
 export interface ChartPopoverProps extends PopoverProps {
   /** Title of the popover */
   title?: React.ReactNode;

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -99,6 +99,8 @@ function ChartPopover(
       {...baseProps}
       className={clsx(popoverStyles.root, styles.root, baseProps.className, { [styles.dismissable]: dismissButton })}
       ref={popoverRef}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <PopoverContainer
         size={size}
@@ -113,12 +115,13 @@ function ChartPopover(
           </div>
         )}
       >
-        <div className={styles['hover-area']} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <div className={styles['hover-area']}>
           <PopoverBody
             dismissButton={dismissButton}
             dismissAriaLabel={dismissAriaLabel}
             header={title}
             onDismiss={onDismiss}
+            className={styles['popover-body']}
           >
             {children}
           </PopoverBody>

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -10,6 +10,7 @@ import PopoverContainer from '../../../popover/container';
 import PopoverBody from '../../../popover/body';
 import popoverStyles from '../../../popover/styles.css.js';
 import { nodeContains } from '../../utils/dom';
+import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import styles from './styles.css.js';
 
@@ -36,35 +37,51 @@ export interface ChartPopoverProps extends PopoverProps {
   /** Event that is fired when the popover is dismissed */
   onDismiss: (outsideClick?: boolean) => void;
 
+  /** Fired when the pointer enters the hoverable area around the popover */
+  onMouseEnter?: (event: React.MouseEvent) => void;
+
+  /** Fired when the pointer leaves the hoverable area around the popover */
+  onMouseLeave?: (event: React.MouseEvent) => void;
+
   /** Popover content */
   children?: React.ReactNode;
 }
 
-export default function ChartPopover({
-  position = 'right',
-  size = 'medium',
-  fixedWidth = false,
-  dismissButton = false,
-  dismissAriaLabel,
+export default React.forwardRef(ChartPopover);
 
-  children,
+function ChartPopover(
+  {
+    position = 'right',
+    size = 'medium',
+    fixedWidth = false,
+    dismissButton = false,
+    dismissAriaLabel,
 
-  title,
-  trackRef,
-  trackKey,
-  onDismiss,
-  container,
+    children,
 
-  ...restProps
-}: ChartPopoverProps) {
+    title,
+    trackRef,
+    trackKey,
+    onDismiss,
+    container,
+
+    onMouseEnter,
+    onMouseLeave,
+
+    ...restProps
+  }: ChartPopoverProps,
+  ref: React.Ref<HTMLElement>
+) {
   const baseProps = getBaseProps(restProps);
-  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const popoverObjectRef = useRef<HTMLDivElement | null>(null);
+
+  const popoverRef = useMergeRefs(popoverObjectRef, ref);
 
   useEffect(() => {
     const onDocumentClick = (event: MouseEvent) => {
       if (
         event.target &&
-        !nodeContains(popoverRef.current, event.target as Element) && // click not in popover
+        !nodeContains(popoverObjectRef.current, event.target as Element) && // click not in popover
         !nodeContains(container, event.target as Element) // click not in segment
       ) {
         onDismiss(true);
@@ -96,14 +113,16 @@ export default function ChartPopover({
           </div>
         )}
       >
-        <PopoverBody
-          dismissButton={dismissButton}
-          dismissAriaLabel={dismissAriaLabel}
-          header={title}
-          onDismiss={onDismiss}
-        >
-          {children}
-        </PopoverBody>
+        <div className={styles['hover-area']} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+          <PopoverBody
+            dismissButton={dismissButton}
+            dismissAriaLabel={dismissAriaLabel}
+            header={title}
+            onDismiss={onDismiss}
+          >
+            {children}
+          </PopoverBody>
+        </div>
       </PopoverContainer>
     </div>
   );

--- a/src/internal/components/chart-popover/styles.scss
+++ b/src/internal/components/chart-popover/styles.scss
@@ -8,11 +8,10 @@
 
 .root {
   @include styles.styles-reset;
-
   position: absolute;
-  pointer-events: none;
+}
 
-  &.dismissable {
-    pointer-events: auto;
-  }
+.hover-area {
+  padding: awsui.$space-static-s;
+  margin: calc(-1 * #{awsui.$space-static-s});
 }

--- a/src/internal/components/chart-popover/styles.scss
+++ b/src/internal/components/chart-popover/styles.scss
@@ -10,8 +10,8 @@
   @include styles.styles-reset;
   position: absolute;
 }
-
 .hover-area {
+  pointer-events: none;
   padding: awsui.$space-static-s;
   margin: calc(-1 * #{awsui.$space-static-s});
 }

--- a/src/internal/components/chart-popover/styles.scss
+++ b/src/internal/components/chart-popover/styles.scss
@@ -15,3 +15,7 @@
   padding: awsui.$space-static-s;
   margin: calc(-1 * #{awsui.$space-static-s});
 }
+
+.popover-body {
+  pointer-events: auto;
+}

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -303,6 +303,9 @@ describe('Details popover', () => {
       await expect(page.getText(popoverContentSelector())).resolves.toContain('Calories\n77');
       await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold\n420');
 
+      // remove hover over the first element to avoid hovering over a popover
+      await page.hoverElement('body');
+
       // Hover over second group
       await page.hoverElement(chartWrapper.findBarGroups().get(2).toSelector());
       await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Chocolate');
@@ -369,7 +372,7 @@ describe('Details popover', () => {
     'can be pinned by clicking on chart background and dismissed by clicking outside chart area in line chart',
     setupTest('#/light/line-chart/test', async page => {
       // Hovers to open popover
-      await page.hoverElement(chartWrapper.findSeries().toSelector());
+      await page.hoverElement(chartWrapper.findChart().toSelector());
       // Clicks background to pin
       await page.click(chartWrapper.findChart().toSelector());
       // Pinned popover
@@ -406,6 +409,18 @@ describe('Details popover', () => {
       await page.waitForAssertion(() =>
         expect(page.isFocused(chartWrapper.findApplication().toSelector())).resolves.toBe(true)
       );
+    })
+  );
+
+  test(
+    'Allow mouse to enter popover when a group is hovering over a point',
+    setupTest('#/light/mixed-line-bar-chart/test', async page => {
+      // Hover over first group
+      await page.hoverElement(chartWrapper.findBarGroups().get(1).toSelector());
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
+
+      await page.hoverElement(chartWrapper.findDetailPopover().findHeader().toSelector());
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
     })
   );
 });

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -114,6 +114,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const plotWidth = containerWidth ? containerWidth - leftLabelsWidth - LEFT_LABELS_MARGIN : 500;
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
+  const popoverRef = useRef<HTMLElement | null>(null);
 
   const isRefresh = useVisualRefresh();
 
@@ -251,10 +252,11 @@ export default function ChartContainer<T extends ChartDataTypes>({
     verticalMarkerX,
   });
 
-  const { onSVGMouseMove, onSVGMouseOut } = useMouseHover<T>({
+  const { onSVGMouseMove, onSVGMouseOut, onPopoverLeave } = useMouseHover<T>({
     scaledSeries,
     barGroups,
     plotRef,
+    popoverRef,
     highlightPoint,
     highlightGroup,
     clearHighlightedSeries,
@@ -549,6 +551,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
         </div>
 
         <ChartPopover
+          ref={popoverRef}
           containerRef={containerRefObject}
           trackRef={highlightedElementRef}
           isOpen={isPopoverOpen}
@@ -557,6 +560,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
           onDismiss={onPopoverDismiss}
           size={detailPopoverSize}
           dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
+          onMouseLeave={onPopoverLeave}
         />
       </div>
     </div>

--- a/src/mixed-line-bar-chart/chart-popover.tsx
+++ b/src/mixed-line-bar-chart/chart-popover.tsx
@@ -20,24 +20,34 @@ export interface MixedChartPopoverProps<T extends ChartDataTypes> {
   onDismiss(): void;
   size: MixedLineBarChartProps<T>['detailPopoverSize'];
   dismissAriaLabel?: string;
+  onMouseEnter?: (event: React.MouseEvent) => void;
+  onMouseLeave?: (event: React.MouseEvent) => void;
 }
 
-export default function MixedChartPopover<T extends ChartDataTypes>({
-  containerRef,
-  trackRef,
-  isOpen,
-  isPinned,
-  highlightDetails,
-  onDismiss,
-  size = 'medium',
-  dismissAriaLabel,
-}: MixedChartPopoverProps<T>) {
+export default React.forwardRef(MixedChartPopover);
+
+function MixedChartPopover<T extends ChartDataTypes>(
+  {
+    containerRef,
+    trackRef,
+    isOpen,
+    isPinned,
+    highlightDetails,
+    onDismiss,
+    size = 'medium',
+    dismissAriaLabel,
+    onMouseEnter,
+    onMouseLeave,
+  }: MixedChartPopoverProps<T>,
+  popoverRef: React.Ref<HTMLElement>
+) {
   return (
     <Transition in={isOpen}>
       {(state, ref) => (
         <div ref={ref} className={clsx(state === 'exiting' && styles.exiting)}>
           {(isOpen || state !== 'exited') && highlightDetails && (
             <ChartPopover
+              ref={popoverRef}
               title={highlightDetails.position}
               trackRef={trackRef}
               trackKey={highlightDetails.position}
@@ -46,6 +56,8 @@ export default function MixedChartPopover<T extends ChartDataTypes>({
               onDismiss={onDismiss}
               container={containerRef.current}
               size={size}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
             >
               <ChartSeriesDetails details={highlightDetails.details} />
             </ChartPopover>

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -9,9 +9,9 @@ import styles from '../styles.css.js';
 import { ChartPlotRef } from '../../internal/components/chart-plot';
 import { VerticalMarkerX } from '../interfaces';
 import { isYThreshold } from '../utils';
+import { POPOVER_DEADZONE } from '../../internal/components/chart-popover';
 
 const MAX_HOVER_MARGIN = 6;
-const POPOVER_DEADZONE = 12;
 
 export interface UseMouseHoverProps<T> {
   plotRef: React.RefObject<ChartPlotRef>;

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -9,9 +9,9 @@ import styles from '../styles.css.js';
 import { ChartPlotRef } from '../../internal/components/chart-plot';
 import { VerticalMarkerX } from '../interfaces';
 import { isYThreshold } from '../utils';
-import { POPOVER_DEADZONE } from '../../internal/components/chart-popover';
 
 const MAX_HOVER_MARGIN = 6;
+const POPOVER_DEADZONE = 12;
 
 export interface UseMouseHoverProps<T> {
   plotRef: React.RefObject<ChartPlotRef>;

--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -320,6 +320,17 @@ describe('Detail popover', () => {
       await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(false);
     })
   );
+
+  test(
+    'allow mouse to enter popover on hover',
+    setupTest(async page => {
+      await page.hoverElement(pieWrapper.findSegments().get(3).toSelector());
+      await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Apples');
+
+      await page.hoverElement(pieWrapper.findDetailPopover().findHeader().toSelector());
+      await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Apples');
+    })
+  );
 });
 
 test(

--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -341,9 +341,9 @@ test(
     await page.waitForVisible(detailsPopoverSelector);
     await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Chocolate');
 
-    await page.click(pieWrapper.findSegments().get(1).toSelector());
-    await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Potatoes');
-    await expect(page.getText(pieWrapper.findHighlightedSegmentLabel().toSelector())).resolves.toBe('Potatoes');
+    await page.click(pieWrapper.findSegments().get(3).toSelector());
+    await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Apples');
+    await expect(page.getText(pieWrapper.findHighlightedSegmentLabel().toSelector())).resolves.toBe('Apples');
   })
 );
 describe('Focus outline', () => {

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -1,13 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
 import { PieChartWrapper } from '../../../lib/components/test-utils/dom';
 import PieChart, { PieChartProps } from '../../../lib/components/pie-chart';
 import styles from '../../../lib/components/pie-chart/styles.css.js';
 import * as colors from '../../../lib/design-tokens';
+import { act } from 'react-dom/test-utils';
 
 const variants: Array<PieChartProps<PieChartProps.Datum>['variant']> = ['pie', 'donut'];
 const sizes: Array<PieChartProps<PieChartProps.Datum>['size']> = ['small', 'medium', 'large'];
@@ -430,6 +431,20 @@ describe('Details popover', () => {
     const detailPopover = wrapper.findDetailPopover();
     expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
     expect(detailPopover?.findContent()?.getElement()).toHaveTextContent('' + defaultData[0].value);
+  });
+
+  test('pressing escape closes the popover', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    wrapper.findApplication()!.focus();
+
+    const detailPopover = wrapper.findDetailPopover();
+    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(wrapper.findDetailPopover()).toBeNull();
   });
 
   test('shows value and percentage by default', () => {

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -463,6 +463,12 @@ describe('Details popover', () => {
     });
 
     expect(wrapper.findDetailPopover()).toBeNull();
+
+    act(() => {
+      fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
+    });
+
+    expect(wrapper.findDetailPopover()).toBeNull();
   });
 
   test('allow mouse to be over details popover ', () => {

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -447,6 +447,54 @@ describe('Details popover', () => {
     expect(wrapper.findDetailPopover()).toBeNull();
   });
 
+  test('pressing escape closes the popover', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    wrapper.findApplication()!.focus();
+
+    const detailPopover = wrapper.findDetailPopover();
+    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
+
+    act(() => {
+      fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
+    });
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(wrapper.findDetailPopover()).toBeNull();
+  });
+
+  test('allow mouse to be over details popover ', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    wrapper.findApplication()!.focus();
+
+    const detailPopover = wrapper.findDetailPopover();
+    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
+
+    act(() => {
+      fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
+    });
+
+    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
+  });
+
+  test('close popover when mouse leaves it ', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    wrapper.findApplication()!.focus();
+
+    const detailPopover = wrapper.findDetailPopover();
+    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
+
+    act(() => {
+      fireEvent.mouseLeave(wrapper!.findDetailPopover()!.getElement(), {
+        relatedTarget: wrapper.findApplication()?.getElement(),
+      });
+    });
+
+    expect(wrapper.findDetailPopover()).toBeNull();
+  });
+
   test('shows value and percentage by default', () => {
     const { wrapper } = renderPieChart(
       <PieChart data={defaultData} i18nStrings={{ detailsValue: 'Value', detailsPercentage: 'Percentage' }} />

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -441,20 +441,6 @@ describe('Details popover', () => {
     expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
 
     act(() => {
-      fireEvent.keyDown(document, { key: 'Escape' });
-    });
-
-    expect(wrapper.findDetailPopover()).toBeNull();
-  });
-
-  test('pressing escape closes the popover', () => {
-    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
-    wrapper.findApplication()!.focus();
-
-    const detailPopover = wrapper.findDetailPopover();
-    expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
-
-    act(() => {
       fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
     });
 

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -21,7 +21,7 @@ interface SegmentsProps<T> {
 
   onMouseDown: (datum: InternalChartDatum<T>) => void;
   onMouseOver: (datum: InternalChartDatum<T>) => void;
-  onMouseOut: () => void;
+  onMouseOut: (event: React.MouseEvent<SVGElement>) => void;
 }
 
 export default function Segments<T extends PieChartProps.Datum>({
@@ -70,7 +70,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   }, [highlightedSegment, pieData, arcFactory]);
 
   return (
-    <g onMouseLeave={() => onMouseOut()}>
+    <g onMouseLeave={event => onMouseOut(event)}>
       {pieData.map(datum => {
         const isHighlighted = highlightedSegment === datum.data.datum;
         const isDimmed = highlightedSegment !== null && !isHighlighted;


### PR DESCRIPTION
### Description

The issue in question is that for screen magnification users, hovering over a point (or a vertical line) presents a popover, but when they move the mouse to read the popover, it goes away (because it's tracking only the point being hovered on). The solution for this is to have an area around the popover that disables the hover logic when the pointer is on top of it.

Related links, issue #, if available: AWSUI-19236, AWSUI-19205

### How has this been tested?

Added integ/unit tests and changed the behaviour for existing tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
