### PR TITLE
fix: Display notifications on top of split panel

### DIFF
--- a/src/app-layout/notifications/styles.scss
+++ b/src/app-layout/notifications/styles.scss
@@ -8,7 +8,7 @@
 
 .notifications,
 .notifications-sticky {
-  z-index: 825;
+  z-index: 850;
 }
 
 .notifications {

--- a/src/app-layout/styles.scss
+++ b/src/app-layout/styles.scss
@@ -7,7 +7,7 @@
 @use '../internal/styles/tokens' as awsui;
 @use './constants' as constants;
 
-$drawer-z-index: 850;
+$drawer-z-index: 830;
 // should be above mobile toolbar
 $drawer-z-index-mobile: 1001;
 

--- a/src/app-layout/styles.scss
+++ b/src/app-layout/styles.scss
@@ -7,7 +7,6 @@
 @use '../internal/styles/tokens' as awsui;
 @use './constants' as constants;
 
-// should be above sticky notifications
 $drawer-z-index: 850;
 // should be above mobile toolbar
 $drawer-z-index-mobile: 1001;

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -15,13 +15,13 @@
   height: var(#{custom-props.$contentHeight});
   position: sticky;
   top: var(#{custom-props.$offsetTop});
-  z-index: 850;
+  z-index: 830;
 
   /*
   The navigation and tools containers (that contain the toggle buttons)
   stretch the full height of the app layout. Normally, this wouldn't be an
   issue because they sit above the app layout's content padding.
-  
+
   But if disableContentPaddings is set to true and there are buttons on the
   left/right edges of the screen, they will be covered by the containers. So
   we need to disable pointer events in the container and re-enable them in
@@ -60,7 +60,7 @@ nav.show-navigation {
   }
 
   /*
-  Apply the animation only in desktop viewports because the AppBar will 
+  Apply the animation only in desktop viewports because the AppBar will
   take control in responsive viewports.
   */
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
@@ -117,8 +117,8 @@ nav.navigation {
   }
 
   /*
-  A non-semantic node is added with a fixed width equal to the final Navigation 
-  width. This will create the visual appearance of horizontal movement and 
+  A non-semantic node is added with a fixed width equal to the final Navigation
+  width. This will create the visual appearance of horizontal movement and
   prevent unwanted text wrapping.
   */
   > .animated-content {

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -10,7 +10,7 @@
 .notifications {
   grid-column: 3;
   grid-row: 1;
-  z-index: 860;
+  z-index: 850;
 
   /*
   In desktop viewports the notifications will always be the first

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -10,11 +10,11 @@
 .notifications {
   grid-column: 3;
   grid-row: 1;
-  z-index: 825;
+  z-index: 860;
 
   /*
-  In desktop viewports the notifications will always be the first 
-  slot rendered in the center column. The padding should create 
+  In desktop viewports the notifications will always be the first
+  slot rendered in the center column. The padding should create
   a centered vertical alignment with the circular buttons for the
   navigation and tools drawers.
   */
@@ -22,8 +22,8 @@
     margin: awsui.$space-xs 0;
 
     /*
-    #{awsui.$space-xs} token needs to align with the $offsetTopWithNotifications 
-    calculation in the layout CSS. 
+    #{awsui.$space-xs} token needs to align with the $offsetTopWithNotifications
+    calculation in the layout CSS.
     */
     &.sticky-notifications {
       position: sticky;
@@ -37,8 +37,8 @@
   }
 
   /*
-  In mobile viewports the notifications should never be sticky even 
-  if the property is set. Padding is added to give adequate 
+  In mobile viewports the notifications should never be sticky even
+  if the property is set. Padding is added to give adequate
   vertical space from the sticky AppBar the subsequent adjacent sibling.
   */
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -8,9 +8,9 @@
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 /*
-When the Split Panel is in the bottom position it was share the same row 
-as the content area. This row is defined as 1 fractional unit which will 
-consume the remaining vertical space in the grid after the notifications 
+When the Split Panel is in the bottom position it was share the same row
+as the content area. This row is defined as 1 fractional unit which will
+consume the remaining vertical space in the grid after the notifications
 and breadcrumbs.
 */
 section.split-panel-bottom {
@@ -24,13 +24,13 @@ section.split-panel-bottom {
   grid-column: 1 / 6;
   grid-row: 5;
   height: auto;
-  /* 
+  /*
   The position sticky will work in conjunction with the align self: end; property.
-  If the grid row scrolls beyond the viewport, the sticky bottom position 
+  If the grid row scrolls beyond the viewport, the sticky bottom position
   will lift it up above the footer so it is always visible.
   */
   position: sticky;
-  z-index: 851;
+  z-index: 840;
 
   // Animation for the height when opening the split panel
   @keyframes openSplitPanelBottom {
@@ -57,7 +57,7 @@ section.split-panel-bottom {
   }
 
   /*
-  Unlike the side position the Split Panel is persistent in the DOM 
+  Unlike the side position the Split Panel is persistent in the DOM
   when in the bottom position.
   */
   &.position-bottom {
@@ -65,11 +65,11 @@ section.split-panel-bottom {
   }
 
   /*
-  Warning! This is a hack! The existing design token for the split panel 
+  Warning! This is a hack! The existing design token for the split panel
   shadow in the bottom position does not render in the refactored code.
-  It appears to be related to the fact that the legacy split panel element 
-  has a height equal to the expanded height and a corresponding translation 
-  of the Y position so it is moved off the screen. This will need to be 
+  It appears to be related to the fact that the legacy split panel element
+  has a height equal to the expanded height and a corresponding translation
+  of the Y position so it is moved off the screen. This will need to be
   refactored with an adjustment to the split panel design token.
   */
   &:not(.is-split-panel-open).position-bottom {
@@ -114,8 +114,8 @@ section.split-panel-side {
   }
 
   /*
-  The min and max widths are applied when the Split Panel is opened otherwise 
-  it would not be possible to animate the width and the box shadow would 
+  The min and max widths are applied when the Split Panel is opened otherwise
+  it would not be possible to animate the width and the box shadow would
   be persistent in the DOM when closed.
   */
   &.is-split-panel-open.position-side {
@@ -130,8 +130,8 @@ section.split-panel-side {
   }
 
   /*
-  A non-semantic node is added with a fixed width equal to the final Split Panel 
-  width. This will create the visual appearance of horizontal movement and 
+  A non-semantic node is added with a fixed width equal to the final Split Panel
+  width. This will create the visual appearance of horizontal movement and
   prevent unwanted text wrapping.
   */
   > .animated-content {

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -8,12 +8,12 @@
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 /*
-The Tools component container has a max width calculation that depends on the 
+The Tools component container has a max width calculation that depends on the
 state of the other siblings within the Layout grid definition. The layout width
-is set in the resize observer in the Layout component. The main offset left 
-will calculate the distance from the start of the Layout component. The minimum 
+is set in the resize observer in the Layout component. The main offset left
+will calculate the distance from the start of the Layout component. The minimum
 content width has a default value that can be set directly with the minContentWidth
-property. The content gap right is computed in the Layout styles based on the 
+property. The content gap right is computed in the Layout styles based on the
 viewport size and state of the Tools drawer.
 */
 .tools-container {
@@ -31,7 +31,7 @@ viewport size and state of the Tools drawer.
   max-width: var(#{custom-props.$toolsMaxWidth});
   position: sticky;
   top: var(#{custom-props.$offsetTop});
-  z-index: 850;
+  z-index: 830;
 
   pointer-events: none;
 
@@ -91,8 +91,8 @@ viewport size and state of the Tools drawer.
   }
 
   /*
-  A non-semantic node is added with a fixed width equal to the final Tools 
-  width. This will create the visual appearance of horizontal movement and 
+  A non-semantic node is added with a fixed width equal to the final Tools
+  width. This will create the visual appearance of horizontal movement and
   prevent unwanted text wrapping.
   */
   > .animated-content {
@@ -101,7 +101,7 @@ viewport size and state of the Tools drawer.
 
   /*
   A right border is needed if the Tools is open and the buttons are persistent in
-  the DOM. This creates a visual vertical boundary between the Tools and the Buttons 
+  the DOM. This creates a visual vertical boundary between the Tools and the Buttons
   only when they are both present. This is the circumstance when there is a Split Panel
   in the side position.
   */
@@ -125,8 +125,8 @@ viewport size and state of the Tools drawer.
 }
 
 /*
-Warning! If these design tokens for padding change it will adversely impact 
-the calculation used to determine the Split Panel maximum width in the 
+Warning! If these design tokens for padding change it will adversely impact
+the calculation used to determine the Split Panel maximum width in the
 handleSplitPanelMaxWidth function in the context.
 */
 .show-tools {
@@ -149,7 +149,7 @@ handleSplitPanelMaxWidth function in the context.
   }
 
   /*
-  Apply the animation only in desktop viewports because the AppBar will 
+  Apply the animation only in desktop viewports because the AppBar will
   take control in responsive viewports.
   */
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -52,7 +52,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   word-wrap: break-word;
   background-color: awsui.$color-background-layout-panel-content;
   // should be above tools and navigation panels to avoid their shadows
-  z-index: 851;
+  z-index: 840;
   &-closed {
     cursor: pointer;
     min-width: constants.$sidebar-size-closed;
@@ -114,7 +114,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   }
 
   /*
-  Removed the position fixed with the AppLayout refactor because the 
+  Removed the position fixed with the AppLayout refactor because the
   SplitPanel is no longer in fixed position in the DOM.
   */
   &.refresh {


### PR DESCRIPTION
### Description

In the App layout, currently the Split panel has a higher z-index (851) than the Flashbar (825). This causes usability issues when a certain number of notifications are displayed, since they are partly covered by the Split panel. If using the Stacked notifications feature, this can also lead to the Notifications bar falling out of reach.

This change fixes this by reordering the following z-indices:

- Side navigation and Tools drawer: from 850 down to 830
- Split panel: from 851 down to 840
- Notifications: from 825 up to 850

This leaves all of them within the range of 800-850 as stated by our [documentation](https://cloudscape.design/get-started/dev-guides/z-index). This is still a safe distance to the next higher z-index elements such as Mobile toolbar, Popover and Top navigation drawer, which start at z-index 1000 and above.

**Note: This fix does have a (very subtle) visual side effect** in Classic, which has been thoroughly discussed with and approved by Visual design because the Flashbar is pushed not only on top of the Split panel but also on top of the Side navigation and the Help panel (both with z-index 850): the Side navigation and Help panel used to cast a very subtle, 2-pixel shadow on the Flashbar, and now this will be the other way around, the Flashbar casting a subtle shadow on the Side navigation and the Help panel.

This change has been approved by both UX and Visual design.

Before:
![Screenshot 2023-02-17 at 09 54 04](https://user-images.githubusercontent.com/1257272/219598680-cc58c5f9-43b6-4339-8e7f-4b455bf18b11.png)

After:
![Screenshot 2023-02-17 at 09 53 49](https://user-images.githubusercontent.com/1257272/219598723-db30d8e2-8ccc-4f07-ad91-ffd1999e6399.png)

An alternative approach would have been to push the Split panel below (z-index less than 825), but this would also have had a visual side effect where the Side navigation and Help panel would cast their shadow on the Split panel. Visual design preferred the former option.

There is no way to fix this without visual side effects, because if Flashbar is on top of Split panel and Split panel is on top of Side navigation and Help panel, then Side navigation and Help panel cannot keep being on top of Flashbar (this would create an impossible circular stack).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

### How has this been tested?

<!-- How did you test to verify your changes? -->

- Manually tested the desired effect
- Ran visual regression tests and inspected that the failures were as expected

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
