### PR TITLE
fix: Dropdown status not announced by screenreader using expandToViewport

### DIFF
--- a/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
+++ b/src/internal/components/dropdown-footer/__tests__/dropdown-footer.test.tsx
@@ -31,8 +31,8 @@ describe('Dropdown footer', () => {
 
   test('adds correct aria attributes', () => {
     const { wrapper } = renderComponent(<DropdownFooter />);
-    const element = wrapper.find('div')!.getElement();
-    expect(element).toHaveAttribute('aria-live', 'polite');
-    expect(element).toHaveAttribute('aria-atomic', 'true');
+    const element = wrapper.find('span')!.getElement();
+    expect(element.firstElementChild).toHaveAttribute('aria-live', 'polite');
+    expect(element.firstElementChild).toHaveAttribute('aria-atomic', 'true');
   });
 });

--- a/src/internal/components/dropdown-footer/index.tsx
+++ b/src/internal/components/dropdown-footer/index.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import styles from './styles.css.js';
 import DropdownStatus from '../dropdown-status/index.js';
+import LiveRegion from '../live-region/index.js';
 
 interface DropdownFooter {
   content?: React.ReactNode | null;
@@ -12,12 +13,10 @@ interface DropdownFooter {
 }
 
 const DropdownFooter: React.FC<DropdownFooter> = ({ content, hasItems = true }: DropdownFooter) => (
-  <div
-    className={clsx(styles.root, { [styles.hidden]: content === null, [styles['no-items']]: !hasItems })}
-    aria-live="polite"
-    aria-atomic="true"
-  >
-    {content && <DropdownStatus>{content}</DropdownStatus>}
+  <div className={clsx(styles.root, { [styles.hidden]: content === null, [styles['no-items']]: !hasItems })}>
+    <LiveRegion visible={true} tagName="div">
+      {content && <DropdownStatus>{content}</DropdownStatus>}
+    </LiveRegion>
   </div>
 );
 


### PR DESCRIPTION
### Description
It is a follow up fix of https://github.com/cloudscape-design/components/pull/608. 
When using `expandToViewport` the dropdown status rendered when dropdown opens. The aria-live div and its content comes in the same time, so no real content change to get announced. The delay in LiveRegion helps the content in aria-live does get changed and announced. 

Related links, issue AWSUI-19995

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
