### PR TITLE
revert: Container flex styles

### DIFF
--- a/pages/container/fit-height.page.tsx
+++ b/pages/container/fit-height.page.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
-import { Checkbox } from '~components';
+import React from 'react';
 import ColumnLayout from '~components/column-layout';
 import Container from '~components/container';
 import Grid from '~components/grid';
@@ -10,26 +9,26 @@ import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
 import styles from './fit-height.scss';
 
-function SmallContainer({ fitHeight }: { fitHeight: boolean }) {
+function SmallContainer() {
   return (
-    <Container fitHeight={fitHeight} header={<Header>Short</Header>} footer="footer">
+    <Container fitHeight={true} header={<Header>Short</Header>} footer="footer">
       <p>One line of text</p>
     </Container>
   );
 }
 
-function MediumContainer({ fitHeight }: { fitHeight: boolean }) {
+function MediumContainer() {
   return (
-    <Container fitHeight={fitHeight} header={<Header>Mid size</Header>} footer="footer">
+    <Container fitHeight={true} header={<Header>Mid size</Header>} footer="footer">
       <p>Content placeholder</p>
       <div style={{ height: 100 }} className={styles.placeholder}></div>
     </Container>
   );
 }
 
-function LargeContainer({ fitHeight }: { fitHeight: boolean }) {
+function LargeContainer() {
   return (
-    <Container fitHeight={fitHeight} header={<Header>Large</Header>} footer="footer">
+    <Container fitHeight={true} header={<Header>Large</Header>} footer="footer">
       <p>
         This container overflows available space. <Link href="#">Learn more</Link>.
       </p>
@@ -39,36 +38,31 @@ function LargeContainer({ fitHeight }: { fitHeight: boolean }) {
 }
 
 export default function () {
-  const [fitHeight, setFitHeight] = useState(true);
-
   return (
     <article>
       <h1>Fit height property demo</h1>
-      <Checkbox checked={fitHeight} onChange={event => setFitHeight(event.detail.checked)}>
-        Fit height
-      </Checkbox>
       <ScreenshotArea>
         <h2>Inside display:grid</h2>
         <div className={styles.grid}>
-          <SmallContainer fitHeight={fitHeight} />
-          <MediumContainer fitHeight={fitHeight} />
-          <LargeContainer fitHeight={fitHeight} />
+          <SmallContainer />
+          <MediumContainer />
+          <LargeContainer />
         </div>
         <h2>Inside column layout</h2>
         <ColumnLayout columns={3}>
-          <SmallContainer fitHeight={fitHeight} />
-          <MediumContainer fitHeight={fitHeight} />
-          <LargeContainer fitHeight={fitHeight} />
+          <SmallContainer />
+          <MediumContainer />
+          <LargeContainer />
         </ColumnLayout>
         <h2>Inside grid</h2>
         <Grid gridDefinition={[{ colspan: 6 }, { colspan: 3 }, { colspan: 3 }]}>
-          <SmallContainer fitHeight={fitHeight} />
-          <MediumContainer fitHeight={fitHeight} />
-          <LargeContainer fitHeight={fitHeight} />
+          <SmallContainer />
+          <MediumContainer />
+          <LargeContainer />
         </Grid>
         <h2>Container inside height limit</h2>
         <div className={styles.heightLimit}>
-          <LargeContainer fitHeight={fitHeight} />
+          <LargeContainer />
         </div>
       </ScreenshotArea>
     </article>

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -9,12 +9,11 @@
 
 .root {
   @include styles.styles-reset;
-  display: flex;
-  flex-flow: column nowrap;
   word-wrap: break-word;
 
   &-fit-height {
-    flex-flow: column;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     height: 100%;
   }
@@ -41,8 +40,6 @@
 }
 
 .header {
-  flex: 0 0 auto;
-
   background-color: awsui.$color-background-container-header;
   border-top-left-radius: awsui.$border-radius-container;
   border-top-right-radius: awsui.$border-radius-container;
@@ -133,13 +130,10 @@ the default white background of the container component.
 }
 
 .content {
-  flex: 1 0 auto;
-
   .root-fit-height > & {
     flex: 1;
     overflow: auto;
   }
-
   &.with-paddings {
     padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
 
@@ -150,8 +144,6 @@ the default white background of the container component.
 }
 
 .footer {
-  flex: 0 0 auto;
-
   &.with-paddings {
     padding: shared.$footer-padding;
   }


### PR DESCRIPTION
Reverts cloudscape-design/components#603

The change was applied to let some teams update their code and stop relying on container styles. The issue is resolved now, so we can release it again