### PR TITLE
fix: Notification bar responsiveness in Firefox

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -144,7 +144,7 @@ the grid layout will be:
 
     > .header {
       font-weight: awsui.$font-button-weight;
-      display: inline;
+      display: inline-block;
     }
 
     > .item-count {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

For a container width below ~400px, the text in the header was unintentionally breaking in Firefox.

Before:
![Screen Shot 2023-02-10 at 17 09 05](https://user-images.githubusercontent.com/1257272/218140171-55d12327-eb7a-4a13-a658-1a106dba43b2.png)

After:
![Screen Shot 2023-02-10 at 17 08 37](https://user-images.githubusercontent.com/1257272/218140188-0cd19630-67dc-47cc-adf8-308028d86dff.png)

<!-- Also include relevant motivation and context. -->

### How has this been tested?

<!-- How did you test to verify your changes? -->

Manually tested on Chrome, Firefox and Safari.

Currently visual regression testing does not cover responsiveness. That can come after #729 is merged.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
