### PR TITLE
fix: Ensure only current autosuggest item is marked as aria-selected

### DIFF
--- a/pages/autosuggest/async.page.tsx
+++ b/pages/autosuggest/async.page.tsx
@@ -187,6 +187,7 @@ export default class App extends React.Component {
           onLoadItems={this.handleLoadItems}
           enteredTextLabel={enteredTextLabel}
           ariaLabel="async autosuggest"
+          selectedAriaLabel="Selected"
           virtualScroll={this.state.virtualScroll}
           expandToViewport={this.state.expandToViewport}
         />

--- a/pages/autosuggest/events.page.tsx
+++ b/pages/autosuggest/events.page.tsx
@@ -61,6 +61,7 @@ export default function AutosuggestEventsPage() {
           enteredTextLabel={enteredTextLabel}
           expandToViewport={urlParams.expandToViewport}
           ariaLabel={'events autosuggest'}
+          selectedAriaLabel="Selected"
         />
       </div>
     </div>

--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -26,6 +26,7 @@ export default function AutosuggestPage() {
         onChange={event => setValue(event.detail.value)}
         enteredTextLabel={enteredTextLabel}
         ariaLabel={'simple autosuggest'}
+        selectedAriaLabel="Selected"
         empty={empty}
       />
       <button id="remove-options" onClick={() => setHasOptions(false)}>

--- a/pages/autosuggest/virtual-resize.page.tsx
+++ b/pages/autosuggest/virtual-resize.page.tsx
@@ -36,6 +36,7 @@ export default function AutosuggestPage() {
           onChange={event => setValue(event.detail.value)}
           enteredTextLabel={enteredTextLabel}
           ariaLabel={'simple autosuggest'}
+          selectedAriaLabel="Selected"
           virtualScroll={true}
         />
       </div>

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
 import styles from '../../../lib/components/autosuggest/styles.css.js';
+import itemStyles from '../../../lib/components/internal/components/selectable-item/styles.css.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
@@ -246,18 +247,49 @@ describe('a11y props', () => {
     expect(input).toHaveAttribute('aria-activedescendant', highlightedOption.getAttribute('id'));
   });
 
-  test('Option should have aria-selected', () => {
-    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+  test('Option should have appropriate aria-selected values', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="2" />);
     wrapper.focus();
     expect(wrapper.findDropdown()!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
       'aria-selected',
       'false'
     );
-    wrapper.findNativeInput().keydown(KeyCode.down);
-    expect(wrapper.findDropdown()!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
+    expect(wrapper.findDropdown()!.find('[data-test-index="2"]')!.getElement()).toHaveAttribute(
       'aria-selected',
       'true'
     );
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown()!.find('[data-test-index="1"]')!.getElement()).toHaveAttribute(
+      'aria-selected',
+      'false'
+    );
+    expect(wrapper.findDropdown()!.find('[data-test-index="2"]')!.getElement()).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  test('Option should have appropriate aria label', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="1" selectedAriaLabel="Selected" />);
+    wrapper.focus();
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(
+      wrapper
+        .findDropdown()!
+        .find('[data-test-index="1"]')!
+        .findByClassName(itemStyles['screenreader-content'])!
+        .getElement()
+    ).toHaveTextContent('Selected');
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(
+      wrapper
+        .findDropdown()!
+        .find('[data-test-index="2"]')!
+        .findByClassName(itemStyles['screenreader-content'])!
+        .getElement()
+    ).not.toHaveTextContent('Selected');
   });
 });
 

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -17,6 +17,7 @@ export interface AutosuggestOptionProps extends BaseComponentProps {
   option: AutosuggestItem;
   highlighted: boolean;
   highlightType: HighlightType;
+  current: boolean;
   enteredTextLabel: (value: string) => string;
   virtualPosition?: number;
   padBottom?: boolean;
@@ -32,6 +33,7 @@ const AutosuggestOption = (
     option,
     highlighted,
     highlightType,
+    current,
     enteredTextLabel,
     virtualPosition,
     padBottom,
@@ -70,7 +72,7 @@ const AutosuggestOption = (
     <SelectableItem
       {...baseProps}
       className={styles.option}
-      ariaSelected={highlighted}
+      ariaSelected={current}
       highlighted={highlighted}
       disabled={option.disabled}
       hasBackground={useEntered}

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -54,7 +54,7 @@ export default function AutosuggestOptionsList({
   const ListComponent = virtualScroll ? VirtualList : PlainList;
 
   const announcement = useAnnouncement({
-    announceSelected: true,
+    announceSelected: autosuggestItemsState.highlightedOption?.value === highlightText,
     highlightedOption: autosuggestItemsState.highlightedOption,
     getParent: option => getParentGroup(option)?.option as undefined | OptionGroup,
     selectedAriaLabel,

--- a/src/autosuggest/plain-list.tsx
+++ b/src/autosuggest/plain-list.tsx
@@ -85,6 +85,7 @@ const PlainList = ({
             highlightText={highlightText}
             option={item}
             highlighted={item === autosuggestItemsState.highlightedOption}
+            current={item.value === highlightText}
             key={index}
             data-mouse-target={index}
             enteredTextLabel={enteredTextLabel}

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -77,6 +77,7 @@ const VirtualList = ({
             highlightText={highlightText}
             option={item}
             highlighted={item === autosuggestItemsState.highlightedOption}
+            current={item.value === highlightText}
             data-mouse-target={index}
             enteredTextLabel={enteredTextLabel}
             virtualPosition={start + (index === 0 ? 1 : 0)}


### PR DESCRIPTION
### Description

After some testing and internal discussion, it's more appropriate to have only the currently-selected item marked as `aria-selected="true"` in autosuggest (previously it was used to indicate the currently focused/highlighted item). This also aligns the behavior with Select and Multiselect.

Related links, issue #, if available: AWSUI-20335

### How has this been tested?

Tested in VO + Chrome/Safari

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
