### PR TITLE
chore: Fix wizard analytics for total time spent

### DIFF
--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -659,4 +659,30 @@ describe('Metrics', () => {
       })
     );
   });
+
+  test('sends a submit metric using the submit button', () => {
+    const [wrapper] = renderDefaultWizard({
+      steps: [
+        { title: 'Step 1', content: 'content 1' },
+        { title: 'Step 2', content: 'content 2' },
+      ],
+    });
+
+    act(() => wrapper.findPrimaryButton().click()); // Move to step 2
+
+    window.panorama?.mockClear(); // clear previous events
+    act(() => wrapper.findPrimaryButton().click()); // Submit
+
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step2',
+        eventDetail: 'step2',
+        eventType: 'csa_wizard_submit',
+        eventValue: expect.any(String),
+        timestamp: expect.any(Number),
+      })
+    );
+  });
 });

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -16,7 +16,7 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 
-import { trackStartStep, trackNavigate, trackSubmit } from './internal/analytics';
+import { trackStartStep, trackNavigate, trackSubmit, trackStartWizard } from './internal/analytics';
 
 export { WizardProps };
 
@@ -86,6 +86,10 @@ export default function Wizard({
       `You have set \`allowSkipTo\` but you have not provided \`i18nStrings.skipToButtonLabel\`. The skip-to button will not be rendered.`
     );
   }
+
+  useEffect(() => {
+    trackStartWizard();
+  }, []);
 
   useEffect(() => {
     trackStartStep(actualActiveStepIndex);

--- a/src/wizard/internal/analytics.tsx
+++ b/src/wizard/internal/analytics.tsx
@@ -32,13 +32,12 @@ const timeEnd = (key = 'current', clear = false) => {
   return (Date.now() - start) / 1000; // Convert to seconds
 };
 
+export const trackStartWizard = () => {
+  timeStart(prefix);
+};
+
 export const trackStartStep = (stepIndex?: number) => {
   const eventContext = createEventContext(stepIndex);
-
-  // Track the starting time of the wizard
-  if (stepIndex === undefined) {
-    timeStart(prefix);
-  }
 
   // End the timer of the previous step
   const time = timeEnd();


### PR DESCRIPTION
This reverts commit f15cf9a715a17b502f19c5a023d2ee56ff1692b8. (Accidentally pushed to main 🤷🏻‍♂️)

### Description

Fixes a bug that didn't track the full start to end duration of the wizard .

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Added a unit test.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
