### PR TITLE
chore: Compile to ES2015 (following up from #794)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -77,12 +77,6 @@
   "env": {
     "browser": true
   },
-  "globals": {
-    // it is a part of es6, but supported in IE11
-    "Set": true,
-    "Map": true,
-    "WeakMap": true
-  },
   "overrides": [
     {
       "files": ["*.js", "build-tools/**"],

--- a/pages/tsconfig.json
+++ b/pages/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ES2015", "DOM"],
+    "target": "ES2015",
     "declaration": false,
     "declarationMap": false,
     "rootDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ES2015", "DOM"],
+    "target": "ES2015",
     "types": [],
     "module": "ES2015",
     "moduleResolution": "node",


### PR DESCRIPTION
### Description

Well, this is embarrassing. Turns out my PR to target ES2015 didn't actually target ES2015. Let's fix that :)

Related links, issue #, if available: n/a

### How has this been tested?

I discovered my mistake while looking at the generated assets, and I can confirm it works by doing just that again.

Check my internal pipeline; no non-flaky failures. An internal dry-run also succeeded, Slack me for the build link :)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
