### PR TITLE
fix: Prevent top navigation identity title from truncating too early

### DIFF
--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -109,13 +109,13 @@ export default function InternalTopNavigation({
             </div>
           )}
 
-          <div className={styles.inputs}>
-            {showSearchSlot && (
+          {showSearchSlot && (
+            <div className={styles.inputs}>
               <div className={clsx(styles.search, !isVirtual && isSearchExpanded && styles['search-expanded'])}>
                 {search}
               </div>
-            )}
-          </div>
+            </div>
+          )}
 
           <div className={styles.utilities}>
             {showSearchUtility && (


### PR DESCRIPTION
### Description

It looks like the `.inputs` div occupies space even if there's no content to show because of uncollapsable paddings. So the solution is to remove it from the DOM completely so that the expectations match up with reality.

Alternatively, I could have updated the calculations in use-top-navigation, but it's better to have less wasted space :)

Related links, issue #, if available: n/a

### How has this been tested?

Local screenshot checks. Compare the "top-navigation/screenshot" page and you'll find that only the final text-only identity should truncate.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
