### PR TITLE
fix: Only animate attribute-editor empty state when it's replacing non-empty

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
+import styles from '../../../lib/components/attribute-editor/styles.css.js';
 import Input from '../../../lib/components/input';
 
 interface Item {
@@ -101,6 +102,16 @@ describe('Attribute Editor', () => {
     test('should render 0 rows when passed empty array', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, items: [] });
       expect(wrapper.findRows()).toHaveLength(0);
+    });
+    test('should fade in empty state when items were previously visible', () => {
+      const { container, rerender } = render(<AttributeEditor {...defaultProps} />);
+      rerender(<AttributeEditor {...defaultProps} items={[]} />);
+      const wrapper = createWrapper(container).findAttributeEditor()!;
+      expect(wrapper.findEmptySlot()?.getElement()).toHaveClass(styles['empty-appear']);
+    });
+    test('should not fade in empty state when it is initially displayed', () => {
+      const wrapper = renderAttributeEditor({ ...defaultProps, items: [] });
+      expect(wrapper.findEmptySlot()?.getElement()).not.toHaveClass(styles['empty-appear']);
     });
   });
 

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -42,9 +42,12 @@ const InternalAttributeEditor = React.forwardRef(
   ) => {
     const [breakpoint, breakpointRef] = useContainerBreakpoints(['default', 'xxs', 'xs']);
     const removeButtonRefs = useRef<Array<ButtonProps.Ref | undefined>>([]);
+    const wasNonEmpty = useRef<boolean>(false);
 
     const baseProps = getBaseProps(props);
     const isEmpty = items && items.length === 0;
+
+    wasNonEmpty.current = wasNonEmpty.current || !isEmpty;
 
     useImperativeHandle(ref, () => ({
       focusRemoveButton(rowIndex: number) {
@@ -57,7 +60,7 @@ const InternalAttributeEditor = React.forwardRef(
     return (
       <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root)}>
         <InternalBox margin={{ bottom: 'l' }}>
-          {isEmpty && <div className={styles.empty}>{empty}</div>}
+          {isEmpty && <div className={clsx(styles.empty, wasNonEmpty.current && styles['empty-appear'])}>{empty}</div>}
           {items.map((item, index) => (
             <Row
               key={index}

--- a/src/attribute-editor/motion.scss
+++ b/src/attribute-editor/motion.scss
@@ -6,7 +6,7 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as tokens;
 
-.empty {
+.empty-appear {
   @include styles.with-motion {
     @include styles.animation-fade-in;
     animation: awsui-motion-fade-in tokens.$motion-duration-transition-show-paced


### PR DESCRIPTION
### Description

Ensure that the Attribute Editor (and Tag Editor) empty state is only animated (fade in) when it is replacing a previously visible non-empty state.

Related links, issue #, if available: n/a

#506
AWSUI-19887

### How has this been tested?

Tested locally, added new unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
