### PR TITLE
chore: Inherit font smoothing for secondary links

### DIFF
--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -32,6 +32,10 @@ $font-sizes: (
       @if $variant == 'info' {
         @include styles.font-smoothing;
       }
+      @if $variant == 'secondary' {
+        -webkit-font-smoothing: inherit;
+        -moz-osx-font-smoothing: inherit;
+      }
       @include styles.link-style(map.get(constants.$link-variants, $variant));
     }
   }


### PR DESCRIPTION
### Description

The link component resets font smoothing at the component boundary, which makes sense for most cases except `secondary` links, which inherit font weight.

It's a `chore:` cause it's a bugfix for a change that hasn't gone out yet.

Related links, issue #, if available: n/a

### How has this been tested?

Only locally, but this should be screenshot testing visible.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
