### PR TITLE
chore: Add branch deployment to build workflow on pull-request

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,10 +9,22 @@ on:
       - main
 
 permissions:
+  id-token: write
   actions: read
   contents: read
   security-events: write
+  deployments: write
 
 jobs:
   build:
     uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
+    with:
+      artifact-path: lib/static-default
+      artifact-name: dev-pages
+  deploy:
+    needs: build
+    uses: cloudscape-design/.github/.github/workflows/deploy.yml@main
+    secrets: inherit
+    with:
+      artifact-name: dev-pages
+      deployment-path: lib/static-default


### PR DESCRIPTION
### Description

Add GitHub deployment job that will deploy all dev page assets for the head commit  change of a pull request.
Related links, issue #, if available: n/a

Depends on this change in the base workflows
https://github.com/cloudscape-design/.github/pull/35

### How has this been tested?

Tested in a forked branch: https://github.com/michaeldowseza/components/pull/4

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
