### PR TITLE
feat: Add errorIconAriaLabel prop in Select, Multiselect, and Autosuggest

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1433,6 +1433,12 @@ receive focus.",
       "type": "AutosuggestProps.EnteredTextLabel",
     },
     Object {
+      "description": "Provides a text alternative for the error icon in the error message.",
+      "name": "errorIconAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
       "name": "errorText",
       "optional": true,
@@ -7704,6 +7710,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "boolean",
     },
     Object {
+      "description": "Provides a text alternative for the error icon in the error message.",
+      "name": "errorIconAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
       "name": "errorText",
       "optional": true,
@@ -10076,6 +10088,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "name": "disabled",
       "optional": true,
       "type": "boolean",
+    },
+    Object {
+      "description": "Provides a text alternative for the error icon in the error message.",
+      "name": "errorIconAriaLabel",
+      "optional": true,
+      "type": "string",
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -7,6 +7,7 @@ import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosugge
 import styles from '../../../lib/components/autosuggest/styles.css.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
+import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
 
 let uniqueId = 1;
 
@@ -172,6 +173,21 @@ describe('Dropdown states', () => {
 
       await expect(container).toValidateA11y();
     });
+  });
+
+  test('should display error status icon with provided aria label', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest
+        {...defaultProps}
+        statusType="error"
+        errorText="Test error text"
+        errorIconAriaLabel="Test error text"
+      />
+    );
+    wrapper.focus();
+    const statusIcon = wrapper.findStatusIndicator()!.findByClassName(statusIconStyles.icon)!.getElement();
+    expect(statusIcon).toHaveAttribute('aria-label', 'Test error text');
+    expect(statusIcon).toHaveAttribute('role', 'img');
   });
 
   it('when no options is matched the dropdown is shown but aria-expanded is false', () => {

--- a/src/internal/components/dropdown-status/__tests__/dropdown-status.test.tsx
+++ b/src/internal/components/dropdown-status/__tests__/dropdown-status.test.tsx
@@ -6,7 +6,8 @@ import {
   DropdownStatusPropsExtended,
   useDropdownStatus,
 } from '../../../../../lib/components/internal/components/dropdown-status';
-
+import createWrapper from '../../../../../lib/components/test-utils/dom';
+import statusIconStyles from '../../../../../lib/components/status-indicator/styles.selectors.js';
 function StatusRender(props: DropdownStatusPropsExtended) {
   const { isSticky, content } = useDropdownStatus(props);
   return (
@@ -18,10 +19,12 @@ function StatusRender(props: DropdownStatusPropsExtended) {
 }
 
 function renderComponent(props: DropdownStatusPropsExtended) {
-  const { getByTestId } = render(<StatusRender {...props} />);
+  const { getByTestId, container } = render(<StatusRender {...props} />);
+  const wrapper = createWrapper(container!);
   return {
     getStickyState: () => getByTestId('sticky-state').textContent,
     getContent: () => getByTestId('content').textContent,
+    getIcon: () => wrapper.findStatusIndicator()!.findByClassName(statusIconStyles.icon)!.getElement(),
   };
 }
 
@@ -95,5 +98,18 @@ describe('useDropdownStatus', () => {
 
     expect(getStickyState()).toBe('true');
     expect(getContent()).toBe('');
+  });
+
+  test('renders error icon with ariaLabel when provided', () => {
+    const { getContent, getIcon } = renderComponent({
+      statusType: 'error',
+      errorText: 'we got a problem',
+      recoveryText: 'do not worry',
+      errorIconAriaLabel: 'error-icon',
+    });
+
+    expect(getContent()).toBe('we got a problem do not worry');
+    expect(getIcon()).toHaveAttribute('aria-label', 'error-icon');
+    expect(getIcon()).toHaveAttribute('role', 'img');
   });
 });

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -58,6 +58,7 @@ export const useDropdownStatus: UseDropdownStatus = ({
   isNoMatch,
   noMatch,
   onRecoveryClick,
+  errorIconAriaLabel,
 }) => {
   const previousStatusType = usePrevious(statusType);
   const statusResult: DropdownStatusResult = { isSticky: true, content: null };
@@ -67,7 +68,11 @@ export const useDropdownStatus: UseDropdownStatus = ({
   } else if (statusType === 'error') {
     statusResult.content = (
       <span>
-        <InternalStatusIndicator type="error" __animate={previousStatusType !== 'error'}>
+        <InternalStatusIndicator
+          type="error"
+          __animate={previousStatusType !== 'error'}
+          iconAriaLabel={errorIconAriaLabel}
+        >
           {errorText}
         </InternalStatusIndicator>{' '}
         {recoveryText && (

--- a/src/internal/components/dropdown-status/interfaces.ts
+++ b/src/internal/components/dropdown-status/interfaces.ts
@@ -25,6 +25,11 @@ export interface DropdownStatusProps {
    * Use the `onLoadItems` event to perform a recovery action (for example, retrying the request).
    **/
   recoveryText?: string;
+
+  /**
+   * Provides a text alternative for the error icon in the error message.
+   */
+  errorIconAriaLabel?: string;
   /**
    * Specifies the current status of loading more options.
    * * `pending` - Indicates that no request in progress, but more options may be loaded.

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -7,6 +7,7 @@ import Multiselect, { MultiselectProps } from '../../../lib/components/multisele
 import tokenGroupStyles from '../../../lib/components/token-group/styles.css.js';
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
 import '../../__a11y__/to-validate-a11y';
+import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
 
 const defaultOptions: MultiselectProps.Options = [
   { label: 'First', value: '1' },
@@ -270,6 +271,22 @@ describe('Dropdown states', () => {
 
       await expect(container).toValidateA11y();
     });
+  });
+  test('should display error status icon with provided aria label', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={[]}
+        options={defaultOptions}
+        statusType="error"
+        errorText="Test error text"
+        errorIconAriaLabel="Test error text"
+      />
+    );
+    wrapper.openDropdown();
+
+    const statusIcon = wrapper.findStatusIndicator()!.findByClassName(statusIconStyles.icon)!.getElement();
+    expect(statusIcon).toHaveAttribute('aria-label', 'Test error text');
+    expect(statusIcon).toHaveAttribute('role', 'img');
   });
 });
 

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -182,6 +182,7 @@ const InternalMultiselect = React.forwardRef(
       isNoMatch,
       noMatch,
       onRecoveryClick: handleRecoveryClick,
+      errorIconAriaLabel: restProps.errorIconAriaLabel,
     });
 
     const filter = (

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -6,6 +6,7 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import Select, { SelectProps } from '../../../lib/components/select';
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
 import '../../__a11y__/to-validate-a11y';
+import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
 
 const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
 const defaultOptions: SelectProps.Options = [
@@ -251,6 +252,22 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
 
         await expect(container).toValidateA11y();
       });
+    });
+    test('should display error status icon with provided aria label', () => {
+      const { wrapper } = renderSelect({
+        statusType: 'error',
+        errorText: 'Test error text',
+        errorIconAriaLabel: 'Test error text',
+      });
+
+      wrapper.openDropdown();
+
+      const statusIcon = wrapper
+        .findStatusIndicator({ expandToViewport })!
+        .findByClassName(statusIconStyles.icon)!
+        .getElement();
+      expect(statusIcon).toHaveAttribute('aria-label', 'Test error text');
+      expect(statusIcon).toHaveAttribute('role', 'img');
     });
   });
 

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -178,6 +178,7 @@ const InternalSelect = React.forwardRef(
       isNoMatch,
       noMatch,
       onRecoveryClick: handleRecoveryClick,
+      errorIconAriaLabel: restProps.errorIconAriaLabel,
     });
 
     const announcement = useAnnouncement({


### PR DESCRIPTION
### Description

This PR adds the `errorIconAriaLabel` prop to Select, Multiselect, Autosuggest.

Related links, issue #, if available: 

AWSUI-20070

### How has this been tested?

Added unit tests for all affected components.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
