### PR TITLE
fix: Prefer case-sensitive match for property filter value matching

### DIFF
--- a/src/property-filter/__tests__/utils.test.ts
+++ b/src/property-filter/__tests__/utils.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ComparisonOperator, FilteringProperty } from '../interfaces';
-import { matchFilteringProperty, matchOperator, matchOperatorPrefix } from '../utils';
+import { ComparisonOperator, FilteringProperty, Token } from '../interfaces';
+import { matchFilteringProperty, matchOperator, matchOperatorPrefix, matchTokenValue } from '../utils';
 
 const filteringProperties: FilteringProperty[] = [
   {
@@ -103,5 +103,37 @@ describe('matchOperatorPrefix', () => {
   test('should return null if filtering text has leading space', () => {
     const operatorPrefix = matchOperatorPrefix(operators, ' !');
     expect(operatorPrefix).toBe(null);
+  });
+});
+
+describe('matchTokenValue', () => {
+  test('should return token as-is if no match found', () => {
+    const token: Token = { propertyKey: 'key', operator: '=', value: 'one' };
+    const result = matchTokenValue(token, [{ propertyKey: 'key', value: 'two' }]);
+    expect(result.value).toBe('one');
+  });
+  test('should match by label', () => {
+    const token: Token = { propertyKey: 'key', operator: '=', value: 'one' };
+    const result = matchTokenValue(token, [
+      { propertyKey: 'key', label: 'one', value: '1' },
+      { propertyKey: 'key', value: 'two' },
+    ]);
+    expect(result.value).toBe('1');
+  });
+  test('should case-insensitive match', () => {
+    const token: Token = { propertyKey: 'key', operator: '=', value: 'one' };
+    const result = matchTokenValue(token, [
+      { propertyKey: 'key', value: 'One' },
+      { propertyKey: 'key', value: 'two' },
+    ]);
+    expect(result.value).toBe('One');
+  });
+  test('should prefer case-sensitive match', () => {
+    const token: Token = { propertyKey: 'key', operator: '=', value: 'one' };
+    const result = matchTokenValue(token, [
+      { propertyKey: 'key', value: 'One' },
+      { propertyKey: 'key', value: 'one' },
+    ]);
+    expect(result.value).toBe('one');
   });
 });

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -62,17 +62,20 @@ export function matchOperatorPrefix(
 }
 
 export function matchTokenValue(token: Token, filteringOptions: readonly FilteringOption[]): Token {
-  const value = token.value.toLowerCase();
-
   const propertyOptions = filteringOptions.filter(option => option.propertyKey === token.propertyKey);
+  const bestMatch = { ...token };
   for (const option of propertyOptions) {
-    const optionText = (option.label ?? option.value ?? '').toLowerCase();
-    if (optionText === value) {
+    if ((option.label && option.label === token.value) || (!option.label && option.value === token.value)) {
+      // exact match found: return it
       return { ...token, value: option.value };
+    }
+    if (token.value.toLowerCase() === (option.label ?? option.value ?? '').toLowerCase()) {
+      // non-exact match: save and keep running in case exact match found later
+      bestMatch.value = option.value;
     }
   }
 
-  return token;
+  return bestMatch;
 }
 
 export function trimStart(source: string): string {


### PR DESCRIPTION
### Description

We can't control casing of property values, so want to ensure that case-sensitive
matching is preferred over looser case-insensitive.

Related links, issue #, if available: AWSUI-20452

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
