### PR TITLE
fix: Add default text color to applayout

### DIFF
--- a/pages/app/styles.scss
+++ b/pages/app/styles.scss
@@ -6,7 +6,6 @@
 /* stylelint-disable-next-line selector-max-type */
 body {
   margin: 0;
-  color: tokens.$color-text-body-default;
   background: tokens.$color-background-container-content;
 }
 

--- a/pages/app/styles.scss
+++ b/pages/app/styles.scss
@@ -6,6 +6,7 @@
 /* stylelint-disable-next-line selector-max-type */
 body {
   margin: 0;
+  color: tokens.$color-text-body-default;
   background: tokens.$color-background-container-content;
 }
 

--- a/src/app-layout/styles.scss
+++ b/src/app-layout/styles.scss
@@ -20,6 +20,7 @@ $drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{awsui.$space-
   display: flex;
   flex-direction: column;
   position: relative;
+  color: awsui.$color-text-body-default;
 }
 
 .root-no-scroll {

--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -13,6 +13,7 @@ div.background {
     background-color: awsui.$color-background-layout-main;
     grid-column: 1 / span 5;
     grid-row: 1 / span 3;
+    color: awsui.$color-text-body-default;
 
     /*
     The cards and table content types have a sticky dark header that is 
@@ -33,6 +34,7 @@ div.background {
     background-color: awsui.$color-background-layout-main;
     grid-column: 1 / span 5;
     grid-row: 4;
+    color: awsui.$color-text-body-default;
 
     /*
     The cards and table content types can have sticky header content that 

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -47,6 +47,7 @@
     minmax(var(#{custom-props.$contentGapRight}), 1fr)
     min-content;
   position: relative;
+  color: awsui.$color-text-body-default;
 
   // Add unified max-width for AppLayout content based on breakpoints.
   &:not(.has-max-content-width) {

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -11,6 +11,7 @@
   grid-column: 3;
   grid-row: 1;
   z-index: 850;
+  color: awsui.$color-text-body-default;
 
   /*
   In desktop viewports the notifications will always be the first

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -147,6 +147,7 @@ the default white background of the container component.
 */
 .dark-header {
   background-color: awsui.$color-background-layout-main;
+  color: awsui.$color-text-body-default;
 }
 
 .content {

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -37,6 +37,7 @@ nodes will directly touch with no gap between them.
     background-color: awsui.$color-background-layout-main;
     grid-column: 1;
     grid-row: 1 / 3;
+    color: awsui.$color-text-body-default;
 
     &.is-overlap-disabled {
       grid-row: 1 / 2;

--- a/src/internal/components/dark-ribbon/styles.scss
+++ b/src/internal/components/dark-ribbon/styles.scss
@@ -8,6 +8,7 @@
 .background-fill {
   background-color: awsui.$color-background-layout-main;
   position: absolute;
+  color: awsui.$color-text-body-default;
 }
 
 .content {

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -167,6 +167,7 @@ the default white background of the container component.
 */
 .dark-header {
   background-color: awsui.$color-background-layout-main;
+  color: awsui.$color-text-body-default;
 }
 
 .header-secondary {

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -208,12 +208,14 @@
     background-color: awsui.$color-background-layout-main;
     grid-column: 1 / span 2;
     grid-row: 1;
+    color: awsui.$color-text-body-default;
   }
 
   > .form-header {
     background-color: awsui.$color-background-layout-main;
     grid-column: 2;
     grid-row: 1;
+    color: awsui.$color-text-body-default;
   }
 
   > .form-header > .form-header-content {


### PR DESCRIPTION
### Description

Spinner with `normal` variant picks up the current color of its context. If there is no color defined in parent elements it is using the default black color. Adding `$color-text-body-default` color to Applayout, to make sure the currentColor is the default text color.

For dark headers in `awsui-context-content-header` context, need to define `$color-text-body-default` to correct children `currentColor` in this context(dark mode color). Otherwise it still uses the light mode color. 

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #AWSUI-20480

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
