### PR TITLE
fix: Use semantic heading for side navigation header

### DIFF
--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -164,16 +164,15 @@ describe('SideNavigation', () => {
     }
   });
 
-  it('does not assume any heading levels', () => {
-    const wrapper = renderSideNavigation({ header: { text: 'Console', href: '#something' } });
-    const headings = wrapper.findAll('h1, h2, h3, h4, h5, h6');
-    expect(headings.length).toBe(0);
-  });
-
   describe('Header', () => {
     it('has specified text', () => {
       const wrapper = renderSideNavigation({ header: { text: 'Console', href: '#something' } });
       expect(wrapper.findHeaderLink()!.getElement()).toHaveTextContent('Console');
+    });
+
+    it('renders the header in a <h2>', () => {
+      const wrapper = renderSideNavigation({ header: { text: 'Console', href: '#something' } });
+      expect(wrapper.find('h2')!.getElement()).toHaveTextContent('Console');
     });
 
     it('has specified href', () => {

--- a/src/side-navigation/internal.tsx
+++ b/src/side-navigation/internal.tsx
@@ -45,7 +45,7 @@ export function Header({ definition, activeHref, fireFollow }: HeaderProps) {
 
   return (
     <>
-      <div className={styles.header}>
+      <h2 className={styles.header}>
         <a
           {...focusVisible}
           href={definition.href}
@@ -63,7 +63,7 @@ export function Header({ definition, activeHref, fireFollow }: HeaderProps) {
           )}
           <span className={styles['header-link-text']}>{definition.text}</span>
         </a>
-      </div>
+      </h2>
       <Divider variant="header" />
     </>
   );

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -13,6 +13,7 @@
 }
 
 .header {
+  margin: 0;
   padding: awsui.$space-scaled-l awsui.$space-panel-nav-left;
   // Additional xl space to prevent text from overlapping the close button.
   padding-right: calc(#{awsui.$space-scaled-xxl} + #{awsui.$space-xl});


### PR DESCRIPTION
### Description

We hadn't done this in the past because having an `<h2>` persistently before the `<h1>` in the DOM order would lead to a confusing page hierarchy. But all signals now point to DOM order not being as important as the meaningful hierarchy of the title itself, so... let's do it

Related links, issue #, if available: AWSUI-19376

### How has this been tested?

Only a small change in the HTML tag used; can't think of a test case that wouldn't be a brittle one. Also, there should be no visual changes caused by this change either.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
