### PR TITLE
fix: Loosen table type definitions for inline editing

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11038,7 +11038,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "allItemsSelectionLabel",
@@ -11048,7 +11048,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "cancelEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "itemSelectionLabel",
@@ -11063,7 +11063,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "submitEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "tableLabel",
@@ -11075,7 +11075,7 @@ add a meaningful description to the whole selection.
       },
       "name": "ariaLabels",
       "optional": true,
-      "type": "TableProps.AriaLabels<T, V>",
+      "type": "TableProps.AriaLabels<T>",
     },
     Object {
       "description": "Adds the specified classes to the root element of the component.",

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -164,7 +164,7 @@ export interface TableProps<T = any, V = any> extends BaseComponentProps {
    * * `submitEditLabel` (EditableColumnDefinition) => string -
    *                      Specifies an alternative text for the submit button in editable cells.
    */
-  ariaLabels?: TableProps.AriaLabels<T, V>;
+  ariaLabels?: TableProps.AriaLabels<T>;
 
   /**
    * Specifies the definition object of the currently sorted column. Make sure you pass an object that's
@@ -350,14 +350,16 @@ export namespace TableProps {
     selectedItems: T[];
   }
   export type IsItemDisabled<T> = (item: T) => boolean;
-  export interface AriaLabels<T, V = any> {
+  export interface AriaLabels<T> {
     allItemsSelectionLabel?: (data: TableProps.SelectionState<T>) => string;
     itemSelectionLabel?: (data: TableProps.SelectionState<T>, row: T) => string;
     selectionGroupLabel?: string;
     tableLabel?: string;
-    activateEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
-    cancelEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
-    submitEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
+    // do not use <T> to prevent overly strict validation on consumer end
+    // it works, practically, we are only interested in `id` and `header` properties only
+    activateEditLabel?: (column: ColumnDefinition<any>) => string;
+    cancelEditLabel?: (column: ColumnDefinition<any>) => string;
+    submitEditLabel?: (column: ColumnDefinition<any>) => string;
   }
   export interface SortingState<T> {
     isDescending?: boolean;


### PR DESCRIPTION
### Description

This code used to work

```
const ariaLabels: TableProps.AriaLabels<null> = {/*labels*/}

<Table ariaLabels={ariaLabels} />
```

But after #522 it stopped, because we added new properties there, `activateEditLabel` and others. They depend on `ColumnDefinition` type, which requires a generic argument too. 

Because of type covariance/countervariance, this assigment was possible before 

```
const ariaLabels: TableProps.AriaLabels<{id: number}>

<Table<{id: number, name: string}>
   ariaLabels={ariaLabels}
/>
```

(you can assign a sub type to a type). But after #522, it has to be the exact match.

There are existing use-cases with the code like this, so we have to maintain the compatibility

Related links, issue #, if available: n/a

### How has this been tested?

TODO: add a test that countervariance is supported

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
