### PR TITLE
fix: notification bar border width in Visual Refresh

### DIFF
--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -22,7 +22,7 @@ $notification-bar-collapsed-item-overflow: (
 );
 $notification-bar-border-width: (
   'classic': 1px,
-  'visual-refresh': 3px,
+  'visual-refresh': 2px,
 );
 
 .stack {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

On refactoring, the border width of the notification bar in Visual Refresh was accidentally changed from 2px to 3px in #775. This made the notification bar 2px taller than expected in Visual Refresh. This PR reverts that unintended change.

### How has this been tested?

<!-- How did you test to verify your changes? -->

This was caught by visual regression tests.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
