### PR TITLE
fix: change unit test ignorePaths to exclude bundled vendor deps

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -20,7 +20,7 @@ module.exports = merge({}, tsPreset, cloudscapePreset, {
     'styles.selectors.js$',
     'icons.js$',
     'environment.js$',
-    'internal/vendor$',
+    '/internal\\/vendor/',
     '<rootDir>/pages',
   ],
   globals: {


### PR DESCRIPTION
### Description
The current pattern specified (`internal/vendor$`) excludes all paths ending in `internal/vendor`, this does not work to ignore the bundled d3-scale from coverage. This PR updates that path to match all files under `internal/vendor`.
<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Verified by comparing coverage output from `jest` before and after change
<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
