### PR TITLE
chore: Update autosuggest and select API docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1456,7 +1456,7 @@ in a slight, visible lag when scrolling complex pages.",
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
 By default the component will filter the provided \`options\` based on the value of the filtering input field.
-Only options that have a \`value\` or \`label\` that contains the input value as a substring
+Only options that have a \`value\`, \`label\`, \`description\` or \`labelTag\` that contains the input value as a substring
 are displayed in the list of options.
 
 If you set this property to \`manual\`, this default filtering mechanism is disabled and all provided \`options\` are
@@ -7669,7 +7669,7 @@ in a slight, visible lag when scrolling complex pages.",
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
 By default the component will filter the provided \`options\` based on the value of the filtering input field.
-Only options that have a \`value\` or \`label\` that contains the input value as a substring
+Only options that have a \`value\`, \`label\`, \`description\` or \`labelTag\` that contains the input value as a substring
 are displayed in the list of options.
 
 If you set this property to \`manual\`, this default filtering mechanism is disabled and all provided \`options\` are
@@ -10037,7 +10037,7 @@ in a slight, visible lag when scrolling complex pages.",
 * \`manual\` - You will set up \`onChange\` or \`onLoadItems\` event listeners and filter options on your side or request
 them from server.
 By default the component will filter the provided \`options\` based on the value of the filtering input field.
-Only options that have a \`value\` or \`label\` that contains the input value as a substring
+Only options that have a \`value\`, \`label\`, \`description\` or \`labelTag\` that contains the input value as a substring
 are displayed in the list of options.
 
 If you set this property to \`manual\`, this default filtering mechanism is disabled and all provided \`options\` are

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -59,7 +59,7 @@ export interface AutosuggestProps
    * them from server.
    *
    * By default the component will filter the provided `options` based on the value of the filtering input field.
-   * Only options that have a `value` or `label` that contains the input value as a substring
+   * Only options that have a `value`, `label`, `description` or `labelTag` that contains the input value as a substring
    * are displayed in the list of options.
    *
    * If you set this property to `manual`, this default filtering mechanism is disabled and all provided `options` are

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -55,7 +55,7 @@ export interface BaseSelectProps
    * them from server.
    *
    * By default the component will filter the provided `options` based on the value of the filtering input field.
-   * Only options that have a `value` or `label` that contains the input value as a substring
+   * Only options that have a `value`, `label`, `description` or `labelTag` that contains the input value as a substring
    * are displayed in the list of options.
    *
    * If you set this property to `manual`, this default filtering mechanism is disabled and all provided `options` are


### PR DESCRIPTION
### Description

Reflect the option fields where the default filtering applies in the API docs.

Code reference to
- autosuggest component's searchable fields: https://github.com/cloudscape-design/components/blob/main/src/autosuggest/utils/utils.ts#L34
- select component's searchable fields: https://github.com/cloudscape-design/components/blob/main/src/internal/components/option/utils/filter-options.ts#L8

Related links, issue #, if available: n/a

### How has this been tested?

- manually verified the changes.
- update documenter snapshots to reflect the changes.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes.
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
