### PR TITLE
fix: Call onNavigationChange and onToolsChange only once per change

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -52,7 +52,7 @@ describeEachAppLayout(() => {
     },
   ].forEach(({ openProp, hideProp, handler, findElement, findLandmarks, findToggle, findClose }) => {
     describe(`${openProp} prop`, () => {
-      test(`Should call handler on open`, () => {
+      test(`Should call handler once on open`, () => {
         const onToggle = jest.fn();
         const props = {
           [openProp]: false,
@@ -61,10 +61,11 @@ describeEachAppLayout(() => {
         const { wrapper } = renderComponent(<AppLayout {...props} />);
 
         findToggle(wrapper).click();
+        expect(onToggle).toHaveBeenCalledTimes(1);
         expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
       });
 
-      test(`Should call handler on close`, () => {
+      test(`Should call handler once on close`, () => {
         const onToggle = jest.fn();
         const props = {
           [openProp]: true,
@@ -73,6 +74,7 @@ describeEachAppLayout(() => {
         const { wrapper } = renderComponent(<AppLayout {...props} />);
 
         findClose(wrapper).click();
+        expect(onToggle).toHaveBeenCalledTimes(1);
         expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: false } }));
       });
 

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -26,7 +26,7 @@ const MobileToggle = React.forwardRef(
         className={clsx(styles['mobile-toggle'])}
         aria-hidden={disabled}
         aria-label={mainLabel}
-        onClick={onClick}
+        onClick={e => e.target === e.currentTarget && onClick()}
       >
         <AppLayoutButton
           ref={ref}


### PR DESCRIPTION
### Description

The mobile toolbar buttons are structured as a clickable button wrapped by a clickable wrapper element. If you clicked on the inner button, event bubbling meant that the outer wrapper would also call the click handler, and this would lead to the function being called twice.

```
<wrapper onClick={onClick}> // <- bubbles up here
  <button onClick={onClick}></button> // <- source
</wrapper>
```

This is a bit of an edge-case and isn't a big deal in _most_ React apps, but it's still incorrect. I went with a simple fix without touching the event bubbling logic itself.

Related links, issue #, if available: AWSUI-20134

### How has this been tested?

Made changes to unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
