### PR TITLE
fix: Click outside of area chart closes popover

### DIFF
--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -227,6 +227,20 @@ describe('Popover', () => {
       await expect(page.hasPopover()).resolves.toBe(false);
     })
   );
+
+  test(
+    'clicking outside of the chart removes popover',
+    setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
+      await page.focusPlot();
+      await page.click(page.chart.toSelector());
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      await expect(page.hasPopover()).resolves.toBe(true);
+
+      await page.openFilter();
+      await expect(page.hasPopover()).resolves.toBe(false);
+    })
+  );
 });
 
 describe('Keyboard navigation', () => {
@@ -340,24 +354,6 @@ describe('Focus delegation', () => {
       await expect(page.getHighlightedSeriesLabel()).resolves.toBe(null);
       await expect(page.getPopoverTitle()).resolves.toBe('3s');
       await expect(page.isPopoverPinned()).resolves.toBe(false);
-    })
-  );
-
-  test(
-    'preserves series highlight when focused away from plot',
-    setupTest('#/light/area-chart/test', 'Linear latency chart', async page => {
-      await page.setWindowSize({ width: 2000, height: 800 });
-      await page.focusPlot();
-
-      await page.keys(['ArrowDown', 'ArrowRight']);
-
-      await expect(page.getPopoverTitle()).resolves.toBe('2s');
-      await expect(page.getHighlightedSeriesLabel()).resolves.toBe('p90');
-
-      await page.focusPlot();
-
-      await expect(page.getPopoverTitle()).resolves.toBe('1s');
-      await expect(page.getHighlightedSeriesLabel()).resolves.toBe('p90');
     })
   );
 

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -6,10 +6,12 @@ import useChartModel, { UseChartModelProps } from '../model/use-chart-model';
 import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import { ChartDataTypes } from '../../internal/components/cartesian-chart/interfaces';
 import { act, render, fireEvent } from '@testing-library/react';
-import { AreaChartProps } from '../interfaces';
+// import { AreaChartProps } from '../interfaces';
 import { KeyCode } from '../../internal/keycode';
 import { useReaction } from '../model/async-store';
 import { ChartModel } from '../model';
+import { AreaChartWrapper } from '../../../lib/components/test-utils/dom';
+import AreaChart, { AreaChartProps } from '../../../lib/components/area-chart';
 import PlotPoint = ChartModel.PlotPoint;
 
 class UseChartModelWrapper extends ElementWrapper {
@@ -104,6 +106,11 @@ function renderChartModelHook(props: UseChartModelProps<ChartDataTypes>) {
   const { rerender, container } = render(<RenderChartModelHook {...props} />);
   const wrapper = new UseChartModelWrapper(container.firstChild as HTMLElement);
   return { rerender, wrapper };
+}
+
+function renderAreaChart(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return { container, wrapper: new AreaChartWrapper(container) };
 }
 
 describe('useChartModel', () => {
@@ -351,6 +358,17 @@ describe('useChartModel', () => {
         });
 
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+      });
+
+      test('clear highlighted X and close popover when click outside', () => {
+        const { wrapper } = renderAreaChart(<AreaChart series={series} statusType="finished" />);
+        wrapper.findApplication()!.focus();
+        wrapper.findChart()!.fireEvent(new MouseEvent('mousedown'));
+
+        expect(wrapper.findDetailPopover()).not.toBeNull();
+
+        wrapper.findDefaultFilter()?.openDropdown();
+        expect(wrapper.findDetailPopover()).toBeNull();
       });
     });
   });

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -296,6 +296,9 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
             plotRef.current!.focusPlot();
           }
         }, 0);
+      } else {
+        interactions.clearHighlight();
+        interactions.clearHighlightedLegend();
       }
     };
 


### PR DESCRIPTION
### Description

Ensure that after clicking outside of a chart component, highlighted segment will be cleared and popover will be dismissed.

Follow-up for [#592](https://github.com/cloudscape-design/components/pull/592)

### How has this been tested?

New integration test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
