### PR TITLE
revert: Revert "fix: Prevent filtering highlight from crashing with Google Translate"

### DIFF
--- a/src/internal/components/option/highlight-match.tsx
+++ b/src/internal/components/option/highlight-match.tsx
@@ -24,7 +24,7 @@ const Highlight = ({ str }: HighlightMatchProps) =>
 
 export default function HighlightMatch({ str, highlightText }: HighlightMatchProps) {
   if (!str || !highlightText) {
-    return <span>{str}</span>;
+    return <>{str}</>;
   }
 
   if (str === highlightText) {
@@ -36,10 +36,10 @@ export default function HighlightMatch({ str, highlightText }: HighlightMatchPro
   const highlighted: (string | JSX.Element)[] = [];
 
   noMatches.forEach((noMatch, idx) => {
-    highlighted.push(<span key={`noMatch-${idx}`}>{noMatch}</span>);
+    highlighted.push(noMatch);
 
     if (matches && idx < matches.length) {
-      highlighted.push(<Highlight key={`match-${idx}`} str={matches[idx]} />);
+      highlighted.push(<Highlight key={idx} str={matches[idx]} />);
     }
   });
 

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -76,7 +76,7 @@ const Item = (
           </div>
         )}
         {isParent ? (
-          <span>{wrappedOption.label || wrappedOption.value}</span>
+          wrappedOption.label || wrappedOption.value
         ) : (
           <Option
             option={{ ...wrappedOption, disabled }}


### PR DESCRIPTION
Reverting this temporarily to unblock later changes while we sort out issues with downstream consumers.