### PR TITLE
fix: Typo in Collection preferences warning

### DIFF
--- a/src/collection-preferences/__tests__/collection-preferences.test.tsx
+++ b/src/collection-preferences/__tests__/collection-preferences.test.tsx
@@ -111,7 +111,7 @@ describe('Collection preferences - Warnings', () => {
     renderCollectionPreferences({ preferences: {} });
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      '[AwsUi] [CollectioPreferences] You provided `preferences` prop without an `onConfirm` handler. This will render a read-only component. If the component should be mutable, set an `onConfirm` handler.'
+      '[AwsUi] [CollectionPreferences] You provided `preferences` prop without an `onConfirm` handler. This will render a read-only component. If the component should be mutable, set an `onConfirm` handler.'
     );
   });
 });

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -140,7 +140,7 @@ export default function CollectionPreferences({
   ...rest
 }: CollectionPreferencesProps) {
   const { __internalRootRef } = useBaseComponent('CollectionPreferences');
-  checkControlled('CollectioPreferences', 'preferences', preferences, 'onConfirm', onConfirm);
+  checkControlled('CollectionPreferences', 'preferences', preferences, 'onConfirm', onConfirm);
   const baseProps = getBaseProps(rest);
   const [modalVisible, setModalVisible] = useState(false);
   const [temporaryPreferences, setTemporaryPreferences] = useState(copyPreferences(preferences || {}));


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

This PR fixes a small typo in a warning message.

<!-- Also include relevant motivation and context. -->

### How has this been tested?

<!-- How did you test to verify your changes? -->

There is a unit test that covers this message, which was affected by the same typo and it was fixed as well.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
