### PR TITLE
fix: Ensure property filter prefers case-sensitive match

### DIFF
--- a/src/property-filter/__tests__/utils.test.ts
+++ b/src/property-filter/__tests__/utils.test.ts
@@ -42,6 +42,14 @@ describe('matchFilteringProperty', () => {
     const property = matchFilteringProperty(filteringProperties, ' Averange latency');
     expect(property).toBe(null);
   });
+  test('should prefer an exact match to non-exact', () => {
+    const properties: FilteringProperty[] = [
+      { key: 'Test', propertyLabel: 'Test', groupValuesLabel: '' },
+      { key: 'test', propertyLabel: 'test', groupValuesLabel: '' },
+    ];
+    const property = matchFilteringProperty(properties, 'test');
+    expect(property).toBe(properties[1]);
+  });
 });
 
 describe('matchOperator', () => {

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -8,13 +8,18 @@ export function matchFilteringProperty(
   filteringProperties: readonly FilteringProperty[],
   filteringText: string
 ): null | FilteringProperty {
-  filteringText = filteringText.toLowerCase();
-
   let maxLength = 0;
   let matchedProperty: null | FilteringProperty = null;
 
   for (const property of filteringProperties) {
-    if (property.propertyLabel.length > maxLength && startsWith(filteringText, property.propertyLabel.toLowerCase())) {
+    if (property.propertyLabel === filteringText) {
+      matchedProperty = property;
+      break;
+    }
+    if (
+      property.propertyLabel.length > maxLength &&
+      startsWith(filteringText.toLowerCase(), property.propertyLabel.toLowerCase())
+    ) {
       maxLength = property.propertyLabel.length;
       matchedProperty = property;
     }


### PR DESCRIPTION
### Description

Ensure that property filter prefers an exact case-sensitive match of property key
over a non-exact match.

Related links, issue #, if available: n/a
AWSUI-19954

### How has this been tested?

New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
