### PR TITLE
fix: Remove update outside of act() for components using useReducedMotion in JSDOM

### DIFF
--- a/src/internal/motion.ts
+++ b/src/internal/motion.ts
@@ -4,4 +4,4 @@ import { findUpUntil } from './utils/dom';
 
 export const isMotionDisabled = (element: HTMLElement): boolean =>
   !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
-  (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)')?.matches);
+  (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false);


### PR DESCRIPTION
### Description

`window.matchMedia` isn't defined in JSDOM. We do have a check for this in TypeScript, but the way we constructed that check means that the function could return undefined. And setState doesn't "dedupe" `undefined` and `false`, so MutationObserver ends up updating the state after the React render.

This feels like debugging incorrect type issues in JavaScript again, but JSDOM quirks are hopefully few and far between...

Related links, issue #, if available: AWSUI-20146 (partial fix)

### How has this been tested?

Manually, in a demo app. But the semantics shouldn't have changed :)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
