### PR TITLE
chore: Remove clear labels from the permutation objects

### DIFF
--- a/pages/autosuggest/permutations.page.tsx
+++ b/pages/autosuggest/permutations.page.tsx
@@ -23,7 +23,6 @@ const permutations = createPermutations<AutosuggestProps>([
       undefined,
     ],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     ariaLabel: ['some label'],
@@ -37,7 +36,6 @@ const permutations = createPermutations<AutosuggestProps>([
       </>,
     ],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     ariaLabel: ['some label'],
@@ -46,7 +44,6 @@ const permutations = createPermutations<AutosuggestProps>([
     value: ['', 'Some option'],
     placeholder: ['Enter some data'],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     ariaLabel: ['some label'],
@@ -54,7 +51,6 @@ const permutations = createPermutations<AutosuggestProps>([
     value: ['', 'Some option'],
     placeholder: ['Enter some data'],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     value: [''],
@@ -62,7 +58,6 @@ const permutations = createPermutations<AutosuggestProps>([
     statusType: ['loading'],
     loadingText: ['Loading more items', undefined],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     value: [''],
@@ -70,7 +65,6 @@ const permutations = createPermutations<AutosuggestProps>([
     statusType: ['error'],
     errorText: ['Error while loading', undefined],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     value: ['', 'op', 'Option 2', 'tag1', 'this is a label tag', 'thisisafilteringtag'],
@@ -125,19 +119,16 @@ const permutations = createPermutations<AutosuggestProps>([
       ],
     ],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
   },
   {
     value: [''],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
     options: [range(20).map(i => ({ value: `option${i}`, label: `Option ${i}` }))],
     virtualScroll: [true, false],
   },
   {
     value: ['some value'],
     enteredTextLabel: [enteredTextLabel],
-    clearAriaLabel: ['Clear'],
     options: [[]],
     virtualScroll: [true, false],
   },
@@ -154,6 +145,7 @@ export default function () {
             <div style={{ marginBottom: '100px' }}>
               <Autosuggest
                 ariaLabel="Input field"
+                clearAriaLabel="Clear"
                 onChange={() => {
                   /*empty handler to suppress react controlled property warning*/
                 }}

--- a/pages/input/permutations.page.tsx
+++ b/pages/input/permutations.page.tsx
@@ -16,7 +16,6 @@ const permutations = createPermutations<InputProps>([
       'Short value',
       'Long value, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
-    clearAriaLabel: ['Clear'],
   },
   {
     value: [''],
@@ -26,28 +25,24 @@ const permutations = createPermutations<InputProps>([
       'Short placeholder',
       'Long placeholder, enough to extend beyond the input width.  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
-    clearAriaLabel: ['Clear'],
   },
   {
     disabled: [false, true],
     type: ['text', 'password', 'search', 'email', 'url'] as const,
     value: ['Non-empty value: Placeholder should be hidden'],
     placeholder: ['Short placeholder'],
-    clearAriaLabel: ['Clear'],
   },
   {
     disabled: [false, true],
     type: ['number'] as const,
     value: ['-1', '1'],
     placeholder: ['Short placeholder'],
-    clearAriaLabel: ['Clear'],
   },
   {
     readOnly: [true],
     type: ['text', 'password', 'search', 'number', 'email', 'url'] as const,
     value: ['100000000'],
     placeholder: ['Short placeholder'],
-    clearAriaLabel: ['Clear'],
   },
 ]);
 
@@ -61,6 +56,7 @@ export default function InputPermutations() {
           render={permutation => (
             <Input
               ariaLabel="Input field"
+              clearAriaLabel="Clear"
               onChange={() => {
                 /*empty handler to suppress react controlled property warning*/
               }}

--- a/pages/text-filter/permutations.page.tsx
+++ b/pages/text-filter/permutations.page.tsx
@@ -12,7 +12,6 @@ const permutations = createPermutations<TextFilterProps>([
     countText: [undefined, 'N matches'],
     filteringText: ['', 'query'],
     filteringPlaceholder: [undefined, 'Filter instances...'],
-    filteringClearAriaLabel: ['Clear'],
   },
 ]);
 
@@ -23,7 +22,9 @@ export default function () {
       <ScreenshotArea disableAnimations={true}>
         <PermutationsView
           permutations={permutations}
-          render={permutation => <TextFilter {...permutation} filteringAriaLabel="filtering example" />}
+          render={permutation => (
+            <TextFilter {...permutation} filteringClearAriaLabel="Clear" filteringAriaLabel="filtering example" />
+          )}
         />
       </ScreenshotArea>
     </>


### PR DESCRIPTION
### Description

To mitigate some permutation matching issues for components as a temporary solution.

Related links, issue #, if available: n/a

### How has this been tested?

Permutations should be identical, if not a little bit cleaner

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
