### PR TITLE
chore: Remove react-resizable dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "mnth": "^2.0.0",
         "react-focus-lock": "~2.8.1",
         "react-keyed-flatten-children": "^1.3.0",
-        "react-resizable": "^1.11.1",
         "react-transition-group": "^4.4.2",
         "react-virtual": "^2.8.2",
         "tslib": "^2.4.0",
@@ -14478,18 +14477,6 @@
         "react": "^16.14.0"
       }
     },
-    "node_modules/react-draggable": {
-      "version": "4.4.5",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
     "node_modules/react-focus-lock": {
       "version": "2.8.1",
       "license": "MIT",
@@ -14517,18 +14504,6 @@
       },
       "peerDependencies": {
         "react": ">=15.0.0"
-      }
-    },
-    "node_modules/react-resizable": {
-      "version": "1.11.1",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "0.14.x || 15.x || 16.x || 17.x",
-        "react-dom": "0.14.x || 15.x || 16.x || 17.x"
       }
     },
     "node_modules/react-router": {
@@ -28182,13 +28157,6 @@
         "scheduler": "^0.19.1"
       }
     },
-    "react-draggable": {
-      "version": "4.4.5",
-      "requires": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      }
-    },
     "react-focus-lock": {
       "version": "2.8.1",
       "requires": {
@@ -28207,13 +28175,6 @@
       "version": "1.3.0",
       "requires": {
         "react-is": "^16.8.6"
-      }
-    },
-    "react-resizable": {
-      "version": "1.11.1",
-      "requires": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.0.3"
       }
     },
     "react-router": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "mnth": "^2.0.0",
     "react-focus-lock": "~2.8.1",
     "react-keyed-flatten-children": "^1.3.0",
-    "react-resizable": "^1.11.1",
     "react-transition-group": "^4.4.2",
     "react-virtual": "^2.8.2",
     "tslib": "^2.4.0",

--- a/src/code-editor/__integ__/code-editor.test.ts
+++ b/src/code-editor/__integ__/code-editor.test.ts
@@ -3,6 +3,7 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import createWrapper from '../../../lib/components/test-utils/selectors';
+import styles from '../../../lib/components/code-editor/resizable-box/styles.selectors.js';
 
 const wrapper = createWrapper();
 const codeEditorWrapper = wrapper.findCodeEditor();
