### PR TITLE
fix: Apply stacked flashbar feature shadows to correct element

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -72,8 +72,8 @@ the grid layout will be:
     );
   }
 
-  > .item:not(:last-child) > .flash,
-  > .item.flash {
+  > .item:not(:last-child) > .flash::before,
+  > .item.flash::before {
     box-shadow: awsui.$shadow-flash-collapsed;
   }
 }


### PR DESCRIPTION
### Description

The recent shadow updates in #702, unified how we apply shadows in many components, including simplifying the shadow approach in Flashbars. Previously, Flashbars applied shadows on different elements depending on the theme (pseudo element in refresh, directly on the Flash item in classic). However the latest update simplified both themes to use a single approach (pseudo element) ([see code diff](https://github.com/cloudscape-design/components/commit/222b99ff1eab212a62dcf7a5154055623e6d38da#diff-830d2afec0c4339df425e599c2a7294f079d8350460fd6426562f3106993526cL28-L49)).

This unintentionally brought a tiny existing bug to light in the unreleased stacked Flashbar feature. More specifically, stacked Flashbars should have a [different shadow](https://github.com/cloudscape-design/components/blob/main/src/flashbar/collapsible.scss#L75-L78) compared to a normal [un-stacked Flashbar shadow](https://github.com/cloudscape-design/components/blob/main/src/flashbar/styles.scss#L36). This was the case in classic but not refresh - because shadows previously were applied to separate elements, the shadow was _overriding_ the original shadows in classic (intended), but it was _adding_ them to the default Flashbar shadow in visual refresh resulting in a double shadow (not intended). 

This bug was barely noticeable to the human eye due to the large spread of shadows in visual refresh, which is why it did not get caught until now. The refactoring in #702, brought this the same bug that was happening in visual refresh to appear in classic as well, resulting in a double shadow on all stacked Flashbars (in classic and refresh - previously just refresh), and is more noticeable in classic as seen in the screenshots below (albeit still very subtle). 

This change also addresses a bug in dark mode visual refresh shadow that was causing it to overlap underlying Flashbars, making them almost invisible. 

Screenshots below, each highlighting:

before #702   |   after #702   |   after #702 with this fix

![Screen Shot 2023-02-08 at 10 05 13 AM copy 2](https://user-images.githubusercontent.com/15003460/217624580-63ab0ff5-564f-4a6a-98e4-854a09879ce3.png)

![Screen Shot 2023-02-08 at 10 03 14 AM copy](https://user-images.githubusercontent.com/15003460/217623950-c6a8709f-2b2d-4d19-8cb1-34b8d149e43b.png)

![Screen Shot 2023-02-08 at 10 53 13 AM](https://user-images.githubusercontent.com/15003460/217625030-6b3a24b3-cac2-4e2d-a54c-6111cba0b333.png)

![Screen Shot 2023-02-08 at 10 03 47 AM copy](https://user-images.githubusercontent.com/15003460/217623904-f2a340b1-346b-4a68-b5a8-148456bb7add.png)

Related links, issue #, if available: n/a

### How has this been tested?

Locally, part of the reason this regression happened in the first place was because there were no tests in place to catch it. These are coming in a separate PR as part of the stacked Flashbar feature release.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
