### PR TITLE
feat: Add 'rel' attribute to Button

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2758,8 +2758,8 @@ It prevents users from clicking the button.",
       "type": "string",
     },
     Object {
-      "description": "Adds a \`rel\` attribute to the link. If the \`rel\` property is provided, it overrides the default behaviour.
-By default, the component sets the \`rel\` attribute to \\"noopener noreferrer\\" when \`target\` is \`\\"_blank\\"\`.",
+      "description": "Adds a \`rel\` attribute to the link. By default, the component sets the \`rel\` attribute to \\"noopener noreferrer\\" when \`target\` is \`\\"_blank\\"\`.
+If the \`rel\` property is provided, it overrides the default behavior.",
       "name": "rel",
       "optional": true,
       "type": "string",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2758,6 +2758,13 @@ It prevents users from clicking the button.",
       "type": "string",
     },
     Object {
+      "description": "Adds a \`rel\` attribute to the link. If the \`rel\` property is provided, it overrides the default behaviour.
+By default, the component sets the \`rel\` attribute to \\"noopener noreferrer\\" when \`target\` is \`\\"_blank\\"\`.",
+      "name": "rel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Specifies where to open the linked URL (for example, to open in a new browser window or tab use \`_blank\`).
 This property only applies when an \`href\` is provided.",
       "name": "target",

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -368,6 +368,11 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).not.toHaveAttribute('rel');
     });
 
+    test('does not set the default "rel" attribute for "target=_blank" if a "rel" prop is provided', () => {
+      const wrapper = renderButton({ href: 'https://amazon.com', target: '_blank', rel: 'nofollow' });
+      expect(wrapper.getElement()).toHaveAttribute('rel', 'nofollow');
+    });
+
     test('can add a download attribute if it is a link', () => {
       let wrapper = renderButton({ download: 'fileName' });
       expect(wrapper.getElement()).not.toHaveAttribute('download');

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -25,6 +25,7 @@ const Button = React.forwardRef(
       wrapText = true,
       href,
       target,
+      rel,
       download,
       formAction = 'submit',
       ariaLabel,
@@ -54,6 +55,7 @@ const Button = React.forwardRef(
         wrapText={wrapText}
         href={href}
         target={target}
+        rel={rel}
         download={download}
         formAction={formAction}
         ariaLabel={ariaLabel}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -82,6 +82,12 @@ export interface ButtonProps extends BaseComponentProps {
   target?: string;
 
   /**
+   * Adds a `rel` attribute to the link. By default, the component sets the `rel` attribute to "noopener noreferrer" when `target` is `"_blank"`.
+   * If the `rel` property is provided, it overrides the default behaviour.
+   */
+  rel?: string;
+
+  /**
    * Specifies whether the linked URL, when selected, will prompt the user to download instead of navigate.
    * You can specify a string value that will be suggested as the name of the downloaded file.
    * This property only applies when an `href` is provided.

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -83,7 +83,7 @@ export interface ButtonProps extends BaseComponentProps {
 
   /**
    * Adds a `rel` attribute to the link. By default, the component sets the `rel` attribute to "noopener noreferrer" when `target` is `"_blank"`.
-   * If the `rel` property is provided, it overrides the default behaviour.
+   * If the `rel` property is provided, it overrides the default behavior.
    */
   rel?: string;
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -40,6 +40,7 @@ export const InternalButton = React.forwardRef(
       wrapText = true,
       href,
       target,
+      rel,
       download,
       formAction = 'submit',
       ariaLabel,
@@ -125,7 +126,7 @@ export const InternalButton = React.forwardRef(
             href={href}
             target={target}
             // security recommendation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
-            rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+            rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}
             tabIndex={isDisabled ? -1 : undefined}
             aria-disabled={isDisabled ? true : undefined}
             download={download}


### PR DESCRIPTION
### Description

Added a `rel` attribute to the `Button` component. 

Without this change, when we add an `href` to the `Button` component with a `target="_blank"`, the `Button` component automatically adds the `rel` value of `"noreferrer noopener"`, and doesn't offer the option of overwriting this value. Some customers need to alter this default behaviour, hence this change.

Our `Link` component already has a way to override the `rel` attribute but the `Button` does not have this prop, so this change will also play into consistency across our components.



Related issue: AWSUI-20328

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