@@ -38,10 +39,12 @@ class CodeEditorPageObject extends BasePageObject {
     await this.click(codeEditorWrapper.findEditor().find('.ace_error').toSelector());
   }
   async getEditorHeight() {
-    return (await this.browser.$('.react-resizable')).getSize('height');
+    const { height } = await this.getBoundingBox(`.${styles['resizable-box']}`);
+    return height;
   }
   async getEditorHeightById(elementId: string) {
-    return (await this.browser.$(`#${elementId} .react-resizable`)).getSize('height');
+    const { height } = await this.getBoundingBox(`#${elementId} .${styles['resizable-box']}`);
+    return height;
   }
   async isDisplayedInViewport(selector: string) {
     return (await this.browser.$(selector)).isDisplayedInViewport();
@@ -50,7 +53,10 @@ class CodeEditorPageObject extends BasePageObject {
     return (await this.browser.$(`#event-content`)).getText();
   }
   findHandle() {
-    return wrapper.findCodeEditor('#code-editor-controlled').find('.react-resizable > span').toSelector();
+    return wrapper
+      .findCodeEditor('#code-editor-controlled')
+      .findByClassName(styles['resizable-box-handle'])
+      .toSelector();
   }
   async dragResizer({ x: deltaX, y: deltaY }: { x: number; y: number }) {
     const handleSelector = await this.findHandle();

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -11,8 +11,9 @@ import {
   renderCodeEditor,
   annotationCallback as emulateAceAnnotationEvent,
 } from './util';
-import { ElementWrapper } from '../../../lib/components/test-utils/dom';
+import { CodeEditorWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/code-editor/styles.css.js';
+import resizableStyles from '../../../lib/components/code-editor/resizable-box/styles.css.js';
 import { warnOnce } from '../../../lib/components/internal/logging';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 
@@ -293,8 +294,8 @@ describe('Code editor component', () => {
   function findPaneItems(wrapper: ElementWrapper) {
     return wrapper.findAll(`.${styles.pane__item}`);
   }
-  function findBox(wrapper: ElementWrapper) {
-    return wrapper.findAll(`.react-resizable`);
+  function findBox(wrapper: CodeEditorWrapper) {
+    return wrapper.findByClassName(resizableStyles['resizable-box'])!;
   }
 
   it('displays annotation content', () => {
@@ -377,7 +378,7 @@ describe('Code editor component', () => {
 
     expect(wrapper.findPane()).not.toBeNull(); // Pane should open
 
-    const [item] = findPaneItems(wrapper as any);
+    const [item] = findPaneItems(wrapper.findPane()!);
     expect(item.getElement().classList).toContain(styles['pane__item--highlighted']);
 
     editorMock.on.mockRestore();
@@ -390,20 +391,28 @@ describe('Code editor component', () => {
 
   it('set defaults editor size to 480px', () => {
     const { wrapper } = renderCodeEditor();
-    const [item] = findBox(wrapper as any);
+    const item = findBox(wrapper);
     expect(item.getElement().style.height).toEqual('480px');
   });
 
   it('sets editor size to the specified editorHeight property', () => {
     const { wrapper } = renderCodeEditor({ editorContentHeight: 240 });
-    const [item] = findBox(wrapper as any);
+    const item = findBox(wrapper);
     expect(item.getElement().style.height).toEqual('240px');
   });
 
   it('sets editor size to 20px if a smaller value are specified', () => {
     const { wrapper } = renderCodeEditor({ editorContentHeight: 10 });
-    const [item] = findBox(wrapper as any);
+    const item = findBox(wrapper);
     expect(item.getElement().style.height).toEqual('20px');
+  });
+
+  it('updates size when resize handle is dragged', () => {
+    const { wrapper } = renderCodeEditor({ editorContentHeight: 10 });
+    editorMock.resize.mockClear();
+    fireEvent.mouseDown(wrapper.findByClassName(resizableStyles['resizable-box-handle'])!.getElement());
+    fireEvent.mouseMove(document.body, { clientY: 100 });
+    expect(editorMock.resize).toBeCalledTimes(1);
   });
 
   it('calls resize on initial render', () => {

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Ace } from 'ace-builds';
 import clsx from 'clsx';
-import { ResizableBox } from 'react-resizable';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 
 import { getBaseProps } from '../internal/base-component';
@@ -23,7 +22,7 @@ import {
 } from './util';
 import { fireNonCancelableEvent } from '../internal/events';
 import { setupEditor } from './setup-editor';
-import handler from './resize-handler';
+import { ResizableBox } from './resizable-box';
 import PreferencesModal from './preferences-modal';
 import LoadingScreen from './loading-screen';
 import ErrorScreen from './error-screen';
@@ -279,18 +278,12 @@ export default function CodeEditor(props: CodeEditorProps) {
       {ace && !props.loading && (
         <>
           <ResizableBox
-            className={styles['resizable-box']}
-            width={Infinity}
             height={Math.max(editorHeight, 20)}
-            minConstraints={[Infinity, 20]}
-            axis="y"
-            handle={handler}
-            onResize={(e, data) => {
-              setEditorHeight(data.size.height);
+            minHeight={20}
+            onResize={height => {
+              setEditorHeight(height);
               onResize();
-              fireNonCancelableEvent(onEditorContentResize, {
-                height: data.size.height,
-              });
+              fireNonCancelableEvent(onEditorContentResize, { height });
             }}
           >
             <div

--- a/src/code-editor/pane.tsx
+++ b/src/code-editor/pane.tsx
@@ -3,14 +3,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import FocusLock from 'react-focus-lock';
-import { ResizableBox } from 'react-resizable';
 import { Ace } from 'ace-builds';
 
 import { KeyCode } from '../internal/keycode';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 
 import { InternalButton } from '../button/internal';
-import handler from './resize-handler';
+import { ResizableBox } from './resizable-box';
 
 import styles from './styles.css.js';
 
@@ -46,6 +45,7 @@ export const Pane = ({
   cursorPositionLabel,
   closeButtonAriaLabel,
 }: PaneProps) => {
+  const [paneHeight, setPaneHeight] = useState(MIN_HEIGHT);
   const listRef = useRef<HTMLTableSectionElement>(null);
   const [isFocusTrapActive, setFocusTrapActive] = useState(false);
 
@@ -95,14 +95,7 @@ export const Pane = ({
 
   return (
     <div id={id} className={styles.pane} onKeyDown={onEscKeyDown} role="tabpanel">
-      <ResizableBox
-        className={styles['resizable-box']}
-        width={Infinity}
-        height={MIN_HEIGHT}
-        minConstraints={[Infinity, MIN_HEIGHT]}
-        axis="y"
-        handle={handler}
-      >
+      <ResizableBox height={paneHeight} minHeight={MIN_HEIGHT} onResize={newHeight => setPaneHeight(newHeight)}>
         <FocusLock
           disabled={!isFocusTrapActive}
           className={styles['focus-lock']}

--- a/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
+++ b/src/code-editor/resizable-box/__tests__/resizable-box.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ResizableBox, ResizeBoxProps } from '../../../../lib/components/code-editor/resizable-box';
+import styles from '../../../../lib/components/code-editor/resizable-box/styles.selectors.js';
+
+const defaultProps: ResizeBoxProps = {
+  height: 100,
+  minHeight: 0,
+  onResize: () => {},
+  children: 'test',
+};
+
+function findBox() {
+  return document.querySelector(`.${styles['resizable-box']}`)!;
+}
+
+function findHandle() {
+  return document.querySelector(`.${styles['resizable-box-handle']}`)!;
+}
+
+test('Height is controlled', () => {
+  const { rerender } = render(<ResizableBox {...defaultProps} />);
+  expect(findBox()).toHaveStyle({ height: '100px' });
+  rerender(<ResizableBox {...defaultProps} height={200} />);
+  expect(findBox()).toHaveStyle({ height: '200px' });
+});
+
+test('Emits resize events', () => {
+  const onResize = jest.fn();
+  render(<ResizableBox {...defaultProps} onResize={onResize} />);
+  fireEvent.mouseDown(findHandle());
+  fireEvent.mouseMove(document.body, { clientY: 80 });
+  expect(onResize).toHaveBeenCalledWith(80);
+  onResize.mockClear();
+  fireEvent.mouseMove(document.body, { clientY: 150 });
+  expect(onResize).toHaveBeenCalledWith(150);
+});
+
+test('Includes offsets into size calculation', () => {
+  const onResize = jest.fn();
+  render(<ResizableBox {...defaultProps} onResize={onResize} />);
+  findBox().getBoundingClientRect = () => ({ top: 50, bottom: 100 } as DOMRect);
+  fireEvent.mouseDown(findHandle(), { clientY: 95 });
+  fireEvent.mouseMove(document.body, { clientY: 130 });
+  // +5 offset for mouseDown position (100 - 95)
+  // -50 for container top offset
+  expect(onResize).toHaveBeenCalledWith(85); // 85 = 130 + 5 - 50
+});
+
+test('Disables selection while drag is active', () => {
+  render(<ResizableBox {...defaultProps} />);
+  fireEvent.mouseDown(findHandle());
+  expect(document.body).toHaveClass(styles['resize-active']);
+  fireEvent.mouseUp(document.body);
+  expect(document.body).not.toHaveClass(styles['resize-active']);
+});
+
+test('Does not respond to events after cursor release', () => {
+  const onResize = jest.fn();
+  render(<ResizableBox {...defaultProps} onResize={onResize} />);
+  fireEvent.mouseDown(findHandle());
+  fireEvent.mouseUp(document.body);
+  fireEvent.mouseMove(document.body, { clientY: 80 });
+  expect(onResize).not.toHaveBeenCalled();
+});
+
+test('Has no effect on other non-left mouse button clicks', () => {
+  const onResize = jest.fn();
+  render(<ResizableBox {...defaultProps} minHeight={50} onResize={onResize} />);
+  fireEvent.mouseDown(findHandle(), { button: 1 });
+  fireEvent.mouseMove(document.body, { clientY: 30 });
+  expect(onResize).not.toHaveBeenCalled();
+});
+
+test('Does not allow to go beyond min size', () => {
+  const onResize = jest.fn();
+  render(<ResizableBox {...defaultProps} minHeight={50} onResize={onResize} />);
+  fireEvent.mouseDown(findHandle());
+  fireEvent.mouseMove(document.body, { clientY: 30 });
+  expect(onResize).toHaveBeenCalledWith(50);
+});
+
+test('Does not cause state warnings after unmounting', () => {
+  const consoleMock = jest.spyOn(console, 'error');
+  function Stateful() {
+    const [height, setHeight] = useState(100);
+    return <ResizableBox {...defaultProps} height={height} onResize={height => setHeight(height)} />;
+  }
+  const { rerender } = render(<Stateful />);
+  fireEvent.mouseDown(findHandle());
+  rerender(<></>);
+  fireEvent.mouseMove(document.body, { clientY: 30 });
+  expect(consoleMock).not.toHaveBeenCalled();
+});

--- a/src/code-editor/resizable-box/index.tsx
+++ b/src/code-editor/resizable-box/index.tsx
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef, useState } from 'react';
+import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
+import styles from './styles.css.js';
+
+export interface ResizeBoxProps {
+  children: React.ReactNode;
+  height: number;
+  minHeight: number;
+  onResize: (newHeight: number) => void;
+}
+
+export function ResizableBox({ children, height, minHeight, onResize }: ResizeBoxProps) {
+  const [dragOffset, setDragOffset] = useState<null | number>(null);
+  const onResizeStable = useStableEventHandler(onResize);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onMouseDown: React.MouseEventHandler = event => {
+    if (event.button !== 0 || !containerRef.current) {
+      return;
+    }
+    const containerBottom = containerRef.current.getBoundingClientRect().bottom;
+    setDragOffset(containerBottom - event.clientY);
+  };
+
+  useEffect(() => {
+    if (dragOffset === null || !containerRef.current) {
+      return;
+    }
+    const container = containerRef.current;
+
+    const onMouseMove = (event: MouseEvent) => {
+      const { top } = container.getBoundingClientRect();
+      const cursor = event.clientY;
+      onResizeStable(Math.max(cursor + dragOffset - top, minHeight));
+    };
+    const onMouseUp = () => {
+      setDragOffset(null);
+    };
+    document.body.classList.add(styles['resize-active']);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.classList.remove(styles['resize-active']);
+    };
+  }, [dragOffset, minHeight, onResizeStable]);
+
+  return (
+    <div ref={containerRef} className={styles['resizable-box']} style={{ height }}>
+      {children}
+      <span className={styles['resizable-box-handle']} onMouseDown={onMouseDown} />
+    </div>
+  );
+}

--- a/src/code-editor/resizable-box/styles.scss
+++ b/src/code-editor/resizable-box/styles.scss
@@ -1,0 +1,37 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use '../../internal/styles/tokens' as awsui;
+@use '../background-inline-svg.scss' as utils;
+
+.resizable-box {
+  position: relative;
+  width: 100%;
+}
+
+.resizable-box-handle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 10; // above editor, when editor is overflowing
+
+  width: awsui.$space-l;
+  height: awsui.$space-l;
+
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  box-sizing: border-box;
+  background-position: bottom right;
+  background-size: awsui.$space-l;
+  @include utils.background-inline-svg(
+    $path: '../assets/resize-handler.svg',
+    $stroke: 'colorStrokeCodeEditorResizeHandler'
+  );
+
+  cursor: ns-resize;
+}
+
+.resize-active {
+  user-select: none;
+}

--- a/src/code-editor/resize-handler.tsx
+++ b/src/code-editor/resize-handler.tsx
@@ -1,9 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import React from 'react';
-
-import styles from './styles.css.js';
-
-const ResizeHandler = <span className={styles['resizable-box-handle']} />;
-
-export default ResizeHandler;

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -7,7 +7,6 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles/foundation' as foundation;
 @use '../internal/hooks/focus-visible' as focus-visible;
-@use './background-inline-svg.scss' as utils;
 @use './ace-editor';
 @use './pane';
 
@@ -17,33 +16,6 @@
   border: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-radius: awsui.$border-radius-code-editor;
   width: 100%;
-}
-
-.resizable-box {
-  position: relative;
-  width: 100%;
-}
-
-.resizable-box-handle {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  z-index: 10; // above editor, when editor is overflowing
-
-  width: awsui.$space-l;
-  height: awsui.$space-l;
-
-  background-repeat: no-repeat;
-  background-origin: content-box;
-  box-sizing: border-box;
-  background-position: bottom right;
-  background-size: awsui.$space-l;
-  @include utils.background-inline-svg(
-    $path: './assets/resize-handler.svg',
-    $stroke: 'colorStrokeCodeEditorResizeHandler'
-  );
-
-  cursor: ns-resize;
 }
 
 .editor {


### PR DESCRIPTION
### Description

This library is unmaintained and not compatible with React 18

Related links, issue #, if available: n/a

### How has this been tested?

* Locally, compared behaviors against stable release
* Added tests for most important behaviors

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
