### PR TITLE
chore: Fix flashbar items property docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5556,7 +5556,7 @@ A flash message object contains the following properties:
 When a user clicks on this button the \`onDismiss\` handler is called.
 * \`dismissLabel\` (string) - Specifies an \`aria-label\` for to the dismiss icon button for improved accessibility.
 * \`statusIconAriaLabel\` (string) - Specifies an \`aria-label\` for to the status icon for improved accessibility.
-* \`ariaRole\` (boolean) - For flash messages added after page load, specifies how this message is communicated to assistive
+* \`ariaRole\` (string) - For flash messages added after page load, specifies how this message is communicated to assistive
 technology. Use \\"status\\" for status updates or informational content. Use \\"alert\\" for important messages that need the
 user's attention.
 * \`action\` (ReactNode) - Specifies an action for the flash message. Although it is technically possible to insert any content,
@@ -5566,14 +5566,13 @@ When a user clicks on this button the \`onButtonClick\` handler is called.
 If the \`action\` property is set, this property is ignored. **Deprecated**, replaced by \`action\`.
 * \`onButtonClick\` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
   using the \`action\` property. **Deprecated**, replaced by \`action\`.
-* \`id\` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
+* \`id\` (string) - Specifies a unique flash message identifier. This property is used in two ways:
   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
 ",
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FlashbarProps.MessageDefinition>",
-      "visualRefreshTag": "\`id\` property",
     },
   ],
   "regions": Array [],

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -39,7 +39,7 @@ export interface FlashbarProps extends BaseComponentProps {
    * When a user clicks on this button the `onDismiss` handler is called.
    * * `dismissLabel` (string) - Specifies an `aria-label` for to the dismiss icon button for improved accessibility.
    * * `statusIconAriaLabel` (string) - Specifies an `aria-label` for to the status icon for improved accessibility.
-   * * `ariaRole` (boolean) - For flash messages added after page load, specifies how this message is communicated to assistive
+   * * `ariaRole` (string) - For flash messages added after page load, specifies how this message is communicated to assistive
    * technology. Use "status" for status updates or informational content. Use "alert" for important messages that need the
    * user's attention.
    * * `action` (ReactNode) - Specifies an action for the flash message. Although it is technically possible to insert any content,
@@ -49,11 +49,9 @@ export interface FlashbarProps extends BaseComponentProps {
    * If the `action` property is set, this property is ignored. **Deprecated**, replaced by `action`.
    * * `onButtonClick` (event => void) - Called when a user clicks on the action button. This is not called if you create a custom button
    *   using the `action` property. **Deprecated**, replaced by `action`.
-   * * `id` (string) - Specifies a unique flash message identifier. This property  is used in two ways:
+   * * `id` (string) - Specifies a unique flash message identifier. This property is used in two ways:
    *   1. As a [keys](https://reactjs.org/docs/lists-and-keys.html#keys) source for React rendering.
    *   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
-   *
-   * @visualrefresh `id` property
    */
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;
 }


### PR DESCRIPTION
### Description

Whoopsie. Just noticed "ariaRole" is described as a boolean. Also removed "id" from being visual refresh exclusive, because we do use it for checking equality between renders for ariaRole (just like key, so I didn't feel the need to elaborate further in the property docs either)

Related links, issue #, if available: n/a

### How has this been tested?

It's a docs change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
