### PR TITLE
feat: Custom content widths for dashboard content type

### DIFF
--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -19,3 +19,9 @@ $adaptive-content-widths: (
   styles.$breakpoint-x-large: 1440px,
   styles.$breakpoint-xx-large: 1620px,
 );
+
+$dashboard-content-widths: (
+  styles.$breakpoint-large: 1280px,
+  styles.$breakpoint-x-large: 1620px,
+  styles.$breakpoint-xx-large: 2160px,
+);

--- a/src/app-layout/content-wrapper/index.tsx
+++ b/src/app-layout/content-wrapper/index.tsx
@@ -41,16 +41,15 @@ const ContentWrapper = React.forwardRef(
       <div
         ref={ref}
         className={clsx(
-          className,
           styles['content-wrapper'],
-          styles[`content-type-${contentType}`],
           !navigationPadding && styles['content-wrapper-no-navigation-padding'],
           !toolsPadding && styles['content-wrapper-no-tools-padding'],
           isMobile && styles['content-wrapper-mobile']
         )}
-        style={contentWidthStyles}
       >
-        {children}
+        <div style={contentWidthStyles} className={clsx(className, styles[`content-type-${contentType}`])}>
+          {children}
+        </div>
       </div>
     );
   }

--- a/src/app-layout/content-wrapper/styles.scss
+++ b/src/app-layout/content-wrapper/styles.scss
@@ -19,7 +19,7 @@
 .content-type-dashboard {
   margin-left: auto;
   margin-right: auto;
-  @each $breakpoint, $width in constants.$adaptive-content-widths {
+  @each $breakpoint, $width in constants.$dashboard-content-widths {
     @include styles.media-breakpoint-up($breakpoint) {
       max-width: $width;
     }

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -337,6 +337,9 @@ const OldAppLayout = React.forwardRef(
     const contentWrapperProps: ContentWrapperProps = {
       contentType,
       navigationPadding: navigationHide || !!navigationOpen,
+      contentWidthStyles: !isMobile
+        ? { minWidth: defaults.minContentWidth, maxWidth: defaults.maxContentWidth }
+        : undefined,
       toolsPadding:
         // tools padding is displayed in one of the three cases
         // 1. Nothing on the that screen edge (no tools panel and no split panel)
@@ -371,10 +374,6 @@ const OldAppLayout = React.forwardRef(
         : splitPanelOpen
         ? splitPanelReportedSize
         : splitPanelReportedHeaderHeight) ?? undefined;
-
-    const contentWidthStyles = !isMobile
-      ? { minWidth: defaults.minContentWidth, maxWidth: defaults.maxContentWidth }
-      : undefined;
 
     const toolsDrawerWidth = (() => {
       if (isMobile) {
@@ -464,11 +463,9 @@ const OldAppLayout = React.forwardRef(
                   </Notifications>
                 )}
                 {((!isMobile && breadcrumbs) || contentHeader) && (
-                  <ContentWrapper {...contentWrapperProps} contentWidthStyles={contentWidthStyles}>
+                  <ContentWrapper {...contentWrapperProps}>
                     {!isMobile && breadcrumbs && (
-                      <div
-                        className={clsx(styles.breadcrumbs, testutilStyles.breadcrumbs, styles['breadcrumbs-desktop'])}
-                      >
+                      <div className={clsx(testutilStyles.breadcrumbs, styles['breadcrumbs-desktop'])}>
                         {breadcrumbs}
                       </div>
                     )}
@@ -499,6 +496,8 @@ const OldAppLayout = React.forwardRef(
                       (isMobile || !breadcrumbs) &&
                       !contentHeader &&
                       styles['content-extra-top-padding'],
+                    testutilStyles.content,
+                    !disableContentHeaderOverlap && contentHeader && styles['content-overlapped'],
                     !hasRenderedNotifications &&
                       !breadcrumbs &&
                       !isMobile &&
@@ -506,26 +505,17 @@ const OldAppLayout = React.forwardRef(
                       styles['content-wrapper-first-child']
                   )}
                 >
-                  <div
-                    className={clsx(
-                      styles.content,
-                      testutilStyles.content,
-                      !disableContentHeaderOverlap && contentHeader && styles['content-overlapped']
-                    )}
-                    style={contentWidthStyles}
+                  <AppLayoutContext.Provider
+                    value={{
+                      stickyOffsetTop:
+                        (disableBodyScroll ? 0 : headerHeight) +
+                        (stickyNotificationsHeight !== null ? stickyNotificationsHeight : 0),
+                      stickyOffsetBottom: footerHeight + (splitPanelBottomOffset || 0),
+                      hasBreadcrumbs: !!breadcrumbs,
+                    }}
                   >
-                    <AppLayoutContext.Provider
-                      value={{
-                        stickyOffsetTop:
-                          (disableBodyScroll ? 0 : headerHeight) +
-                          (stickyNotificationsHeight !== null ? stickyNotificationsHeight : 0),
-                        stickyOffsetBottom: footerHeight + (splitPanelBottomOffset || 0),
-                        hasBreadcrumbs: !!breadcrumbs,
-                      }}
-                    >
-                      {content}
-                    </AppLayoutContext.Provider>
-                  </div>
+                    {content}
+                  </AppLayoutContext.Provider>
                 </ContentWrapper>
               </div>
               {finalSplitPanePosition === 'bottom' && splitPanelWrapped}

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -56,6 +56,13 @@
         #{custom-props.$defaultMaxContentWidth}: $width;
       }
     }
+    &.content-type-dashboard {
+      @each $breakpoint, $width in constants.$dashboard-content-widths {
+        @include styles.media-breakpoint-up($breakpoint) {
+          #{custom-props.$defaultMaxContentWidth}: $width;
+        }
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
### Description

Change content width for `contentType="dashboard"`, according to design feedback

Related links, issue #, if available: n/a

### How has this been tested?

* Can be seen on [this page](https://d21d5uik3ws71m.cloudfront.net/components/49cc0fa40ff3006d6857e53c219b3bfddd7d835b/index.html#/light/app-layout/dashboard-content-type)
* Also see the CR-85870916 for relevant screenshot test changes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
