### PR TITLE
refactor: Use app layout internals only inside app layout

### DIFF
--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -534,6 +534,7 @@ const OldAppLayout = React.forwardRef(
                           (disableBodyScroll ? 0 : headerHeight) +
                           (stickyNotificationsHeight !== null ? stickyNotificationsHeight : 0),
                         stickyOffsetBottom: footerHeight + (splitPanelBottomOffset || 0),
+                        hasBreadcrumbs: !!breadcrumbs,
                       }}
                     >
                       {content}

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import { InternalButton } from '../../button/internal';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -29,7 +29,7 @@ export default function AppBar() {
     isToolsOpen,
     toolsHide,
     isAnyPanelOpen,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
   const { refs: focusRefsNav } = useFocusControl(isNavigationOpen);
   const { refs: focusRefsTools } = useFocusControl(isToolsOpen, true);
 

--- a/src/app-layout/visual-refresh/background.tsx
+++ b/src/app-layout/visual-refresh/background.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 
 /**
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Background() {
-  const { hasNotificationsContent, hasStickyBackground, stickyNotifications } = useContext(AppLayoutContext);
+  const { hasNotificationsContent, hasStickyBackground, stickyNotifications } = useAppLayoutInternals();
 
   return (
     <div className={clsx(styles.background, 'awsui-context-content-header')}>

--- a/src/app-layout/visual-refresh/header.tsx
+++ b/src/app-layout/visual-refresh/header.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 
 /**
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Header() {
-  const { breadcrumbs, contentHeader, hasNotificationsContent } = useContext(AppLayoutContext);
+  const { breadcrumbs, contentHeader, hasNotificationsContent } = useAppLayoutInternals();
 
   if (!contentHeader) {
     return null;

--- a/src/app-layout/visual-refresh/index.tsx
+++ b/src/app-layout/visual-refresh/index.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import AppBar from './app-bar';
-import { AppLayoutContext, AppLayoutProvider } from './context';
+import { AppLayoutInternalsProvider } from './context';
 import { AppLayoutProps } from '../interfaces';
 import Background from './background';
 import Header from './header';
@@ -12,6 +12,7 @@ import Navigation from './navigation';
 import Notifications from './notifications';
 import SplitPanel from './split-panel';
 import Tools from './tools';
+import { useMobile } from '../../internal/hooks/use-mobile';
 
 /**
  * In mobile viewports the AppBar position changes to sticky and is placed
@@ -25,10 +26,10 @@ const AppLayoutWithRef = React.forwardRef(function AppLayout(
   props: AppLayoutProps,
   ref: React.Ref<AppLayoutProps.Ref>
 ) {
-  const { isMobile } = useContext(AppLayoutContext);
+  const isMobile = useMobile();
 
   return (
-    <AppLayoutProvider {...props} ref={ref}>
+    <AppLayoutInternalsProvider {...props} ref={ref}>
       <SplitPanel>
         <Layout>
           <Background />
@@ -52,7 +53,7 @@ const AppLayoutWithRef = React.forwardRef(function AppLayout(
           </Tools>
         </Layout>
       </SplitPanel>
-    </AppLayoutProvider>
+    </AppLayoutInternalsProvider>
   );
 });
 

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 import { AppLayoutProps } from '../interfaces';
@@ -42,7 +42,7 @@ export default function Layout({ children }: LayoutProps) {
     splitPanelPosition,
     stickyNotifications,
     toolsHide,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   const isOverlapDisabled = getOverlapDisabled(dynamicOverlapHeight, contentHeader, disableContentHeaderOverlap);
 

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import customCssProps from '../../internal/generated/custom-css-properties';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -26,7 +26,7 @@ export default function Main() {
     offsetBottom,
     footerHeight,
     splitPanelPosition,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   const isUnfocusable = isMobile && isAnyPanelOpen;
   const splitPanelHeight = offsetBottom - footerHeight;

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import { InternalButton } from '../../button/internal';
 import TriggerButton from './trigger-button';
 import styles from './styles.css.js';
@@ -31,7 +31,7 @@ export default function Navigation() {
     isToolsOpen,
     isAnyPanelOpen,
     toolsHide,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   const { refs: focusRefs } = useFocusControl(isNavigationOpen);
 

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 
@@ -12,7 +12,7 @@ import testutilStyles from '../test-classes/styles.css.js';
  */
 export default function Notifications() {
   const { ariaLabels, hasNotificationsContent, notifications, notificationsElement, stickyNotifications } =
-    useContext(AppLayoutContext);
+    useAppLayoutInternals();
 
   if (!notifications) {
     return null;

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import {
   SplitPanelContextProvider,
   SplitPanelContextProps,
@@ -32,7 +32,7 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     splitPanelSize,
     headerHeight,
     footerHeight,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   const [openButtonAriaLabel, setOpenButtonAriaLabel] = useState<undefined | string>(undefined);
 
@@ -88,7 +88,7 @@ function SplitPanelBottom() {
     splitPanelPosition,
     splitPanelReportedSize,
     splitPanelReportedHeaderHeight,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   if (!splitPanel) {
     return null;
@@ -133,7 +133,7 @@ function SplitPanelSide() {
     splitPanelMaxWidth,
     splitPanelMinWidth,
     splitPanelReportedSize,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   if (!splitPanel) {
     return null;

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../../button/internal';
-import { AppLayoutContext } from './context';
+import { useAppLayoutInternals } from './context';
 import { useSplitPanelContext } from '../../internal/context/split-panel-context';
 import TriggerButton from './trigger-button';
 import styles from './styles.css.js';
@@ -42,7 +42,7 @@ export default function Tools({ children }: ToolsProps) {
     navigationHide,
     toolsFocusControl,
     splitPanelPosition,
-  } = useContext(AppLayoutContext);
+  } = useAppLayoutInternals();
 
   const { openButtonAriaLabel } = useSplitPanelContext();
 

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import InternalContainer from '../../../lib/components/container/internal';
+import { AppLayoutContext } from '../../../lib/components/internal/context/app-layout-context';
+
+jest.mock('../../../lib/components/container/use-sticky-header', () => ({
+  useStickyHeader: () => ({ isSticky: true }),
+}));
+
+const defaultContext = { stickyOffsetTop: 0, stickyOffsetBottom: 0, hasBreadcrumbs: false };
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test('should report sticky background in full-page variant', () => {
+  const setHasStickyBackground = jest.fn();
+  const { rerender } = render(
+    <AppLayoutContext.Provider value={{ ...defaultContext, setHasStickyBackground }}>
+      <InternalContainer variant="full-page">test content</InternalContainer>
+    </AppLayoutContext.Provider>
+  );
+  expect(setHasStickyBackground).toHaveBeenCalledWith(true);
+  setHasStickyBackground.mockReset();
+  rerender(<></>);
+  expect(setHasStickyBackground).toHaveBeenCalledWith(false);
+});
+
+test('should not report sticky state in default variant', () => {
+  const setHasStickyBackground = jest.fn();
+  const { rerender } = render(
+    <AppLayoutContext.Provider value={{ ...defaultContext, setHasStickyBackground }}>
+      <InternalContainer variant="default">test content</InternalContainer>
+    </AppLayoutContext.Provider>
+  );
+  expect(setHasStickyBackground).not.toHaveBeenCalled();
+  rerender(<></>);
+  expect(setHasStickyBackground).not.toHaveBeenCalled();
+});

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useContext, useEffect, useRef } from 'react';
-import { AppLayoutContext } from '../app-layout/visual-refresh/context';
+import React, { useEffect, useRef } from 'react';
 import { ContainerProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
+import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
-import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap';
+import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
@@ -53,7 +53,7 @@ export default function InternalContainer({
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
-  const { setHasStickyBackground } = useContext(AppLayoutContext);
+  const { setHasStickyBackground } = useAppLayoutContext();
   const isRefresh = useVisualRefresh();
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
@@ -65,24 +65,21 @@ export default function InternalContainer({
 
   /**
    * The visual refresh AppLayout component needs to know if a child component
-   * has a high constrast sticky header. This is to make sure the background element
+   * has a high contrast sticky header. This is to make sure the background element
    * stays in the same vertical position as the header content.
    */
-  useEffect(
-    function handleHasStickyBackground() {
-      const shouldUpdateStickyBackground = isRefresh && isSticky && variant === 'full-page';
-      if (shouldUpdateStickyBackground) {
-        setHasStickyBackground(true);
-      }
+  useEffect(() => {
+    const shouldUpdateStickyBackground = isSticky && variant === 'full-page' && setHasStickyBackground;
+    if (shouldUpdateStickyBackground) {
+      setHasStickyBackground(true);
+    }
 
-      return function cleanup() {
-        if (shouldUpdateStickyBackground) {
-          setHasStickyBackground(false);
-        }
-      };
-    },
-    [isRefresh, isSticky, setHasStickyBackground, variant]
-  );
+    return () => {
+      if (shouldUpdateStickyBackground) {
+        setHasStickyBackground(false);
+      }
+    };
+  }, [isSticky, setHasStickyBackground, variant]);
 
   return (
     <div

--- a/src/content-layout/index.tsx
+++ b/src/content-layout/index.tsx
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useRef } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
-import { AppLayoutContext } from '../app-layout/visual-refresh/context';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { ContentLayoutProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
+import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import useBaseComponent from '../internal/hooks/use-base-component';
-import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap';
+import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
@@ -16,7 +16,7 @@ export { ContentLayoutProps };
 
 export default function ContentLayout({ children, disableOverlap, header, ...rest }: ContentLayoutProps) {
   const baseProps = getBaseProps(rest);
-  const { breadcrumbs } = useContext(AppLayoutContext);
+  const { hasBreadcrumbs } = useAppLayoutContext();
 
   const rootElement = useRef<HTMLDivElement>(null);
   const { __internalRootRef } = useBaseComponent('ContentLayout');
@@ -51,7 +51,11 @@ export default function ContentLayout({ children, disableOverlap, header, ...res
 
       {header && (
         <div
-          className={clsx(styles.header, { [styles['has-breadcrumbs']]: breadcrumbs }, 'awsui-context-content-header')}
+          className={clsx(
+            styles.header,
+            { [styles['has-breadcrumbs']]: isVisualRefresh && hasBreadcrumbs },
+            'awsui-context-content-header'
+          )}
         >
           {header}
         </div>

--- a/src/internal/context/app-layout-context.ts
+++ b/src/internal/context/app-layout-context.ts
@@ -5,11 +5,15 @@ import { useContext, createContext } from 'react';
 export interface AppLayoutContextProps {
   stickyOffsetBottom: number;
   stickyOffsetTop: number;
+  hasBreadcrumbs: boolean;
+  setHasStickyBackground?: (hasBackground: boolean) => void;
+  setDynamicOverlapHeight?: (height: number) => void;
 }
 
 export const AppLayoutContext = createContext<AppLayoutContextProps>({
   stickyOffsetTop: 0,
   stickyOffsetBottom: 0,
+  hasBreadcrumbs: false,
 });
 
 export function useAppLayoutContext() {

--- a/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
+++ b/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { useDynamicOverlap } from '../../../../../lib/components/app-layout/visual-refresh/hooks/use-dynamic-overlap';
-import { AppLayoutContext, AppLayoutProvider } from '../../../../../lib/components/app-layout/visual-refresh/context';
+import { useDynamicOverlap } from '../../../../../lib/components/internal/hooks/use-dynamic-overlap';
+import { AppLayoutContext } from '../../../../../lib/components/internal/context/app-layout-context';
 
 jest.mock('../../../../../lib/components/internal/hooks/container-queries/use-container-query', () => ({
   useContainerQuery: () => [800, () => {}],
@@ -14,13 +14,14 @@ function renderApp(children: React.ReactNode) {
   const testId = 'resolver';
 
   function App(props: { children: React.ReactNode }) {
+    const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState<number | undefined>(0);
     return (
-      <AppLayoutProvider>
-        <AppLayoutContext.Consumer>
-          {context => <div data-testid={testId}>{context.dynamicOverlapHeight}</div>}
-        </AppLayoutContext.Consumer>
+      <AppLayoutContext.Provider
+        value={{ hasBreadcrumbs: false, stickyOffsetTop: 0, stickyOffsetBottom: 0, setDynamicOverlapHeight }}
+      >
+        <div data-testid={testId}>{dynamicOverlapHeight}</div>
         {props.children}
-      </AppLayoutProvider>
+      </AppLayoutContext.Provider>
     );
   }
 

--- a/src/internal/hooks/use-dynamic-overlap/index.ts
+++ b/src/internal/hooks/use-dynamic-overlap/index.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useContext, useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
-import { AppLayoutContext } from '../context';
-import { useContainerQuery } from '../../../internal/hooks/container-queries';
+import { useAppLayoutContext } from '../../context/app-layout-context';
+import { useContainerQuery } from '../container-queries';
 
 export interface UseDynamicOverlapProps {
   /**
@@ -20,18 +20,18 @@ export interface UseDynamicOverlapProps {
  */
 export function useDynamicOverlap(props?: UseDynamicOverlapProps) {
   const disabled = props?.disabled ?? false;
-  const { setDynamicOverlapHeight } = useContext(AppLayoutContext);
+  const { setDynamicOverlapHeight } = useAppLayoutContext();
   const [overlapContainerQuery, overlapElementRef] = useContainerQuery(rect => rect.height);
 
   useLayoutEffect(
     function handleDynamicOverlapHeight() {
       if (!disabled) {
-        setDynamicOverlapHeight(overlapContainerQuery ?? 0);
+        setDynamicOverlapHeight?.(overlapContainerQuery ?? 0);
       }
 
       return () => {
         if (!disabled) {
-          setDynamicOverlapHeight(0);
+          setDynamicOverlapHeight?.(0);
         }
       };
     },

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -147,6 +147,7 @@ export default function SplitPanel({
       value={{
         stickyOffsetTop: topOffset,
         stickyOffsetBottom: bottomOffset,
+        hasBreadcrumbs: false,
       }}
     >
       {children}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -28,7 +28,7 @@ import StickyScrollbar from './sticky-scrollbar';
 import useFocusVisible from '../internal/hooks/focus-visible';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
-import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap';
+import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import LiveRegion from '../internal/components/live-region';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';

--- a/src/table/sticky-scrollbar.tsx
+++ b/src/table/sticky-scrollbar.tsx
@@ -1,11 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { forwardRef, useContext } from 'react';
-import { AppLayoutContext } from '../app-layout/visual-refresh/context';
+import React, { forwardRef } from 'react';
 import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useStickyScrollbar } from './use-sticky-scrollbar';
-import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
 
 interface StickyScrollbarProps {
@@ -19,18 +17,15 @@ export default forwardRef(StickyScrollbar);
 function StickyScrollbar({ wrapperRef, tableRef, onScroll }: StickyScrollbarProps, ref: React.Ref<HTMLDivElement>) {
   const scrollbarRef = React.useRef<HTMLDivElement>(null);
   const scrollbarContentRef = React.useRef<HTMLDivElement>(null);
-  const isRefresh = useVisualRefresh();
   const mergedRef = useMergeRefs(ref, scrollbarRef);
 
   /**
    * Use the appropriate AppLayout context (Classic or Visual Refresh) to determine
    * the offsetBottom value to be used in the useStickyScrollbar hook.
    */
-  const { stickyOffsetBottom: offsetBottomClassic } = useAppLayoutContext();
-  const { offsetBottom: offsetBottomVisualRefresh } = useContext(AppLayoutContext);
-  const offsetBottom = isRefresh ? offsetBottomVisualRefresh : offsetBottomClassic;
+  const { stickyOffsetBottom } = useAppLayoutContext();
 
-  useStickyScrollbar(scrollbarRef, scrollbarContentRef, tableRef, wrapperRef, offsetBottom);
+  useStickyScrollbar(scrollbarRef, scrollbarContentRef, tableRef, wrapperRef, stickyOffsetBottom);
 
   return (
     <div ref={mergedRef} className={styles['sticky-scrollbar']} onScroll={onScroll}>

--- a/src/wizard/wizard-form-header.tsx
+++ b/src/wizard/wizard-form-header.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
 import React from 'react';
-import { useDynamicOverlap } from '../app-layout/visual-refresh/hooks/use-dynamic-overlap.js';
+import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import styles from './styles.css.js';
 
 interface WizardFormHeaderProps {


### PR DESCRIPTION
### Description

There are two app layout contexts. One for use inside other components to calculate offsets (mostly for sticky elements). Second is intended to be used only inside app layout sub-components and only in visual refresh. Let's make it more strict

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Dev pipeline build

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
