### PR TITLE
feat: Improve collection preferences modal responsiveness when only using some features

### DIFF
--- a/pages/collection-preferences/simple.page.tsx
+++ b/pages/collection-preferences/simple.page.tsx
@@ -100,7 +100,7 @@ export default function CollectionPreferencesPermutations() {
           customPreference={customPreference}
         />
         <CollectionPreferences
-          className={`cp-4`}
+          className="cp-4"
           {...baseProperties}
           visibleContentPreference={visibleContentPreference}
         />

--- a/pages/collection-preferences/simple.page.tsx
+++ b/pages/collection-preferences/simple.page.tsx
@@ -99,6 +99,11 @@ export default function CollectionPreferencesPermutations() {
           wrapLinesPreference={wrapLinesPreference}
           customPreference={customPreference}
         />
+        <CollectionPreferences
+          className={`cp-4`}
+          {...baseProperties}
+          visibleContentPreference={visibleContentPreference}
+        />
       </ScreenshotArea>
     </>
   );

--- a/src/collection-preferences/__integ__/collection-preferences.test.ts
+++ b/src/collection-preferences/__integ__/collection-preferences.test.ts
@@ -48,7 +48,7 @@ describe('Collection preferences', () => {
   );
 
   test(
-    'renders 2 columns',
+    'renders 2 columns if all preferences are present',
     setupTest(async page => {
       const wrapper = createWrapper().findCollectionPreferences('.cp-1');
       await page.waitForVisible(wrapper.findTriggerButton().toSelector());

--- a/src/collection-preferences/__integ__/collection-preferences.test.ts
+++ b/src/collection-preferences/__integ__/collection-preferences.test.ts
@@ -4,34 +4,46 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 
-class PageObject extends BasePageObject {}
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/collection-preferences/simple');
+    await page.setWindowSize({ width: 1200, height: 1200 });
+    await testFn(page);
+  });
+};
 
 describe('Collection preferences', () => {
   test(
-    'renders 1 column',
-    useBrowser(async browser => {
-      await browser.url('#/light/collection-preferences/simple');
-      const page = new PageObject(browser);
-      await page.setWindowSize({ width: 1200, height: 1200 });
-
+    'renders no columns if there is only custom content',
+    setupTest(async page => {
       const wrapper = createWrapper().findCollectionPreferences('.cp-3');
       await page.waitForVisible(wrapper.findTriggerButton().toSelector());
       await page.click(wrapper.findTriggerButton().toSelector());
       await expect(page.isExisting(wrapper.findModal().toSelector())).resolves.toBe(true);
 
+      // The content is small enough so that it doesn't need column layout
       const columnLayout = wrapper.findModal().findContent().findColumnLayout();
-      await expect(page.isExisting(columnLayout.findColumn(1).toSelector())).resolves.toBe(true);
-      await expect(page.isExisting(columnLayout.findColumn(2).toSelector())).resolves.toBe(false);
+      await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
+    })
+  );
+
+  test(
+    'renders no columns if there is only visible content preferences',
+    setupTest(async page => {
+      const wrapper = createWrapper().findCollectionPreferences('.cp-4');
+      await page.waitForVisible(wrapper.findTriggerButton().toSelector());
+      await page.click(wrapper.findTriggerButton().toSelector());
+
+      // The content is small enough so that it doesn't need column layout
+      const columnLayout = wrapper.findModal().findContent().findColumnLayout();
+      await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
     })
   );
 
   test(
     'renders 2 columns',
-    useBrowser(async browser => {
-      await browser.url('#/light/collection-preferences/simple');
-      const page = new PageObject(browser);
-      await page.setWindowSize({ width: 1200, height: 1200 });
-
+    setupTest(async page => {
       const wrapper = createWrapper().findCollectionPreferences('.cp-1');
       await page.waitForVisible(wrapper.findTriggerButton().toSelector());
       await page.click(wrapper.findTriggerButton().toSelector());

--- a/src/collection-preferences/__integ__/collection-preferences.test.ts
+++ b/src/collection-preferences/__integ__/collection-preferences.test.ts
@@ -25,6 +25,8 @@ describe('Collection preferences', () => {
       // The content is small enough so that it doesn't need column layout
       const columnLayout = wrapper.findModal().findContent().findColumnLayout();
       await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
+
+      await expect(page.isExisting(wrapper.findModal().findWrapLinesPreference().toSelector())).resolves.toBe(true);
     })
   );
 
@@ -38,6 +40,10 @@ describe('Collection preferences', () => {
       // The content is small enough so that it doesn't need column layout
       const columnLayout = wrapper.findModal().findContent().findColumnLayout();
       await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
+
+      await expect(page.isExisting(wrapper.findModal().findVisibleContentPreference().toSelector())).resolves.toBe(
+        true
+      );
     })
   );
 

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -70,7 +70,13 @@ export default function CollectionPreferences({
     setTemporaryPreferences(copyPreferences(preferences || {}));
   };
 
-  const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
+  const hasLeftContent = !!(
+    pageSizePreference ||
+    wrapLinesPreference ||
+    stripedRowsPreference ||
+    contentDensityPreference ||
+    customPreference
+  );
   const hasRightContent = !!visibleContentPreference;
 
   const onChange = (changedPreferences: CollectionPreferencesProps.Preferences) =>

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -73,7 +73,7 @@ export default function CollectionPreferences({
   const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
   const hasRightContent = !!visibleContentPreference;
 
-  const onChange = changedPreferences =>
+  const onChange = (changedPreferences: CollectionPreferencesProps.Preferences) =>
     setTemporaryPreferences(mergePreferences(changedPreferences, temporaryPreferences));
 
   return (

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -70,7 +70,6 @@ const ModalContent = ({
   }
 
   const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
-  // const hasRightContent = !!visibleContentPreference;
 
   return (
     <ModalContentLayout
@@ -133,7 +132,6 @@ export default function CollectionPreferences({
   confirmLabel,
   cancelLabel,
   disabled = false,
-  modalSize = 'large',
   onConfirm,
   onCancel,
   visibleContentPreference,
@@ -170,6 +168,9 @@ export default function CollectionPreferences({
     setModalVisible(false);
     setTemporaryPreferences(copyPreferences(preferences || {}));
   };
+
+  const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
+  const hasRightContent = !!visibleContentPreference;
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
@@ -214,7 +215,7 @@ export default function CollectionPreferences({
             </InternalBox>
           }
           closeAriaLabel={cancelLabel}
-          size={modalSize}
+          size={hasLeftContent && hasRightContent ? 'large' : 'medium'}
           onDismiss={onCancelListener}
         >
           <ModalContent

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -28,105 +28,6 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 
 export { CollectionPreferencesProps };
 
-interface ModalContentProps
-  extends Pick<
-    CollectionPreferencesProps,
-    | 'preferences'
-    | 'visibleContentPreference'
-    | 'pageSizePreference'
-    | 'wrapLinesPreference'
-    | 'stripedRowsPreference'
-    | 'contentDensityPreference'
-    | 'customPreference'
-  > {
-  onChange: (preferences: CollectionPreferencesProps.Preferences) => void;
-}
-
-const ModalContent = ({
-  preferences = {},
-  pageSizePreference,
-  wrapLinesPreference,
-  stripedRowsPreference,
-  contentDensityPreference,
-  customPreference,
-  visibleContentPreference,
-  onChange,
-}: ModalContentProps) => {
-  if (
-    !visibleContentPreference &&
-    !pageSizePreference &&
-    !wrapLinesPreference &&
-    !stripedRowsPreference &&
-    !contentDensityPreference &&
-    customPreference
-  ) {
-    return (
-      <CustomPreference
-        value={preferences.custom}
-        customPreference={customPreference}
-        onChange={custom => onChange({ custom })}
-      />
-    );
-  }
-
-  const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
-
-  return (
-    <ModalContentLayout
-      left={
-        hasLeftContent && (
-          <InternalSpaceBetween size="l">
-            {pageSizePreference && (
-              <PageSizePreference
-                value={preferences.pageSize}
-                {...pageSizePreference}
-                onChange={pageSize => onChange({ pageSize })}
-              />
-            )}
-            {wrapLinesPreference && (
-              <WrapLinesPreference
-                value={preferences.wrapLines}
-                {...wrapLinesPreference}
-                onChange={wrapLines => onChange({ wrapLines })}
-              />
-            )}
-            {stripedRowsPreference && (
-              <StripedRowsPreference
-                value={preferences.stripedRows}
-                {...stripedRowsPreference}
-                onChange={stripedRows => onChange({ stripedRows })}
-              />
-            )}
-            {contentDensityPreference && (
-              <ContentDensityPreference
-                value={preferences.contentDensity}
-                {...contentDensityPreference}
-                onChange={contentDensity => onChange({ contentDensity })}
-              />
-            )}
-            {customPreference && (
-              <CustomPreference
-                value={preferences.custom}
-                customPreference={customPreference}
-                onChange={custom => onChange({ custom })}
-              />
-            )}
-          </InternalSpaceBetween>
-        )
-      }
-      right={
-        visibleContentPreference && (
-          <VisibleContentPreference
-            value={preferences.visibleContent}
-            {...visibleContentPreference}
-            onChange={visibleContent => onChange({ visibleContent })}
-          />
-        )
-      }
-    />
-  );
-};
-
 export default function CollectionPreferences({
   title,
   confirmLabel,
@@ -171,6 +72,9 @@ export default function CollectionPreferences({
 
   const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
   const hasRightContent = !!visibleContentPreference;
+
+  const onChange = changedPreferences =>
+    setTemporaryPreferences(mergePreferences(changedPreferences, temporaryPreferences));
 
   return (
     <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
@@ -218,16 +122,56 @@ export default function CollectionPreferences({
           size={hasLeftContent && hasRightContent ? 'large' : 'medium'}
           onDismiss={onCancelListener}
         >
-          <ModalContent
-            preferences={temporaryPreferences}
-            visibleContentPreference={visibleContentPreference}
-            pageSizePreference={pageSizePreference}
-            wrapLinesPreference={wrapLinesPreference}
-            stripedRowsPreference={stripedRowsPreference}
-            contentDensityPreference={contentDensityPreference}
-            customPreference={customPreference}
-            onChange={changedPreferences =>
-              setTemporaryPreferences(mergePreferences(changedPreferences, temporaryPreferences))
+          <ModalContentLayout
+            left={
+              hasLeftContent && (
+                <InternalSpaceBetween size="l">
+                  {pageSizePreference && (
+                    <PageSizePreference
+                      value={temporaryPreferences.pageSize}
+                      {...pageSizePreference}
+                      onChange={pageSize => onChange({ pageSize })}
+                    />
+                  )}
+                  {wrapLinesPreference && (
+                    <WrapLinesPreference
+                      value={temporaryPreferences.wrapLines}
+                      {...wrapLinesPreference}
+                      onChange={wrapLines => onChange({ wrapLines })}
+                    />
+                  )}
+                  {stripedRowsPreference && (
+                    <StripedRowsPreference
+                      value={temporaryPreferences.stripedRows}
+                      {...stripedRowsPreference}
+                      onChange={stripedRows => onChange({ stripedRows })}
+                    />
+                  )}
+                  {contentDensityPreference && (
+                    <ContentDensityPreference
+                      value={temporaryPreferences.contentDensity}
+                      {...contentDensityPreference}
+                      onChange={contentDensity => onChange({ contentDensity })}
+                    />
+                  )}
+                  {customPreference && (
+                    <CustomPreference
+                      value={temporaryPreferences.custom}
+                      customPreference={customPreference}
+                      onChange={custom => onChange({ custom })}
+                    />
+                  )}
+                </InternalSpaceBetween>
+              )
+            }
+            right={
+              visibleContentPreference && (
+                <VisibleContentPreference
+                  value={temporaryPreferences.visibleContent}
+                  {...visibleContentPreference}
+                  onChange={visibleContent => onChange({ visibleContent })}
+                />
+              )
             }
           />
         </InternalModal>

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -69,46 +69,51 @@ const ModalContent = ({
     );
   }
 
+  const hasLeftContent = !!(pageSizePreference || wrapLinesPreference || stripedRowsPreference || customPreference);
+  // const hasRightContent = !!visibleContentPreference;
+
   return (
     <ModalContentLayout
       left={
-        <InternalSpaceBetween size="l">
-          {pageSizePreference && (
-            <PageSizePreference
-              value={preferences.pageSize}
-              {...pageSizePreference}
-              onChange={pageSize => onChange({ pageSize })}
-            />
-          )}
-          {wrapLinesPreference && (
-            <WrapLinesPreference
-              value={preferences.wrapLines}
-              {...wrapLinesPreference}
-              onChange={wrapLines => onChange({ wrapLines })}
-            />
-          )}
-          {stripedRowsPreference && (
-            <StripedRowsPreference
-              value={preferences.stripedRows}
-              {...stripedRowsPreference}
-              onChange={stripedRows => onChange({ stripedRows })}
-            />
-          )}
-          {contentDensityPreference && (
-            <ContentDensityPreference
-              value={preferences.contentDensity}
-              {...contentDensityPreference}
-              onChange={contentDensity => onChange({ contentDensity })}
-            />
-          )}
-          {customPreference && (
-            <CustomPreference
-              value={preferences.custom}
-              customPreference={customPreference}
-              onChange={custom => onChange({ custom })}
-            />
-          )}
-        </InternalSpaceBetween>
+        hasLeftContent && (
+          <InternalSpaceBetween size="l">
+            {pageSizePreference && (
+              <PageSizePreference
+                value={preferences.pageSize}
+                {...pageSizePreference}
+                onChange={pageSize => onChange({ pageSize })}
+              />
+            )}
+            {wrapLinesPreference && (
+              <WrapLinesPreference
+                value={preferences.wrapLines}
+                {...wrapLinesPreference}
+                onChange={wrapLines => onChange({ wrapLines })}
+              />
+            )}
+            {stripedRowsPreference && (
+              <StripedRowsPreference
+                value={preferences.stripedRows}
+                {...stripedRowsPreference}
+                onChange={stripedRows => onChange({ stripedRows })}
+              />
+            )}
+            {contentDensityPreference && (
+              <ContentDensityPreference
+                value={preferences.contentDensity}
+                {...contentDensityPreference}
+                onChange={contentDensity => onChange({ contentDensity })}
+              />
+            )}
+            {customPreference && (
+              <CustomPreference
+                value={preferences.custom}
+                customPreference={customPreference}
+                onChange={custom => onChange({ custom })}
+              />
+            )}
+          </InternalSpaceBetween>
+        )
       }
       right={
         visibleContentPreference && (
@@ -128,6 +133,7 @@ export default function CollectionPreferences({
   confirmLabel,
   cancelLabel,
   disabled = false,
+  modalSize = 'large',
   onConfirm,
   onCancel,
   visibleContentPreference,
@@ -208,7 +214,7 @@ export default function CollectionPreferences({
             </InternalBox>
           }
           closeAriaLabel={cancelLabel}
-          size="large"
+          size={modalSize}
           onDismiss={onCancelListener}
         >
           <ModalContent

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { ModalProps } from '../modal/interfaces';
 
 export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
   /**
@@ -20,6 +21,11 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Determines whether the preferences trigger button is disabled.
    */
   disabled?: boolean;
+  /**
+   * Determines the width of the preferences modal dialog.
+   * Refer to the [modal documentation](/components/modal/) for more details.
+   */
+  modalSize?: ModalProps.Size;
   /**
    * Configures the built-in "page size selection" preference.
    *

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
-import { ModalProps } from '../modal/interfaces';
 
 export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
   /**
@@ -21,11 +20,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Determines whether the preferences trigger button is disabled.
    */
   disabled?: boolean;
-  /**
-   * Determines the width of the preferences modal dialog.
-   * Refer to the [modal documentation](/components/modal/) for more details.
-   */
-  modalSize?: ModalProps.Size;
   /**
    * Configures the built-in "page size selection" preference.
    *

--- a/src/collection-preferences/utils.tsx
+++ b/src/collection-preferences/utils.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import InternalCheckbox from '../checkbox/internal';
 import InternalColumnLayout from '../column-layout/internal';
 import InternalFormField from '../form-field/internal';
@@ -49,8 +50,8 @@ export const ModalContentLayout = ({ left, right }: ModalContentLayoutProps) => 
   if (smallContainer) {
     return (
       <div ref={ref}>
-        <div>{left}</div>
-        {right && <div className={styles['second-column-small']}>{right}</div>}
+        {left && <div>{left}</div>}
+        {right && <div className={clsx(left && styles['second-column-small'])}>{right}</div>}
       </div>
     );
   }

--- a/src/collection-preferences/utils.tsx
+++ b/src/collection-preferences/utils.tsx
@@ -55,11 +55,11 @@ export const ModalContentLayout = ({ left, right }: ModalContentLayoutProps) => 
     );
   }
 
-  const columns = right ? 2 : 1;
+  const columns = left && right ? 2 : 1;
   return (
     <div ref={ref}>
       <InternalColumnLayout columns={columns} variant="text-grid">
-        <div>{left}</div>
+        {left && <div>{left}</div>}
         {right && <div>{right}</div>}
       </InternalColumnLayout>
     </div>


### PR DESCRIPTION
### Description

This change makes sure that the collection preferences modal switches to a one-column layout (instead of two columns) whenever possible. For example, when there is only content for the left-hand side (page sizes, custom preferences, ...), or when there's only content for the right-hand side (visible column preferences).

Additionally, the size of the modal is reduces from "large" to "medium" if only one column is rendered.

These changes removes some unused space and makes sure that we use the space more efficiently.

Related links, issue #, if available: AWSDesignSystem-369

Internal document: mp8XA9mFCRQI

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
