### PR TITLE
test: Default container with disabled paddings behaves as a flow layout

### DIFF
--- a/pages/container/simple.page.tsx
+++ b/pages/container/simple.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import Box from '~components/box';
 import Container from '~components/container';
 import Header from '~components/header';
 import ExpandableSection from '~components/expandable-section';
@@ -106,6 +107,9 @@ export default function SimpleContainers() {
             disableContentPaddings={true}
             header={<Header variant="h2">Container Without Content</Header>}
           ></Container>
+          <Container disableContentPaddings={true} header="Container with disabled paddings and box">
+            <Box margin={'m'}>Content that has margin</Box>
+          </Container>
         </SpaceBetween>
       </ScreenshotArea>
     </article>

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -11,10 +11,10 @@
   @include styles.styles-reset;
   word-wrap: break-word;
   position: relative;
-  display: flex;
-  flex-direction: column;
 
   &.fit-height {
+    display: flex;
+    flex-direction: column;
     height: 100%;
   }
 

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -11,10 +11,10 @@
   @include styles.styles-reset;
   word-wrap: break-word;
   position: relative;
+  display: flex;
+  flex-direction: column;
 
   &.fit-height {
-    display: flex;
-    flex-direction: column;
     height: 100%;
   }
 


### PR DESCRIPTION
### Description

While adding features to the container component, it started to behave as flexbox layout by default. 
It was not intended by design, and was fixed afterwards.  
This test will cover the use-case with empty container without paddings, where the container is just a wrapper with some styling for borders and shadows.
![image](https://user-images.githubusercontent.com/29692746/222680079-62cdd606-bfae-43f3-8f82-9b233a93bf3d.png)

Related links, issue #, if available: AWSUI-20439

### How has this been tested?

* One more example added to `/container/simple`: 'Container with disabled paddings and box'

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
