### PR TITLE
chore: Turn visible content title into an H3

### DIFF
--- a/src/collection-preferences/__tests__/visible-content.test.tsx
+++ b/src/collection-preferences/__tests__/visible-content.test.tsx
@@ -27,9 +27,10 @@ describe('Content selection', () => {
   test('correctly displays title', () => {
     const wrapper = renderWithContentSelection({});
     wrapper.findTriggerButton().click();
-    expect(wrapper.findModal()!.findVisibleContentPreference()!.findTitle().getElement()).toHaveTextContent(
-      'Content selection title'
-    );
+
+    const titleElement = wrapper.findModal()!.findVisibleContentPreference()!.findTitle().getElement();
+    expect(titleElement).toHaveTextContent('Content selection title');
+    expect(titleElement.tagName).toBe('H3');
   });
   test('correctly displays group labels', () => {
     const wrapper = renderWithContentSelection({});

--- a/src/collection-preferences/visible-content.scss
+++ b/src/collection-preferences/visible-content.scss
@@ -17,6 +17,7 @@ $border: awsui.$border-divider-list-width solid awsui.$color-border-divider-defa
 .visible-content-title {
   @include styles.font-label;
   color: awsui.$color-text-form-label;
+  margin: 0;
   margin-bottom: awsui.$space-scaled-l;
 }
 

--- a/src/collection-preferences/visible-content.tsx
+++ b/src/collection-preferences/visible-content.tsx
@@ -71,9 +71,9 @@ export default function VisibleContentPreference({
   const outerGroupLabelId = `${idPrefix}-outer`;
   return (
     <div className={styles['visible-content']}>
-      <div {...className('title')} id={outerGroupLabelId}>
+      <h3 {...className('title')} id={outerGroupLabelId}>
         {title}
-      </div>
+      </h3>
       <InternalSpaceBetween {...className('groups')} size="xs">
         {options.map((optionGroup, optionGroupIndex) => {
           const groupLabelId = `${idPrefix}-${optionGroupIndex}`;


### PR DESCRIPTION
### Description

Given the visual and positional context of the Visible content title, it is perceived as a heading.
We are making this text and explicit heading (h3) to make reflect the semantics in code.

Related links, issue #, if available: AWSUI-20177

![Screenshot 2023-01-30 at 16 54 05](https://user-images.githubusercontent.com/2446349/215527135-3262f49e-9d96-4d5c-8c22-89abaecb20f2.png)

### How has this been tested?

Tested locally using VoiceOver.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
