### PR TITLE
fix: Add ARIA label to Flashbar

### DIFF
--- a/pages/flashbar/interactive.page.tsx
+++ b/pages/flashbar/interactive.page.tsx
@@ -28,6 +28,8 @@ function generateItem(
   };
 }
 
+const ariaLabel = 'Notifications';
+
 export default function FlashbarPermutations() {
   const dismiss = (index: string) => {
     setItems(items => items.filter(item => item.id !== index));
@@ -54,11 +56,11 @@ export default function FlashbarPermutations() {
   const [collapsible, setCollapsible] = useState(false);
   const [items, setItems] = useState(() => [...range(5).map(() => generateItem('info', dismiss, false, true))]);
 
-  const privateProps = collapsible
+  const restProps = collapsible
     ? {
         stackItems: true,
         i18nStrings: {
-          ariaLabel: 'Notifications',
+          ariaLabel,
           notificationBarText: 'Notifications',
           notificationBarAriaLabel: 'View all notifications',
           errorIconAriaLabel: 'Error',
@@ -68,7 +70,11 @@ export default function FlashbarPermutations() {
           inProgressIconAriaLabel: 'In progress',
         },
       }
-    : {};
+    : {
+        i18nStrings: {
+          ariaLabel,
+        },
+      };
 
   return (
     <>
@@ -94,7 +100,7 @@ export default function FlashbarPermutations() {
           </Button>
           <Button onClick={() => removeLastAndAdd('error')}>Add And Remove</Button>
         </SpaceBetween>
-        <Flashbar items={items} {...privateProps} />
+        <Flashbar items={items} {...restProps} />
       </SpaceBetween>
     </>
   );

--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import Flashbar from '../../../lib/components/flashbar';
-import { createFlashbarWrapper } from './common';
+import { createFlashbarWrapper, findList } from './common';
 import createWrapper, { FlashbarWrapper } from '../../../lib/components/test-utils/dom';
 import { FlashbarProps, FlashType, CollapsibleFlashbarProps } from '../interfaces';
 import { render } from '@testing-library/react';
@@ -255,10 +255,6 @@ describe('Collapsible Flashbar', () => {
     });
   });
 });
-
-function findList(flashbar: FlashbarWrapper) {
-  return flashbar.find('ul');
-}
 
 // Entire interactive element including the counter and the actual <button/> element
 function findNotificationBar(flashbar: FlashbarWrapper): HTMLElement | undefined {

--- a/src/flashbar/__tests__/common.ts
+++ b/src/flashbar/__tests__/common.ts
@@ -1,8 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import createWrapper from '../../../lib/components/test-utils/dom';
+import createWrapper, { FlashbarWrapper } from '../../../lib/components/test-utils/dom';
 import { render } from '@testing-library/react';
 
 export function createFlashbarWrapper(element: React.ReactElement) {
   return createWrapper(render(element).container).findFlashbar()!;
+}
+
+export function findList(flashbar: FlashbarWrapper) {
+  return flashbar.find('ul');
 }

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -6,7 +6,7 @@ import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
 import Button from '../../../lib/components/button';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/flashbar/styles.css.js';
-import { createFlashbarWrapper } from './common';
+import { createFlashbarWrapper, findList } from './common';
 
 let mockUseAnimations = false;
 let useAnimations = false;
@@ -333,6 +333,44 @@ describe('Flashbar component', () => {
           'aria-label',
           iconLabel
         );
+      });
+
+      describe('Accessibility', () => {
+        test('renders items in an unordered list', () => {
+          const flashbar = createFlashbarWrapper(
+            <Flashbar
+              items={[
+                {
+                  header: 'The header',
+                  content: 'The content',
+                },
+              ]}
+            />
+          );
+          const list = flashbar.find('ul')!;
+          expect(list).toBeTruthy();
+          expect(list.findAll('li')).toHaveLength(1);
+        });
+
+        test('applies ARIA label to the unordered list', () => {
+          const customAriaLabel = 'Custom text';
+          const flashbar = createFlashbarWrapper(
+            <Flashbar
+              items={[
+                {
+                  header: 'The header',
+                  content: 'The content',
+                },
+              ]}
+              i18nStrings={{
+                ariaLabel: customAriaLabel,
+              }}
+            />
+          );
+          const list = findList(flashbar)!;
+          expect(list).toBeTruthy();
+          expect(list.getElement().getAttribute('aria-label')).toEqual(customAriaLabel);
+        });
       });
     });
   }

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -43,7 +43,7 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
     setInitialAnimationState(rects);
   }, [getElementsToAnimate]);
 
