### PR TITLE
fix: Use composedPath to support click events originating from a shadow DOM

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -11,6 +11,26 @@ const renderButtonDropdown = (props: Parameters<typeof ButtonDropdown>[0]) => {
   return createWrapper(renderResult.container).findButtonDropdown()!;
 };
 
+const renderButtonDropdownInShadowDOM = (props: Parameters<typeof ButtonDropdown>[0]) => {
+  const shadowHost = document.createElement('div');
+  const shadowRoot = shadowHost.attachShadow({ mode: 'open' });
+  document.body.appendChild(shadowHost);
+
+  const renderResult = render(
+    <div>
+      <ButtonDropdown {...props} />
+    </div>,
+    {
+      container: shadowRoot,
+    }
+  );
+
+  return {
+    wrapper: createWrapper(renderResult.container.firstElementChild!).findButtonDropdown()!,
+    cleanup: () => document.body.removeChild(shadowHost),
+  };
+};
+
 const items: ButtonDropdownProps.Items = [
   { id: 'i1', text: 'item1', description: 'Item 1 description' },
   {
@@ -130,6 +150,46 @@ describe('ButtonDropdown component', () => {
       expect(wrapper.findOpenDropdown()).toBeTruthy();
       triggerButton.click();
       expect(wrapper.findOpenDropdown()).not.toBeTruthy();
+    });
+  });
+  describe('Shadow DOM', () => {
+    test('should invoke onItemClick callback upon clicking an option', () => {
+      const itemClickSpy = jest.fn();
+      const { wrapper, cleanup } = renderButtonDropdownInShadowDOM({ items, onItemClick: itemClickSpy });
+
+      // open the dropdown
+      wrapper.openDropdown();
+
+      // click the first option
+      const optionId = items[0].id!;
+      const option = wrapper.findItemById(optionId)?.getElement();
+      option?.click();
+
+      // callback must be called
+      expect(itemClickSpy).toHaveBeenCalled();
+
+      // verify that the dropdown is now hidden
+      expect(wrapper.findItemById(optionId)).toBeNull();
+      cleanup();
+    });
+
+    test('should toggle dropdown when clicking the trigger', () => {
+      const { wrapper, cleanup } = renderButtonDropdownInShadowDOM({ items });
+
+      // open the dropdown
+      const triggerButton = wrapper.findNativeButton().getElement();
+      triggerButton.click();
+
+      // verify that the option is visible
+      const optionId = items[0].id!;
+      expect(wrapper.findItemById(optionId)).toBeTruthy();
+
+      // click again on the trigger button
+      triggerButton.click();
+
+      // verify that the dropdown is now hidden
+      expect(wrapper.findItemById(optionId)).toBeNull();
+      cleanup();
     });
   });
 });

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -291,7 +291,9 @@ const Dropdown = ({
       return;
     }
     const clickListener = (e: MouseEvent) => {
-      if (!dropdownRef.current?.contains(e.target as Node) && !triggerRef.current?.contains(e.target as Node)) {
+      const target = e.composedPath()[0];
+
+      if (!dropdownRef.current?.contains(target as Node) && !triggerRef.current?.contains(target as Node)) {
         fireNonCancelableEvent(onDropdownClose);
       }
     };


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Use [composedPath](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) to support click events originating from a shadow DOM

<!-- Also include relevant motivation and context. -->

### Backgorund
Our application is a micro-frontend that is rendered inside a Shadow DOM. We have been using this UI library for about a year now.

However, this [commit](https://github.com/cloudscape-design/components/commit/5fced58558b90769fc22a58c4657fdb8ff2bac58) seems to have broken our `ButtonDropdown`. 
When a user picks an option, the menu dropdown closes but the `onItemClick` does **not get triggered** anymore.

![button-dropdown-stopped-working](https://user-images.githubusercontent.com/3698859/220498510-02519e43-6c68-4ecd-851d-c07657075f88.gif)

See: [How event retargeting and how event propagation works inside Shadow DOM
](https://pm.dartus.fr/blog/a-complete-guide-on-shadow-dom-and-event-propagation/#event.prototype.target-and-event-retargeting)



Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
