### PR TITLE
chore: Avoid unnecessary use of getBoundingClientRect in Flashbar

### DIFF
--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -1,17 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-let mockScrollingConditions = false;
-jest.mock('../../../lib/components/flashbar/utils', () => {
-  const originalModule = jest.requireActual('../../../lib/components/flashbar/utils');
-  return {
-    __esModule: true,
-    ...originalModule,
-    isElementTopBeyondViewport: (...args: any) =>
-      mockScrollingConditions ? true : originalModule.isElementTopBeyondViewport(...args),
-  };
-});
-
 const scrollElementIntoViewMock = jest.fn();
 jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => {
   const originalModule = jest.requireActual('../../../lib/components/internal/utils/scrollable-containers');
@@ -278,14 +267,8 @@ describe('Collapsible Flashbar', () => {
   });
 
   describe('Sticky', () => {
-    beforeAll(() => {
-      mockScrollingConditions = true;
-    });
-    afterAll(() => {
-      mockScrollingConditions = false;
-    });
-
-    it('scrolls the button into view when collapsing if it moves up beyond the viewport', () => {
+    it('scrolls the button into view when collapsing', () => {
+      scrollElementIntoViewMock.mockClear();
       const flashbar = renderFlashbar();
       findNotificationBar(flashbar)!.click();
       findNotificationBar(flashbar)!.click();

--- a/src/flashbar/__tests__/utils.test.ts
+++ b/src/flashbar/__tests__/utils.test.ts
@@ -1,10 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-  getVisibleCollapsedItems,
-  getItemType,
-  isElementTopBeyondViewport,
-} from '../../../lib/components/flashbar/utils';
+import { getVisibleCollapsedItems, getItemType } from '../../../lib/components/flashbar/utils';
 import { FlashbarProps, FlashType } from '../interfaces';
 
 describe('getVisibleCollapsedItems', () => {
@@ -89,41 +85,5 @@ describe('getVisibleCollapsedItems', () => {
       { type: 'success' },
     ];
     expect(getVisibleCollapsedItems(items, 4).map(({ type }) => ({ type }))).toEqual(items);
-  });
-});
-
-describe('isElementTopBeyondViewport', () => {
-  beforeAll(() => {
-    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-      width: 100,
-      height: 100,
-      top,
-      left: 0,
-      bottom: 0,
-      right: 0,
-      x: 0,
-      y: top,
-      toJSON: () => null,
-    }));
-  });
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-  let top = 0;
-  const element = document.createElement('div');
-
-  it('returns true when element top is negative', () => {
-    top = -1;
-    expect(isElementTopBeyondViewport(element)).toBe(true);
-  });
-
-  it('returns false when element top is positive', () => {
-    top = 1;
-    expect(isElementTopBeyondViewport(element)).toBe(false);
-  });
-
-  it('returns false when element top is zero', () => {
-    top = 0;
-    expect(isElementTopBeyondViewport(element)).toBe(false);
   });
 });

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -12,13 +12,7 @@ import useFocusVisible from '../internal/hooks/focus-visible';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 
 import styles from './styles.css.js';
-import {
-  counterTypes,
-  getFlashTypeCount,
-  getVisibleCollapsedItems,
-  isElementTopBeyondViewport,
-  StackableItem,
-} from './utils';
+import { counterTypes, getFlashTypeCount, getVisibleCollapsedItems, StackableItem } from './utils';
 import { animate, getDOMRects } from '../internal/animate';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { IconProps } from '../icon/interfaces';
@@ -148,12 +142,6 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
     if (initialAnimationState) {
       updateBottomSpacing();
 
-      // When collapsing, scroll up if necessary to avoid losing track of the focused button
-      const shouldScrollUp =
-        notificationBarRef.current &&
-        !isFlashbarStackExpanded &&
-        isElementTopBeyondViewport(notificationBarRef.current);
-
       animate({
         elements: getElementsToAnimate(),
         oldState: initialAnimationState,
@@ -161,7 +149,8 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
         onTransitionsEnd: () => setTransitioning(false),
       });
 
-      if (notificationBarRef.current && shouldScrollUp) {
+      // When collapsing, scroll up if necessary to avoid losing track of the focused button
+      if (!isFlashbarStackExpanded && notificationBarRef.current) {
         scrollElementIntoView(notificationBarRef.current);
       }
 

--- a/src/flashbar/utils.ts
+++ b/src/flashbar/utils.ts
@@ -123,7 +123,3 @@ export const counterTypes: {
   { type: 'info', labelName: 'infoIconAriaLabel', iconName: 'status-info' },
   { type: 'progress', labelName: 'inProgressIconAriaLabel', iconName: 'status-in-progress' },
 ];
-
-export function isElementTopBeyondViewport(element: HTMLElement) {
-  return element.getBoundingClientRect().top < 0;
-}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

See https://github.com/cloudscape-design/components/pull/719#discussion_r1100554050 for more context.

Our `scrollElementIntoView` helper calls the native `scrollIntoView` with the `block' option set to 'nearest', which will not scroll if the element is already in the viewport. Therefore it's not necessary to call to check beforehand if that is the case.

<!-- Also include relevant motivation and context. -->

### How has this been tested?

- Adapted unit test accordingly
- Manually tested that the view does not scroll if the button is already in the viewport, with Chrome and Firefox

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
