### PR TITLE
fix: remove operator chars from aria announcement

### DIFF
--- a/src/select/__tests__/use-announcement.test.ts
+++ b/src/select/__tests__/use-announcement.test.ts
@@ -38,6 +38,15 @@ const options = [
       },
     ],
   },
+  {
+    label: 'Group 3',
+    options: [
+      {
+        label: 'Child =',
+        value: 'should-not-be-announced-5',
+      },
+    ],
+  },
 ];
 
 const { flatOptions, parentMap } = flattenOptions(options);
@@ -91,6 +100,18 @@ describe('useAnnouncement', () => {
       },
     });
     expect(hook.result.current).toEqual('Selected Group 1 Child 1');
+  });
+
+  test('announcements with selected highlighted item should not include operator characters', () => {
+    const hook = renderHook(useAnnouncement, {
+      initialProps: {
+        getParent,
+        selectedAriaLabel: 'Selected',
+        highlightedOption: flatOptions[8],
+        announceSelected: true,
+      },
+    });
+    expect(hook.result.current).toEqual('Selected Group 3 Child');
   });
 
   test('should return custom announcement string when renderHighlightedAriaLive is provided', () => {

--- a/src/select/utils/use-announcement.ts
+++ b/src/select/utils/use-announcement.ts
@@ -55,7 +55,16 @@ export function useAnnouncement<Option extends OptionHolder>({
   }
 
   // Use default renderer with selected ARIA label if defined and relevant.
+  /**
+   * The replace method on the end will remove all characters "=", "!=", "<", ">", "<=", ">=", ":"
+   * from the announcement, not just specific instances of them. This was added to avoid screen
+   * readers reading "equals equals" and similarly confusing combinations of operators
+   */
   const selectedAnnouncement = announceSelected && selectedAriaLabel ? selectedAriaLabel : '';
   const defaultDescription = defaultOptionDescription(option, group);
-  return [selectedAnnouncement, defaultDescription].filter(Boolean).join(' ');
+  return [selectedAnnouncement, defaultDescription]
+    .filter(Boolean)
+    .join(' ')
+    .replace(/[=!<>:]/g, '')
+    .trim();
 }


### PR DESCRIPTION
### Description
This PR removes "=", "!=", "<", ">", "<=", ">=", ":" from the announcement returned from use-announcement to fix an a11y bug in which operator characters were read multiple times. This change was tested via unit test and using the mac VoiceOver tool.

This fixes two a11y issues in the property filter (the autocomplete popup and edit filter dialog). See below for more info.

### Change Motivation
Some options in the search form's autocomplete popup and edit filter dialog have confusing accessible names announced by screen readers. This is a result of how special characters are used within the option text. For example, the option "Status != Does not equal" is announced by screen readers as "Status equals does not equal". This is because special characters (with the exception of some punctuation characters) are read literally by screen readers. The search filter options may be difficult to understand using a screen reader

### How has this been tested?
I added a simple unit test to show the behavior of removing an operator character. I can expand on this if this team determines it's appropriate. Just let me know! 

I tested this with VoiceOver in as many configurations as I could and it reliably removes the operator character from voice over reading. Instead of reading "Instance Equals Equals" and other similar redundancies it now skips the operator character and instead reads the operator description. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
