### PR TITLE
revert: Re-release Inline Editing

### DIFF
--- a/pages/table/editable-data.ts
+++ b/pages/table/editable-data.ts
@@ -1,0 +1,268 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface TagOption {
+  label: string;
+  value: string;
+}
+
+export interface DistributionInfo {
+  Id: string;
+  ARN: string;
+  Status: string;
+  LastModifiedTime: string;
+  DomainName: string;
+  Origin: string;
+  CertificateMinVersion: string;
+  Tags: TagOption[];
+}
+
+export const originSuggestions = [
+  { value: 'aws-ui.s3.amazonaws.com' },
+  { value: 'aws-ui-browserstack.s3.amazonaws.com' },
+  { value: 'aws-ui-performance-testing.s3.amazonaws.com' },
+  { value: 'polaris.corp.amazon.com.s3.amazonaws.com' },
+];
+
+export const tlsVersions = [
+  { label: 'TLS 1.0', value: 'TLS 1.0' },
+  { label: 'TLS 1.1', value: 'TLS 1.1' },
+  { label: 'TLS 1.2', value: 'TLS 1.2' },
+  { label: 'TLS 1.3', value: 'TLS 1.3' },
+];
+
+export const tagOptions = [
+  {
+    label: 'Option 1',
+    value: '1',
+  },
+  {
+    label: 'Option 2',
+    value: '2',
+  },
+  {
+    label: 'Option 3',
+    value: '3',
+  },
+  {
+    label: 'Option 4',
+    value: '4',
+  },
+  {
+    label: 'Option 5',
+    value: '5',
+  },
+];
+
+export const initialItems: DistributionInfo[] = [
+  {
+    Id: 'EKXAM4L45YPC8',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/EKXAM4L45YPC8',
+    Status: 'Deployed',
+    LastModifiedTime: '2016-12-05T14:52:34.332Z',
+    DomainName: 'd2nwo6agzqjpi5.cloudfront.net',
+    Origin: 'aws-ui.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E2SH67AF9QONDI',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E2SH67AF9QONDI',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:26:30.958Z',
+    DomainName: 'd3tjwveh3exj5p.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [tagOptions[0]],
+  },
+  {
+    Id: 'E1DSU9EZHK1EFT',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1DSU9EZHK1EFT',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:26:48.998Z',
+    DomainName: 'd2l92xs4awobp2.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [tagOptions[1]],
+  },
+  {
+    Id: 'E3FD25X9M22KQW',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E3FD25X9M22KQW',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-03-28T14:01:59.134Z',
+    DomainName: 'df2e9lsq5eg3f.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E2XULKFU2T6A3N',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E2XULKFU2T6A3N',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-03-28T14:02:09.607Z',
+    DomainName: 'd37ojh3f70e9ly.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1KO77AQWA7TOF',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1KO77AQWA7TOF',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:27:02.160Z',
+    DomainName: 'dikexib0qpmpu.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1AD6J6WB9DBQL',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1AD6J6WB9DBQL',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:27:12.012Z',
+    DomainName: 'd20bq7uc02g87g.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1QS6YZC9T0JTD',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1QS6YZC9T0JTD',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:27:21.017Z',
+    DomainName: 'd1nr2qeg20fxwo.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E3T55WLRRILQSF',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E3T55WLRRILQSF',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-11-05T13:25:14.277Z',
+    DomainName: 'd2dtcwy61csefe.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E30T1S83X14FVG',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E30T1S83X14FVG',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-09-13T16:09:25.398Z',
+    DomainName: 'd3f1vm4iawzl4h.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E2ZXFXK3PEWUEX',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E2ZXFXK3PEWUEX',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-09-18T01:14:45.995Z',
+    DomainName: 'd3z8wfq2yxdb6.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'EUJXHSTJWEP1I',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/EUJXHSTJWEP1I',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-10-24T08:06:30.175Z',
+    DomainName: 'd12l1zncg92pjt.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'EP9HH29HEFFJN',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/EP9HH29HEFFJN',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-09T12:03:00.351Z',
+    DomainName: 'd102648o8sh00f.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1VSYI8LJ837IZ',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1VSYI8LJ837IZ',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-10T11:56:40.474Z',
+    DomainName: 'd2gxuxbgmog6e6.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E2W4EMV0NYKJ3A',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E2W4EMV0NYKJ3A',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-09T12:04:11.314Z',
+    DomainName: 'd1m0brbl2pnxzt.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'EO7WQXJVTM1ZK',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/EO7WQXJVTM1ZK',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-09T12:04:43.701Z',
+    DomainName: 'dlmh1440dha1a.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1NHT41698KCSA',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1NHT41698KCSA',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-04T10:29:11.944Z',
+    DomainName: 'ds6krf2a9jh8h.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'EAR97EDHDJM3Q',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/EAR97EDHDJM3Q',
+    Status: 'Deployed',
+    LastModifiedTime: '2020-05-25T16:15:18.456Z',
+    DomainName: 'd20kr5jeroe2r9.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E1H3C2KSX7G7GH',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E1H3C2KSX7G7GH',
+    Status: 'Deployed',
+    LastModifiedTime: '2019-12-14T11:08:33.882Z',
+    DomainName: 'd2w44xc1hxiel9.cloudfront.net',
+    Origin: 'aws-ui-performance-testing.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'E3T0B2OABO7PQN',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/E3T0B2OABO7PQN',
+    Status: 'Deployed',
+    LastModifiedTime: '2020-01-06T09:53:44.650Z',
+    DomainName: 'd27banjocfuo3h.cloudfront.net',
+    Origin: 'aws-ui-browserstack.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+  {
+    Id: 'ECXBLT0NPVL3',
+    ARN: 'arn:aws:cloudfront::982970425367:distribution/ECXBLT0NPVL3',
+    Status: 'Deployed',
+    LastModifiedTime: '2020-03-11T16:36:03.384Z',
+    DomainName: 'd3ocvvlf9b34fa.cloudfront.net',
+    Origin: 'polaris.corp.amazon.com.s3.amazonaws.com',
+    CertificateMinVersion: 'TLS 1.0',
+    Tags: [],
+  },
+];

--- a/pages/table/editable-utils.tsx
+++ b/pages/table/editable-utils.tsx
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import HelpPanel from '~components/help-panel';
+
+export function HelpContent() {
+  return (
+    <HelpPanel header="How to use the demo">
+      <h3>Client-side validation</h3>
+      <ul>
+        <li>&quot;Domain name&quot; column does not allow spaces</li>
+      </ul>
+      <h3>Server side validation</h3>
+      <ul>
+        <li>Submit the codeword &quot;inline&quot; to show validation message inline</li>
+      </ul>
+    </HelpPanel>
+  );
+}

--- a/pages/table/editable-with-app-layout.page.tsx
+++ b/pages/table/editable-with-app-layout.page.tsx
@@ -1,0 +1,344 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { ForwardedRef, forwardRef, useEffect, useRef, useState } from 'react';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import Input from '~components/input';
+import Alert from '~components/alert';
+import BreadcrumbGroup from '~components/breadcrumb-group';
+import Table, { TableProps } from '~components/table';
+import Select, { SelectProps } from '~components/select';
+import TimeInput, { TimeInputProps } from '~components/time-input';
+import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
+import Multiselect, { MultiselectProps } from '~components/multiselect';
+import { Link, Box, Button, Modal, SpaceBetween } from '~components';
+import { initialItems, DistributionInfo, tlsVersions, originSuggestions, tagOptions } from './editable-data';
+import { HelpContent } from './editable-utils';
+
+let __editStateDirty = false;
+
+// Passes for any valid (fq) domain name including punycode
+// https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html
+const DOMAIN_NAME = /^\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b$/i;
+
+export const ariaLabels: TableProps.AriaLabels<DistributionInfo> = {
+  tableLabel: 'Distributions',
+  activateEditLabel: column => `Edit ${column.header}`,
+  cancelEditLabel: column => `Cancel editing ${column.header}`,
+  submitEditLabel: column => `Submit edit ${column.header}`,
+};
+
+const withSideEffect =
+  (sideEffect: () => void) =>
+  <T extends (...args: any[]) => void>(fn: T) =>
+  (...args: Parameters<T>) => {
+    sideEffect();
+    return fn(...args);
+  };
+
+const setDirty = () => {
+  __editStateDirty = true;
+};
+const setClean = () => {
+  __editStateDirty = false;
+};
+
+const withDirtyState = withSideEffect(setDirty);
+const withCleanState = withSideEffect(setClean);
+
+const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
+  {
+    id: 'Id',
+    header: 'Distribution ID',
+    sortingField: 'Id',
+    width: 180,
+    cell: (item: DistributionInfo) => <Link href={`/#/distributions/${item.Id}`}>{item.Id}</Link>,
+  },
+  {
+    id: 'DomainName',
+    header: 'Domain name',
+    minWidth: 180,
+    editConfig: {
+      ariaLabel: 'Domain name',
+      editIconAriaLabel: 'editable',
+      errorIconAriaLabel: 'Domain Name Error',
+      validation(item, value: string) {
+        const currentValue = value ?? item.DomainName;
+        if (!DOMAIN_NAME.test(currentValue)) {
+          return 'Must be a valid domain name';
+        }
+        if (errorsMeta.get(item)) {
+          return errorsMeta.get(item);
+        }
+      },
+    },
+    cell(item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) {
+      if (isEditing) {
+        return (
+          <Input
+            autoFocus={true}
+            value={currentValue ?? item.DomainName}
+            onChange={withDirtyState(event => setValue(event.detail.value))}
+          />
+        );
+      }
+
+      return item.DomainName;
+    },
+  },
+  {
+    id: 'Status',
+    header: 'Status',
+    minWidth: 176,
+    cell: (item: DistributionInfo) => item.Status,
+  },
+  {
+    id: 'Origin',
+    header: 'Origin',
+    minWidth: 200,
+    editConfig: {
+      ariaLabel: 'Origin',
+      editIconAriaLabel: 'editable',
+    },
+    cell: (item, { isEditing, setValue, currentValue }: TableProps.CellContext<string>) => {
+      if (isEditing) {
+        return (
+          <Autosuggest
+            autoFocus={true}
+            value={currentValue ?? item.Origin}
+            onChange={withDirtyState<NonNullable<AutosuggestProps['onChange']>>(event => setValue(event.detail.value))}
+            options={originSuggestions}
+            enteredTextLabel={value => `Use Custom Origin "${value}"`}
+            expandToViewport={true}
+            ariaLabel="Origin Domain"
+            placeholder="Enter an origin domain name"
+          />
+        );
+      }
+      return item.Origin;
+    },
+  },
+  {
+    id: 'CertificateMinVersion',
+    header: 'TLS Version',
+    minWidth: 176,
+    editConfig: {
+      ariaLabel: 'Certificate Minimum Version',
+      editIconAriaLabel: 'editable',
+    },
+    cell(item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) {
+      if (isEditing) {
+        const value = currentValue ?? item.CertificateMinVersion;
+
+        return (
+          <Select
+            autoFocus={true}
+            selectedOption={tlsVersions.find(option => option.value === value) ?? null}
+            onChange={withDirtyState<NonNullable<SelectProps['onChange']>>(event => {
+              setValue(event.detail.selectedOption.value ?? item.CertificateMinVersion);
+            })}
+            options={tlsVersions}
+          />
+        );
+      }
+
+      return item.CertificateMinVersion;
+    },
+  },
+  {
+    id: 'LastModifiedTime',
+    header: 'Last Modified',
+    editConfig: {
+      ariaLabel: 'Last Modified',
+      editIconAriaLabel: 'editable',
+    },
+    cell: (item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) => {
+      const time = new Date(item.LastModifiedTime);
+      const value = [time.getHours(), time.getMinutes()].map(part => part.toString().padStart(2, '0')).join(':');
+      if (isEditing) {
+        return (
+          <TimeInput
+            autoFocus={true}
+            format="hh:mm"
+            value={currentValue ?? value}
+            onChange={withDirtyState<NonNullable<TimeInputProps['onChange']>>(event => {
+              setValue(event.detail.value);
+            })}
+          />
+        );
+      }
+
+      return value;
+    },
+  },
+  {
+    id: 'Tags',
+    header: 'Tags',
+    minWidth: 200,
+    editConfig: {
+      ariaLabel: 'Tags',
+      editIconAriaLabel: 'editable',
+    },
+    cell(item, { isEditing, setValue, currentValue }: TableProps.CellContext<MultiselectProps.Options>) {
+      const value = currentValue ?? (item.Tags as MultiselectProps.Options);
+      if (isEditing) {
+        return (
+          <Box padding={{ vertical: 'xxs' }}>
+            <Multiselect
+              autoFocus={true}
+              selectedOptions={value}
+              onChange={withDirtyState<NonNullable<MultiselectProps['onChange']>>(event => {
+                setValue(event.detail.selectedOptions);
+              })}
+              options={tagOptions}
+              placeholder="Choose options"
+              selectedAriaLabel="Selected"
+              deselectAriaLabel={e => `Remove ${e.label}`}
+            />
+          </Box>
+        );
+      }
+      return value.map(tag => tag.label).join(', ');
+    },
+  },
+];
+
+let errorsMeta = new WeakMap<DistributionInfo, string>();
+
+const Demo = forwardRef(
+  (
+    { setModalVisible }: { setModalVisible: React.Dispatch<React.SetStateAction<boolean>> },
+    tableRef: ForwardedRef<TableProps.Ref>
+  ) => {
+    const [items, setItems] = useState(initialItems);
+
+    const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo, string> = async (
+      currentItem,
+      column,
+      newValue
+    ) => {
+      let value = newValue;
+      await new Promise(r => setTimeout(r, 1000));
+      errorsMeta.delete(currentItem);
+      if (value === 'inline') {
+        errorsMeta.set(currentItem, 'Server does not accept this value, try another');
+        throw new Error('Inline error');
+      }
+      if (
+        column.id === 'LastModifiedTime' &&
+        (new Date(value).toString() === 'Invalid Date' || !isNaN(+new Date(value)))
+      ) {
+        const time = new Date(currentItem.LastModifiedTime);
+        const [hours, minutes] = value.split(':').map(Number);
+        time.setHours(hours);
+        time.setMinutes(minutes);
+        value = time.toISOString();
+      }
+
+      const newItem = { ...currentItem, [column.id as keyof DistributionInfo]: value };
+
+      setItems(items => items.map(item => (item === currentItem ? newItem : item)));
+      setClean();
+    };
+
+    return (
+      <Table
+        variant="full-page"
+        ref={tableRef}
+        header={
+          <Header variant="awsui-h1-sticky" counter={`(${items.length})`}>
+            Distributions
+          </Header>
+        }
+        stickyHeader={true}
+        submitEdit={handleSubmit}
+        onEditCancel={evt => {
+          if (__editStateDirty) {
+            evt.preventDefault();
+            setModalVisible(true);
+          }
+          errorsMeta = new WeakMap();
+        }}
+        columnDefinitions={columns}
+        items={items}
+        resizableColumns={true}
+        ariaLabels={ariaLabels}
+      />
+    );
+  }
+);
+
+export default function () {
+  const [modalVisible, setModalVisible] = useState(false);
+  const tableRef = useRef<TableProps.Ref>(null);
+
+  const onBeforeUnload = (evt: BeforeUnloadEvent) => {
+    if (__editStateDirty) {
+      evt.preventDefault();
+      evt.returnValue = '';
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  });
+
+  return (
+    <AppLayout
+      contentType="table"
+      navigationHide={true}
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'AWS-UI Demos', href: '#' },
+            { text: 'Editable table', href: '#' },
+          ]}
+        />
+      }
+      ariaLabels={{
+        navigation: 'Side navigation',
+        navigationToggle: 'Open navigation',
+        navigationClose: 'Close navigation',
+        notifications: 'Notifications',
+        tools: 'Tools',
+        toolsToggle: 'Open tools',
+        toolsClose: 'Close tools',
+      }}
+      tools={<HelpContent />}
+      content={
+        <>
+          <Demo setModalVisible={setModalVisible} ref={tableRef} />
+          <Modal
+            visible={modalVisible}
+            header="Discard changes"
+            closeAriaLabel="Close modal"
+            onDismiss={withCleanState(() => setModalVisible(false))}
+            footer={
+              <Box float="right">
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Button variant="link" onClick={withCleanState(() => setModalVisible(false))}>
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={withCleanState(() => {
+                      setModalVisible(false);
+                      tableRef.current?.cancelEdit?.();
+                    })}
+                  >
+                    Discard
+                  </Button>
+                </SpaceBetween>
+              </Box>
+            }
+          >
+            <Alert type="warning" statusIconAriaLabel="Warning">
+              Are you sure you want to discard any unsaved changes?
+            </Alert>
+          </Modal>
+        </>
+      }
+    />
+  );
+}

