### PR TITLE
chore: use weaker types for inline editing

### DIFF
--- a/pages/table/editable-with-app-layout.page.tsx
+++ b/pages/table/editable-with-app-layout.page.tsx
@@ -212,11 +212,7 @@ const Demo = forwardRef(
   ) => {
     const [items, setItems] = useState(initialItems);
 
-    const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo, string> = async (
-      currentItem,
-      column,
-      newValue
-    ) => {
+    const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo> = async (currentItem, column, newValue) => {
       let value = newValue;
       await new Promise(r => setTimeout(r, 1000));
       errorsMeta.delete(currentItem);
@@ -226,6 +222,7 @@ const Demo = forwardRef(
       }
       if (
         column.id === 'LastModifiedTime' &&
+        typeof value === 'string' &&
         (new Date(value).toString() === 'Invalid Date' || !isNaN(+new Date(value)))
       ) {
         const time = new Date(currentItem.LastModifiedTime);

--- a/pages/table/tall-rows.page.tsx
+++ b/pages/table/tall-rows.page.tsx
@@ -16,13 +16,13 @@ export default function () {
 
   const tallItemsConfig: TableProps.ColumnDefinition<Instance>[] = columnsConfig.map((config, index) => ({
     ...config,
-    cell: (item: Instance) =>
+    cell: (item, ...rest) =>
       index === 0 ? (
         <Link onFollow={() => setClicks(prev => prev + 1)}>{item.id}</Link>
       ) : (
         <ul>
           {range(0, 20).map(index => {
-            return <li key={index}>{(config.cell as TableProps.CellRenderer<Instance>)(item)}</li>;
+            return <li key={index}>{config.cell(item, ...rest)}</li>;
           })}
         </ul>
       ),

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11038,7 +11038,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "allItemsSelectionLabel",
@@ -11048,7 +11048,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "cancelEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "itemSelectionLabel",
@@ -11063,7 +11063,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "submitEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "tableLabel",
@@ -11075,7 +11075,7 @@ add a meaningful description to the whole selection.
       },
       "name": "ariaLabels",
       "optional": true,
-      "type": "TableProps.AriaLabels<T, V>",
+      "type": "TableProps.AriaLabels<T>",
     },
     Object {
       "description": "Adds the specified classes to the root element of the component.",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11121,7 +11121,7 @@ add a meaningful description to the whole selection.
            Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.",
       "name": "columnDefinitions",
       "optional": false,
-      "type": "ReadonlyArray<TableProps.ColumnDefinition<T, V>>",
+      "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",
     },
     Object {
       "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
@@ -11275,7 +11275,7 @@ Return a promise to keep loading state while the submit request is in progress."
           },
           Object {
             "name": "column",
-            "type": "TableProps.ColumnDefinition<ItemType, ValueType>",
+            "type": "TableProps.ColumnDefinition<ItemType>",
           },
           Object {
             "name": "newValue",
@@ -11287,7 +11287,7 @@ Return a promise to keep loading state while the submit request is in progress."
       },
       "name": "submitEdit",
       "optional": true,
-      "type": "TableProps.SubmitEditFunction<T, V>",
+      "type": "TableProps.SubmitEditFunction<T>",
     },
     Object {
       "description": "Use this property to inform screen readers how many items there are in a table.

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -9,14 +9,14 @@ const testItem = {
   test: 'test',
 };
 
-const column: TableProps.ColumnDefinition<typeof testItem, string> = {
+const column: TableProps.ColumnDefinition<typeof testItem> = {
   id: 'test',
   header: 'Test',
   editConfig: {
     ariaLabel: 'test input',
     editIconAriaLabel: 'error',
   },
-  cell: (item, { isEditing, setValue, currentValue }) => {
+  cell: (item, { isEditing, setValue, currentValue }: TableProps.CellContext<any>) => {
     if (isEditing) {
       return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
     }
@@ -32,7 +32,7 @@ const TestComponent = ({ isEditing = false }) => {
     <table>
       <tbody>
         <tr>
-          <TableBodyCell<typeof testItem, string>
+          <TableBodyCell<typeof testItem>
             column={column}
             item={testItem}
             isEditing={isEditing}

--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -16,10 +16,10 @@ const defaultItems: Item[] = [
   { id: 3, name: 'Bananas' },
 ];
 
-const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
+const editableColumns: TableProps.ColumnDefinition<Item>[] = [
   {
     header: 'id',
-    cell: (item: Item, { isEditing }) => {
+    cell: (item, { isEditing }) => {
       if (isEditing) {
         return <input type="number" value={item.id} readOnly={true} data-testid={`id-editing-${item.id}`} />;
       }
@@ -33,7 +33,7 @@ const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
   },
   {
     header: 'name',
-    cell: (item: Item, { isEditing }) => {
+    cell: (item, { isEditing }) => {
       if (isEditing) {
         return <input type="number" value={item.name} readOnly={true} data-testid={`name-editing-${item.name}`} />;
       }
@@ -46,6 +46,10 @@ const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
     },
   },
 ];
+
+const defaultAriaLabels: TableProps.AriaLabels<{ id: number }> = {
+  tableLabel: 'Distributions',
+};
 
 function renderTable(jsx: React.ReactElement) {
   const { container, rerender, getByTestId, queryByTestId } = render(jsx);
@@ -71,5 +75,19 @@ describe('Editable Table TestUtils', () => {
     const buttons = getByTestId('id-editing-1').closest('form')!.querySelectorAll('button')!;
     expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[0]);
     expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[1]);
+  });
+
+  test('renders when items and labels types do not match', () => {
+    const ariaLabels: TableProps.AriaLabels<Item> = {
+      ...defaultAriaLabels,
+      submitEditLabel: column => `Submit edit for ${column.header}`,
+      cancelEditLabel: column => `Cancel edit for ${column.header}`,
+      activateEditLabel: column => `Activate edit for ${column.header}`,
+    };
+
+    const { wrapper } = renderTable(
+      <Table<Item> columnDefinitions={editableColumns} items={defaultItems} ariaLabels={ariaLabels} />
+    );
+    expect(wrapper.findBodyCell(2, 2)!.getElement()!).toBeInTheDocument();
   });
 });

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -22,17 +22,17 @@ const submitHandlerFallback = () => {
   throw new Error('The function `handleSubmit` is required for editable columns');
 };
 
-interface TableBodyCellProps<ItemType, ValueType> extends TableTdElementProps {
-  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+interface TableBodyCellProps<ItemType> extends TableTdElementProps {
+  column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
   isEditing: boolean;
   onEditStart: () => void;
   onEditEnd: () => void;
-  submitEdit?: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  submitEdit?: TableProps.SubmitEditFunction<ItemType>;
   ariaLabels: TableProps['ariaLabels'];
 }
 
-function TableCellEditable<ItemType, ValueType>({
+function TableCellEditable<ItemType>({
   className,
   item,
   column,
@@ -43,7 +43,7 @@ function TableCellEditable<ItemType, ValueType>({
   ariaLabels,
   isVisualRefresh,
   ...rest
-}: TableBodyCellProps<ItemType, ValueType>) {
+}: TableBodyCellProps<ItemType>) {
   const editActivateRef = useRef<ButtonProps.Ref>(null);
   const cellRef = useRef<HTMLTableCellElement>(null);
   const focusVisible = useFocusVisible();
@@ -116,10 +116,10 @@ function TableCellEditable<ItemType, ValueType>({
   );
 }
 
-export function TableBodyCell<ItemType, ValueType>({
+export function TableBodyCell<ItemType>({
   isEditable,
   ...rest
-}: TableBodyCellProps<ItemType, ValueType> & { isEditable: boolean }) {
+}: TableBodyCellProps<ItemType> & { isEditable: boolean }) {
   if (isEditable || rest.isEditing) {
     return <TableCellEditable {...rest} />;
   }

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -12,25 +12,25 @@ import { Optional } from '../../internal/types';
 // A function that does nothing
 const noop = () => undefined;
 
-interface InlineEditorProps<ItemType, ValueType> {
+interface InlineEditorProps<ItemType> {
   ariaLabels: TableProps['ariaLabels'];
-  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+  column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
   onEditEnd: () => void;
-  submitEdit: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  submitEdit: TableProps.SubmitEditFunction<ItemType>;
   __onRender?: () => void;
 }
 
-export function InlineEditor<ItemType, ValueType>({
+export function InlineEditor<ItemType>({
   ariaLabels,
   item,
   column,
   onEditEnd,
   submitEdit,
   __onRender,
-}: InlineEditorProps<ItemType, ValueType>) {
+}: InlineEditorProps<ItemType>) {
   const [currentEditLoading, setCurrentEditLoading] = useState(false);
-  const [currentEditValue, setCurrentEditValue] = useState<Optional<ValueType>>();
+  const [currentEditValue, setCurrentEditValue] = useState<Optional<any>>();
 
   const cellContext = {
     isEditing: true,

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -11,11 +11,11 @@ import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
-interface TableHeaderCellProps<ItemType, ValueType> {
+interface TableHeaderCellProps<ItemType> {
   className?: string;
   style?: React.CSSProperties;
   tabIndex: number;
-  column: TableProps.ColumnDefinition<ItemType, ValueType>;
+  column: TableProps.ColumnDefinition<ItemType>;
   activeSortingColumn?: TableProps.SortingColumn<ItemType>;
   sortingDescending?: boolean;
   sortingDisabled?: boolean;
@@ -32,7 +32,7 @@ interface TableHeaderCellProps<ItemType, ValueType> {
   isEditable?: boolean;
 }
 
-export function TableHeaderCell<ItemType, ValueType>({
+export function TableHeaderCell<ItemType>({
   className,
   style,
   tabIndex,
@@ -51,7 +51,7 @@ export function TableHeaderCell<ItemType, ValueType>({
   resizableColumns,
   onResizeFinish,
   isEditable,
-}: TableHeaderCellProps<ItemType, ValueType>) {
+}: TableHeaderCellProps<ItemType>) {
   const focusVisible = useFocusVisible();
   const sortable = !!column.sortingComparator || !!column.sortingField;
   const sorted = !!activeSortingColumn && isSorted(column, activeSortingColumn);

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -164,7 +164,7 @@ export interface TableProps<T = any, V = any> extends BaseComponentProps {
    * * `submitEditLabel` (EditableColumnDefinition) => string -
    *                      Specifies an alternative text for the submit button in editable cells.
    */
-  ariaLabels?: TableProps.AriaLabels<T, V>;
+  ariaLabels?: TableProps.AriaLabels<T>;
 
   /**
    * Specifies the definition object of the currently sorted column. Make sure you pass an object that's
@@ -350,14 +350,16 @@ export namespace TableProps {
     selectedItems: T[];
   }
   export type IsItemDisabled<T> = (item: T) => boolean;
-  export interface AriaLabels<T, V = any> {
+  export interface AriaLabels<T> {
     allItemsSelectionLabel?: (data: TableProps.SelectionState<T>) => string;
     itemSelectionLabel?: (data: TableProps.SelectionState<T>, row: T) => string;
     selectionGroupLabel?: string;
     tableLabel?: string;
-    activateEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
-    cancelEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
-    submitEditLabel?: (column: EditableColumnDefinition<T, V>) => string;
+    // do not use <T> to prevent overly strict validation on consumer end
+    // it works, practically, we are only interested in `id` and `header` properties only
+    activateEditLabel?: (column: ColumnDefinition<any>) => string;
+    cancelEditLabel?: (column: ColumnDefinition<any>) => string;
+    submitEditLabel?: (column: ColumnDefinition<any>) => string;
   }
   export interface SortingState<T> {
     isDescending?: boolean;

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -19,7 +19,7 @@ export interface TableForwardRefType {
   <T>(props: TableProps<T> & { ref?: React.Ref<TableProps.Ref> }): JSX.Element;
 }
 
-export interface TableProps<T = any, V = any> extends BaseComponentProps {
+export interface TableProps<T = any> extends BaseComponentProps {
   /**
    * Heading element of the table container. Use the [header component](/components/header/).
    */
@@ -98,7 +98,7 @@ export interface TableProps<T = any, V = any> extends BaseComponentProps {
    *            Return a string from the function to display an error message. Return `undefined` (or no return) from the function to indicate that the value is valid.
    *
    */
-  columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T, V>>;
+  columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
   /**
    * Specifies the selection type (`'single' | 'multi'`).
    */
@@ -269,7 +269,7 @@ export interface TableProps<T = any, V = any> extends BaseComponentProps {
    * Specifies a function that will be called after user submits an inline edit.
    * Return a promise to keep loading state while the submit request is in progress.
    */
-  submitEdit?: TableProps.SubmitEditFunction<T, V>;
+  submitEdit?: TableProps.SubmitEditFunction<T>;
 
   /**
    * Called whenever user cancels an inline edit. Use this function to reset any
@@ -281,16 +281,11 @@ export interface TableProps<T = any, V = any> extends BaseComponentProps {
 export namespace TableProps {
   export type TrackBy<T> = string | ((item: T) => string);
 
-  export type EditableColumnDefinition<T, V = any> = Extract<ColumnDefinition<T, V>, ColumnEditConfig<T, V>>;
-
   export interface CellContext<V> {
     isEditing?: boolean;
     currentValue: Optional<V>;
     setValue: (value: V | undefined) => void;
   }
-
-  export type CellRenderer<T> = (item: T) => React.ReactNode;
-  export type EditableCellRenderer<T, V = any> = (item: T, context: CellContext<V>) => React.ReactNode;
 
   export interface EditConfig<T, V = any> {
     /**
@@ -321,25 +316,16 @@ export namespace TableProps {
     validation?: (item: T, value: Optional<V>) => Optional<string>;
   }
 
-  export type ColumnEditConfig<ItemType, ValueType> =
-    | {
-        editConfig?: undefined;
-        cell: CellRenderer<ItemType>;
-      }
-    | {
-        editConfig: EditConfig<ItemType, ValueType>;
-        cell: EditableCellRenderer<ItemType, ValueType>;
-      };
-
-  export type ColumnDefinition<ItemType, ValueType = any> = {
+  export type ColumnDefinition<ItemType> = {
     id?: string;
     header: React.ReactNode;
     ariaLabel?(data: LabelData): string;
     width?: number | string;
     minWidth?: number | string;
     maxWidth?: number | string;
-  } & SortingColumn<ItemType> &
-    ColumnEditConfig<ItemType, ValueType>;
+    editConfig?: EditConfig<ItemType>;
+    cell(item: ItemType, context: CellContext<any>): React.ReactNode;
+  } & SortingColumn<ItemType>;
 
   export type SelectionType = 'single' | 'multi';
   export type Variant = 'container' | 'embedded' | 'stacked' | 'full-page';
@@ -408,9 +394,9 @@ export namespace TableProps {
     cancelEdit?(): void;
   }
 
-  export type SubmitEditFunction<ItemType, ValueType = any> = (
+  export type SubmitEditFunction<ItemType, ValueType = unknown> = (
     item: ItemType,
-    column: ColumnDefinition<ItemType, ValueType>,
+    column: ColumnDefinition<ItemType>,
     newValue: ValueType
   ) => Promise<void> | void;
 }

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -34,11 +34,11 @@ import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
 import { TableTdElement } from './body-cell/td-element';
 
-type InternalTableProps<T, V> = SomeRequired<TableProps<T, V>, 'items' | 'selectedItems' | 'variant'> &
+type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
 
 const InternalTable = React.forwardRef(
-  <T, V>(
+  <T,>(
     {
       header,
       footer,
@@ -77,7 +77,7 @@ const InternalTable = React.forwardRef(
       firstIndex,
       renderAriaLive,
       ...rest
-    }: InternalTableProps<T, V>,
+    }: InternalTableProps<T>,
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseProps = getBaseProps(rest);


### PR DESCRIPTION
### Description

This PR changes some the types used by Inline Editing to be weaker. The stronger types seem to break some consuming packages. 

Includes changes proposed by @just-boris in #595 

Related links, issue #, if available: n/a

### How has this been tested?
Dry run build 6282595099 and 6284939920
<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.