### PR TITLE
feat: New truncate-heading prop for header

### DIFF
--- a/pages/header/level-1.page.tsx
+++ b/pages/header/level-1.page.tsx
@@ -11,20 +11,20 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 type PageHeadersContext = React.Context<
   AppContextType<{
-    overflowHeading: boolean;
+    truncateHeading: boolean;
   }>
 >;
 
 export default function PageHeadersDemo() {
   const {
-    urlParams: { overflowHeading = false },
+    urlParams: { truncateHeading = false },
     setUrlParams,
   } = useContext(AppContext as PageHeadersContext);
 
   return (
     <>
-      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
-        Overflow heading
+      <Checkbox checked={truncateHeading} onChange={e => setUrlParams({ truncateHeading: e.detail.checked })}>
+        Truncate heading
       </Checkbox>
       <ScreenshotArea>
         <Header
@@ -36,12 +36,12 @@ export default function PageHeadersDemo() {
               <Button>And a third Button with very long text</Button>
             </SpaceBetween>
           }
-          overflowHeading={overflowHeading}
+          truncateHeading={truncateHeading}
         >
           My large and long title with buttons
         </Header>
 
-        <Header variant="h1" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+        <Header variant="h1" actions={<Button>Button</Button>} truncateHeading={truncateHeading}>
           My large and long title with single button
         </Header>
 
@@ -50,12 +50,12 @@ export default function PageHeadersDemo() {
           actions={<Button>Button</Button>}
           info={<Link variant="info">Info</Link>}
           description="This is a page header"
-          overflowHeading={overflowHeading}
+          truncateHeading={truncateHeading}
         >
           Page header with description and info link
         </Header>
 
-        <Header variant="h1" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+        <Header variant="h1" actions={<Button>Button</Button>} truncateHeading={truncateHeading}>
           LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
         </Header>
       </ScreenshotArea>

--- a/pages/header/level-1.page.tsx
+++ b/pages/header/level-1.page.tsx
@@ -1,44 +1,64 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
+import { Checkbox } from '~components';
 import Button from '~components/button';
 import Header from '~components/header';
 import Link from '~components/link';
 import SpaceBetween from '~components/space-between';
+import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 
+type PageHeadersContext = React.Context<
+  AppContextType<{
+    overflowHeading: boolean;
+  }>
+>;
+
 export default function PageHeadersDemo() {
+  const {
+    urlParams: { overflowHeading = false },
+    setUrlParams,
+  } = useContext(AppContext as PageHeadersContext);
+
   return (
-    <ScreenshotArea>
-      <Header
-        variant="h1"
-        actions={
-          <SpaceBetween direction="horizontal" size="xs">
-            <Button>Button</Button>
-            <Button>And Button</Button>
-            <Button>And a third Button with very long text</Button>
-          </SpaceBetween>
-        }
-      >
-        My large and long title with buttons
-      </Header>
+    <>
+      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
+        Overflow heading
+      </Checkbox>
+      <ScreenshotArea>
+        <Header
+          variant="h1"
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button>Button</Button>
+              <Button>And Button</Button>
+              <Button>And a third Button with very long text</Button>
+            </SpaceBetween>
+          }
+          overflowHeading={overflowHeading}
+        >
+          My large and long title with buttons
+        </Header>
 
-      <Header variant="h1" actions={<Button>Button</Button>}>
-        My large and long title with single button
-      </Header>
+        <Header variant="h1" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+          My large and long title with single button
+        </Header>
 
-      <Header
-        variant="h1"
-        actions={<Button>Button</Button>}
-        info={<Link variant="info">Info</Link>}
-        description="This is a page header"
-      >
-        Page header with description and info link
-      </Header>
+        <Header
+          variant="h1"
+          actions={<Button>Button</Button>}
+          info={<Link variant="info">Info</Link>}
+          description="This is a page header"
+          overflowHeading={overflowHeading}
+        >
+          Page header with description and info link
+        </Header>
 
-      <Header variant="h1" actions={<Button>Button</Button>}>
-        LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
-      </Header>
-    </ScreenshotArea>
+        <Header variant="h1" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+          LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
+        </Header>
+      </ScreenshotArea>
+    </>
   );
 }

--- a/pages/header/level-2.page.tsx
+++ b/pages/header/level-2.page.tsx
@@ -13,20 +13,20 @@ import AppContext, { AppContextType } from '../app/app-context';
 
 type PageHeadersContext = React.Context<
   AppContextType<{
-    overflowHeading: boolean;
+    truncateHeading: boolean;
   }>
 >;
 
 export default function ContainerHeadersDemo() {
   const {
-    urlParams: { overflowHeading = false },
+    urlParams: { truncateHeading = false },
     setUrlParams,
   } = useContext(AppContext as PageHeadersContext);
 
   return (
     <>
-      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
-        Overflow heading
+      <Checkbox checked={truncateHeading} onChange={e => setUrlParams({ truncateHeading: e.detail.checked })}>
+        Truncate heading
       </Checkbox>
       <ScreenshotArea>
         <SpaceBetween size="l">
@@ -34,13 +34,13 @@ export default function ContainerHeadersDemo() {
             variant="h2"
             headingTagOverride="h1"
             actions={<Button>Button</Button>}
-            overflowHeading={overflowHeading}
+            truncateHeading={truncateHeading}
           >
             Standalone header
           </Header>
           <Container
             header={
-              <Header variant="h2" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+              <Header variant="h2" actions={<Button>Button</Button>} truncateHeading={truncateHeading}>
                 Container
               </Header>
             }
@@ -49,7 +49,7 @@ export default function ContainerHeadersDemo() {
           </Container>
           <Container
             header={
-              <Header variant="h2" info={<Link variant="info">Info</Link>} overflowHeading={overflowHeading}>
+              <Header variant="h2" info={<Link variant="info">Info</Link>} truncateHeading={truncateHeading}>
                 With info-link
               </Header>
             }
@@ -77,7 +77,7 @@ export default function ContainerHeadersDemo() {
                     <Button>And a third Button with very long text</Button>
                   </SpaceBetween>
                 }
-                overflowHeading={overflowHeading}
+                truncateHeading={truncateHeading}
               >
                 Container #3 has a very long title that will interfere with the button group on the right
               </Header>
@@ -105,7 +105,7 @@ export default function ContainerHeadersDemo() {
                     .
                   </>
                 }
-                overflowHeading={overflowHeading}
+                truncateHeading={truncateHeading}
               >
                 Container
               </Header>
@@ -121,7 +121,7 @@ export default function ContainerHeadersDemo() {
                 counter="10"
                 info={<Link variant="info">Info</Link>}
                 description="This container uses a semantically correct h2 in the header. Here is some more text for a very long example because sometimes descriptions have a lot of text and you just need to know what it will look like so here is more text."
-                overflowHeading={overflowHeading}
+                truncateHeading={truncateHeading}
               >
                 Container with a counter and a longer title so you can see how the info link wraps to the next line
               </Header>
@@ -131,7 +131,7 @@ export default function ContainerHeadersDemo() {
           </Container>
           <Container
             header={
-              <Header variant="h2" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+              <Header variant="h2" actions={<Button>Button</Button>} truncateHeading={truncateHeading}>
                 Container#6LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
               </Header>
             }

--- a/pages/header/level-2.page.tsx
+++ b/pages/header/level-2.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
 import Button from '~components/button';
 import Container from '~components/container';
 import Header from '~components/header';
@@ -8,112 +8,138 @@ import Link from '~components/link';
 import SpaceBetween from '~components/space-between';
 import ScreenshotArea from '../utils/screenshot-area';
 import TextContent from '~components/text-content';
+import { Checkbox } from '~components';
+import AppContext, { AppContextType } from '../app/app-context';
+
+type PageHeadersContext = React.Context<
+  AppContextType<{
+    overflowHeading: boolean;
+  }>
+>;
 
 export default function ContainerHeadersDemo() {
+  const {
+    urlParams: { overflowHeading = false },
+    setUrlParams,
+  } = useContext(AppContext as PageHeadersContext);
+
   return (
-    <ScreenshotArea>
-      <SpaceBetween size="l">
-        <Header variant="h2" headingTagOverride="h1" actions={<Button>Button</Button>}>
-          Standalone header
-        </Header>
-        <Container
-          header={
-            <Header variant="h2" actions={<Button>Button</Button>}>
-              Container
-            </Header>
-          }
-        >
-          Lorem ipsum dolor sit amet.
-        </Container>
-        <Container
-          header={
-            <Header variant="h2" info={<Link variant="info">Info</Link>}>
-              With info-link
-            </Header>
-          }
-        >
-          Header in this container should have consistent spacing above and below
-        </Container>
-        <h3>H3 element to make axe happy with the h4 below</h3>
-        <Container
-          header={
-            <TextContent>
-              <h4>This is an h4 wrapped in TextContent</h4>
-            </TextContent>
-          }
-        >
-          Header in this container should have consistent spacing above and below
-        </Container>
-        <Container
-          header={
-            <Header
-              variant="h2"
-              actions={
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button>Button</Button>
-                  <Button>And Button</Button>
-                  <Button>And a third Button with very long text</Button>
-                </SpaceBetween>
-              }
-            >
-              Container #3 has a very long title that will interfere with the button group on the right
-            </Header>
-          }
-        >
-          This container uses a semantically correct h2 in the header.
-        </Container>
-        <Container
-          header={
-            <Header
-              variant="h2"
-              actions={
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button>Button</Button>
-                  <Button>And Button</Button>
-                  <Button>And a third Button with very long text</Button>
-                </SpaceBetween>
-              }
-              description={
-                <>
-                  Some additional text{' '}
-                  <Link fontSize="inherit" variant="primary" external={true} externalIconAriaLabel="(External)">
-                    with a link
-                  </Link>
-                  .
-                </>
-              }
-            >
-              Container
-            </Header>
-          }
-        >
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-        </Container>
-        <Container
-          header={
-            <Header
-              variant="h2"
-              actions={<Button>Button</Button>}
-              counter="10"
-              info={<Link variant="info">Info</Link>}
-              description="This container uses a semantically correct h2 in the header. Here is some more text for a very long example because sometimes descriptions have a lot of text and you just need to know what it will look like so here is more text."
-            >
-              Container with a counter and a longer title so you can see how the info link wraps to the next line
-            </Header>
-          }
-        >
-          <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-        </Container>
-        <Container
-          header={
-            <Header variant="h2" actions={<Button>Button</Button>}>
-              Container#6LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
-            </Header>
-          }
-        >
-          Lorem ipsum dolor sit amet.
-        </Container>
-      </SpaceBetween>
-    </ScreenshotArea>
+    <>
+      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
+        Overflow heading
+      </Checkbox>
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          <Header
+            variant="h2"
+            headingTagOverride="h1"
+            actions={<Button>Button</Button>}
+            overflowHeading={overflowHeading}
+          >
+            Standalone header
+          </Header>
+          <Container
+            header={
+              <Header variant="h2" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+                Container
+              </Header>
+            }
+          >
+            Lorem ipsum dolor sit amet.
+          </Container>
+          <Container
+            header={
+              <Header variant="h2" info={<Link variant="info">Info</Link>} overflowHeading={overflowHeading}>
+                With info-link
+              </Header>
+            }
+          >
+            Header in this container should have consistent spacing above and below
+          </Container>
+          <h3>H3 element to make axe happy with the h4 below</h3>
+          <Container
+            header={
+              <TextContent>
+                <h4>This is an h4 wrapped in TextContent</h4>
+              </TextContent>
+            }
+          >
+            Header in this container should have consistent spacing above and below
+          </Container>
+          <Container
+            header={
+              <Header
+                variant="h2"
+                actions={
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button>Button</Button>
+                    <Button>And Button</Button>
+                    <Button>And a third Button with very long text</Button>
+                  </SpaceBetween>
+                }
+                overflowHeading={overflowHeading}
+              >
+                Container #3 has a very long title that will interfere with the button group on the right
+              </Header>
+            }
+          >
+            This container uses a semantically correct h2 in the header.
+          </Container>
+          <Container
+            header={
+              <Header
+                variant="h2"
+                actions={
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button>Button</Button>
+                    <Button>And Button</Button>
+                    <Button>And a third Button with very long text</Button>
+                  </SpaceBetween>
+                }
+                description={
+                  <>
+                    Some additional text{' '}
+                    <Link fontSize="inherit" variant="primary" external={true} externalIconAriaLabel="(External)">
+                      with a link
+                    </Link>
+                    .
+                  </>
+                }
+                overflowHeading={overflowHeading}
+              >
+                Container
+              </Header>
+            }
+          >
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+          </Container>
+          <Container
+            header={
+              <Header
+                variant="h2"
+                actions={<Button>Button</Button>}
+                counter="10"
+                info={<Link variant="info">Info</Link>}
+                description="This container uses a semantically correct h2 in the header. Here is some more text for a very long example because sometimes descriptions have a lot of text and you just need to know what it will look like so here is more text."
+                overflowHeading={overflowHeading}
+              >
+                Container with a counter and a longer title so you can see how the info link wraps to the next line
+              </Header>
+            }
+          >
+            <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
+          </Container>
+          <Container
+            header={
+              <Header variant="h2" actions={<Button>Button</Button>} overflowHeading={overflowHeading}>
+                Container#6LongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableTextLongUnbreakableText
+              </Header>
+            }
+          >
+            Lorem ipsum dolor sit amet.
+          </Container>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
   );
 }

--- a/pages/header/level-3.page.tsx
+++ b/pages/header/level-3.page.tsx
@@ -1,26 +1,55 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
+import { Checkbox } from '~components';
 import Button from '~components/button';
 import Header from '~components/header';
 import Link from '~components/link';
 import SpaceBetween from '~components/space-between';
+import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 
+type PageHeadersContext = React.Context<
+  AppContextType<{
+    overflowHeading: boolean;
+  }>
+>;
+
 export default function HeadersLevel3Demo() {
+  const {
+    urlParams: { overflowHeading = false },
+    setUrlParams,
+  } = useContext(AppContext as PageHeadersContext);
+
   return (
-    <ScreenshotArea>
-      <SpaceBetween size="xs">
-        <Header variant="h3" headingTagOverride="h1">
-          h1 override
-        </Header>
-        <Header variant="h3" headingTagOverride="h2" actions={<Button>Edit</Button>}>
-          Wizard section header
-        </Header>
-        <Header variant="h3" description="Some header description" info={<Link variant="info">Info</Link>} counter="3">
-          Full blown header
-        </Header>
-      </SpaceBetween>
-    </ScreenshotArea>
+    <>
+      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
+        Overflow heading
+      </Checkbox>
+      <ScreenshotArea>
+        <SpaceBetween size="xs">
+          <Header variant="h3" headingTagOverride="h1" overflowHeading={overflowHeading}>
+            h1 override
+          </Header>
+          <Header
+            variant="h3"
+            headingTagOverride="h2"
+            actions={<Button>Edit</Button>}
+            overflowHeading={overflowHeading}
+          >
+            Wizard section header
+          </Header>
+          <Header
+            variant="h3"
+            description="Some header description"
+            info={<Link variant="info">Info</Link>}
+            counter="3"
+            overflowHeading={overflowHeading}
+          >
+            Full blown header
+          </Header>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
   );
 }

--- a/pages/header/level-3.page.tsx
+++ b/pages/header/level-3.page.tsx
@@ -11,31 +11,31 @@ import ScreenshotArea from '../utils/screenshot-area';
 
 type PageHeadersContext = React.Context<
   AppContextType<{
-    overflowHeading: boolean;
+    truncateHeading: boolean;
   }>
 >;
 
 export default function HeadersLevel3Demo() {
   const {
-    urlParams: { overflowHeading = false },
+    urlParams: { truncateHeading = false },
     setUrlParams,
   } = useContext(AppContext as PageHeadersContext);
 
   return (
     <>
-      <Checkbox checked={overflowHeading} onChange={e => setUrlParams({ overflowHeading: e.detail.checked })}>
-        Overflow heading
+      <Checkbox checked={truncateHeading} onChange={e => setUrlParams({ truncateHeading: e.detail.checked })}>
+        Truncate heading
       </Checkbox>
       <ScreenshotArea>
         <SpaceBetween size="xs">
-          <Header variant="h3" headingTagOverride="h1" overflowHeading={overflowHeading}>
+          <Header variant="h3" headingTagOverride="h1" truncateHeading={truncateHeading}>
             h1 override
           </Header>
           <Header
             variant="h3"
             headingTagOverride="h2"
             actions={<Button>Edit</Button>}
-            overflowHeading={overflowHeading}
+            truncateHeading={truncateHeading}
           >
             Wizard section header
           </Header>
@@ -44,7 +44,7 @@ export default function HeadersLevel3Demo() {
             description="Some header description"
             info={<Link variant="info">Info</Link>}
             counter="3"
-            overflowHeading={overflowHeading}
+            truncateHeading={truncateHeading}
           >
             Full blown header
           </Header>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5931,9 +5931,9 @@ provided by the variant.",
       "type": "string",
     },
     Object {
-      "description": "Determines if the heading (specified with the \`children\` property) overflows with ellipsis when there is not enough space.
+      "description": "Determines if the heading (specified with the \`children\` property) should be truncated with ellipsis when there is not enough space.
 Defaults to \`false\`.",
-      "name": "overflowHeading",
+      "name": "truncateHeading",
       "optional": true,
       "type": "boolean",
     },

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5931,6 +5931,13 @@ provided by the variant.",
       "type": "string",
     },
     Object {
+      "description": "Determines if the heading (specified with the \`children\` property) overflows with ellipsis when there is not enough space.
+Defaults to \`false\`.",
+      "name": "overflowHeading",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "defaultValue": "\\"h2\\"",
       "description": "Specifies the variant of the header:
 * \`h1\` - Use this for page level headers.

--- a/src/header/interfaces.ts
+++ b/src/header/interfaces.ts
@@ -41,6 +41,11 @@ export interface HeaderProps extends BaseComponentProps {
    * Area next to the heading to display an Info link.
    */
   info?: React.ReactNode;
+  /**
+   * Determines if the heading (specified with the `children` property) overflows with ellipsis when there is not enough space.
+   * Defaults to `false`.
+   */
+  overflowHeading?: boolean;
 }
 
 export namespace HeaderProps {

--- a/src/header/interfaces.ts
+++ b/src/header/interfaces.ts
@@ -42,10 +42,10 @@ export interface HeaderProps extends BaseComponentProps {
    */
   info?: React.ReactNode;
   /**
-   * Determines if the heading (specified with the `children` property) overflows with ellipsis when there is not enough space.
+   * Determines if the heading (specified with the `children` property) should be truncated with ellipsis when there is not enough space.
    * Defaults to `false`.
    */
-  overflowHeading?: boolean;
+  truncateHeading?: boolean;
 }
 
 export namespace HeaderProps {

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -9,6 +9,7 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { HeaderProps } from './interfaces';
 import styles from './styles.css.js';
 import { SomeRequired } from '../internal/types';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 
 interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, InternalBaseComponentProps {
   __disableActionsWrapping?: boolean;
@@ -16,6 +17,7 @@ interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, Inte
 
 export default function InternalHeader({
   variant,
+  overflowHeading,
   headingTagOverride,
   children,
   actions,
@@ -60,10 +62,20 @@ export default function InternalHeader({
             isRefresh && styles[`title-variant-${variantOverride}-refresh`]
           )}
         >
-          <HeadingTag className={clsx(styles.heading, styles[`heading-variant-${variantOverride}`])}>
-            <span className={clsx(styles['heading-text'], styles[`heading-text-variant-${variantOverride}`])}>
+          <HeadingTag
+            className={clsx(
+              styles.heading,
+              styles[`heading-variant-${variantOverride}`],
+              overflowHeading && styles['heading-overflow']
+            )}
+          >
+            <span
+              className={clsx(styles['heading-text'], styles[`heading-text-variant-${variantOverride}`])}
+              aria-hidden={overflowHeading}
+            >
               {children}
             </span>
+            {overflowHeading && <ScreenreaderOnly>{children}</ScreenreaderOnly>}
             {counter !== undefined && <span className={styles.counter}> {counter}</span>}
           </HeadingTag>
           {info && <span className={styles.info}>{info}</span>}

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -17,7 +17,7 @@ interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, Inte
 
 export default function InternalHeader({
   variant,
-  overflowHeading,
+  truncateHeading,
   headingTagOverride,
   children,
   actions,
@@ -66,16 +66,16 @@ export default function InternalHeader({
             className={clsx(
               styles.heading,
               styles[`heading-variant-${variantOverride}`],
-              overflowHeading && styles['heading-overflow']
+              truncateHeading && styles['heading-overflow']
             )}
           >
             <span
               className={clsx(styles['heading-text'], styles[`heading-text-variant-${variantOverride}`])}
-              aria-hidden={overflowHeading}
+              aria-hidden={truncateHeading}
             >
               {children}
             </span>
-            {overflowHeading && <ScreenreaderOnly>{children}</ScreenreaderOnly>}
+            {truncateHeading && <ScreenreaderOnly>{children}</ScreenreaderOnly>}
             {counter !== undefined && <span className={styles.counter}> {counter}</span>}
           </HeadingTag>
           {info && <span className={styles.info}>{info}</span>}

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -185,6 +185,7 @@
 }
 
 .heading-text {
+  /* used in test-utils */
   &-variant-h1 {
     @include styles.font-heading-xl;
   }

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -103,6 +103,10 @@
 }
 
 .title {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+
   @include styles.text-wrapping;
   color: awsui.$color-text-heading-default;
 
@@ -159,7 +163,7 @@
 .heading {
   margin: 0;
   // We display heading element inline to achieve the proper line-wrapping with info links
-  display: inline;
+  display: inline-block;
   font-size: inherit;
   @include styles.info-link-spacing();
 
@@ -172,10 +176,15 @@
   &-variant-h3 {
     @include styles.font(heading-m);
   }
+  &-overflow {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
 }
 
 .heading-text {
-  /* used in test-utils */
   &-variant-h1 {
     @include styles.font-heading-xl;
   }


### PR DESCRIPTION
### Description

Default heading wrapping behavior might not be applicable when used inside small containers. When new property is set, the heading is truncated with ellipsis instead.

When the heading is truncated some part of its information is lost (exception - screen-reader users). That means the feature can only be used when there is an alternative way to obtain it.

### How has this been tested?

Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
