### PR TITLE
fix: Notifications bar height

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -137,6 +137,8 @@ the grid layout will be:
     cursor: pointer;
     margin-top: 0;
     margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   > .status {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

The visual implementation of the Notifications bar is based on the button's implementation, and it is supposed to have the same height as well (22px, excluding padding and border). However, there is a `button` element inside the Notifications bar without a padding defined, which gets the browser default of 1px of vertical padding, making the Notifications bar 2px taller than it should be. This also caused the text to not be fully vertically centered.

This fixes it by explicitly setting this internal button's vertical padding to 0.

Before:

![localhost_8080_ (6)](https://user-images.githubusercontent.com/1257272/219430571-43efcd24-b1b3-4540-ba12-26f6372e885c.png)
![localhost_8080_ (7)](https://user-images.githubusercontent.com/1257272/219430668-d6b08d91-e8b7-416f-ac0d-9344efb8d1d6.png)

After:

![localhost_8080_ (8)](https://user-images.githubusercontent.com/1257272/219452593-190f17d4-c4ba-4068-9027-1d0303124d44.png)
![localhost_8080_ (9)](https://user-images.githubusercontent.com/1257272/219452600-aff43a03-4373-4351-84ff-01bad4a058f5.png)

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Manually tested, in Classic as well as Visual Refresh
- Visual regression tests will catch the differences and will have to be reviewed and manually approved

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
