### PR TITLE
feat: Make split panel header scrollable when page height is small

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -4,6 +4,7 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import mobileStyles from '../../../lib/components/app-layout/mobile-toolbar/styles.selectors.js';
+import styles from '../../../lib/components/split-panel/styles.selectors.js';
 import { viewports } from './constants';
 
 const wrapper = createWrapper().findAppLayout();
@@ -171,6 +172,32 @@ test(
     expect((await page.getSplitPanelSize()).height).toEqual(160);
     await page.dragResizerTo({ x: 0, y: 0 });
     expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
+  })
+);
+
+test(
+  'should split panel header position NOT be fixed for constrained heights',
+  setupTest(async page => {
+    await page.openPanel();
+    const { top: topBeforeScroll } = await page.getBoundingBox(
+      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
+    );
+    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 10 });
+    const { top: topAfterScroll } = await page.getBoundingBox(
+      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
+    );
+    expect(topAfterScroll).toEqual(topBeforeScroll);
+
+    await page.setWindowSize({ width: 680, height: 360 });
+    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 0 });
+    const { top: topBeforeScrollOnSmallScreen } = await page.getBoundingBox(
+      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
+    );
+    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 50 });
+    const { top: topAfterScrollOnSmallScreen } = await page.getBoundingBox(
+      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
+    );
+    expect(topAfterScrollOnSmallScreen).toEqual(topBeforeScrollOnSmallScreen - 50);
   })
 );
 

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -326,6 +326,13 @@ const OldAppLayout = React.forwardRef(
       onPreferencesChange: onSplitPanelPreferencesSet,
       reportSize: setSplitPanelReportedSize,
       reportHeaderHeight: setSplitPanelReportedHeaderHeight,
+      isStickyHeader: () => {
+        const height =
+          disableBodyScroll && legacyScrollRootRef.current
+            ? legacyScrollRootRef.current.clientHeight
+            : document.documentElement.clientHeight - headerHeight - footerHeight;
+        return height > CONSTRAINED_PAGE_HEIGHT;
+      },
     };
     const splitPanelWrapped = splitPanel && (
       <SplitPanelContextProvider value={splitPanelContext}>{splitPanel}</SplitPanelContextProvider>

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -13,6 +13,7 @@ import { AppLayoutProps } from '../interfaces';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
 import { Transition } from '../../internal/components/transition';
 import customCssProps from '../../internal/generated/custom-css-properties';
+import { CONSTRAINED_PAGE_HEIGHT } from '../../split-panel/utils/size-utils';
 
 /**
  * If there is no Split Panel in the AppLayout context then the SplitPanel
@@ -67,6 +68,7 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     openButtonAriaLabel,
     setOpenButtonAriaLabel,
     lastInteraction: splitPanelLastInteraction,
+    isStickyHeader: () => document.documentElement.clientHeight - headerHeight - footerHeight > CONSTRAINED_PAGE_HEIGHT,
   };
 
   return <SplitPanelContextProvider value={context}>{children}</SplitPanelContextProvider>;

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -32,6 +32,7 @@ export interface SplitPanelContextProps {
   reportHeaderHeight: (pixels: number) => void;
   openButtonAriaLabel?: string;
   setOpenButtonAriaLabel?: (value: string) => void;
+  isStickyHeader: () => boolean;
 }
 
 const SplitPanelContext = createContext<SplitPanelContextProps | null>(null);

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -19,4 +19,5 @@ export const defaultSplitPanelContextProps: SplitPanelContextProps = {
   onPreferencesChange: jest.fn(),
   reportSize: jest.fn(),
   reportHeaderHeight: jest.fn(),
+  isStickyHeader: jest.fn(),
 };

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -14,6 +14,7 @@ interface SplitPanelContentBottomProps extends SplitPanelContentProps {
   state: TransitionStatus;
   transitioningElementRef: React.Ref<any>;
   appLayoutMaxWidth: React.CSSProperties | undefined;
+  isStickyHeader: () => boolean;
 }
 
 export function SplitPanelContentBottom({
@@ -29,6 +30,7 @@ export function SplitPanelContentBottom({
   appLayoutMaxWidth,
   panelHeaderId,
   onToggle,
+  isStickyHeader,
 }: SplitPanelContentBottomProps) {
   const isRefresh = useVisualRefresh();
   const {
@@ -77,7 +79,14 @@ export function SplitPanelContentBottom({
     >
       {isOpen && <div className={styles['slider-wrapper-bottom']}>{resizeHandle}</div>}
       <div className={styles['drawer-content-bottom']} aria-labelledby={panelHeaderId} role="region">
-        <div className={clsx(styles['pane-header-wrapper-bottom'], centeredMaxWidthClasses)} ref={headerRef}>
+        <div
+          className={clsx(
+            styles['pane-header-wrapper-bottom'],
+            { [styles['sticky-header']]: isStickyHeader() },
+            centeredMaxWidthClasses
+          )}
+          ref={headerRef}
+        >
           {header}
         </div>
         <div className={clsx(styles['content-bottom'], centeredMaxWidthClasses)} aria-hidden={!isOpen}>

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -59,6 +59,7 @@ export default function SplitPanel({
     onToggle,
     reportSize,
     setOpenButtonAriaLabel,
+    isStickyHeader,
   } = useSplitPanelContext();
   const baseProps = getBaseProps(restProps);
   const focusVisible = useFocusVisible();
@@ -292,6 +293,7 @@ export default function SplitPanel({
               state={state}
               transitioningElementRef={transitioningElementRef}
               appLayoutMaxWidth={appLayoutMaxWidth}
+              isStickyHeader={isStickyHeader}
             >
               {wrappedChildren}
             </SplitPanelContentBottom>

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -160,6 +160,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   display: flex;
   justify-content: center;
   z-index: 2;
+  background-color: awsui.$color-background-layout-panel-content;
 }
 
 .slider-wrapper-side {
@@ -198,14 +199,16 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
 }
 
 .pane-header-wrapper-bottom {
-  /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
-  position: sticky;
-  top: 0;
   display: flex;
   align-items: center;
   flex-direction: column;
   z-index: 1; // should be above .content-bottom
   padding: 0 awsui.$space-scaled-2x-xxxl;
+  &.sticky-header {
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    position: sticky;
+    top: 0;
+  }
   .drawer-mobile > .drawer-content-bottom > & {
     padding: 0 awsui.$space-l;
   }


### PR DESCRIPTION
### Description

Split panel header should not be fixed when page height is constraint.
Split panel resizer should still be fixed at the top of the panel.

Related links, issue AWSUI-20054

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
