### PR TITLE
chore: Update screenshot max page height

### DIFF
--- a/pages/utils/screenshot-area.tsx
+++ b/pages/utils/screenshot-area.tsx
@@ -7,7 +7,7 @@ import { colorTextStatusError } from '~design-tokens';
 import styles from './screenshot-area.scss';
 
 // replicates the same constant from BrowserTestTools package
-const MAX_PAGE_HEIGHT = 20000;
+const MAX_PAGE_HEIGHT = 16000;
 
 interface ScreenshotAreaProps {
   className?: string;


### PR DESCRIPTION
### Description

The current max page size for the screenshots is out of date (reduced from 20000 to 16000). This PR updates it.

There is also a corresponding [PR](https://github.com/cloudscape-design/browser-test-tools/pull/37) for browser-test-tools, as these values should be kept in sync.

### How has this been tested?

My dev pipeline (v3-rucarva)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
