### PR TITLE
feat: Update "Edit" icon

### DIFF
--- a/themes/icons/edit.svg
+++ b/themes/icons/edit.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-  <polyline class="stroke-linejoin-round" points="13 8 13 14 3 14 3 2 9.5 2"/>
-  <line class="stroke-linejoin-round" x1="6" y1="10" x2="14" y2="2"/>
+	<path class="filled" d="M8.2 13.9H14v.1H8.1l.1-.1Zm2.37-9.17.7.7-5.3 5.3-.7-.7 5.3-5.3Zm2.71-2.7a.1.1 0 0 1 .14 0l.57.57a.1.1 0 0 1 0 .14l-.58.58-.71-.71.58-.58ZM3.15 12.15l.7.71-.24.24a1 1 0 0 1-.43.26l-.74.2.21-.73a1 1 0 0 1 .26-.44l.24-.24Z" />
 </svg>


### PR DESCRIPTION
### Description

This change replaces the existing "Edit" icon with a new icon. This is intended to reduce confusion caused by the similar appearance of the "External" icon and the "Edit" icon.

<!-- Include a summary of the changes and the related issue. -->


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### Preview
Note that GitHub's commit diff renders the icons incorrectly, because it does not contain our logic for setting the appropriate stroke width per icon size. You can see a screenshot of the new icon in each size here:

![edit-icon](https://user-images.githubusercontent.com/9086585/222467876-343398cf-c6cf-4545-96ea-cee61203ee47.jpg) 

### How has this been tested?

Tested manually in the dev pages.

Check out this PR locally, run the package and visit
-  http://localhost:8080/#/light/icon/variant-normal and
-  http://localhost:8080/#/light/table/editable-with-app-layout/

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
