### PR TITLE
fix: Container flex styles

### DIFF
--- a/pages/container/fit-height.page.tsx
+++ b/pages/container/fit-height.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
+import { Checkbox } from '~components';
 import ColumnLayout from '~components/column-layout';
 import Container from '~components/container';
 import Grid from '~components/grid';
@@ -9,26 +10,26 @@ import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
 import styles from './fit-height.scss';
 
-function SmallContainer() {
+function SmallContainer({ fitHeight }: { fitHeight: boolean }) {
   return (
-    <Container fitHeight={true} header={<Header>Short</Header>} footer="footer">
+    <Container fitHeight={fitHeight} header={<Header>Short</Header>} footer="footer">
       <p>One line of text</p>
     </Container>
   );
 }
 
-function MediumContainer() {
+function MediumContainer({ fitHeight }: { fitHeight: boolean }) {
   return (
-    <Container fitHeight={true} header={<Header>Mid size</Header>} footer="footer">
+    <Container fitHeight={fitHeight} header={<Header>Mid size</Header>} footer="footer">
       <p>Content placeholder</p>
       <div style={{ height: 100 }} className={styles.placeholder}></div>
     </Container>
   );
 }
 
-function LargeContainer() {
+function LargeContainer({ fitHeight }: { fitHeight: boolean }) {
   return (
-    <Container fitHeight={true} header={<Header>Large</Header>} footer="footer">
+    <Container fitHeight={fitHeight} header={<Header>Large</Header>} footer="footer">
       <p>
         This container overflows available space. <Link href="#">Learn more</Link>.
       </p>
@@ -38,31 +39,36 @@ function LargeContainer() {
 }
 
 export default function () {
+  const [fitHeight, setFitHeight] = useState(true);
+
   return (
     <article>
       <h1>Fit height property demo</h1>
+      <Checkbox checked={fitHeight} onChange={event => setFitHeight(event.detail.checked)}>
+        Fit height
+      </Checkbox>
       <ScreenshotArea>
         <h2>Inside display:grid</h2>
         <div className={styles.grid}>
-          <SmallContainer />
-          <MediumContainer />
-          <LargeContainer />
+          <SmallContainer fitHeight={fitHeight} />
+          <MediumContainer fitHeight={fitHeight} />
+          <LargeContainer fitHeight={fitHeight} />
         </div>
         <h2>Inside column layout</h2>
         <ColumnLayout columns={3}>
-          <SmallContainer />
-          <MediumContainer />
-          <LargeContainer />
+          <SmallContainer fitHeight={fitHeight} />
+          <MediumContainer fitHeight={fitHeight} />
+          <LargeContainer fitHeight={fitHeight} />
         </ColumnLayout>
         <h2>Inside grid</h2>
         <Grid gridDefinition={[{ colspan: 6 }, { colspan: 3 }, { colspan: 3 }]}>
-          <SmallContainer />
-          <MediumContainer />
-          <LargeContainer />
+          <SmallContainer fitHeight={fitHeight} />
+          <MediumContainer fitHeight={fitHeight} />
+          <LargeContainer fitHeight={fitHeight} />
         </Grid>
         <h2>Container inside height limit</h2>
         <div className={styles.heightLimit}>
-          <LargeContainer />
+          <LargeContainer fitHeight={fitHeight} />
         </div>
       </ScreenshotArea>
     </article>

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -9,11 +9,12 @@
 
 .root {
   @include styles.styles-reset;
+  display: flex;
+  flex-flow: column nowrap;
   word-wrap: break-word;
 
   &-fit-height {
-    display: flex;
-    flex-direction: column;
+    flex-flow: column;
     overflow: hidden;
     height: 100%;
   }
@@ -40,6 +41,8 @@
 }
 
 .header {
+  flex: 0 0 auto;
+
   background-color: awsui.$color-background-container-header;
   border-top-left-radius: awsui.$border-radius-container;
   border-top-right-radius: awsui.$border-radius-container;
@@ -130,10 +133,13 @@ the default white background of the container component.
 }
 
 .content {
+  flex: 1 0 auto;
+
   .root-fit-height > & {
     flex: 1;
     overflow: auto;
   }
+
   &.with-paddings {
     padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
 
@@ -144,6 +150,8 @@ the default white background of the container component.
 }
 
 .footer {
+  flex: 0 0 auto;
+
   &.with-paddings {
     padding: shared.$footer-padding;
   }


### PR DESCRIPTION
### Description

The https://github.com/cloudscape-design/components/pull/589 broke container styles when used in a specific way because certain styles have been unconditionally removed.

Before fix:

<img width="1440" alt="Screenshot 2022-12-30 at 09 48 08" src="https://user-images.githubusercontent.com/20790937/210051877-30a46c2c-2048-442a-b490-62c368488ffd.png">

After fix:

<img width="1440" alt="Screenshot 2022-12-30 at 09 48 51" src="https://user-images.githubusercontent.com/20790937/210051948-e22183dc-6b83-4b12-9915-91eeda836465.png">

SIM: AWSUI-20048

### How has this been tested?

Manual tests so far. Can add a screenshot test for fitHeight=false after merged.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
