### PR TITLE
Cast searchText to string before toLowerCase

### DIFF
--- a/src/property-filter/filter-options.ts
+++ b/src/property-filter/filter-options.ts
@@ -31,7 +31,7 @@ function isGroup(optionOrGroup: AutosuggestProps.Option): optionOrGroup is Autos
 }
 
 function matchSingleOption(option: OptionDefinition, searchText: string): boolean {
-  searchText = searchText.toLowerCase();
+  searchText = `${searchText}`.toLowerCase();
 
   const label = (option.label ?? '').toLowerCase();
   const labelPrefix = option.__labelPrefix ?? '';


### PR DESCRIPTION
`###` Description

It is possible to pass a _number_ value as searchText depending on user input, causing an exception to be thrown. 

Related links, issue #, if available: n/a

### How has this been tested?

Manually verified this change fixes the issues I observed.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
