### PR TITLE
fix: Flashbar bottom spacing management logic

### DIFF
--- a/pages/flashbar/common.ts
+++ b/pages/flashbar/common.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { FlashbarProps } from '~components';
+
+export const i18nStrings = {
+  ariaLabel: 'Notifications',
+  notificationBarText: 'Notifications',
+  notificationBarAriaLabel: 'View all notifications',
+  errorIconAriaLabel: 'Error',
+  successIconAriaLabel: 'Success',
+  warningIconAriaLabel: 'Warning',
+  infoIconAriaLabel: 'Information',
+  inProgressIconAriaLabel: 'In progress',
+};
+
+const RANDOM_NUMBER_RANGE = 1000;
+
+export function generateItem(
+  type: FlashbarProps.Type,
+  dismiss: (index: string) => void,
+  hasHeader = false,
+  initial = false
+): FlashbarProps.MessageDefinition {
+  const randomKey = `key_${Math.floor(Math.random() * RANDOM_NUMBER_RANGE)}`;
+  return {
+    type,
+    id: randomKey,
+    dismissible: true,
+    dismissLabel: 'Dismiss',
+    onDismiss: () => dismiss(randomKey),
+    buttonText: 'Do Action',
+    statusIconAriaLabel: 'Info',
+    content: `This is a flash item with key ${randomKey.split('_').join(' ')}`,
+    ariaRole: initial ? undefined : type === 'error' ? 'alert' : 'status',
+    ...(hasHeader && { header: 'Has Header Content' }),
+  };
+}

--- a/pages/flashbar/interactive.page.tsx
+++ b/pages/flashbar/interactive.page.tsx
@@ -4,33 +4,9 @@ import * as React from 'react';
 import { useState } from 'react';
 import { range } from 'lodash';
 import { Button, SpaceBetween, Flashbar, FlashbarProps, Toggle } from '~components';
+import { generateItem, i18nStrings } from './common';
 
