### PR TITLE
fix: Responsiveness of Flashbar notification bar

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -122,13 +122,15 @@ the grid layout will be:
   color: awsui.$color-text-layout-toggle;
   cursor: pointer;
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   grid-column: 2;
   grid-row: 2;
-  gap: awsui.$space-xxs;
+  column-gap: calc(#{awsui.$space-m} + #{awsui.$space-xxs});
   letter-spacing: awsui.$font-button-letter-spacing;
   margin-left: auto;
   margin-right: auto;
+  row-gap: 0;
   text-align: center;
   text-decoration: none;
   z-index: 1;
@@ -146,7 +148,12 @@ the grid layout will be:
   }
 
   > .status {
-    display: inline-block;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: awsui.$space-m;
+    justify-content: center;
+    row-gap: 0;
 
     > .header {
       font-weight: awsui.$font-button-weight;
@@ -154,8 +161,6 @@ the grid layout will be:
     }
 
     > .item-count {
-      margin-left: awsui.$space-m;
-      margin-right: awsui.$space-m;
       white-space: nowrap;
 
       > .type-count {

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -9,9 +9,12 @@
 @use '../internal/styles/typography' as typography;
 @use './collapsible.motion';
 
+$collapsed-item-overflow: 10px;
+
 .stack {
+  $notification-bar-horizontal-margin: 3 * $collapsed-item-overflow;
   display: grid;
-  grid-template-columns: 1fr minmax(70px, auto) 1fr;
+  grid-template-columns: $notification-bar-horizontal-margin 1fr $notification-bar-horizontal-margin;
 }
 
 .stack > .expanded {
@@ -33,13 +36,14 @@ the grid layout will be:
 [10px] [item 2 start] [10px] [fractional unit] [10px] [item 2 end] [10px]
 [10px] [10px] [item 3 start] [fractional unit] [item 3 end] [10px] [10px]
 */
+
 .stack > .collapsed {
   display: grid;
   grid-column: 1 / 4;
   grid-template-columns:
-    repeat(var(#{custom-props.$flashbarStackDepth}), 10px)
+    repeat(var(#{custom-props.$flashbarStackDepth}), $collapsed-item-overflow)
     1fr
-    repeat(var(#{custom-props.$flashbarStackDepth}), 10px);
+    repeat(var(#{custom-props.$flashbarStackDepth}), $collapsed-item-overflow);
   row-gap: 8px;
   z-index: 0;
 

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -160,17 +160,15 @@ the grid layout will be:
       display: inline-block;
     }
 
-    > .item-count {
+    > .item-count > .type-count {
       white-space: nowrap;
 
-      > .type-count {
-        > .count-number {
-          margin-left: awsui.$space-xxs;
-        }
+      > .count-number {
+        margin-left: awsui.$space-xxs;
+      }
 
-        &:not(:last-child) {
-          margin-right: awsui.$space-s;
-        }
+      &:not(:last-child) {
+        margin-right: awsui.$space-s;
       }
     }
   }

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -127,6 +127,7 @@ the grid layout will be:
   grid-column: 2;
   grid-row: 2;
   column-gap: calc(#{awsui.$space-m} + #{awsui.$space-xxs});
+  justify-content: center;
   letter-spacing: awsui.$font-button-letter-spacing;
   margin-left: auto;
   margin-right: auto;
@@ -160,15 +161,16 @@ the grid layout will be:
       display: inline-block;
     }
 
-    > .item-count > .type-count {
-      white-space: nowrap;
+    > .item-count {
+      column-gap: awsui.$space-s;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
+      row-gap: 0;
 
-      > .count-number {
+      > .type-count > .count-number {
         margin-left: awsui.$space-xxs;
-      }
-
-      &:not(:last-child) {
-        margin-right: awsui.$space-s;
       }
     }
   }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

The following was happening to the notification bar on viewports below ~410px width:

- It would occupy the whole container width, covering the stacked notifications and therefore removing the visual cues about multiple notifications being present:
<img src="https://user-images.githubusercontent.com/1257272/220129367-1d512d35-3e7e-4077-a597-af445f1454b1.png" width="350px" alt="screenshot taken from browser" />

- It would not allow to shrink below ~250px, and it would start to occupy space to the right for narrower viewports:

<img src="https://user-images.githubusercontent.com/1257272/220129383-c6458fbe-6d5b-4674-950a-74d5e468ea3f.png" width="250px" alt="screenshot taken from browser" />

This change introduces the following improvements:

- A margin to the sides is reserved, so that the bottom items in the stack is always visible:

<img src="https://user-images.githubusercontent.com/1257272/220132157-84fffc41-7d02-4992-b9b6-20e90746512d.png" width="350px" alt="screenshot taken from browser" />

- Horizontal margin was removed from the item counter block, so that the component can shrink somewhat further before continuing to wrap:

<img src="https://user-images.githubusercontent.com/1257272/220132347-d7994e4e-0abb-4234-b84f-1c2d9b63877e.png" width="300px" alt="screenshot taken from browser" />

- When shrinking even further, the item counters can also wrap. All items are kept centered:

<img src="https://user-images.githubusercontent.com/1257272/220132627-fb68b3e3-d661-4804-8889-bb75076ae302.png" width="250px" alt="screenshot taken from browser" />

### How has this been tested?

<!-- How did you test to verify your changes? -->
- Manually tested on Chrome, Firefox and Safari
- Visual regression tests exist for different sizes, which would catch regressions

Backstop visual regression test for Flashbar in mobile is failing, which is expected.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
