### PR TITLE
feat: Add autofocus property on select and multiselect component

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7663,6 +7663,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "boolean",
     },
     Object {
+      "description": "Automatically focuses the trigger when component is mounted.",
+      "name": "autoFocus",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",
       "optional": true,
@@ -10044,6 +10050,12 @@ To use it correctly, define an ID for the element you want to use as label and s
     Object {
       "description": "Adds \`aria-required\` to the native input element.",
       "name": "ariaRequired",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
+      "description": "Automatically focuses the trigger when component is mounted.",
+      "name": "autoFocus",
       "optional": true,
       "type": "boolean",
     },

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -26,6 +26,7 @@ export interface ButtonTriggerProps extends BaseComponentProps {
   onClick?: CancelableEventHandler;
   onFocus?: CancelableEventHandler;
   onBlur?: CancelableEventHandler<{ relatedTarget: Node | null }>;
+  autoFocus?: boolean;
 }
 
 const ButtonTrigger = (
@@ -47,6 +48,7 @@ const ButtonTrigger = (
     onClick,
     onFocus,
     onBlur,
+    autoFocus,
     ...restProps
   }: ButtonTriggerProps,
   ref: React.Ref<HTMLButtonElement>
@@ -80,6 +82,7 @@ const ButtonTrigger = (
     onClick: onClick && (event => fireCancelableEvent(onClick, {}, event)),
     onFocus: onFocus && (event => fireCancelableEvent(onFocus, {}, event)),
     onBlur: onBlur && (event => fireCancelableEvent(onBlur, { relatedTarget: event.relatedTarget }, event)),
+    autoFocus,
   };
 
   if (invalid) {

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -423,3 +423,8 @@ test('Trigger should have refer to the element using aria-label value and placeh
     .join(' ');
   expect(label).toBe('multi select select options');
 });
+
+test('Trigger receives focus when autofocus is true', () => {
+  const { wrapper } = renderMultiselect(<Multiselect selectedOptions={[]} options={groupOptions} autoFocus={true} />);
+  expect(document.activeElement).toBe(wrapper.findTrigger().getElement());
+});

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -39,6 +39,11 @@ export interface MultiselectProps extends BaseSelectProps {
    * The event `detail` contains the current `selectedOptions`.
    */
   onChange?: NonCancelableEventHandler<MultiselectProps.MultiselectChangeDetail>;
+
+  /**
+   * Automatically focuses the trigger when component is mounted.
+   */
+  autoFocus?: boolean;
 }
 
 export namespace MultiselectProps {

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -70,6 +70,7 @@ const InternalMultiselect = React.forwardRef(
       hideTokens = false,
       expandToViewport,
       __internalRootRef = null,
+      autoFocus,
       ...restProps
     }: InternalMultiselectProps,
     externalRef: React.Ref<MultiselectProps.Ref>
@@ -198,7 +199,7 @@ const InternalMultiselect = React.forwardRef(
       <Trigger
         placeholder={placeholder}
         disabled={disabled}
-        triggerProps={getTriggerProps(disabled)}
+        triggerProps={getTriggerProps(disabled, autoFocus)}
         selectedOption={null}
         isOpen={isOpen}
         {...formFieldContext}

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -269,4 +269,9 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
       expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeFalsy();
     });
   });
+
+  test('should render with focus when autoFocus=true', () => {
+    const { wrapper } = renderSelect({ autoFocus: true });
+    expect(wrapper.findTrigger().getElement()).toHaveFocus();
+  });
 });

--- a/src/select/__tests__/trigger.test.tsx
+++ b/src/select/__tests__/trigger.test.tsx
@@ -145,4 +145,12 @@ describe('Trigger component', () => {
       expect(buttonTriggerEl).toHaveTextContent('Option 1Label tag');
     });
   });
+  describe('autoFocus', () => {
+    test('receives focus when autoFocus is true', () => {
+      const wrapper = renderComponent({ ...defaultProps, triggerProps: { autoFocus: true } });
+      const buttonTriggerEl = wrapper.getElement();
+
+      expect(buttonTriggerEl).toHaveFocus();
+    });
+  });
 });

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -86,7 +86,7 @@ describe('useSelect', () => {
 
     test('should return getTriggerProps that configures the trigger', () => {
       const triggerProps = getTriggerProps();
-      expect(Object.keys(triggerProps)).toEqual(['ref', 'onFocus', 'onMouseDown', 'onKeyDown']);
+      expect(Object.keys(triggerProps)).toEqual(['ref', 'onFocus', 'autoFocus', 'onMouseDown', 'onKeyDown']);
       expect(triggerProps.ref).toEqual({ current: null });
     });
 

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -146,6 +146,11 @@ export interface SelectProps extends BaseSelectProps {
    * The event `detail` contains the current `selectedOption`.
    */
   onChange?: NonCancelableEventHandler<SelectProps.ChangeDetail>;
+
+  /**
+   * Automatically focuses the trigger when component is mounted.
+   */
+  autoFocus?: boolean;
 }
 
 export namespace SelectProps {

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -27,7 +27,7 @@ import checkControlled from '../internal/hooks/check-controlled';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { OptionGroup } from '../internal/components/option/interfaces.js';
-import { SomeRequired } from '../internal/types.js';
+import { SomeRequired } from '../internal/types';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
 
@@ -63,6 +63,7 @@ const InternalSelect = React.forwardRef(
       onChange,
       virtualScroll,
       expandToViewport,
+      autoFocus,
       __inFilteringToken,
       __internalRootRef = null,
       ...restProps
@@ -148,7 +149,7 @@ const InternalSelect = React.forwardRef(
         placeholder={placeholder}
         disabled={disabled}
         triggerVariant={triggerVariant}
-        triggerProps={getTriggerProps(disabled)}
+        triggerProps={getTriggerProps(disabled, autoFocus)}
         selectedOption={selectedOption}
         isOpen={isOpen}
         inFilteringToken={__inFilteringToken}

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -40,6 +40,7 @@ export interface SelectTriggerProps {
   onMouseDown?: (event: CustomEvent) => void;
   onKeyDown?: (event: CustomEvent<BaseKeyDetail>) => void;
   onFocus: NonCancelableEventHandler;
+  autoFocus?: boolean;
 }
 
 export function useSelect({
@@ -138,10 +139,11 @@ export function useSelect({
     onBlur: handleBlur,
   });
 
-  const getTriggerProps = (disabled = false) => {
+  const getTriggerProps = (disabled = false, autoFocus = false) => {
     const triggerProps: SelectTriggerProps = {
       ref: triggerRef,
       onFocus: () => closeDropdown(),
+      autoFocus,
     };
     if (!disabled) {
       triggerProps.onMouseDown = (event: CustomEvent) => {


### PR DESCRIPTION
### Description

Give select and multiselect a feature that other components already have

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
