### PR TITLE
useDynamicOverlap: overlapHeight on the body element

### DIFF
--- a/pages/app-layout/1-overlap-height-property.page.tsx
+++ b/pages/app-layout/1-overlap-height-property.page.tsx
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Button } from '~components';
+import Alert from '~components/alert';
+import AppLayout from '~components/app-layout';
+import ContentLayout from '~components/content-layout';
+import Header from '~components/header';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import { Breadcrumbs, Containers } from '../app-layout/utils/content-blocks';
+import ScreenshotArea from '../utils/screenshot-area';
+import appLayoutLabels from '../app-layout/utils/labels';
+
+export default function () {
+  const [alertVisible, setVisible] = useState(true);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        contentType="form"
+        ariaLabels={appLayoutLabels}
+        breadcrumbs={<Breadcrumbs />}
+        content={
+          <ContentLayout
+            header={
+              <SpaceBetween size="m">
+                <Header
+                  variant="h1"
+                  info={<Link>Info</Link>}
+                  description="When you create a new distribution."
+                  actions={<Button variant="primary">Create distribution</Button>}
+                >
+                  CONTENT LAYOUT IS SETTING OVERLAP HEIGHT AT THE ROOT
+                </Header>
+                {alertVisible && (
+                  <Alert
+                    statusIconAriaLabel="Info"
+                    dismissible={true}
+                    dismissAriaLabel="Close alert"
+                    onDismiss={() => setVisible(false)}
+                  >
+                    Demo alert
+                  </Alert>
+                )}
+              </SpaceBetween>
+            }
+          >
+            <Containers />
+          </ContentLayout>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -8,6 +8,11 @@
 @use '../constants' as constants;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
+/* stylelint-disable-next-line */
+body {
+  #{custom-props.$overlapHeight}: #{awsui.$space-dark-header-overlap-distance};
+}
+
 /*
   The first and last column definitions have two responsibilities.
   If Navigation and/or Tools exist then that will determine the width of
@@ -36,7 +41,6 @@
   #{custom-props.$notificationsHeight}: 0px;
   #{custom-props.$offsetTop}: 0px;
   #{custom-props.$offsetTopWithNotifications}: 0px;
-  #{custom-props.$overlapHeight}: #{awsui.$space-dark-header-overlap-distance};
   background-color: awsui.$color-background-layout-main;
   display: grid;
   grid-template-rows: repeat(3, auto) var(#{custom-props.$overlapHeight}) 1fr;

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -160,8 +160,6 @@ function getOverlapDisabled(
 
   if (disableContentHeaderOverlap) {
     isOverlapDisabled = true;
-  } else if (!contentHeader && dynamicOverlapHeight <= 0) {
-    isOverlapDisabled = true;
   }
 
   return isOverlapDisabled;

--- a/src/content-layout/index.tsx
+++ b/src/content-layout/index.tsx
@@ -4,10 +4,11 @@ import React, { useRef } from 'react';
 import clsx from 'clsx';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { ContentLayoutProps } from './interfaces';
+import customCssProps from '../internal/generated/custom-css-properties';
 import { getBaseProps } from '../internal/base-component';
 import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import useBaseComponent from '../internal/hooks/use-base-component';
-import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
+import { useContainerQuery } from '../internal/hooks/container-queries';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
@@ -21,7 +22,7 @@ export default function ContentLayout({ children, disableOverlap, header, ...res
   const rootElement = useRef<HTMLDivElement>(null);
   const { __internalRootRef } = useBaseComponent('ContentLayout');
   const mergedRef = useMergeRefs(rootElement, __internalRootRef);
-  const overlapElement = useDynamicOverlap();
+  const [overlapHeight, overlapElement] = useContainerQuery(rect => rect.height);
   const isVisualRefresh = useVisualRefresh();
 
   /**
@@ -30,6 +31,15 @@ export default function ContentLayout({ children, disableOverlap, header, ...res
    * will not be displayed at all. This is handled in the CSS not the JavaScript.
    */
   const isOverlapDisabled = !children || !header || disableOverlap;
+
+  /**
+   * Instead of using the AppLayout context and useDynamicOverlap hook, the overlapHeight
+   * custom property was lifted to the body element. The property is still private and
+   * namespaced, but can be overridden as needed by internal components. This is similar
+   * to how we add a 'block-body-scroll' class the body dynamically when drawers
+   * are opened on mobile viewports.
+   */
+  document.body.style.setProperty(`${customCssProps.overlapHeight}`, `${overlapHeight}px`);
 
   return (
     <div


### PR DESCRIPTION
This is a draft PR that is complimentary to #667 which demonstrates how subgrid feature detection can pass through the parent grid definition to a descendent node. Alternatively, this PR demonstrates how lifting the overlapHeight property to the body element allows for any internal component to override the value as needed.

**Important note: this is not making the custom property public.** It is simply lifting it up the DOM tree to avoid using a React context or a ref.

Enjoy! :)

<img width="1571" alt="default value" src="https://user-images.githubusercontent.com/438181/214601958-0168b462-933b-4584-a5d9-f4e5023a3169.png">

<img width="1570" alt="content layout" src="https://user-images.githubusercontent.com/438181/214601988-d1cdaddb-6bd0-4479-9869-0676ac78eca2.png">

