### PR TITLE
feat: Wraps tokens in Property Filter

### DIFF
--- a/pages/table/header-space.page.tsx
+++ b/pages/table/header-space.page.tsx
@@ -1,0 +1,453 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+import PropertyFilter from '~components/property-filter';
+import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
+import Pagination from '~components/pagination';
+import Table from '~components/table';
+import Button from '~components/button';
+import SpaceBetween from '~components/space-between';
+import Box from '~components/box';
+import Select, { SelectProps } from '~components/select';
+import TextFilter from '~components/text-filter';
+import Header from '~components/header';
+import Input from '~components/input';
+import ScreenshotArea from '../utils/screenshot-area';
+import { allItems, TableItem } from '../property-filter/table.data';
+import { columnDefinitions, i18nStrings, filteringProperties } from '../property-filter/common-props';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import { paginationLabels, getMatchesCountText, pageSizeOptions, visibleContentOptions } from './shared-configs';
+import styles from './table.scss';
+
+export default function () {
+  const [selectedOption, setSelectedOption] = React.useState<SelectProps.Option | null>({
+    label: 'Option 1',
+    value: '1',
+  });
+  const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>({
+    pageSize: 5,
+    visibleContent: ['id', 'type', 'dnsName', 'state'],
+    wrapLines: false,
+  });
+  const { items, collectionProps, actions, propertyFilterProps, filterProps, filteredItemsCount, paginationProps } =
+    useCollection(allItems, {
+      propertyFiltering: {
+        empty: 'empty',
+        noMatch: (
+          <Box textAlign="center" color="inherit">
+            <Box variant="strong" textAlign="center" color="inherit">
+              No matches
+            </Box>
+            <Box variant="p" padding={{ bottom: 's' }} color="inherit">
+              We can’t find a match.
+            </Box>
+            <Button
+              onClick={() =>
+                actions.setPropertyFiltering({ tokens: [], operation: propertyFilterProps.query.operation })
+              }
+            >
+              Clear filter
+            </Button>
+          </Box>
+        ),
+        filteringProperties,
+      },
+      sorting: {},
+      pagination: { pageSize: preferences.pageSize },
+    });
+
+  return (
+    <>
+      <ScreenshotArea disableAnimations={true}>
+        <SpaceBetween size="l">
+          {/* 
+             EXAMPLE 1
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                Instances
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            filter={
+              <PropertyFilter
+                {...propertyFilterProps}
+                virtualScroll={true}
+                countText={`${items.length} matches`}
+                i18nStrings={i18nStrings}
+              />
+            }
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 2
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                description="This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go. This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go. This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go. This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go."
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                Instances
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            filter={
+              <PropertyFilter
+                {...propertyFilterProps}
+                virtualScroll={true}
+                countText={`${items.length} matches`}
+                i18nStrings={i18nStrings}
+              />
+            }
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 3
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                description="This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go."
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                Instances
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            filter={
+              <PropertyFilter
+                {...propertyFilterProps}
+                virtualScroll={true}
+                countText={`${items.length} matches`}
+                i18nStrings={i18nStrings}
+                hideOperations={false}
+                disableFreeTextFiltering={false}
+                customControl={
+                  <Select
+                    selectedOption={selectedOption}
+                    onChange={({ detail }) => setSelectedOption(detail.selectedOption)}
+                    options={[
+                      { label: 'Option 1', value: '1' },
+                      { label: 'Option 2', value: '2' },
+                      { label: 'Option 3', value: '3' },
+                      { label: 'Option 4', value: '4' },
+                      { label: 'Option 5', value: '5' },
+                    ]}
+                    selectedAriaLabel="Selected"
+                  />
+                }
+              />
+            }
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 4
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                description="This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go. This is a very long description for a table header for us to test text wrapping and where other stuff
+                  will go."
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                So Many Instances That I Decided I Needed A Very Long Title To Describe How Many
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 5
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                Instances
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            filter={
+              <PropertyFilter
+                {...propertyFilterProps}
+                virtualScroll={true}
+                countText={`${items.length} matches`}
+                i18nStrings={i18nStrings}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 6 - text filter
+            */}
+          <Table<TableItem>
+            header={
+              <Header
+                headingTagOverride={'h1'}
+                actions={
+                  <SpaceBetween size="xs" direction="horizontal">
+                    <Button>View details</Button>
+                    <Button>Edit</Button>
+                    <Button>Delete</Button>
+                    <Button variant="primary">Create distribution</Button>
+                  </SpaceBetween>
+                }
+              >
+                Instances
+              </Header>
+            }
+            items={items}
+            {...collectionProps}
+            filter={
+              <div className={styles.inputContainer}>
+                <div className={styles.inputFilter}>
+                  <TextFilter
+                    {...filterProps!}
+                    countText={getMatchesCountText(filteredItemsCount!)}
+                    filteringAriaLabel="Filter instances"
+                  />
+                </div>
+                <div className={styles.selectFilter}>
+                  <Input value="" onChange={() => {}} />
+                </div>
+                <div className={styles.selectFilter}>
+                  <Input value="" onChange={() => {}} />
+                </div>
+              </div>
+            }
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 7
+            */}
+          <Table<TableItem>
+            header={<Header headingTagOverride={'h1'}>Instances</Header>}
+            items={items}
+            {...collectionProps}
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 8
+            */}
+          <Table<TableItem>
+            header={<Header headingTagOverride={'h1'}>Instances</Header>}
+            items={items}
+            {...collectionProps}
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 9
+            */}
+          <Table<TableItem>
+            items={items}
+            {...collectionProps}
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+          {/* 
+             EXAMPLE 10
+            */}
+          <Table<TableItem>
+            items={items}
+            {...collectionProps}
+            pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
+            filter={
+              <PropertyFilter
+                {...propertyFilterProps}
+                virtualScroll={true}
+                countText={`${items.length} matches`}
+                i18nStrings={i18nStrings}
+              />
+            }
+            preferences={
+              <CollectionPreferences
+                title="Preferences"
+                confirmLabel="Confirm"
+                cancelLabel="Cancel"
+                onConfirm={({ detail }) => setPreferences(detail)}
+                preferences={preferences}
+                pageSizePreference={{
+                  title: 'Select page size',
+                  options: pageSizeOptions,
+                }}
+                visibleContentPreference={{
+                  title: 'Select visible columns',
+                  options: visibleContentOptions,
+                }}
+              />
+            }
+            columnDefinitions={columnDefinitions}
+          />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/pages/table/table.scss
+++ b/pages/table/table.scss
@@ -1,0 +1,45 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.inputContainer {
+  display: flex;
+  flex-wrap: wrap;
+  order: 0;
+  flex-grow: 10;
+  margin-right: 0;
+  margin-bottom: -1rem;
+}
+
+.inputFilter {
+  order: 0;
+  flex-grow: 6;
+  width: auto;
+  max-width: 728px;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+}
+
+.selectFilter {
+  max-width: 130px;
+  flex-grow: 2;
+  width: auto;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 1152px) {
+  .input-container {
+    margin-right: -1rem;
+  }
+
+  .select-filter {
+    max-width: none;
+  }
+
+  .input-filter {
+    width: 100%;
+    max-width: none;
+  }
+}

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -14,20 +14,27 @@
 }
 
 .tools {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: repeat(2, auto);
   flex-wrap: wrap;
   padding: awsui.$space-scaled-xs 0 awsui.$space-scaled-xxs;
 
   &-filtering {
-    flex: 1 1 0%;
+    grid-column: 1 / span 2;
+    grid-row: 1 / span 2;
     max-width: 100%;
-    margin-right: awsui.$space-l;
   }
 
   &-align-right {
+    grid-column: 2;
+    grid-row: 1;
     display: flex;
     margin-left: auto;
+
+    &-wrap {
+      grid-row: 3;
+    }
   }
 
   &-pagination + &-preferences {

--- a/src/table/tools-header.tsx
+++ b/src/table/tools-header.tsx
@@ -3,7 +3,10 @@
 import clsx from 'clsx';
 import React from 'react';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
+import { useContainerQuery } from '../internal/hooks/container-queries';
+import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import styles from './styles.css.js';
+import { mobileBreakpoint } from '../internal/breakpoints';
 
 interface ToolsHeaderProps {
   header: React.ReactNode;
@@ -13,16 +16,66 @@ interface ToolsHeaderProps {
 }
 
 export default function ToolsHeader({ header, filter, pagination, preferences }: ToolsHeaderProps) {
+  const [overlap, setOverlap] = React.useState(false);
   const [breakpoint, ref] = useContainerBreakpoints(['xs']);
+  const [toolsWidth, toolsRef] = useContainerQuery(rect => rect.width);
+  const [paginationAndPreferencesWidth, paginationAndPreferencesRef] = useContainerQuery(rect => rect.width);
+  const mergedRef = useMergeRefs(ref, toolsRef);
   const isSmall = breakpoint === 'default';
   const hasTools = filter || pagination || preferences;
+  const FILTER_WIDTH = toolsWidth && paginationAndPreferencesWidth && toolsWidth - paginationAndPreferencesWidth;
+
+  // This value is from the search field on the Property Filter.
+  // It is the xs breakpoint, minus the table tools container padding.
+  const OVERLAP_WIDTH = mobileBreakpoint - 2 * 20;
+
+  React.useEffect(() => {
+    if (FILTER_WIDTH && FILTER_WIDTH < OVERLAP_WIDTH) {
+      setOverlap(true);
+      return;
+    }
+    setOverlap(false);
+  }, [FILTER_WIDTH, OVERLAP_WIDTH]);
+
+  function isPropertyFilter(children: any) {
+    const reactChildren = (
+      <>
+        {React.Children.map(children, child => {
+          return child.type.displayName === 'PropertyFilter';
+        })}
+      </>
+    );
+    return reactChildren?.props?.children?.includes(true);
+  }
+
+  function getFilterSlotMaxWidth() {
+    if (isPropertyFilter(filter)) {
+      return 'none';
+    }
+    if (isSmall) {
+      return '100%';
+    }
+
+    return `${FILTER_WIDTH}px`;
+  }
+
   return (
     <>
       {header}
       {hasTools && (
-        <div ref={ref} className={clsx(styles.tools, isSmall && styles['tools-small'])}>
-          {filter && <div className={styles['tools-filtering']}>{filter}</div>}
-          <div className={styles['tools-align-right']}>
+        <div ref={mergedRef} className={clsx(styles.tools, isSmall && styles['tools-small'])}>
+          {filter && (
+            <div style={{ maxWidth: getFilterSlotMaxWidth() }} className={styles['tools-filtering']}>
+              {filter}
+            </div>
+          )}
+          <div
+            ref={paginationAndPreferencesRef}
+            className={clsx(
+              styles['tools-align-right'],
+              ((isPropertyFilter(filter) && overlap) || isSmall) && styles['tools-align-right-wrap']
+            )}
+          >
             {pagination && <div className={styles['tools-pagination']}>{pagination}</div>}
             {preferences && <div className={styles['tools-preferences']}>{preferences}</div>}
           </div>


### PR DESCRIPTION
### Description

Currently, the Property Filter tokens wrap too early.
![image](https://user-images.githubusercontent.com/9701338/216147402-d22ad025-adde-4ca1-993f-1ec78fc3e5f4.png)

This is because the filter slot can only expand until it hits pagination & preferences.
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/9701338/216147792-0267021e-2dce-46aa-bcf3-d140e09c9e79.png">

This solution expands the filter slot to the edge of the table using CSS Grid. The way it avoids overlapping by using Container Queries and the max-width property on the PropertyFilter.

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/9701338/216148127-1a729de8-6625-451f-b9ab-f92af3bf8da6.png">

Once it hits that value, the pagination & preferences wraps to the bottom, but the tokens continue to wrap to the edge.

<img width="869" alt="image" src="https://user-images.githubusercontent.com/9701338/216149142-8d9a57b5-7db8-4516-9607-fc5267eec1e8.png">

For non PropertyFilters, the behavior is the same as it is currently. It does this by checking that the filter slot is a PropertyFilter.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
I created a new testing page called `header-space` with as many different variants of the Table Header I could come up with. 

<!-- How can reviewers test these changes efficiently? -->
Feel free to test using this [demo link](https://protozoa.amazon.dev/prototypes/be4f6145-700b-441f-9222-065e7363da43/#/light/table/header-space).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
