### PR TITLE
fix: Remove wrong deprecated tag on flashbar interfaces

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5562,7 +5562,8 @@ user's attention.
 * \`action\` (ReactNode) - Specifies an action for the flash message. Although it is technically possible to insert any content,
 our UX guidelines only allow you to add a button.
 * \`buttonText\` (string) - Specifies that an action button should be displayed, with the specified text.
-When a user clicks on this button the \`onButtonClick\` handler is called. If the \`action\` property is set, this property is ignored.
+When a user clicks on this button the \`onButtonClick\` handler is called.
+If the \`action\` property is set, this property is ignored. **Deprecated**, replaced by \`action\`.
 * \`onButtonClick\` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
   using the \`action\` property. **Deprecated**, replaced by \`action\`.
 * \`id\` (string) - Specifies a unique flash message identifier. This property  is used in two ways:

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5545,7 +5545,6 @@ Object {
       "type": "string",
     },
     Object {
-      "deprecatedTag": "Replaced by \`action\`.",
       "description": "Specifies flash messages that appear in the same order that they are listed.
 The value is an array of flash message definition objects.
 A flash message object contains the following properties:

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -45,7 +45,8 @@ export interface FlashbarProps extends BaseComponentProps {
    * * `action` (ReactNode) - Specifies an action for the flash message. Although it is technically possible to insert any content,
    * our UX guidelines only allow you to add a button.
    * * `buttonText` (string) - Specifies that an action button should be displayed, with the specified text.
-   * When a user clicks on this button the `onButtonClick` handler is called. If the `action` property is set, this property is ignored.
+   * When a user clicks on this button the `onButtonClick` handler is called.
+   * If the `action` property is set, this property is ignored. **Deprecated**, replaced by `action`.
    * * `onButtonClick` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
    *   using the `action` property. **Deprecated**, replaced by `action`.
    * * `id` (string) - Specifies a unique flash message identifier. This property  is used in two ways:

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -52,7 +52,6 @@ export interface FlashbarProps extends BaseComponentProps {
    *   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
    *   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
    *
-   * @deprecated Replaced by `action`.
    * @visualrefresh `id` property
    */
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;


### PR DESCRIPTION
### Description

Removed wrong `@deprecated` tag from the `items` property in the `Flashbar` component interfaces.

Without this fix, it would generate wrong documentation.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
