### PR TITLE
fix: Allow select/multiselect buttons to be activated with Enter

### DIFF
--- a/src/internal/components/options-list/utils/use-keyboard.ts
+++ b/src/internal/components/options-list/utils/use-keyboard.ts
@@ -79,6 +79,7 @@ export const useTriggerKeyboard: UseTriggerKeyboard = ({ openDropdown, goHome })
           openDropdown();
           break;
         case KeyCode.space:
+        case KeyCode.enter:
           e.preventDefault();
           openDropdown();
           break;

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { render, waitFor } from '@testing-library/react';
+import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Select, { SelectProps } from '../../../lib/components/select';
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
@@ -60,6 +61,18 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     expect(wrapper.findDropdown({ expandToViewport })!.findOptionByValue('1')).toBeTruthy();
     wrapper.closeDropdown({ expandToViewport });
     expect(wrapper.findDropdown({ expandToViewport })?.findOpenDropdown()).toBeFalsy();
+  });
+
+  test('allows dropdown to be opened with Space', () => {
+    const { wrapper } = renderSelect();
+    wrapper.findTrigger()!.keydown(KeyCode.space);
+    expect(wrapper.findDropdown({ expandToViewport })).toBeTruthy();
+  });
+
+  test('allows dropdown to be opened with Enter', () => {
+    const { wrapper } = renderSelect();
+    wrapper.findTrigger()!.keydown(KeyCode.enter);
+    expect(wrapper.findDropdown({ expandToViewport })).toBeTruthy();
   });
 
   test('selects top-level option', () => {


### PR DESCRIPTION
### Description

It's a button, and buttons activate with Enter. This isn't what the native `<select>` does, but accessibility software announces the listbox trigger as a button, so keyboard users expect button controls.

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
