### PR TITLE
fix: Select options state be announced by screen reader

### DIFF
--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -26,11 +26,7 @@ export interface DropdownStatusPropsExtended extends DropdownStatusProps {
 }
 
 function DropdownStatus({ children }: { children: React.ReactNode }) {
-  return (
-    <div className={styles.root} aria-live="polite">
-      {children}
-    </div>
-  );
+  return <div className={styles.root}>{children}</div>;
 }
 
 type UseDropdownStatus = ({

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -280,11 +280,13 @@ const InternalMultiselect = React.forwardRef(
           trigger={trigger}
           header={filter}
           onMouseDown={handleMouseDown}
-          footer={dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+          footer={dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null}
           expandToViewport={expandToViewport}
         >
           <ListComponent
-            listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+            listBottom={
+              !dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null
+            }
             menuProps={menuProps}
             getOptionProps={getOptionProps}
             filteredOptions={filteredOptions}

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -215,11 +215,13 @@ const InternalSelect = React.forwardRef(
           trigger={trigger}
           header={filter}
           onMouseDown={handleMouseDown}
-          footer={dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+          footer={dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null}
           expandToViewport={expandToViewport}
         >
           <ListComponent
-            listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+            listBottom={
+              !dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null
+            }
             menuProps={menuProps}
             getOptionProps={getOptionProps}
             filteredOptions={filteredOptions}


### PR DESCRIPTION
### Description

Dropdown footer is rendered with select and wrapped by aria-live https://github.com/cloudscape-design/components/blob/40a405bd591436179a2e1e9a4287664bc7f6582c/src/internal/components/dropdown-footer/index.tsx#L17. In order to announce the content when opening the dropdown, the content should be updated dynamically when the dropdown opens. 

Related links, issue AWSUI-19995

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
