### PR TITLE
feat: Add ref with focus to code editor

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3736,7 +3736,14 @@ Use this to retry loading the code editor or to provide another option for the u
       "name": "onValidate",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets input focus onto the code editor control.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "CodeEditor",
   "properties": Array [
     Object {

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { KeyCode } from '../../internal/keycode';
-import CodeEditor from '../../../lib/components/code-editor';
+import CodeEditor, { CodeEditorProps } from '../../../lib/components/code-editor';
 import {
   aceMock,
   editorMock,
@@ -34,6 +34,13 @@ describe('Code editor component', () => {
     const { wrapper } = renderCodeEditor({ loading: true });
     expect(wrapper.findLoadingScreen()).toBeDefined();
     expect(wrapper.findLoadingScreen()!.getElement()).toHaveTextContent('Loading code editor');
+  });
+
+  it('allows programmatically to be focused', () => {
+    const ref = React.createRef<CodeEditorProps.Ref>();
+    const { wrapper } = renderCodeEditor({}, ref);
+    ref.current!.focus();
+    expect(wrapper.findEditor()?.getElement()).toHaveFocus();
   });
 
   it('displays error screen', () => {

--- a/src/code-editor/__tests__/util.tsx
+++ b/src/code-editor/__tests__/util.tsx
@@ -76,9 +76,9 @@ export const defaultProps: CodeEditorProps = {
   i18nStrings,
 };
 
-export function renderCodeEditor(props: Partial<CodeEditorProps> = {}) {
+export function renderCodeEditor(props: Partial<CodeEditorProps> = {}, ref?: React.Ref<CodeEditorProps.Ref>) {
   const renderProps = { ...defaultProps, ...props };
-  const { container, rerender, unmount } = render(<CodeEditor {...renderProps} />);
+  const { container, rerender, unmount } = render(<CodeEditor ref={ref} {...renderProps} />);
   return {
     wrapper: createWrapper(container).findCodeEditor()!,
     rerender,

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -165,4 +165,11 @@ export namespace CodeEditorProps {
   export interface ValidateDetail {
     annotations: Ace.Annotation[];
   }
+
+  export interface Ref {
+    /**
+     * Sets input focus onto the code editor control.
+     */
+    focus(): void;
+  }
 }


### PR DESCRIPTION
### Description

Adding a `ref` to the code editor with `focus` function to allow customers to have the ability to focus on the code editor component when needed.

Related links, issue #, if available: n/a
AWSUI-20473

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
