### PR TITLE
chore: Remove package-lock from themeable source template

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -4,7 +4,7 @@ const { parallel } = require('gulp');
 const path = require('path');
 const { writeFile, listPublicItems, listBetaVersions } = require('../utils/files');
 const themes = require('../utils/themes');
-const { task, copyTask } = require('../utils/gulp-utils');
+const { task } = require('../utils/gulp-utils');
 const workspace = require('../utils/workspace');
 const pkg = require('../../package.json');
 
@@ -87,7 +87,6 @@ module.exports = parallel([
       },
       { injectDependencies: true }
     ),
-    copyTask(`package-lock:${theme.name}`, ['package-lock.json'], theme.outputPath),
     generatePackageJson(path.join(workspace.targetPath, theme.designTokensDir), theme.designTokensPackageJson),
   ]),
   generatePackageJson(path.join(workspace.targetPath, 'components-definitions'), {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Remove the package-lock file from the template of themeable-components.

<!-- Also include relevant motivation and context. -->
AWSUI-19722

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
