### PR TITLE
fix: Ensure CodeEditor buttons don't submit parent forms

### DIFF
--- a/src/code-editor/tab-button.tsx
+++ b/src/code-editor/tab-button.tsx
@@ -54,6 +54,7 @@ export const TabButton = React.forwardRef(
           [styles['tab-button--disabled']]: disabled,
           [styles['tab-button--refresh']]: isRefresh,
         })}
+        type="button"
         onClick={onClick}
         onFocus={onFocus}
         onBlur={onBlur}


### PR DESCRIPTION
### Description

Title says it all :)

Related links, issue #, if available: AWSUI-20526

### How has this been tested?

New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
