### PR TITLE
fix: Calculate `lastIndex` of table renderAriaLive correctly

### DIFF
--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -94,7 +94,7 @@ describe('labels', () => {
     test('Should render a live region with table total count and indices when renderAriaLive and firstIndex are available', () => {
       const firstIndex = 1;
       const totalItemsCount = defaultItems.length;
-      const lastIndex = firstIndex + defaultItems.length;
+      const lastIndex = firstIndex + defaultItems.length - 1;
 
       const wrapper = renderTableWrapper({
         firstIndex,

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -270,7 +270,7 @@ const InternalTable = React.forwardRef(
           >
             {!!renderAriaLive && !!firstIndex && (
               <LiveRegion>
-                <span>{renderAriaLive({ totalItemsCount, firstIndex, lastIndex: firstIndex + items.length })}</span>
+                <span>{renderAriaLive({ totalItemsCount, firstIndex, lastIndex: firstIndex + items.length - 1 })}</span>
               </LiveRegion>
             )}
             <table


### PR DESCRIPTION
### Description

Previous calculation was incorrect: announced e.g. "Items 1 to 21" when 20 items are displayed per page.

Related links, issue #, if available: n/a

### How has this been tested?

Unit test update

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
