### PR TITLE
fix: Make current page breadcrumb item not a link

### DIFF
--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -67,11 +67,6 @@ describe('BreadcrumbGroup Component', () => {
       });
     });
 
-    test('sets last item to be current', () => {
-      const lastItemWrapper = wrapper.findBreadcrumbLink(3);
-      expect(lastItemWrapper!.getElement()).toHaveAttribute('aria-current', 'page');
-    });
-
     test('has ellipsis', () => {
       expect(wrapper.findDropdown()!.findNativeButton()).not.toBe(null);
       expect(wrapper.findByClassName(styles.ellipsis)!.getElement()).toBeInTheDocument();

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -105,13 +105,10 @@ describe('BreadcrumbGroup Item', () => {
       lastLink = links[links.length - 1];
     });
 
-    test('does not have an href', () => {
-      expect(lastLink.getElement()).not.toHaveAttribute('href', '#');
-    });
-
-    test('has correct aria attributes', () => {
-      expect(lastLink.getElement()).toHaveAttribute('aria-current', 'page');
-      expect(lastLink.getElement()).toHaveAttribute('aria-disabled', 'true');
+    test('should not be a link', () => {
+      expect(lastLink.getElement()).not.toHaveAttribute('href');
+      expect(lastLink.getElement()).not.toHaveAttribute('aria-current');
+      expect(lastLink.getElement().tagName).toEqual('a');
     });
 
     test('should not trigger click event', () => {

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -108,7 +108,7 @@ describe('BreadcrumbGroup Item', () => {
     test('should not be a link', () => {
       expect(lastLink.getElement()).not.toHaveAttribute('href');
       expect(lastLink.getElement()).not.toHaveAttribute('aria-current');
-      expect(lastLink.getElement().tagName).toEqual('a');
+      expect(lastLink.getElement().tagName).toEqual('SPAN');
     });
 
     test('should not trigger click event', () => {

--- a/src/test-utils/dom/breadcrumb-group/index.ts
+++ b/src/test-utils/dom/breadcrumb-group/index.ts
@@ -15,7 +15,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
    * @see findBreadcrumbLink
    */
   findBreadcrumbLinks(): Array<ElementWrapper> {
-    return this.findAll(`.${itemStyles.breadcrumb} a`);
+    return this.findAll(`.${itemStyles.breadcrumb}>*`);
   }
   /**
    * Returns a link for a given index.
@@ -29,7 +29,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
     if (index > 1) {
       index++;
     }
-    return this.find(`.${styles.item}:nth-child(${index}) a`);
+    return this.find(`.${styles.item}:nth-child(${index})>*`);
   }
 
   findDropdown(): ButtonDropdownWrapper | null {

--- a/src/test-utils/dom/breadcrumb-group/index.ts
+++ b/src/test-utils/dom/breadcrumb-group/index.ts
@@ -15,7 +15,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
    * @see findBreadcrumbLink
    */
   findBreadcrumbLinks(): Array<ElementWrapper> {
-    return this.findAll(`.${itemStyles.breadcrumb}>*:first-child`);
+    return this.findAll(`.${itemStyles.breadcrumb} .${itemStyles.anchor}`);
   }
   /**
    * Returns a link for a given index.
@@ -29,7 +29,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
     if (index > 1) {
       index++;
     }
-    return this.find(`.${styles.item}:nth-child(${index})>*:first-child`);
+    return this.find(`.${styles.item}:nth-child(${index}) .${itemStyles.anchor}`);
   }
 
   findDropdown(): ButtonDropdownWrapper | null {

--- a/src/test-utils/dom/breadcrumb-group/index.ts
+++ b/src/test-utils/dom/breadcrumb-group/index.ts
@@ -9,18 +9,20 @@ import buttonDropdownStyles from '../../../button-dropdown/styles.selectors.js';
 export default class BreadcrumbGroupWrapper extends ComponentWrapper {
   static rootSelector: string = styles['breadcrumb-group'];
   /**
-   * Returns all links.
+   * Returns all breadcrumb items. Note that this includes the 'current' page item for backwards compatibility,
+   * even though it is not technically a link.
    *
-   * To find a specific link use the `findBreadcrumbLink(n)` function as chaining `findBreadcrumbLinks().get(n)` can return unexpected results.
+   * To find a specific item use the `findBreadcrumbLink(n)` function as chaining `findBreadcrumbLinks().get(n)` can return unexpected results.
    * @see findBreadcrumbLink
    */
   findBreadcrumbLinks(): Array<ElementWrapper> {
     return this.findAll(`.${itemStyles.breadcrumb} .${itemStyles.anchor}`);
   }
   /**
-   * Returns a link for a given index.
+   * Returns an item for a given index. Note that this may return the 'current' page item for backwards compatibility,
+   * even though it is not technically a link.
    *
-   * @param index 1-based link index
+   * @param index 1-based item index
    */
   findBreadcrumbLink(index: number): ElementWrapper | null {
     // We insert the breadcrumb-ellipsis as the second element so we have to filter it out.

--- a/src/test-utils/dom/breadcrumb-group/index.ts
+++ b/src/test-utils/dom/breadcrumb-group/index.ts
@@ -15,7 +15,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
    * @see findBreadcrumbLink
    */
   findBreadcrumbLinks(): Array<ElementWrapper> {
-    return this.findAll(`.${itemStyles.breadcrumb}>*`);
+    return this.findAll(`.${itemStyles.breadcrumb}>*:first-child`);
   }
   /**
    * Returns a link for a given index.
@@ -29,7 +29,7 @@ export default class BreadcrumbGroupWrapper extends ComponentWrapper {
     if (index > 1) {
       index++;
     }
-    return this.find(`.${styles.item}:nth-child(${index})>*`);
+    return this.find(`.${styles.item}:nth-child(${index})>*:first-child`);
   }
 
   findDropdown(): ButtonDropdownWrapper | null {


### PR DESCRIPTION
### Description

Previously the current page item was kinda a link and kinda not, which was causing some accessibility issues. After internal discussion and reviewing reference implementations, the best approach is to make it just text.

Related links, issue #, if available: AWSUI-20172

### How has this been tested?

Updated unit tests, deployed locally & tested with VO & Chrome. See internal ticket for more details.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
