### PR TITLE
fix: Click outside of chart removes section selection

### DIFF
--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -296,6 +296,9 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
             plotRef.current!.focusPlot();
           }
         }, 0);
+      } else {
+        interactions.clearHighlight();
+        interactions.clearHighlightedLegend();
       }
     };
 

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -296,9 +296,6 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
             plotRef.current!.focusPlot();
           }
         }, 0);
-      } else {
-        interactions.clearHighlight();
-        interactions.clearHighlightedLegend();
       }
     };
 

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -4,6 +4,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import createWrapper, { BarChartWrapper, MixedLineBarChartWrapper } from '../../../lib/components/test-utils/selectors';
 import chartPlotStyles from '../../../lib/components/internal/components/chart-plot/styles.selectors.js';
+import mixedChartStyles from '../../../lib/components/mixed-line-bar-chart/styles.selectors.js';
 
 const chartWrapper = createWrapper().findMixedLineBarChart('#chart');
 const groupedBarWrapper = new BarChartWrapper('#chart-grouped');
@@ -21,6 +22,8 @@ const highlightedSeriesSelector = (wrapper: MixedLineBarChartWrapper = chartWrap
   wrapper.findHighlightedSeries().toSelector();
 const seriesSVGSelector = (wrapper: MixedLineBarChartWrapper = chartWrapper) =>
   wrapper.find(`.${chartPlotStyles.root}`).toSelector();
+const dimmedElementsSelector = (wrapper: MixedLineBarChartWrapper = chartWrapper) =>
+  wrapper.findAll(`.${mixedChartStyles['series--dimmed']}`).toSelector();
 const filterWrapper = chartWrapper.findDefaultFilter();
 const legendWrapper = chartWrapper.findLegend();
 
@@ -254,6 +257,19 @@ describe('Series', () => {
       await expect(page.getText(popoverContentSelector())).resolves.toContain('Happiness\n300');
       await expect(page.getText(popoverContentSelector())).resolves.toContain('Calories\n77');
       await expect(page.getText(popoverContentSelector())).resolves.toContain('Threshold\n420');
+    })
+  );
+
+  test(
+    'clicking outside of the chart removes all highlights for pinned element',
+    setupTest('#/light/bar-chart/test', async page => {
+      // Click on it to reveal the dismiss button
+      await page.hoverElement(chartWrapper.findBarGroups().get(3).toSelector());
+      await page.click(chartWrapper.toSelector());
+      await expect(page.isDisplayed(dimmedElementsSelector())).resolves.toBe(true);
+
+      await page.click('#focus-target');
+      await expect(page.isDisplayed(dimmedElementsSelector())).resolves.toBe(false);
     })
   );
 });

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -948,6 +948,18 @@ describe('Details popover', () => {
 
     expect(wrapper.findApplication()!.getElement()).toHaveFocus();
   });
+
+  test('no highlighted segment when pressing outside', () => {
+    const { wrapper } = renderMixedChart(<MixedLineBarChart {...barChartProps} />);
+
+    wrapper.findApplication()!.focus();
+    wrapper.findChart()!.fireEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    expect(wrapper.findByClassName(styles['series--dimmed'])).not.toBeNull();
+
+    wrapper.findDefaultFilter()?.openDropdown();
+    expect(wrapper.findByClassName(styles['series--dimmed'])).toBeNull();
+  });
 });
 
 test('highlighted series are controllable', () => {

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -310,6 +310,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
       }, 0);
     } else {
       clearAllHighlights();
+      setVerticalMarkerX(null);
     }
   };
 

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -202,17 +202,21 @@ export default function ChartContainer<T extends ChartDataTypes>({
     [setHighlightedGroupIndex, setHighlightedPoint, highlightSeries]
   );
 
+  const clearAllHighlights = useCallback(() => {
+    setHighlightedPoint(null);
+    highlightSeries(null);
+    setHighlightedGroupIndex(null);
+  }, [highlightSeries, setHighlightedGroupIndex, setHighlightedPoint]);
+
   // Highlight all points at a given X in a line chart
   const highlightX = useCallback(
     (marker: VerticalMarkerX<T> | null) => {
       if (marker) {
-        setHighlightedPoint(null);
-        highlightSeries(null);
-        setHighlightedGroupIndex(null);
+        clearAllHighlights();
       }
       setVerticalMarkerX(marker);
     },
-    [highlightSeries, setHighlightedGroupIndex, setHighlightedPoint]
+    [clearAllHighlights]
   );
 
   // Highlight all points and bars at a given X index in a mixed line and bar chart
@@ -226,11 +230,9 @@ export default function ChartContainer<T extends ChartDataTypes>({
   );
 
   const clearHighlightedSeries = useCallback(() => {
-    highlightSeries(null);
-    setHighlightedGroupIndex(null);
-    setHighlightedPoint(null);
+    clearAllHighlights();
     dismissPopover();
-  }, [dismissPopover, highlightSeries, setHighlightedGroupIndex, setHighlightedPoint]);
+  }, [dismissPopover, clearAllHighlights]);
 
   const { isGroupNavigation, ...handlers } = useNavigation({
     series,
@@ -306,6 +308,8 @@ export default function ChartContainer<T extends ChartDataTypes>({
           plotRef.current?.focusPlot();
         }
       }, 0);
+    } else {
+      clearAllHighlights();
     }
   };
 