-  const { baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef, ref } = useFlashbar({
+  const { ariaLabel, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef, ref } = useFlashbar({
     items,
     ...restProps,
     onItemsAdded: newItems => {
@@ -166,7 +166,6 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
         collapsedIndex: index,
       }));
 
-  const ariaLabel = i18nStrings?.ariaLabel;
   const notificationBarText = i18nStrings?.notificationBarText;
 
   const getItemId = (item: StackableItem | FlashbarProps.MessageDefinition) =>

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -6,19 +6,20 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useReducedMotion, useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { getBaseProps } from '../internal/base-component';
-import { FlashbarProps } from './interfaces';
+import { CollapsibleFlashbarProps, FlashbarProps } from './interfaces';
 import { focusFlashById } from './flash';
 
 export const componentName = 'Flashbar';
 
 // Common logic for collapsible and non-collapsible Flashbar
 export function useFlashbar({
+  i18nStrings,
   items,
   onItemsAdded,
   onItemsChanged,
   onItemsRemoved,
   ...restProps
-}: FlashbarProps & {
+}: CollapsibleFlashbarProps & {
   onItemsAdded?: (items: FlashbarProps.MessageDefinition[]) => void;
   onItemsRemoved?: (items: FlashbarProps.MessageDefinition[]) => void;
   onItemsChanged?: (options?: { allItemsHaveId?: boolean; isReducedMotion?: boolean }) => void;
@@ -63,5 +64,14 @@ export function useFlashbar({
     }
   }, [nextFocusId, ref]);
 
-  return { allItemsHaveId, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef, ref };
+  return {
+    allItemsHaveId,
+    ariaLabel: i18nStrings?.ariaLabel,
+    baseProps,
+    breakpoint,
+    isReducedMotion,
+    isVisualRefresh,
+    mergedRef,
+    ref,
+  };
 }

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -58,7 +58,7 @@ export interface FlashbarProps extends BaseComponentProps {
 
 export type FlashType = FlashbarProps.Type | 'progress';
 
-export interface CollapsibleFlashbarProps {
+export interface CollapsibleFlashbarProps extends BaseComponentProps {
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;
   stackItems?: boolean;
   i18nStrings?: CollapsibleFlashbarProps.I18nStrings;

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import React from 'react';
 import { Flash } from './flash';
-import { FlashbarProps } from './interfaces';
+import { CollapsibleFlashbarProps, FlashbarProps } from './interfaces';
 import { TIMEOUT_FOR_ENTERING_ANIMATION } from './constant';
 import { TransitionGroup } from 'react-transition-group';
 import { Transition } from '../internal/components/transition';
@@ -14,11 +14,13 @@ import { useFlashbar } from './common';
 
 export { FlashbarProps };
 
-export default function NonCollapsibleFlashbar({ items, ...restProps }: FlashbarProps) {
-  const { allItemsHaveId, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef } = useFlashbar({
-    items,
-    ...restProps,
-  });
+export default function NonCollapsibleFlashbar({ items, ...restProps }: FlashbarProps | CollapsibleFlashbarProps) {
+  const { allItemsHaveId, ariaLabel, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef } = useFlashbar(
+    {
+      items,
+      ...restProps,
+    }
+  );
 
   /**
    * All the flash items should have ids so we can identify which DOM element is being
@@ -41,7 +43,7 @@ export default function NonCollapsibleFlashbar({ items, ...restProps }: Flashbar
     return (
       // This is a proxy for <ul>, so we're not applying a class to another actual component.
       // eslint-disable-next-line react/forbid-component-props
-      <TransitionGroup component="ul" className={styles['flash-list']}>
+      <TransitionGroup component="ul" className={styles['flash-list']} aria-label={ariaLabel}>
         {items.map((item, index) => (
           <Transition
             transitionChangeDelay={{ entering: TIMEOUT_FOR_ENTERING_ANIMATION }}
@@ -69,7 +71,7 @@ export default function NonCollapsibleFlashbar({ items, ...restProps }: Flashbar
     }
 
     return (
-      <ul className={styles['flash-list']}>
+      <ul className={styles['flash-list']} aria-label={ariaLabel}>
         {items.map((item, index) => (
           <li key={item.id ?? index} className={styles['flash-list-item']}>
             {renderItem(item, item.id ?? index)}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

A requirement for an ARIA label was defined while developing the Stacked notifications feature. For that reason the ARIA label was added to the "collapsible" version of the Flashbar only, but in reality it should always be there, also when not using the new feature.

This change backports the ARIA label to the "regular Flashbar, making sure that once the stacking feature is released, the new `i18nStrings.ariaLabel` prop has the desired effect regardless of the stacking feature being used (i.e, `stackItems` set to `true`) or not.

(The prop itself will become public once the stacking feature is public)

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

- Added 2 unit tests, which are run twice each (with and without animations)
- Manually tested by inspecting the list element with browser tools

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
