### PR TITLE
fix: Prevent table firstIndex property from being printed to the page

### DIFF
--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -266,7 +266,7 @@ const InternalTable = React.forwardRef(
             {...wrapperProps}
             {...focusVisibleProps}
           >
-            {renderAriaLive && firstIndex && (
+            {!!renderAriaLive && !!firstIndex && (
               <LiveRegion>
                 <span>{renderAriaLive({ totalItemsCount, firstIndex, lastIndex: firstIndex + items.length })}</span>
               </LiveRegion>


### PR DESCRIPTION
### Description

When `firstIndex` is `0`, the expression is falsy, but React treats it as a printable value, so we get a random "0" printed to the page.

Maybe this is a good time to think about [react/no-leaked-render](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)?

Related links, issue #, if available: AWSUI-20107

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
