### PR TITLE
refactor: Move size observers into split panel code

### DIFF
--- a/src/app-layout/utils/use-observed-element.ts
+++ b/src/app-layout/utils/use-observed-element.ts
@@ -3,18 +3,10 @@
 import { useResizeObserver } from '../../internal/hooks/container-queries';
 import { useCallback, useState } from 'react';
 
-export function useObservedElement(
-  selectorOrRef: string | React.MutableRefObject<HTMLElement> | (() => HTMLElement | null) | undefined
-) {
+export function useObservedElement(selector: string) {
   const getElement = useCallback(() => {
-    if (typeof selectorOrRef === 'string') {
-      return document.querySelector(selectorOrRef);
-    } else if (typeof selectorOrRef === 'function') {
-      return selectorOrRef() ?? null;
-    } else {
-      return selectorOrRef?.current ?? null;
-    }
-  }, [selectorOrRef]);
+    return document.querySelector(selector);
+  }, [selector]);
 
   const [height, setHeight] = useState(0);
 

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -50,7 +50,6 @@ interface AppLayoutContextProps extends AppLayoutProps {
   setHasStickyBackground: (value: boolean) => void;
   setIsNavigationOpen: (value: boolean) => void;
   setIsToolsOpen: (value: boolean) => void;
-  setOffsetBottom: (value: number) => void;
   setSplitPanelReportedSize: (value: number) => void;
   setSplitPanelReportedHeaderHeight: (value: number) => void;
   headerHeight: number;
@@ -111,7 +110,6 @@ const defaults: AppLayoutContextProps = {
   setHasStickyBackground: (value: boolean) => value,
   setIsNavigationOpen: (value: boolean) => value,
   setIsToolsOpen: (value: boolean) => value,
-  setOffsetBottom: (value: number) => void value,
   setSplitPanelReportedSize: (value: number) => void value,
   setSplitPanelReportedHeaderHeight: (value: number) => void value,
   splitPanelMaxWidth: 280,
@@ -149,6 +147,7 @@ export const AppLayoutProvider = React.forwardRef(
       headerSelector = '#b #h',
       footerSelector = '#b #h',
       children,
+      splitPanel,
       ...props
     }: AppLayoutProviderProps,
     forwardRef: React.Ref<AppLayoutProps.Ref>
@@ -511,12 +510,18 @@ export const AppLayoutProvider = React.forwardRef(
     );
 
     /**
-     * The offsetBottom value is used to determine the distance from the bottom of the
-     * viewport a sticky element should be placed. A non-zero value means that there
-     * is either a footer outside of the AppLayout, a SplitPanel in the bottom position
-     * within the AppLayout, or both.
+     * Determine the offsetBottom value based on the presence of a footer element and
+     * the SplitPanel component. Ignore the SplitPanel if it is not in the bottom
+     * position. Use the size property if it is open and the header height if it is closed.
      */
-    const [offsetBottom, setOffsetBottom] = useState(0);
+    let offsetBottom = footerHeight;
+    if (splitPanel && splitPanelPosition === 'bottom') {
+      if (isSplitPanelOpen) {
+        offsetBottom += splitPanelReportedSize;
+      } else {
+        offsetBottom += splitPanelReportedHeaderHeight;
+      }
+    }
 
     return (
       <AppLayoutContext.Provider
@@ -553,9 +558,9 @@ export const AppLayoutProvider = React.forwardRef(
           offsetBottom,
           setDynamicOverlapHeight,
           setHasStickyBackground,
-          setOffsetBottom,
           setSplitPanelReportedSize,
           setSplitPanelReportedHeaderHeight,
+          splitPanel,
           splitPanelMaxWidth,
           splitPanelMinWidth,
           splitPanelPosition,

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -52,12 +52,14 @@ interface AppLayoutContextProps extends AppLayoutProps {
   setIsToolsOpen: (value: boolean) => void;
   setOffsetBottom: (value: number) => void;
   setSplitPanelReportedSize: (value: number) => void;
+  setSplitPanelReportedHeaderHeight: (value: number) => void;
   headerHeight: number;
   footerHeight: number;
   splitPanelMaxWidth: number;
   splitPanelMinWidth: number;
   splitPanelPosition: AppLayoutProps.SplitPanelPosition;
   splitPanelReportedSize: number;
+  splitPanelReportedHeaderHeight: number;
   toolsFocusControl: FocusControlState;
 }
 
@@ -111,12 +113,14 @@ const defaults: AppLayoutContextProps = {
   setIsToolsOpen: (value: boolean) => value,
   setOffsetBottom: (value: number) => void value,
   setSplitPanelReportedSize: (value: number) => void value,
+  setSplitPanelReportedHeaderHeight: (value: number) => void value,
   splitPanelMaxWidth: 280,
   splitPanelMinWidth: 280,
   splitPanelOpen: false,
   splitPanelPosition: 'bottom',
   splitPanelPreferences: { position: 'bottom' },
   splitPanelReportedSize: 0,
+  splitPanelReportedHeaderHeight: 0,
   splitPanelSize: 0,
   stickyNotifications: false,
   tools: null,
@@ -393,6 +397,7 @@ export const AppLayoutProvider = React.forwardRef(
      * onSplitPanelResize event.
      */
     const [splitPanelReportedSize, setSplitPanelReportedSize] = useState(0);
+    const [splitPanelReportedHeaderHeight, setSplitPanelReportedHeaderHeight] = useState(0);
 
     const [splitPanelSize, setSplitPanelSize] = useControllable(
       props.splitPanelSize,
@@ -550,11 +555,13 @@ export const AppLayoutProvider = React.forwardRef(
           setHasStickyBackground,
           setOffsetBottom,
           setSplitPanelReportedSize,
+          setSplitPanelReportedHeaderHeight,
           splitPanelMaxWidth,
           splitPanelMinWidth,
           splitPanelPosition,
           splitPanelPreferences,
           splitPanelReportedSize,
+          splitPanelReportedHeaderHeight,
           splitPanelSize,
           toolsHide,
           toolsOpen: isToolsOpen,

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -15,13 +15,14 @@ import { fireNonCancelableEvent } from '../../internal/events';
 import { getSplitPanelPosition } from './split-panel';
 import { useControllable } from '../../internal/hooks/use-controllable';
 import { useMobile } from '../../internal/hooks/use-mobile';
-import { useContainerQuery, useResizeObserver } from '../../internal/hooks/container-queries';
+import { useContainerQuery } from '../../internal/hooks/container-queries';
 import { getSplitPanelDefaultSize } from '../../split-panel/utils/size-utils';
 import styles from './styles.css.js';
 import { isDevelopment } from '../../internal/is-development';
 import { warnOnce } from '../../internal/logging';
 import { applyDefaults } from '../defaults';
 import { FocusControlState, useFocusControl } from '../utils/use-focus-control';
+import { useObservedElement } from '../utils/use-observed-element';
 
 interface AppLayoutContextProps extends AppLayoutProps {
   dynamicOverlapHeight: number;
@@ -303,13 +304,8 @@ export const AppLayoutProvider = React.forwardRef(
      * Query the DOM for the header and footer elements based on the selectors provided
      * by the properties and pass the heights to the custom property definitions.
      */
-    const [headerHeight, setHeaderHeight] = useState(0);
-    const getHeader = useCallback(() => document.querySelector(headerSelector), [headerSelector]);
-    useResizeObserver(getHeader, entry => setHeaderHeight(entry.borderBoxHeight));
-
-    const [footerHeight, setFooterHeight] = useState(0);
-    const getFooter = useCallback(() => document.querySelector(footerSelector), [footerSelector]);
-    useResizeObserver(getFooter, entry => setFooterHeight(entry.borderBoxHeight));
+    const headerHeight = useObservedElement(headerSelector);
+    const footerHeight = useObservedElement(footerSelector);
 
     /**
      * Set the default values for the minimum and maximum Split Panel width when it is

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -43,13 +43,10 @@ export default function Layout({ children }: LayoutProps) {
     splitPanel,
     stickyNotifications,
     toolsHide,
+    splitPanelReportedHeaderHeight,
   } = useContext(AppLayoutContext);
 
-  const {
-    getHeader: getSplitPanelHeader,
-    position: splitPanelPosition,
-    size: splitPanelSize,
-  } = useContext(SplitPanelContext);
+  const { position: splitPanelPosition, size: splitPanelSize } = useContext(SplitPanelContext);
 
   const isOverlapDisabled = getOverlapDisabled(dynamicOverlapHeight, contentHeader, disableContentHeaderOverlap);
 
@@ -76,8 +73,7 @@ export default function Layout({ children }: LayoutProps) {
         if (isSplitPanelOpen) {
           offsetBottom += splitPanelSize;
         } else {
-          const splitPanelHeader = getSplitPanelHeader();
-          offsetBottom += splitPanelHeader ? splitPanelHeader.clientHeight : 0;
+          offsetBottom += splitPanelReportedHeaderHeight;
         }
       }
 
@@ -85,12 +81,12 @@ export default function Layout({ children }: LayoutProps) {
     },
     [
       footerHeight,
-      getSplitPanelHeader,
       isSplitPanelOpen,
       setOffsetBottom,
       splitPanelPosition,
       splitPanel,
       splitPanelSize,
+      splitPanelReportedHeaderHeight,
     ]
   );
 

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useLayoutEffect } from 'react';
+import React, { useContext } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
-import { SplitPanelContext } from '../../internal/context/split-panel-context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 import { AppLayoutProps } from '../interfaces';
@@ -39,14 +38,11 @@ export default function Layout({ children }: LayoutProps) {
     minContentWidth,
     navigationHide,
     notificationsHeight,
-    setOffsetBottom,
     splitPanel,
+    splitPanelPosition,
     stickyNotifications,
     toolsHide,
-    splitPanelReportedHeaderHeight,
   } = useContext(AppLayoutContext);
-
-  const { position: splitPanelPosition, size: splitPanelSize } = useContext(SplitPanelContext);
 
   const isOverlapDisabled = getOverlapDisabled(dynamicOverlapHeight, contentHeader, disableContentHeaderOverlap);
 
@@ -58,36 +54,6 @@ export default function Layout({ children }: LayoutProps) {
     isToolsOpen,
     splitPanel,
     toolsHide
-  );
-
-  /**
-   * Determine the offsetBottom value based on the presence of a footer element and
-   * the SplitPanel component. Ignore the SplitPanel if it is not in the bottom
-   * position. Use the size property if it is open and the header height if it is closed.
-   */
-  useLayoutEffect(
-    function handleOffsetBottom() {
-      let offsetBottom = footerHeight;
-
-      if (splitPanel && splitPanelPosition === 'bottom') {
-        if (isSplitPanelOpen) {
-          offsetBottom += splitPanelSize;
-        } else {
-          offsetBottom += splitPanelReportedHeaderHeight;
-        }
-      }
-
-      setOffsetBottom(offsetBottom);
-    },
-    [
-      footerHeight,
-      isSplitPanelOpen,
-      setOffsetBottom,
-      splitPanelPosition,
-      splitPanel,
-      splitPanelSize,
-      splitPanelReportedHeaderHeight,
-    ]
   );
 
   return (

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
 import {
@@ -12,7 +12,6 @@ import styles from './styles.css.js';
 import { AppLayoutProps } from '../interfaces';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
 import { Transition } from '../../internal/components/transition';
-import { useObservedElement } from '../utils/use-observed-element';
 import customCssProps from '../../internal/generated/custom-css-properties';
 
 /**
@@ -28,6 +27,7 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     isSplitPanelForcedPosition,
     isSplitPanelOpen,
     setSplitPanelReportedSize,
+    setSplitPanelReportedHeaderHeight,
     splitPanelPosition,
     splitPanelSize,
     headerHeight,
@@ -43,9 +43,6 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
   );
   useEffectOnUpdate(() => setSplitPanelLastInteraction({ type: 'position' }), [splitPanelPosition]);
 
-  const splitPanelRef = useRef<HTMLDivElement>(null);
-  const splitPanelHeaderRef = useRef<HTMLDivElement>(null);
-
   const context: SplitPanelContextProps = {
     bottomOffset: 0,
     getMaxHeight: () => {
@@ -54,7 +51,6 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
       return availableHeight < 400 ? availableHeight - 40 : availableHeight - 250;
     },
     getMaxWidth: () => document.documentElement.clientWidth,
-    getHeader: () => splitPanelHeaderRef.current,
     isForcedPosition: isSplitPanelForcedPosition,
     isMobile,
     isOpen: isSplitPanelOpen,
@@ -64,10 +60,9 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     onToggle: handleSplitPanelClick,
     position: splitPanelPosition,
     reportSize: setSplitPanelReportedSize,
+    reportHeaderHeight: setSplitPanelReportedHeaderHeight,
     rightOffset: 0,
     size: splitPanelSize || 0,
-    splitPanelRef,
-    splitPanelHeaderRef,
     topOffset: 0,
     openButtonAriaLabel,
     setOpenButtonAriaLabel,
@@ -84,12 +79,16 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
  * on the the presence and state of the Navigation and Tools components.
  */
 function SplitPanelBottom() {
-  const { disableBodyScroll, isNavigationOpen, isSplitPanelOpen, isToolsOpen, splitPanel, splitPanelReportedSize } =
-    useContext(AppLayoutContext);
-
-  const { position: splitPanelPosition, getHeader } = useContext(SplitPanelContext);
-
-  const headerHeight = useObservedElement(getHeader);
+  const {
+    disableBodyScroll,
+    isNavigationOpen,
+    isSplitPanelOpen,
+    isToolsOpen,
+    splitPanel,
+    splitPanelPosition,
+    splitPanelReportedSize,
+    splitPanelReportedHeaderHeight,
+  } = useContext(AppLayoutContext);
 
   if (!splitPanel) {
     return null;
@@ -109,7 +108,7 @@ function SplitPanelBottom() {
           ref={transitionEventsRef}
           style={{
             [customCssProps.splitPanelReportedSize]: `${splitPanelReportedSize}px`,
-            [customCssProps.splitPanelReportedHeaderSize]: `${headerHeight}px`,
+            [customCssProps.splitPanelReportedHeaderSize]: `${splitPanelReportedHeaderHeight}px`,
           }}
         >
           <SplitPanel></SplitPanel>
@@ -127,10 +126,14 @@ function SplitPanelBottom() {
  * for this position are computed in the Tools component.
  */
 function SplitPanelSide() {
-  const { isSplitPanelOpen, splitPanel, splitPanelMaxWidth, splitPanelMinWidth, splitPanelReportedSize } =
-    useContext(AppLayoutContext);
-
-  const { position: splitPanelPosition } = useContext(SplitPanelContext);
+  const {
+    isSplitPanelOpen,
+    splitPanel,
+    splitPanelPosition,
+    splitPanelMaxWidth,
+    splitPanelMinWidth,
+    splitPanelReportedSize,
+  } = useContext(AppLayoutContext);
 
   if (!splitPanel) {
     return null;

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -13,7 +13,6 @@ export interface SplitPanelContextProps {
   size: number;
   getMaxWidth: () => number;
   getMaxHeight: () => number;
-  getHeader: () => HTMLElement | null;
   disableContentPaddings?: boolean;
   contentWidthStyles?: React.CSSProperties;
   contentWrapperPaddings?: {
@@ -26,12 +25,11 @@ export interface SplitPanelContextProps {
   // The lastInteraction property indicates last meaningful state transition used to trigger split-panel effects.
   // We can't observe properties in a regular way because split-panel is being mounted in several places at once.
   lastInteraction?: SplitPanelLastInteraction;
-  splitPanelRef?: React.Ref<any>;
-  splitPanelHeaderRef?: React.Ref<any>;
   onResize: (detail: { size: number }) => void;
   onToggle: () => void;
   onPreferencesChange: (detail: { position: 'side' | 'bottom' }) => void;
   reportSize: (pixels: number) => void;
+  reportHeaderHeight: (pixels: number) => void;
   openButtonAriaLabel?: string;
   setOpenButtonAriaLabel?: (value: string) => void;
 }
@@ -45,17 +43,15 @@ export const SplitPanelContext = createContext<SplitPanelContextProps>({
   size: 0,
   getMaxWidth: () => 0,
   getMaxHeight: () => 0,
-  getHeader: () => null,
   isOpen: true,
   isMobile: false,
   isForcedPosition: false,
   lastInteraction: undefined,
-  splitPanelRef: undefined,
-  splitPanelHeaderRef: undefined,
   onResize: () => {},
   onToggle: () => {},
   onPreferencesChange: () => {},
   reportSize: () => {},
+  reportHeaderHeight: () => {},
 });
 
 export function useSplitPanelContext() {

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -50,7 +50,6 @@ const defaultContextProps: SplitPanelContextProps = {
   size: 0,
   getMaxWidth: () => 500,
   getMaxHeight: () => 500,
-  getHeader: () => null,
   isOpen: true,
   isMobile: false,
   isForcedPosition: false,
@@ -58,6 +57,7 @@ const defaultContextProps: SplitPanelContextProps = {
   onToggle: jest.fn(),
   onPreferencesChange: jest.fn(),
   reportSize: jest.fn(),
+  reportHeaderHeight: jest.fn(),
 };
 
 function renderSplitPanel({

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -1,13 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { TransitionStatus } from '../internal/components/transition';
 import { SplitPanelContentProps } from './interfaces';
 import styles from './styles.css.js';
 import { useSplitPanelContext } from '../internal/context/split-panel-context';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { useResizeObserver } from '../internal/hooks/container-queries';
 
 interface SplitPanelContentBottomProps extends SplitPanelContentProps {
   state: TransitionStatus;
@@ -37,9 +38,17 @@ export function SplitPanelContentBottom({
     disableContentPaddings,
     contentWrapperPaddings,
     isMobile,
-    splitPanelHeaderRef,
+    reportHeaderHeight,
   } = useSplitPanelContext();
   const transitionContentBottomRef = useMergeRefs(splitPanelRef || null, transitioningElementRef);
+
+  const headerRef = useRef<HTMLDivElement>(null);
+  useResizeObserver(headerRef, entry => reportHeaderHeight(entry.borderBoxHeight));
+  useEffect(() => {
+    // report empty height when unmounting the panel
+    return () => reportHeaderHeight(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const centeredMaxWidthClasses = clsx({
     [styles['pane-bottom-center-align']]: isRefresh,
@@ -68,7 +77,7 @@ export function SplitPanelContentBottom({
     >
       {isOpen && <div className={styles['slider-wrapper-bottom']}>{resizeHandle}</div>}
       <div className={styles['drawer-content-bottom']} aria-labelledby={panelHeaderId} role="region">
-        <div className={clsx(styles['pane-header-wrapper-bottom'], centeredMaxWidthClasses)} ref={splitPanelHeaderRef}>
+        <div className={clsx(styles['pane-header-wrapper-bottom'], centeredMaxWidthClasses)} ref={headerRef}>
           {header}
         </div>
         <div className={clsx(styles['content-bottom'], centeredMaxWidthClasses)} aria-hidden={!isOpen}>

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -53,7 +53,6 @@ export default function SplitPanel({
     contentWidthStyles,
     isOpen,
     isForcedPosition,
-    splitPanelRef,
     lastInteraction,
     onPreferencesChange,
     onResize,
@@ -246,7 +245,7 @@ export default function SplitPanel({
     }
   }, [rightOffset, __internalRootRef]);
 
-  const mergedRef = useMergeRefs(splitPanelRef, splitPanelRefObject, __internalRootRef);
+  const mergedRef = useMergeRefs(splitPanelRefObject, __internalRootRef);
 
   /**
    * The AppLayout factor moved the circular buttons out of the


### PR DESCRIPTION
### Description

Move resize observers down from app layout to split panel code

Related links, issue #, if available: n/a

### How has this been tested?

Locally, PR build, dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
