### PR TITLE
feat: Add ariaControls prop to RadioGroup

### DIFF
--- a/pages/radio-group/progressive-disclosure.page.tsx
+++ b/pages/radio-group/progressive-disclosure.page.tsx
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Box from '~components/box';
+import FormField from '~components/form-field';
+import RadioGroup from '~components/radio-group';
+import Select, { SelectProps } from '~components/select';
+
+const langOptions: Array<SelectProps.Option> = [
+  { value: 'en-US', label: 'English (United States)' },
+  { value: 'en-GB', label: 'English (United Kingdom)' },
+  { value: 'de-DE', label: 'Deutsch (Deutschland)' },
+  { value: 'de-CH', label: 'Deutsch (Schweiz)' },
+];
+
+export default function RadiosPage() {
+  const [radioSelection, setRadioSelection] = useState<string>('');
+  const [lang, setLang] = useState<SelectProps.Option>(langOptions[0]);
+
+  return (
+    <Box padding="l">
+      <h1>Radio group progressive disclosure demo</h1>
+      <FormField
+        label="Language settings"
+        description="You can select a specific language or have this service automatically identify the language in your media."
+      >
+        <RadioGroup
+          value={radioSelection}
+          onChange={event => setRadioSelection(event.detail.value)}
+          ariaControls="language-settings"
+          items={[
+            {
+              label: 'Specific language',
+              value: 'specific',
+              description:
+                'If you know the language spoken in the source media, choose this option for optimal results.',
+            },
+            {
+              label: 'Automatic language detection',
+              value: 'automatic',
+              description: 'If you do not know the language spoken in the source media, choose this option.',
+            },
+          ]}
+        />
+      </FormField>
+      <Box id="language-settings" display={radioSelection !== 'specific' ? 'none' : 'block'}>
+        <FormField label="Language" description="Select the language you want to use.">
+          <Select
+            selectedOption={lang}
+            onChange={event => setLang(event.detail.selectedOption)}
+            options={langOptions}
+          />
+        </FormField>
+      </Box>
+    </Box>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -9392,6 +9392,13 @@ Object {
   "name": "RadioGroup",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-controls\` attribute to the radio group.
+If the radio group controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.",
+      "name": "ariaControls",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
 Use this property if the component isn't surrounded by a form field, or you want to override the value

--- a/src/radio-group/__tests__/radio-group.test.tsx
+++ b/src/radio-group/__tests__/radio-group.test.tsx
@@ -31,12 +31,14 @@ test('renders attributes for assistive technology when set', function () {
   const ariaLabelledby = 'something';
   const ariaDescribedby = 'something else';
   const ariaLabel = 'the last one';
+  const ariaControls = 'some-id-being-controlled';
 
   const { wrapper } = renderRadioGroup(
     <RadioGroup
       ariaLabelledby={ariaLabelledby}
       ariaDescribedby={ariaDescribedby}
       ariaLabel={ariaLabel}
+      ariaControls={ariaControls}
       value={null}
       items={defaultItems}
     />
@@ -45,6 +47,7 @@ test('renders attributes for assistive technology when set', function () {
   expect(rootElement).toHaveAttribute('aria-labelledby', ariaLabelledby);
   expect(rootElement).toHaveAttribute('aria-describedby', ariaDescribedby);
   expect(rootElement).toHaveAttribute('aria-label', ariaLabel);
+  expect(rootElement).toHaveAttribute('aria-controls', ariaControls);
 });
 
 test('does not render attributes for assistive technology when not set', function () {
@@ -53,6 +56,7 @@ test('does not render attributes for assistive technology when not set', functio
   expect(rootElement).not.toHaveAttribute('aria-labelledby');
   expect(rootElement).not.toHaveAttribute('aria-describedby');
   expect(rootElement).not.toHaveAttribute('aria-label');
+  expect(rootElement).not.toHaveAttribute('aria-controls');
 });
 
 describe('name', () => {

--- a/src/radio-group/interfaces.ts
+++ b/src/radio-group/interfaces.ts
@@ -41,6 +41,12 @@ export interface RadioGroupProps extends BaseComponentProps, FormFieldControlPro
   ariaRequired?: boolean;
 
   /**
+   * Adds `aria-controls` attribute to the radio group.
+   * If the radio group controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.
+   */
+  ariaControls?: string;
+
+  /**
    * Called when the user selects a different radio button. The event `detail` contains the current `value`.
    */
   onChange?: NonCancelableEventHandler<RadioGroupProps.ChangeDetail>;

--- a/src/radio-group/internal.tsx
+++ b/src/radio-group/internal.tsx
@@ -21,6 +21,7 @@ const InternalRadioGroup = React.forwardRef(
       items,
       ariaLabel,
       ariaRequired,
+      ariaControls,
       onChange,
       __internalRootRef = null,
       ...props
@@ -40,6 +41,7 @@ const InternalRadioGroup = React.forwardRef(
         aria-label={ariaLabel}
         aria-describedby={ariaDescribedby}
         aria-required={ariaRequired}
+        aria-controls={ariaControls}
         {...baseProps}
         className={clsx(baseProps.className, styles.root)}
         ref={__internalRootRef}


### PR DESCRIPTION
### Description
This PR adds the `ariaControls` prop to RadioGroup component.
This should allow users to implement a progressive disclosure pattern AND make it accessible.

~~NOTE: The API documentation needs to reviewed and potentially changed; hold off on merging just yet.~~ _approved_

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
* Updated existing Unit Tests
* Created a dev page that uses the prop to implement this pattern.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.