### PR TITLE
fix: Buttondropdown trigger should toggle dropdown

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -122,5 +122,14 @@ describe('ButtonDropdown component', () => {
         `[AwsUi] [ButtonDropdown] A javascript: URL was blocked as a security precaution. The URL was "javascript:alert('Hello!')".`
       );
     });
+
+    test('should toggle dropdown on clicking the trigger', () => {
+      const wrapper = renderButtonDropdown({ items });
+      const triggerButton = wrapper.findNativeButton().getElement();
+      triggerButton.click();
+      expect(wrapper.findOpenDropdown()).toBeTruthy();
+      triggerButton.click();
+      expect(wrapper.findOpenDropdown()).not.toBeTruthy();
+    });
   });
 });

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -126,6 +126,7 @@ const DatePicker = React.forwardRef(
             placeholder={placeholder}
             ref={internalInputRef}
             autoFocus={autoFocus}
+            onFocus={onDropdownCloseHandler}
           />
         </div>
         <div>

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -291,7 +291,7 @@ const Dropdown = ({
       return;
     }
     const clickListener = (e: MouseEvent) => {
-      if (!dropdownRef.current?.contains(e.target as Node)) {
+      if (!dropdownRef.current?.contains(e.target as Node) && !triggerRef.current?.contains(e.target as Node)) {
         fireNonCancelableEvent(onDropdownClose);
       }
     };


### PR DESCRIPTION
### Description

Cause: 
when clicking on the trigger in Buttondropdown, it firstly calls onDropdownClose() which closes the dropdown https://github.com/cloudscape-design/components/blob/40a405bd591436179a2e1e9a4287664bc7f6582c/src/internal/components/dropdown/index.tsx#L271-L283
Then it calls toggleDropdown(), it reopens the dropdown https://github.com/cloudscape-design/components/blob/11b4eacd8433b467c2ef7f3e7b7f695e53cfa104/src/button-dropdown/internal.tsx#L81-L84

Calling onDropdownClose when the clicking target is the trigger is also not ideal for other components using Dropdown and onDropdownClose, which are DateRangePicker and DatePicker. For example, when clicking the trigger of DRP, the dropdown gets closed and opened again. 

The fix is to treat trigger as dropdown content, not call onDropdownClose when clicking it. And handle click event on  components own trigger, because they are expecting different behaviors (Buttondropdown toggles dropdown, DatePicker wants close it when clicking input but keeps open on clicking button, DRP keeps open when clicking trigger). Having one common handler plus individual one makes it messy as now. 

Related links, issue AWSUI-20087

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
