### PR TITLE
fix: Changed container bottom spacing for fit height mode

### DIFF
--- a/pages/container/fit-height.page.tsx
+++ b/pages/container/fit-height.page.tsx
@@ -1,46 +1,80 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext } from 'react';
 import ColumnLayout from '~components/column-layout';
-import Container from '~components/container';
+import Container, { ContainerProps } from '~components/container';
 import Grid from '~components/grid';
 import Header from '~components/header';
 import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
 import styles from './fit-height.scss';
 
+type DemoContext = React.Context<AppContextType<{ hideFooters: boolean; disableContentPaddings: boolean }>>;
+
+function ContainerPlayground(props: ContainerProps) {
+  const { urlParams } = useContext(AppContext as DemoContext);
+  return (
+    <Container
+      {...props}
+      disableContentPaddings={urlParams.disableContentPaddings}
+      footer={urlParams.hideFooters ? null : props.footer}
+    />
+  );
+}
+
 function SmallContainer() {
   return (
-    <Container fitHeight={true} header={<Header>Short</Header>} footer="footer">
+    <ContainerPlayground fitHeight={true} header={<Header>Short</Header>} footer="footer">
       <p>One line of text</p>
-    </Container>
+    </ContainerPlayground>
   );
 }
 
 function MediumContainer() {
   return (
-    <Container fitHeight={true} header={<Header>Mid size</Header>} footer="footer">
+    <ContainerPlayground fitHeight={true} header={<Header>Mid size</Header>} footer="footer">
       <p>Content placeholder</p>
       <div style={{ height: 100 }} className={styles.placeholder}></div>
-    </Container>
+    </ContainerPlayground>
   );
 }
 
 function LargeContainer() {
   return (
-    <Container fitHeight={true} header={<Header>Large</Header>} footer="footer">
+    <ContainerPlayground fitHeight={true} header={<Header>Large</Header>} footer="footer">
       <p>
         This container overflows available space. <Link href="#">Learn more</Link>.
       </p>
       <div style={{ height: 400 }} className={styles.placeholder}></div>
-    </Container>
+    </ContainerPlayground>
   );
 }
 
 export default function () {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   return (
     <article>
       <h1>Fit height property demo</h1>
+      <SpaceBetween size="s" direction="horizontal">
+        <label>
+          <input
+            type="checkbox"
+            checked={urlParams.hideFooters ?? false}
+            onChange={event => setUrlParams({ hideFooters: event.target.checked })}
+          />{' '}
+          Hide footers
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={urlParams.disableContentPaddings ?? false}
+            onChange={event => setUrlParams({ disableContentPaddings: event.target.checked })}
+          />{' '}
+          Disable content paddings
+        </label>
+      </SpaceBetween>
       <ScreenshotArea>
         <h2>Inside display:grid</h2>
         <div className={styles.grid}>

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -89,7 +89,9 @@ export default function InternalContainer({
         styles.root,
         styles[`variant-${variant}`],
         fitHeight && styles['fit-height'],
-        isSticky && [styles['sticky-enabled']]
+        isSticky && [styles['sticky-enabled']],
+        !disableContentPaddings && styles['with-content-paddings'],
+        footer && styles['with-footer']
       )}
       ref={mergedRef}
     >
@@ -116,13 +118,7 @@ export default function InternalContainer({
           </div>
         </StickyHeaderContext.Provider>
       )}
-      <div
-        className={clsx(styles.content, {
-          [styles['with-paddings']]: !disableContentPaddings,
-        })}
-      >
-        {children}
-      </div>
+      <div className={styles.content}>{children}</div>
       {footer && (
         <div
           className={clsx(styles.footer, {

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -154,12 +154,18 @@ the default white background of the container component.
     flex: 1;
     overflow: auto;
   }
-  &.with-paddings {
+  .with-content-paddings > & {
     padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
+  }
+  .with-content-paddings > .header + & {
+    padding-top: awsui.$space-container-content-top;
+  }
+}
 
-    .header + & {
-      padding-top: awsui.$space-container-content-top;
-    }
+.fit-height.with-content-paddings:not(.with-footer) {
+  padding-bottom: awsui.$space-scaled-l;
+  & > .content {
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
### Description

If container has no footer, ensure it still has some spacing outside the scroll fold

Related links, issue #, if available: n/a

### How has this been tested?

1. Visit [container/fit-height](https://d21d5uik3ws71m.cloudfront.net/components/c86eeea228e412b01ce7ae0e95bad699206e22e5/index.html#/light/container/fit-height) demo page to try new behaviors
2. I also deployed it for screenshot tests in my dev-pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
