### PR TITLE
chore: Add context assertion to split panel component

### DIFF
--- a/src/__tests__/required-props-for-components.ts
+++ b/src/__tests__/required-props-for-components.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { i18nStrings } from '../code-editor/__tests__/common';
+export { defaultSplitPanelContextProps } from '../split-panel/__tests__/helpers';
 
 const defaultProps: Record<string, Record<string, any>> = {
   tabs: { tabs: [] },

--- a/src/__tests__/utils.tsx
+++ b/src/__tests__/utils.tsx
@@ -4,6 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import path from 'path';
 import fs from 'fs';
+import React from 'react';
+import { SplitPanelContextProvider } from '../../lib/components/internal/context/split-panel-context';
+import { defaultSplitPanelContextProps } from './required-props-for-components';
 
 const componentsDir = path.resolve(__dirname, '../../lib/components');
 const definitionsDir = path.resolve(__dirname, '../../lib/components-definitions/components');
@@ -36,7 +39,29 @@ export function supportsDOMProperties(componentName: string) {
   return !componentsWithoutDOMPropertiesSupport.includes(componentName);
 }
 
+type WrapperComponent = React.ComponentType<{ children: React.ReactNode }>;
+
+const WrappedSplitPanel: WrapperComponent = ({ children }) => (
+  <SplitPanelContextProvider value={defaultSplitPanelContextProps}>{children}</SplitPanelContextProvider>
+);
+
+function wrap({ default: Component }: { default: React.ComponentType }, Wrapper: WrapperComponent) {
+  const Wrapped = (props: any) => {
+    return (
+      <Wrapper>
+        <Component {...props} />
+      </Wrapper>
+    );
+  };
+  Wrapped.displayName = Component.displayName;
+  return { default: Wrapped };
+}
+
 export function requireComponent(componentName: string): any {
+  if (componentName === 'split-panel') {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return wrap(require(path.join(componentsDir, 'split-panel')), WrappedSplitPanel);
+  }
   return require(path.join(componentsDir, componentName));
 }
 

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -21,7 +21,7 @@ import { useContainerQuery } from '../internal/hooks/container-queries';
 import { useStableEventHandler } from '../internal/hooks/use-stable-event-handler';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import {
-  SplitPanelContext,
+  SplitPanelContextProvider,
   SplitPanelContextProps,
   SplitPanelLastInteraction,
 } from '../internal/context/split-panel-context';
@@ -328,7 +328,7 @@ const OldAppLayout = React.forwardRef(
       reportHeaderHeight: setSplitPanelReportedHeaderHeight,
     };
     const splitPanelWrapped = splitPanel && (
-      <SplitPanelContext.Provider value={splitPanelContext}>{splitPanel}</SplitPanelContext.Provider>
+      <SplitPanelContextProvider value={splitPanelContext}>{splitPanel}</SplitPanelContextProvider>
     );
 
     const contentWrapperProps: ContentWrapperProps = {

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -4,7 +4,6 @@ import React, { useContext } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
 import customCssProps from '../../internal/generated/custom-css-properties';
-import { SplitPanelContext } from '../../internal/context/split-panel-context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 
@@ -26,9 +25,8 @@ export default function Main() {
     splitPanel,
     offsetBottom,
     footerHeight,
+    splitPanelPosition,
   } = useContext(AppLayoutContext);
-
-  const { position: splitPanelPosition } = useContext(SplitPanelContext);
 
   const isUnfocusable = isMobile && isAnyPanelOpen;
   const splitPanelHeight = offsetBottom - footerHeight;

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useState } from 'react';
 import clsx from 'clsx';
 import { AppLayoutContext } from './context';
 import {
-  SplitPanelContext,
+  SplitPanelContextProvider,
   SplitPanelContextProps,
   SplitPanelLastInteraction,
 } from '../../internal/context/split-panel-context';
@@ -69,14 +69,14 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     lastInteraction: splitPanelLastInteraction,
   };
 
