### PR TITLE
feat: Adds striped row for screenshot test

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -253,6 +253,11 @@ const permutations = createPermutations<TableProps>([
     items: [createSimpleItems(3)],
     variant: ['embedded', 'stacked', 'full-page'],
   },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    stripedRows: [true],
+    items: [createSimpleItems(3)],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 


### PR DESCRIPTION
### Description

Adding a striped table to the permutations page for a visual screenshot test.

See the CR link with id CR-81552994 for more context.

### How has this been tested?
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/9701338/207711458-82610d2f-7631-4e52-9745-9dcb5b85144c.png">


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
