### PR TITLE
fix: Improve HTML validity of Internal Inputs in TextFilter

### DIFF
--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -157,7 +157,7 @@ function InternalInput(
   const mergedRef = useMergeRefs(ref, inputRef);
 
   return (
-    <div {...baseProps} className={clsx(baseProps.className, styles['input-container'])} ref={__internalRootRef}>
+    <span {...baseProps} className={clsx(baseProps.className, styles['input-container'])} ref={__internalRootRef}>
       {__leftIcon && (
         <span onClick={__onLeftIconClick} className={iconClassName('left', !!__onLeftIconClick)}>
           <InternalIcon name={__leftIcon} variant={disabled ? 'disabled' : __leftIconVariant} />
@@ -173,7 +173,7 @@ function InternalInput(
           <InternalIcon name={__rightIcon} variant={disabled ? 'disabled' : __rightIconVariant} />
         </span>
       )}
-    </div>
+    </span>
   );
 }
 


### PR DESCRIPTION
### Description

This PR changes the outer element of the Internal Input to a span, rather than a div to ensure that when nested in a span (as in the Text Filter Component) that the HTML remains valid.

Note: the element already had display:flex applied so no changes needed to preserve box layout

Addresses AWSUI-20178

### How has this been tested?

Tested manually with local build, visual regression

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- [x] Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- [x] Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- [x] Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
