### PR TITLE
chore: Let Flashbar render the items in the same order as in the array, also when using the Stacked notifications feature

### DIFF
--- a/pages/flashbar/collapsible.permutations.page.tsx
+++ b/pages/flashbar/collapsible.permutations.page.tsx
@@ -53,8 +53,8 @@ const permutations = createPermutations<FlashbarProps>([
       [sampleNotifications.success],
       [sampleNotifications.error],
       [sampleNotifications.warning],
-      [sampleNotifications.success, sampleNotifications.error],
-      [sampleNotifications.success, sampleNotifications.error, sampleNotifications.warning],
+      [sampleNotifications.error, sampleNotifications.success],
+      [sampleNotifications.warning, sampleNotifications.error, sampleNotifications.success],
     ],
   },
 ]);

--- a/pages/flashbar/interactive.page.tsx
+++ b/pages/flashbar/interactive.page.tsx
@@ -36,7 +36,7 @@ export default function FlashbarPermutations() {
   };
 
   const add = (type: FlashbarProps.Type, hasHeader = false) => {
-    setItems(items => [...items, generateItem(type, dismiss, hasHeader)]);
+    setItems(items => [generateItem(type, dismiss, hasHeader), ...items]);
   };
 
   const addMultiple = (type: FlashbarProps.Type, hasHeader = false) => {
@@ -45,12 +45,12 @@ export default function FlashbarPermutations() {
     setTimeout(() => add(type, hasHeader), 200);
   };
 
-  const addTop = (type: FlashbarProps.Type, hasHeader = false) => {
-    setItems(items => [generateItem(type, dismiss, hasHeader), ...items]);
+  const addToBottom = (type: FlashbarProps.Type, hasHeader = false) => {
+    setItems(items => [...items, generateItem(type, dismiss, hasHeader)]);
   };
 
-  const removeLastAndAdd = (type: FlashbarProps.Type, hasHeader = false) => {
-    setItems(items => [...items.slice(0, items.length - 1), generateItem(type, dismiss, hasHeader)]);
+  const removeAndAddToBottom = (type: FlashbarProps.Type, hasHeader = false) => {
+    setItems(items => [generateItem(type, dismiss, hasHeader), ...items.slice(1, items.length)]);
   };
 
   const [collapsible, setCollapsible] = useState(false);
@@ -95,10 +95,10 @@ export default function FlashbarPermutations() {
             Add Multiple Error Flashes
           </Button>
           <Button onClick={() => add('warning')}>Add Warning Flash</Button>
-          <Button data-id="add-to-top" onClick={() => addTop('error')}>
-            Add To Top
+          <Button data-id="add-error-to-bottom" onClick={() => addToBottom('error')}>
+            Add To Bottom
           </Button>
-          <Button onClick={() => removeLastAndAdd('error')}>Add And Remove</Button>
+          <Button onClick={() => removeAndAddToBottom('error')}>Add And Remove</Button>
         </SpaceBetween>
         <Flashbar items={items} {...restProps} />
       </SpaceBetween>

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -8,22 +8,22 @@ describe('Collapsible Flashbar', () => {
     it(
       'can expand and collapse stacked notifications with the keyboard',
       setupTest(async page => {
-        await page.toggleCollapsibleFeature();
+        await page.toggleStackingFeature();
 
         // Navigate past all buttons to add and remove flashes
         await page.keys(new Array(8).fill('Tab'));
 
-        await expect(page.findFlashes()).resolves.toBe(1);
+        await expect(page.countFlashes()).resolves.toBe(1);
         await page.keys('Space');
 
-        await expect(page.findFlashes()).resolves.toBe(5);
+        await expect(page.countFlashes()).resolves.toBe(5);
         await expect(page.isFlashFocused(1)).resolves.toBe(true);
 
         // Navigate past all flash buttons
         await page.keys(new Array(11).fill('Tab'));
 
         await page.keys('Space');
-        await expect(page.findFlashes()).resolves.toBe(1);
+        await expect(page.countFlashes()).resolves.toBe(1);
       })
     );
   });
@@ -33,9 +33,9 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding flash with ariaRole="status" does not move focus',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.addInfoFlash();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -43,9 +43,9 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding flash with ariaRole="alert" moves focus to the new flash',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
@@ -53,9 +53,9 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding new non-alert flashes does not move focus to the new flash',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
@@ -67,9 +67,9 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding flash with ariaRole="status" does not move focus',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addInfoFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
@@ -78,9 +78,9 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding flash with ariaRole="alert" moves focus to the new flash',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           return expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
@@ -89,13 +89,13 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding new non-alert flashes does not move focus to the new flash',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
           await page.addInfoFlash();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(false);
         })
       );
@@ -103,12 +103,12 @@ describe('Collapsible Flashbar', () => {
       test(
         'adding new non-alert flashes does not move focus to previous alert flashes',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.toggleCollapsedState();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addErrorFlash();
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.addInfoFlash();
           await expect(page.isFlashFocused(2)).resolves.toBe(false);
         })
@@ -119,22 +119,14 @@ describe('Collapsible Flashbar', () => {
       test(
         'focuses on the first flash',
         setupTest(async page => {
-          await page.toggleCollapsibleFeature();
+          await page.toggleStackingFeature();
           await page.addErrorFlash();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await page.toggleCollapsedState();
-          await wait(FOCUS_THROTTLE_DELAY);
+          await page.pause(FOCUS_THROTTLE_DELAY);
           await expect(page.isFlashFocused(1)).resolves.toBe(true);
         })
       );
     });
   });
 });
