### PR TITLE
fix: Property filter to accept non-string primitives as values and la…

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -1242,4 +1242,21 @@ describe('property filter parts', () => {
     const { container } = renderComponent();
     expect(createWrapper(container).findByClassName(styles.input)!.getElement()).not.toBe(null);
   });
+
+  test('throws no exception when non-string primitive types are used as values or labels', () => {
+    const { propertyFilterWrapper: wrapper } = renderComponent({
+      filteringProperties: [
+        {
+          key: 1,
+          propertyLabel: 1,
+          operators: ['!:', ':', '=', '!='],
+          groupValuesLabel: 1,
+        } as any,
+      ],
+      filteringOptions: [{ propertyKey: 1, value: 1 } as any, { propertyKey: 1, value: 11 } as any],
+      query: { tokens: [{ propertyKey: 1, value: 1, operator: '=' } as any], operation: 'and' },
+    });
+    act(() => wrapper.setInputValue('1=2'));
+    act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+  });
 });

--- a/src/property-filter/filter-options.ts
+++ b/src/property-filter/filter-options.ts
@@ -33,8 +33,12 @@ function isGroup(optionOrGroup: AutosuggestProps.Option): optionOrGroup is Autos
 function matchSingleOption(option: OptionDefinition, searchText: string): boolean {
   searchText = searchText.toLowerCase();
 
-  const label = (option.label ?? '').toLowerCase();
+  const label = toString(option.label).toLowerCase();
   const labelPrefix = option.__labelPrefix ?? '';
-  const value = (option.value ? option.value.slice(labelPrefix.length) : '').toLowerCase();
+  const value = toString(option.value).slice(labelPrefix.length).toLowerCase();
   return label.indexOf(searchText) !== -1 || value.indexOf(searchText) !== -1;
+}
+
+function toString(value: unknown): string {
+  return '' + value;
 }


### PR DESCRIPTION
…bels

### Description

The fix is made for non-TS customers.

### How has this been tested?

New unit test is added.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
