### PR TITLE
fix: Popover dismiss button and content displaced

### DIFF
--- a/pages/popover/header-variant.page.tsx
+++ b/pages/popover/header-variant.page.tsx
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import ScreenshotArea from '../utils/screenshot-area';
+import Popover from '~components/popover';
+
+export default function () {
+  return (
+    <article>
+      <h1>Popover header variant</h1>
+      <ScreenshotArea>
+        <Popover
+          data-testid="popover-without-title"
+          size="medium"
+          position="bottom"
+          content={
+            <>
+              Enabling continuous backup failed, because of the following error: Dummy Point
+              dummyarn:backup:my-region-1:123456123456:recovery-point:continuous:nthcba123456ac4321bd0af/db/system-cl0ud5cape,
+              is in state FAILED, and can not be updated.
+            </>
+          }
+          dismissAriaLabel="Close"
+          fixedWidth={true}
+        >
+          Open popover without header and fixed width
+        </Popover>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/popover/body.scss
+++ b/src/popover/body.scss
@@ -55,6 +55,7 @@
   @include styles.text-flex-wrapping;
   color: awsui.$color-text-body-secondary;
   flex: 1 1 auto;
+  min-width: 0;
   &-overflow-visible {
     overflow: visible;
   }


### PR DESCRIPTION
### Description

When using a popover without a title, fixed width and a long content string, the closing icon was displaced outside the popover.
Defining the min-width for the content fixed this behavior and place the closing icon inside the popover.

See this before/after image:
<img width="717" alt="Screenshot 2023-02-27 at 13 39 34" src="https://user-images.githubusercontent.com/569011/221566304-21566699-cb1e-493e-8df6-08fa548b5993.png">

Related links, issue #, if available: AWSUI-20388

### How has this been tested?

- verified manually on in our supported browsers.
- added additional screenshot test covering the new example page.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
