### PR TITLE
feat: Optimize visual refresh detection and add development warning

### DIFF
--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh-static.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh-static.test.tsx
@@ -6,15 +6,6 @@ import { render, screen } from '@testing-library/react';
 
 jest.mock('../../../environment', () => ({ ALWAYS_VISUAL_REFRESH: true }), { virtual: true });
 
-const originalFn = window.CSS.supports;
-beforeEach(() => {
-  window.CSS.supports = jest.fn().mockReturnValue(true);
-});
-
-afterEach(() => {
-  window.CSS.supports = originalFn;
-});
-
 describe('useVisualRefresh with locked visual refresh mode', () => {
   function App() {
     const isRefresh = useVisualRefresh();


### PR DESCRIPTION
### Description

1. Add a development mode warning when visual refresh class was detected too late
2. Removed CSS-vars checks, because we do not support any browsers without CSS-vars
3. Optimize `ALWAYS_VISUAL_REFRESH` constant handling, help minifiers to detect and remove unused code

### How has this been tested?

Added extra unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
