### PR TITLE
feat: Display visible column groups as expandable sections

### DIFF
--- a/pages/collection-preferences/responsive.page.tsx
+++ b/pages/collection-preferences/responsive.page.tsx
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
+import SpaceBetween from '~components/space-between';
+
+const baseProperties: CollectionPreferencesProps<boolean> = {
+  title: 'Preferences',
+  confirmLabel: 'Confirm',
+  cancelLabel: 'Cancel',
+  onConfirm: () => {},
+
+  preferences: {
+    wrapLines: true,
+    pageSize: 10,
+    visibleContent: ['a', 'b', 'c', 'd', 'e'],
+    custom: true,
+  },
+};
+
+const pageSizePreference = {
+  title: 'Page size',
+  options: [
+    { label: '20 items', value: 20 },
+    { label: '50 items', value: 50 },
+    { label: '100 items', value: 100 },
+  ],
+};
+
+const wrapLinesPreference = {
+  label: 'Wrap lines',
+  description: 'Wrap lines description',
+};
+
+export default function CollectionPreferencesPage() {
+  return (
+    <SpaceBetween size="l">
+      <h1>Collection preferences</h1>
+
+      <label>
+        No columns <CollectionPreferences {...baseProperties} pageSizePreference={pageSizePreference} />
+      </label>
+
+      <label>
+        One column group{' '}
+        <CollectionPreferences
+          {...baseProperties}
+          pageSizePreference={pageSizePreference}
+          wrapLinesPreference={wrapLinesPreference}
+          visibleContentPreference={{
+            title: 'Select visible columns',
+            options: [
+              {
+                label: 'Main resource properties',
+                options: [
+                  { id: 'a', label: 'Column A' },
+                  { id: 'b', label: 'Column B' },
+                  { id: 'c', label: 'Column C' },
+                  { id: 'd', label: 'Column D' },
+                  { id: 'e', label: 'Column E' },
+                ],
+              },
+            ],
+          }}
+        />
+      </label>
+      <label>
+        Two column groups{' '}
+        <CollectionPreferences
+          {...baseProperties}
+          pageSizePreference={pageSizePreference}
+          wrapLinesPreference={wrapLinesPreference}
+          visibleContentPreference={{
+            title: 'Select visible columns',
+            options: [
+              {
+                label: 'Main resource properties',
+                options: [
+                  { id: 'a', label: 'Column A' },
+                  { id: 'b', label: 'Column B' },
+                  { id: 'c', label: 'Column C' },
+                  { id: 'd', label: 'Column D' },
+                  { id: 'e', label: 'Column E' },
+                ],
+              },
+              {
+                label: 'Secondary resource properties',
+                options: [
+                  { id: 'f', label: 'Column F' },
+                  { id: 'g', label: 'Column G' },
+                  { id: 'h', label: 'Column H' },
+                  { id: 'i', label: 'Column I' },
+                  { id: 'j', label: 'Column J' },
+                ],
+              },
+            ],
+          }}
+        />
+      </label>
+    </SpaceBetween>
+  );
+}

--- a/src/collection-preferences/__tests__/visible-content.test.tsx
+++ b/src/collection-preferences/__tests__/visible-content.test.tsx
@@ -4,6 +4,7 @@ import { CollectionPreferencesProps } from '../../../lib/components/collection-p
 import { CollectionPreferencesWrapper } from '../../../lib/components/test-utils/dom';
 import { renderCollectionPreferences, visibleContentPreference } from './shared';
 import styles from '../../../lib/components/collection-preferences/styles.css.js';
