### PR TITLE
chore: Add "Getting started" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,31 @@ Cloudscape was built for and is used by [Amazon Web Services (AWS)](https://aws.
 
 Components APIs and guidelines can be found in the [Components section of the Cloudscape website](https://cloudscape.design/components/).
 
+## Getting started
+For an in-depth guide on getting started with Cloudscape development, check out the [Cloudscape website](https://cloudscape.design/get-started/integration/using-cloudscape-components/).
+
+### Installation
+All Cloudscape packages are available on npm.
+
+```sh
+npm install @cloudscape-design/components @cloudscape-design/global-styles
+```
+
+### Using Cloudscape components
+Here is a basic example that renders a primary button:
+
+```jsx
+import Button from '@cloudscape-design/components/button';
+import '@cloudscape-design/global-styles/index.css';
+
+function App {
+  return <Button variant="primary">Click me</Button>;
+}
+```
+
+You can also play around with a small example on CodeSandbox:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/cloudscape-design-system-react-javascript-ljs1t7)
 
 ## Getting help
 


### PR DESCRIPTION
### Description
This change adds a "Getting started" section to the `README` file.
This is a very common thing to have and allows developers to jump straight into code if they want to.

Related links, issue #, if available: AWSUI-20003

### How has this been tested?

Tested manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
