### PR TITLE
chore: Use wizard id for funnel id in metrics

### DIFF
--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -539,6 +539,21 @@ describe('Metrics', () => {
     jest.spyOn(window, 'panorama');
   });
 
+  test('sets the funnel to the wizard id if provided', () => {
+    renderDefaultWizard({ id: 'wizard-id' });
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_wizard_step1',
+        eventDetail: 'step1',
+        eventType: 'csa_wizard_step',
+        timestamp: expect.any(Number),
+        funnel: 'wizard-id',
+      })
+    );
+  });
+
   test('sends a startStep step metric on initial render', () => {
     renderDefaultWizard();
     expect(window.panorama).toBeCalledTimes(1);

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -34,6 +34,7 @@ export default function Wizard({
 }: WizardProps) {
   const { __internalRootRef } = useBaseComponent('Wizard');
   const baseProps = getBaseProps(rest);
+  const funnelId = baseProps.id;
 
   const [breakpoint, breakpointsRef] = useContainerBreakpoints(['xs']);
   const ref = useMergeRefs(breakpointsRef, __internalRootRef);
@@ -54,7 +55,7 @@ export default function Wizard({
   const isLastStep = actualActiveStepIndex >= steps.length - 1;
 
   const navigationEvent = (requestedStepIndex: number, reason: WizardProps.NavigationReason) => {
-    trackNavigate(actualActiveStepIndex, requestedStepIndex, reason);
+    trackNavigate(actualActiveStepIndex, requestedStepIndex, reason, funnelId);
     setActiveStepIndex(requestedStepIndex);
     fireNonCancelableEvent(onNavigate, { requestedStepIndex, reason });
   };
@@ -64,7 +65,7 @@ export default function Wizard({
   const onPreviousClick = () => navigationEvent(actualActiveStepIndex - 1, 'previous');
   const onPrimaryClick = () => {
     if (isLastStep) {
-      trackSubmit(actualActiveStepIndex);
+      trackSubmit(actualActiveStepIndex, funnelId);
       fireNonCancelableEvent(onSubmit);
     } else {
       navigationEvent(actualActiveStepIndex + 1, 'next');
@@ -92,8 +93,8 @@ export default function Wizard({
   }, []);
 
   useEffect(() => {
-    trackStartStep(actualActiveStepIndex);
-  }, [actualActiveStepIndex]);
+    trackStartStep(actualActiveStepIndex, funnelId);
+  }, [actualActiveStepIndex, funnelId]);
 
   return (
     <div {...baseProps} className={clsx(styles.root, baseProps.className)} ref={ref}>

--- a/src/wizard/internal/analytics.tsx
+++ b/src/wizard/internal/analytics.tsx
@@ -39,7 +39,7 @@ export const trackStartWizard = () => {
   timeStart(prefix);
 };
 
-export const trackStartStep = (stepIndex?: number) => {
+export const trackStartStep = (stepIndex?: number, funnelId?: string) => {
   const eventContext = createEventContext(stepIndex);
 
   // End the timer of the previous step
@@ -52,6 +52,7 @@ export const trackStartStep = (stepIndex?: number) => {
     eventContext,
     eventDetail: createEventDetail(stepIndex),
     eventType: createEventType('step'),
+    ...(funnelId && { funnel: funnelId }),
     ...(time !== undefined && { eventValue: time.toString() }),
   });
 };
@@ -59,7 +60,8 @@ export const trackStartStep = (stepIndex?: number) => {
 export const trackNavigate = (
   activeStepIndex: number,
   requestedStepIndex: number,
-  reason: WizardProps.NavigationReason
+  reason: WizardProps.NavigationReason,
+  funnelId?: string
 ) => {
   const eventContext = createEventContext(activeStepIndex);
   const time = timeEnd();
@@ -69,10 +71,11 @@ export const trackNavigate = (
     eventDetail: createEventDetail(requestedStepIndex),
     eventType: createEventType('navigate'),
     eventValue: { reason, ...(time !== undefined && { time }) },
+    ...(funnelId && { funnel: funnelId }),
   });
 };
 
-export const trackSubmit = (stepIndex: number) => {
+export const trackSubmit = (stepIndex: number, funnelId?: string) => {
   const eventContext = createEventContext(stepIndex);
   // End the timer of the wizard
   const time = timeEnd(prefix);
@@ -82,5 +85,6 @@ export const trackSubmit = (stepIndex: number) => {
     eventDetail: createEventDetail(stepIndex),
     eventType: createEventType('submit'),
     ...(time !== undefined && { eventValue: time.toString() }),
+    ...(funnelId && { funnel: funnelId }),
   });
 };


### PR DESCRIPTION
### Description

Pass the wizard id, that is optional and deprecated, to the custom metric event as the funnel id. This is a best effort attempt for grouping metrics by an id as there is currently no other identifier available. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Added a base unit test.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
