### PR TITLE
chore: Split simple columns permutations for the Table

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import range from 'lodash/range';
-import Box from '~components/box';
-import Button from '~components/button';
-import Header from '~components/header';
 import Link from '~components/link';
 import Table, { TableProps } from '~components/table';
 import createPermutations from '../utils/permutations';
@@ -15,20 +12,6 @@ function createSimpleItems(count: number) {
   const texts = ['One', 'Two', 'Three', 'Four'];
   return range(count).map(number => ({ number, text: texts[number % texts.length] }));
 }
-const SELECTED_ITEMS: TableProps['selectedItems'] = [{ text: 'One' }, { text: 'Two' }, { text: 'Three' }];
-
-const SIMPLE_COLUMNS: TableProps.ColumnDefinition<any>[] = [
-  {
-    id: 'text',
-    cell: item => <Link>{item.text}</Link>,
-    header: 'Text',
-  },
-  {
-    id: 'number',
-    cell: item => item.number,
-    header: 'Number',
-  },
-];
 
 const SORTABLE_COLUMNS: TableProps.ColumnDefinition<any>[] = [
   {
@@ -99,42 +82,6 @@ const permutations = createPermutations<TableProps>([
         },
       ],
     ],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    loading: [true],
-    loadingText: ['Loading items'],
-    items: [[]],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    empty: [
-      'No data',
-      <Box textAlign="center" color="inherit">
-        <Box variant="strong" textAlign="center" color="inherit">
-          No resources
-        </Box>
-        <Box variant="p" padding={{ bottom: 's' }} color="inherit">
-          No resources to display.
-        </Box>
-        <Button>Create resource</Button>
-      </Box>,
-    ],
-    items: [[]],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    footer: [null, 'footer'],
-    empty: [null, 'empty'],
-    items: [[], createSimpleItems(3)],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    header: [null, <Header variant="h2">Table header</Header>],
-    pagination: [null, 'pagination'],
-    filter: [null, 'filtering', 'property filtering'],
-    preferences: [null, 'preferences'],
-    items: [createSimpleItems(3)],
   },
   {
     columnDefinitions: [PROPERTY_COLUMNS],
@@ -224,15 +171,6 @@ const permutations = createPermutations<TableProps>([
     ],
   },
   {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    items: [createSimpleItems(3)],
-    selectionType: ['single', 'multi'],
-    selectedItems: [SELECTED_ITEMS, SELECTED_ITEMS.slice(0, 2)],
-    trackBy: ['text'],
-    isItemDisabled: [undefined, () => true],
-    ariaLabels: [ARIA_LABELS],
-  },
-  {
     columnDefinitions: [SORTABLE_COLUMNS],
     items: [createSimpleItems(3)],
     sortingColumn: [SORTABLE_COLUMNS[0], undefined],
@@ -245,18 +183,6 @@ const permutations = createPermutations<TableProps>([
     sortingColumn: [SORTABLE_COLUMNS[0]],
     sortingDescending: [true],
     ariaLabels: [ARIA_LABELS],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    header: [null, <Box>header</Box>],
-    footer: [null, <Box>footer</Box>],
-    items: [createSimpleItems(3)],
-    variant: ['embedded', 'stacked', 'full-page'],
-  },
-  {
-    columnDefinitions: [SIMPLE_COLUMNS],
-    stripedRows: [true],
-    items: [createSimpleItems(3)],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -7,7 +7,7 @@ import Table, { TableProps } from '~components/table';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
-
+import { ARIA_LABELS } from './shared-configs';
 function createSimpleItems(count: number) {
   const texts = ['One', 'Two', 'Three', 'Four'];
   return range(count).map(number => ({ number, text: texts[number % texts.length] }));
@@ -50,13 +50,6 @@ const PROPERTY_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     cell: item => item.value,
   },
 ];
-
-const ARIA_LABELS: TableProps['ariaLabels'] = {
-  selectionGroupLabel: 'group label',
-  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item selected`,
-  itemSelectionLabel: ({ selectedItems }, item) =>
-    `${item.text} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
-};
 
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<TableProps>([
@@ -175,14 +168,12 @@ const permutations = createPermutations<TableProps>([
     items: [createSimpleItems(3)],
     sortingColumn: [SORTABLE_COLUMNS[0], undefined],
     sortingDisabled: [true, false],
-    ariaLabels: [ARIA_LABELS],
   },
   {
     columnDefinitions: [SORTABLE_COLUMNS],
     items: [createSimpleItems(3)],
     sortingColumn: [SORTABLE_COLUMNS[0]],
     sortingDescending: [true],
-    ariaLabels: [ARIA_LABELS],
   },
 ]);
 /* eslint-enable react/jsx-key */
@@ -192,7 +183,10 @@ export default function () {
     <>
       <h1>Table permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView permutations={permutations} render={permutation => <Table {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => <Table {...permutation} ariaLabels={ARIA_LABELS} />}
+        />
       </ScreenshotArea>
     </>
   );

--- a/pages/table/shared-configs.tsx
+++ b/pages/table/shared-configs.tsx
@@ -157,3 +157,10 @@ export const simpleColumns: TableProps.ColumnDefinition<Item>[] = [
     header: 'Number',
   },
 ];
+
+export const ARIA_LABELS: TableProps['ariaLabels'] = {
+  selectionGroupLabel: 'group label',
+  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item selected`,
+  itemSelectionLabel: ({ selectedItems }, item) =>
+    `${item.text} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
+};

--- a/pages/table/simple-permutations.page.tsx
+++ b/pages/table/simple-permutations.page.tsx
@@ -10,7 +10,7 @@ import Table, { TableProps } from '~components/table';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
-
+import { ARIA_LABELS } from './shared-configs';
 function createSimpleItems(count: number) {
   const texts = ['One', 'Two', 'Three', 'Four'];
   return range(count).map(number => ({ number, text: texts[number % texts.length] }));
@@ -29,13 +29,6 @@ const SIMPLE_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     header: 'Number',
   },
 ];
-
-const ARIA_LABELS: TableProps['ariaLabels'] = {
-  selectionGroupLabel: 'group label',
-  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item selected`,
-  itemSelectionLabel: ({ selectedItems }, item) =>
-    `${item.text} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
-};
 
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<TableProps>([
@@ -82,7 +75,6 @@ const permutations = createPermutations<TableProps>([
     selectedItems: [SELECTED_ITEMS, SELECTED_ITEMS.slice(0, 2)],
     trackBy: ['text'],
     isItemDisabled: [undefined, () => true],
-    ariaLabels: [ARIA_LABELS],
   },
   {
     columnDefinitions: [SIMPLE_COLUMNS],
@@ -102,9 +94,12 @@ const permutations = createPermutations<TableProps>([
 export default function () {
   return (
     <>
-      <h1>Table permutations</h1>
+      <h1>Simple table permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView permutations={permutations} render={permutation => <Table {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => <Table {...permutation} ariaLabels={ARIA_LABELS} />}
+        />
       </ScreenshotArea>
     </>
   );

--- a/pages/table/simple-permutations.page.tsx
+++ b/pages/table/simple-permutations.page.tsx
@@ -1,0 +1,111 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import range from 'lodash/range';
+import Box from '~components/box';
+import Button from '~components/button';
+import Header from '~components/header';
+import Link from '~components/link';
+import Table, { TableProps } from '~components/table';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+function createSimpleItems(count: number) {
+  const texts = ['One', 'Two', 'Three', 'Four'];
+  return range(count).map(number => ({ number, text: texts[number % texts.length] }));
+}
+const SELECTED_ITEMS: TableProps['selectedItems'] = [{ text: 'One' }, { text: 'Two' }, { text: 'Three' }];
+
+const SIMPLE_COLUMNS: TableProps.ColumnDefinition<any>[] = [
+  {
+    id: 'text',
+    cell: item => <Link>{item.text}</Link>,
+    header: 'Text',
+  },
+  {
+    id: 'number',
+    cell: item => item.number,
+    header: 'Number',
+  },
+];
+
+const ARIA_LABELS: TableProps['ariaLabels'] = {
+  selectionGroupLabel: 'group label',
+  allItemsSelectionLabel: ({ selectedItems }) => `${selectedItems.length} item selected`,
+  itemSelectionLabel: ({ selectedItems }, item) =>
+    `${item.text} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
+};
+
+/* eslint-disable react/jsx-key */
+const permutations = createPermutations<TableProps>([
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    loading: [true],
+    loadingText: ['Loading items'],
+    items: [[]],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    empty: [
+      'No data',
+      <Box textAlign="center" color="inherit">
+        <Box variant="strong" textAlign="center" color="inherit">
+          No resources
+        </Box>
+        <Box variant="p" padding={{ bottom: 's' }} color="inherit">
+          No resources to display.
+        </Box>
+        <Button>Create resource</Button>
+      </Box>,
+    ],
+    items: [[]],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    footer: [null, 'footer'],
+    empty: [null, 'empty'],
+    items: [[], createSimpleItems(3)],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    header: [null, <Header variant="h2">Table header</Header>],
+    pagination: [null, 'pagination'],
+    filter: [null, 'filtering', 'property filtering'],
+    preferences: [null, 'preferences'],
+    items: [createSimpleItems(3)],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    items: [createSimpleItems(3)],
+    selectionType: ['single', 'multi'],
+    selectedItems: [SELECTED_ITEMS, SELECTED_ITEMS.slice(0, 2)],
+    trackBy: ['text'],
+    isItemDisabled: [undefined, () => true],
+    ariaLabels: [ARIA_LABELS],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    header: [null, <Box>header</Box>],
+    footer: [null, <Box>footer</Box>],
+    items: [createSimpleItems(3)],
+    variant: ['embedded', 'stacked', 'full-page'],
+  },
+  {
+    columnDefinitions: [SIMPLE_COLUMNS],
+    stripedRows: [true],
+    items: [createSimpleItems(3)],
+  },
+]);
+/* eslint-enable react/jsx-key */
+
+export default function () {
+  return (
+    <>
+      <h1>Table permutations</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <Table {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}


### PR DESCRIPTION
### Description

Split the `SIMPLE_COLUMNS` permutations for the table, to decrease page length in our screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
