### PR TITLE
fix: Allow checkboxes and toggles to be nested inside label elements

### DIFF
--- a/src/checkbox/styles.scss
+++ b/src/checkbox/styles.scss
@@ -9,8 +9,8 @@
 
 $checkbox-size: awsui.$size-control;
 
-// tag selector bumps specificity of this rule above the rule in the abstract switch styles applied to the same element
-div.root {
+// double selector bumps specificity of this rule above the rule in the abstract switch styles applied to the same element
+.root.root {
   @include styles.styles-reset;
   display: flex;
 }

--- a/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
+++ b/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import AbstractSwitch, { AbstractSwitchProps } from '../../../../../lib/components/internal/components/abstract-switch';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
+import '../../../../__a11y__/to-validate-a11y';
 
 function renderAbstractSwitch(props: AbstractSwitchProps) {
   const { container } = render(<AbstractSwitch {...props} />);
@@ -11,63 +12,85 @@ function renderAbstractSwitch(props: AbstractSwitchProps) {
 }
 const noop = () => {};
 
-describe('Abstract switch component, aria-labelledby', () => {
-  test('should not have a labelId if a label is not provided', () => {
-    const wrapper = renderAbstractSwitch({
-      controlClassName: '',
-      outlineClassName: '',
-      styledControl: <div />,
-      controlId: 'custom-id',
-      description: 'Description goes here',
-      nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
-      onClick: noop,
-    });
+describe('Abstract switch', () => {
+  test('renders inside a <label> with proper html semantics', () => {
+    const { container } = render(
+      <label>
+        <AbstractSwitch
+          controlClassName=""
+          outlineClassName=""
+          styledControl={<div />}
+          controlId="custom-id"
+          description="Description goes here"
+          nativeControl={nativeControlProps => (
+            <input {...nativeControlProps} className="switch-element" type="radio" />
+          )}
+          onClick={noop}
+        />
+      </label>
+    );
 
-    const nativeControl = wrapper.find('.switch-element')!.getElement();
-    expect(nativeControl).not.toHaveAttribute('aria-labelledby');
-    expect(wrapper.find('#custom-id-label')).toBeNull();
+    expect(container).toValidateA11y();
   });
 
-  test('should be set to labelId if a label is provided', () => {
-    const wrapper = renderAbstractSwitch({
-      controlClassName: '',
-      outlineClassName: '',
-      styledControl: <div />,
-      label: 'Label goes here',
-      controlId: 'custom-id',
-      description: 'Description goes here',
-      nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
-      onClick: noop,
+  describe('aria-labelledby', () => {
+    test('should not have a labelId if a label is not provided', () => {
+      const wrapper = renderAbstractSwitch({
+        controlClassName: '',
+        outlineClassName: '',
+        styledControl: <div />,
+        controlId: 'custom-id',
+        description: 'Description goes here',
+        nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+        onClick: noop,
+      });
+
+      const nativeControl = wrapper.find('.switch-element')!.getElement();
+      expect(nativeControl).not.toHaveAttribute('aria-labelledby');
+      expect(wrapper.find('#custom-id-label')).toBeNull();
     });
 
-    const nativeControl = wrapper.find('.switch-element')!.getElement();
+    test('should be set to labelId if a label is provided', () => {
+      const wrapper = renderAbstractSwitch({
+        controlClassName: '',
+        outlineClassName: '',
+        styledControl: <div />,
+        label: 'Label goes here',
+        controlId: 'custom-id',
+        description: 'Description goes here',
+        nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+        onClick: noop,
+      });
 
-    expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label');
-    expect(nativeControl).toHaveAttribute('aria-describedby', 'custom-id-description');
+      const nativeControl = wrapper.find('.switch-element')!.getElement();
 
-    expect(wrapper.find('#custom-id-label')?.getElement()).toHaveTextContent('Label goes here');
-    expect(wrapper.find('#custom-id-description')?.getElement()).toHaveTextContent('Description goes here');
-  });
+      expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label');
+      expect(nativeControl).toHaveAttribute('aria-describedby', 'custom-id-description');
 
-  test('should include labelId if an ariaLabelledBy id is provided', () => {
-    const wrapper = renderAbstractSwitch({
-      controlClassName: '',
-      outlineClassName: '',
-      styledControl: <div />,
-      controlId: 'custom-id',
-      ariaLabelledby: 'some-custom-label',
-      ariaDescribedby: 'some-custom-description',
-      label: 'label',
-      description: 'description',
-      nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
-      onClick: noop,
+      expect(wrapper.find('#custom-id-label')?.getElement()).toHaveTextContent('Label goes here');
+      expect(wrapper.find('#custom-id-description')?.getElement()).toHaveTextContent('Description goes here');
     });
 
-    const nativeControl = wrapper.find('.switch-element')!.getElement();
-    expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label some-custom-label');
-    expect(nativeControl).toHaveAttribute('aria-describedby', 'some-custom-description custom-id-description');
+    test('should include labelId if an ariaLabelledBy id is provided', () => {
+      const wrapper = renderAbstractSwitch({
+        controlClassName: '',
+        outlineClassName: '',
+        styledControl: <div />,
+        controlId: 'custom-id',
+        ariaLabelledby: 'some-custom-label',
+        ariaDescribedby: 'some-custom-description',
+        label: 'label',
+        description: 'description',
+        nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+        onClick: noop,
+      });
 
-    expect(wrapper.find('#custom-id-label')).not.toBe(null);
-    expect(wrapper.find('#custom-id-description')).not.toBe(null);
+      const nativeControl = wrapper.find('.switch-element')!.getElement();
+      expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label some-custom-label');
+      expect(nativeControl).toHaveAttribute('aria-describedby', 'some-custom-description custom-id-description');
+
+      expect(wrapper.find('#custom-id-label')).not.toBe(null);
+      expect(wrapper.find('#custom-id-description')).not.toBe(null);
+    });
   });
 });

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -68,8 +68,8 @@ export default function AbstractSwitch({
   }
 
   return (
-    <div {...rest} className={clsx(styles.wrapper, rest.className)} ref={__internalRootRef}>
-      <div
+    <span {...rest} className={clsx(styles.wrapper, rest.className)} ref={__internalRootRef}>
+      <span
         className={styles['label-wrapper']}
         aria-disabled={disabled ? 'true' : undefined}
         onClick={disabled ? undefined : onClick}
@@ -105,7 +105,7 @@ export default function AbstractSwitch({
             </span>
           )}
         </span>
-      </div>
-    </div>
+      </span>
+    </span>
   );
 }


### PR DESCRIPTION
### Description

You can't put `<div>`s inside `<label>`s, so using divs for the abstract switch disqualifies it from a bunch of pretty common situations.

Related links, issue #, if available: n/a

### How has this been tested?

Both divs are flexboxes, so nothing should change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
