### PR TITLE
fix: Always set role="dialog" on popover with dismiss button

### DIFF
--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -203,17 +203,6 @@ describe('ARIA labels', () => {
     expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('aria-labelledby');
   });
 
-  it('sets aria-labelledby when dismiss button is not present', () => {
-    const wrapper = renderPopover({
-      children: 'Trigger',
-      content: 'Popover',
-      header: 'Hello!',
-      dismissButton: false,
-    });
-    wrapper.findTrigger().click();
-    expect(wrapper.findBody()!.getElement()).toHaveAttribute('aria-labelledby');
-  });
-
   it('does not use aria-live if dismissButton is true', () => {
     const wrapper = renderPopover({ children: 'Trigger', content: 'Popover' });
     wrapper.findTrigger().click();
@@ -250,15 +239,15 @@ describe('ARIA labels', () => {
     expect(wrapper.findDismissButton()!.getElement()).toHaveAttribute('aria-label', 'Close');
   });
 
-  it('does not set role="dialog" when there is no header', () => {
-    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissAriaLabel: 'Close' });
-    wrapper.findTrigger().click();
-    expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('role', 'dialog');
-  });
-
-  it('set role="dialog" when there is a header', () => {
-    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', header: 'Header' });
+  it('sets role="dialog" if dismissButton is true', () => {
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissButton: true });
     wrapper.findTrigger().click();
     expect(wrapper.findBody()!.getElement()).toHaveAttribute('role', 'dialog');
+  });
+
+  it('does not set role="dialog" if dismissButton is false', () => {
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissButton: false });
+    wrapper.findTrigger().click();
+    expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('role', 'dialog');
   });
 });

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -73,17 +73,26 @@ export default function PopoverBody({
     </div>
   );
 
+  const isDialog = showDismissButton;
+  const shouldTrapFocus = showDismissButton && variant !== 'annotation';
+
+  const dialogProps = isDialog
+    ? {
+        role: 'dialog',
+        'aria-modal': shouldTrapFocus ? true : undefined,
+        'aria-labelledby': ariaLabelledby ?? (header ? labelledById : undefined),
+      }
+    : {};
+
   return (
     <div
       className={clsx(styles.body, className, {
         [styles['body-overflow-visible']]: overflowVisible === 'both',
       })}
-      role={header ? 'dialog' : undefined}
       onKeyDown={onKeyDown}
-      aria-modal={showDismissButton && variant !== 'annotation' ? true : undefined}
-      aria-labelledby={ariaLabelledby ?? (header ? labelledById : undefined)}
+      {...dialogProps}
     >
-      <FocusLock disabled={variant === 'annotation' || !showDismissButton} autoFocus={false}>
+      <FocusLock disabled={!shouldTrapFocus} autoFocus={false}>
         {header && (
           <div className={clsx(styles['header-row'], showDismissButton && styles['has-dismiss'])}>
             {dismissButton}

--- a/src/popover/index.tsx
+++ b/src/popover/index.tsx
@@ -5,6 +5,8 @@ import InternalPopover from './internal';
 import { getExternalProps } from '../internal/utils/external-props';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
+import { isDevelopment } from '../internal/is-development';
+import { warnOnce } from '../internal/logging';
 import { PopoverProps } from './interfaces';
 
 export { PopoverProps };
@@ -16,12 +18,20 @@ export default function Popover({
   triggerType = 'text',
   dismissButton = true,
   renderWithPortal = false,
+  header,
   ...rest
 }: PopoverProps) {
+  if (isDevelopment) {
+    if (dismissButton && !header) {
+      warnOnce('Popover', `You should provide a \`header\` when \`dismissButton\` is true.`);
+    }
+  }
+
   const baseComponentProps = useBaseComponent('Popover');
   const externalProps = getExternalProps(rest);
   return (
     <InternalPopover
+      header={header}
       position={position}
       size={size}
       fixedWidth={fixedWidth}


### PR DESCRIPTION
### Description

The current state is: if a popover has no header, it's not marked as a dialog, even if it traps focus. Not great.

This was originally changed to ensure popover dialogs always have valid titles, but an unlabeled dialog is better (well, less terrible) than a non-dialog focus trap. We may need to allow users to provide assistive tech only aria-labels for dialog headings in the future, but I'll wait for customer data before I do that; an explicit heading still provides an equal experience for everyone, and screen readers still read out unlabeled dialog contents.

So we have popovers acting as:
- Announcements: (e.g. "Text copied", no dismiss button, just aria-live)
- Modal dialogs: (i.e. has a dismiss button, should have a header)
- Non-modal dialogs: (i.e. annotation popovers, you can tab straight through them)

Related links, issue #, if available: doesn't fix, but comes from AWSUI-20299

### How has this been tested?

Changed unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
