### PR TITLE
chore: Fix wizard rerendering causing multiple start step events

### DIFF
--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -1,12 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import WizardWrapper from '../../../lib/components/test-utils/dom/wizard';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Button from '../../../lib/components/button';
 import Wizard, { WizardProps } from '../../../lib/components/wizard';
 import styles from '../../../lib/components/wizard/styles.selectors.js';
+
+declare global {
+  interface Window {
+    AWSC?: any;
+    panorama?: any;
+  }
+}
 
 const DEFAULT_I18N_SETS = [
   {
@@ -523,5 +530,133 @@ describe('Custom actions', () => {
 
     wrapper.findSecondaryActions()!.findButton()!.click();
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Metrics', () => {
+  beforeEach(() => {
+    window.panorama = () => {};
+    jest.spyOn(window, 'panorama');
+  });
+
+  test('sends a startStep step metric on initial render', () => {
+    renderDefaultWizard();
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step1',
+        eventDetail: 'step1',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('does not send multiple startStep metrics on rerenders', () => {
+    const [, rerender] = renderDefaultWizard();
+    rerender({});
+    expect(window.panorama).toBeCalledTimes(1);
+  });
+
+  test('sends a startStep metric when navigating to a new step when navigating between steps using the primary button', () => {
+    const [wrapper] = renderDefaultWizard();
+    act(() => wrapper.findPrimaryButton().click());
+
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step2',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('sends a startStep metric when navigating to previous step using the primary button', () => {
+    const [wrapper] = renderDefaultWizard();
+    act(() => wrapper.findPrimaryButton().click());
+
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step2',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+      })
+    );
+
+    act(() => wrapper.findPreviousButton()!.click());
+
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step1',
+        eventDetail: 'step1',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('sends a startStep metric when navigating to a new step when navigating with the navigation', () => {
+    const [wrapper] = renderDefaultWizard({
+      steps: [
+        { title: 'Step 1', isOptional: true, content: 'content 1' },
+        { title: 'Step 2', isOptional: true, content: 'content 2' },
+        { title: 'Step 3', isOptional: true, content: 'content 3' },
+      ],
+      allowSkipTo: true,
+    });
+    act(() => wrapper.findMenuNavigationLink(2)!.click());
+
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step2',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('sends a navigate metric when navigating between steps using the primary button', () => {
+    const [wrapper] = renderDefaultWizard();
+    act(() => wrapper.findPrimaryButton().click());
+    expect(window.panorama).toBeCalledTimes(3); // start step 1, navigate, start step 2
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step1',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_navigate',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  test('sends a startStep metric when navigating to a new step when navigating with the navigation', () => {
+    const [wrapper] = renderDefaultWizard({
+      steps: [
+        { title: 'Step 1', isOptional: true, content: 'content 1' },
+        { title: 'Step 2', isOptional: true, content: 'content 2' },
+        { title: 'Step 3', isOptional: true, content: 'content 3' },
+      ],
+      allowSkipTo: true,
+    });
+    act(() => wrapper.findMenuNavigationLink(2)!.click());
+
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step1',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_navigate',
+        timestamp: expect.any(Number),
+      })
+    );
   });
 });

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent } from '../internal/events';
@@ -15,9 +15,8 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 
-import { useWizardAnalytics } from './internal/analytics';
+import { trackStartStep, trackNavigate, trackSubmit } from './internal/analytics';
 
 export { WizardProps };
 
@@ -38,7 +37,6 @@ export default function Wizard({
 
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
   const ref = useMergeRefs(breakpointsRef, __internalRootRef);
-  const { trackStartStep, trackNavigate, trackSubmit } = useWizardAnalytics();
 
   const smallContainer = breakpoint === 'default';
 
@@ -89,9 +87,9 @@ export default function Wizard({
     );
   }
 
-  useEffectOnUpdate(() => {
+  useEffect(() => {
     trackStartStep(actualActiveStepIndex);
-  }, [actualActiveStepIndex, trackStartStep]);
+  }, [actualActiveStepIndex]);
 
   return (
     <div {...baseProps} className={clsx(styles.root, baseProps.className)} ref={ref}>

--- a/src/wizard/internal/analytics.tsx
+++ b/src/wizard/internal/analytics.tsx
@@ -32,53 +32,53 @@ const timeEnd = (key = 'current', clear = false) => {
   return (Date.now() - start) / 1000; // Convert to seconds
 };
 
-export const useWizardAnalytics = () => {
-  const trackStartStep = (stepIndex?: number) => {
-    const eventContext = createEventContext(stepIndex);
+export const trackStartStep = (stepIndex?: number) => {
+  const eventContext = createEventContext(stepIndex);
 
-    // Track the starting time of the wizard
-    if (stepIndex === undefined) {
-      timeStart(prefix);
-    }
+  // Track the starting time of the wizard
+  if (stepIndex === undefined) {
+    timeStart(prefix);
+  }
 
-    // End the timer of the previous step
-    const time = timeEnd();
+  // End the timer of the previous step
+  const time = timeEnd();
 
-    // Start a new timer of the current step
-    timeStart();
+  // Start a new timer of the current step
+  timeStart();
 
-    Metrics.sendPanoramaMetric({
-      eventContext,
-      eventDetail: createEventDetail(stepIndex),
-      eventType: createEventType('step'),
-      ...(time !== undefined && { eventValue: time.toString() }),
-    });
-  };
+  Metrics.sendPanoramaMetric({
+    eventContext,
+    eventDetail: createEventDetail(stepIndex),
+    eventType: createEventType('step'),
+    ...(time !== undefined && { eventValue: time.toString() }),
+  });
+};
 
-  const trackNavigate = (activeStepIndex: number, requestedStepIndex: number, reason: WizardProps.NavigationReason) => {
-    const eventContext = createEventContext(activeStepIndex);
-    const time = timeEnd();
+export const trackNavigate = (
+  activeStepIndex: number,
+  requestedStepIndex: number,
+  reason: WizardProps.NavigationReason
+) => {
+  const eventContext = createEventContext(activeStepIndex);
+  const time = timeEnd();
 
-    Metrics.sendPanoramaMetric({
-      eventContext,
-      eventDetail: createEventDetail(requestedStepIndex),
-      eventType: createEventType('navigate'),
-      eventValue: { reason, ...(time !== undefined && { time }) },
-    });
-  };
+  Metrics.sendPanoramaMetric({
+    eventContext,
+    eventDetail: createEventDetail(requestedStepIndex),
+    eventType: createEventType('navigate'),
+    eventValue: { reason, ...(time !== undefined && { time }) },
+  });
+};
 
-  const trackSubmit = (stepIndex: number) => {
-    const eventContext = createEventContext(stepIndex);
-    // End the timer of the wizard
-    const time = timeEnd(prefix);
+export const trackSubmit = (stepIndex: number) => {
+  const eventContext = createEventContext(stepIndex);
+  // End the timer of the wizard
+  const time = timeEnd(prefix);
 
-    Metrics.sendPanoramaMetric({
-      eventContext,
-      eventDetail: createEventDetail(stepIndex),
-      eventType: createEventType('submit'),
-      ...(time !== undefined && { eventValue: time.toString() }),
-    });
-  };
-
-  return { trackStartStep, trackNavigate, trackSubmit };
+  Metrics.sendPanoramaMetric({
+    eventContext,
+    eventDetail: createEventDetail(stepIndex),
+    eventType: createEventType('submit'),
+    ...(time !== undefined && { eventValue: time.toString() }),
+  });
 };


### PR DESCRIPTION
### Description

Removed `trackStartStep` as a dependency of the effect hook. As the functions inside the `useWizardAnalytics` hook are recreated on render it causes this hook to trigger multiple times. The intention of the effect is to send an event only when the step index changes.

Related links, issue #, if available: n/a

### How has this been tested?

A quick test in the dev page while logging the events while triggering a re-render in the parent component. As seen in the before multiple events are fire but in the after only a single event is fired.

Before:
![Screenshot 2023-01-11 at 14 13 45](https://user-images.githubusercontent.com/2368590/211815485-d6970812-3e09-4f27-815f-60dd6b1e68ea.png)

After:
![Screenshot 2023-01-11 at 14 14 30](https://user-images.githubusercontent.com/2368590/211815509-0d3b4bc6-0943-4e92-b1fd-960df88a4b30.png)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
