### PR TITLE
chore: Support Visual Refresh theme in metrics

### DIFF
--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -37,7 +37,7 @@ const AppContext = createContext<AppContextType>(appContextDefaults);
 
 export default AppContext;
 
-function parseQuery(query: string) {
+export function parseQuery(query: string) {
   const queryParams = { ...appContextDefaults.urlParams, ...qs.parse(query.substring(1)) } as Record<string, any>;
 
   return mapValues(queryParams, value => {

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -19,7 +19,10 @@ export default function ThemeSwitcher() {
     vrSwitchProps.readOnly = true;
   } else {
     vrSwitchProps.checked = urlParams.visualRefresh;
-    vrSwitchProps.onChange = event => setUrlParams({ visualRefresh: event.target.checked });
+    vrSwitchProps.onChange = event => {
+      setUrlParams({ visualRefresh: event.target.checked });
+      window.location.reload();
+    };
   }
 
   return (

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -3,8 +3,8 @@
 import React, { Suspense, useContext, useEffect } from 'react';
 import { render } from 'react-dom';
 import { HashRouter, Redirect } from 'react-router-dom';
+import { createHashHistory } from 'history';
 import { applyMode, applyDensity, disableMotion } from '@cloudscape-design/global-styles';
-import { useEffectOnUpdate } from '~components/internal/hooks/use-effect-on-update';
 import './polyfills';
 
 // import font-size reset and Ember font
@@ -16,18 +16,14 @@ import PageView from './components/page-view';
 import IndexPage from './components/index-page';
 import Header from './components/header';
 import StrictModeWrapper from './components/strict-mode-wrapper';
-import AppContext, { AppContextProvider } from './app-context';
+import AppContext, { AppContextProvider, parseQuery } from './app-context';
 
 function App() {
   const {
     mode,
     pageId,
-    urlParams: { density, motionDisabled, visualRefresh },
+    urlParams: { density, motionDisabled },
   } = useContext(AppContext);
-
-  useEffectOnUpdate(() => {
-    window.location.reload();
-  }, [visualRefresh]);
 
   const isAppLayout =
     pageId !== undefined && (pageId.indexOf('app-layout') > -1 || pageId.indexOf('content-layout') > -1);
@@ -71,9 +67,11 @@ function App() {
   );
 }
 
-// The VR class needs to be set before any React rendering takes occurs.
-const vrDisabled = window.location.hash.includes('visualRefresh=false');
-document.getElementById('app')?.classList.toggle('awsui-visual-refresh', !vrDisabled);
+const history = createHashHistory();
+const { visualRefresh } = parseQuery(history.location.search);
+
+// The VR class needs to be set before any React rendering occurs.
+document.body.classList.toggle('awsui-visual-refresh', visualRefresh);
 
 render(
   <HashRouter>

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -56,15 +56,6 @@ function App() {
     }
   }, [isMacOS]);
 
-  useEffect(() => {
-    // NB: do not use classList.toggle, it does not work as expected in IE
-    if (visualRefresh) {
-      document.body.classList.add('awsui-visual-refresh');
-    } else {
-      document.body.classList.remove('awsui-visual-refresh');
-    }
-  }, [visualRefresh]);
-
   if (!mode) {
     return <Redirect to="/light/" />;
   }
@@ -79,6 +70,10 @@ function App() {
     </StrictModeWrapper>
   );
 }
+
+// The VR class needs to be set before any React rendering takes occurs.
+const vrDisabled = window.location.hash.includes('visualRefresh=false');
+document.getElementById('app')?.classList.toggle('awsui-visual-refresh', !vrDisabled);
 
 render(
   <HashRouter>

--- a/src/internal/hooks/use-telemetry/index.ts
+++ b/src/internal/hooks/use-telemetry/index.ts
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react';
 import { Metrics } from '../../metrics';
+import { useVisualRefresh } from '../use-visual-mode';
 
 export function useTelemetry(componentName: string) {
+  const isVisualRefresh = useVisualRefresh();
+
   useEffect(() => {
+    Metrics.initMetrics(isVisualRefresh ? 'vr' : undefined);
     if (typeof window !== 'undefined') {
       Metrics.sendMetricOnce('awsui-viewport-width', window.innerWidth || 0);
       Metrics.sendMetricOnce('awsui-viewport-height', window.innerHeight || 0);

--- a/src/internal/hooks/use-telemetry/index.ts
+++ b/src/internal/hooks/use-telemetry/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react';
+import { THEME } from '../../environment';
 import { Metrics } from '../../metrics';
 import { useVisualRefresh } from '../use-visual-mode';
 
@@ -8,7 +9,7 @@ export function useTelemetry(componentName: string) {
   const isVisualRefresh = useVisualRefresh();
 
   useEffect(() => {
-    Metrics.initMetrics(isVisualRefresh ? 'vr' : undefined);
+    Metrics.initMetrics(isVisualRefresh ? 'vr' : THEME);
     if (typeof window !== 'undefined') {
       Metrics.sendMetricOnce('awsui-viewport-width', window.innerWidth || 0);
       Metrics.sendMetricOnce('awsui-viewport-height', window.innerHeight || 0);

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -29,10 +29,13 @@ declare const AWSUI_METRIC_ORIGIN: string | undefined;
 const oneTimeMetrics: Record<string, boolean> = {};
 
 // In case we need to override the theme for VR
-let theme = THEME;
+let theme: string | undefined = undefined;
 function setTheme(newTheme: string) {
   theme = newTheme;
 }
+
+// react is the only framework we're using
+const framework = 'react';
 
 const buildMetricHash = ({ source, action }: MetricsLogItem): string => {
   return [`src${source}`, `action${action}`].join('_');
@@ -104,14 +107,9 @@ const findAWSC = (currentWindow?: MetricsWindow): AWSC | undefined => {
   }
 };
 
-// react is the only framework we're logging
-const framework = 'react';
-
 export const Metrics = {
-  initMetrics(overrideTheme?: string) {
-    if (overrideTheme) {
-      setTheme(overrideTheme);
-    }
+  initMetrics(theme: string) {
+    setTheme(theme);
   },
 
   /**
@@ -119,6 +117,11 @@ export const Metrics = {
    * Does nothing if Console Platform client logging JS is not present in page.
    */
   sendMetric(metricName: string, value: number, detail?: string): void {
+    if (!theme) {
+      // Metrics need to be initialized first (initMetrics)
+      return;
+    }
+
     if (!metricName || !/^[a-zA-Z0-9_-]{1,32}$/.test(metricName)) {
       console.error(`Invalid metric name: ${metricName}`);
       return;

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -119,6 +119,7 @@ export const Metrics = {
   sendMetric(metricName: string, value: number, detail?: string): void {
     if (!theme) {
       // Metrics need to be initialized first (initMetrics)
+      console.error('Metrics need to be initalized first.');
       return;
     }
 

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { THEME, PACKAGE_VERSION } from './environment';
+import { PACKAGE_VERSION } from './environment';
 
 export interface MetricsLogItem {
   source: string;
@@ -29,7 +29,7 @@ declare const AWSUI_METRIC_ORIGIN: string | undefined;
 const oneTimeMetrics: Record<string, boolean> = {};
 
 // In case we need to override the theme for VR
-let theme: string | undefined = undefined;
+let theme = '';
 function setTheme(newTheme: string) {
   theme = newTheme;
 }
@@ -68,7 +68,7 @@ const buildMetricDetail = ({ source, action, version }: MetricsLogItem): string 
 };
 
 const buildMetricName = ({ source, version }: MetricsLogItem): string => {
-  return ['awsui', source, `${formatVersionForMetricName(THEME, version)}`].join('_');
+  return ['awsui', source, `${formatVersionForMetricName(theme, version)}`].join('_');
 };
 
 const findPanorama = (currentWindow?: MetricsWindow): any | undefined => {

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -28,6 +28,12 @@ declare const AWSUI_METRIC_ORIGIN: string | undefined;
 
 const oneTimeMetrics: Record<string, boolean> = {};
 
+// In case we need to override the theme for VR
+let theme = THEME;
+function setTheme(newTheme: string) {
+  theme = newTheme;
+}
+
 const buildMetricHash = ({ source, action }: MetricsLogItem): string => {
   return [`src${source}`, `action${action}`].join('_');
 };
@@ -50,7 +56,7 @@ const buildMetricDetail = ({ source, action, version }: MetricsLogItem): string 
   const detailObject = {
     o: metricOrigin,
     s: source,
-    t: THEME,
+    t: theme,
     a: action,
     f: framework,
     v: formatMajorVersionForMetricDetail(version),
@@ -98,15 +104,14 @@ const findAWSC = (currentWindow?: MetricsWindow): AWSC | undefined => {
   }
 };
 
-// react is the default framework we're logging, for angular we need to set it explicitly
-let framework = 'react';
-function setFramework(fwk: string) {
-  framework = fwk;
-}
+// react is the only framework we're logging
+const framework = 'react';
 
 export const Metrics = {
-  initMetrics(fwk: string) {
-    setFramework(fwk);
+  initMetrics(overrideTheme?: string) {
+    if (overrideTheme) {
+      setTheme(overrideTheme);
+    }
   },
 
   /**

--- a/src/internal/utils/__tests__/init-metrics.test.ts
+++ b/src/internal/utils/__tests__/init-metrics.test.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Metrics } from '../../metrics';
+
+jest.mock('../../environment', () => ({ PACKAGE_VERSION: '3.0 (HEAD)' }), { virtual: true });
+
+// This test file is separate from metrics.test.ts because we want to test an uninitialized Metrics module
+describe('Metrics.initMetrics', () => {
+  beforeEach(() => {
+    window.AWSC = {
+      Clog: {
+        log: () => {},
+      },
+    };
+    jest.spyOn(window.AWSC.Clog, 'log');
+  });
+
+  test('is required before sending metrics', () => {
+    Metrics.sendMetric('name', 0);
+    expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(0);
+
+    Metrics.initMetrics('default');
+    Metrics.sendMetric('name', 0);
+    expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/internal/utils/__tests__/init-metrics.test.ts
+++ b/src/internal/utils/__tests__/init-metrics.test.ts
@@ -16,8 +16,11 @@ describe('Metrics.initMetrics', () => {
   });
 
   test('is required before sending metrics', () => {
+    const consoleSpy = jest.spyOn(console, 'error');
+
     Metrics.sendMetric('name', 0);
     expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(0);
+    expect(consoleSpy).toHaveBeenCalled();
 
     Metrics.initMetrics('default');
     Metrics.sendMetric('name', 0);

--- a/src/internal/utils/__tests__/metrics.test.ts
+++ b/src/internal/utils/__tests__/metrics.test.ts
@@ -27,6 +27,10 @@ describe('Client Metrics support', () => {
     jest.spyOn(window.AWSC.Clog, 'log');
   };
 
+  const initMetrics = () => {
+    Metrics.initMetrics('default');
+  };
+
   const definePanorama = () => {
     window.panorama = () => {};
     jest.spyOn(window, 'panorama');
@@ -47,6 +51,7 @@ describe('Client Metrics support', () => {
 
   beforeEach(() => {
     delete window.AWSC;
+    initMetrics();
   });
 
   afterEach(() => {
@@ -287,13 +292,15 @@ describe('Client Metrics support', () => {
   });
 
   describe('initMetrics', () => {
-    test('sets framework and does not log a metric', () => {
+    afterEach(() => {
+      initMetrics();
+    });
+
+    test('sets theme', () => {
       defineClog();
-      Metrics.initMetrics('DummyFrameWork');
+      Metrics.initMetrics('dummy-theme');
 
-      expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(0);
-
-      // check that the framework is correctly set
+      // check that the theme is correctly set
       Metrics.sendMetricObject(
         {
           source: 'pkg',
@@ -302,7 +309,7 @@ describe('Client Metrics support', () => {
         },
         1
       );
-      checkMetric(`awsui_pkg_d50`, ['main', 'pkg', 'default', 'used', 'DummyFrameWork', '5.0']);
+      checkMetric(`awsui_pkg_d50`, ['main', 'pkg', 'dummy-theme', 'used', 'react', '5.0']);
     });
   });
 
@@ -315,7 +322,7 @@ describe('Client Metrics support', () => {
         'DummyComponentName',
         'default',
         'used',
-        'DummyFrameWork',
+        'react',
         '3.0(HEAD)',
       ]);
     });
@@ -325,11 +332,11 @@ describe('Client Metrics support', () => {
     test('logs the component loaded metric', () => {
       defineClog();
       Metrics.logComponentLoaded();
-      checkMetric(`awsui_components_d30`, ['main', 'components', 'default', 'loaded', 'DummyFrameWork', '3.0(HEAD)']);
+      checkMetric(`awsui_components_d30`, ['main', 'components', 'default', 'loaded', 'react', '3.0(HEAD)']);
     });
   });
 
-  describe.only('sendPanoramaMetric', () => {
+  describe('sendPanoramaMetric', () => {
     test('does nothing when panorama is undefined', () => {
       Metrics.sendPanoramaMetric('name', {}); // only proves no exception thrown
     });

--- a/src/internal/utils/__tests__/metrics.test.ts
+++ b/src/internal/utils/__tests__/metrics.test.ts
@@ -1,14 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Metrics } from '../../metrics';
-jest.mock(
-  '../../environment',
-  () => ({
-    THEME: 'default',
-    PACKAGE_VERSION: '3.0 (HEAD)',
-  }),
-  { virtual: true }
-);
+
+jest.mock('../../environment', () => ({ PACKAGE_VERSION: '3.0 (HEAD)' }), { virtual: true });
 
 declare global {
   interface Window {


### PR DESCRIPTION
### Description
We want to identify the "runtime" Visual Refresh theme in the metrics, which is currently taken from the `THEME` environment variable and ignores the VR context. This change re-introduces the forgotten `initMetrics` function that overrides the metrics theme for VR.

Related links, issue #, if available: AWSUI-20010

### How has this been tested?
I have tested this locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
