### PR TITLE
fix: Container with empty content has incorrect header border radius

### DIFF
--- a/pages/container/simple.page.tsx
+++ b/pages/container/simple.page.tsx
@@ -102,6 +102,10 @@ export default function SimpleContainers() {
               Content area takes the available vertical space
             </Container>
           </div>
+          <Container
+            disableContentPaddings={true}
+            header={<Header variant="h2">Container Without Content</Header>}
+          ></Container>
         </SpaceBetween>
       </ScreenshotArea>
     </article>

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -24,7 +24,7 @@ export default function Container({
       disableContentPaddings={disableContentPaddings}
       {...externalProps}
       {...baseComponentProps}
-      __hiddenContent={disableContentPaddings && !props.children}
+      __hiddenContent={!props.children}
     />
   );
 }

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -24,6 +24,7 @@ export default function Container({
       disableContentPaddings={disableContentPaddings}
       {...externalProps}
       {...baseComponentProps}
+      __hiddenContent={disableContentPaddings && !props.children}
     />
   );
 }


### PR DESCRIPTION
### Description

When container has no content and disableContentPaddings, the bottom border radius are overlapped by header. The change adds border radius when no content in the container, as we did for collapsed ExpandableSection. 
For test, add one more instance in simple.page, it will show in the screenshot tests. 

Related links, issue AWSUI-20171

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
