### PR TITLE
chore: reuse unique ID function to de-duplicate logic

### DIFF
--- a/pages/flashbar/common.ts
+++ b/pages/flashbar/common.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FlashbarProps } from '~components';
+import { generateUniqueId } from '~components/internal/hooks/use-unique-id';
 
 export const i18nStrings = {
   ariaLabel: 'Notifications',
@@ -14,15 +15,13 @@ export const i18nStrings = {
   inProgressIconAriaLabel: 'In progress',
 };
 
-const RANDOM_NUMBER_RANGE = 1000;
-
 export function generateItem(
   type: FlashbarProps.Type,
   dismiss: (index: string) => void,
   hasHeader = false,
   initial = false
 ): FlashbarProps.MessageDefinition {
-  const randomKey = `key_${Math.floor(Math.random() * RANDOM_NUMBER_RANGE)}`;
+  const randomKey = generateUniqueId('key_');
   return {
     type,
     id: randomKey,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Small follow-up from #715 (see [comment](https://github.com/cloudscape-design/components/pull/715#discussion_r1099963151)): reuse existing `generateUniqueId` logic instead of creating a new one.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
