### PR TITLE
chore: Remove deprecatedTag in event api 

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5,8 +5,8 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
-      "deprecatedTag": "Replaced by \`action\`.",
-      "description": "Fired when the user clicks the action button.",
+      "description": "Fired when the user clicks the action button.
+**Deprecated** Replaced by \`action\`.",
       "name": "onButtonClick",
     },
     Object {
@@ -3636,9 +3636,9 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
-      "deprecatedTag": "Replaced by \`onDelayedChange\`.",
       "description": "An event handler called when the value changes.
-The event \`detail\` contains the current value of the code editor content.",
+The event \`detail\` contains the current value of the code editor content.
+**Deprecated** Replaced by \`onDelayedChange\`.",
       "detailInlineType": Object {
         "name": "CodeEditorProps.ChangeDetail",
         "properties": Array [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
+      "deprecatedTag": "Replaced by \`action\`.",
       "description": "Fired when the user clicks the action button.",
       "name": "onButtonClick",
     },
@@ -3635,6 +3636,7 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
+      "deprecatedTag": "Replaced by \`onDelayedChange\`.",
       "description": "An event handler called when the value changes.
 The event \`detail\` contains the current value of the code editor content.",
       "detailInlineType": Object {

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -59,7 +59,7 @@ export interface AlertProps extends BaseComponentProps {
   onDismiss?: NonCancelableEventHandler;
   /**
    * Fired when the user clicks the action button.
-   * @deprecated Replaced by `action`.
+   * **Deprecated** Replaced by `action`.
    */
   onButtonClick?: NonCancelableEventHandler;
 }

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -33,7 +33,7 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
   /**
    * An event handler called when the value changes.
    * The event `detail` contains the current value of the code editor content.
-   * @deprecated Replaced by `onDelayedChange`.
+   * **Deprecated** Replaced by `onDelayedChange`.
    */
   onChange?: NonCancelableEventHandler<CodeEditorProps.ChangeDetail>;
 


### PR DESCRIPTION
### Description

Remove deprecatedTag in event api to unblock fix https://github.com/cloudscape-design/documenter/pull/18.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
