### PR TITLE
fix: Prevent filtering highlight from crashing with Google Translate

### DIFF
--- a/src/internal/components/option/highlight-match.tsx
+++ b/src/internal/components/option/highlight-match.tsx
@@ -24,7 +24,7 @@ const Highlight = ({ str }: HighlightMatchProps) =>
 
 export default function HighlightMatch({ str, highlightText }: HighlightMatchProps) {
   if (!str || !highlightText) {
-    return <>{str}</>;
+    return <span>{str}</span>;
   }
 
   if (str === highlightText) {
@@ -36,10 +36,10 @@ export default function HighlightMatch({ str, highlightText }: HighlightMatchPro
   const highlighted: (string | JSX.Element)[] = [];
 
   noMatches.forEach((noMatch, idx) => {
-    highlighted.push(noMatch);
+    highlighted.push(<span key={`noMatch-${idx}`}>{noMatch}</span>);
 
     if (matches && idx < matches.length) {
-      highlighted.push(<Highlight key={idx} str={matches[idx]} />);
+      highlighted.push(<Highlight key={`match-${idx}`} str={matches[idx]} />);
     }
   });
 

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -76,7 +76,7 @@ const Item = (
           </div>
         )}
         {isParent ? (
-          wrappedOption.label || wrappedOption.value
+          <span>{wrappedOption.label || wrappedOption.value}</span>
         ) : (
           <Option
             option={{ ...wrappedOption, disabled }}


### PR DESCRIPTION
### Description

Bit of a quick fix for https://github.com/facebook/react/issues/11538, specifically in the case of filtering highlight styles (the blue text that highlights the part of the selection that's matched).

Related links, issue #, if available: AWSUI-20453

### How has this been tested?

Soo... you'll have to manually test this.

1. Download Google Translate from the Chrome Web Store.
2. Set your primary language in the extension to something other than English.
3. Pick a page with the property filter, select with filtering, or multiselect with filtering and translate the page.
4. Try filtering the results - the app shouldn't crash.

Maybe, in the long term, we could somehow assert that the DOM never has text nodes with siblings, maybe with a MutationObserver or something, but that's just a idea floating in my head.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
