### PR TITLE
fix: AppLayout announces hidden slots in mobile view

### DIFF
--- a/pages/app-layout/notifications-refresh.page.tsx
+++ b/pages/app-layout/notifications-refresh.page.tsx
@@ -23,8 +23,10 @@ export default function () {
       }
       navigation={<Navigation />}
       navigationOpen={navigationOpen}
+      onNavigationChange={e => setNavigationOpen(e.detail.open)}
       tools={<Tools>{toolsContent.long}</Tools>}
       toolsOpen={toolsOpen}
+      onToolsChange={e => setToolsOpen(e.detail.open)}
       breadcrumbs={<Breadcrumbs />}
       maxContentWidth={maxContentWidth}
       content={

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -221,6 +221,8 @@ describeEachThemeAppLayout(true, theme => {
   describe('unfocusable content', () => {
     const props = {
       content: 'Body content',
+      contentHeader: 'Content header',
+      notifications: 'Notifications',
       navigation: 'Navigation',
       tools: 'Help',
       breadcrumbs: 'Breadcrumbs',
@@ -238,7 +240,7 @@ describeEachThemeAppLayout(true, theme => {
       if (isUsingGridLayout) {
         // In refactored Visual Refresh we make tools-container unfocusable. This is needed
         // because of CSS animations the tools-container is not set to `display: none;` anymore.
-        expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(3);
+        expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(5);
         expect(wrapper.findByClassName(testUtilsStyles['mobile-bar'])?.getElement()).toHaveClass(unfocusableClassName);
         expect(wrapper.findByClassName(testUtilsStyles.content)?.getElement()).toHaveClass(unfocusableClassName);
         expect(wrapper.findByClassName(visualRefreshRefactoredStyles['tools-container'])?.getElement()).toHaveClass(
@@ -257,7 +259,7 @@ describeEachThemeAppLayout(true, theme => {
       if (isUsingGridLayout) {
         // In refactored Visual Refresh we make navigation-container unfocusable. This is needed
         // because of CSS animations the tools-container is not set to `display: none;` anymore.
-        expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(3);
+        expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(5);
         expect(wrapper.findByClassName(testUtilsStyles['mobile-bar'])?.getElement()).toHaveClass(unfocusableClassName);
         expect(wrapper.findByClassName(testUtilsStyles.content)?.getElement()).toHaveClass(unfocusableClassName);
         expect(

--- a/src/app-layout/visual-refresh/header.tsx
+++ b/src/app-layout/visual-refresh/header.tsx
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Header() {
-  const { breadcrumbs, contentHeader, hasNotificationsContent } = useAppLayoutInternals();
+  const { breadcrumbs, contentHeader, hasNotificationsContent, isMobile, isAnyPanelOpen } = useAppLayoutInternals();
 
   if (!contentHeader) {
     return null;
@@ -23,6 +23,7 @@ export default function Header() {
         {
           [styles['has-breadcrumbs']]: breadcrumbs,
           [styles['has-notifications-content']]: hasNotificationsContent,
+          [styles.unfocusable]: isMobile && isAnyPanelOpen,
         },
         'awsui-context-content-header'
       )}

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -129,7 +129,9 @@
 }
 
 // Prevent content that is visually hidden behind drawers and content area in mobile view from receiving focus
-/* stylelint-disable-next-line selector-max-universal, selector-combinator-disallowed-list */
+/* stylelint-disable selector-max-universal, selector-combinator-disallowed-list */
+.unfocusable,
 .unfocusable * {
   visibility: hidden !important;
 }
+/* stylelint-enable selector-max-universal, selector-combinator-disallowed-list */

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -11,8 +11,15 @@ import testutilStyles from '../test-classes/styles.css.js';
  * that the design tokens used are overridden with the appropriate values.
  */
 export default function Notifications() {
-  const { ariaLabels, hasNotificationsContent, notifications, notificationsElement, stickyNotifications } =
-    useAppLayoutInternals();
+  const {
+    ariaLabels,
+    hasNotificationsContent,
+    notifications,
+    notificationsElement,
+    stickyNotifications,
+    isMobile,
+    isAnyPanelOpen,
+  } = useAppLayoutInternals();
 
   if (!notifications) {
     return null;
@@ -27,6 +34,7 @@ export default function Notifications() {
         {
           [styles['has-notifications-content']]: hasNotificationsContent,
           [styles['sticky-notifications']]: stickyNotifications,
+          [styles.unfocusable]: isMobile && isAnyPanelOpen,
         },
         testutilStyles.notifications,
         'awsui-context-content-header'


### PR DESCRIPTION
### Description

When the AppLayout is used in mobile view and the navigation panel is opened, it covers the whole page. Before this PR, the contents of the `notifications` and `contentHeader` slots were still accessible through tabbing and through screenreaders. This PR makes the covered areas inaccessible while the side panels are open.


Related links, issue #, if available:
- AWSUI-20253

### How has this been tested?

Manual testing in the dev page at http://localhost:8080/#/light/app-layout/notifications-refresh

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
