### PR TITLE
fix: Debounce countText announcement and link it to text filter input

### DIFF
--- a/src/s3-resource-selector/s3-modal/__tests__/buckets-table.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/buckets-table.test.tsx
@@ -139,7 +139,7 @@ test('filtering buckets', async () => {
   expect(wrapper.findTextFilter()!.findResultsCount().getElement()).toHaveTextContent('0 matches');
   wrapper.findEmptySlot()!.findButton()!.click();
   expect(wrapper.findRows()).toHaveLength(2);
-  expect(wrapper.findTextFilter()!.findResultsCount().getElement()).toBeEmptyDOMElement();
+  expect(wrapper.findTextFilter()!.findResultsCount().getElement()).toHaveTextContent('');
 });
 
 test('paginating buckets', async () => {

--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -18,21 +18,11 @@ test('should have no initial value for filtering', () => {
   expect(wrapper.findInput().findNativeInput().getElement().value).toBe('');
 });
 
-test('should attach aria-describedby when countText is provided', () => {
+test('should attach aria-describedby to the filtering input', () => {
   const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="N matches" />);
   const ariaDescribedby = wrapper.findInput().findNativeInput().getElement().getAttribute('aria-describedby');
   expect(ariaDescribedby).not.toBeNull();
-  expect(document.getElementById(ariaDescribedby!)).toBeInTheDocument();
-});
-
-test('should unset aria-describedby when countText is empty', () => {
-  const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="" />);
-  expect(wrapper.find('[aria-describedby]')).toBeNull();
-});
-
-test('should unset aria-describedby when filteringText is empty', () => {
-  const { wrapper } = renderTextFilter(<TextFilter filteringText="" countText="N matches" />);
-  expect(wrapper.find('[aria-describedby]')).toBeNull();
+  expect(document.getElementById(ariaDescribedby!)).toHaveTextContent('N matches');
 });
 
 test('should apply filteringPlaceholder', () => {

--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -18,9 +18,21 @@ test('should have no initial value for filtering', () => {
   expect(wrapper.findInput().findNativeInput().getElement().value).toBe('');
 });
 
-test('should clear aria-describedby for filtering', () => {
-  const { wrapper } = renderTextFilter(<TextFilter filteringText="" />);
-  expect(wrapper.find('[aria-describedby]')).toBe(null);
+test('should attach aria-describedby when countText is provided', () => {
+  const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="N matches" />);
+  const ariaDescribedby = wrapper.findInput().findNativeInput().getElement().getAttribute('aria-describedby');
+  expect(ariaDescribedby).not.toBeNull();
+  expect(document.getElementById(ariaDescribedby!)).toBeInTheDocument();
+});
+
+test('should unset aria-describedby when countText is empty', () => {
+  const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="" />);
+  expect(wrapper.find('[aria-describedby]')).toBeNull();
+});
+
+test('should unset aria-describedby when filteringText is empty', () => {
+  const { wrapper } = renderTextFilter(<TextFilter filteringText="" countText="N matches" />);
+  expect(wrapper.find('[aria-describedby]')).toBeNull();
 });
 
 test('should apply filteringPlaceholder', () => {

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -9,6 +9,11 @@ import { fireNonCancelableEvent } from '../internal/events';
 import styles from './styles.css.js';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { TextFilterProps } from './interfaces';
+import LiveRegion from '../internal/components/live-region';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
+
+// Debounce delay for live region (based on testing with VoiceOver)
+const LIVE_REGION_DELAY = 2000;
 
 type InternalTextFilterProps = TextFilterProps & InternalBaseComponentProps;
 
@@ -28,9 +33,11 @@ const InternalTextFilter = React.forwardRef(
     }: InternalTextFilterProps,
     ref: React.Ref<TextFilterProps.Ref>
   ) => {
-    const inputRef = useRef<HTMLInputElement>(null);
     const baseProps = getBaseProps(rest);
+    const inputRef = useRef<HTMLInputElement>(null);
     useForwardFocus(ref, inputRef);
+
+    const liveContentId = useUniqueId('text-filter');
     const showResults = filteringText && countText && !disabled;
 
     return (
@@ -44,16 +51,15 @@ const InternalTextFilter = React.forwardRef(
           value={filteringText}
           disabled={disabled}
           autoComplete={false}
+          ariaDescribedby={showResults ? liveContentId : undefined}
           clearAriaLabel={filteringClearAriaLabel}
           onChange={event => fireNonCancelableEvent(onChange, { filteringText: event.detail.value })}
           __onDelayedInput={event => fireNonCancelableEvent(onDelayedChange, { filteringText: event.detail.value })}
         />
-        <span
-          aria-live="polite"
-          aria-atomic="true"
-          className={clsx(styles.results, showResults && styles['results-visible'])}
-        >
-          {showResults ? countText : ''}
+        <span className={clsx(styles.results, showResults && styles['results-visible'])}>
+          <LiveRegion delay={LIVE_REGION_DELAY} visible={true}>
+            <span id={liveContentId}>{showResults ? countText : ''}</span>
+          </LiveRegion>
         </span>
       </div>
     );

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -37,7 +37,7 @@ const InternalTextFilter = React.forwardRef(
     const inputRef = useRef<HTMLInputElement>(null);
     useForwardFocus(ref, inputRef);
 
-    const liveContentId = useUniqueId('text-filter');
+    const countTextId = useUniqueId('text-filter');
     const showResults = filteringText && countText && !disabled;
 
     return (
@@ -51,14 +51,14 @@ const InternalTextFilter = React.forwardRef(
           value={filteringText}
           disabled={disabled}
           autoComplete={false}
-          ariaDescribedby={showResults ? liveContentId : undefined}
+          ariaDescribedby={countTextId}
           clearAriaLabel={filteringClearAriaLabel}
           onChange={event => fireNonCancelableEvent(onChange, { filteringText: event.detail.value })}
           __onDelayedInput={event => fireNonCancelableEvent(onDelayedChange, { filteringText: event.detail.value })}
         />
         <span className={clsx(styles.results, showResults && styles['results-visible'])}>
           <LiveRegion delay={LIVE_REGION_DELAY} visible={true}>
-            <span id={liveContentId}>{showResults ? countText : ''}</span>
+            <span id={countTextId}>{showResults ? countText : ''}</span>
           </LiveRegion>
         </span>
       </div>


### PR DESCRIPTION
### Description

1. Debounce countText using `LiveRegion` instead of using aria-live directly, so that announcements wait for a little bit after text input is done being announced. Went for 2 seconds after manual testing, but there's no rule here.
2. Attach countText to the input using `aria-describedby` as a "fallback", so it's always announced at the end when the user focuses into the text field.

Related links, issue #, if available: AWSUI-20166

### How has this been tested?

Unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
