### PR TITLE
refactor: Move edit mode cell render to its own function

### DIFF
--- a/pages/table/editable-with-app-layout.page.tsx
+++ b/pages/table/editable-with-app-layout.page.tsx
@@ -71,9 +71,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
           return errorsMeta.get(item);
         }
       },
-    },
-    cell(item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) {
-      if (isEditing) {
+      editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
         return (
           <Input
             autoFocus={true}
@@ -81,10 +79,9 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
             onChange={withDirtyState(event => setValue(event.detail.value))}
           />
         );
-      }
-
-      return item.DomainName;
+      },
     },
+    cell: item => item.DomainName,
   },
   {
     id: 'Status',
@@ -99,9 +96,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
     editConfig: {
       ariaLabel: 'Origin',
       editIconAriaLabel: 'editable',
-    },
-    cell: (item, { isEditing, setValue, currentValue }: TableProps.CellContext<string>) => {
-      if (isEditing) {
+      editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
         return (
           <Autosuggest
             autoFocus={true}
@@ -114,9 +109,9 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
             placeholder="Enter an origin domain name"
           />
         );
-      }
-      return item.Origin;
+      },
     },
+    cell: item => item.Origin,
   },
   {
     id: 'CertificateMinVersion',
@@ -125,9 +120,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
     editConfig: {
       ariaLabel: 'Certificate Minimum Version',
       editIconAriaLabel: 'editable',
-    },
-    cell(item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) {
-      if (isEditing) {
+      editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
         const value = currentValue ?? item.CertificateMinVersion;
 
         return (
@@ -140,10 +133,9 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
             options={tlsVersions}
           />
         );
-      }
-
-      return item.CertificateMinVersion;
+      },
     },
+    cell: item => item.CertificateMinVersion,
   },
   {
     id: 'LastModifiedTime',
@@ -151,11 +143,9 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
     editConfig: {
       ariaLabel: 'Last Modified',
       editIconAriaLabel: 'editable',
-    },
-    cell: (item, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) => {
-      const time = new Date(item.LastModifiedTime);
-      const value = [time.getHours(), time.getMinutes()].map(part => part.toString().padStart(2, '0')).join(':');
-      if (isEditing) {
+      editingCell(item, { currentValue, setValue }: TableProps.CellContext<string>) {
+        const time = new Date(item.LastModifiedTime);
+        const value = [time.getHours(), time.getMinutes()].map(part => part.toString().padStart(2, '0')).join(':');
         return (
           <TimeInput
             autoFocus={true}
@@ -166,8 +156,11 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
             })}
           />
         );
-      }
-
+      },
+    },
+    cell: item => {
+      const time = new Date(item.LastModifiedTime);
+      const value = [time.getHours(), time.getMinutes()].map(part => part.toString().padStart(2, '0')).join(':');
       return value;
     },
   },
