### PR TITLE
fix: Remove mutation observer from useVisualContext

### DIFF
--- a/src/internal/components/visual-context/index.tsx
+++ b/src/internal/components/visual-context/index.tsx
@@ -1,24 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useState } from 'react';
-import { useMutationObserver } from '../../hooks/use-mutation-observer';
+import React, { useLayoutEffect, useState } from 'react';
 import { findUpUntil } from '../../utils/dom';
-
-export const useVisualContext = (elementRef: React.RefObject<HTMLElement>) => {
-  const contextMatch = /awsui-context-([\w-]+)/;
-  const [value, setValue] = useState('');
-  useMutationObserver(elementRef, node => {
-    const contextParent = findUpUntil(node, node => !!node.className.match(contextMatch));
-    setValue(contextParent ? contextParent.className.match(contextMatch)![1] : '');
-  });
-  return value;
-};
 
 interface VisualContextProps {
   contextName: string;
   className?: string;
   children: React.ReactNode;
+}
+
+const contextMatch = /awsui-context-([\w-]+)/;
+
+export function useVisualContext(elementRef: React.RefObject<HTMLElement>) {
+  const [value, setValue] = useState('');
+
+  useLayoutEffect(() => {
+    if (elementRef.current) {
+      const contextParent = findUpUntil(elementRef.current, node => !!node.className.match(contextMatch));
+      setValue(contextParent?.className.match(contextMatch)![1] ?? '');
+    }
+  }, [elementRef]);
+
+  return value;
 }
 
 /**


### PR DESCRIPTION
### Description

With React 18, `useMutationObserver` seems to be firing its callback _after_ the rendering is complete, which causes it to throw "an update was not wrapped in act(...)" errors in the top navigation component, since it renders a dropdown inside a custom visual context. So the visual context is initially `""`, but is updated after render to be `"top-navigation"`.

Unlike other "settings" (mode, motion, and density), visual contexts are used internally within the components in pretty close proximity to the children and aren't really updated outside of the React loop, so we could just get away with a simple `useLayoutEffect` instead of a mutation observer.

Related links, issue #, if available: AWSUI-20146 (partial fix)

### How has this been tested?

Existing tests should cover this. Also tested this in a demo application, which stops it from throwing "an update was not wrapped in act(...)" errors. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
