### PR TITLE
revert: Make split panel header scrollable when page height is small"

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -4,7 +4,6 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import mobileStyles from '../../../lib/components/app-layout/mobile-toolbar/styles.selectors.js';
-import styles from '../../../lib/components/split-panel/styles.selectors.js';
 import { viewports } from './constants';
 
 const wrapper = createWrapper().findAppLayout();
@@ -172,32 +171,6 @@ test(
     expect((await page.getSplitPanelSize()).height).toEqual(160);
     await page.dragResizerTo({ x: 0, y: 0 });
     expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
-  })
-);
-
-test(
-  'should split panel header position NOT be fixed for constrained heights',
-  setupTest(async page => {
-    await page.openPanel();
-    const { top: topBeforeScroll } = await page.getBoundingBox(
-      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
-    );
-    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 10 });
-    const { top: topAfterScroll } = await page.getBoundingBox(
-      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
-    );
-    expect(topAfterScroll).toEqual(topBeforeScroll);
-
-    await page.setWindowSize({ width: 680, height: 360 });
-    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 0 });
-    const { top: topBeforeScrollOnSmallScreen } = await page.getBoundingBox(
-      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
-    );
-    await page.elementScrollTo(wrapper.findByClassName(styles['drawer-content-bottom']).toSelector(), { top: 50 });
-    const { top: topAfterScrollOnSmallScreen } = await page.getBoundingBox(
-      wrapper.findByClassName(styles['pane-header-wrapper-bottom']).toSelector()
-    );
-    expect(topAfterScrollOnSmallScreen).toEqual(topBeforeScrollOnSmallScreen - 50);
   })
 );
 

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -326,9 +326,6 @@ const OldAppLayout = React.forwardRef(
       onPreferencesChange: onSplitPanelPreferencesSet,
       reportSize: setSplitPanelReportedSize,
       reportHeaderHeight: setSplitPanelReportedHeaderHeight,
-      headerShouldStick: () => {
-        return document.documentElement.clientHeight - headerHeight - footerHeight > CONSTRAINED_PAGE_HEIGHT;
-      },
     };
     const splitPanelWrapped = splitPanel && (
       <SplitPanelContextProvider value={splitPanelContext}>{splitPanel}</SplitPanelContextProvider>

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -13,7 +13,6 @@ import { AppLayoutProps } from '../interfaces';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
 import { Transition } from '../../internal/components/transition';
 import customCssProps from '../../internal/generated/custom-css-properties';
-import { CONSTRAINED_PAGE_HEIGHT } from '../../split-panel/utils/size-utils';
 
 /**
  * If there is no Split Panel in the AppLayout context then the SplitPanel
@@ -68,8 +67,6 @@ function SplitPanel({ children }: React.PropsWithChildren<unknown>) {
     openButtonAriaLabel,
     setOpenButtonAriaLabel,
     lastInteraction: splitPanelLastInteraction,
-    headerShouldStick: () =>
-      document.documentElement.clientHeight - headerHeight - footerHeight > CONSTRAINED_PAGE_HEIGHT,
   };
 
   return <SplitPanelContextProvider value={context}>{children}</SplitPanelContextProvider>;

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -32,7 +32,6 @@ export interface SplitPanelContextProps {
   reportHeaderHeight: (pixels: number) => void;
   openButtonAriaLabel?: string;
   setOpenButtonAriaLabel?: (value: string) => void;
-  headerShouldStick: () => boolean;
 }
 
 const SplitPanelContext = createContext<SplitPanelContextProps | null>(null);

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -19,5 +19,4 @@ export const defaultSplitPanelContextProps: SplitPanelContextProps = {
   onPreferencesChange: jest.fn(),
   reportSize: jest.fn(),
   reportHeaderHeight: jest.fn(),
-  headerShouldStick: jest.fn(),
 };

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -39,7 +39,6 @@ export function SplitPanelContentBottom({
     contentWrapperPaddings,
     isMobile,
     reportHeaderHeight,
-    headerShouldStick,
   } = useSplitPanelContext();
   const transitionContentBottomRef = useMergeRefs(splitPanelRef || null, transitioningElementRef);
 
@@ -76,16 +75,9 @@ export function SplitPanelContentBottom({
       }}
       ref={transitionContentBottomRef}
     >
+      {isOpen && <div className={styles['slider-wrapper-bottom']}>{resizeHandle}</div>}
       <div className={styles['drawer-content-bottom']} aria-labelledby={panelHeaderId} role="region">
-        {isOpen && <div className={styles['slider-wrapper-bottom']}>{resizeHandle}</div>}
-        <div
-          className={clsx(
-            styles['pane-header-wrapper-bottom'],
-            { [styles['sticky-header']]: headerShouldStick() },
-            centeredMaxWidthClasses
-          )}
-          ref={headerRef}
-        >
+        <div className={clsx(styles['pane-header-wrapper-bottom'], centeredMaxWidthClasses)} ref={headerRef}>
           {header}
         </div>
         <div className={clsx(styles['content-bottom'], centeredMaxWidthClasses)} aria-hidden={!isOpen}>

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -152,7 +152,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
 }
 
 .slider-wrapper-bottom {
-  position: sticky;
+  position: absolute;
   top: 0;
   left: 0;
   width: 100%;
@@ -160,7 +160,6 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   display: flex;
   justify-content: center;
   z-index: 2;
-  background-color: awsui.$color-background-layout-panel-content;
 }
 
 .slider-wrapper-side {
@@ -199,15 +198,14 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
 }
 
 .pane-header-wrapper-bottom {
+  /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+  position: sticky;
+  top: 0;
   display: flex;
   align-items: center;
   flex-direction: column;
   z-index: 1; // should be above .content-bottom
   padding: 0 awsui.$space-scaled-2x-xxxl;
-  &.sticky-header {
-    position: sticky;
-    top: 0;
-  }
   .drawer-mobile > .drawer-content-bottom > & {
     padding: 0 awsui.$space-l;
   }
@@ -217,7 +215,6 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   :not(.drawer-closed) > .drawer-content-bottom > & {
     background-color: awsui.$color-background-layout-panel-content;
     border-bottom: awsui.$border-panel-header-width solid awsui.$color-border-divider-default;
-    margin-top: -$slider-width - 2px; // the height of the slider in bottom split panel
   }
 }
 


### PR DESCRIPTION
Reverts cloudscape-design/components#635 because it caused a visual regression