### PR TITLE
fix: Avoid similar announcement of menu button on buttons in toggle panel.

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -121,8 +121,8 @@ describeEachAppLayout(() => {
         const { wrapper } = renderComponent(<AppLayout />);
         expect(findToggle(wrapper).getElement()).toHaveAttribute('aria-expanded', 'false');
         expect(findToggle(wrapper).getElement()).toHaveAttribute('aria-haspopup', 'true');
-        expect(findClose(wrapper).getElement()).toHaveAttribute('aria-expanded', 'true');
-        expect(findClose(wrapper).getElement()).toHaveAttribute('aria-haspopup', 'true');
+        expect(findClose(wrapper).getElement()).not.toHaveAttribute('aria-expanded');
+        expect(findClose(wrapper).getElement()).not.toHaveAttribute('aria-haspopup');
       });
 
       test('Does not add a label to the toggle and landmark when they are not defined', () => {

--- a/src/app-layout/toggles/index.tsx
+++ b/src/app-layout/toggles/index.tsx
@@ -44,8 +44,8 @@ export const AppLayoutButton = React.forwardRef(
         onClick={onClick}
         iconName={iconName}
         disabled={disabled}
-        ariaExpanded={ariaExpanded}
-        __nativeAttributes={{ 'aria-haspopup': true }}
+        ariaExpanded={ariaExpanded ? undefined : false}
+        __nativeAttributes={{ 'aria-haspopup': ariaExpanded ? undefined : true }}
       />
     );
   }

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -57,7 +57,7 @@ export default function AppBar() {
         >
           <InternalButton
             ariaLabel={ariaLabels?.navigationToggle ?? undefined}
-            ariaExpanded={isNavigationOpen}
+            ariaExpanded={isNavigationOpen ? undefined : false}
             iconName="menu"
             formAction="none"
             onClick={() => handleNavigationClick(true)}
@@ -65,7 +65,7 @@ export default function AppBar() {
             className={testutilStyles['navigation-toggle']}
             ref={focusRefsNav.toggle}
             disabled={isAnyPanelOpen}
-            __nativeAttributes={{ 'aria-haspopup': true }}
+            __nativeAttributes={{ 'aria-haspopup': isNavigationOpen ? undefined : true }}
           />
         </nav>
       )}

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -109,8 +109,6 @@ export default function Navigation() {
                   formAction="none"
                   className={testutilStyles['navigation-close']}
                   ref={focusRefs.close}
-                  ariaExpanded={true}
-                  __nativeAttributes={{ 'aria-haspopup': true }}
                 />
               </div>
               {navigation}

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -104,8 +104,6 @@ export default function Tools({ children }: ToolsProps) {
                     formAction="none"
                     className={testutilStyles['tools-close']}
                     ref={focusRefs.close}
-                    ariaExpanded={true}
-                    __nativeAttributes={{ 'aria-haspopup': true }}
                   />
                 </div>
 


### PR DESCRIPTION
### Description

> The expanded state of side navigation region is not clear to users of screen reader. It is recommended to remove the aria-expanded and aria-haspopup attributes from the Close (X) control of the side nav. Presently both the close control as well as the hamburger menu control have these attributes, which result in similar announcement of ‘menu’ on both, which in turn can lead to confusion. Keeping the aria-haspopup along with aria-expanded on the hamburger menu control would be sufficient to provide the information

Related links, issue AWSUI-20160

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
