### PR TITLE
fix: Stacked Flashbar notification bar animation

### DIFF
--- a/src/flashbar/collapsible.motion.scss
+++ b/src/flashbar/collapsible.motion.scss
@@ -8,7 +8,7 @@
 .stack {
   > .animation-running > .item,
   > .animation-running > .flash-list-item,
-  > .animation-running.toggle {
+  > .animation-running.notification-bar {
     @include styles.with-motion {
       transition-timing-function: tokens.$motion-easing-refresh-only-a;
       transition-duration: tokens.$motion-duration-refresh-only-fast;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

In the [previous PR](https://github.com/cloudscape-design/components/pull/715) the class name of the Flashbar notification bar had been renamed from the old `toggle` to the new `notification-bar`, both in the component as well as in the `collapsible.scss` file —but not in `collapsible.motion.scss`. This led to the notification bar not animating anymore when collapsing and expanding.

This PR fixes this by applying that missing renaming.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually only. We don't have a proper way to test animations programmatically AFAIK.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
