### PR TITLE
fix: Invalid html markup div as child element span

### DIFF
--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import { DEBOUNCE_DEFAULT_DELAY } from '../../../lib/components/internal/debounce';
 import TextFilter, { TextFilterProps } from '../../../lib/components/text-filter';
 import createWrapper from '../../../lib/components/test-utils/dom';
+import '../../__a11y__/to-validate-a11y';
 
 function renderTextFilter(jsx: React.ReactElement) {
   const { container } = render(jsx);
@@ -105,4 +106,9 @@ describe('countText', () => {
     const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="10 matches" />);
     expect(wrapper.findResultsCount().getElement().textContent).toEqual('10 matches');
   });
+});
+
+test('check a11y', async () => {
+  const { wrapper } = renderTextFilter(<TextFilter filteringText="" filteringAriaLabel="filter instances" />);
+  await expect(wrapper.getElement()).toValidateA11y();
 });

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -33,7 +33,7 @@ const InternalTextFilter = React.forwardRef(
     const showResults = filteringText && countText && !disabled;
 
     return (
-      <span {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
+      <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <InternalInput
           ref={inputRef}
           className={styles.input}
@@ -53,7 +53,7 @@ const InternalTextFilter = React.forwardRef(
         >
           {showResults ? countText : ''}
         </span>
-      </span>
+      </div>
     );
   }
 );


### PR DESCRIPTION
### Description

<TextFilter> component has div as child element of span. 

Related links, issue AWSUI-20167

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