-  return <SplitPanelContext.Provider value={{ ...context }}>{children}</SplitPanelContext.Provider>;
+  return <SplitPanelContextProvider value={context}>{children}</SplitPanelContextProvider>;
 }
 
 /**
  * This is the render function for the SplitPanel when it is in bottom position.
  * The Split Panel container will be another row entry in the grid definition in
  * the Layout component. The start and finish columns will be variable based
- * on the the presence and state of the Navigation and Tools components.
+ * on the presence and state of the Navigation and Tools components.
  */
 function SplitPanelBottom() {
   const {

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -4,7 +4,7 @@ import React, { useContext } from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../../button/internal';
 import { AppLayoutContext } from './context';
-import { SplitPanelContext } from '../../internal/context/split-panel-context';
+import { useSplitPanelContext } from '../../internal/context/split-panel-context';
 import TriggerButton from './trigger-button';
 import styles from './styles.css.js';
 import splitPanelStyles from '../../split-panel/styles.css.js';
@@ -41,9 +41,10 @@ export default function Tools({ children }: ToolsProps) {
     isAnyPanelOpen,
     navigationHide,
     toolsFocusControl,
+    splitPanelPosition,
   } = useContext(AppLayoutContext);
 
-  const { position: splitPanelPosition, openButtonAriaLabel } = useContext(SplitPanelContext);
+  const { openButtonAriaLabel } = useSplitPanelContext();
 
   const hasSplitPanel = getSplitPanelStatus(splitPanel, splitPanelPosition);
   const hasToolsForm = getToolsFormStatus(hasSplitPanel, isMobile, isSplitPanelOpen, isToolsOpen, toolsHide);

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -34,26 +34,14 @@ export interface SplitPanelContextProps {
   setOpenButtonAriaLabel?: (value: string) => void;
 }
 
-export const SplitPanelContext = createContext<SplitPanelContextProps>({
-  topOffset: 0,
-  bottomOffset: 0,
-  leftOffset: 0,
-  rightOffset: 0,
-  position: 'bottom',
-  size: 0,
-  getMaxWidth: () => 0,
-  getMaxHeight: () => 0,
-  isOpen: true,
-  isMobile: false,
-  isForcedPosition: false,
-  lastInteraction: undefined,
-  onResize: () => {},
-  onToggle: () => {},
-  onPreferencesChange: () => {},
-  reportSize: () => {},
-  reportHeaderHeight: () => {},
-});
+const SplitPanelContext = createContext<SplitPanelContextProps | null>(null);
+
+export const SplitPanelContextProvider = SplitPanelContext.Provider;
 
 export function useSplitPanelContext() {
-  return useContext(SplitPanelContext);
+  const ctx = useContext(SplitPanelContext);
+  if (!ctx) {
+    throw new Error('Split panel can only be used inside app layout');
+  }
+  return ctx;
 }

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { SplitPanelContextProps } from '../../../lib/components/internal/context/split-panel-context';
+
+export const defaultSplitPanelContextProps: SplitPanelContextProps = {
+  topOffset: 0,
+  bottomOffset: 0,
+  leftOffset: 0,
+  rightOffset: 0,
+  position: 'bottom',
+  size: 0,
+  getMaxWidth: () => 500,
+  getMaxHeight: () => 500,
+  isOpen: true,
+  isMobile: false,
+  isForcedPosition: false,
+  onResize: jest.fn(),
+  onToggle: jest.fn(),
+  onPreferencesChange: jest.fn(),
+  reportSize: jest.fn(),
+  reportHeaderHeight: jest.fn(),
+};


### PR DESCRIPTION
### Description

Add explicit assertion about split panel used inside app layout.

Using it outside app layout is not supported, so it is better to fail fast than dealing with unclear bug reports.

Related links, issue #, if available: n/a

### How has this been tested?

* Locally, added an extra unit test
* Deployed this branch to my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