@@ -178,10 +171,8 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
     editConfig: {
       ariaLabel: 'Tags',
       editIconAriaLabel: 'editable',
-    },
-    cell(item, { isEditing, setValue, currentValue }: TableProps.CellContext<MultiselectProps.Options>) {
-      const value = currentValue ?? (item.Tags as MultiselectProps.Options);
-      if (isEditing) {
+      editingCell(item, { currentValue, setValue }: TableProps.CellContext<MultiselectProps.Options>) {
+        const value = currentValue ?? (item.Tags as MultiselectProps.Options);
         return (
           <Box padding={{ vertical: 'xxs' }}>
             <Multiselect
@@ -197,8 +188,10 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
             />
           </Box>
         );
-      }
-      return value.map(tag => tag.label).join(', ');
+      },
+    },
+    cell(item) {
+      return item.Tags.map(tag => tag.label).join(', ');
     },
   },
 ];

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11106,13 +11106,8 @@ add a meaningful description to the whole selection.
 * \`id\` (string) - Specifies a unique column identifier. The property is used 1) as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering,
   and 2) to match entries in the \`visibleColumns\` property, if defined.
 * \`header\` (ReactNode) - Determines the display of the column header.
-* \`cell\` ((item, cellContext) => ReactNode) - Determines the display of a cell's content. You receive the current table row
-  item as an argument. If inline editing is enabled for the column, the \`cell\` function is called with an additional
- \`cellContext\` argument that provides the following properties:
-* * \`cellContext.isEditing\` (boolean) - Indicates whether the cell is currently being edited. Use this to conditionally render
-       the cell content. For example, you can render a text input field when the cell is being edited, and plain text otherwise.
-* * \`cellContext.currentValue\` (ValueType) - State to keep track of a value in input fields while editing.
-* * \`cellContext.setValue\` ((ValueType) => void) - Function to update \`currentValue\`. This should be called when the value in input field changes.
+* \`cell\` ((item) => ReactNode) - Determines the display of a cell's content. You receive the current table row
+  item as an argument.
 * \`width\` (string | number) - Specifies the column width. Corresponds to the \`width\` css-property. If the width is not set,
   the browser automatically adjusts the column width based on the content. When \`resizableColumns\` property is
   set to \`true\`, additional constraints apply: 1) string values are not allowed, and 2) the last visible column always
@@ -11141,7 +11136,12 @@ add a meaningful description to the whole selection.
 * * \`editConfig.editIconAriaLabel\` (string) - Specifies an alternate text for the edit icon used in column header.
 * * \`editConfig.constraintText\` (string) - Constraint text that is displayed below the edit control.
 * * \`editConfig.validation\` ((item, value) => string) - A function that allows you to validate the value of the edit control.
-           Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.",
+           Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.
+* * \`editConfig.editingCell\` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
+       You receive the current table row \`item\` and a \`cellContext\` object as arguments.
+       The \`cellContext\` object contains the following properties:
+ *  * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
+ *  * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.",
       "name": "columnDefinitions",
       "optional": false,
       "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -15,13 +15,11 @@ const column: TableProps.ColumnDefinition<typeof testItem> = {
   editConfig: {
     ariaLabel: 'test input',
     editIconAriaLabel: 'error',
-  },
-  cell: (item, { isEditing, setValue, currentValue }: TableProps.CellContext<any>) => {
-    if (isEditing) {
+    editingCell: (item, { setValue, currentValue }: TableProps.CellContext<any>) => {
       return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
-    }
-    return item.test;
+    },
   },
+  cell: item => item.test,
 };
 
 const onEditEnd = jest.fn();
@@ -65,7 +63,7 @@ const TestComponent2 = ({ column }: any) => {
           <TableBodyCell<typeof testItem>
             column={column}
             item={testItem}
-            isEditing={false}
+            isEditing={true}
             onEditStart={onEditStart}
             onEditEnd={onEditEnd}
             ariaLabels={{
@@ -73,7 +71,7 @@ const TestComponent2 = ({ column }: any) => {
               cancelEditLabel: () => 'cancel edit',
               submitEditLabel: () => 'submit edit',
             }}
-            isEditable={false}
+            isEditable={true}
             isPrevSelected={false}
             isNextSelected={false}
             isFirstRow={true}
@@ -119,14 +117,17 @@ describe('TableBodyCell', () => {
     expect(onEditEnd).toHaveBeenCalled();
   });
 
-  it('should render with fallback state', () => {
+  it('should render with default state at edit start', () => {
     const col: typeof column = {
       ...column,
-      cell: (_item, { isEditing, setValue, currentValue }) => {
-        expect(isEditing).toBe(false);
-        expect(setValue).toBeInstanceOf(Function);
-        expect(currentValue).toBeUndefined();
-        return _item.test;
+      editConfig: {
+        ...column.editConfig,
+        editingCell: (item, { setValue, currentValue }) => {
+          // testing default values
+          expect(setValue).toBeInstanceOf(Function);
+          expect(currentValue).toBeUndefined();
+          return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
+        },
       },
     };
     render(<TestComponent2 column={col} />);

--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -19,30 +19,30 @@ const defaultItems: Item[] = [
 const editableColumns: TableProps.ColumnDefinition<Item>[] = [
   {
     header: 'id',
-    cell: (item, { isEditing }) => {
-      if (isEditing) {
-        return <input type="number" value={item.id} readOnly={true} data-testid={`id-editing-${item.id}`} />;
-      }
+    cell: item => {
       return item.id;
     },
     editConfig: {
       ariaLabel: 'Edit id',
       errorIconAriaLabel: 'Error',
       editIconAriaLabel: 'Edit',
+      editingCell: item => {
+        return <input type="number" value={item.id} readOnly={true} data-testid={`id-editing-${item.id}`} />;
+      },
     },
   },
   {
     header: 'name',
-    cell: (item, { isEditing }) => {
-      if (isEditing) {
-        return <input type="number" value={item.name} readOnly={true} data-testid={`name-editing-${item.name}`} />;
-      }
+    cell: item => {
       return item.name;
     },
     editConfig: {
       ariaLabel: 'Edit id',
       errorIconAriaLabel: 'Error',
       editIconAriaLabel: 'Edit',
+      editingCell: item => {
+        return <input type="number" value={item.name} readOnly={true} data-testid={`name-editing-${item.name}`} />;
+      },
     },
   },
 ];

--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -30,13 +30,11 @@ const TestComponent = () => {
       ariaLabel: 'test-input',
       errorIconAriaLabel: 'error-icon',
       validation: () => (thereBeErrors ? 'there be errors' : undefined),
-    },
-    cell: (item: any, { isEditing, currentValue, setValue }: TableProps.CellContext<string>) =>
-      isEditing ? (
+      editingCell: (item: any, { currentValue, setValue }: TableProps.CellContext<string>) => (
         <input value={currentValue ?? item.test} onChange={() => setValue('test')} />
-      ) : (
-        <span>{currentValue ?? item.test}</span>
       ),
+    },
+    cell: (item: any) => <span>{item.test}</span>,
   };
 
   return (

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -42,8 +42,8 @@ const defaultColumnsWithIds: TableProps.ColumnDefinition<Item>[] = [
   { id: 'name', header: 'name', cell: item => item.name },
 ];
 const editableColumns: TableProps.ColumnDefinition<Item>[] = [
-  { header: 'id', cell: (item: Item) => item.id, editConfig: {} },
-  { header: 'name', cell: (item: Item) => item.name, editConfig: {} },
+  { header: 'id', cell: (item: Item) => item.id, editConfig: { editingCell: item => item.id } },
+  { header: 'name', cell: (item: Item) => item.name, editConfig: { editingCell: item => item.name } },
 ];
 
 const statefulColumns: TableProps.ColumnDefinition<Item>[] = [
@@ -283,18 +283,19 @@ test('should submit edits successfully', async () => {
         {
           id: 'name',
           header: 'Name',
-          cell: (item, { isEditing, setValue, currentValue }) => (
-            <input
-              type="text"
-              id="test-input"
-              onChange={e => setValue(e.target.value)}
-              value={currentValue ?? item.name}
-              disabled={!isEditing}
-            />
-          ),
+          cell: item => <input type="text" id="test-input" value={item.name} readOnly={true} disabled={true} />,
           editConfig: {
             ariaLabel: 'test-name',
             constraintText: 'test-constraint',
+            editingCell: (item, { setValue, currentValue }) => (
+              <input
+                type="text"
+                id="test-input"
+                onChange={e => setValue(e.target.value)}
+                value={currentValue ?? item.name}
+                disabled={false}
+              />
+            ),
           },
         },
       ]}

--- a/src/table/__tests__/use-focus-navigation.test.tsx
+++ b/src/table/__tests__/use-focus-navigation.test.tsx
@@ -17,6 +17,10 @@ function renderComponent(jsx: React.ReactElement) {
   return { wrapper, rerender, getByTestId, queryByTestId, unmount };
 }
 
+const editConfig = {
+  editingCell: () => <div />,
+};
+
 const TestComponent = () => {
   const tableRef = React.useRef<HTMLTableElement>(null);
 
@@ -194,7 +198,17 @@ describe('useTableFocusNavigation', () => {
         useTableFocusNavigation(
           'none',
           { current: table },
-          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
+          [
+            {
+              editConfig,
+            },
+            {
+              editConfig,
+            },
+            {
+              editConfig,
+            },
+          ],
           3
         )
       );
@@ -207,12 +221,7 @@ describe('useTableFocusNavigation', () => {
 
     it('should detach event listener for focus navigation', () => {
       const { unmount } = renderHook(() =>
-        useTableFocusNavigation(
-          'none',
-          { current: table },
-          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
-          3
-        )
+        useTableFocusNavigation('none', { current: table }, [{ editConfig }, { editConfig }, { editConfig }], 3)
       );
       expect(removeEventListener).not.toHaveBeenCalled();
       unmount();
@@ -221,12 +230,7 @@ describe('useTableFocusNavigation', () => {
 
     it('satisfies istanbul coverage', () => {
       renderHook(() =>
-        useTableFocusNavigation(
-          'multi',
-          { current: null },
-          [{ editConfig: {} }, { editConfig: {} }, { editConfig: {} }],
-          3
-        )
+        useTableFocusNavigation('multi', { current: null }, [{ editConfig }, { editConfig }, { editConfig }], 3)
       );
       expect(removeEventListener).not.toHaveBeenCalled();
       expect(addEventListenerRoot).not.toHaveBeenCalled();

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -12,13 +12,6 @@ import { TableTdElement, TableTdElementProps } from './td-element';
 import { InlineEditor } from './inline-editor';
 import { useStableScrollPosition } from './use-stable-scroll-position';
 
-const readonlyState = Object.freeze({
-  isEditing: false,
-  currentValue: undefined,
-  /* istanbul ignore next */
-  setValue: () => {},
-});
-
 const submitHandlerFallback = () => {
   throw new Error('The function `handleSubmit` is required for editable columns');
 };
@@ -100,7 +93,7 @@ function TableCellEditable<ItemType>({
         />
       ) : (
         <>
-          {column.cell(item, readonlyState)}
+          {column.cell(item)}
           <span className={styles['body-cell-editor']}>
             <Button
               __hideFocusOutline={true}
@@ -125,5 +118,5 @@ export function TableBodyCell<ItemType>({
     return <TableCellEditable {...rest} />;
   }
   const { column, item } = rest;
-  return <TableTdElement {...rest}>{column.cell(item, readonlyState)}</TableTdElement>;
+  return <TableTdElement {...rest}>{column.cell(item)}</TableTdElement>;
 }

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -33,7 +33,6 @@ export function InlineEditor<ItemType>({
   const [currentEditValue, setCurrentEditValue] = useState<Optional<any>>();
 
   const cellContext = {
-    isEditing: true,
     currentValue: currentEditValue,
     setValue: setCurrentEditValue,
   };
@@ -85,7 +84,7 @@ export function InlineEditor<ItemType>({
   }, [__onRender]);
 
   // asserting non-undefined editConfig here because this component is unreachable otherwise
-  const { ariaLabel = undefined, validation = noop, errorIconAriaLabel } = column.editConfig!;
+  const { ariaLabel = undefined, validation = noop, errorIconAriaLabel, editingCell } = column.editConfig!;
 
   return (
     <form
@@ -104,7 +103,7 @@ export function InlineEditor<ItemType>({
         errorText={validation(item, currentEditValue)}
       >
         <div className={styles['body-cell-editor-row']}>
-          {column.cell(item, cellContext)}
+          {editingCell(item, cellContext)}
           <span className={styles['body-cell-editor-controls']}>
             <SpaceBetween direction="horizontal" size="xxs">
               {!currentEditLoading ? (

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -65,13 +65,8 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * `id` (string) - Specifies a unique column identifier. The property is used 1) as a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering,
    *   and 2) to match entries in the `visibleColumns` property, if defined.
    * * `header` (ReactNode) - Determines the display of the column header.
-   * * `cell` ((item, cellContext) => ReactNode) - Determines the display of a cell's content. You receive the current table row
-   *   item as an argument. If inline editing is enabled for the column, the `cell` function is called with an additional
-   *  `cellContext` argument that provides the following properties:
-   * * * `cellContext.isEditing` (boolean) - Indicates whether the cell is currently being edited. Use this to conditionally render
-   *        the cell content. For example, you can render a text input field when the cell is being edited, and plain text otherwise.
-   * * * `cellContext.currentValue` (ValueType) - State to keep track of a value in input fields while editing.
-   * * * `cellContext.setValue` ((ValueType) => void) - Function to update `currentValue`. This should be called when the value in input field changes.
+   * * `cell` ((item) => ReactNode) - Determines the display of a cell's content. You receive the current table row
+   *   item as an argument.
    * * `width` (string | number) - Specifies the column width. Corresponds to the `width` css-property. If the width is not set,
    *   the browser automatically adjusts the column width based on the content. When `resizableColumns` property is
    *   set to `true`, additional constraints apply: 1) string values are not allowed, and 2) the last visible column always
@@ -101,7 +96,11 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * * * `editConfig.constraintText` (string) - Constraint text that is displayed below the edit control.
    * * * `editConfig.validation` ((item, value) => string) - A function that allows you to validate the value of the edit control.
    *            Return a string from the function to display an error message. Return `undefined` (or no return) from the function to indicate that the value is valid.
-   *
+   * * * `editConfig.editingCell` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
+   *        You receive the current table row `item` and a `cellContext` object as arguments.
+   *        The `cellContext` object contains the following properties:
+   *  *  * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
+   *  *  * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
   /**
@@ -287,7 +286,6 @@ export namespace TableProps {
   export type TrackBy<T> = string | ((item: T) => string);
 
   export interface CellContext<V> {
-    isEditing?: boolean;
     currentValue: Optional<V>;
     setValue: (value: V | undefined) => void;
   }
@@ -319,6 +317,11 @@ export namespace TableProps {
      * @param value - The current value of the edit control.
      */
     validation?: (item: T, value: Optional<V>) => Optional<string>;
+
+    /**
+     * Determines the display of a cell's content when inline edit is active.
+     */
+    editingCell(item: T, ctx: TableProps.CellContext<any>): React.ReactNode;
   }
 
   export type ColumnDefinition<ItemType> = {
@@ -329,7 +332,7 @@ export namespace TableProps {
     minWidth?: number | string;
     maxWidth?: number | string;
     editConfig?: EditConfig<ItemType>;
-    cell(item: ItemType, context: CellContext<any>): React.ReactNode;
+    cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 
   export type SelectionType = 'single' | 'multi';


### PR DESCRIPTION
### Description

This PR refactors the API for Inline Editing in Table to remove edit mode out of `columnDefinition.cell` function.

Initial release of the feature included this update to the API for `columnDefinition`
```diff
-     cell(item: ItemType): React.ReactNode;
+     cell(item: ItemType, cellContext: CellContext<any>): React.ReactNode;
```

Multiple consoles appear to be using this function for their own testing; this API change then causes the build failures due to mismatching call signature (TypeScript type mismatch).

We decided to rollback this API change and adopt this API where edit mode rendering is done through `columnDefinition.editConfig`
```diff
  export interface EditConfig<T, V = any> {
    ariaLabel?: string;
    errorIconAriaLabel?: string;
    editIconAriaLabel?: string;
    constraintText?: string;
    validation?: (item: T, value: Optional<V>) => Optional<string>;

+    /**
+     * Determines the display of a cell's content when inline edit is active.
+     */
+    editingCell(item: T, ctx: TableProps.CellContext<any>): React.ReactNode;
  }
```
```diff
-     cell(item: ItemType, cellContext: CellContext<any>): React.ReactNode;
+     cell(item: ItemType): React.ReactNode;
```

API documentation is also updated to reflect this change.

Related links, issue #, if available: n/a

### How has this been tested?

The changes are also reflected on my dev pipeline
Corresponding changes have been made on CR-83279545 for Examples and https://github.com/cloudscape-design/demos/pull/34 for demos

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