--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -95,6 +95,19 @@ describe('Segments', () => {
       await expect(page.isDisplayed(highlightedSegmentSelector)).resolves.toBe(false);
     })
   );
+
+  test(
+    'clicking outside of the chart removes all highlights for pinned element',
+    setupTest(async page => {
+      await page.click(pieWrapper.findSegments().get(2).toSelector());
+      await expect(page.getText(pieWrapper.findHighlightedSegmentLabel().toSelector())).resolves.toContain('Chocolate');
+      await page.waitForVisible(detailsPopoverSelector);
+      await expect(page.isDisplayed(detailsDismissSelector)).resolves.toBe(true);
+
+      await page.click('#focus-target');
+      await expect(page.isDisplayed(highlightedSegmentSelector)).resolves.toBe(false);
+    })
+  );
 });
 
 describe('Filter', () => {

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -411,6 +411,17 @@ describe('Segments', () => {
     const { wrapper } = renderPieChart(<PieChart data={dataWithZero} highlightedSegment={dataWithZero[2]} />);
     expect(wrapper.findHighlightedSegment()).toBeNull();
   });
+
+  test('no highlighted segment when pressing outside', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    act(() => {
+      fireEvent.mouseDown(wrapper!.findSegments()[0].getElement());
+    });
+    expect(wrapper.findHighlightedSegment()).not.toBeNull();
+
+    wrapper.findDefaultFilter()?.openDropdown();
+    expect(wrapper.findHighlightedSegment()).toBeNull();
+  });
 });
 
 describe('Details popover', () => {
@@ -521,6 +532,16 @@ describe('Details popover', () => {
     wrapper.findDetailPopover()?.findDismissButton()?.click();
 
     expect(wrapper.findDetailPopover()).toBeNull();
+  });
+
+  test('pressing spase on a focused segment opens the popover', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    wrapper.findSegments()[1].click();
+    wrapper.findDetailPopover()?.findDismissButton()?.click();
+
+    wrapper.findApplication()!.keydown(KeyCode.space);
+
+    expect(createWrapper(wrapper.getElement()).findPopover()?.findDismissButton()).not.toBeNull();
   });
 
   test('details popover can be customized', () => {

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -220,7 +220,13 @@ export default <T extends PieChartProps.Datum>({
   );
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.keyCode !== KeyCode.right && event.keyCode !== KeyCode.left && event.keyCode !== KeyCode.enter) {
+      const keyCode = event.keyCode;
+      if (
+        keyCode !== KeyCode.right &&
+        keyCode !== KeyCode.left &&
+        keyCode !== KeyCode.enter &&
+        keyCode !== KeyCode.space
+      ) {
         return;
       }
 
@@ -228,18 +234,18 @@ export default <T extends PieChartProps.Datum>({
 
       let nextIndex = highlightedSegmentIndex || 0;
       const MAX = pieData.length - 1;
-      if (event.keyCode === KeyCode.right) {
+      if (keyCode === KeyCode.right) {
         nextIndex++;
         if (nextIndex > MAX) {
           nextIndex = 0;
         }
-      } else if (event.keyCode === KeyCode.left) {
+      } else if (keyCode === KeyCode.left) {
         nextIndex--;
         if (nextIndex < 0) {
           nextIndex = MAX;
         }
       }
-      if (event.keyCode === KeyCode.enter) {
+      if (keyCode === KeyCode.enter || keyCode === KeyCode.space) {
         setPinnedSegment(pieData[nextIndex].data.datum);
       }
       highlightSegment(pieData[nextIndex].data);
@@ -286,6 +292,8 @@ export default <T extends PieChartProps.Datum>({
         plotRef.current!.focusApplication();
         popoverDismissedRecently.current = false;
       }, 0);
+    } else {
+      onHighlightChange(null);
     }
   };
 


### PR DESCRIPTION
### Description

Ensure that after clicking outside of a chart component, highlighted segment will be cleared.

Additionally fixes discrepancy between space and enter keys behaviour for Pie chart.
It will work similarly to other charts.

Area chart behaviour will be adjusted separately. 

Related links, issue #, if available: AWSUI-19991

### How has this been tested?

New integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
