### PR TITLE
fix: Ensure autosuggest `enteredTextLabel` is accessible

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
 import styles from '../../../lib/components/autosuggest/styles.css.js';
+import itemStyles from '../../../lib/components/internal/components/selectable-item/styles.css.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
@@ -88,6 +89,14 @@ test('should display entered text option/label', () => {
   wrapper.setInputValue('1');
   expect(enteredTextLabel).toBeCalledWith('1');
   expect(wrapper.findEnteredTextOption()!.getElement()).toHaveTextContent('Custom function with 1 placeholder');
+});
+
+test('entered text option should not get screenreader override', () => {
+  const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="1" />);
+  wrapper.focus();
+  expect(
+    wrapper.findEnteredTextOption()!.findByClassName(itemStyles['screenreader-content'])?.getElement().textContent
+  ).toBeFalsy();
 });
 
 test('should not close dropdown when no realted target in blur', () => {

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -51,6 +51,9 @@ const AutosuggestOption = (
   let optionContent;
   if (useEntered) {
     optionContent = enteredTextLabel(option.value || '');
+    // we don't want fancy generated content for screenreader for the "Use..." option,
+    // just the visible text is fine
+    screenReaderContent = undefined;
   } else if (isParent) {
     optionContent = option.label;
   } else {


### PR DESCRIPTION
### Description

The `enteredTextLabel` (e.g. "Use ...") item previously got a screenreader override that didn't contain the appropriate message. This fixes that.

Related links, issue #, if available: AWSUI-20334

### How has this been tested?

Tested DOM output, and checked for expected announcements in VO & Chrome.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