-const RANDOM_NUMBER_RANGE = 1000;
-
-function generateItem(
-  type: FlashbarProps.Type,
-  dismiss: (index: string) => void,
-  hasHeader = false,
-  initial = false
-): FlashbarProps.MessageDefinition {
-  const randomKey = `key_${Math.floor(Math.random() * RANDOM_NUMBER_RANGE)}`;
-  return {
-    type,
-    id: randomKey,
-    dismissible: true,
-    dismissLabel: 'Dismiss',
-    onDismiss: () => dismiss(randomKey),
-    buttonText: 'Do Action',
-    statusIconAriaLabel: 'Info',
-    content: `This is a flash item with key ${randomKey.split('_').join(' ')}`,
-    ariaRole: initial ? undefined : type === 'error' ? 'alert' : 'status',
-    ...(hasHeader && { header: 'Has Header Content' }),
-  };
-}
-
-const ariaLabel = 'Notifications';
-
-export default function FlashbarPermutations() {
+export default function InteractiveFlashbar() {
   const dismiss = (index: string) => {
     setItems(items => items.filter(item => item.id !== index));
   };
@@ -59,26 +35,17 @@ export default function FlashbarPermutations() {
   const restProps = collapsible
     ? {
         stackItems: true,
-        i18nStrings: {
-          ariaLabel,
-          notificationBarText: 'Notifications',
-          notificationBarAriaLabel: 'View all notifications',
-          errorIconAriaLabel: 'Error',
-          successIconAriaLabel: 'Success',
-          warningIconAriaLabel: 'Warning',
-          infoIconAriaLabel: 'Information',
-          inProgressIconAriaLabel: 'In progress',
-        },
+        i18nStrings,
       }
     : {
         i18nStrings: {
-          ariaLabel,
+          ariaLabel: i18nStrings.ariaLabel,
         },
       };
 
   return (
     <>
-      <h1>Flashbar dismissal test</h1>
+      <h1>Flashbar interactions test</h1>
       <SpaceBetween size="xs">
         <Toggle checked={collapsible} onChange={({ detail }) => setCollapsible(detail.checked)}>
           <span data-id="stack-items">Stack items</span>

--- a/pages/flashbar/sticky-app-layout.page.tsx
+++ b/pages/flashbar/sticky-app-layout.page.tsx
@@ -4,27 +4,32 @@ import * as React from 'react';
 import { range } from 'lodash';
 import { SpaceBetween, Flashbar, AppLayout } from '~components';
 import { generateItem, i18nStrings } from './common';
+import appLayoutLabels from '../app-layout/utils/labels';
 
 export default function StickyFlashbar() {
   const items = [...range(10).map(() => generateItem('info', () => null, false, true))];
   return (
     <AppLayout
+      ariaLabels={appLayoutLabels}
       stickyNotifications={true}
       navigationOpen={false}
       notifications={<Flashbar items={items} stackItems={true} i18nStrings={i18nStrings} />}
       content={
-        <SpaceBetween size="xxl" direction="vertical">
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-          <p>Content</p>
-        </SpaceBetween>
+        <>
+          <h1>Sticky Flashbar test</h1>
+          <SpaceBetween size="xxl" direction="vertical">
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+            <p>Content</p>
+          </SpaceBetween>
+        </>
       }
     />
   );

--- a/pages/flashbar/sticky.page.tsx
+++ b/pages/flashbar/sticky.page.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { range } from 'lodash';
+import { SpaceBetween, Flashbar, AppLayout } from '~components';
+import { generateItem, i18nStrings } from './common';
+
+export default function StickyFlashbar() {
+  const items = [...range(10).map(() => generateItem('info', () => null, false, true))];
+  return (
+    <AppLayout
+      stickyNotifications={true}
+      navigationOpen={false}
+      notifications={<Flashbar items={items} stackItems={true} i18nStrings={i18nStrings} />}
+      content={
+        <SpaceBetween size="xxl" direction="vertical">
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+          <p>Content</p>
+        </SpaceBetween>
+      }
+    />
+  );
+}

--- a/src/app-layout/notifications/styles.scss
+++ b/src/app-layout/notifications/styles.scss
@@ -4,9 +4,11 @@
 */
 
 @use '../../internal/styles/tokens' as awsui;
+@use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .notifications-sticky {
   top: 0;
   z-index: 825;
   position: sticky;
+  #{custom-props.$flashbarStickyBottomMargin}: #{awsui.$space-xxl};
 }

--- a/src/app-layout/notifications/styles.scss
+++ b/src/app-layout/notifications/styles.scss
@@ -4,7 +4,7 @@
 */
 
 @use '../../internal/styles/tokens' as awsui;
-@use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
+@use '../../internal/generated/custom-css-properties/index' as custom-props;
 
 .notifications-sticky {
   top: 0;

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -28,6 +28,7 @@
     &.sticky-notifications {
       position: sticky;
       top: calc(var(#{custom-props.$offsetTop}) + #{awsui.$space-xs});
+      #{custom-props.$flashbarStickyBottomMargin}: #{awsui.$space-xxl};
     }
 
     &:not(.has-notifications-content) {

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -139,7 +139,7 @@ describe('Collapsible Flashbar', () => {
         await page.setWindowSize(windowDimensions);
         await page.toggleCollapsedState();
         expect(await page.getNotificationBarBottom()).toBeGreaterThan(windowDimensions.height);
-        await page.windowScrollTo({ top: 1000 });
+        await page.windowScrollTo({ top: 1200 });
         expect(await page.getNotificationBarBottom()).toBeLessThan(windowDimensions.height);
         await page.setWindowSize({ width: windowDimensions.width, height: windowDimensions.height + 5 });
         expect(await page.getNotificationBarBottom()).toBeLessThan(windowDimensions.height + 5);

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { setupTest } from './pages/interactive-page';
+import { FlashbarInteractivePage, setupTest } from './pages/interactive-page';
 import { FOCUS_THROTTLE_DELAY } from '../utils';
+import { createWrapper } from '@cloudscape-design/test-utils-core/selectors';
 
 describe('Collapsible Flashbar', () => {
   describe('Keyboard navigation', () => {
@@ -129,4 +130,29 @@ describe('Collapsible Flashbar', () => {
       );
     });
   });
+
+  describe('Layout', () => {
+    test(
+      'keeps a space to the screen bottom to prevent the notification bar from getting cropped',
+      setupTest(async page => {
+        const smallWindowHeight = 400;
+        await page.toggleStackingFeature();
+        await page.toggleCollapsedState();
+        await page.setWindowSize({ width: 1000, height: smallWindowHeight });
+        expect(await getLastFlashBottom(page)).toBeGreaterThan(smallWindowHeight);
+        await page.windowScrollTo({ top: 1000 });
+        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
+        await page.setWindowSize({ width: 1000, height: smallWindowHeight + 5 });
+        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
+        await page.setWindowSize({ width: 1000, height: smallWindowHeight });
+        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
+      })
+    );
+  });
 });
+
+async function getLastFlashBottom(page: FlashbarInteractivePage) {
+  const items = createWrapper().findFlashbar().findItems();
+  const lastItem = items.get(await page.countFlashes());
+  return (await page.getBoundingBox(lastItem.toSelector())).bottom;
+}

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { FlashbarInteractivePage, setupTest } from './pages/interactive-page';
 import { FOCUS_THROTTLE_DELAY } from '../utils';
-import { createWrapper } from '@cloudscape-design/test-utils-core/selectors';
+import { setupTest } from './pages/interactive-page';
+import { setupTest as setupStickyFlashbarTest } from './pages/sticky-page';
 
 describe('Collapsible Flashbar', () => {
   describe('Keyboard navigation', () => {
@@ -131,28 +131,21 @@ describe('Collapsible Flashbar', () => {
     });
   });
 
-  describe('Layout', () => {
+  describe('Sticky Flashbar', () => {
     test(
       'keeps a space to the screen bottom to prevent the notification bar from getting cropped',
-      setupTest(async page => {
-        const smallWindowHeight = 400;
-        await page.toggleStackingFeature();
+      setupStickyFlashbarTest(async page => {
+        const windowDimensions = { width: 1000, height: 500 };
+        await page.setWindowSize(windowDimensions);
         await page.toggleCollapsedState();
-        await page.setWindowSize({ width: 1000, height: smallWindowHeight });
-        expect(await getLastFlashBottom(page)).toBeGreaterThan(smallWindowHeight);
+        expect(await page.getNotificationBarBottom()).toBeGreaterThan(windowDimensions.height);
         await page.windowScrollTo({ top: 1000 });
-        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
-        await page.setWindowSize({ width: 1000, height: smallWindowHeight + 5 });
-        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
-        await page.setWindowSize({ width: 1000, height: smallWindowHeight });
-        expect(await getLastFlashBottom(page)).toBeLessThan(smallWindowHeight);
+        expect(await page.getNotificationBarBottom()).toBeLessThan(windowDimensions.height);
+        await page.setWindowSize({ width: windowDimensions.width, height: windowDimensions.height + 5 });
+        expect(await page.getNotificationBarBottom()).toBeLessThan(windowDimensions.height + 5);
+        await page.setWindowSize({ width: windowDimensions.width, height: windowDimensions.height });
+        expect(await page.getNotificationBarBottom()).toBeLessThan(windowDimensions.height);
       })
     );
   });
 });
-
-async function getLastFlashBottom(page: FlashbarInteractivePage) {
-  const items = createWrapper().findFlashbar().findItems();
-  const lastItem = items.get(await page.countFlashes());
-  return (await page.getBoundingBox(lastItem.toSelector())).bottom;
-}

--- a/src/flashbar/__integ__/pages/base.ts
+++ b/src/flashbar/__integ__/pages/base.ts
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import selectors from '../../../../lib/components/flashbar/styles.selectors.js';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { FlashbarInteractivePage } from './interactive-page';
+
+export const flashbar = createWrapper().findFlashbar();
+
+export class FlashbarBasePage extends BasePageObject {
+  async toggleCollapsedState() {
+    const selector = this.getNotificationBar();
+    await this.click(selector);
+  }
+
+  countFlashes() {
+    return this.getElementsCount(createWrapper().findFlashbar().findItems().toSelector());
+  }
+
+  getNotificationBar() {
+    return createWrapper().findFlashbar().findByClassName(selectors['notification-bar']).toSelector();
+  }
+
+  isFlashFocused(index: number) {
+    return this.isFocused(
+      flashbar.findItems().get(index).findByClassName(selectors['flash-focus-container']).toSelector()
+    );
+  }
+}
+
+export const setupTest = (path: string, testFn: (page: FlashbarInteractivePage) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new FlashbarInteractivePage(browser);
+    await browser.url(`#/light/flashbar/${path}`);
+    await page.waitForVisible(flashbar.toSelector());
+    await testFn(page);
+  });
+};

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -1,13 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-import selectors from '../../../../lib/components/flashbar/styles.selectors.js';
-import createWrapper from '../../../../lib/components/test-utils/selectors';
+import { FlashbarBasePage, flashbar } from './base';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
-export const flashbar = createWrapper().findFlashbar();
-
-export class FlashbarInteractivePage extends BasePageObject {
+export class FlashbarInteractivePage extends FlashbarBasePage {
   async addInfoFlash() {
     await this.click('[data-id="add-info"]');
   }
@@ -26,21 +22,6 @@ export class FlashbarInteractivePage extends BasePageObject {
 
   async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
-  }
-
-  async toggleCollapsedState() {
-    const selector = createWrapper().findFlashbar().findByClassName(selectors.toggle).toSelector();
-    await this.click(selector);
-  }
-
-  countFlashes() {
-    return this.getElementsCount(createWrapper().findFlashbar().findItems().toSelector());
-  }
-
-  isFlashFocused(index: number) {
-    return this.isFocused(
-      flashbar.findItems().get(index).findByClassName(selectors['flash-focus-container']).toSelector()
-    );
   }
 }
 

--- a/src/flashbar/__integ__/pages/sticky-page.ts
+++ b/src/flashbar/__integ__/pages/sticky-page.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { FlashbarBasePage, flashbar } from './base';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+export class StickyFlashbarPage extends FlashbarBasePage {
+  async getNotificationBarBottom() {
+    const notificationBar = this.getNotificationBar();
+    return (await this.getBoundingBox(notificationBar)).bottom;
+  }
+}
+
+export const setupTest = (testFn: (page: StickyFlashbarPage) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new StickyFlashbarPage(browser);
+    await browser.url(`#/light/flashbar/sticky`);
+    await page.waitForVisible(flashbar.toSelector());
+    await testFn(page);
+  });
+};

--- a/src/flashbar/__integ__/pages/sticky-page.ts
+++ b/src/flashbar/__integ__/pages/sticky-page.ts
@@ -13,7 +13,7 @@ export class StickyFlashbarPage extends FlashbarBasePage {
 export const setupTest = (testFn: (page: StickyFlashbarPage) => Promise<void>) => {
   return useBrowser(async browser => {
     const page = new StickyFlashbarPage(browser);
-    await browser.url(`#/light/flashbar/sticky`);
+    await browser.url(`#/light/flashbar/sticky-app-layout`);
     await page.waitForVisible(flashbar.toSelector());
     await testFn(page);
   });

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -105,16 +105,16 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
         const listElement = listElementRef?.current;
         const flashbar = listElement?.parentElement;
         if (listElement && flashbar) {
-          const bottom = listElement.getBoundingClientRect().bottom;
-          const windowHeight = window.innerHeight;
-          // Apply the class first (before rendering)
-          // so that we can make calculations based on the applied padding-bottom;
+          // Make sure the bottom padding is present when we make the calculations,
           // then we might decide to remove it or not.
-          flashbar.classList.add(styles['spaced-bottom']);
-          const applySpacing =
-            isFlashbarStackExpanded && bottom + parseInt(getComputedStyle(flashbar).paddingBottom) >= windowHeight;
+          flashbar.classList.remove(styles.floating);
+          // We add `window.scrollY` because `getBoundingClientRect().bottom` returns coordinates relative to the
+          // window, but we are interested in the vertical coordinate of the Flashbar relative to the document body top.
+          const bottom = flashbar.getBoundingClientRect().bottom + window.scrollY;
+          const windowHeight = window.innerHeight;
+          const applySpacing = isFlashbarStackExpanded && bottom >= windowHeight;
           if (!applySpacing) {
-            flashbar.classList.remove(styles['spaced-bottom']);
+            flashbar.classList.add(styles.floating);
           }
         }
       }, resizeListenerThrottleDelay),

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -108,11 +108,12 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
           // Make sure the bottom padding is present when we make the calculations,
           // then we might decide to remove it or not.
           flashbar.classList.remove(styles.floating);
-          // We add `window.scrollY` because `getBoundingClientRect().bottom` returns coordinates relative to the
-          // window, but we are interested in the vertical coordinate of the Flashbar relative to the document body top.
-          const bottom = flashbar.getBoundingClientRect().bottom + window.scrollY;
           const windowHeight = window.innerHeight;
-          const applySpacing = isFlashbarStackExpanded && bottom >= windowHeight;
+          // Take the parent region into account if using the App Layout, because it might have additional margins.
+          // Otherwise we use the Flashbar component for this calculation.
+          const outerElement = flashbar.parentElement?.parentElement || flashbar;
+          const applySpacing =
+            isFlashbarStackExpanded && Math.ceil(outerElement.getBoundingClientRect().bottom) >= windowHeight;
           if (!applySpacing) {
             flashbar.classList.add(styles.floating);
           }
@@ -286,7 +287,7 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
         {isCollapsible && (
           <div
             className={clsx(
-              styles.toggle,
+              styles['notification-bar'],
               isVisualRefresh && styles['visual-refresh'],
               isFlashbarStackExpanded ? styles.expanded : styles.collapsed,
               transitioning && styles['animation-running']

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -107,7 +107,7 @@ the grid layout will be:
   }
 }
 
-.stack > .toggle {
+.stack > .notification-bar {
   @include styles.text-wrapping;
 
   background: awsui.$color-background-layout-toggle-default;
@@ -226,10 +226,8 @@ the grid layout will be:
   }
 }
 
-// Leave some space below the Flashbar, but only when it reaches the end of the page (not "floating").
-.stack.expanded {
-  padding-bottom: awsui.$space-xxl;
-  &.floating {
-    padding-bottom: 0;
-  }
+// Prevent the sticky Flashbar from reaching the end of the window by leaving some space below.
+.stack.expanded:not(.floating) {
+  // Default to 0 so that this does not apply to non-sticky Flashbar.
+  padding-bottom: var(#{custom-props.$flashbarStickyBottomMargin}, 0);
 }

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -226,7 +226,10 @@ the grid layout will be:
   }
 }
 
-// Leave some space below the Flashbar, but only when it reaches the end of the page.
-.stack.spaced-bottom {
+// Leave some space below the Flashbar, but only when it reaches the end of the page (not "floating").
+.stack.expanded {
   padding-bottom: awsui.$space-xxl;
+  &.floating {
+    padding-bottom: 0;
+  }
 }

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -33,5 +33,6 @@ const customCssPropertiesList = [
   'contentScrollMargin',
   'flashbarStackDepth',
   'flashbarStackIndex',
+  'flashbarStickyBottomMargin',
 ];
 module.exports = customCssPropertiesList;


### PR DESCRIPTION
### Description
#### Background

The Stacked notifications feature adds an element called "notifications bar" to the Flashbar, which partially overlaps the Flashbar and partially overlaps the content below. We don't want it to create extra space with the content below (e.g, sticky table headers should still collapse without any space between the flashbar and the table), but at the same time, there should be some space with the window bottom in order to prevent the notifications bar from getting cropped (there is a function for that called `updateBottomSpacing`).

Right:
<img width="636" alt="Screenshot 2023-02-06 at 14 38 40" src="https://user-images.githubusercontent.com/1257272/216990507-f8ccd761-0193-477d-bf2b-f2eb63556c76.png">
Wrong:
<img width="634" alt="Screenshot 2023-02-06 at 14 41 20" src="https://user-images.githubusercontent.com/1257272/216990533-c9aadce1-5153-4b45-b09c-9709cfcec34b.png">

#### The fix

This change fixes a few issues that were making this behavior not totally reliable:
- Account for extra margin of the parent notifications region when using App Layout with Visual Refresh
- The extra padding was being applied to non-sticky Flashbar, but it should be applied only to the sticky one
- Rounding issues

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

- Added integration test. A new testing page for the sticky behavior had to be added for this
- Manually tested with: Chrome, Firefox and Safari: sticky and non-sticky; Visual Refresh and Classic

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