--- a/pages/table/editable-with-app-layout.page.tsx
+++ b/pages/table/editable-with-app-layout.page.tsx
@@ -212,11 +212,7 @@ const Demo = forwardRef(
   ) => {
     const [items, setItems] = useState(initialItems);
 
-    const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo, string> = async (
-      currentItem,
-      column,
-      newValue
-    ) => {
+    const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo> = async (currentItem, column, newValue) => {
       let value = newValue;
       await new Promise(r => setTimeout(r, 1000));
       errorsMeta.delete(currentItem);
@@ -226,6 +222,7 @@ const Demo = forwardRef(
       }
       if (
         column.id === 'LastModifiedTime' &&
+        typeof value === 'string' &&
         (new Date(value).toString() === 'Invalid Date' || !isNaN(+new Date(value)))
       ) {
         const time = new Date(currentItem.LastModifiedTime);

--- a/pages/table/tall-rows.page.tsx
+++ b/pages/table/tall-rows.page.tsx
@@ -16,13 +16,13 @@ export default function () {
 
   const tallItemsConfig: TableProps.ColumnDefinition<Instance>[] = columnsConfig.map((config, index) => ({
     ...config,
-    cell: (item: Instance) =>
+    cell: (item, ...rest) =>
       index === 0 ? (
         <Link onFollow={() => setClicks(prev => prev + 1)}>{item.id}</Link>
       ) : (
         <ul>
           {range(0, 20).map(index => {
-            return <li key={index}>{(config.cell as TableProps.CellRenderer<Instance>)(item)}</li>;
+            return <li key={index}>{config.cell(item, ...rest)}</li>;
           })}
         </ul>
       ),

--- a/pages/table/tall-rows.page.tsx
+++ b/pages/table/tall-rows.page.tsx
@@ -16,14 +16,14 @@ export default function () {
 
   const tallItemsConfig: TableProps.ColumnDefinition<Instance>[] = columnsConfig.map((config, index) => ({
     ...config,
-    cell: (item: any) =>
+    cell: (item: Instance) =>
       index === 0 ? (
         <Link onFollow={() => setClicks(prev => prev + 1)}>{item.id}</Link>
       ) : (
         <ul>
-          {range(0, 20).map(index => (
-            <li key={index}>{config.cell(item)}</li>
-          ))}
+          {range(0, 20).map(index => {
+            return <li key={index}>{(config.cell as TableProps.CellRenderer<Instance>)(item)}</li>;
+          })}
         </ul>
       ),
   }));

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10886,6 +10886,12 @@ including the hidden via preferences columns. Use this event to persist the colu
       "name": "onColumnWidthsChange",
     },
     Object {
+      "cancelable": true,
+      "description": "Called whenever user cancels an inline edit. Use this function to reset any
+validation states, or show warning for unsaved changes.",
+      "name": "onEditCancel",
+    },
+    Object {
       "cancelable": false,
       "description": "Note: This feature is provided for backwards compatibility. Its use is not recommended,
 and it may be deprecated in the future.
@@ -10992,6 +10998,12 @@ The event detail contains the current sortingColumn and isDescending.",
   ],
   "functions": Array [
     Object {
+      "description": "Dismiss an inline edit if currently active.",
+      "name": "cancelEdit",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+    Object {
       "description": "When the sticky header is enabled and you call this function, the table
 scroll parent scrolls to reveal the first row of the table.",
       "name": "scrollToTop",
@@ -11007,20 +11019,36 @@ scroll parent scrolls to reveal the first row of the table.",
 * \`allItemsSelectionLabel\` ((SelectionState) => string) - Specifies the alternative text for multi-selection column header.
 * \`selectionGroupLabel\` (string) - Specifies the alternative text for the whole selection and single-selection column header.
                                    It is prefixed to \`itemSelectionLabel\` and \`allItemsSelectionLabel\` when they are set.
-* \`tableLabel\` (string) - Provides a alternative text for the table. If you use a header for this table, you may reuse the string
+* \`tableLabel\` (string) - Provides an alternative text for the table. If you use a header for this table, you may reuse the string
                           to provide a caption-like description. For example, tableLabel=Instances will be announced as 'Instances table'.
 You can use the first argument of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The \`itemSelectionLabel\` for individual
 items also receives the corresponding  \`Item\` object. You can use the \`selectionGroupLabel\` to
 add a meaningful description to the whole selection.
+* \`activateEditLabel\` (EditableColumnDefinition) => string -
+                     Specifies an alternative text for the edit button in editable cells.
+* \`cancelEditLabel\` (EditableColumnDefinition) => string -
+                     Specifies an alternative text for the cancel button in editable cells.
+* \`submitEditLabel\` (EditableColumnDefinition) => string -
+                     Specifies an alternative text for the submit button in editable cells.
 ",
       "inlineType": Object {
         "name": "TableProps.AriaLabels",
         "properties": Array [
           Object {
+            "name": "activateEditLabel",
+            "optional": true,
+            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+          },
+          Object {
             "name": "allItemsSelectionLabel",
             "optional": true,
             "type": "(data: TableProps.SelectionState<T>) => string",
+          },
+          Object {
+            "name": "cancelEditLabel",
+            "optional": true,
+            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
           },
           Object {
             "name": "itemSelectionLabel",
@@ -11033,6 +11061,11 @@ add a meaningful description to the whole selection.
             "type": "string",
           },
           Object {
+            "name": "submitEditLabel",
+            "optional": true,
+            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+          },
+          Object {
             "name": "tableLabel",
             "optional": true,
             "type": "string",
@@ -11042,7 +11075,7 @@ add a meaningful description to the whole selection.
       },
       "name": "ariaLabels",
       "optional": true,
-      "type": "TableProps.AriaLabels<T>",
+      "type": "TableProps.AriaLabels<T, V>",
     },
     Object {
       "description": "Adds the specified classes to the root element of the component.",
@@ -11063,7 +11096,8 @@ add a meaningful description to the whole selection.
   fills the remaining space of the table so the specified width is ignored.
 * \`minWidth\` (string | number) - Specifies the minimum column width. Corresponds to the \`min-width\` css-property. When
   \`resizableColumns\` property is set to \`true\`, additional constraints apply: 1) string values are not allowed,
-  and 2) the column can't resize below than the specified width (defaults to \\"120px\\").
+  and 2) the column can't resize below than the specified width (defaults to \\"120px\\"). We recommend that you set a minimum width
+  of at least 176px for columns that are editable.
 * \`maxWidth\` (string | number) - Specifies the maximum column width. Corresponds to the \`max-width\` css-property.
   Note that when the \`resizableColumns\` property is set to \`true\` this property is ignored.
 * \`ariaLabel\` (LabelData => string) - An optional function that's called to provide an \`aria-label\` for the cell header.
@@ -11077,10 +11111,17 @@ add a meaningful description to the whole selection.
 * \`sortingComparator\` ((T, T) => number) - Enables custom column sorting. The value is used in [collection hooks](/get-started/dev-guides/collection-hooks/)
   to reorder the items. This property accepts a custom comparator that is used to compare two items.
   The comparator must implement ascending ordering, and the output is inverted automatically in case of descending order.
-  If present, the \`sortingField\` property is ignored.",
+  If present, the \`sortingField\` property is ignored.
+* \`editConfig\` (EditConfig) - Enables inline editing in column when present. The value is used to configure the editing behavior.
+* * \`editConfig.ariaLabel\` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
+* * \`editConfig.errorIconAriaLabel\` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
+* * \`editConfig.editIconAriaLabel\` (string) - Specifies an alternate text for the edit icon used in column header.
+* * \`editConfig.constraintText\` (string) - Constraint text that is displayed below the edit control.
+* * \`editConfig.validation\` ((item, value) => string) - A function that allows you to validate the value of the edit control.
+           Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.",
       "name": "columnDefinitions",
       "optional": false,
-      "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",
+      "type": "ReadonlyArray<TableProps.ColumnDefinition<T, V>>",
     },
     Object {
       "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
@@ -11221,6 +11262,32 @@ need to position the sticky header below other fixed position elements on the pa
       "name": "stripedRows",
       "optional": true,
       "type": "boolean",
+    },
+    Object {
+      "description": "Specifies a function that will be called after user submits an inline edit.
+Return a promise to keep loading state while the submit request is in progress.",
+      "inlineType": Object {
+        "name": "TableProps.SubmitEditFunction",
+        "parameters": Array [
+          Object {
+            "name": "item",
+            "type": "ItemType",
+          },
+          Object {
+            "name": "column",
+            "type": "TableProps.ColumnDefinition<ItemType, ValueType>",
+          },
+          Object {
+            "name": "newValue",
+            "type": "ValueType",
+          },
+        ],
+        "returnType": "Promise<void> | void",
+        "type": "function",
+      },
+      "name": "submitEdit",
+      "optional": true,
+      "type": "TableProps.SubmitEditFunction<T, V>",
     },
     Object {
       "description": "Use this property to inform screen readers how many items there are in a table.

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11038,7 +11038,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "allItemsSelectionLabel",
@@ -11048,7 +11048,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "cancelEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "itemSelectionLabel",
@@ -11063,7 +11063,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "submitEditLabel",
             "optional": true,
-            "type": "(column: TableProps.EditableColumnDefinition<T, V>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>) => string",
           },
           Object {
             "name": "tableLabel",
@@ -11075,7 +11075,7 @@ add a meaningful description to the whole selection.
       },
       "name": "ariaLabels",
       "optional": true,
-      "type": "TableProps.AriaLabels<T, V>",
+      "type": "TableProps.AriaLabels<T>",
     },
     Object {
       "description": "Adds the specified classes to the root element of the component.",
@@ -11121,7 +11121,7 @@ add a meaningful description to the whole selection.
            Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.",
       "name": "columnDefinitions",
       "optional": false,
-      "type": "ReadonlyArray<TableProps.ColumnDefinition<T, V>>",
+      "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",
     },
     Object {
       "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
@@ -11275,7 +11275,7 @@ Return a promise to keep loading state while the submit request is in progress."
           },
           Object {
             "name": "column",
-            "type": "TableProps.ColumnDefinition<ItemType, ValueType>",
+            "type": "TableProps.ColumnDefinition<ItemType>",
           },
           Object {
             "name": "newValue",
@@ -11287,7 +11287,7 @@ Return a promise to keep loading state while the submit request is in progress."
       },
       "name": "submitEdit",
       "optional": true,
-      "type": "TableProps.SubmitEditFunction<T, V>",
+      "type": "TableProps.SubmitEditFunction<T>",
     },
     Object {
       "description": "Use this property to inform screen readers how many items there are in a table.

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -18,6 +18,7 @@ type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   __nativeAttributes?: Record<string, any>;
   __iconClass?: string;
   __activated?: boolean;
+  __hideFocusOutline?: boolean;
 } & InternalBaseComponentProps;
 
 export const InternalButton = React.forwardRef(
@@ -43,6 +44,7 @@ export const InternalButton = React.forwardRef(
       formAction = 'submit',
       ariaLabel,
       ariaExpanded,
+      __hideFocusOutline = false,
       __nativeAttributes,
       __internalRootRef = null,
       __activated = false,
@@ -85,7 +87,7 @@ export const InternalButton = React.forwardRef(
 
     const buttonProps = {
       ...props,
-      ...focusVisible,
+      ...(__hideFocusOutline ? undefined : focusVisible),
       ...__nativeAttributes,
       // https://github.com/microsoft/TypeScript/issues/36659
       ref: useMergeRefs(buttonRef as any, __internalRootRef),

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -86,4 +86,16 @@ export interface InternalFormFieldProps extends FormFieldProps, InternalBaseComp
    * Visually hide the label.
    */
   __hideLabel?: boolean;
+
+  /**
+   * Disable the gutter applied by default.
+   */
+  __disableGutters?: boolean;
+
+  /**
+   * Use a React based implementation of the autofocus behavior. This is to prevent scroll jumps
+   * when the autofocus behavior is triggered. Built-in browser autofocus behavior seems to
+   * trigger a scroll jump even when the element is already in the viewport.
+   */
+  __useReactAutofocus?: boolean;
 }

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -46,6 +46,8 @@ export default function InternalFormField({
   errorText,
   __hideLabel,
   __internalRootRef = null,
+  __disableGutters = false,
+  __useReactAutofocus = false,
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
@@ -71,6 +73,7 @@ export default function InternalFormField({
     ariaLabelledby: joinStrings(parentAriaLabelledby, slotIds.label) || undefined,
     ariaDescribedby: joinStrings(parentAriaDescribedby, ariaDescribedBy) || undefined,
     invalid: !!errorText || !!parentInvalid,
+    __useReactAutofocus,
   };
 
   return (
@@ -91,7 +94,7 @@ export default function InternalFormField({
       )}
 
       <div className={clsx(styles.controls, __hideLabel && styles['label-hidden'])}>
-        <InternalGrid gridDefinition={gridDefinition}>
+        <InternalGrid gridDefinition={gridDefinition} disableGutters={__disableGutters}>
           <FormFieldContext.Provider
             value={{
               controlId: generatedControlId,

--- a/src/input/__tests__/internal.test.tsx
+++ b/src/input/__tests__/internal.test.tsx
@@ -62,3 +62,14 @@ test('overrides form-field properties', () => {
   expect(element).toHaveAttribute('aria-describedby', 'description');
   expect(element).not.toHaveAttribute('aria-invalid');
 });
+
+test('internal autoFocus implementation triggers focus on mount', () => {
+  render(
+    <InternalFormField __useReactAutofocus={true}>
+      <InternalInput value="" autoFocus={true} __inheritFormFieldProps={true} />
+    </InternalFormField>
+  );
+  const element = createWrapper().find('input')!.getElement();
+  expect(element).toHaveFocus();
+  expect(element).toHaveAttribute('data-awsui-react-autofocus', 'true');
+});

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { MouseEventHandler, Ref, useRef } from 'react';
+import React, { MouseEventHandler, Ref, useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { IconProps } from '../icon/interfaces';
@@ -99,7 +99,14 @@ function InternalInput(
   __onRightIconClick = __onRightIconClick ?? searchProps.__onRightIconClick;
 
   const formFieldContext = useFormFieldContext(rest);
-  const { ariaLabelledby, ariaDescribedby, controlId, invalid } = __inheritFormFieldProps ? formFieldContext : rest;
+  const { ariaLabelledby, ariaDescribedby, controlId, invalid, __useReactAutofocus } = __inheritFormFieldProps
+    ? formFieldContext
+    : { __useReactAutofocus: undefined, ...rest };
+
+  const autoFocusEnabled = __nativeAttributes?.autoFocus || autoFocus;
+  const reactAutofocusProps = __useReactAutofocus
+    ? { autoFocus: !autoFocusEnabled, 'data-awsui-react-autofocus': autoFocusEnabled }
+    : {};
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
@@ -138,6 +145,7 @@ function InternalInput(
     },
     onFocus: onFocus && (() => fireNonCancelableEvent(onFocus)),
     ...__nativeAttributes,
+    ...reactAutofocusProps,
   };
 
   if (type === 'number') {
@@ -167,6 +175,12 @@ function InternalInput(
   if (attributes.type === 'visualSearch') {
     attributes.type = 'text';
   }
+
+  useEffect(() => {
+    if (__useReactAutofocus && autoFocusEnabled) {
+      inputRef.current?.focus({ preventScroll: true });
+    }
+  }, [__useReactAutofocus, autoFocusEnabled]);
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles['input-container'])} ref={__internalRootRef}>

--- a/src/internal/context/form-field-context.ts
+++ b/src/internal/context/form-field-context.ts
@@ -47,7 +47,11 @@ export interface FormFieldValidationControlProps extends FormFieldControlProps {
   invalid?: boolean;
 }
 
-export const FormFieldContext = createContext<FormFieldValidationControlProps>({});
+interface InternalFormFieldControlProps extends FormFieldValidationControlProps {
+  __useReactAutofocus?: boolean;
+}
+
+export const FormFieldContext = createContext<InternalFormFieldControlProps>({});
 
 function applyDefault<T>(fields: T, defaults: T, keys: (keyof T)[]) {
   const result = <T>{};
@@ -59,5 +63,11 @@ function applyDefault<T>(fields: T, defaults: T, keys: (keyof T)[]) {
 
 export function useFormFieldContext(props: FormFieldValidationControlProps) {
   const context = useContext(FormFieldContext);
-  return applyDefault(props, context, ['invalid', 'controlId', 'ariaLabelledby', 'ariaDescribedby']);
+  return applyDefault<InternalFormFieldControlProps>(props, context, [
+    'invalid',
+    'controlId',
+    'ariaLabelledby',
+    'ariaDescribedby',
+    '__useReactAutofocus',
+  ]);
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 /**
  * Makes specified properties required.
  *
@@ -17,3 +16,13 @@
 export type SomeRequired<Type, Keys extends keyof Type> = Type & {
   [Key in Keys]-?: Type[Key];
 };
+
+/**
+ * Utility type that makes a union of given type and undefined.
+ * @example
+ * ```
+ * type OptionalString = Optional<string>
+ * type OptionalStringOrNumber = Optional<string | number>
+ * ```
+ */
+export type Optional<Type> = Type | undefined;

--- a/src/select/parts/styles.scss
+++ b/src/select/parts/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
+@use '../../internal/hooks/focus-visible' as focus-visible;
 
 .placeholder {
   @include styles.form-placeholder;
@@ -36,6 +37,14 @@ $checkbox-size: awsui.$size-control;
 
 .trigger {
   @include styles.text-overflow-ellipsis;
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(
+      (
+        'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),
+        'horizontal': calc(-1 * #{awsui.$space-scaled-xs}),
+      )
+    );
+  }
 }
 
 .layout-strut {

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+const DOMAIN_ERROR = 'Must be a valid domain name';
+const tableWrapper = createWrapper().findTable()!;
+
+// $ = selector
+const EDIT_BTN$ = 'button:first-child:last-child';
+
+const bodyCell = tableWrapper.findBodyCell(2, 2)!;
+const cellRoot$ = bodyCell.toSelector();
+const cellInputField$ = bodyCell.findFormField().find('input').toSelector();
+const cellEditButton$ = bodyCell.find(EDIT_BTN$).toSelector();
+const cellSaveButton = tableWrapper.findEditingCellSaveButton();
+
+// for arrow key navigation
+const mainCell = tableWrapper.findBodyCell(4, 5);
+const mainCell$ = mainCell.toSelector();
+const leftCell$ = tableWrapper.findBodyCell(4, 4).find(EDIT_BTN$).toSelector();
+const rightCell$ = tableWrapper.findBodyCell(4, 6).find(EDIT_BTN$).toSelector();
+const cellAbove$ = tableWrapper.findBodyCell(3, 5).find(EDIT_BTN$).toSelector();
+const cellBelow$ = tableWrapper.findBodyCell(5, 5).find(EDIT_BTN$).toSelector();
+
+const bodyCellError = bodyCell.findFormField().findError().toSelector();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await page.setWindowSize({ width: 1200, height: 800 });
+    await browser.url('#/light/table/editable-with-app-layout');
+    await testFn(page);
+  });
+};
+
+test(
+  'input field is displayed when editable cell is clicked',
+  setupTest(async page => {
+    const value = await page.getText(cellRoot$);
+    await page.click(cellRoot$);
+    await expect(page.getValue(cellInputField$)).resolves.toBe(value);
+  })
+);
+
+test(
+  'errorText is displayed when input field is invalid',
+  setupTest(async page => {
+    await page.click(cellRoot$);
+    await page.setValue(cellInputField$, 'xyz .com'); // space is not allowed
+    await expect(page.getText(bodyCellError)).resolves.toBe(DOMAIN_ERROR);
+  })
+);
+
+test(
+  'cell is focused after edit is submitted',
+  setupTest(async page => {
+    await page.click(cellRoot$);
+    await page.click(cellSaveButton.toSelector());
+    await expect(page.isFocused(cellEditButton$)).resolves.toBe(true);
+  })
+);
+
+test(
+  'cell focus is moved when arrow keys are pressed',
+  setupTest(async page => {
+    await page.click(mainCell$);
+    await page.click(cellSaveButton.toSelector());
+    await page.keys(['ArrowRight']);
+    await expect(page.isFocused(rightCell$)).resolves.toBe(true);
+    await page.keys(['ArrowLeft', 'ArrowLeft']);
+    await expect(page.isFocused(leftCell$)).resolves.toBe(true);
+    await page.keys(['ArrowRight', 'ArrowUp']);
+    await expect(page.isFocused(cellAbove$)).resolves.toBe(true);
+    await page.keys(['ArrowDown', 'ArrowDown']);
+    await expect(page.isFocused(cellBelow$)).resolves.toBe(true);
+  })
+);

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -57,6 +57,36 @@ const TestComponent = ({ isEditing = false }) => {
   );
 };
 
+const TestComponent2 = ({ column }: any) => {
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <TableBodyCell<typeof testItem>
+            column={column}
+            item={testItem}
+            isEditing={false}
+            onEditStart={onEditStart}
+            onEditEnd={onEditEnd}
+            ariaLabels={{
+              activateEditLabel: () => 'activate edit',
+              cancelEditLabel: () => 'cancel edit',
+              submitEditLabel: () => 'submit edit',
+            }}
+            isEditable={false}
+            isPrevSelected={false}
+            isNextSelected={false}
+            isFirstRow={true}
+            isLastRow={true}
+            isSelected={false}
+            wrapLines={false}
+          />
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
 describe('TableBodyCell', () => {
   it('should render', () => {
     const { container } = render(<TestComponent />);
@@ -87,5 +117,18 @@ describe('TableBodyCell', () => {
     fireEvent.change(container.querySelector('input')!, { target: { value: 'test2' } });
     fireEvent.click(screen.getByRole('button', { name: 'cancel edit' }));
     expect(onEditEnd).toHaveBeenCalled();
+  });
+
+  it('should render with fallback state', () => {
+    const col: typeof column = {
+      ...column,
+      cell: (_item, { isEditing, setValue, currentValue }) => {
+        expect(isEditing).toBe(false);
+        expect(setValue).toBeInstanceOf(Function);
+        expect(currentValue).toBeUndefined();
+        return _item.test;
+      },
+    };
+    render(<TestComponent2 column={col} />);
   });
 });

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -9,14 +9,14 @@ const testItem = {
   test: 'test',
 };
 
-const column: TableProps.ColumnDefinition<typeof testItem, string> = {
+const column: TableProps.ColumnDefinition<typeof testItem> = {
   id: 'test',
   header: 'Test',
   editConfig: {
     ariaLabel: 'test input',
     editIconAriaLabel: 'error',
   },
-  cell: (item, { isEditing, setValue, currentValue }) => {
+  cell: (item, { isEditing, setValue, currentValue }: TableProps.CellContext<any>) => {
     if (isEditing) {
       return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
     }
@@ -32,7 +32,7 @@ const TestComponent = ({ isEditing = false }) => {
     <table>
       <tbody>
         <tr>
-          <TableBodyCell<typeof testItem, string>
+          <TableBodyCell<typeof testItem>
             column={column}
             item={testItem}
             isEditing={isEditing}

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { TableBodyCell } from '../../../lib/components/table/body-cell';
+import { TableProps } from '../interfaces';
+
+const testItem = {
+  test: 'test',
+};
+
+const column: TableProps.ColumnDefinition<typeof testItem, string> = {
+  id: 'test',
+  header: 'Test',
+  editConfig: {
+    ariaLabel: 'test input',
+    editIconAriaLabel: 'error',
+  },
+  cell: (item, { isEditing, setValue, currentValue }) => {
+    if (isEditing) {
+      return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
+    }
+    return item.test;
+  },
+};
+
+const onEditEnd = jest.fn();
+const onEditStart = jest.fn();
+
+const TestComponent = ({ isEditing = false }) => {
+  return (
+    <table>
+      <tbody>
+        <tr>
+          <TableBodyCell<typeof testItem, string>
+            column={column}
+            item={testItem}
+            isEditing={isEditing}
+            onEditStart={onEditStart}
+            onEditEnd={onEditEnd}
+            ariaLabels={{
+              activateEditLabel: () => 'activate edit',
+              cancelEditLabel: () => 'cancel edit',
+              submitEditLabel: () => 'submit edit',
+            }}
+            isEditable={true}
+            isPrevSelected={false}
+            isNextSelected={false}
+            isFirstRow={true}
+            isLastRow={true}
+            isSelected={false}
+            wrapLines={false}
+          />
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+describe('TableBodyCell', () => {
+  it('should render', () => {
+    const { container } = render(<TestComponent />);
+    expect(container.querySelector('td')).toBeInTheDocument();
+  });
+
+  it('should call onEditStart', () => {
+    render(<TestComponent />);
+    fireEvent.click(screen.getByRole('button', { name: 'activate edit' }));
+    expect(onEditStart).toHaveBeenCalled();
+  });
+
+  it('should call onEditEnd', () => {
+    render(<TestComponent isEditing={true} />);
+    fireEvent.click(screen.getByRole('button', { name: 'submit edit' }));
+    expect(onEditEnd).toHaveBeenCalled();
+  });
+
+  it('should call onEditEnd with value', () => {
+    const { container } = render(<TestComponent isEditing={true} />);
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'test2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'submit edit' }));
+    expect(onEditEnd).toHaveBeenCalled();
+  });
+
+  it('should call onEditEnd with value', () => {
+    const { container } = render(<TestComponent isEditing={true} />);
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'test2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'cancel edit' }));
+    expect(onEditEnd).toHaveBeenCalled();
+  });
+});

--- a/src/table/__tests__/click-away.test.tsx
+++ b/src/table/__tests__/click-away.test.tsx
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Box from '../../../lib/components/box';
+
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import { ClickAway, useClickAway } from '../body-cell/click-away';
+
+const onHookClickAway = jest.fn() as () => void;
+const onComponentClickAway = jest.fn() as () => void;
+
+const TestHookComponent = () => {
+  const clickAwayRef = useClickAway(onHookClickAway);
+  return (
+    <Box variant="div">
+      <div data-testid="outside">outside text</div>
+      <div ref={clickAwayRef} data-testid="inside">
+        some text
+        <div data-testid="inside-inside">nested calls</div>
+      </div>
+    </Box>
+  );
+};
+
+const TestComponentWithClickAway = () => {
+  return (
+    <Box>
+      <div data-testid="outside">outside text</div>
+      <ClickAway onClick={onComponentClickAway}>
+        inside
+        <div data-testid="inside-inside">nested calls</div>
+      </ClickAway>
+    </Box>
+  );
+};
+
+function renderComponent(jsx: React.ReactElement) {
+  const { container, rerender, getByTestId, queryByTestId } = render(jsx);
+  const wrapper = createWrapper(container).findBox()!;
+  return { wrapper, rerender, getByTestId, queryByTestId };
+}
+
+describe('Hook Version', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call the callback when clicking outside the element', () => {
+    const { getByTestId } = renderComponent(<TestHookComponent />);
+    fireEvent.click(getByTestId('outside'));
+    expect(onHookClickAway).toHaveBeenCalled();
+  });
+
+  test('should not call the callback when clicking inside the element', () => {
+    const { getByTestId } = renderComponent(<TestHookComponent />);
+    fireEvent.click(getByTestId('inside'));
+    expect(onHookClickAway).not.toHaveBeenCalled();
+  });
+
+  test('should not call the callback when clicking inside the nested element', () => {
+    const { getByTestId } = renderComponent(<TestHookComponent />);
+    fireEvent.click(getByTestId('inside-inside'));
+    expect(onHookClickAway).not.toHaveBeenCalled();
+  });
+});
+
+describe('Component Version', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call the callback when clicking outside the element', () => {
+    const { getByTestId } = renderComponent(<TestComponentWithClickAway />);
+    fireEvent.click(getByTestId('outside'));
+    expect(onComponentClickAway).toHaveBeenCalled();
+  });
+
+  test('should not call the callback when clicking inside the element', () => {
+    const { wrapper } = renderComponent(<TestComponentWithClickAway />);
+    fireEvent.click(wrapper.getElement().querySelector('[data-testid="outside"] + span')!);
+    expect(onComponentClickAway).not.toHaveBeenCalled();
+  });
+
+  test('should not call the callback when clicking inside the nested element', () => {
+    const { getByTestId } = renderComponent(<TestComponentWithClickAway />);
+    fireEvent.click(getByTestId('inside-inside'));
+    expect(onComponentClickAway).not.toHaveBeenCalled();
+  });
+});

--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -16,10 +16,10 @@ const defaultItems: Item[] = [
   { id: 3, name: 'Bananas' },
 ];
 
-const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
+const editableColumns: TableProps.ColumnDefinition<Item>[] = [
   {
     header: 'id',
-    cell: (item: Item, { isEditing }) => {
+    cell: (item, { isEditing }) => {
       if (isEditing) {
         return <input type="number" value={item.id} readOnly={true} data-testid={`id-editing-${item.id}`} />;
       }
@@ -33,7 +33,7 @@ const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
   },
   {
     header: 'name',
-    cell: (item: Item, { isEditing }) => {
+    cell: (item, { isEditing }) => {
       if (isEditing) {
         return <input type="number" value={item.name} readOnly={true} data-testid={`name-editing-${item.name}`} />;
       }
@@ -46,6 +46,10 @@ const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
     },
   },
 ];
+
+const defaultAriaLabels: TableProps.AriaLabels<{ id: number }> = {
+  tableLabel: 'Distributions',
+};
 
 function renderTable(jsx: React.ReactElement) {
   const { container, rerender, getByTestId, queryByTestId } = render(jsx);
@@ -71,5 +75,19 @@ describe('Editable Table TestUtils', () => {
     const buttons = getByTestId('id-editing-1').closest('form')!.querySelectorAll('button')!;
     expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[0]);
     expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[1]);
+  });
+
+  test('renders when items and labels types do not match', () => {
+    const ariaLabels: TableProps.AriaLabels<Item> = {
+      ...defaultAriaLabels,
+      submitEditLabel: column => `Submit edit for ${column.header}`,
+      cancelEditLabel: column => `Cancel edit for ${column.header}`,
+      activateEditLabel: column => `Activate edit for ${column.header}`,
+    };
+
+    const { wrapper } = renderTable(
+      <Table<Item> columnDefinitions={editableColumns} items={defaultItems} ariaLabels={ariaLabels} />
+    );
+    expect(wrapper.findBodyCell(2, 2)!.getElement()!).toBeInTheDocument();
   });
 });

--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import Table, { TableProps } from '../../../lib/components/table';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const defaultItems: Item[] = [
+  { id: 1, name: 'Apples' },
+  { id: 2, name: 'Oranges' },
+  { id: 3, name: 'Bananas' },
+];
+
+const editableColumns: TableProps.ColumnDefinition<Item, string | number>[] = [
+  {
+    header: 'id',
+    cell: (item: Item, { isEditing }) => {
+      if (isEditing) {
+        return <input type="number" value={item.id} readOnly={true} data-testid={`id-editing-${item.id}`} />;
+      }
+      return item.id;
+    },
+    editConfig: {
+      ariaLabel: 'Edit id',
+      errorIconAriaLabel: 'Error',
+      editIconAriaLabel: 'Edit',
+    },
+  },
+  {
+    header: 'name',
+    cell: (item: Item, { isEditing }) => {
+      if (isEditing) {
+        return <input type="number" value={item.name} readOnly={true} data-testid={`name-editing-${item.name}`} />;
+      }
+      return item.name;
+    },
+    editConfig: {
+      ariaLabel: 'Edit id',
+      errorIconAriaLabel: 'Error',
+      editIconAriaLabel: 'Edit',
+    },
+  },
+];
+
+function renderTable(jsx: React.ReactElement) {
+  const { container, rerender, getByTestId, queryByTestId } = render(jsx);
+  const wrapper = createWrapper(container).findTable()!;
+  return { wrapper, rerender, getByTestId, queryByTestId };
+}
+
+describe('Editable Table TestUtils', () => {
+  test('should find the correct active cell', () => {
+    const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+    const cellId0 = wrapper.findBodyCell(1, 1)!.getElement()!;
+    const cellName0 = wrapper.findBodyCell(1, 2)!.getElement()!;
+    fireEvent.click(cellId0);
+    expect(wrapper.findEditingCell()!.getElement()!).toBe(cellId0);
+    fireEvent.click(cellName0);
+    expect(wrapper.findEditingCell()!.getElement()!).toBe(cellName0);
+  });
+
+  test('should find the correct edit controls', () => {
+    const { wrapper, getByTestId } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+    const cellId0 = wrapper.findBodyCell(1, 1)!.getElement()!;
+    fireEvent.click(cellId0);
+    const buttons = getByTestId('id-editing-1').closest('form')!.querySelectorAll('button')!;
+    expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[0]);
+    expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[1]);
+  });
+});

--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -1,0 +1,152 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { TableProps } from '../interfaces';
+
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import { InlineEditor } from '../../../lib/components/table/body-cell/inline-editor';
+
+const handleSubmitEdit = jest.fn((): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, 500));
+});
+const handleEditEnd = jest.fn();
+
+let thereBeErrors = false;
+
+function renderComponent(jsx: React.ReactElement) {
+  const { container, rerender, getByTestId, queryByTestId } = render(jsx);
+  const wrapper = createWrapper(container).find('[data-testid="inline-editor"]')!;
+  return { wrapper, rerender, getByTestId, queryByTestId };
+}
+
+const TestComponent = () => {
+  const column = {
+    id: 'test',
+    header: 'test',
+    editConfig: {
+      ariaLabel: 'test-input',
+      errorIconAriaLabel: 'error-icon',
+      validation: () => (thereBeErrors ? 'there be errors' : undefined),
+    },
+    cell: (item: any, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) =>
+      isEditing ? (
+        <input value={currentValue ?? item.test} onChange={() => setValue('test')} />
+      ) : (
+        <span>{currentValue ?? item.test}</span>
+      ),
+  };
+
+  return (
+    <div data-testid="inline-editor">
+      <InlineEditor
+        ariaLabels={{
+          submitEditLabel: () => 'save edit',
+          cancelEditLabel: () => 'cancel edit',
+        }}
+        item={{
+          test: 'test',
+        }}
+        column={column}
+        onEditEnd={handleEditEnd}
+        submitEdit={handleSubmitEdit}
+      />
+    </div>
+  );
+};
+
+describe('InlineEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    thereBeErrors = false;
+    cleanup();
+  });
+
+  it('should render', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    expect(getByTestId('inline-editor')).toBeInTheDocument();
+  });
+
+  it('should show error', () => {
+    thereBeErrors = true;
+    const changeEvent = new Event('change', { bubbles: true });
+    const { wrapper } = renderComponent(<TestComponent />);
+    const input = wrapper.find('input')!.getElement();
+    fireEvent.click(input);
+    fireEvent(input, changeEvent);
+    expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeInTheDocument();
+  });
+
+  it('should submit edit', () => {
+    thereBeErrors = false;
+    const changeEvent = new Event('change', { bubbles: true });
+    const { wrapper } = renderComponent(<TestComponent />);
+    const input = wrapper.find('input')!.getElement();
+
+    fireEvent.click(input);
+
+    fireEvent(input, changeEvent);
+    expect(wrapper.find('[aria-label="error-icon"]')?.getElement()).toBeUndefined();
+
+    fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
+    waitFor(() => {
+      expect(handleSubmitEdit).toHaveBeenCalled();
+      expect(handleSubmitEdit.mock.lastCall.length).toBe(3);
+    });
+
+    expect(handleEditEnd).toHaveBeenCalled();
+  });
+
+  it('should handle failed submission', () => {
+    thereBeErrors = false;
+    const changeEvent = new Event('change', { bubbles: true });
+    const { wrapper } = renderComponent(<TestComponent />);
+    const input = wrapper.find('input')!.getElement();
+
+    fireEvent.click(input);
+    fireEvent(input, changeEvent);
+
+    // eslint-disable-next-line require-await
+    handleSubmitEdit.mockImplementation(() => Promise.reject(new Error('test error')));
+
+    fireEvent.click(wrapper.getElement().querySelector('[aria-label="save edit"]')!);
+    waitFor(() => {
+      expect(handleSubmitEdit).toHaveBeenCalled();
+      expect(handleSubmitEdit.mock.lastCall.length).toBe(3);
+      expect(handleEditEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should cancel edit', () => {
+    const { wrapper } = renderComponent(<TestComponent />);
+    fireEvent.click(wrapper.find('button:first-child')!.getElement());
+    expect(handleEditEnd).toHaveBeenCalled();
+    expect(handleSubmitEdit).not.toHaveBeenCalled();
+  });
+
+  // useless test but need the coverage
+  it('should render spinner while submitting', () => {
+    thereBeErrors = false;
+    const changeEvent = new Event('change', { bubbles: true });
+    const { wrapper } = renderComponent(<TestComponent />);
+
+    const input = wrapper.find('input')!.getElement();
+    fireEvent.click(input);
+    fireEvent(input, changeEvent);
+
+    const button = wrapper.findButton('[aria-label="save edit"]')!;
+    fireEvent.click(button.getElement());
+    waitFor(() => {
+      expect(button.findLoadingIndicator()).not.toBeNull();
+      expect(button).toHaveAttribute('disabled');
+    });
+    waitFor(() => {
+      expect(button.findLoadingIndicator()).toBeNull();
+      expect(button).not.toHaveAttribute('disabled');
+    });
+  });
+});

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import Table, { TableProps } from '../../../lib/components/table';
 import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
 import headerCellStyles from '../../../lib/components/table/header-cell/styles.css.js';
@@ -145,6 +145,31 @@ test('should render table header with icons to indicate editable columns', () =>
   });
 });
 
+test('should cancel edit using ref imperative method', async () => {
+  const ref = React.createRef<any>();
+  const { wrapper } = renderTable(
+    <Table
+      columnDefinitions={editableColumns}
+      items={defaultItems}
+      submitEdit={async () => {
+        await new Promise((resolve, reject) => setTimeout(reject, 1000));
+      }}
+      ref={ref}
+    />
+  );
+
+  const bodyCell = wrapper.findBodyCell(2, 2)!;
+  const button = bodyCell.findButton(`[type="button"]`)!;
+
+  fireEvent.click(button.getElement());
+  act(() => {
+    ref.current.cancelEdit();
+  });
+  await waitFor(() => {
+    expect(wrapper.find(`[data-inline-editing-active="true"]`)?.getElement()).toBeUndefined();
+  });
+});
+
 test('should render table with react content', () => {
   const columns: TableProps.ColumnDefinition<Item>[] = [
     ...defaultColumns,
@@ -237,4 +262,74 @@ test('inner state can be tracked by column id', () => {
   rerender(<Table columnDefinitions={statefulColumnsWithId.slice(1)} items={defaultItems} />);
   expect(queryByTestId('display-1-1')).toBeNull();
   expect(queryByTestId('display-2-1')).toHaveTextContent('1');
+});
+
+test('should submit edits successfully', async () => {
+  const data = {
+    name: 'apple',
+  };
+
+  const mockSubmitFn = jest.fn();
+
+  const submitEditFn = async (item: typeof data, column: any, value: any) => {
+    mockSubmitFn(item, column, value);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    data.name = value;
+  };
+
+  const { wrapper } = renderTable(
+    <Table<{ name: string }>
+      columnDefinitions={[
+        {
+          id: 'name',
+          header: 'Name',
+          cell: (item, { isEditing, setValue, currentValue }) => (
+            <input
+              type="text"
+              id="test-input"
+              onChange={e => setValue(e.target.value)}
+              value={currentValue ?? item.name}
+              disabled={!isEditing}
+            />
+          ),
+          editConfig: {
+            ariaLabel: 'test-name',
+            constraintText: 'test-constraint',
+          },
+        },
+      ]}
+      items={[data]}
+      ariaLabels={{
+        activateEditLabel() {
+          return 'activate-edit';
+        },
+        cancelEditLabel() {
+          return 'cancel-edit';
+        },
+        submitEditLabel() {
+          return 'save-edit';
+        },
+      }}
+      submitEdit={submitEditFn}
+    />
+  );
+
+  const bodyCell = wrapper.find('td');
+  const button = bodyCell?.findButton(`[aria-label="activate-edit"]`);
+
+  // activate edit
+  fireEvent.click(button!.getElement()!);
+
+  expect(bodyCell?.getElement()?.querySelector('input')).not.toBeDisabled();
+  fireEvent.change(bodyCell!.getElement()!.querySelector('input')!, {
+    target: { value: 'banana' },
+  });
+
+  // submit edit
+  fireEvent.click(bodyCell!.findButton(`[aria-label="save-edit"]`)!.getElement()!);
+  expect(mockSubmitFn).toHaveBeenCalled();
+  expect(bodyCell!.findButton(`[aria-label="save-edit"]`)?.findLoadingIndicator()?.getElement()).toBeVisible();
+  await waitFor(() => {
+    expect(data.name).toBe('banana');
+  });
 });

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -41,6 +41,10 @@ const defaultColumnsWithIds: TableProps.ColumnDefinition<Item>[] = [
   { id: 'id', header: 'id', cell: item => item.id },
   { id: 'name', header: 'name', cell: item => item.name },
 ];
+const editableColumns: TableProps.ColumnDefinition<Item>[] = [
+  { header: 'id', cell: (item: Item) => item.id, editConfig: {} },
+  { header: 'name', cell: (item: Item) => item.name, editConfig: {} },
+];
 
 const statefulColumns: TableProps.ColumnDefinition<Item>[] = [
   {
@@ -130,6 +134,14 @@ test('should render table with accessible headers', () => {
   const columnHeaders = wrapper.findColumnHeaders();
   columnHeaders.forEach(header => {
     expect(header.getElement()).toHaveAttribute('scope', 'col');
+  });
+});
+
+test('should render table header with icons to indicate editable columns', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+  const columnHeaders = wrapper.findColumnHeaders();
+  columnHeaders.forEach(header => {
+    expect(header.getElement().querySelector('svg')).toBeInTheDocument();
   });
 });
 

--- a/src/table/__tests__/use-focus-navigation.test.tsx
+++ b/src/table/__tests__/use-focus-navigation.test.tsx
@@ -1,0 +1,235 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import useTableFocusNavigation from '../use-table-focus-navigation';
+import { renderHook } from '../../__tests__/render-hook';
+
+const focusFn = jest.fn();
+const rootRemoveEventListener = jest.fn();
+
+function renderComponent(jsx: React.ReactElement) {
+  const { container, rerender, getByTestId, queryByTestId, unmount } = render(jsx);
+  const wrapper = createWrapper(container).find('table')!;
+  return { wrapper, rerender, getByTestId, queryByTestId, unmount };
+}
+
+const TestComponent = () => {
+  const tableRef = React.useRef<HTMLTableElement>(null);
+
+  const editConfig = { __mock: true };
+
+  useTableFocusNavigation('none', tableRef, [{ editConfig }, { editConfig: undefined }, { editConfig }] as any, 3);
+
+  const focusHandler = (evt: React.FocusEvent) => {
+    focusFn(evt.target.innerHTML);
+  };
+
+  const tdProps = {
+    'data-inline-editing-active': 'false',
+    onFocus: focusHandler,
+    onClick(evt: any) {
+      evt.target?.focus();
+    },
+  };
+
+  const handleKeyup = (evt: React.KeyboardEvent) => {
+    if (evt.key === 'BIGUP') {
+      jest.spyOn(tableRef.current!, 'removeEventListener').mockImplementation(rootRemoveEventListener as any);
+    }
+  };
+
+  return (
+    <table data-testid="table-root" onKeyUp={handleKeyup} ref={tableRef}>
+      <tbody>
+        <tr>
+          <td {...tdProps}>
+            <button data-testid="0,0" type="button">
+              0,0
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="0,1" type="button">
+              0,1
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="0,2" type="button">
+              0,2
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td {...tdProps}>
+            <button data-testid="1,0" type="button">
+              1,0
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="1,1" type="button">
+              1,1
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="1,2" type="button">
+              1,2
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td {...tdProps}>
+            <button data-testid="2,0" type="button">
+              2,0
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="2,1" type="button">
+              2,1
+            </button>
+          </td>
+          <td {...tdProps}>
+            <button data-testid="2,2" type="button">
+              2,2
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+describe('useTableFocusNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should skip over non-editable cells', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.click(getByTestId('0,0'));
+    fireEvent.keyDown(getByTestId('0,0'), { key: 'ArrowRight' });
+
+    waitFor(() => expect(focusFn.mock.calls).toEqual([['0,0'], ['0,2']]));
+  });
+
+  it('should skip over non-editable cells when navigating backwards', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.click(getByTestId('0,2'));
+    fireEvent.keyDown(getByTestId('0,2'), { key: 'ArrowLeft' });
+
+    waitFor(() => expect(focusFn.mock.calls).toEqual([['0,2'], ['0,0']]));
+  });
+
+  it('should navigate focus vertically', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.click(getByTestId('0,0'));
+    fireEvent.keyDown(getByTestId('0,0'), { key: 'ArrowDown' });
+    fireEvent.keyDown(getByTestId('1,0'), { key: 'ArrowUp' });
+
+    waitFor(() => expect(focusFn.mock.calls).toEqual([['0,0'], ['1,0'], ['0,0']]));
+  });
+
+  it('should navigate focus horizontally', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.click(getByTestId('0,0'));
+
+    fireEvent.keyDown(getByTestId('0,0'), { key: 'ArrowRight' });
+
+    fireEvent.keyDown(getByTestId('0,2'), { key: 'ArrowLeft' });
+
+    waitFor(() => expect(focusFn.mock.calls).toEqual([['0,0'], ['0,2'], ['0,0']]));
+  });
+
+  it('should not navigate focus while editing a cell', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.keyUp(getByTestId('0,0'), { key: 'UPD' });
+    fireEvent.click(getByTestId('0,0'));
+    expect(focusFn).toHaveBeenCalledWith('0,0');
+    getByTestId('0,0').parentElement!.setAttribute('data-inline-editing-active', 'true');
+    fireEvent.keyDown(getByTestId('0,0'), { key: 'ArrowRight' });
+    expect(focusFn).not.toHaveBeenCalledWith('0,1');
+  });
+
+  it('should remove event listener when focus navigation is disabled', () => {
+    const { getByTestId, unmount } = renderComponent(<TestComponent />);
+    fireEvent.click(getByTestId('0,0'));
+    fireEvent.keyUp(getByTestId('0,0'), { key: 'BIGUP' });
+    unmount();
+    waitFor(() => expect(rootRemoveEventListener).toHaveBeenCalled());
+  });
+
+  it('should not navigate focus when focus navigation is disabled', () => {
+    const { getByTestId } = renderComponent(<TestComponent />);
+    fireEvent.keyUp(getByTestId('0,0'), { key: 'BIGUP' });
+    fireEvent.click(getByTestId('0,0'));
+    fireEvent.keyDown(getByTestId('0,0'), { key: 'ArrowRight' });
+    expect(focusFn).not.toHaveBeenCalledWith('0,1');
+  });
+
+  describe('eventListeners', () => {
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+    const addEventListenerRoot = jest.fn();
+    let table = document.createElement('table');
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      table = document.createElement('table');
+      for (let i = 0; i < 3; i++) {
+        const row = table.insertRow();
+        for (let j = 0; j < 3; j++) {
+          const cell = row.insertCell();
+          const button = document.createElement('button');
+          cell.appendChild(button);
+          jest.spyOn(cell, 'addEventListener').mockImplementation(addEventListener);
+          jest.spyOn(cell, 'removeEventListener').mockImplementation(removeEventListener);
+        }
+      }
+      jest.spyOn(table, 'addEventListener').mockImplementation(addEventListenerRoot);
+    });
+    it('should attach event listener for focus navigation', () => {
+      renderHook(() =>
+        useTableFocusNavigation(
+          'none',
+          { current: table },
+          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
+          3
+        )
+      );
+
+      waitFor(() => {
+        expect(addEventListener).toHaveBeenCalledWith('focusin', expect.any(Function), { passive: true });
+        expect(addEventListenerRoot).toHaveBeenCalled();
+      });
+    });
+
+    it('should detach event listener for focus navigation', () => {
+      const { unmount } = renderHook(() =>
+        useTableFocusNavigation(
+          'none',
+          { current: table },
+          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
+          3
+        )
+      );
+      expect(removeEventListener).not.toHaveBeenCalled();
+      unmount();
+      waitFor(() => expect(removeEventListener).toHaveBeenCalled());
+    });
+
+    it('satisfies istanbul coverage', () => {
+      renderHook(() =>
+        useTableFocusNavigation(
+          'multi',
+          { current: null },
+          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
+          3
+        )
+      );
+      expect(removeEventListener).not.toHaveBeenCalled();
+      expect(addEventListenerRoot).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/table/__tests__/use-stable-scroll-position.test.tsx
+++ b/src/table/__tests__/use-stable-scroll-position.test.tsx
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { renderHook } from '../../__tests__/render-hook';
+import { getScrollableParent, isScrollable, useStableScrollPosition } from '../body-cell/use-stable-scroll-position';
+
+const TestComponent = () => {
+  const activeElementRef = React.useRef<HTMLTableCellElement>(null);
+  const { storeScrollPosition, restoreScrollPosition } = useStableScrollPosition(activeElementRef);
+
+  return (
+    <>
+      <div
+        style={{
+          overflowX: 'scroll',
+          width: 200,
+          height: 200,
+        }}
+        data-testid="scrollableParent"
+      >
+        <table style={{ width: 1000, height: 2000 }}>
+          <tbody>
+            <tr>
+              <td ref={activeElementRef} data-testid="activeElement" tabIndex={0}>
+                TEST
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <button onClick={storeScrollPosition}>store</button>
+      <button onClick={restoreScrollPosition}>restore</button>
+    </>
+  );
+};
+
+describe('useStableScrollPosition', () => {
+  it('works with document.body if no scrollable parent exists', () => {
+    const emptyRef = React.createRef<HTMLTableCellElement>();
+    const { result } = renderHook(() => useStableScrollPosition(emptyRef));
+    document.body.scrollLeft = 100;
+    document.body.scrollTop = 200;
+    result.current.storeScrollPosition();
+    document.body.scrollLeft = 0;
+    document.body.scrollTop = 0;
+    result.current.restoreScrollPosition();
+    expect(document.body.scrollLeft).toBe(100);
+    expect(document.body.scrollTop).toBe(200);
+
+    // cleanup
+    document.body.scrollLeft = 0;
+    document.body.scrollTop = 0;
+  });
+
+  it('works with nearest scrollable parent', () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    const parentElement = getByTestId('scrollableParent');
+
+    parentElement.scrollLeft = 10;
+    parentElement.scrollTop = 20;
+
+    screen.getByText(/\bstore/i).click();
+    expect(parentElement.scrollLeft).toBe(10);
+    expect(parentElement.scrollTop).toBe(20);
+
+    parentElement.scrollLeft = 30;
+    parentElement.scrollTop = 40;
+    screen.getByText(/\brestore/i).click();
+
+    waitFor(() => {
+      expect(parentElement.scrollLeft).toBe(10);
+      expect(parentElement.scrollTop).toBe(20);
+    });
+  });
+});
+
+describe('isScrollable', () => {
+  it('returns true if element is scrollable', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const scrollableParent = getByTestId('scrollableParent');
+    // necessary because jsdom doesn't actually render the scroll behavior
+    Object.defineProperty(scrollableParent, 'clientWidth', { value: 100 });
+    Object.defineProperty(scrollableParent, 'scrollWidth', { value: 1000 });
+    expect(isScrollable(scrollableParent)).toBe(true);
+  });
+
+  it('returns false if element is not scrollable', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const activeElement = getByTestId('activeElement');
+    expect(isScrollable(activeElement)).toBe(false); // non-overflowing element
+
+    const scrollableParent = getByTestId('scrollableParent');
+    Object.defineProperty(scrollableParent, 'clientWidth', { value: 100 });
+    Object.defineProperty(scrollableParent, 'scrollWidth', { value: 1000 });
+    scrollableParent.style.overflowX = 'hidden';
+    expect(isScrollable(scrollableParent)).toBe(false); // overflowing but hidden (so not scrollable)
+  });
+});
+
+describe('getScrollableParent', () => {
+  it('returns the scrollable parent', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const activeElement = getByTestId('activeElement');
+    const scrollableParent = getByTestId('scrollableParent');
+    Object.defineProperty(scrollableParent, 'clientWidth', { value: 100 });
+    Object.defineProperty(scrollableParent, 'scrollWidth', { value: 1000 });
+    expect(getScrollableParent(activeElement)).toBe(scrollableParent);
+  });
+
+  it('returns the body if no scrollable parent is found', () => {
+    const { getByTestId } = render(<TestComponent />);
+    const activeElement = getByTestId('activeElement');
+    const scrollableParent = getByTestId('scrollableParent');
+    Object.defineProperty(scrollableParent, 'clientWidth', { value: 100 });
+    Object.defineProperty(scrollableParent, 'scrollWidth', { value: 100 });
+    expect(getScrollableParent(activeElement)).toBe(document.body);
+  });
+
+  it('returns the body if called with null', () => {
+    expect(getScrollableParent(null)).toBe(document.body);
+  });
+});

--- a/src/table/body-cell/click-away.tsx
+++ b/src/table/body-cell/click-away.tsx
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef } from 'react';
+import { containsOrEqual } from '../../internal/utils/dom';
+import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
+
+export function useClickAway(onClick: () => void) {
+  const awayRef = useRef<any>(null);
+  const onClickStable = useStableEventHandler(onClick);
+  useEffect(() => {
+    function handleClick(event: Event) {
+      if (!containsOrEqual(awayRef.current, event.target as Node)) {
+        onClickStable();
+      }
+    }
+    // contains returns wrong result if the next render would remove the element
+    // but capture phase happens before the render, so returns correct result
+    // Ref: https://github.com/facebook/react/issues/20325
+    document.addEventListener('click', handleClick, { capture: true });
+    return () => document.removeEventListener('click', handleClick, { capture: true });
+  }, [onClickStable]);
+  return awayRef;
+}
+
+interface ClickAwayActive {
+  onClick: () => void;
+  children: React.ReactNode;
+}
+export function ClickAway({ onClick, children }: ClickAwayActive) {
+  const onClickStable = useStableEventHandler(onClick);
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    function handleClick(event: Event) {
+      if (!containsOrEqual(ref.current, event.target as Node)) {
+        onClickStable();
+      }
+    }
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [onClickStable]);
+  return <span ref={ref}>{children}</span>;
+}

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -22,17 +22,17 @@ const submitHandlerFallback = () => {
   throw new Error('The function `handleSubmit` is required for editable columns');
 };
 
-interface TableBodyCellProps<ItemType, ValueType> extends TableTdElementProps {
-  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+interface TableBodyCellProps<ItemType> extends TableTdElementProps {
+  column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
   isEditing: boolean;
   onEditStart: () => void;
   onEditEnd: () => void;
-  submitEdit?: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  submitEdit?: TableProps.SubmitEditFunction<ItemType>;
   ariaLabels: TableProps['ariaLabels'];
 }
 
-function TableCellEditable<ItemType, ValueType>({
+function TableCellEditable<ItemType>({
   className,
   item,
   column,
@@ -43,7 +43,7 @@ function TableCellEditable<ItemType, ValueType>({
   ariaLabels,
   isVisualRefresh,
   ...rest
-}: TableBodyCellProps<ItemType, ValueType>) {
+}: TableBodyCellProps<ItemType>) {
   const editActivateRef = useRef<ButtonProps.Ref>(null);
   const cellRef = useRef<HTMLTableCellElement>(null);
   const focusVisible = useFocusVisible();
@@ -116,10 +116,10 @@ function TableCellEditable<ItemType, ValueType>({
   );
 }
 
-export function TableBodyCell<ItemType, ValueType>({
+export function TableBodyCell<ItemType>({
   isEditable,
   ...rest
-}: TableBodyCellProps<ItemType, ValueType> & { isEditable: boolean }) {
+}: TableBodyCellProps<ItemType> & { isEditable: boolean }) {
   if (isEditable || rest.isEditing) {
     return <TableCellEditable {...rest} />;
   }

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -2,72 +2,127 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
 import styles from './styles.css.js';
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
+import useFocusVisible from '../../internal/hooks/focus-visible';
+import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
+import Button from '../../button/internal';
+import { ButtonProps } from '../../button/interfaces';
 import { TableProps } from '../interfaces';
-import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
+import { TableTdElement, TableTdElementProps } from './td-element';
+import { InlineEditor } from './inline-editor';
+import { useStableScrollPosition } from './use-stable-scroll-position';
 
-interface TableBodyCellProps {
-  className?: string;
-  style?: React.CSSProperties;
-  wrapLines: boolean | undefined;
-  isFirstRow: boolean;
-  isLastRow: boolean;
-  isEvenRow?: boolean;
-  stripedRows?: boolean;
-  isSelected: boolean;
-  isNextSelected: boolean;
-  isPrevSelected: boolean;
-  children?: React.ReactNode;
-  hasSelection?: boolean;
-  hasFooter?: boolean;
+const readonlyState = Object.freeze({
+  isEditing: false,
+  currentValue: undefined,
+  setValue: () => {},
+});
+
+const submitHandlerFallback = () => {
+  throw new Error('The function `handleSubmit` is required for editable columns');
+};
+
+interface TableBodyCellProps<ItemType, ValueType> extends TableTdElementProps {
+  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+  item: ItemType;
+  isEditing: boolean;
+  onEditStart: () => void;
+  onEditEnd: () => void;
+  submitEdit?: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  ariaLabels: TableProps['ariaLabels'];
 }
 
-export function TableBodyCell({
+function TableCellEditable<ItemType, ValueType>({
   className,
-  style,
-  children,
-  wrapLines,
-  isFirstRow,
-  isLastRow,
-  isSelected,
-  isNextSelected,
-  isPrevSelected,
-  isEvenRow,
-  stripedRows,
-  hasSelection,
-  hasFooter,
-}: TableBodyCellProps) {
-  const isVisualRefresh = useVisualRefresh();
+  item,
+  column,
+  isEditing,
+  onEditStart,
+  onEditEnd,
+  submitEdit,
+  ariaLabels,
+  isVisualRefresh,
+  ...rest
+}: TableBodyCellProps<ItemType, ValueType>) {
+  const editActivateRef = useRef<ButtonProps.Ref>(null);
+  const cellRef = useRef<HTMLTableCellElement>(null);
+  const focusVisible = useFocusVisible();
+  const { storeScrollPosition, restoreScrollPosition } = useStableScrollPosition(cellRef);
+
+  const handleEditStart = () => {
+    storeScrollPosition();
+    if (!isEditing) {
+      onEditStart();
+    }
+  };
+
+  const scheduleRestoreScrollPosition = useCallback(
+    () => setTimeout(restoreScrollPosition, 0),
+    [restoreScrollPosition]
+  );
+
+  const tdNativeAttributes = {
+    ...(focusVisible as Record<string, string>),
+    onFocus: scheduleRestoreScrollPosition,
+    'data-inline-editing-active': isEditing.toString(),
+  };
+
+  useEffectOnUpdate(() => {
+    if (!isEditing && editActivateRef.current) {
+      editActivateRef.current.focus({ preventScroll: true });
+    }
+    const timer = scheduleRestoreScrollPosition();
+    return () => clearTimeout(timer);
+  }, [isEditing, scheduleRestoreScrollPosition]);
 
   return (
-    <td
-      style={style}
+    <TableTdElement
+      {...rest}
+      nativeAttributes={tdNativeAttributes as TableTdElementProps['nativeAttributes']}
       className={clsx(
         className,
-        styles['body-cell'],
-        wrapLines && styles['body-cell-wrap'],
-        isFirstRow && styles['body-cell-first-row'],
-        isLastRow && styles['body-cell-last-row'],
-        isSelected && styles['body-cell-selected'],
-        isNextSelected && styles['body-cell-next-selected'],
-        isPrevSelected && styles['body-cell-prev-selected'],
-        !isEvenRow && stripedRows && styles['body-cell-shaded'],
-        stripedRows && styles['has-striped-rows'],
-        isVisualRefresh && styles['is-visual-refresh'],
-        hasSelection && styles['has-selection'],
-        hasFooter && styles['has-footer']
+        styles['body-cell-editable'],
+        isEditing && styles['body-cell-edit-active'],
+        isVisualRefresh && styles['is-visual-refresh']
       )}
+      onClick={handleEditStart}
+      ref={cellRef}
     >
-      {children}
-    </td>
+      {isEditing ? (
+        <InlineEditor
+          ariaLabels={ariaLabels}
+          column={column}
+          item={item}
+          onEditEnd={onEditEnd}
+          submitEdit={submitEdit ?? submitHandlerFallback}
+          __onRender={restoreScrollPosition}
+        />
+      ) : (
+        <>
+          {column.cell(item, readonlyState)}
+          <span className={styles['body-cell-editor']}>
+            <Button
+              __hideFocusOutline={true}
+              __internalRootRef={editActivateRef}
+              ariaLabel={ariaLabels?.activateEditLabel?.(column)}
+              formAction="none"
+              iconName="edit"
+              variant="inline-icon"
+            />
+          </span>
+        </>
+      )}
+    </TableTdElement>
   );
 }
 
-interface TableBodyCellContentProps<ItemType> extends TableBodyCellProps {
-  column: TableProps.ColumnDefinition<ItemType>;
-  item: ItemType;
-}
-
-export function TableBodyCellContent<ItemType>({ item, column, ...rest }: TableBodyCellContentProps<ItemType>) {
-  return <TableBodyCell {...rest}>{column.cell(item)}</TableBodyCell>;
+export function TableBodyCell<ItemType, ValueType>({
+  isEditable,
+  ...rest
+}: TableBodyCellProps<ItemType, ValueType> & { isEditable: boolean }) {
+  if (isEditable || rest.isEditing) {
+    return <TableCellEditable {...rest} />;
+  }
+  const { column, item } = rest;
+  return <TableTdElement {...rest}>{column.cell(item, readonlyState)}</TableTdElement>;
 }

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -15,6 +15,7 @@ import { useStableScrollPosition } from './use-stable-scroll-position';
 const readonlyState = Object.freeze({
   isEditing: false,
   currentValue: undefined,
+  /* istanbul ignore next */
   setValue: () => {},
 });
 

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -12,25 +12,25 @@ import { Optional } from '../../internal/types';
 // A function that does nothing
 const noop = () => undefined;
 
-interface InlineEditorProps<ItemType, ValueType> {
+interface InlineEditorProps<ItemType> {
   ariaLabels: TableProps['ariaLabels'];
-  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+  column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
   onEditEnd: () => void;
-  submitEdit: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  submitEdit: TableProps.SubmitEditFunction<ItemType>;
   __onRender?: () => void;
 }
 
-export function InlineEditor<ItemType, ValueType>({
+export function InlineEditor<ItemType>({
   ariaLabels,
   item,
   column,
   onEditEnd,
   submitEdit,
   __onRender,
-}: InlineEditorProps<ItemType, ValueType>) {
+}: InlineEditorProps<ItemType>) {
   const [currentEditLoading, setCurrentEditLoading] = useState(false);
-  const [currentEditValue, setCurrentEditValue] = useState<Optional<ValueType>>();
+  const [currentEditValue, setCurrentEditValue] = useState<Optional<any>>();
 
   const cellContext = {
     isEditing: true,

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+import Button from '../../button/internal';
+import FormField from '../../form-field/internal';
+import SpaceBetween from '../../space-between/internal';
+import { useClickAway } from './click-away';
+import { TableProps } from '../interfaces';
+import styles from './styles.css.js';
+import { Optional } from '../../internal/types';
+
+// A function that does nothing
+const noop = () => undefined;
+
+interface InlineEditorProps<ItemType, ValueType> {
+  ariaLabels: TableProps['ariaLabels'];
+  column: TableProps.EditableColumnDefinition<ItemType, ValueType>;
+  item: ItemType;
+  onEditEnd: () => void;
+  submitEdit: TableProps.SubmitEditFunction<ItemType, ValueType>;
+  __onRender?: () => void;
+}
+
+export function InlineEditor<ItemType, ValueType>({
+  ariaLabels,
+  item,
+  column,
+  onEditEnd,
+  submitEdit,
+  __onRender,
+}: InlineEditorProps<ItemType, ValueType>) {
+  const [currentEditLoading, setCurrentEditLoading] = useState(false);
+  const [currentEditValue, setCurrentEditValue] = useState<Optional<ValueType>>();
+
+  const cellContext = {
+    isEditing: true,
+    currentValue: currentEditValue,
+    setValue: setCurrentEditValue,
+  };
+
+  function finishEdit(cancel = false) {
+    if (!cancel) {
+      setCurrentEditValue(undefined);
+    }
+    onEditEnd();
+  }
+
+  async function onSubmitClick(evt: React.FormEvent) {
+    evt.preventDefault();
+    if (currentEditValue === undefined) {
+      finishEdit();
+      return;
+    }
+
+    setCurrentEditLoading(true);
+    try {
+      await submitEdit(item, column, currentEditValue);
+      setCurrentEditLoading(false);
+      finishEdit();
+    } catch (e) {
+      setCurrentEditLoading(false);
+    }
+  }
+
+  function onCancel() {
+    if (currentEditLoading) {
+      return;
+    }
+    finishEdit(true);
+  }
+
+  function handleEscape(event: React.KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      onCancel();
+    }
+  }
+
+  const clickAwayRef = useClickAway(onCancel);
+
+  useEffect(() => {
+    if (__onRender) {
+      const timer = setTimeout(__onRender, 1);
+      return () => clearTimeout(timer);
+    }
+  }, [__onRender]);
+
+  // asserting non-undefined editConfig here because this component is unreachable otherwise
+  const { ariaLabel = undefined, validation = noop, errorIconAriaLabel } = column.editConfig!;
+
+  return (
+    <form
+      ref={clickAwayRef}
+      onSubmit={onSubmitClick}
+      onKeyDown={handleEscape}
+      className={styles['body-cell-editor-form']}
+    >
+      <FormField
+        stretch={true}
+        label={ariaLabel}
+        __hideLabel={true}
+        __disableGutters={true}
+        __useReactAutofocus={true}
+        i18nStrings={{ errorIconAriaLabel }}
+        errorText={validation(item, currentEditValue)}
+      >
+        <div className={styles['body-cell-editor-row']}>
+          {column.cell(item, cellContext)}
+          <span className={styles['body-cell-editor-controls']}>
+            <SpaceBetween direction="horizontal" size="xxs">
+              {!currentEditLoading ? (
+                <Button
+                  ariaLabel={ariaLabels?.cancelEditLabel?.(column)}
+                  formAction="none"
+                  iconName="close"
+                  variant="inline-icon"
+                  onClick={onCancel}
+                />
+              ) : null}
+              <Button
+                ariaLabel={ariaLabels?.submitEditLabel?.(column)}
+                formAction="submit"
+                iconName="check"
+                variant="inline-icon"
+                loading={currentEditLoading}
+              />
+            </SpaceBetween>
+          </span>
+        </div>
+      </FormField>
+    </form>
+  );
+}

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -3,7 +3,9 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
+@use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
+@use '../../internal/hooks/focus-visible' as focus-visible;
 
 $cell-vertical-padding: awsui.$space-scaled-xs;
 // Calculate padding to prevent a shift in content after selection due to the difference
@@ -36,6 +38,35 @@ $border-placeholder: awsui.$border-item-width solid transparent;
     border-right: $border-placeholder;
     padding-right: $cell-edge-horizontal-padding;
   }
+  &.is-visual-refresh:first-child {
+    &:not(.has-striped-rows) {
+      padding-left: awsui.$space-xxxs;
+      &:not(.body-cell-edit-active).body-cell-editable:hover {
+        padding-left: calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width});
+      }
+    }
+
+    /*
+      Striped rows requires additional left padding because the
+      shaded background makes the child content appear too close
+      to the table edge.
+      */
+    &:first-child.has-striped-rows {
+      padding-left: awsui.$space-xxs;
+    }
+
+    /*
+      Remove the placeholder border if the row is not selectable.
+      Rows that are not selectable will reserve the horizontal space
+      that the placeholder border would consume.
+      */
+    &:not(.has-selection):not(.body-cell-editable) {
+      border-left: none;
+    }
+  }
+  &:first-child:not(.is-visual-refresh) {
+    padding-left: $cell-edge-horizontal-padding;
+  }
   &-first-row {
     border-top: $border-placeholder;
   }
@@ -47,7 +78,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
 
     &.has-footer {
       /*
-      Add a bottom border to the body cells of the last row as a separator between the 
+      Add a bottom border to the body cells of the last row as a separator between the
       table and the footer
       */
       border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
@@ -104,38 +135,109 @@ $border-placeholder: awsui.$border-item-width solid transparent;
   &-selected:not(.body-cell-prev-selected) {
     padding-top: $cell-vertical-padding;
   }
-}
+  &-editor {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    position: absolute;
 
-/*
-In Visual Refresh the first cell of each row should align with the 
-left edge of the table as closely as possible.
-*/
-.body-cell:not(.is-visual-refresh) {
-  &:first-child {
-    padding-left: $cell-edge-horizontal-padding;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    padding-right: awsui.$space-xs;
+
+    &-form {
+      margin: calc(-1 * #{awsui.$space-xs}) calc(-1.5 * #{awsui.$space-xs});
+      .is-visual-refresh.body-cell:first-child.has-striped-rows > & {
+        margin-left: calc(-1 * #{awsui.$space-xxs});
+      }
+
+      .is-visual-refresh.body-cell:first-child:not(.has-striped-rows) > & {
+        margin-left: calc(-1 * #{awsui.$space-xxxs});
+      }
+    }
+
+    &-row {
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+      justify-content: space-between;
+      column-gap: awsui.$space-xxs;
+      & > :not(:last-child) {
+        flex-grow: 1;
+      }
+    }
+    &-controls {
+      flex-shrink: 0;
+    }
   }
-}
+  &.body-cell-editable {
+    position: relative;
+    cursor: pointer;
 
-.body-cell.is-visual-refresh {
-  /*
-  Remove the placeholder border if the row is not selectable. 
-  Rows that are not selectable will reserve the horizontal space 
-  that the placeholder border would consume.
-  */
-  &:first-child:not(.has-selection) {
-    border-left: none;
+    &.body-cell-edit-active {
+      overflow: visible;
+    }
+
+    &:not(.body-cell-edit-active) {
+      & > .body-cell-editor {
+        opacity: 0;
+      }
+      &:hover {
+        position: relative;
+        background-color: awsui.$color-background-dropdown-item-hover;
+        border: awsui.$border-divider-list-width solid awsui.$color-border-control-default;
+        left: calc(-1 * #{awsui.$border-divider-list-width});
+        right: calc(-1 * #{awsui.$border-divider-list-width});
+        & > .body-cell-editor {
+          padding-right: calc(#{awsui.$space-xs} - (2 * #{awsui.$border-divider-list-width}));
+        }
+        &.body-cell-last-row.body-cell-selected,
+        &.body-cell-next-selected {
+          padding-top: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2));
+          padding-bottom: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2));
+        }
+        &.body-cell-last-row:not(.body-cell-selected) {
+          padding-top: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+        }
+        &.body-cell-first-row:not(.body-cell-selected) {
+          padding-top: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+          padding-bottom: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+        }
+      }
+      &:hover,
+      &[data-awsui-focus-visible='true']:focus-within {
+        padding-right: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
+        & > .body-cell-editor {
+          opacity: 1;
+        }
+      }
+      &:hover:first-child {
+        left: 0;
+        right: 0;
+      }
+      &[data-awsui-focus-visible='true']:not(:hover):focus-within {
+        @include styles.focus-highlight(
+          (
+            'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),
+            'horizontal': calc(-1 * #{awsui.$space-scaled-xxs}),
+          )
+        );
+      }
+    }
   }
-
-  &:first-child:not(.has-striped-rows) {
-    padding-left: awsui.$space-xxxs;
-  }
-
-  /*
-  Striped rows requires additional left padding because the 
-  shaded background makes the child content appear too close 
-  to the table edge.
-  */
-  &:first-child.has-striped-rows {
-    padding-left: awsui.$space-xxs;
+  &-editable.is-visual-refresh:not(.body-cell-edit-active):hover {
+    &:first-child {
+      border-top-left-radius: awsui.$border-radius-control-default-focus-ring;
+      border-bottom-left-radius: awsui.$border-radius-control-default-focus-ring;
+    }
+    &:last-child {
+      border-top-right-radius: awsui.$border-radius-control-default-focus-ring;
+      border-bottom-right-radius: awsui.$border-radius-control-default-focus-ring;
+    }
+    &.body-cell-first-row > .body-cell-editor {
+      padding-top: awsui.$border-divider-list-width;
+    }
   }
 }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React from 'react';
+import styles from './styles.css.js';
+
+export interface TableTdElementProps {
+  className?: string;
+  style?: React.CSSProperties;
+  wrapLines: boolean | undefined;
+  isFirstRow: boolean;
+  isLastRow: boolean;
+  isSelected: boolean;
+  isNextSelected: boolean;
+  isPrevSelected: boolean;
+  nativeAttributes?: Omit<React.HTMLAttributes<HTMLTableCellElement>, 'style' | 'className' | 'onClick'>;
+  onClick?: () => void;
+  children?: React.ReactNode;
+  isEvenRow?: boolean;
+  stripedRows?: boolean;
+  hasSelection?: boolean;
+  hasFooter?: boolean;
+  isVisualRefresh?: boolean;
+}
+
+export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElementProps>(
+  (
+    {
+      className,
+      style,
+      children,
+      wrapLines,
+      isFirstRow,
+      isLastRow,
+      isSelected,
+      isNextSelected,
+      isPrevSelected,
+      nativeAttributes,
+      onClick,
+      isEvenRow,
+      stripedRows,
+      isVisualRefresh,
+      hasSelection,
+      hasFooter,
+    },
+    ref
+  ) => {
+    return (
+      <td
+        style={style}
+        className={clsx(
+          className,
+          styles['body-cell'],
+          wrapLines && styles['body-cell-wrap'],
+          isFirstRow && styles['body-cell-first-row'],
+          isLastRow && styles['body-cell-last-row'],
+          isSelected && styles['body-cell-selected'],
+          isNextSelected && styles['body-cell-next-selected'],
+          isPrevSelected && styles['body-cell-prev-selected'],
+          !isEvenRow && stripedRows && styles['body-cell-shaded'],
+          stripedRows && styles['has-striped-rows'],
+          isVisualRefresh && styles['is-visual-refresh'],
+          hasSelection && styles['has-selection'],
+          hasFooter && styles['has-footer']
+        )}
+        onClick={onClick}
+        ref={ref}
+        {...nativeAttributes}
+      >
+        {children}
+      </td>
+    );
+  }
+);

--- a/src/table/body-cell/use-stable-scroll-position.tsx
+++ b/src/table/body-cell/use-stable-scroll-position.tsx
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useRef } from 'react';
+
+export function isScrollable(ele: HTMLElement) {
+  const overflowXStyle = window.getComputedStyle(ele).overflowX;
+  const isOverflowHidden = overflowXStyle.indexOf('hidden') !== -1;
+
+  return ele.scrollWidth > ele.clientWidth && !isOverflowHidden;
+}
+
+export function getScrollableParent(ele: HTMLElement | null): HTMLElement {
+  return !ele || ele === document.body
+    ? document.body
+    : isScrollable(ele)
+    ? ele
+    : getScrollableParent(ele.parentElement);
+}
+
+export interface UseStableScrollPositionResult {
+  /** Stores the current scroll position of the nearest scrollable container. */
+  storeScrollPosition: () => void;
+  /** Restores the scroll position of the nearest scrollable container to the last stored position. */
+  restoreScrollPosition: () => void;
+}
+
+const shouldScroll = ([cx, cy]: [number, number], [px, py]: [number, number]) => {
+  return cx - px > 5 || cy - py > 5;
+};
+
+/**
+ * This hook stores the scroll position of the nearest scrollable parent of the
+ * `activeElementRef` when `storeScrollPosition` is called, and restores it when
+ * `restoreScrollPosition` is called.
+ * @param activeElementRef Ref to an active element in the table. This is used to find the nearest scrollable parent.
+ */
+export function useStableScrollPosition<T extends HTMLElement>(
+  activeElementRef: React.RefObject<T>
+): UseStableScrollPositionResult {
+  const scrollRef = useRef<Parameters<HTMLBodyElement['scroll']>>();
+
+  const storeScrollPosition = useCallback(() => {
+    const scrollableParent = getScrollableParent(activeElementRef.current ?? document.body);
+    if (scrollableParent) {
+      scrollRef.current = [scrollableParent.scrollLeft, scrollableParent.scrollTop];
+    }
+  }, [activeElementRef]);
+
+  const restoreScrollPosition = useCallback(() => {
+    const scrollableParent = getScrollableParent(activeElementRef.current ?? document.body);
+    if (
+      scrollRef.current &&
+      scrollRef.current.toString() !== '0,0' &&
+      shouldScroll(scrollRef.current, [scrollableParent.scrollLeft, scrollableParent.scrollTop])
+    ) {
+      [scrollableParent.scrollLeft, scrollableParent.scrollTop] = scrollRef.current;
+    }
+  }, [activeElementRef]);
+
+  return { storeScrollPosition, restoreScrollPosition };
+}

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -11,11 +11,11 @@ import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
-interface TableHeaderCellProps<ItemType, ValueType> {
+interface TableHeaderCellProps<ItemType> {
   className?: string;
   style?: React.CSSProperties;
   tabIndex: number;
-  column: TableProps.ColumnDefinition<ItemType, ValueType>;
+  column: TableProps.ColumnDefinition<ItemType>;
   activeSortingColumn?: TableProps.SortingColumn<ItemType>;
   sortingDescending?: boolean;
   sortingDisabled?: boolean;
@@ -32,7 +32,7 @@ interface TableHeaderCellProps<ItemType, ValueType> {
   isEditable?: boolean;
 }
 
-export function TableHeaderCell<ItemType, ValueType>({
+export function TableHeaderCell<ItemType>({
   className,
   style,
   tabIndex,
@@ -51,7 +51,7 @@ export function TableHeaderCell<ItemType, ValueType>({
   resizableColumns,
   onResizeFinish,
   isEditable,
-}: TableHeaderCellProps<ItemType, ValueType>) {
+}: TableHeaderCellProps<ItemType>) {
   const focusVisible = useFocusVisible();
   const sortable = !!column.sortingComparator || !!column.sortingField;
   const sorted = !!activeSortingColumn && isSorted(column, activeSortingColumn);

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -11,15 +11,15 @@ import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
-interface TableHeaderCellProps {
+interface TableHeaderCellProps<ItemType, ValueType> {
   className?: string;
   style?: React.CSSProperties;
   tabIndex: number;
-  column: TableProps.ColumnDefinition<any>;
-  activeSortingColumn: TableProps.SortingColumn<any> | undefined;
-  sortingDescending: boolean | undefined;
-  sortingDisabled: boolean | undefined;
-  wrapLines: boolean | undefined;
+  column: TableProps.ColumnDefinition<ItemType, ValueType>;
+  activeSortingColumn?: TableProps.SortingColumn<ItemType>;
+  sortingDescending?: boolean;
+  sortingDisabled?: boolean;
+  wrapLines?: boolean;
   showFocusRing: boolean;
   hidden?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
@@ -29,9 +29,10 @@ interface TableHeaderCellProps {
   onFocus?: () => void;
   onBlur?: () => void;
   resizableColumns?: boolean;
+  isEditable?: boolean;
 }
 
-export function TableHeaderCell({
+export function TableHeaderCell<ItemType, ValueType>({
   className,
   style,
   tabIndex,
@@ -49,7 +50,8 @@ export function TableHeaderCell({
   updateColumn,
   resizableColumns,
   onResizeFinish,
-}: TableHeaderCellProps) {
+  isEditable,
+}: TableHeaderCellProps<ItemType, ValueType>) {
   const focusVisible = useFocusVisible();
   const sortable = !!column.sortingComparator || !!column.sortingField;
   const sorted = !!activeSortingColumn && isSorted(column, activeSortingColumn);
@@ -115,6 +117,11 @@ export function TableHeaderCell({
       >
         <div className={clsx(styles['header-cell-text'], wrapLines && styles['header-cell-text-wrap'])} id={headerId}>
           {column.header}
+          {isEditable ? (
+            <span className={styles['edit-icon']} role="img" aria-label={column.editConfig?.editIconAriaLabel}>
+              <InternalIcon name="edit" />
+            </span>
+          ) : null}
         </div>
         {sortingStatus && (
           <span className={styles['sorting-icon']}>

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -53,8 +53,10 @@
   color: awsui.$color-text-column-sorting-icon;
 }
 
-.header-cell-disabled.header-cell-sorted > .header-cell-content > .sorting-icon {
-  color: awsui.$color-text-interactive-disabled;
+.edit-icon {
+  margin-left: awsui.$space-xxs;
+  margin-top: awsui.$space-scaled-xxs;
+  color: inherit;
 }
 
 .header-cell-content {
@@ -76,6 +78,12 @@
   &.header-cell-fake-focus {
     @include styles.focus-highlight(awsui.$space-table-header-focus-outline-gutter);
   }
+
+  .header-cell-disabled.header-cell-sorted > & {
+    & > .sorting-icon {
+      color: awsui.$color-text-interactive-disabled;
+    }
+  }
 }
 
 .header-cell-sortable:not(.header-cell-disabled) {
@@ -85,7 +93,7 @@
   & > .header-cell-content:hover,
   &.header-cell-sorted > .header-cell-content {
     color: awsui.$color-text-interactive-active;
-    > .sorting-icon {
+    & > .sorting-icon {
       color: awsui.$color-text-interactive-active;
     }
   }
@@ -106,8 +114,8 @@
 
 /*
 In Visual Refresh the first cell in the header should align
-with the left edge of the table as closely as possible. If the 
-last header cell is sortable the sort icon should align with the 
+with the left edge of the table as closely as possible. If the
+last header cell is sortable the sort icon should align with the
 settings icon in the pagination slot.
 */
 .header-cell:not(.is-visual-refresh) {
@@ -122,8 +130,8 @@ settings icon in the pagination slot.
   }
 
   /*
-  Striped rows requires additional left padding because the 
-  shaded background makes the child content appear too close 
+  Striped rows requires additional left padding because the
+  shaded background makes the child content appear too close
   to the table edge.
   */
   &:first-child.has-striped-rows {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -34,11 +34,11 @@ import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
 import { TableTdElement } from './body-cell/td-element';
 
-type InternalTableProps<T, V> = SomeRequired<TableProps<T, V>, 'items' | 'selectedItems' | 'variant'> &
+type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
 
 const InternalTable = React.forwardRef(
-  <T, V>(
+  <T,>(
     {
       header,
       footer,
@@ -77,7 +77,7 @@ const InternalTable = React.forwardRef(
       firstIndex,
       renderAriaLive,
       ...rest
-    }: InternalTableProps<T, V>,
+    }: InternalTableProps<T>,
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseProps = getBaseProps(rest);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useImperativeHandle, useRef } from 'react';
+import React, { useImperativeHandle, useRef, useState } from 'react';
 import { TableForwardRefType, TableProps } from './interfaces';
 import InternalContainer from '../container/internal';
 import { getBaseProps } from '../internal/base-component';
 import ToolsHeader from './tools-header';
 import Thead, { TheadProps } from './thead';
-import { TableBodyCell, TableBodyCellContent } from './body-cell';
+import { TableBodyCell } from './body-cell';
 import InternalStatusIndicator from '../status-indicator/internal';
 import { useContainerQuery } from '../internal/hooks/container-queries';
 import { supportsStickyPosition } from '../internal/utils/dom';
@@ -15,7 +15,7 @@ import SelectionControl from './selection-control';
 import { checkSortingState, getColumnKey, getItemKey, toContainerVariant } from './utils';
 import { useRowEvents } from './use-row-events';
 import { focusMarkers, useFocusMove, useSelection } from './use-selection';
-import { fireNonCancelableEvent } from '../internal/events';
+import { fireCancelableEvent, fireNonCancelableEvent } from '../internal/events';
 import { isDevelopment } from '../internal/is-development';
 import { checkColumnWidths, ColumnWidthsProvider, DEFAULT_WIDTH } from './use-column-widths';
 import { useScrollSync } from '../internal/hooks/use-scroll-sync';
@@ -27,16 +27,18 @@ import StickyHeader, { StickyHeaderRef } from './sticky-header';
 import StickyScrollbar from './sticky-scrollbar';
 import useFocusVisible from '../internal/hooks/focus-visible';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
-import { SomeRequired } from '../internal/types';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap';
 import LiveRegion from '../internal/components/live-region';
+import useTableFocusNavigation from './use-table-focus-navigation';
+import { SomeRequired } from '../internal/types';
+import { TableTdElement } from './body-cell/td-element';
 
-type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
+type InternalTableProps<T, V> = SomeRequired<TableProps<T, V>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
 
 const InternalTable = React.forwardRef(
-  <T,>(
+  <T, V>(
     {
       header,
       footer,
@@ -65,6 +67,8 @@ const InternalTable = React.forwardRef(
       onRowContextMenu,
       wrapLines,
       stripedRows,
+      submitEdit,
+      onEditCancel,
       resizableColumns,
       onColumnWidthsChange,
       variant,
@@ -73,7 +77,7 @@ const InternalTable = React.forwardRef(
       firstIndex,
       renderAriaLive,
       ...rest
-    }: InternalTableProps<T>,
+    }: InternalTableProps<T, V>,
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseProps = getBaseProps(rest);
@@ -91,8 +95,17 @@ const InternalTable = React.forwardRef(
     const theadRef = useRef<HTMLTableRowElement>(null);
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
     const scrollbarRef = React.useRef<HTMLDivElement>(null);
+    const [currentEditCell, setCurrentEditCell] = useState<[number, number] | null>(null);
+    const [currentEditLoading, setCurrentEditLoading] = useState(false);
 
-    useImperativeHandle(ref, () => ({ scrollToTop: stickyHeaderRef.current?.scrollToTop || (() => undefined) }));
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToTop: stickyHeaderRef.current?.scrollToTop || (() => undefined),
+        cancelEdit: () => setCurrentEditCell(null),
+      }),
+      []
+    );
 
     const handleScroll = useScrollSync(
       [wrapperRefObject, scrollbarRef, secondaryWrapperRef],
@@ -170,9 +183,24 @@ const InternalTable = React.forwardRef(
     const focusVisibleProps = useFocusVisible();
 
     const getMouseDownTarget = useMouseDownTarget();
+    const wrapWithInlineLoadingState = (submitEdit: TableProps['submitEdit']) => {
+      if (!submitEdit) {
+        return undefined;
+      }
+      return async (...args: Parameters<typeof submitEdit>) => {
+        setCurrentEditLoading(true);
+        try {
+          await submitEdit(...args);
+        } finally {
+          setCurrentEditLoading(false);
+        }
+      };
+    };
 
     const hasDynamicHeight = computedVariant === 'full-page';
     const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
+
+    useTableFocusNavigation(selectionType, tableRefObject, visibleColumnDefinitions, items?.length);
 
     return (
       <ColumnWidthsProvider
@@ -309,11 +337,9 @@ const InternalTable = React.forwardRef(
                         aria-rowindex={firstIndex ? firstIndex + rowIndex + 1 : undefined}
                       >
                         {selectionType !== undefined && (
-                          <TableBodyCell
-                            className={clsx(
-                              styles['selection-control'],
-                              isVisualRefresh && styles['is-visual-refresh']
-                            )}
+                          <TableTdElement
+                            className={clsx(styles['selection-control'])}
+                            isVisualRefresh={isVisualRefresh}
                             isFirstRow={firstVisible}
                             isLastRow={lastVisible}
                             isSelected={isSelected}
@@ -331,34 +357,50 @@ const InternalTable = React.forwardRef(
                               onShiftToggle={updateShiftToggle}
                               {...getItemSelectionProps(item)}
                             />
-                          </TableBodyCell>
+                          </TableTdElement>
                         )}
-                        {visibleColumnDefinitions.map((column, colIndex) => (
-                          <TableBodyCellContent
-                            key={getColumnKey(column, colIndex)}
-                            style={
-                              resizableColumns
-                                ? {}
-                                : {
-                                    width: column.width,
-                                    minWidth: column.minWidth,
-                                    maxWidth: column.maxWidth,
-                                  }
-                            }
-                            column={column}
-                            item={item}
-                            wrapLines={wrapLines}
-                            isFirstRow={firstVisible}
-                            isLastRow={lastVisible}
-                            isSelected={isSelected}
-                            isNextSelected={isNextSelected}
-                            isPrevSelected={isPrevSelected}
-                            stripedRows={stripedRows}
-                            isEvenRow={isEven}
-                            hasSelection={hasSelection}
-                            hasFooter={hasFooter}
-                          />
-                        ))}
+                        {visibleColumnDefinitions.map((column, colIndex) => {
+                          const isEditing =
+                            !!currentEditCell && currentEditCell[0] === rowIndex && currentEditCell[1] === colIndex;
+                          const isEditable = !!column.editConfig && !currentEditLoading;
+                          return (
+                            <TableBodyCell
+                              key={getColumnKey(column, colIndex)}
+                              style={
+                                resizableColumns
+                                  ? {}
+                                  : {
+                                      width: column.width,
+                                      minWidth: column.minWidth,
+                                      maxWidth: column.maxWidth,
+                                    }
+                              }
+                              ariaLabels={ariaLabels}
+                              column={column}
+                              item={item}
+                              wrapLines={wrapLines}
+                              isEditable={isEditable}
+                              isEditing={isEditing}
+                              isFirstRow={firstVisible}
+                              isLastRow={lastVisible}
+                              isSelected={isSelected}
+                              isNextSelected={isNextSelected}
+                              isPrevSelected={isPrevSelected}
+                              onEditStart={() => setCurrentEditCell([rowIndex, colIndex])}
+                              onEditEnd={() => {
+                                const wasCancelled = fireCancelableEvent(onEditCancel, {});
+                                if (!wasCancelled) {
+                                  setCurrentEditCell(null);
+                                }
+                              }}
+                              submitEdit={wrapWithInlineLoadingState(submitEdit)}
+                              hasFooter={hasFooter}
+                              stripedRows={stripedRows}
+                              isEvenRow={isEven}
+                              isVisualRefresh={isVisualRefresh}
+                            />
+                          );
+                        })}
                       </tr>
                     );
                   })

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -143,6 +143,7 @@ const Thead = React.forwardRef(
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 onFocus={() => onCellFocus?.(colIndex)}
                 onBlur={onCellBlur}
+                isEditable={!!column.editConfig}
               />
             );
           })}

--- a/src/table/use-table-focus-navigation.ts
+++ b/src/table/use-table-focus-navigation.ts
@@ -1,0 +1,166 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import { TableProps } from './interfaces';
+
+function iterateTableCells<T extends HTMLElement>(
+  table: T,
+  func: (cell: HTMLTableCellElement, rowIndex: number, columnIndex: number) => void
+) {
+  table.querySelectorAll('tr').forEach((row: HTMLTableRowElement, rowIndex: number) => {
+    row.querySelectorAll('td').forEach((cell, cellIndex) => {
+      func(cell, rowIndex, cellIndex);
+    });
+  });
+}
+
+/**
+ * This hook is used to navigate between table cells using the keyboard arrow keys.
+ * All the functionality is implemented in the hook, so the table component does not
+ * need to implement any keyboard event handlers.
+ * @param enable - Toggle functionality of the hook
+ * @param tableRoot - A ref to a table container. Ideally the root element of the table (<table>); tbody is also acceptable.
+ * @param columnDefinitions - The column definitions for the table.
+ * @param numRows - The number of rows in the table.
+ */
+function useTableFocusNavigation<T extends { editConfig?: TableProps.EditConfig<any> }>(
+  selectionType: 'single' | 'multi' | 'none' = 'none',
+  tableRoot: RefObject<HTMLTableElement>,
+  columnDefinitions: Readonly<T[]>,
+  numRows: number
+) {
+  const currentFocusCell = useRef<[number, number] | null>(null);
+
+  const focusableColumns = useMemo(() => {
+    const cols = columnDefinitions.map(column => !!column.editConfig);
+    if (selectionType !== 'none') {
+      cols.unshift(false);
+    }
+    return cols;
+  }, [columnDefinitions, selectionType]);
+
+  const maxColumnIndex = useMemo(() => focusableColumns.length - 1, [focusableColumns]);
+  const minColumnIndex = useMemo(() => (selectionType !== 'none' ? 1 : 0), [selectionType]);
+
+  const focusCell = useCallback(
+    (rowIndex: number, columnIndex: number) => {
+      if (tableRoot?.current) {
+        iterateTableCells(tableRoot.current, (cell, rIndex, cIndex) => {
+          if (rIndex === rowIndex && cIndex === columnIndex) {
+            const editButton = cell.querySelector('button:last-child') as HTMLButtonElement | null;
+            editButton?.focus?.({ preventScroll: true });
+          }
+        });
+      }
+    },
+    [tableRoot]
+  );
+
+  const shiftFocus = useCallback(
+    (vertical: -1 | 0 | 1, horizontal: -1 | 0 | 1) => {
+      // istanbul ignore if next
+      if (!currentFocusCell.current) {
+        return;
+      }
+      const [rowIndex, columnIndex] = currentFocusCell.current.slice();
+      let newRowIndex = rowIndex;
+      let newColumnIndex = columnIndex;
+
+      if (vertical !== 0) {
+        newRowIndex = Math.min(numRows, Math.max(rowIndex + vertical, 0));
+      }
+
+      if (horizontal !== 0) {
+        while (newColumnIndex <= maxColumnIndex && newColumnIndex >= minColumnIndex) {
+          newColumnIndex += horizontal;
+          if (focusableColumns[newColumnIndex]) {
+            break;
+          }
+        }
+      }
+
+      if (
+        (rowIndex !== newRowIndex || columnIndex !== newColumnIndex) &&
+        currentFocusCell.current &&
+        tableRoot.current
+      ) {
+        focusCell(newRowIndex, newColumnIndex);
+      }
+    },
+    [focusCell, focusableColumns, maxColumnIndex, minColumnIndex, numRows, tableRoot]
+  );
+
+  const handleArrowKeyEvents = useCallback(
+    (event: KeyboardEvent) => {
+      const abort =
+        !!tableRoot.current?.querySelector('[data-inline-editing-active = "true"]') ||
+        !document.activeElement?.closest('[data-inline-editing-active]');
+
+      if (abort) {
+        return;
+      }
+      switch (event.key) {
+        case 'ArrowUp':
+          event.preventDefault();
+          shiftFocus(-1, 0);
+          break;
+        case 'ArrowDown':
+          event.preventDefault();
+          shiftFocus(1, 0);
+          break;
+        case 'ArrowLeft':
+          event.preventDefault();
+          shiftFocus(0, -1);
+          break;
+        case 'ArrowRight':
+          event.preventDefault();
+          shiftFocus(0, 1);
+          break;
+        // istanbul ignore next (default case = do nothing, not testable)
+        default:
+          return;
+      }
+    },
+    [shiftFocus, tableRoot]
+  );
+
+  useEffect(() => {
+    const eventListeners = new Map<[number, number], { focusin(evt: any): void }>();
+    // istanbul ignore if
+    if (!tableRoot.current) {
+      return;
+    }
+
+    const tableElement = tableRoot.current;
+
+    // istanbul ignore next (tested in use-focus-navigation.test.tsx#L210)
+    function cleanUpListeners() {
+      iterateTableCells(tableElement, (cell, rowIndex, columnIndex) => {
+        const listeners = eventListeners.get([rowIndex, columnIndex]);
+        if (listeners?.focusin) {
+          cell.removeEventListener('focusin', listeners.focusin);
+        }
+      });
+      tableElement.removeEventListener('keydown', handleArrowKeyEvents);
+    }
+
+    iterateTableCells(tableElement, (cell, rowIndex, cellIndex) => {
+      if (!focusableColumns[cellIndex]) {
+        return;
+      }
+      const listenerFns = {
+        focusin: () => {
+          currentFocusCell.current = [rowIndex, cellIndex];
+        },
+      };
+      eventListeners.set([rowIndex, cellIndex], listenerFns);
+      cell.addEventListener('focusin', listenerFns.focusin, { passive: true });
+    });
+    tableElement.addEventListener('keydown', handleArrowKeyEvents);
+
+    return () => tableElement && cleanUpListeners();
+  }, [focusableColumns, handleArrowKeyEvents, tableRoot]);
+}
+
+export default useTableFocusNavigation;

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -3,6 +3,7 @@
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import styles from '../../../table/styles.selectors.js';
 import headerCellStyles from '../../../table/header-cell/styles.selectors.js';
+import bodyCellStyles from '../../../table/body-cell/styles.selectors.js';
 import selectionStyles from '../../../table/selection-control/styles.selectors.js';
 import resizerStyles from '../../../table/resizer/styles.selectors.js';
 import CollectionPreferencesWrapper from '../collection-preferences';
@@ -131,5 +132,21 @@ export default class TableWrapper extends ComponentWrapper {
 
   findPagination(): PaginationWrapper | null {
     return this.findComponent(`.${styles['tools-pagination']}`, PaginationWrapper);
+  }
+
+  findEditingCell(): ElementWrapper | null {
+    return this.findNativeTable().findByClassName(bodyCellStyles['body-cell-edit-active']);
+  }
+
+  private _findEditingCellControls(): ElementWrapper | null {
+    return this.findEditingCell()?.findByClassName(bodyCellStyles['body-cell-editor-controls']) ?? null;
+  }
+
+  findEditingCellSaveButton(): ElementWrapper | null {
+    return this._findEditingCellControls()?.find('button[type="submit"]') ?? null;
+  }
+
+  findEditingCellCancelButton(): ElementWrapper | null {
+    return this._findEditingCellControls()?.find('button:first-child') ?? null;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es5", "es2015.collection", "es2015.Iterable", "dom"],
+    "lib": ["es5", "es2015.collection", "es2015.Iterable", "es2015.promise", "dom"],
     "types": [],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
### Description

This PR is undoing the revert of Inline Editing feature, there are some additional fixes from #605 to prevent typescript mismatches downstream (reason for initial revert)

Related links, issue #, if available: 

CR-82830418 needs to be merged to release this to live

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
