### PR TITLE
fix: Make focus locking for modals less aggressive

### DIFF
--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -352,7 +352,7 @@ const Dropdown = ({
       </div>
 
       <TabTrap
-        onFocus={() => dropdownRef.current && getFirstFocusable(dropdownRef.current)?.focus()}
+        focusNextCallback={() => dropdownRef.current && getFirstFocusable(dropdownRef.current)?.focus()}
         disabled={!open || !loopFocus}
       />
 
@@ -361,7 +361,7 @@ const Dropdown = ({
           {(state, ref) => (
             <div ref={dropdownContainerRef}>
               <TabTrap
-                onFocus={() => triggerRef.current && getLastFocusable(triggerRef.current)?.focus()}
+                focusNextCallback={() => triggerRef.current && getLastFocusable(triggerRef.current)?.focus()}
                 disabled={!open || !loopFocus}
               />
 
@@ -385,7 +385,7 @@ const Dropdown = ({
               </TransitionContent>
 
               <TabTrap
-                onFocus={() => triggerRef.current && getFirstFocusable(triggerRef.current)?.focus()}
+                focusNextCallback={() => triggerRef.current && getFirstFocusable(triggerRef.current)?.focus()}
                 disabled={!open || !loopFocus}
               />
             </div>

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -352,7 +352,7 @@ const Dropdown = ({
       </div>
 
       <TabTrap
-        focusNextCallback={() => dropdownRef.current && getFirstFocusable(dropdownRef.current)?.focus()}
+        onFocus={() => dropdownRef.current && getFirstFocusable(dropdownRef.current)?.focus()}
         disabled={!open || !loopFocus}
       />
 
@@ -361,7 +361,7 @@ const Dropdown = ({
           {(state, ref) => (
             <div ref={dropdownContainerRef}>
               <TabTrap
-                focusNextCallback={() => triggerRef.current && getLastFocusable(triggerRef.current)?.focus()}
+                onFocus={() => triggerRef.current && getLastFocusable(triggerRef.current)?.focus()}
                 disabled={!open || !loopFocus}
               />
 
@@ -385,7 +385,7 @@ const Dropdown = ({
               </TransitionContent>
 
               <TabTrap
-                focusNextCallback={() => triggerRef.current && getFirstFocusable(triggerRef.current)?.focus()}
+                onFocus={() => triggerRef.current && getFirstFocusable(triggerRef.current)?.focus()}
                 disabled={!open || !loopFocus}
               />
             </div>

--- a/src/internal/components/focus-lock/__tests__/focus-lock.test.tsx
+++ b/src/internal/components/focus-lock/__tests__/focus-lock.test.tsx
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import FocusLock, { FocusLockProps } from '../../../../../lib/components/internal/components/focus-lock';
+
+type TestFixtureProps = Omit<FocusLockProps, 'children'> & { unmount?: boolean };
+function TestFixture({ unmount = false, ...props }: TestFixtureProps) {
+  return (
+    <>
+      <button id="initial" />
+      {!unmount && (
+        <FocusLock {...props}>
+          <button id="inner" />
+        </FocusLock>
+      )}
+    </>
+  );
+}
+
+function renderFocusLock(props: TestFixtureProps = {}) {
+  const { rerender } = render(<TestFixture {...props} />);
+  return {
+    focusInitial() {
+      document.querySelector<HTMLButtonElement>('#initial')!.focus();
+    },
+    getInitial() {
+      return document.querySelector<HTMLButtonElement>('#initial');
+    },
+    getInner() {
+      return document.querySelector<HTMLButtonElement>('#inner');
+    },
+    rerender(props: TestFixtureProps = {}) {
+      rerender(<TestFixture {...props} />);
+    },
+  };
+}
+
+describe('Focus lock', () => {
+  describe('autoFocus', () => {
+    it('does nothing if autoFocus=false', () => {
+      renderFocusLock();
+      expect(document.body).toHaveFocus();
+    });
+
+    it('moves focus to the first focusable element on mount', () => {
+      const { getInner } = renderFocusLock({ autoFocus: true });
+      expect(getInner()).toHaveFocus();
+    });
+
+    it('does not move focus if lock is disabled', () => {
+      renderFocusLock({ autoFocus: true, disabled: true });
+      expect(document.body).toHaveFocus();
+    });
+
+    it('moves focus to the first focusable element when lock moves from disabled to enabled', () => {
+      const { rerender, getInner } = renderFocusLock({ autoFocus: true, disabled: true });
+      expect(document.body).toHaveFocus();
+      rerender({ autoFocus: true, disabled: false });
+      expect(getInner()).toHaveFocus();
+    });
+  });
+
+  describe('restoreFocus', () => {
+    it('returns focus to the previously focused element when disabled', () => {
+      // Focus the initial element.
+      const { rerender, focusInitial, getInner, getInitial } = renderFocusLock({
+        autoFocus: true,
+        restoreFocus: true,
+        disabled: true,
+      });
+      focusInitial();
+
+      // Move focus into the lock.
+      rerender({ autoFocus: true, restoreFocus: true, disabled: false });
+      expect(getInner()).toHaveFocus();
+
+      // Disable the focus lock, returning focus back to the initial element.
+      rerender({ autoFocus: true, restoreFocus: true, disabled: true });
+      expect(getInitial()).toHaveFocus();
+    });
+
+    it('returns focus to the previously focused element when removed from DOM', () => {
+      // Focus the initial element.
+      const { rerender, focusInitial, getInner, getInitial } = renderFocusLock({
+        autoFocus: true,
+        restoreFocus: true,
+        unmount: true,
+      });
+      focusInitial();
+
+      // Move focus into the lock.
+      rerender({ autoFocus: true, restoreFocus: true, unmount: false });
+      expect(getInner()).toHaveFocus();
+
+      // Remove the focus lock, returning focus back to the initial element.
+      rerender({ autoFocus: true, restoreFocus: true, unmount: true });
+      expect(getInitial()).toHaveFocus();
+    });
+  });
+});

--- a/src/internal/components/focus-lock/index.tsx
+++ b/src/internal/components/focus-lock/index.tsx
@@ -63,11 +63,11 @@ export default function FocusLock({ className, disabled, autoFocus, restoreFocus
 
   return (
     <>
-      <TabTrap disabled={disabled} onFocus={focusLast} />
+      <TabTrap disabled={disabled} focusNextCallback={focusLast} />
       <div className={className} ref={mergedRef}>
         {children}
       </div>
-      <TabTrap disabled={disabled} onFocus={focusFirst} />
+      <TabTrap disabled={disabled} focusNextCallback={focusFirst} />
     </>
   );
 }

--- a/src/internal/components/focus-lock/index.tsx
+++ b/src/internal/components/focus-lock/index.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useMergeRefs } from '../../hooks/use-merge-refs';
+
 import TabTrap from '../tab-trap/index';
 import { getFirstFocusable, getLastFocusable } from './utils';
 
@@ -8,11 +10,25 @@ export interface FocusLockProps {
   className?: string;
   disabled?: boolean;
   autoFocus?: boolean;
+  restoreFocus?: boolean;
   children: React.ReactNode;
 }
 
-export default function FocusLock({ className, disabled, autoFocus, children }: FocusLockProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+export default function FocusLock({ className, disabled, autoFocus, restoreFocus, children }: FocusLockProps) {
+  const returnFocusToRef = useRef<HTMLOrSVGElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Using a callback ref to detect component unmounts, which is safer than using useEffect.
+  const restoreFocusHandler = useCallback(
+    (elem: HTMLDivElement | null) => {
+      if (elem === null && restoreFocus) {
+        returnFocusToRef.current?.focus();
+      }
+    },
+    [restoreFocus]
+  );
+
+  const mergedRef = useMergeRefs(containerRef, restoreFocusHandler);
 
   const focusFirst = () => {
     if (containerRef.current) {
@@ -27,18 +43,31 @@ export default function FocusLock({ className, disabled, autoFocus, children }: 
   };
 
   useEffect(() => {
-    if (autoFocus) {
+    if (autoFocus && !disabled) {
+      returnFocusToRef.current = document.activeElement as HTMLOrSVGElement | null;
       focusFirst();
     }
-  }, [autoFocus]);
+  }, [autoFocus, disabled]);
+
+  // Returns focus when disabled changes from false to true.
+  const [prevDisabled, setPrevDisabled] = useState(!!disabled);
+  useEffect(() => {
+    if (prevDisabled !== !!disabled) {
+      setPrevDisabled(!!disabled);
+      if (disabled && restoreFocus) {
+        returnFocusToRef.current?.focus();
+        returnFocusToRef.current = null;
+      }
+    }
+  }, [prevDisabled, disabled, restoreFocus]);
 
   return (
     <>
-      <TabTrap disabled={disabled} focusNextCallback={focusLast} />
-      <div className={className} ref={containerRef}>
+      <TabTrap disabled={disabled} onFocus={focusLast} />
+      <div className={className} ref={mergedRef}>
         {children}
       </div>
-      <TabTrap disabled={disabled} focusNextCallback={focusFirst} />
+      <TabTrap disabled={disabled} onFocus={focusFirst} />
     </>
   );
 }

--- a/src/internal/components/tab-trap/index.tsx
+++ b/src/internal/components/tab-trap/index.tsx
@@ -3,15 +3,15 @@
 import React from 'react';
 
 export interface TabTrapProps {
-  onFocus: (event: React.FocusEvent) => void;
+  focusNextCallback: (event: React.FocusEvent) => void;
   disabled?: boolean;
 }
 
 /**
  * This component handles focus-forwarding when using keyboard tab navigation.
- * When the user focuses this component, the `onFocus` callback function is called
+ * When the user focuses this component, the `focusNextCallback` function is called
  * which can forward the focus to another element.
  */
-export default function TabTrap({ onFocus, disabled = false }: TabTrapProps) {
-  return <div tabIndex={disabled ? -1 : 0} onFocus={onFocus} />;
+export default function TabTrap({ focusNextCallback, disabled = false }: TabTrapProps) {
+  return <div tabIndex={disabled ? -1 : 0} onFocus={focusNextCallback} />;
 }

--- a/src/internal/components/tab-trap/index.tsx
+++ b/src/internal/components/tab-trap/index.tsx
@@ -3,17 +3,15 @@
 import React from 'react';
 
 export interface TabTrapProps {
-  focusNextCallback: FocusNextElement;
+  onFocus: (event: React.FocusEvent) => void;
   disabled?: boolean;
 }
 
-export interface FocusNextElement {
-  (): void;
-}
-
-// This component handles focus-forwarding when navigating through the calendar grid.
-// When the customer focuses that component the `next` callback function is called
-// with forwards the focus.
-export default function TabTrap({ focusNextCallback, disabled = false }: TabTrapProps) {
-  return <div tabIndex={disabled ? -1 : 0} onFocus={focusNextCallback} />;
+/**
+ * This component handles focus-forwarding when using keyboard tab navigation.
+ * When the user focuses this component, the `onFocus` callback function is called
+ * which can forward the focus to another element.
+ */
+export default function TabTrap({ onFocus, disabled = false }: TabTrapProps) {
+  return <div tabIndex={disabled ? -1 : 0} onFocus={onFocus} />;
 }

--- a/src/internal/hooks/use-merge-refs/index.tsx
+++ b/src/internal/hooks/use-merge-refs/index.tsx
@@ -9,12 +9,14 @@ import React, { useMemo } from 'react';
  *  const mergedRef = useMergeRefs(ref1, ref2, ref3)
  *  <div ref={refs}>...</div>
  */
-export function useMergeRefs(...refs: Array<React.RefCallback<any> | React.MutableRefObject<any> | null | undefined>) {
+export function useMergeRefs<T = any>(
+  ...refs: Array<React.RefCallback<T> | React.MutableRefObject<T> | null | undefined>
+): React.RefCallback<T> | null {
   return useMemo(() => {
     if (refs.every(ref => ref === null || ref === undefined)) {
       return null;
     }
-    return (value: any) => {
+    return (value: T | null) => {
       refs.forEach(ref => {
         if (typeof ref === 'function') {
           ref(value);

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -1,26 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef } from 'react';
-import FocusLock from 'react-focus-lock';
-import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
-import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import { KeyCode } from '../internal/keycode';
-import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { InternalButton } from '../button/internal';
+import { SomeRequired } from '../internal/types';
+
 import InternalHeader from '../header/internal';
+import { InternalButton } from '../button/internal';
 import Portal from '../internal/components/portal';
+import FocusLock from '../internal/components/focus-lock';
+
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 
 import { disableBodyScrolling, enableBodyScrolling } from './body-scroll';
 import { ModalProps } from './interfaces';
 import styles from './styles.css.js';
-import { SomeRequired } from '../internal/types';
-import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 
 type InternalModalProps = SomeRequired<ModalProps, 'size' | 'closeAriaLabel'> & InternalBaseComponentProps;
 
@@ -39,7 +40,6 @@ export default function InternalModal({
 }: InternalModalProps) {
   const instanceUniqueId = useUniqueId();
   const headerId = `${rest.id || instanceUniqueId}-header`;
-  const focusLockRef = useRef<HTMLDivElement>(null);
   const lastMouseDownElementRef = useRef<HTMLElement | null>(null);
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
 
@@ -73,11 +73,6 @@ export default function InternalModal({
     }
   }, [visible]);
 
-  // Imitate autoFocus=true when the modal opens but not when a focused element inside modal gets removed.
-  const onFocusActivation = () => {
-    focusLockRef.current && getFirstFocusable(focusLockRef.current)?.focus();
-  };
-
   const dismiss = (reason: string) => fireNonCancelableEvent(onDismiss, { reason });
 
   const onOverlayMouseDown = (event: React.MouseEvent) => {
@@ -110,14 +105,7 @@ export default function InternalModal({
         onClick={onOverlayClick}
         ref={mergedRef}
       >
-        <FocusLock
-          disabled={!visible}
-          autoFocus={false}
-          returnFocus={true}
-          className={styles['focus-lock']}
-          ref={focusLockRef}
-          onActivation={onFocusActivation}
-        >
+        <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
           <div
             className={clsx(
               styles.dialog,

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -1,27 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef } from 'react';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import { KeyCode } from '../internal/keycode';
-import { SomeRequired } from '../internal/types';
-
-import InternalHeader from '../header/internal';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { InternalButton } from '../button/internal';
+import InternalHeader from '../header/internal';
 import Portal from '../internal/components/portal';
-import FocusLock from '../internal/components/focus-lock';
-
-import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 
 import { disableBodyScrolling, enableBodyScrolling } from './body-scroll';
 import { ModalProps } from './interfaces';
 import styles from './styles.css.js';
+import { SomeRequired } from '../internal/types';
+import FocusLock from '../internal/components/focus-lock';
 
 type InternalModalProps = SomeRequired<ModalProps, 'size' | 'closeAriaLabel'> & InternalBaseComponentProps;
 


### PR DESCRIPTION
### Description

Switch from "react-focus-lock" to a much more basic homegrown implementation that is mostly just a pair of wrapping focus guards. In the process, added a "restoreFocus" prop to the internal focus lock to handle returning focus automatically.

Also, minor things: ~~(1) slightly renamed things in tab-trap.tsx, (2) moved around imports in modal so they're a little less chaotic~~ *undone to hit code coverage*, and (3) added nicer typings to useMergeRefs. Basically just touched up everything I ended up encountering.

Related links, issue #, if available: AWSUI-20140

### How has this been tested?

Existing tests in modal should continue to not fail. ~~Writing unit tests for this, I felt like I was just reimplementing modal, so I let modal test this logic for me.~~ Fine, Codecov, I wrote unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
