### PR TITLE
feat: Announce removal of items from AttributeEditor & TagEditor

### DIFF
--- a/pages/attribute-editor/simple.page.tsx
+++ b/pages/attribute-editor/simple.page.tsx
@@ -15,11 +15,13 @@ interface ControlProps extends InputProps {
   prop: keyof Tag;
 }
 
-const i18nStrings = {
+const labelProps = {
   addButtonText: 'Add new item',
   removeButtonText: 'Remove',
   empty: 'No tags associated to the resource',
-};
+  i18nStrings: { itemRemovedAriaLive: 'An item was removed.' },
+} as AttributeEditorProps<unknown>;
+
 const tagLimit = 50;
 
 const Control = React.memo(({ value, index, setItems, prop }: ControlProps) => {
@@ -84,11 +86,12 @@ export default function AttributeEditorPage() {
   );
 
   const additionalInfo = useMemo(() => `You can add ${tagLimit - items.length} more tags.`, [items.length]);
+
   return (
     <Box margin="xl">
       <h1>Attribute Editor - Functional</h1>
-      <AttributeEditor
-        {...i18nStrings}
+      <AttributeEditor<Tag>
+        {...labelProps}
         additionalInfo={additionalInfo}
         items={items}
         definition={definition}

--- a/pages/tag-editor/shared.ts
+++ b/pages/tag-editor/shared.ts
@@ -33,6 +33,7 @@ export const I18N_STRINGS: TagEditorProps.I18nStrings = {
     'Invalid value. Values can only contain alphanumeric characters, spaces and any of the following: _.:/=+@-',
   awsPrefixError: 'Cannot start with aws:',
   clearAriaLabel: 'Clear',
+  itemRemovedAriaLive: 'A tag was removed.',
   tagLimit: (availableTags, tagLimit) =>
     availableTags === tagLimit
       ? `You can up to ${tagLimit} tags.`

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1081,6 +1081,11 @@ A maximum of four fields are supported.
             "optional": true,
             "type": "string",
           },
+          Object {
+            "name": "itemRemovedAriaLive",
+            "optional": true,
+            "type": "string",
+          },
         ],
         "type": "object",
       },
@@ -11838,6 +11843,11 @@ character validation. You should use this property only when absolutely necessar
           Object {
             "name": "invalidValueError",
             "optional": false,
+            "type": "string",
+          },
+          Object {
+            "name": "itemRemovedAriaLive",
+            "optional": true,
             "type": "string",
           },
           Object {

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import createWrapper, { AttributeEditorWrapper } from '../../../lib/components/test-utils/dom';
 import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/attribute-editor';
 import styles from '../../../lib/components/attribute-editor/styles.css.js';
@@ -78,6 +78,26 @@ const expectRowErrorTextContent = (wrapper: AttributeEditorWrapper, rowIndex: nu
     expect(errorField!.getElement()).toHaveTextContent(expectedValue);
   });
 };
+
+function TestComponent(propOverrides: Partial<AttributeEditorProps<Item>> = {}) {
+  const [items, setItems] = React.useState(defaultProps.items!);
+  const onRemoveButtonClick = (event: any) => {
+    const newItems = items.slice();
+    newItems.splice(event.detail.itemIndex, 1);
+    setItems(newItems);
+  };
+
+  return (
+    <AttributeEditor
+      {...defaultProps}
+      items={items}
+      onRemoveButtonClick={onRemoveButtonClick}
+      i18nStrings={{ ...defaultProps.i18nStrings, itemRemovedAriaLive: 'An item was removed.' }}
+      additionalInfo="+++ADDN+++"
+      {...propOverrides}
+    />
+  );
+}
 
 describe('Attribute Editor', () => {
   describe('items property', () => {
@@ -185,6 +205,18 @@ describe('Attribute Editor', () => {
       wrapper.findRow(1)!.findRemoveButton()!.click();
 
       expect(onRemoveButtonClick).toHaveBeenCalledWith(expect.objectContaining({ detail: { itemIndex: 0 } }));
+    });
+
+    test('renders itemRemovedAriaLive on remove button click', async () => {
+      const { container } = render(<TestComponent />);
+      const wrapper = createWrapper(container).findAttributeEditor()!;
+
+      wrapper.findRow(1)!.findRemoveButton()!.click();
+      await waitFor(() =>
+        expect(wrapper.find(`[data-testid="removal-announcement"]`)?.getElement()).toHaveTextContent(
+          'An item was removed.'
+        )
+      );
     });
   });
 

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -42,6 +42,8 @@ export namespace AttributeEditorProps {
 
   export interface I18nStrings {
     errorIconAriaLabel?: string;
+
+    itemRemovedAriaLive?: string;
   }
 }
 

--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -32,6 +32,14 @@ function renderTagEditor(props: Partial<TagEditorProps> = {}): RenderResult {
   };
 }
 
+function StatefulTestComponent(props: Partial<TagEditorProps>) {
+  const [internalTags, setInternalTags] = React.useState(props.tags || []);
+  const onChange = (event: any) => {
+    setInternalTags(event.detail.tags);
+  };
+  return <TagEditor {...defaultProps} {...props} tags={internalTags} onChange={onChange} />;
+}
+
 describe('Tag Editor component', () => {
   test('should set a tag key', () => {
     const { wrapper, onChangeSpy } = renderTagEditor({
@@ -343,6 +351,25 @@ describe('Tag Editor component', () => {
           detail: { tags: [{ key: 'key', value: 'value', existing: true, markedForRemoval: true }], valid: true },
         })
       );
+    });
+  });
+
+  test('should render itemRemovedAriaLive when a tag is removed', () => {
+    const tags = [
+      { key: 'key', value: 'value', existing: false },
+      { key: 'key2', value: 'value', existing: false },
+      { key: 'key3', value: 'value', existing: false },
+    ];
+
+    const { container } = render(
+      <StatefulTestComponent tags={tags} i18nStrings={{ ...i18nStrings, itemRemovedAriaLive: 'removal-text-test' }} />
+    );
+    const wrapper = createWrapper(container).findTagEditor()!;
+
+    wrapper.findRow(1)!.findRemoveButton()!.click();
+
+    waitFor(() => {
+      expect(wrapper.find(`[data-testid="removal-announcement"]`)!.getElement()).toHaveTextContent('removal-text-test');
     });
   });
 

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -121,6 +121,7 @@ export namespace TagEditorProps {
     invalidValueError: string;
     awsPrefixError: string;
     clearAriaLabel?: string;
+    itemRemovedAriaLive?: string;
     tagLimit: (availableTags: number, tagLimit: number) => string;
     tagLimitReached: (tagLimit: number) => string;
     tagLimitExceeded: (tagLimit: number) => string;


### PR DESCRIPTION
### Description
This PR introduces two new props in AttributeEditor & TagEditor, these props allow you to announce removal of an item to screenreader users.


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available:
Resolves a11y bug reported in AWSUI-20076

### How has this been tested?
Unit tests & manual testing with VoiceOver

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.