+import expandableSectionStyles from '../../../lib/components/expandable-section/styles.css.js';
 
 function renderWithContentSelection(props: Partial<CollectionPreferencesProps>): CollectionPreferencesWrapper {
   return renderCollectionPreferences({ visibleContentPreference, ...props });
@@ -38,7 +39,7 @@ describe('Content selection', () => {
     const groupLabels = wrapper
       .findModal()!
       .findVisibleContentPreference()!
-      .findAllByClassName(styles['visible-content-group-label']);
+      .findAllByClassName(expandableSectionStyles.root);
     expect(groupLabels).toHaveLength(2);
     expect(groupLabels[0].getElement()).toHaveTextContent('Group label one');
     expect(groupLabels[1].getElement()).toHaveTextContent('Group label two');
@@ -81,17 +82,14 @@ describe('Content selection', () => {
   test('sets aria attributes', () => {
     const wrapper = renderWithContentSelection({ preferences: { visibleContent: ['id'] }, onConfirm: () => {} });
     wrapper.findTriggerButton().click();
-    const titleId = wrapper.findModal()!.findVisibleContentPreference()!.findTitle().getElement().id;
     // group
-    const innerGroup = wrapper.findModal()!.findVisibleContentPreference()!.findOptionsGroups()[0]!.getElement();
-    expect(innerGroup).toHaveAttribute('role', 'group');
-    const innergroupLabelId = wrapper
+    const innerGroup = wrapper
       .findModal()!
       .findVisibleContentPreference()!
-      .findOptionsGroups()[0]!
-      .findByClassName(styles['visible-content-group-label'])!
-      .getElement().id;
-    expect(innerGroup).toHaveAttribute('aria-labelledby', `${titleId} ${innergroupLabelId}`);
+      .findOptionsGroups()[0]
+      .find('[role="group"]')!
+      .getElement();
+    expect(innerGroup).toHaveAttribute('role', 'group');
   });
   test('label is associated with toggle', () => {
     const wrapper = renderWithContentSelection({ preferences: { visibleContent: ['id'] }, onConfirm: () => {} });

--- a/src/collection-preferences/visible-content.scss
+++ b/src/collection-preferences/visible-content.scss
@@ -11,14 +11,9 @@ $border: awsui.$border-divider-list-width solid awsui.$color-border-divider-defa
 .visible-content,
 .visible-content-toggle,
 .visible-content-groups,
-.visible-content-group {
-  /* used in test-utils */
-}
+.visible-content-group,
 .visible-content-title {
-  @include styles.font-label;
-  color: awsui.$color-text-form-label;
-  margin: 0;
-  margin-bottom: awsui.$space-scaled-l;
+  /* used in test-utils */
 }
 
 .visible-content-group-label {

--- a/src/collection-preferences/visible-content.tsx
+++ b/src/collection-preferences/visible-content.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import InternalBox from '../box/internal';
 import InternalExpandableSection from '../expandable-section/internal';
 import InternalToggle from '../toggle/internal';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
@@ -71,9 +72,9 @@ export default function VisibleContentPreference({
   const outerGroupLabelId = `${idPrefix}-outer`;
   return (
     <div className={styles['visible-content']}>
-      <h3 {...className('title')} id={outerGroupLabelId}>
+      <InternalBox variant="h3" {...className('title')} id={outerGroupLabelId}>
         {title}
-      </h3>
+      </InternalBox>
       <div {...className('groups')}>
         {options.map((optionGroup, optionGroupIndex) => {
           return (

--- a/src/collection-preferences/visible-content.tsx
+++ b/src/collection-preferences/visible-content.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import InternalSpaceBetween from '../space-between/internal';
+import InternalExpandableSection from '../expandable-section/internal';
 import InternalToggle from '../toggle/internal';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 
@@ -74,28 +74,24 @@ export default function VisibleContentPreference({
       <h3 {...className('title')} id={outerGroupLabelId}>
         {title}
       </h3>
-      <InternalSpaceBetween {...className('groups')} size="xs">
+      <div {...className('groups')}>
         {options.map((optionGroup, optionGroupIndex) => {
-          const groupLabelId = `${idPrefix}-${optionGroupIndex}`;
           return (
-            <div
+            <InternalExpandableSection
               key={optionGroupIndex}
+              defaultExpanded={optionGroupIndex === 0}
+              headerText={optionGroup.label}
               {...className('group')}
-              role="group"
-              aria-labelledby={`${outerGroupLabelId} ${groupLabelId}`}
             >
-              <div {...className('group-label')} id={groupLabelId}>
-                {optionGroup.label}
-              </div>
               <div>
                 {optionGroup.options.map((option, optionIndex) =>
                   selectionOption(option, optionGroupIndex, optionIndex)
                 )}
               </div>
-            </div>
+            </InternalExpandableSection>
           );
         })}
-      </InternalSpaceBetween>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Description
In an effort to better utilize space in the collection preferences, column groups for visible column preferences are rendered as expandable sections. The primary/first column group is expanded by default, and all other groups are collapsed by default.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
