### PR TITLE
chore: Revert use base-component utils from the toolkit (#714)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@cloudscape-design/collection-hooks": "^1.0.0",
-        "@cloudscape-design/component-toolkit": "^1.0.0-beta",
         "@cloudscape-design/test-utils-core": "^1.0.0",
         "@cloudscape-design/theming-runtime": "^1.0.0",
         "@juggle/resize-observer": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@cloudscape-design/collection-hooks": "^1.0.0",
-    "@cloudscape-design/component-toolkit": "^1.0.0-beta",
     "@cloudscape-design/test-utils-core": "^1.0.0",
     "@cloudscape-design/theming-runtime": "^1.0.0",
     "@juggle/resize-observer": "^3.3.1",

--- a/src/__tests__/use-base-component.test.tsx
+++ b/src/__tests__/use-base-component.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { getAllComponents, requireComponent, supportsDOMProperties } from './utils';
 import { getRequiredPropsForComponent } from './required-props-for-components';
-import { COMPONENT_METADATA_KEY } from '@cloudscape-design/component-toolkit/internal';
+import { COMPONENT_METADATA_KEY } from '../../lib/components/internal/hooks/use-base-component/component-metadata';
 import { pascalCase } from 'change-case';
 import { PACKAGE_VERSION } from '../../lib/components/internal/environment';
 

--- a/src/__tests__/use-telemetry-usage.test.tsx
+++ b/src/__tests__/use-telemetry-usage.test.tsx
@@ -4,6 +4,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { getAllComponents, requireComponent } from './utils';
 import { getRequiredPropsForComponent } from './required-props-for-components';
+import {
+  MetricsTestHelper,
+  formatVersionForMetricName,
+  formatMajorVersionForMetricDetail,
+} from '../../lib/components/internal/metrics';
+import { THEME, PACKAGE_VERSION } from '../../lib/components/internal/environment';
+import { Checkbox, Button } from '../../lib/components';
 
 declare global {
   interface Window {
@@ -11,6 +18,18 @@ declare global {
     AWSUI_METRIC_ORIGIN?: string;
   }
 }
+
+const verifyMetricsAreLoggedOnlyOnce = () => {
+  const callCount = window.AWSC.Clog.log.mock.calls.length;
+  const metricNames = window.AWSC.Clog.log.mock.calls.map((call: any) => {
+    return call[0];
+  });
+  expect(new Set(metricNames).size === callCount).toBeTruthy();
+};
+
+const getExpectedMetricName = (lowerCaseComponentName: string) => {
+  return `awsui_${lowerCaseComponentName}_${formatVersionForMetricName(THEME, PACKAGE_VERSION)}`;
+};
 
 describe('useTelemetry hook is used in all public components', () => {
   const componentRoot = document.createElement('div');
@@ -32,21 +51,88 @@ describe('useTelemetry hook is used in all public components', () => {
     jest.spyOn(window.AWSC.Clog, 'log');
   });
 
-  getAllComponents().forEach(componentName => {
-    const { default: Component } = requireComponent(componentName);
-    const props = { ...getRequiredPropsForComponent(componentName), ...runtimeProps[componentName] };
+  afterEach(() => {
+    jest.clearAllMocks();
+    new MetricsTestHelper().resetOneTimeMetricsCache();
+  });
 
-    test(`component ${componentName}`, () => {
-      const component = <Component {...props} />;
-      const { rerender } = render(component, { container: componentRoot });
+  describe('emit the metrics and viewport dimensions for component usage', () => {
+    getAllComponents().forEach(componentName => {
+      const lowerCaseComponentName = componentName.replace(/-/g, '').toLowerCase();
+      const { default: Component } = requireComponent(componentName);
+      const props = { ...getRequiredPropsForComponent(componentName), ...runtimeProps[componentName] };
 
-      // On the first render the metrics got sent.
-      const callCount = window.AWSC.Clog.log.mock.calls.length;
-      expect(callCount).toBeGreaterThan(0);
+      test(`component ${componentName}`, () => {
+        const component = <Component {...props} className="example" />;
+        const { rerender } = render(component, { container: componentRoot });
+        const expectedMetricName = getExpectedMetricName(lowerCaseComponentName);
 
-      // On the second render no logs should get sent.
-      rerender(component);
-      expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(callCount);
+        // on the first render the metrics got sent
+        const callCount = window.AWSC.Clog.log.mock.calls.length;
+        // the order is defined in the telemetry hook
+        expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(1, 'awsui-viewport-width', 1024, undefined);
+        expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(2, 'awsui-viewport-height', 768, undefined);
+        expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(
+          3,
+          'awsui_components_d30',
+          1,
+          expect.stringContaining('loaded')
+        );
+        expect(window.AWSC.Clog.log).toHaveBeenLastCalledWith(
+          expectedMetricName,
+          1,
+          JSON.stringify({
+            o: 'main',
+            s: lowerCaseComponentName,
+            t: 'default',
+            a: 'used',
+            f: 'react',
+            v: formatMajorVersionForMetricDetail(PACKAGE_VERSION),
+          })
+        );
+
+        verifyMetricsAreLoggedOnlyOnce();
+
+        // on the second render no logs should get sent
+        rerender(component);
+        expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(callCount);
+      });
+    });
+
+    test('one-time metrics (viewport, component usage) do not repeat', () => {
+      render(<Checkbox checked={true} />);
+      window.AWSC.Clog.log.mockClear();
+      render(<Button />);
+      expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(1);
+      expect(window.AWSC.Clog.log).toHaveBeenCalledWith(
+        getExpectedMetricName('button'),
+        1,
+        JSON.stringify({
+          o: 'main',
+          s: 'button',
+          t: 'default',
+          a: 'used',
+          f: 'react',
+          v: formatMajorVersionForMetricDetail(PACKAGE_VERSION),
+        })
+      );
+    });
+
+    test('supports custom origin', () => {
+      window.AWSUI_METRIC_ORIGIN = 'custom';
+      render(<Button />);
+      expect(window.AWSC.Clog.log).toHaveBeenCalledWith(
+        getExpectedMetricName('button'),
+        1,
+        JSON.stringify({
+          o: 'custom',
+          s: 'button',
+          t: 'default',
+          a: 'used',
+          f: 'react',
+          v: formatMajorVersionForMetricDetail(PACKAGE_VERSION),
+        })
+      );
     });
   });
 });

--- a/src/flashbar/internal/analytics.ts
+++ b/src/flashbar/internal/analytics.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from '../../internal/environment';
-import { Metrics } from '@cloudscape-design/component-toolkit/internal';
+import { Metrics } from '../../internal/metrics';
 import { FlashbarProps } from '../interfaces';
 import { getFlashTypeCount } from '../utils';
 

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -1,11 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { initAwsUiVersions } from '@cloudscape-design/component-toolkit/internal';
-import { PACKAGE_SOURCE, PACKAGE_VERSION } from '../environment';
-
 // these styles needed to be imported for every public component
 import './styles.css.js';
+import { PACKAGE_SOURCE, PACKAGE_VERSION } from '../environment';
+import { initAwsUiVersions } from './init-awsui-versions.js';
 
 initAwsUiVersions(PACKAGE_SOURCE, PACKAGE_VERSION);
 

--- a/src/internal/base-component/init-awsui-versions.ts
+++ b/src/internal/base-component/init-awsui-versions.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: move to component-toolkit/internal/base-component
+
+// not using `declare global {}` to avoid polluting customers' typings with this info
+interface CustomWindow extends Window {
+  awsuiVersions?: { [source: string]: string[] };
+}
+declare const window: CustomWindow | undefined;
+
+// expose version info, so it can be checked using the browser devtools
+export function initAwsUiVersions(source: string, packageVersion: string) {
+  if (typeof window !== 'undefined') {
+    if (!window.awsuiVersions) {
+      window.awsuiVersions = {};
+    }
+    if (!window.awsuiVersions[source]) {
+      window.awsuiVersions[source] = [];
+    }
+    window.awsuiVersions[source].push(packageVersion);
+  }
+}

--- a/src/internal/hooks/use-base-component/__tests__/use-base-component.test.tsx
+++ b/src/internal/hooks/use-base-component/__tests__/use-base-component.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import useBaseComponent, {
   InternalBaseComponentProps,
 } from '../../../../../lib/components/internal/hooks/use-base-component';
-import { COMPONENT_METADATA_KEY } from '@cloudscape-design/component-toolkit/internal';
+import { COMPONENT_METADATA_KEY } from '../../../../../lib/components/internal/hooks/use-base-component/component-metadata';
 import { PACKAGE_VERSION } from '../../../../../lib/components/internal/environment';
 import { useTelemetry } from '../../../../../lib/components/internal/hooks/use-telemetry';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
@@ -62,6 +62,23 @@ test('should call the useTelemetry hook passing down the given component name', 
   jest.resetAllMocks();
   render(<Demo />);
   expect(useTelemetry).toHaveBeenCalledWith('DemoComponent');
+});
+
+test('overriding the metadata is not possible', () => {
+  const { container } = render(<Demo />);
+  const rootNode: any = container.firstChild;
+  expect(rootNode[COMPONENT_METADATA_KEY]?.name).toBe('DemoComponent');
+  expect(rootNode[COMPONENT_METADATA_KEY]?.version).toBe(PACKAGE_VERSION);
+
+  expect(() => {
+    rootNode[COMPONENT_METADATA_KEY]!.name = 'changed name';
+  }).toThrow(`Cannot assign to read only property 'name' of object '#<Object>'`);
+  expect(() => {
+    rootNode[COMPONENT_METADATA_KEY]!.version = 'changed version';
+  }).toThrow(`Cannot assign to read only property 'version' of object '#<Object>'`);
+
+  expect(rootNode[COMPONENT_METADATA_KEY]?.name).toBe('DemoComponent');
+  expect(rootNode[COMPONENT_METADATA_KEY]?.version).toBe(PACKAGE_VERSION);
 });
 
 test('metadata get attached on the Portal component root DOM node when elementRef is changing', () => {

--- a/src/internal/hooks/use-base-component/component-metadata.ts
+++ b/src/internal/hooks/use-base-component/component-metadata.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useRef } from 'react';
+
+// TODO: move to component-toolkit/internal/base-component
+
+export const COMPONENT_METADATA_KEY = '__awsuiMetadata__';
+
+export function useComponentMetadata<T = any>(componentName: string, packageVersion: string) {
+  interface AwsUiMetadata {
+    name: string;
+    version: string;
+  }
+
+  interface HTMLMetadataElement extends HTMLElement {
+    [COMPONENT_METADATA_KEY]: AwsUiMetadata;
+  }
+
+  const elementRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (elementRef.current && !Object.prototype.hasOwnProperty.call(elementRef.current, COMPONENT_METADATA_KEY)) {
+      const node = elementRef.current as unknown as HTMLMetadataElement;
+      const metadata = { name: componentName, version: packageVersion };
+
+      Object.freeze(metadata);
+      Object.defineProperty(node, COMPONENT_METADATA_KEY, { value: metadata, writable: false });
+    }
+    // Some component refs change dynamically. E.g. The Modal component where
+    // the content gets rendered conditionally inside a Portal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef.current]);
+
+  return elementRef;
+}

--- a/src/internal/hooks/use-base-component/index.ts
+++ b/src/internal/hooks/use-base-component/index.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { MutableRefObject } from 'react';
-import { useComponentMetadata } from '@cloudscape-design/component-toolkit/internal';
+import { useComponentMetadata } from './component-metadata';
 import { useTelemetry } from '../use-telemetry';
 import { PACKAGE_VERSION } from '../../environment';
 

--- a/src/internal/hooks/use-telemetry/index.ts
+++ b/src/internal/hooks/use-telemetry/index.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useComponentMetrics } from '@cloudscape-design/component-toolkit/internal';
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from '../../environment';
 import { useVisualRefresh } from '../use-visual-mode';
+import * as telemetry from './telemetry';
 
 export function useTelemetry(componentName: string) {
   const theme = useVisualRefresh() ? 'vr' : THEME;
-  useComponentMetrics(componentName, { packageSource: PACKAGE_SOURCE, packageVersion: PACKAGE_VERSION, theme });
+  telemetry.useTelemetry(componentName, { packageSource: PACKAGE_SOURCE, packageVersion: PACKAGE_VERSION, theme });
 }

--- a/src/internal/hooks/use-telemetry/telemetry.ts
+++ b/src/internal/hooks/use-telemetry/telemetry.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+import { Metrics } from '../../metrics/metrics';
+
+// TODO: move to component-toolkit/internal/base-component
+
+interface Settings {
+  packageSource: string;
+  packageVersion: string;
+  theme: string;
+}
+
+export function useTelemetry(componentName: string, { packageSource, packageVersion, theme }: Settings) {
+  useEffect(() => {
+    const metrics = new Metrics(packageSource, packageVersion);
+
+    metrics.initMetrics(theme);
+    if (typeof window !== 'undefined') {
+      metrics.sendMetricOnce('awsui-viewport-width', window.innerWidth || 0);
+      metrics.sendMetricOnce('awsui-viewport-height', window.innerHeight || 0);
+    }
+    metrics.logComponentLoaded();
+    metrics.logComponentUsed(componentName.toLowerCase());
+    // Components do not change the name dynamically. Explicit empty array to prevent accidental double metrics
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/internal/metrics/index.ts
+++ b/src/internal/metrics/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { Metrics, MetricsTestHelper } from './metrics';
+export { formatMajorVersionForMetricDetail, formatVersionForMetricName } from './metrics-formatters';

--- a/src/internal/metrics/log-clients.ts
+++ b/src/internal/metrics/log-clients.ts
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: move to component-toolkit/internal/metrics
+
+export interface AWSC {
+  Clog: any;
+}
+
+export interface MetricsWindow extends Window {
+  AWSC?: AWSC;
+  panorama?: any;
+}
+
+export interface MetricsV2EventItem {
+  eventType?: string;
+  eventContext?: string;
+  eventDetail?: string | Record<string, string | number | boolean>;
+  eventValue?: string | Record<string, string | number | boolean>;
+}
+
+export interface MetricsLogItem {
+  source: string;
+  action: string;
+  version: string;
+}
+
+/**
+ * Console Platform's client logging JS API client.
+ */
+export class CLogClient {
+  /**
+   * Sends metric but only if Console Platform client logging JS API is present in the page.
+   */
+  sendMetric(metricName: string, value: number, detail?: string): void {
+    if (!metricName || !/^[a-zA-Z0-9_-]{1,32}$/.test(metricName)) {
+      console.error(`Invalid metric name: ${metricName}`);
+      return;
+    }
+    if (detail && detail.length > 200) {
+      console.error(`Detail for metric ${metricName} is too long: ${detail}`);
+      return;
+    }
+    const AWSC = this.findAWSC(window);
+    if (typeof AWSC === 'object' && typeof AWSC.Clog === 'object' && typeof AWSC.Clog.log === 'function') {
+      AWSC.Clog.log(metricName, value, detail);
+    }
+  }
+
+  private findAWSC(currentWindow?: MetricsWindow): AWSC | undefined {
+    try {
+      if (typeof currentWindow?.AWSC === 'object') {
+        return currentWindow?.AWSC;
+      }
+
+      if (!currentWindow || currentWindow.parent === currentWindow) {
+        // When the window has no more parents, it references itself
+        return undefined;
+      }
+
+      return this.findAWSC(currentWindow.parent);
+    } catch (ex) {
+      // Most likely a cross-origin access error
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Console Platform's client v2 logging JS API client.
+ */
+export class PanoramaClient {
+  /**
+   * Sends metric but only if Console Platform client v2 logging JS API is present in the page.
+   */
+  sendMetric(metric: MetricsV2EventItem): void {
+    if (typeof metric.eventDetail === 'object') {
+      metric.eventDetail = JSON.stringify(metric.eventDetail);
+    }
+    if (metric.eventDetail && metric.eventDetail.length > 200) {
+      console.error(`Detail for metric is too long: ${metric.eventDetail}`);
+      return;
+    }
+    if (typeof metric.eventValue === 'object') {
+      metric.eventValue = JSON.stringify(metric.eventValue);
+    }
+    const panorama = this.findPanorama(window);
+    if (typeof panorama === 'function') {
+      panorama('trackCustomEvent', { ...metric, timestamp: Date.now() });
+    }
+  }
+
+  private findPanorama(currentWindow?: MetricsWindow): any | undefined {
+    try {
+      if (typeof currentWindow?.panorama === 'function') {
+        return currentWindow?.panorama;
+      }
+
+      if (!currentWindow || currentWindow.parent === currentWindow) {
+        // When the window has no more parents, it references itself
+        return undefined;
+      }
+
+      return this.findPanorama(currentWindow.parent);
+    } catch (ex) {
+      // Most likely a cross-origin access error
+      return undefined;
+    }
+  }
+}

--- a/src/internal/metrics/metrics-formatters.ts
+++ b/src/internal/metrics/metrics-formatters.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MetricsLogItem } from './log-clients';
+
+// TODO: move to component-toolkit/internal/metrics
+
+declare const AWSUI_METRIC_ORIGIN: string | undefined;
+
+// React is the only framework we're using.
+const framework = 'react';
+
+export function buildMetricHash({ source, action }: MetricsLogItem): string {
+  return [`src${source}`, `action${action}`].join('_');
+}
+
+export function buildMetricDetail({ source, action, version }: MetricsLogItem, theme: string): string {
+  const metricOrigin = typeof AWSUI_METRIC_ORIGIN !== 'undefined' ? AWSUI_METRIC_ORIGIN : 'main';
+  const detailObject = {
+    o: metricOrigin,
+    s: source,
+    t: theme,
+    a: action,
+    f: framework,
+    v: formatMajorVersionForMetricDetail(version),
+  };
+  return JSON.stringify(detailObject);
+}
+
+export function buildMetricName({ source, version }: MetricsLogItem, theme: string): string {
+  return ['awsui', source, `${formatVersionForMetricName(theme, version)}`].join('_');
+}
+
+export function formatMajorVersionForMetricDetail(version: string) {
+  return version.replace(/\s/g, '');
+}
+
+export function formatVersionForMetricName(theme: string, version: string) {
+  return `${theme.charAt(0)}${getMajorVersion(version).replace('.', '')}`;
+}
+
+function getMajorVersion(versionString: string): string {
+  const majorVersionMatch = versionString.match(/^(\d+\.\d+)/);
+  return majorVersionMatch ? majorVersionMatch[1] : '';
+}

--- a/src/internal/metrics/metrics.ts
+++ b/src/internal/metrics/metrics.ts
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: move to component-toolkit/internal/metrics
+
+import { CLogClient, PanoramaClient, MetricsLogItem, MetricsV2EventItem } from './log-clients';
+import { buildMetricDetail, buildMetricHash, buildMetricName } from './metrics-formatters';
+
+const oneTimeMetrics: Record<string, boolean> = {};
+
+// In case we need to override the theme for VR.
+let theme = '';
+function setTheme(newTheme: string) {
+  theme = newTheme;
+}
+
+export class Metrics {
+  readonly source: string;
+  readonly packageVersion: string;
+
+  private clog = new CLogClient();
+  private panorama = new PanoramaClient();
+
+  constructor(source: string, packageVersion: string) {
+    this.source = source;
+    this.packageVersion = packageVersion;
+  }
+
+  initMetrics(theme: string) {
+    setTheme(theme);
+  }
+
+  /**
+   * Calls Console Platform's client logging JS API with provided metric name, value, and detail.
+   * Does nothing if Console Platform client logging JS is not present in page.
+   */
+  sendMetric(metricName: string, value: number, detail?: string): void {
+    if (!theme) {
+      // Metrics need to be initialized first (initMetrics)
+      console.error('Metrics need to be initialized first.');
+      return;
+    }
+
+    this.clog.sendMetric(metricName, value, detail);
+  }
+
+  /**
+   * Calls Console Platform's client v2 logging JS API with provided metric name and detail.
+   * Does nothing if Console Platform client logging JS is not present in page.
+   */
+  sendPanoramaMetric(metric: MetricsV2EventItem): void {
+    this.panorama.sendMetric(metric);
+  }
+
+  sendMetricObject(metric: MetricsLogItem, value: number): void {
+    this.sendMetric(buildMetricName(metric, theme), value, buildMetricDetail(metric, theme));
+  }
+
+  sendMetricObjectOnce(metric: MetricsLogItem, value: number): void {
+    const metricHash = buildMetricHash(metric);
+    if (!oneTimeMetrics[metricHash]) {
+      this.sendMetricObject(metric, value);
+      oneTimeMetrics[metricHash] = true;
+    }
+  }
+
+  /*
+   * Calls Console Platform's client logging only the first time the provided metricName is used.
+   * Subsequent calls with the same metricName are ignored.
+   */
+  sendMetricOnce(metricName: string, value: number, detail?: string): void {
+    if (!oneTimeMetrics[metricName]) {
+      this.sendMetric(metricName, value, detail);
+      oneTimeMetrics[metricName] = true;
+    }
+  }
+
+  /*
+   * Reports a metric value 1 to Console Platform's client logging service to indicate that the
+   * component was loaded. The component load event will only be reported as used to client logging
+   * service once per page view.
+   */
+  logComponentLoaded() {
+    this.sendMetricObjectOnce({ source: this.source, action: 'loaded', version: this.packageVersion }, 1);
+  }
+
+  /*
+   * Reports a metric value 1 to Console Platform's client logging service to indicate that the
+   * component was used in the page.  A component will only be reported as used to client logging
+   * service once per page view.
+   */
+  logComponentUsed(componentName: string) {
+    this.sendMetricObjectOnce(
+      {
+        source: componentName,
+        action: 'used',
+        version: this.packageVersion,
+      },
+      1
+    );
+  }
+}
+
+export class MetricsTestHelper {
+  resetOneTimeMetricsCache() {
+    for (const prop in oneTimeMetrics) {
+      delete oneTimeMetrics[prop];
+    }
+  }
+}

--- a/src/internal/utils/__tests__/init-metrics.test.ts
+++ b/src/internal/utils/__tests__/init-metrics.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Metrics } from '@cloudscape-design/component-toolkit/internal';
+import { Metrics } from '../../metrics/metrics';
 
 const metrics = new Metrics('components', '3.0 (HEAD)');
 

--- a/src/internal/utils/__tests__/metrics.test.ts
+++ b/src/internal/utils/__tests__/metrics.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Metrics } from '@cloudscape-design/component-toolkit/internal';
+import { Metrics } from '../../metrics/metrics';
 
 const metrics = new Metrics('components', '3.0 (HEAD)');
 

--- a/src/wizard/internal/analytics.tsx
+++ b/src/wizard/internal/analytics.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from '../../internal/environment';
-import { Metrics } from '@cloudscape-design/component-toolkit/internal';
+import { Metrics } from '../../internal/metrics';
 import { WizardProps } from '../interfaces';
 
 const metrics = new Metrics(PACKAGE_SOURCE, PACKAGE_VERSION);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "incremental": true
   },
   "include": ["src", "types"],
-  "exclude": ["**/__tests__/**", "src/test-utils/**", "**/__integ__/**", "**/__a11y__/**", "src/internal/vendor/**"]
+   "exclude": ["**/__tests__/**", "src/test-utils/**", "**/__integ__/**", "**/__a11y__/**", "src/internal/vendor/**"]
 }

--- a/tsconfig.unit.json
+++ b/tsconfig.unit.json
@@ -11,5 +11,11 @@
     "noEmit": true,
     "resolveJsonModule": true
   },
-  "include": ["types", "**/__tests__/**/*.tsx", "**/__tests__/**/*.ts", "**/__mocks__/**/*.ts", "types"]
+  "include": [
+    "types",
+    "**/__tests__/**/*.tsx",
+    "**/__tests__/**/*.ts",
+    "**/__mocks__/**/*.ts",
+    "types"
+  ]
 }


### PR DESCRIPTION
This reverts commit 78f5b59d86946d8af20b948b1cf5828a2ce308d1.

Reason: downstream build failures.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
