### PR TITLE
chore: mark disableBodyScroll property as deprecated

### DIFF
--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -18,6 +18,7 @@ export interface AppLayoutProps extends BaseComponentProps {
 
   /**
    * Activates a backwards-compatibility mode for applications with non-fixed headers and footers.
+   * @deprecated This layout is being phased out and may miss some features
    */
   disableBodyScroll?: boolean;
 


### PR DESCRIPTION
### Description

This property was originally added to support legacy behaviours. Thankfully, they are gone by 2023, so we can also declare it deprecated on our end, to prevent new code with this property to be created

Related links, issue #, if available: n/a

### How has this been tested?

n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
