### PR TITLE
fix: Add missing API doc for table cell render function

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11088,8 +11088,13 @@ add a meaningful description to the whole selection.
 * \`id\` (string) - Specifies a unique column identifier. The property is used 1) as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering,
   and 2) to match entries in the \`visibleColumns\` property, if defined.
 * \`header\` (ReactNode) - Determines the display of the column header.
-* \`cell\` ((item) => ReactNode) - Determines the display of a cell's content. You receive the current table row
-  item as an argument.
+* \`cell\` ((item, cellContext) => ReactNode) - Determines the display of a cell's content. You receive the current table row
+  item as an argument. If inline editing is enabled for the column, the \`cell\` function is called with an additional
+ \`cellContext\` argument that provides the following properties:
+* * \`cellContext.isEditing\` (boolean) - Indicates whether the cell is currently being edited. Use this to conditionally render
+       the cell content. For example, you can render a text input field when the cell is being edited, and plain text otherwise.
+* * \`cellContext.currentValue\` (ValueType) - State to keep track of a value in input fields while editing.
+* * \`cellContext.setValue\` ((ValueType) => void) - Function to update \`currentValue\`. This should be called when the value in input field changes.
 * \`width\` (string | number) - Specifies the column width. Corresponds to the \`width\` css-property. If the width is not set,
   the browser automatically adjusts the column width based on the content. When \`resizableColumns\` property is
   set to \`true\`, additional constraints apply: 1) string values are not allowed, and 2) the last visible column always

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -65,8 +65,13 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `id` (string) - Specifies a unique column identifier. The property is used 1) as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering,
    *   and 2) to match entries in the `visibleColumns` property, if defined.
    * * `header` (ReactNode) - Determines the display of the column header.
-   * * `cell` ((item) => ReactNode) - Determines the display of a cell's content. You receive the current table row
-   *   item as an argument.
+   * * `cell` ((item, cellContext) => ReactNode) - Determines the display of a cell's content. You receive the current table row
+   *   item as an argument. If inline editing is enabled for the column, the `cell` function is called with an additional
+   *  `cellContext` argument that provides the following properties:
+   * * * `cellContext.isEditing` (boolean) - Indicates whether the cell is currently being edited. Use this to conditionally render
+   *        the cell content. For example, you can render a text input field when the cell is being edited, and plain text otherwise.
+   * * * `cellContext.currentValue` (ValueType) - State to keep track of a value in input fields while editing.
+   * * * `cellContext.setValue` ((ValueType) => void) - Function to update `currentValue`. This should be called when the value in input field changes.
    * * `width` (string | number) - Specifies the column width. Corresponds to the `width` css-property. If the width is not set,
    *   the browser automatically adjusts the column width based on the content. When `resizableColumns` property is
    *   set to `true`, additional constraints apply: 1) string values are not allowed, and 2) the last visible column always


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
The API Doc for this field seems to have gone missing between the first release and re-release somehow. This PR restores this doc.

Content reviewed by @fralongo on 22.12.2022
<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
