### PR TITLE
feat: Announce additional information in Attribute editor to assistive technology

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -225,7 +225,9 @@ describe('Attribute Editor', () => {
 
     test('has an ARIA live region', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
-      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement()).toBeInTheDocument();
+      expect(
+        wrapper.find(`.${liveRegionStyles.root}[data-testid="info-live-region"]`)?.getElement()
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
 import styles from '../../../lib/components/attribute-editor/styles.css.js';
@@ -207,6 +207,19 @@ describe('Attribute Editor', () => {
     test('renders correctly', () => {
       const wrapper = renderAttributeEditor({ additionalInfo: 'test' });
       expect(wrapper.findAdditionalInfo()!.getElement()).toHaveTextContent('test');
+    });
+
+    test('is conneced to add button with aria-describedby', () => {
+      const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
+      const buttonElement = wrapper.findAddButton().getElement();
+      const info = wrapper.findAdditionalInfo()?.getElement();
+      expect(buttonElement).toHaveAttribute('aria-describedby', info?.id);
+    });
+
+    test('is part of an ARIA live region', () => {
+      const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
+      const liveRegion = wrapper.find('[aria-live]')?.getElement();
+      waitFor(() => expect(liveRegion).toHaveTextContent('Test Info'));
     });
   });
 

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -5,6 +5,7 @@ import { render, waitFor } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
 import styles from '../../../lib/components/attribute-editor/styles.css.js';
+import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 import Input from '../../../lib/components/input';
 
 interface Item {
@@ -218,7 +219,7 @@ describe('Attribute Editor', () => {
 
     test('is part of an ARIA live region', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
-      const liveRegion = wrapper.find('[aria-live]')?.getElement();
+      const liveRegion = wrapper.find(`.${liveRegionStyles.root}`)?.getElement();
       waitFor(() => expect(liveRegion).toHaveTextContent('Test Info'));
     });
   });

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
 import styles from '../../../lib/components/attribute-editor/styles.css.js';
@@ -217,10 +217,9 @@ describe('Attribute Editor', () => {
       expect(buttonElement).toHaveAttribute('aria-describedby', info?.id);
     });
 
-    test('is part of an ARIA live region', () => {
+    test('has an ARIA live region', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
-      const liveRegion = wrapper.find(`.${liveRegionStyles.root}`)?.getElement();
-      waitFor(() => expect(liveRegion).toHaveTextContent('Test Info'));
+      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement()).toBeInTheDocument();
     });
   });
 

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -148,6 +148,12 @@ describe('Attribute Editor', () => {
       const buttonElement = wrapper.findAddButton().getElement();
       expect(buttonElement).toHaveAttribute('disabled');
     });
+
+    test('has no aria-describedby if there is no additional info', () => {
+      const wrapper = renderAttributeEditor({ ...defaultProps });
+      const buttonElement = wrapper.findAddButton().getElement();
+      expect(buttonElement).not.toHaveAttribute('aria-describedby');
+    });
   });
 
   describe('remove button', () => {

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -209,7 +209,7 @@ describe('Attribute Editor', () => {
       expect(wrapper.findAdditionalInfo()!.getElement()).toHaveTextContent('test');
     });
 
-    test('is conneced to add button with aria-describedby', () => {
+    test('is connected to add button with aria-describedby', () => {
       const wrapper = renderAttributeEditor({ ...defaultProps, additionalInfo: 'Test Info' });
       const buttonElement = wrapper.findAddButton().getElement();
       const info = wrapper.findAdditionalInfo()?.getElement();

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -6,7 +6,7 @@ import styles from './styles.css.js';
 
 interface AdditionalInfoProps {
   children: React.ReactNode;
-  id: string;
+  id?: string;
 }
 
 export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -1,12 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import LiveRegion from '../internal/components/live-region';
 import styles from './styles.css.js';
 
 interface AdditionalInfoProps {
   children: React.ReactNode;
+  id: string;
 }
 
-export const AdditionalInfo = ({ children }: AdditionalInfoProps) => (
-  <div className={styles['additional-info']}>{children}</div>
+export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (
+  <LiveRegion visible={true}>
+    <div id={id} className={styles['additional-info']}>
+      {children}
+    </div>
+  </LiveRegion>
 );

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -11,8 +11,8 @@ interface AdditionalInfoProps {
 
 export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (
   <LiveRegion visible={true}>
-    <div id={id} className={styles['additional-info']}>
+    <span id={id} className={styles['additional-info']}>
       {children}
-    </div>
+    </span>
   </LiveRegion>
 );

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -10,9 +10,9 @@ interface AdditionalInfoProps {
 }
 
 export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (
-  <LiveRegion visible={true}>
-    <span id={id} className={styles['additional-info']}>
+  <LiveRegion visible={true} tagName="div">
+    <div id={id} className={styles['additional-info']}>
       {children}
-    </span>
+    </div>
   </LiveRegion>
 );

--- a/src/attribute-editor/additional-info.tsx
+++ b/src/attribute-editor/additional-info.tsx
@@ -10,7 +10,7 @@ interface AdditionalInfoProps {
 }
 
 export const AdditionalInfo = ({ children, id }: AdditionalInfoProps) => (
-  <LiveRegion visible={true} tagName="div">
+  <LiveRegion visible={true} tagName="div" data-testid="info-live-region">
     <div id={id} className={styles['additional-info']}>
       {children}
     </div>

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -59,6 +59,7 @@ const InternalAttributeEditor = React.forwardRef(
     const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
     const additionalInfoId = useUniqueId('attribute-editor-info');
+    const infoAriaDescribedBy = additionalInfo ? additionalInfoId : undefined;
 
     return (
       <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root)}>
@@ -84,11 +85,11 @@ const InternalAttributeEditor = React.forwardRef(
           disabled={disableAddButton}
           onClick={onAddButtonClick}
           formAction="none"
-          __nativeAttributes={{ 'aria-describedby': additionalInfoId }}
+          __nativeAttributes={{ 'aria-describedby': infoAriaDescribedBy }}
         >
           {addButtonText}
         </InternalButton>
-        {additionalInfo && <AdditionalInfo id={additionalInfoId}>{additionalInfo}</AdditionalInfo>}
+        {additionalInfo && <AdditionalInfo id={infoAriaDescribedBy}>{additionalInfo}</AdditionalInfo>}
       </div>
     );
   }

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -18,6 +18,7 @@ import InternalBox from '../box/internal';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 type InternalAttributeEditorProps<T> = SomeRequired<AttributeEditorProps<T>, 'items'> & InternalBaseComponentProps;
 
@@ -57,6 +58,8 @@ const InternalAttributeEditor = React.forwardRef(
 
     const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
+    const additionalInfoId = useUniqueId('attribute-editor-info');
+
     return (
       <div {...baseProps} ref={mergedRef} className={clsx(baseProps.className, styles.root)}>
         <InternalBox margin={{ bottom: 'l' }}>
@@ -81,10 +84,11 @@ const InternalAttributeEditor = React.forwardRef(
           disabled={disableAddButton}
           onClick={onAddButtonClick}
           formAction="none"
+          __nativeAttributes={{ 'aria-describedby': additionalInfoId }}
         >
           {addButtonText}
         </InternalButton>
-        {additionalInfo && <AdditionalInfo>{additionalInfo}</AdditionalInfo>}
+        {additionalInfo && <AdditionalInfo id={additionalInfoId}>{additionalInfo}</AdditionalInfo>}
       </div>
     );
   }

--- a/src/internal/components/live-region/__tests__/live-region.test.tsx
+++ b/src/internal/components/live-region/__tests__/live-region.test.tsx
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../../../lib/components/test-utils/dom';
+import LiveRegion from '../../../../../lib/components/internal/components/live-region';
+
+const renderLiveRegion = (jsx: React.ReactElement) => {
+  const { container } = render(jsx);
+  return { wrapper: createWrapper(container), container };
+};
+
+describe('LiveRegion', () => {
+  it('renders', () => {
+    const { wrapper } = renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
+    const source = wrapper.find('[aria-hidden=true]')?.getElement();
+    const liveRegion = wrapper.find('[aria-live]')?.getElement();
+
+    expect(source).toHaveTextContent('Announcement');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('renders with a span by default', () => {
+    const { wrapper } = renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
+    const source = wrapper.find('[aria-hidden=true]')?.getElement();
+
+    expect(source?.tagName).toBe('SPAN');
+  });
+
+  it('wraps visible content in a span by default', () => {
+    const { wrapper } = renderLiveRegion(<LiveRegion visible={true}>Announcement</LiveRegion>);
+    const visibleSource = wrapper.find(':first-child')?.getElement();
+
+    expect(visibleSource?.tagName).toBe('SPAN');
+  });
+
+  it('can render with a div', () => {
+    const { wrapper } = renderLiveRegion(<LiveRegion tagName="div">Announcement</LiveRegion>);
+    const source = wrapper.find('[aria-hidden=true]')?.getElement();
+
+    expect(source?.tagName).toBe('DIV');
+  });
+
+  it('can wrap visible content in a div', () => {
+    const { wrapper } = renderLiveRegion(
+      <LiveRegion tagName="div" visible={true}>
+        Announcement
+      </LiveRegion>
+    );
+    const visibleSource = wrapper.find(':first-child')?.getElement();
+
+    expect(visibleSource?.tagName).toBe('DIV');
+  });
+
+  it('can render assertive live region', () => {
+    const { wrapper } = renderLiveRegion(<LiveRegion assertive={true}>Announcement</LiveRegion>);
+    expect(wrapper.find('[aria-live="assertive"]')?.getElement()).toBeInTheDocument();
+  });
+});

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -12,6 +12,7 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
   assertive?: boolean;
   delay?: number;
   visible?: boolean;
+  tagName?: 'span' | 'div';
   children: React.ReactNode;
 }
 
@@ -50,9 +51,16 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
  */
 export default memo(LiveRegion);
 
-function LiveRegion({ assertive = false, delay = 10, visible = false, children, ...restProps }: LiveRegionProps) {
-  const sourceRef = useRef<HTMLSpanElement>(null);
-  const targetRef = useRef<HTMLSpanElement>(null);
+function LiveRegion({
+  assertive = false,
+  delay = 10,
+  visible = false,
+  tagName: TagName = 'span',
+  children,
+  ...restProps
+}: LiveRegionProps) {
+  const sourceRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
+  const targetRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
 
   /*
     When React state changes, React often produces too many DOM updates, causing NVDA to
@@ -95,13 +103,13 @@ function LiveRegion({ assertive = false, delay = 10, visible = false, children, 
 
   return (
     <>
-      {visible && <span ref={sourceRef}>{children}</span>}
+      {visible && <TagName ref={sourceRef}>{children}</TagName>}
 
       <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
         {!visible && (
-          <span ref={sourceRef} aria-hidden="true">
+          <TagName ref={sourceRef} aria-hidden="true">
             {children}
-          </span>
+          </TagName>
         )}
 
         <span ref={targetRef} aria-atomic="true" aria-live={assertive ? 'assertive' : 'polite'}></span>

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -260,17 +260,15 @@ const TagEditor = React.forwardRef(
         disableAddButton={remainingTags <= 0}
         empty={i18nStrings.emptyTags}
         additionalInfo={
-          <div aria-live="polite">
-            {remainingTags < 0 ? (
-              <FormFieldError errorIconAriaLabel={i18nStrings.errorIconAriaLabel}>
-                {i18nStrings.tagLimitExceeded(tagLimit) ?? ''}
-              </FormFieldError>
-            ) : remainingTags === 0 ? (
-              i18nStrings.tagLimitReached(tagLimit) ?? ''
-            ) : (
-              i18nStrings.tagLimit(remainingTags, tagLimit)
-            )}
-          </div>
+          remainingTags < 0 ? (
+            <FormFieldError errorIconAriaLabel={i18nStrings.errorIconAriaLabel}>
+              {i18nStrings.tagLimitExceeded(tagLimit) ?? ''}
+            </FormFieldError>
+          ) : remainingTags === 0 ? (
+            i18nStrings.tagLimitReached(tagLimit) ?? ''
+          ) : (
+            i18nStrings.tagLimit(remainingTags, tagLimit)
+          )
         }
         definition={definition}
         i18nStrings={i18nStrings}


### PR DESCRIPTION
### Description

This change makes two improvements to the additional information text in attribute editor (and tag editor) for assistive technology:

1. Connect the text to the Add button using `aria-describedby`
2. Put the additional content in an ARIA live region

Related links, issue #, if available: AWSUI-20074

### How has this been tested?
Tested manually with VoiceOver.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