-
-function wait(amount: number) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(true);
-    }, amount);
-  });
-}

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { setupTest } from './pages/interactive-page';
+import { FOCUS_THROTTLE_DELAY } from '../utils';
 
-const initialCount = 5;
 test(
   'adding flash with ariaRole="status" does not move focus',
   setupTest(async page => {
     await page.addInfoFlash();
-    return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(false);
+    return expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
 
@@ -15,7 +15,7 @@ test(
   'adding flash with ariaRole="alert" moves focus to the new flash',
   setupTest(async page => {
     await page.addErrorFlash();
-    return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
+    return expect(page.isFlashFocused(1)).resolves.toBe(true);
   })
 );
 
@@ -23,24 +23,38 @@ test(
   'adding new non-alert flashes does not move focus to previous alert flashes',
   setupTest(async page => {
     await page.addErrorFlash();
-    await expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
+    await expect(page.isFlashFocused(1)).resolves.toBe(true);
     await page.addInfoFlash();
-    await expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(false);
+    await page.pause(FOCUS_THROTTLE_DELAY);
+    await expect(page.isFlashFocused(1)).resolves.toBe(false);
   })
 );
 
 test(
   'adding multiple flashes with ariaRole="alert" throttles focus moves',
   setupTest(async page => {
+    const initialCount = await page.countFlashes();
     await page.addSequentialErrorFlashes();
-    return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
+    await page.pause(300);
+    const currentCount = await page.countFlashes();
+    const firstAddedItemIndex = currentCount - initialCount;
+    return expect(page.isFlashFocused(firstAddedItemIndex)).resolves.toBe(true);
   })
 );
 
 test(
   'adding flash with ariaRole="alert" to the top moves focus to the new flash',
   setupTest(async page => {
-    await page.addErrorFlashToTop();
+    await page.addErrorFlash();
     return expect(page.isFlashFocused(1)).resolves.toBe(true);
+  })
+);
+
+test(
+  'adding flash with ariaRole="alert" to the bottom moves focus to the new flash',
+  setupTest(async page => {
+    const initialCount = await page.countFlashes();
+    await page.addErrorFlashToBottom();
+    return expect(page.isFlashFocused(initialCount + 1)).resolves.toBe(true);
   })
 );

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -16,15 +16,15 @@ export class FlashbarInteractivePage extends BasePageObject {
     await this.click('[data-id="add-error"]');
   }
 
-  async addErrorFlashToTop() {
-    await this.click('[data-id="add-to-top"]');
+  async addErrorFlashToBottom() {
+    await this.click('[data-id="add-error-to-bottom"]');
   }
 
   async addSequentialErrorFlashes() {
     await this.click('[data-id="add-multiple"]');
   }
 
-  async toggleCollapsibleFeature() {
+  async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
   }
 
@@ -33,7 +33,7 @@ export class FlashbarInteractivePage extends BasePageObject {
     await this.click(selector);
   }
 
-  findFlashes() {
+  countFlashes() {
     return this.getElementsCount(createWrapper().findFlashbar().findItems().toSelector());
   }
 

--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -35,12 +35,12 @@ const defaultProps = {
 
 describe('Collapsible Flashbar', () => {
   describe('Basic behavior', () => {
-    it('shows only the header and content of the last item in the array when collapsed', () => {
+    it('shows only the header and content of the first item in the array when collapsed', () => {
       const flashbar = renderFlashbar();
       const items = flashbar.findItems();
       expect(items.length).toBe(1);
-      expect(items[0].findHeader()!.getElement()).toHaveTextContent('Success');
-      expect(items[0].findContent()!.getElement()).toHaveTextContent('Everything went fine');
+      expect(items[0].findHeader()!.getElement()).toHaveTextContent(defaultItems[0].header!.toString());
+      expect(items[0].findContent()!.getElement()).toHaveTextContent(defaultItems[0].content!.toString());
     });
 
     it('shows toggle element with desired text', () => {
@@ -64,24 +64,24 @@ describe('Collapsible Flashbar', () => {
       const flashbar = renderFlashbar();
       const items = flashbar.findItems();
       expect(items.length).toBe(1);
-      expect(items[0].findHeader()!.getElement()).toHaveTextContent('Success');
-      expect(items[0].findContent()!.getElement()).toHaveTextContent('Everything went fine');
+      expect(items[0].findHeader()!.getElement()).toHaveTextContent(defaultItems[0].header!.toString());
+      expect(items[0].findContent()!.getElement()).toHaveTextContent(defaultItems[0].content!.toString());
 
       findNotificationBar(flashbar)!.click();
 
       const expandedItems = flashbar.findItems();
       expect(expandedItems.length).toBe(2);
-      expect(expandedItems[0].findHeader()!.getElement()).toHaveTextContent('Success');
-      expect(expandedItems[0].findContent()!.getElement()).toHaveTextContent('Everything went fine');
-      expect(expandedItems[1].findHeader()!.getElement()).toHaveTextContent('Error');
-      expect(expandedItems[1].findContent()!.getElement()).toHaveTextContent('There was an error');
+      expect(expandedItems[0].findHeader()!.getElement()).toHaveTextContent(defaultItems[0].header!.toString());
+      expect(expandedItems[0].findContent()!.getElement()).toHaveTextContent(defaultItems[0].content!.toString());
+      expect(expandedItems[1].findHeader()!.getElement()).toHaveTextContent(defaultItems[1].header!.toString());
+      expect(expandedItems[1].findContent()!.getElement()).toHaveTextContent(defaultItems[1].content!.toString());
 
       findNotificationBar(flashbar)!.click();
 
       const collapsedItems = flashbar.findItems();
       expect(collapsedItems.length).toBe(1);
-      expect(collapsedItems[0].findHeader()!.getElement()).toHaveTextContent('Success');
-      expect(collapsedItems[0].findContent()!.getElement()).toHaveTextContent('Everything went fine');
+      expect(collapsedItems[0].findHeader()!.getElement()).toHaveTextContent(defaultItems[0].header!.toString());
+      expect(collapsedItems[0].findContent()!.getElement()).toHaveTextContent(defaultItems[0].content!.toString());
     });
 
     it('collapses automatically when enough items are added', () => {

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -88,9 +88,9 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
 
   useLayoutEffect(() => {
     if (isFlashbarStackExpanded && items?.length) {
-      const lastItem = items[items.length - 1];
-      if (lastItem.id !== undefined) {
-        focusFlashById(ref.current, lastItem.id);
+      const mostRecentItem = items[0];
+      if (mostRecentItem.id !== undefined) {
+        focusFlashById(ref.current, mostRecentItem.id);
       }
     }
     // Run this after expanding, but not every time the items change.
@@ -152,16 +152,13 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
 
   const isCollapsible = items.length > maxNonCollapsibleItems;
 
-  // When using the stacking feature, the items are shown in reverse order (last item on top)
-  const reversedItems = items.slice().reverse();
-
   const countByType = getFlashTypeCount(items);
 
   const stackDepth = Math.min(3, items.length);
 
   const itemsToShow = isFlashbarStackExpanded
-    ? reversedItems.map((item, index) => ({ ...item, expandedIndex: index }))
-    : getVisibleCollapsedItems(reversedItems, stackDepth).map((item: StackableItem, index: number) => ({
+    ? items.map((item, index) => ({ ...item, expandedIndex: index }))
+    : getVisibleCollapsedItems(items, stackDepth).map((item: StackableItem, index: number) => ({
         ...item,
         collapsedIndex: index,
       }));


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

After this change, the behavior of the Flashbar when using the Stacking feature matches the current behavior when it comes to item order: the first item in the `items` array is displayed visually at the top of the stack and the last one of the array is displayed at the bottom.

### How has this been tested?

<!-- How did you test to verify your changes? -->
- Covered by existing unit tests and integration tests
- Added one integration test
- Manually tested

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
