### PR TITLE
fix: Ensure correct selection and resize controls are focused when sticky header is enabled

### DIFF
--- a/pages/app-layout/with-table.page.tsx
+++ b/pages/app-layout/with-table.page.tsx
@@ -18,6 +18,7 @@ const items = generateItems(20);
 export default function () {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
+  const [selectedItems, setSelectedItems] = useState<Instance[]>([]);
 
   function openHelp(article: keyof typeof toolsContent) {
     setToolsOpen(true);
@@ -52,6 +53,10 @@ export default function () {
               </Header>
             }
             stickyHeader={true}
+            resizableColumns={true}
+            selectionType="multi"
+            selectedItems={selectedItems}
+            onSelectionChange={e => setSelectedItems(e.detail.selectedItems)}
             variant="full-page"
             columnDefinitions={columnsConfig}
             items={items}

--- a/pages/app-layout/with-table.page.tsx
+++ b/pages/app-layout/with-table.page.tsx
@@ -18,7 +18,6 @@ const items = generateItems(20);
 export default function () {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [selectedTool, setSelectedTool] = useState<keyof typeof toolsContent>('long');
-  const [selectedItems, setSelectedItems] = useState<Instance[]>([]);
 
   function openHelp(article: keyof typeof toolsContent) {
     setToolsOpen(true);
@@ -53,10 +52,6 @@ export default function () {
               </Header>
             }
             stickyHeader={true}
-            resizableColumns={true}
-            selectionType="multi"
-            selectedItems={selectedItems}
-            onSelectionChange={e => setSelectedItems(e.detail.selectedItems)}
             variant="full-page"
             columnDefinitions={columnsConfig}
             items={items}

--- a/pages/table/sticky-header-focusable-elements.page.tsx
+++ b/pages/table/sticky-header-focusable-elements.page.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Header from '~components/header';
+import Table from '~components/table';
+import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems, Instance } from './generate-data';
+import { columnsConfig, selectionLabels } from './shared-configs';
+
+const items = generateItems(20);
+
+export default function () {
+  const [selectedItems, setSelectedItems] = useState<Instance[]>([]);
+
+  return (
+    <>
+      <button id="focus-target">Focus target</button>
+      <ScreenshotArea style={{ padding: '10px 50px' }}>
+        <Table
+          header={<Header headingTagOverride="h1">Testing table</Header>}
+          columnDefinitions={columnsConfig}
+          ariaLabels={selectionLabels}
+          items={items}
+          resizableColumns={true}
+          stickyHeader={true}
+          selectedItems={selectedItems}
+          selectionType="multi"
+          onSelectionChange={e => setSelectedItems(e.detail.selectedItems)}
+        />
+        <div style={{ height: '90vh', padding: 10 }}>Placeholder to allow page scroll beyond table</div>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -14,7 +14,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 
 interface InternalProps extends CheckboxProps, InternalBaseComponentProps {
   tabIndex?: -1;
-  forceOutline?: boolean;
+  showOutline?: boolean;
 }
 
 const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
@@ -32,7 +32,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
       onBlur,
       onChange,
       tabIndex,
-      forceOutline,
+      showOutline,
       __internalRootRef,
       ...rest
     },
@@ -62,7 +62,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
         ariaLabel={ariaLabel}
         ariaLabelledby={ariaLabelledby}
         ariaDescribedby={ariaDescribedby}
-        forceOutline={forceOutline}
+        showOutline={showOutline}
         nativeControl={nativeControlProps => (
           <input
             {...nativeControlProps}

--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -14,6 +14,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 
 interface InternalProps extends CheckboxProps, InternalBaseComponentProps {
   tabIndex?: -1;
+  forceOutline?: boolean;
 }
 
 const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
@@ -31,6 +32,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
       onBlur,
       onChange,
       tabIndex,
+      forceOutline,
       __internalRootRef,
       ...rest
     },
@@ -60,6 +62,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
         ariaLabel={ariaLabel}
         ariaLabelledby={ariaLabelledby}
         ariaDescribedby={ariaDescribedby}
+        forceOutline={forceOutline}
         nativeControl={nativeControlProps => (
           <input
             {...nativeControlProps}

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -11,7 +11,7 @@ export interface AbstractSwitchProps extends React.HTMLAttributes<HTMLElement>, 
   controlId?: string;
   controlClassName: string;
   outlineClassName: string;
-  forceOutline?: boolean;
+  showOutline?: boolean;
   disabled?: boolean;
   nativeControl: (props: React.InputHTMLAttributes<HTMLInputElement>) => React.ReactElement;
   styledControl: React.ReactElement;
@@ -32,7 +32,7 @@ export default function AbstractSwitch({
   controlId,
   controlClassName,
   outlineClassName,
-  forceOutline,
+  showOutline,
   disabled,
   nativeControl,
   styledControl,
@@ -87,7 +87,7 @@ export default function AbstractSwitch({
             'aria-labelledby': ariaLabelledByIds.length ? joinString(ariaLabelledByIds) : undefined,
             'aria-label': ariaLabel,
           })}
-          <span className={clsx(styles.outline, outlineClassName, forceOutline && styles['force-outline'])} />
+          <span className={clsx(styles.outline, outlineClassName, showOutline && styles['show-outline'])} />
         </span>
         <span className={clsx(styles.content, !label && !description && styles['empty-content'])}>
           {label && (

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -11,6 +11,7 @@ export interface AbstractSwitchProps extends React.HTMLAttributes<HTMLElement>, 
   controlId?: string;
   controlClassName: string;
   outlineClassName: string;
+  forceOutline?: boolean;
   disabled?: boolean;
   nativeControl: (props: React.InputHTMLAttributes<HTMLInputElement>) => React.ReactElement;
   styledControl: React.ReactElement;
@@ -31,6 +32,7 @@ export default function AbstractSwitch({
   controlId,
   controlClassName,
   outlineClassName,
+  forceOutline,
   disabled,
   nativeControl,
   styledControl,
@@ -85,7 +87,7 @@ export default function AbstractSwitch({
             'aria-labelledby': ariaLabelledByIds.length ? joinString(ariaLabelledByIds) : undefined,
             'aria-label': ariaLabel,
           })}
-          <span className={clsx(styles.outline, outlineClassName)} />
+          <span className={clsx(styles.outline, outlineClassName, forceOutline && styles['force-outline'])} />
         </span>
         <span className={clsx(styles.content, !label && !description && styles['empty-content'])}>
           {label && (

--- a/src/internal/components/abstract-switch/styles.scss
+++ b/src/internal/components/abstract-switch/styles.scss
@@ -15,7 +15,7 @@
 
 .outline {
   display: none;
-  &.force-outline {
+  &.show-outline {
     display: block;
   }
 }

--- a/src/internal/components/abstract-switch/styles.scss
+++ b/src/internal/components/abstract-switch/styles.scss
@@ -15,11 +15,13 @@
 
 .outline {
   display: none;
+  &.force-outline {
+    display: block;
+  }
 }
 
 .native-input {
   @include focus-visible.when-visible {
-    /* stylelint-disable-next-line selector-max-type, @cloudscape-design/no-implicit-descendant */
     & + .outline {
       display: block;
     }

--- a/src/table/__integ__/sticky-header.test.ts
+++ b/src/table/__integ__/sticky-header.test.ts
@@ -118,14 +118,12 @@ describe('Sticky header', () => {
     setupTest(async page => {
       await page.click(togglePaginationSelector);
       await page.click(tableWrapper.findTextFilter().findInput().toSelector());
-      // skip preferences toggle
-      await page.keys(['Tab', 'Tab']);
+      // skip preferences toggle and table scrollable region
+      await page.keys(['Tab', 'Tab', 'Tab']);
       // select all checkbox
       await expect(
         page.isFocused(tableWrapper.findSelectAllTrigger().find('input').toSelector())
       ).resolves.toBeTruthy();
-      // skips table scrollable region
-      await page.keys('Tab');
       // column headers
       for (const column of ['ID', 'Type', 'DNS name', 'Image ID', 'State']) {
         await page.keys('Tab');

--- a/src/table/__integ__/sticky-header.test.ts
+++ b/src/table/__integ__/sticky-header.test.ts
@@ -4,6 +4,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import styles from '../../../lib/components/table/styles.selectors.js';
+import selectionStyles from '../../../lib/components/table/selection-control/styles.selectors.js';
 
 const tableWrapper = createWrapper().findTable();
 const tableScrollWrapper = tableWrapper.findByClassName(styles.wrapper);
@@ -26,8 +27,13 @@ class StickyHeaderPage extends BasePageObject {
         }));
     }, selector);
   }
+
   findTable() {
     return tableWrapper.toSelector();
+  }
+
+  findTableHiddenSelectAllTrigger() {
+    return tableWrapper.find(`.${styles.wrapper} .${selectionStyles.root} input`);
   }
 }
 
@@ -120,10 +126,8 @@ describe('Sticky header', () => {
       await page.click(tableWrapper.findTextFilter().findInput().toSelector());
       // skip preferences toggle and table scrollable region
       await page.keys(['Tab', 'Tab', 'Tab']);
-      // select all checkbox
-      await expect(
-        page.isFocused(tableWrapper.findSelectAllTrigger().find('input').toSelector())
-      ).resolves.toBeTruthy();
+      // find the hidden table select checkbox
+      await expect(page.isFocused(page.findTableHiddenSelectAllTrigger().getElement())).resolves.toBeTruthy();
       // column headers
       for (const column of ['ID', 'Type', 'DNS name', 'Image ID', 'State']) {
         await page.keys('Tab');

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -26,24 +26,30 @@ const column: TableProps.ColumnDefinition<typeof testItem> = {
   cell: item => item.test,
 };
 
-it('renders a fake focus outline on the sort control', () => {
-  const { container } = render(
+function TableWrapper({ children }: { children: React.ReactNode }) {
+  return (
     <table>
       <thead>
-        <tr>
-          <TableHeaderCell<typeof testItem>
-            focusedComponent={{ type: 'column', col: 0 }}
-            column={column}
-            colIndex={0}
-            tabIndex={0}
-            onFocusedComponentChange={() => {}}
-            updateColumn={() => {}}
-            onClick={() => {}}
-            onResizeFinish={() => {}}
-          />
-        </tr>
+        <tr>{children}</tr>
       </thead>
     </table>
+  );
+}
+
+it('renders a fake focus outline on the sort control', () => {
+  const { container } = render(
+    <TableWrapper>
+      <TableHeaderCell<typeof testItem>
+        focusedComponent={{ type: 'column', col: 0 }}
+        column={column}
+        colIndex={0}
+        tabIndex={0}
+        onFocusedComponentChange={() => {}}
+        updateColumn={() => {}}
+        onClick={() => {}}
+        onResizeFinish={() => {}}
+      />
+    </TableWrapper>
   );
   // Activate focus-visible
   fireEvent.keyDown(document.body, { key: 'Tab', keyCode: 65 });
@@ -52,23 +58,19 @@ it('renders a fake focus outline on the sort control', () => {
 
 it('renders a fake focus outline on the resize control', () => {
   const { container } = render(
-    <table>
-      <thead>
-        <tr>
-          <TableHeaderCell<typeof testItem>
-            focusedComponent={{ type: 'resizer', col: 0 }}
-            column={column}
-            colIndex={0}
-            tabIndex={0}
-            resizableColumns={true}
-            onFocusedComponentChange={() => {}}
-            updateColumn={() => {}}
-            onClick={() => {}}
-            onResizeFinish={() => {}}
-          />
-        </tr>
-      </thead>
-    </table>
+    <TableWrapper>
+      <TableHeaderCell<typeof testItem>
+        focusedComponent={{ type: 'resizer', col: 0 }}
+        column={column}
+        colIndex={0}
+        tabIndex={0}
+        resizableColumns={true}
+        onFocusedComponentChange={() => {}}
+        updateColumn={() => {}}
+        onClick={() => {}}
+        onResizeFinish={() => {}}
+      />
+    </TableWrapper>
   );
   // Activate focus-visible
   fireEvent.keyDown(document.body, { key: 'Tab', keyCode: 65 });

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { TableHeaderCell } from '../../../lib/components/table/header-cell';
+import { TableProps } from '../interfaces';
+
+import styles from '../../../lib/components/table/header-cell/styles.css.js';
+import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
+
+const testItem = {
+  test: 'test',
+};
+
+const column: TableProps.ColumnDefinition<typeof testItem> = {
+  id: 'test',
+  header: 'Test',
+  sortingField: 'test',
+  editConfig: {
+    ariaLabel: 'test input',
+    editIconAriaLabel: 'error',
+    editingCell: (item, { setValue, currentValue }: TableProps.CellContext<any>) => {
+      return <input type="text" value={currentValue ?? item.test} onChange={e => setValue(e.target.value)} />;
+    },
+  },
+  cell: item => item.test,
+};
+
+it('renders a fake focus outline on the sort control', () => {
+  const { container } = render(
+    <table>
+      <thead>
+        <tr>
+          <TableHeaderCell<typeof testItem>
+            focusedComponent={{ type: 'column', col: 0 }}
+            column={column}
+            colIndex={0}
+            tabIndex={0}
+            onFocusedComponentChange={() => {}}
+            updateColumn={() => {}}
+            onClick={() => {}}
+            onResizeFinish={() => {}}
+          />
+        </tr>
+      </thead>
+    </table>
+  );
+  // Activate focus-visible
+  fireEvent.keyDown(document.body, { key: 'Tab', keyCode: 65 });
+  expect(container.querySelector(`.${styles['header-cell-fake-focus']}`)).toBeInTheDocument();
+});
+
+it('renders a fake focus outline on the resize control', () => {
+  const { container } = render(
+    <table>
+      <thead>
+        <tr>
+          <TableHeaderCell<typeof testItem>
+            focusedComponent={{ type: 'resizer', col: 0 }}
+            column={column}
+            colIndex={0}
+            tabIndex={0}
+            resizableColumns={true}
+            onFocusedComponentChange={() => {}}
+            updateColumn={() => {}}
+            onClick={() => {}}
+            onResizeFinish={() => {}}
+          />
+        </tr>
+      </thead>
+    </table>
+  );
+  // Activate focus-visible
+  fireEvent.keyDown(document.body, { key: 'Tab', keyCode: 65 });
+  expect(container.querySelector(`.${resizerStyles['has-focus']}`)).toBeInTheDocument();
+});

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -10,7 +10,7 @@ import { getAriaSort, getSortingIconName, getSortingStatus, isSorted } from './u
 import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
-import { InteractiveElement } from '../thead';
+import { InteractiveComponent } from '../thead';
 
 interface TableHeaderCellProps<ItemType> {
   className?: string;
@@ -31,8 +31,8 @@ interface TableHeaderCellProps<ItemType> {
   resizableColumns?: boolean;
   isEditable?: boolean;
 
-  focusedElement?: InteractiveElement | null;
-  onFocusedElementChange?: (element: InteractiveElement | null) => void;
+  focusedComponent?: InteractiveComponent | null;
+  onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -44,8 +44,8 @@ export function TableHeaderCell<ItemType>({
   sortingDescending,
   sortingDisabled,
   wrapLines,
-  focusedElement,
-  onFocusedElementChange,
+  focusedComponent,
+  onFocusedComponentChange,
   hidden,
   onClick,
   colIndex,
@@ -95,8 +95,8 @@ export function TableHeaderCell<ItemType>({
       <div
         className={clsx(styles['header-cell-content'], {
           [styles['header-cell-fake-focus']]:
-            focusedElement?.type === 'column' &&
-            focusedElement.col === colIndex &&
+            focusedComponent?.type === 'column' &&
+            focusedComponent.col === colIndex &&
             focusVisible['data-awsui-focus-visible'],
         })}
         aria-label={
@@ -116,8 +116,8 @@ export function TableHeaderCell<ItemType>({
               role: 'button',
               ...focusVisible,
               onClick: handleClick,
-              onFocus: () => onFocusedElementChange?.({ type: 'column', col: colIndex }),
-              onBlur: () => onFocusedElementChange?.(null),
+              onFocus: () => onFocusedComponentChange?.({ type: 'column', col: colIndex }),
+              onBlur: () => onFocusedComponentChange?.(null),
             })}
       >
         <div className={clsx(styles['header-cell-text'], wrapLines && styles['header-cell-text-wrap'])} id={headerId}>
@@ -139,15 +139,15 @@ export function TableHeaderCell<ItemType>({
           <Resizer
             tabIndex={tabIndex}
             showFocusRing={
-              focusedElement?.type === 'resizer' &&
-              focusedElement.col === colIndex &&
+              focusedComponent?.type === 'resizer' &&
+              focusedComponent.col === colIndex &&
               focusVisible['data-awsui-focus-visible']
             }
             onDragMove={newWidth => updateColumn(colIndex, newWidth)}
             onFinish={onResizeFinish}
             ariaLabelledby={headerId}
-            onFocus={() => onFocusedElementChange?.({ type: 'resizer', col: colIndex })}
-            onBlur={() => onFocusedElementChange?.(null)}
+            onFocus={() => onFocusedComponentChange?.({ type: 'resizer', col: colIndex })}
+            onBlur={() => onFocusedComponentChange?.(null)}
             minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
           />
         </>

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -10,6 +10,7 @@ import { getAriaSort, getSortingIconName, getSortingStatus, isSorted } from './u
 import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
+import { InteractiveElement } from '../thead';
 
 interface TableHeaderCellProps<ItemType> {
   className?: string;
@@ -20,7 +21,6 @@ interface TableHeaderCellProps<ItemType> {
   sortingDescending?: boolean;
   sortingDisabled?: boolean;
   wrapLines?: boolean;
-  showFocusRing: boolean;
   hidden?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
   onResizeFinish: () => void;
@@ -30,6 +30,9 @@ interface TableHeaderCellProps<ItemType> {
   onBlur?: () => void;
   resizableColumns?: boolean;
   isEditable?: boolean;
+
+  focusedElement?: InteractiveElement | null;
+  onFocusedElementChange?: (element: InteractiveElement | null) => void;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -41,12 +44,11 @@ export function TableHeaderCell<ItemType>({
   sortingDescending,
   sortingDisabled,
   wrapLines,
-  showFocusRing,
+  focusedElement,
+  onFocusedElementChange,
   hidden,
   onClick,
   colIndex,
-  onFocus,
-  onBlur,
   updateColumn,
   resizableColumns,
   onResizeFinish,
@@ -92,7 +94,10 @@ export function TableHeaderCell<ItemType>({
     >
       <div
         className={clsx(styles['header-cell-content'], {
-          [styles['header-cell-fake-focus']]: showFocusRing && focusVisible['data-awsui-focus-visible'],
+          [styles['header-cell-fake-focus']]:
+            focusedElement?.type === 'column' &&
+            focusedElement.col === colIndex &&
+            focusVisible['data-awsui-focus-visible'],
         })}
         aria-label={
           column.ariaLabel
@@ -111,8 +116,8 @@ export function TableHeaderCell<ItemType>({
               role: 'button',
               ...focusVisible,
               onClick: handleClick,
-              onFocus,
-              onBlur,
+              onFocus: () => onFocusedElementChange?.({ type: 'column', col: colIndex }),
+              onBlur: () => onFocusedElementChange?.(null),
             })}
       >
         <div className={clsx(styles['header-cell-text'], wrapLines && styles['header-cell-text-wrap'])} id={headerId}>
@@ -132,9 +137,17 @@ export function TableHeaderCell<ItemType>({
       {resizableColumns && (
         <>
           <Resizer
+            tabIndex={tabIndex}
+            showFocusRing={
+              focusedElement?.type === 'resizer' &&
+              focusedElement.col === colIndex &&
+              focusVisible['data-awsui-focus-visible']
+            }
             onDragMove={newWidth => updateColumn(colIndex, newWidth)}
             onFinish={onResizeFinish}
             ariaLabelledby={headerId}
+            onFocus={() => onFocusedElementChange?.({ type: 'resizer', col: colIndex })}
+            onBlur={() => onFocusedElementChange?.(null)}
             minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
           />
         </>

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -283,8 +283,7 @@ const InternalTable = React.forwardRef(
               <Thead
                 ref={theadRef}
                 hidden={stickyHeader}
-                onCellFocus={colIndex => stickyHeaderRef.current?.setFocusedColumn(colIndex)}
-                onCellBlur={() => stickyHeaderRef.current?.setFocusedColumn(null)}
+                onFocusedElementChange={el => stickyHeaderRef.current?.setFocus(el)}
                 {...theadProps}
               />
               <tbody>

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -283,7 +283,7 @@ const InternalTable = React.forwardRef(
               <Thead
                 ref={theadRef}
                 hidden={stickyHeader}
-                onFocusedElementChange={el => stickyHeaderRef.current?.setFocus(el)}
+                onFocusedComponentChange={component => stickyHeaderRef.current?.setFocus(component)}
                 {...theadProps}
               />
               <tbody>

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -15,13 +15,27 @@ interface ResizerProps {
   onFinish: () => void;
   ariaLabelledby?: string;
   minWidth?: number;
+  tabIndex?: number;
+
+  showFocusRing?: boolean;
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 const AUTO_GROW_START_TIME = 10;
 const AUTO_GROW_INTERVAL = 10;
 const AUTO_GROW_INCREMENT = 5;
 
-export function Resizer({ onDragMove, onFinish, ariaLabelledby, minWidth = DEFAULT_WIDTH }: ResizerProps) {
+export function Resizer({
+  onDragMove,
+  onFinish,
+  ariaLabelledby,
+  minWidth = DEFAULT_WIDTH,
+  tabIndex,
+  showFocusRing,
+  onFocus,
+  onBlur,
+}: ResizerProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [headerCell, setHeaderCell] = useState<HTMLElement>();
   const autoGrowTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
@@ -124,7 +138,11 @@ export function Resizer({ onDragMove, onFinish, ariaLabelledby, minWidth = DEFAU
   }, [headerCell, isDragging, onDragStable, onFinishStable, resizerHasFocus, minWidth]);
   return (
     <span
-      className={clsx(styles.resizer, isDragging && styles['resizer-active'], resizerHasFocus && styles['has-focus'])}
+      className={clsx(
+        styles.resizer,
+        isDragging && styles['resizer-active'],
+        (resizerHasFocus || showFocusRing) && styles['has-focus']
+      )}
       onMouseDown={event => {
         if (event.button !== 0) {
           return;
@@ -139,9 +157,11 @@ export function Resizer({ onDragMove, onFinish, ariaLabelledby, minWidth = DEFAU
         setHeaderCellWidth(headerCell.getBoundingClientRect().width);
         setResizerHasFocus(true);
         setHeaderCell(headerCell);
+        onFocus?.();
       }}
       onBlur={() => {
         setResizerHasFocus(false);
+        onBlur?.();
       }}
       role="separator"
       aria-orientation="vertical"
@@ -150,7 +170,7 @@ export function Resizer({ onDragMove, onFinish, ariaLabelledby, minWidth = DEFAU
       // aria-valuetext is needed because the VO announces "collapsed" when only aria-valuenow set without aria-valuemax
       aria-valuetext={headerCellWidth.toString()}
       aria-valuemin={minWidth}
-      tabIndex={0}
+      tabIndex={tabIndex}
     />
   );
 }

--- a/src/table/selection-control/index.tsx
+++ b/src/table/selection-control/index.tsx
@@ -9,7 +9,7 @@ import RadioButton from '../../radio-group/radio-button';
 
 import { TableProps } from '../interfaces';
 import styles from './styles.css.js';
-import { InteractiveElement } from '../thead';
+import { InteractiveComponent } from '../thead';
 
 export interface SelectionControlProps {
   selectionType: TableProps['selectionType'];
@@ -24,8 +24,8 @@ export interface SelectionControlProps {
   ariaLabel?: string;
   tabIndex?: -1;
 
-  focusedElement?: InteractiveElement | null;
-  onFocusedElementChange?: (element: InteractiveElement | null) => void;
+  focusedComponent?: InteractiveComponent | null;
+  onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
 }
 
 export default function SelectionControl({
@@ -37,8 +37,8 @@ export default function SelectionControl({
   name,
   ariaLabel,
 
-  focusedElement,
-  onFocusedElementChange,
+  focusedComponent,
+  onFocusedComponentChange,
   ...sharedProps
 }: SelectionControlProps) {
   const controlId = useUniqueId();
@@ -85,9 +85,9 @@ export default function SelectionControl({
   const selector = isMultiSelection ? (
     <InternalCheckbox
       {...sharedProps}
-      forceOutline={focusedElement?.type === 'selection'}
-      onFocus={() => onFocusedElementChange?.({ type: 'selection' })}
-      onBlur={() => onFocusedElementChange?.(null)}
+      showOutline={focusedComponent?.type === 'selection'}
+      onFocus={() => onFocusedComponentChange?.({ type: 'selection' })}
+      onBlur={() => onFocusedComponentChange?.(null)}
       controlId={controlId}
       indeterminate={indeterminate}
     />

--- a/src/table/selection-control/index.tsx
+++ b/src/table/selection-control/index.tsx
@@ -9,6 +9,7 @@ import RadioButton from '../../radio-group/radio-button';
 
 import { TableProps } from '../interfaces';
 import styles from './styles.css.js';
+import { InteractiveElement } from '../thead';
 
 export interface SelectionControlProps {
   selectionType: TableProps['selectionType'];
@@ -22,6 +23,9 @@ export interface SelectionControlProps {
   onFocusDown?: KeyboardEventHandler;
   ariaLabel?: string;
   tabIndex?: -1;
+
+  focusedElement?: InteractiveElement | null;
+  onFocusedElementChange?: (element: InteractiveElement | null) => void;
 }
 
 export default function SelectionControl({
@@ -32,6 +36,9 @@ export default function SelectionControl({
   onFocusDown,
   name,
   ariaLabel,
+
+  focusedElement,
+  onFocusedElementChange,
   ...sharedProps
 }: SelectionControlProps) {
   const controlId = useUniqueId();
@@ -76,7 +83,14 @@ export default function SelectionControl({
   };
 
   const selector = isMultiSelection ? (
-    <InternalCheckbox {...sharedProps} controlId={controlId} indeterminate={indeterminate} />
+    <InternalCheckbox
+      {...sharedProps}
+      forceOutline={focusedElement?.type === 'selection'}
+      onFocus={() => onFocusedElementChange?.({ type: 'selection' })}
+      onBlur={() => onFocusedElementChange?.(null)}
+      controlId={controlId}
+      indeterminate={indeterminate}
+    />
   ) : (
     <RadioButton {...sharedProps} controlId={controlId} name={name} value={''} label={''} />
   );

--- a/src/table/sticky-header.tsx
+++ b/src/table/sticky-header.tsx
@@ -4,14 +4,14 @@ import clsx from 'clsx';
 import React, { forwardRef, useContext, useImperativeHandle, useRef, useState } from 'react';
 import { StickyHeaderContext } from '../container/use-sticky-header';
 import { TableProps } from './interfaces';
-import Thead, { InteractiveElement, TheadProps } from './thead';
+import Thead, { InteractiveComponent, TheadProps } from './thead';
 import { useStickyHeader } from './use-sticky-header';
 import styles from './styles.css.js';
 
 export interface StickyHeaderRef {
   scrollToTop(): void;
   scrollToRow(node: null | HTMLElement): void;
-  setFocus(element: InteractiveElement | null): void;
+  setFocus(element: InteractiveComponent | null): void;
 }
 
 interface StickyHeaderProps {
@@ -44,7 +44,7 @@ function StickyHeader(
   const secondaryTableRef = useRef<HTMLTableElement>(null);
   const { isStuck } = useContext(StickyHeaderContext);
 
-  const [focusedElement, setFocusedElement] = useState<InteractiveElement | null>(null);
+  const [focusedComponent, setFocusedComponent] = useState<InteractiveComponent | null>(null);
   const { scrollToRow, scrollToTop } = useStickyHeader(
     tableRef,
     theadRef,
@@ -56,7 +56,7 @@ function StickyHeader(
   useImperativeHandle(ref, () => ({
     scrollToTop,
     scrollToRow,
-    setFocus: setFocusedElement,
+    setFocus: setFocusedComponent,
   }));
 
   return (
@@ -73,7 +73,13 @@ function StickyHeader(
       onScroll={onScroll}
     >
       <table className={clsx(styles.table, styles['table-layout-fixed'])} role="table" ref={secondaryTableRef}>
-        <Thead ref={secondaryTheadRef} sticky={true} stuck={isStuck} {...theadProps} focusedElement={focusedElement} />
+        <Thead
+          ref={secondaryTheadRef}
+          sticky={true}
+          stuck={isStuck}
+          focusedComponent={focusedComponent}
+          {...theadProps}
+        />
       </table>
     </div>
   );

--- a/src/table/sticky-header.tsx
+++ b/src/table/sticky-header.tsx
@@ -4,14 +4,14 @@ import clsx from 'clsx';
 import React, { forwardRef, useContext, useImperativeHandle, useRef, useState } from 'react';
 import { StickyHeaderContext } from '../container/use-sticky-header';
 import { TableProps } from './interfaces';
-import Thead, { TheadProps } from './thead';
+import Thead, { InteractiveElement, TheadProps } from './thead';
 import { useStickyHeader } from './use-sticky-header';
 import styles from './styles.css.js';
 
 export interface StickyHeaderRef {
   scrollToTop(): void;
   scrollToRow(node: null | HTMLElement): void;
-  setFocusedColumn(columnIndex: null | number): void;
+  setFocus(element: InteractiveElement | null): void;
 }
 
 interface StickyHeaderProps {
@@ -44,7 +44,7 @@ function StickyHeader(
   const secondaryTableRef = useRef<HTMLTableElement>(null);
   const { isStuck } = useContext(StickyHeaderContext);
 
-  const [focusedColumn, setFocusedColumn] = useState<number | null>(null);
+  const [focusedElement, setFocusedElement] = useState<InteractiveElement | null>(null);
   const { scrollToRow, scrollToTop } = useStickyHeader(
     tableRef,
     theadRef,
@@ -53,7 +53,11 @@ function StickyHeader(
     wrapperRef
   );
 
-  useImperativeHandle(ref, () => ({ scrollToTop, scrollToRow, setFocusedColumn }));
+  useImperativeHandle(ref, () => ({
+    scrollToTop,
+    scrollToRow,
+    setFocus: setFocusedElement,
+  }));
 
   return (
     <div
@@ -69,7 +73,7 @@ function StickyHeader(
       onScroll={onScroll}
     >
       <table className={clsx(styles.table, styles['table-layout-fixed'])} role="table" ref={secondaryTableRef}>
-        <Thead ref={secondaryTheadRef} sticky={true} stuck={isStuck} showFocusRing={focusedColumn} {...theadProps} />
+        <Thead ref={secondaryTheadRef} sticky={true} stuck={isStuck} {...theadProps} focusedElement={focusedElement} />
       </table>
     </div>
   );

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -14,7 +14,7 @@ import styles from './styles.css.js';
 import headerCellStyles from './header-cell/styles.css.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
 
-export type InteractiveElement =
+export type InteractiveComponent =
   | { type: 'selection' }
   | { type: 'column'; col: number }
   | { type: 'resizer'; col: number };
@@ -39,8 +39,8 @@ export interface TheadProps {
   singleSelectionHeaderAriaLabel?: string;
   stripedRows?: boolean;
 
-  focusedElement?: InteractiveElement | null;
-  onFocusedElementChange?: (element: InteractiveElement | null) => void;
+  focusedComponent?: InteractiveComponent | null;
+  onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
 }
 
 const Thead = React.forwardRef(
@@ -65,8 +65,8 @@ const Thead = React.forwardRef(
       hidden = false,
       stuck = false,
 
-      focusedElement,
-      onFocusedElementChange,
+      focusedComponent,
+      onFocusedComponentChange,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
@@ -101,8 +101,8 @@ const Thead = React.forwardRef(
                 onFocusDown={event => {
                   onFocusMove!(event.target as HTMLElement, -1, +1);
                 }}
-                focusedElement={focusedElement}
-                onFocusedElementChange={onFocusedElementChange}
+                focusedComponent={focusedComponent}
+                onFocusedComponentChange={onFocusedComponentChange}
                 {...selectAllProps}
                 {...(sticky ? { tabIndex: -1 } : {})}
               />
@@ -138,8 +138,8 @@ const Thead = React.forwardRef(
                   maxWidth: resizableColumns || sticky ? undefined : column.maxWidth,
                 }}
                 tabIndex={sticky ? -1 : 0}
-                focusedElement={focusedElement}
-                onFocusedElementChange={onFocusedElementChange}
+                focusedComponent={focusedComponent}
+                onFocusedComponentChange={onFocusedComponentChange}
                 column={column}
                 activeSortingColumn={sortingColumn}
                 sortingDescending={sortingDescending}


### PR DESCRIPTION
### Description

Basically, this implementation manually tracks the three kinds of focusable elements in the header: selection checkbox, sort button, resize control — and passes it to the sticky header, which draws fake focus rings around them. This means keyboard users always interact with the "real" controls, but the focus visuals are always visible. Mouse interaction still means that focus is placed inside an aria-hidden region, but... baby steps. This is the clearest approach for now, since we're sorta stuck with using the fake floating header (can't use `position: sticky` because of an inner scroll container).

After shipping the immediate fix, it might be nice to pass the focus to the "real" control on click so that you can switch between keyboard/mouse, but that might introduce weird unintended consequences. So I'll play it safe and leave that out of this one.

It's a shame that we have to have a fake header, but it's the best way to maintain the current design and keep scroll lag-free: I did work on a quick test that always used a real header (see [table-sticky-refactor](https://github.com/cloudscape-design/components/tree/table-sticky-refactor)), but it means sticky needs to be implemented with JS scroll handlers.

Related links, issue #, if available: AWSUI-20270

### How has this been tested?

Fixing some existing tests where we check that the tab order is as expected. For the actual simulated focus outlines, visual tests are probably the least brittle way of checking this, especially since the change spans multiple components.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
