### PR TITLE
feat: Make Stacked notifications feature public

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5543,6 +5543,68 @@ Object {
       "type": "string",
     },
     Object {
+      "description": "An object containing all the necessary localized strings required by the component. The object should contain:
+* \`ariaLabel\` - Specifies the ARIA label for the list of notifications.
+If stackItems is set to true, it should also contain:
+* \`notificationBarAriaLabel\` - (optional) Specifies the ARIA label for the notification bar
+* \`notificationBarText\` - Specifies the text shown in the notification bar
+* \`errorIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type error.
+* \`warningIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type warning.
+* \`infoIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type info.
+* \`successIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type success.
+* \`inProgressIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of in-progress items (where loading is set to true).
+",
+      "inlineType": Object {
+        "name": "FlashbarProps.I18nStrings",
+        "properties": Array [
+          Object {
+            "name": "ariaLabel",
+            "optional": false,
+            "type": "string",
+          },
+          Object {
+            "name": "errorIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "inProgressIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "infoIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "notificationBarAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "notificationBarText",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "successIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "warningIconAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "i18nStrings",
+      "optional": true,
+      "type": "FlashbarProps.I18nStrings",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
@@ -5578,6 +5640,12 @@ If the \`action\` property is set, this property is ignored. **Deprecated**, rep
       "name": "items",
       "optional": false,
       "type": "ReadonlyArray<FlashbarProps.MessageDefinition>",
+    },
+    Object {
+      "description": "Specifies whether flash messages should be stacked.",
+      "name": "stackItems",
+      "optional": true,
+      "type": "boolean",
     },
   ],
   "regions": Array [],

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5545,14 +5545,16 @@ Object {
     Object {
       "description": "An object containing all the necessary localized strings required by the component. The object should contain:
 * \`ariaLabel\` - Specifies the ARIA label for the list of notifications.
-If stackItems is set to true, it should also contain:
+
+If \`stackItems\` is set to \`true\`, it should also contain:
+
 * \`notificationBarAriaLabel\` - (optional) Specifies the ARIA label for the notification bar
-* \`notificationBarText\` - Specifies the text shown in the notification bar
-* \`errorIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type error.
-* \`warningIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type warning.
-* \`infoIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type info.
-* \`successIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of items of type success.
-* \`inProgressIconAriaLabel\` - Specifies the ARIA label for the icon displayed next to the number of in-progress items (where loading is set to true).
+* \`notificationBarText\` - (optional) Specifies the text shown in the notification bar
+* \`errorIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`error\`.
+* \`warningIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`warning\`.
+* \`infoIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`info\`.
+* \`successIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`success\`.
+* \`inProgressIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where \`loading\` is set to \`true\`).
 ",
       "inlineType": Object {
         "name": "FlashbarProps.I18nStrings",

--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -26,7 +26,7 @@ import React from 'react';
 import Flashbar from '../../../lib/components/flashbar';
 import { createFlashbarWrapper, findList } from './common';
 import createWrapper, { FlashbarWrapper } from '../../../lib/components/test-utils/dom';
-import { FlashbarProps, FlashType, CollapsibleFlashbarProps } from '../interfaces';
+import { FlashbarProps, FlashType } from '../interfaces';
 import { render } from '@testing-library/react';
 
 const sampleItems: Record<FlashType, FlashbarProps.MessageDefinition> = {
@@ -332,8 +332,8 @@ function findInnerCounterElement(flashbar: FlashbarWrapper) {
 
 function renderFlashbar(
   customProps: Partial<
-    Omit<CollapsibleFlashbarProps, 'i18nStrings' | 'stackItems'> & {
-      i18nStrings?: Partial<CollapsibleFlashbarProps.I18nStrings>;
+    Omit<FlashbarProps, 'i18nStrings' | 'stackItems'> & {
+      i18nStrings?: Partial<FlashbarProps.I18nStrings>;
     }
   > = {
     items: defaultItems,

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import customCssProps from '../internal/generated/custom-css-properties';
 import { Flash, focusFlashById } from './flash';
-import { FlashbarProps, CollapsibleFlashbarProps } from './interfaces';
+import { FlashbarProps } from './interfaces';
 import InternalIcon from '../icon/internal';
 import { TransitionGroup } from 'react-transition-group';
 import { Transition } from '../internal/components/transition';
@@ -35,7 +35,7 @@ const maxNonCollapsibleItems = 1;
 
 const resizeListenerThrottleDelay = 100;
 
-export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarProps & CollapsibleFlashbarProps) {
+export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarProps) {
   const [enteringItems, setEnteringItems] = useState<ReadonlyArray<FlashbarProps.MessageDefinition>>([]);
   const [exitingItems, setExitingItems] = useState<ReadonlyArray<FlashbarProps.MessageDefinition>>([]);
   const [isFlashbarStackExpanded, setIsFlashbarStackExpanded] = useState(false);

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useReducedMotion, useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { getBaseProps } from '../internal/base-component';
-import { CollapsibleFlashbarProps, FlashbarProps } from './interfaces';
+import { FlashbarProps } from './interfaces';
 import { focusFlashById } from './flash';
 
 export const componentName = 'Flashbar';
@@ -19,7 +19,7 @@ export function useFlashbar({
   onItemsChanged,
   onItemsRemoved,
   ...restProps
-}: CollapsibleFlashbarProps & {
+}: FlashbarProps & {
   onItemsAdded?: (items: FlashbarProps.MessageDefinition[]) => void;
   onItemsRemoved?: (items: FlashbarProps.MessageDefinition[]) => void;
   onItemsChanged?: (options?: { allItemsHaveId?: boolean; isReducedMotion?: boolean }) => void;

--- a/src/flashbar/index.tsx
+++ b/src/flashbar/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect } from 'react';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
-import { FlashbarProps, CollapsibleFlashbarProps } from './interfaces';
+import { FlashbarProps } from './interfaces';
 import CollapsibleFlashbar from './collapsible-flashbar';
 import NonCollapsibleFlashbar from './non-collapsible-flashbar';
 
@@ -10,7 +10,7 @@ import { sendRenderMetric } from './internal/analytics';
 
 export { FlashbarProps };
 
-export default function Flashbar(props: FlashbarProps | CollapsibleFlashbarProps) {
+export default function Flashbar(props: FlashbarProps) {
   useEffect(() => {
     if (props.items.length > 0) {
       sendRenderMetric(props.items);
@@ -24,7 +24,7 @@ export default function Flashbar(props: FlashbarProps | CollapsibleFlashbarProps
   }
 }
 
-function isStackedFlashbar(props: any): props is CollapsibleFlashbarProps {
+function isStackedFlashbar(props: FlashbarProps) {
   return 'stackItems' in props && props.stackItems;
 }
 

--- a/src/flashbar/index.tsx
+++ b/src/flashbar/index.tsx
@@ -17,15 +17,11 @@ export default function Flashbar(props: FlashbarProps) {
     }
   }, [props.items]);
 
-  if (isStackedFlashbar(props)) {
+  if (props.stackItems) {
     return <CollapsibleFlashbar {...props} />;
   } else {
     return <NonCollapsibleFlashbar {...props} />;
   }
-}
-
-function isStackedFlashbar(props: FlashbarProps) {
-  return 'stackItems' in props && props.stackItems;
 }
 
 applyDisplayName(Flashbar, 'Flashbar');

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -73,16 +73,18 @@ export interface FlashbarProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component. The object should contain:
+   *
    * * `ariaLabel` - Specifies the ARIA label for the list of notifications.
    *
-   * If stackItems is set to true, it should also contain:
+   * If `stackItems` is set to `true`, it should also contain:
+   *
    * * `notificationBarAriaLabel` - (optional) Specifies the ARIA label for the notification bar
-   * * `notificationBarText` - Specifies the text shown in the notification bar
-   * * `errorIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type error.
-   * * `warningIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type warning.
-   * * `infoIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type info.
-   * * `successIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type success.
-   * * `inProgressIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of in-progress items (where loading is set to true).
+   * * `notificationBarText` - (optional) Specifies the text shown in the notification bar
+   * * `errorIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `error`.
+   * * `warningIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `warning`.
+   * * `infoIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `info`.
+   * * `successIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `success`.
+   * * `inProgressIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where `loading` is set to `true`).
    */
   i18nStrings?: FlashbarProps.I18nStrings;
 }

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -21,6 +21,17 @@ export namespace FlashbarProps {
     onDismiss?: ButtonProps['onClick'];
   }
 
+  export interface I18nStrings {
+    ariaLabel: string;
+    errorIconAriaLabel?: string;
+    infoIconAriaLabel?: string;
+    inProgressIconAriaLabel?: string;
+    notificationBarAriaLabel?: string;
+    notificationBarText?: string;
+    successIconAriaLabel?: string;
+    warningIconAriaLabel?: string;
+  }
+
   export type Type = 'success' | 'warning' | 'info' | 'error';
   export type AriaRole = 'alert' | 'status';
 }
@@ -54,25 +65,26 @@ export interface FlashbarProps extends BaseComponentProps {
    *   2. To identify which flash message will be removed from the DOM when it is dismissed, to animate it out.
    */
   items: ReadonlyArray<FlashbarProps.MessageDefinition>;
+
+  /**
+   * Specifies whether flash messages should be stacked.
+   */
+  stackItems?: boolean;
+
+  /**
+   * An object containing all the necessary localized strings required by the component. The object should contain:
+   * * `ariaLabel` - Specifies the ARIA label for the list of notifications.
+   *
+   * If stackItems is set to true, it should also contain:
+   * * `notificationBarAriaLabel` - (optional) Specifies the ARIA label for the notification bar
+   * * `notificationBarText` - Specifies the text shown in the notification bar
+   * * `errorIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type error.
+   * * `warningIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type warning.
+   * * `infoIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type info.
+   * * `successIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of items of type success.
+   * * `inProgressIconAriaLabel` - Specifies the ARIA label for the icon displayed next to the number of in-progress items (where loading is set to true).
+   */
+  i18nStrings?: FlashbarProps.I18nStrings;
 }
 
 export type FlashType = FlashbarProps.Type | 'progress';
-
-export interface CollapsibleFlashbarProps extends BaseComponentProps {
-  items: ReadonlyArray<FlashbarProps.MessageDefinition>;
-  stackItems?: boolean;
-  i18nStrings?: CollapsibleFlashbarProps.I18nStrings;
-}
-
-export namespace CollapsibleFlashbarProps {
-  export interface I18nStrings {
-    ariaLabel: string;
-    errorIconAriaLabel?: string;
-    infoIconAriaLabel?: string;
-    inProgressIconAriaLabel?: string;
-    notificationBarAriaLabel?: string;
-    notificationBarText?: string;
-    successIconAriaLabel?: string;
-    warningIconAriaLabel?: string;
-  }
-}

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import React from 'react';
 import { Flash } from './flash';
-import { CollapsibleFlashbarProps, FlashbarProps } from './interfaces';
+import { FlashbarProps } from './interfaces';
 import { TIMEOUT_FOR_ENTERING_ANIMATION } from './constant';
 import { TransitionGroup } from 'react-transition-group';
 import { Transition } from '../internal/components/transition';
@@ -14,7 +14,7 @@ import { useFlashbar } from './common';
 
 export { FlashbarProps };
 
-export default function NonCollapsibleFlashbar({ items, ...restProps }: FlashbarProps | CollapsibleFlashbarProps) {
+export default function NonCollapsibleFlashbar({ items, ...restProps }: FlashbarProps) {
   const { allItemsHaveId, ariaLabel, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef } = useFlashbar(
     {
       items,

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -9,6 +9,8 @@ export default class FlashbarWrapper extends ComponentWrapper {
 
   /**
    * Returns the individual flashes of this flashbar.
+   *
+   * If the items are stacked, only the item at the top of the stack is returned.
    */
   findItems(): Array<FlashWrapper> {
     return this.findAllByClassName(styles['flash-list-item']).map(item => new FlashWrapper(item.getElement()));


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

This change does the following:
- Merge the private API props for the Stacked notifications feature with the public Flashbar API
- Make changes to the new API prop docs according to content review
- Make changes to test utils docs, also content reviewed

<!-- Also include relevant motivation and context. -->

### How has this been tested?

<!-- How did you test to verify your changes? -->

Documenter output was fed into a website build, albeit in a semi-manual process.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
