### PR TITLE
revert: "fix: Add role 'presentaion' to SideNavigation divider (#800)"

### DIFF
--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -40,14 +40,10 @@ describe('SideNavigation', () => {
 
   it('renders dividers', () => {
     const wrapper = renderSideNavigation({
-      items: [
-        { type: 'link', text: 'Page 1', href: '#something' },
-        { type: 'divider' },
-        { type: 'link', text: 'Page 2', href: '#something-else' },
-      ],
+      items: [{ type: 'divider' }],
     });
 
-    expect(wrapper.findItemByIndex(2)!.findDivider()).toBeTruthy();
+    expect(wrapper.findItemByIndex(1)?.findDivider()).toBeTruthy();
   });
 
   it('re-renders different section types correctly', () => {

--- a/src/side-navigation/internal.tsx
+++ b/src/side-navigation/internal.tsx
@@ -64,7 +64,7 @@ export function Header({ definition, activeHref, fireFollow }: HeaderProps) {
           <span className={styles['header-link-text']}>{definition.text}</span>
         </a>
       </h2>
-      <Divider isPresentational={true} variant="header" />
+      <Divider variant="header" />
     </>
   );
 }
@@ -78,8 +78,7 @@ export function ItemList({ variant, items, activeHref, fireChange, fireFollow }:
   return (
     <ul className={clsx(styles.list, styles[`list-variant-${variant}`])}>
       {items.map((item, i) => (
-        <li key={i} className={styles['list-item']} role={item.type === 'divider' ? 'presentation' : 'listitem'}>
-          {item.type === 'divider' && <Divider isPresentational={true} variant="default" />}
+        <li key={i} className={styles['list-item']}>
           {item.type === 'link' && (
             <Link definition={item} activeHref={activeHref} fireChange={fireChange} fireFollow={fireFollow} />
           )}
@@ -107,6 +106,9 @@ export function ItemList({ variant, items, activeHref, fireChange, fireFollow }:
               variant={variant}
             />
           )}
+          {((i === 0 && item.type === 'divider') || (items[i + 1] && items[i + 1].type === 'divider')) && (
+            <Divider variant="default" />
+          )}
         </li>
       ))}
     </ul>
@@ -115,16 +117,10 @@ export function ItemList({ variant, items, activeHref, fireChange, fireFollow }:
 
 interface DividerProps {
   variant: 'default' | 'header';
-  isPresentational?: boolean;
 }
 
-function Divider({ variant = 'default', isPresentational = false }: DividerProps) {
-  return (
-    <hr
-      className={clsx(styles.divider, styles[`divider-${variant}`])}
-      role={isPresentational ? 'presentation' : undefined}
-    />
-  );
+function Divider({ variant = 'default' }: DividerProps) {
+  return <hr className={clsx(styles.divider, styles[`divider-${variant}`])} />;
 }
 
 interface LinkProps extends BaseItemComponentProps {


### PR DESCRIPTION
### Description

This reverts commit [9359ffd](https://github.com/cloudscape-design/components/commit/9359ffd24cc5d9b5041f007510d1e36af8b9d6c8)

While the change was approved by AWS A11y team, a11y test tools like Continuum and Axe are strict on this markup.
Assuming that customers may also have automated a11y tests, it's better to revert this change and reconsider the approach. 

Related links, issue #, if available: n/a

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
