### PR TITLE
feat: Announce selected state of chart legend button  by screen reader

### DIFF
--- a/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
+++ b/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
@@ -115,4 +115,14 @@ describe('Chart legend', () => {
     legend.pressLeft();
     expect(legend.findFocusedLabel()).toEqual(series[2].label);
   });
+
+  test('should set aria-pressed as true when the button is selected', () => {
+    const legend = renderChartLegend();
+
+    legend.focus();
+    legend.pressLeft();
+    expect(legend.wrapper.find('[role="button"]')!.getElement().getAttribute('aria-pressed')).toBe('true');
+    legend.pressLeft();
+    expect(legend.wrapper.find('[role="button"]')!.getElement().getAttribute('aria-pressed')).toBe('false');
+  });
 });

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -127,6 +127,7 @@ function ChartLegend<T>({
                 {...focusVisible}
                 role="button"
                 key={index}
+                aria-pressed={isHighlighted}
                 className={clsx(styles.marker, {
                   [styles['marker--dimmed']]: isDimmed,
                   [styles['marker--highlighted']]: isHighlighted,


### PR DESCRIPTION

### Description

When button is focused and series is highlighted, the selected state should be announced by screenreader. 

Related links, issue #AWSUI-19996

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
