### PR TITLE
feat: Split Side navigation by dividers into separate lists

### DIFF
--- a/src/side-navigation/__tests__/complex-side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/complex-side-navigation.test.tsx
@@ -1,0 +1,221 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import SideNavigation, { SideNavigationProps } from '../../../lib/components/side-navigation';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { SideNavigationItemWrapper } from '../../../lib/components/test-utils/dom/side-navigation';
+
+function renderSideNavigation(props: SideNavigationProps = {}) {
+  const { container } = render(<SideNavigation {...props} />);
+  return createWrapper(container).findSideNavigation()!;
+}
+
+it('Side navigation with all possible items', () => {
+  const wrapper = renderSideNavigation({
+    items: [
+      {
+        type: 'link',
+        text: 'Page 1',
+        href: '#/page1',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        type: 'section',
+        text: 'Section 1',
+        items: [
+          {
+            type: 'link',
+            text: 'Page 2',
+            href: '#/page2',
+          },
+          {
+            type: 'link',
+            text: 'Page 3',
+            href: '#/page3',
+          },
+          { type: 'divider' },
+          {
+            type: 'link',
+            text: 'Page 4',
+            href: '#/page4',
+          },
+          {
+            type: 'link',
+            text: 'Page 5',
+            href: '#/page5',
+          },
+        ],
+      },
+      { type: 'divider' },
+      {
+        type: 'section-group',
+        title: 'Section group 1',
+        items: [
+          {
+            type: 'link',
+            text: 'Page 6',
+            href: '#/page6',
+          },
+          {
+            type: 'link',
+            text: 'Page 7',
+            href: '#/page7',
+          },
+          {
+            type: 'section',
+            text: 'Section 2',
+            items: [
+              {
+                type: 'link',
+                text: 'Page 8',
+                href: '#/page8',
+              },
+              {
+                type: 'link',
+                text: 'Page 9',
+                href: '#/page9',
+              },
+            ],
+          },
+          {
+            type: 'expandable-link-group',
+            text: 'Expandable link group',
+            href: '#/exp-link-group',
+            defaultExpanded: true,
+            items: [
+              {
+                type: 'link',
+                text: 'Page 10',
+                href: '#/page10',
+              },
+              {
+                type: 'link',
+                text: 'Page 11',
+                href: '#/page11',
+              },
+              { type: 'divider' },
+              {
+                type: 'link',
+                text: 'Page 12',
+                href: '#/page12',
+              },
+              {
+                type: 'link',
+                text: 'Page 13',
+                href: '#/page13',
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'divider' },
+      {
+        type: 'section-group',
+        title: 'Section group 2',
+        items: [
+          {
+            type: 'link',
+            text: 'Page 14',
+            href: '#/page14',
+          },
+          {
+            type: 'link-group',
+            text: 'Link group',
+            href: '#/link-group',
+            items: [
+              {
+                type: 'link',
+                text: 'Page 15',
+                href: '#/page15',
+              },
+              {
+                type: 'link',
+                text: 'Page 16',
+                href: '#/page16',
+              },
+              { type: 'divider' },
+              {
+                type: 'link',
+                text: 'Page 17',
+                href: '#/page17',
+              },
+              {
+                type: 'link',
+                text: 'Page 18',
+                href: '#/page18',
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'divider' },
+      { type: 'link', text: 'Notifications', href: '#/notifications' },
+      {
+        type: 'link',
+        text: 'External Link',
+        href: 'https://aws.amazon.com/',
+        external: true,
+        externalIconAriaLabel: 'Opens in a new tab',
+      },
+    ],
+  });
+
+  expect(wrapper.findItemByIndex(1)!.findLink()!.getElement()).toHaveTextContent('Page 1');
+
+  expect(wrapper.findItemByIndex(2)!.findDivider()).toBeTruthy();
+
+  // Section 1 with 1 divider
+  expect(wrapper.findItemByIndex(3)!.findSectionTitle()!.getElement()).toHaveTextContent('Section 1');
+  expect(wrapper.findItemByIndex(3)!.findItemByIndex(1)!.findLink()!.getElement()).toHaveTextContent('Page 2');
+  expect(wrapper.findItemByIndex(3)!.findItemByIndex(3)!.findDivider()).toBeTruthy();
+  expect(wrapper.findItemByIndex(3)!.findItemByIndex(4)!.findLink()!.getElement()).toHaveTextContent('Page 4');
+
+  expect(wrapper.findItemByIndex(4)!.findDivider()).toBeTruthy();
+
+  // Section group 1
+  expect(wrapper.findItemByIndex(5)!.findSectionGroupTitle()!.getElement()).toHaveTextContent('Section group 1');
+  expect(wrapper.findItemByIndex(5)!.findItemByIndex(1)!.findLink()!.getElement()).toHaveTextContent('Page 6');
+  // Section 2 inside Section group 1
+  expect(wrapper.findItemByIndex(5)!.findItemByIndex(3)!.findSectionTitle()!.getElement()).toHaveTextContent(
+    'Section 2'
+  );
+  expect(
+    wrapper.findItemByIndex(5)!.findItemByIndex(3)!.findItemByIndex(1)!.findLink()!.getElement()
+  ).toHaveTextContent('Page 8');
+  // Expandable link group inside Section group 1
+  expect(wrapper.findItemByIndex(5)!.findItemByIndex(4)!.findExpandableLinkGroup()).toBeTruthy();
+  expect(
+    wrapper
+      .findItemByIndex(5)!
+      .findItemByIndex(4)!
+      .findExpandableLinkGroup()!
+      .findExpandedContent()!
+      .findComponent('ul', SideNavigationItemWrapper)!
+      .findItemByIndex(1)!
+      .findLink()!
+      .getElement()
+  ).toHaveTextContent('Page 10');
+
+  expect(wrapper.findItemByIndex(6)!.findDivider()).toBeTruthy();
+
+  // Section group 2
+  expect(wrapper.findItemByIndex(7)!.findSectionGroupTitle()!.getElement()).toHaveTextContent('Section group 2');
+  expect(wrapper.findItemByIndex(7)!.findItemByIndex(2)!.findLink()!.getElement()).toHaveTextContent('Link group');
+
+  expect(
+    wrapper
+      .findItemByIndex(7)!
+      .findItemByIndex(2)!
+      .findComponent('ul', SideNavigationItemWrapper)!
+      .findItemByIndex(1)!
+      .findLink()!
+      .getElement()
+  ).toHaveTextContent('Page 15');
+
+  expect(wrapper.findItemByIndex(8)!.findDivider()).toBeTruthy();
+
+  expect(wrapper.findItemByIndex(9)!.findLink()!.getElement()).toHaveTextContent('Notifications');
+});

--- a/src/side-navigation/index.tsx
+++ b/src/side-navigation/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent, fireCancelableEvent } from '../internal/events';
 import { SideNavigationProps } from './interfaces';
-import { Header, ItemList } from './internal';
+import { Header, NavigationItemsList } from './internal';
 import { generateExpandableItemsMapping, checkDuplicateHrefs } from './util';
 import styles from './styles.css.js';
 import { isDevelopment } from '../internal/is-development';
@@ -62,7 +62,7 @@ export default function SideNavigation({
       )}
       {items && (
         <div className={styles['list-container']}>
-          <ItemList
+          <NavigationItemsList
             variant="root"
             items={items}
             fireFollow={onFollowHandler}

--- a/src/side-navigation/styles.scss
+++ b/src/side-navigation/styles.scss
@@ -58,8 +58,11 @@
 
 .list-variant-root {
   margin: 0;
-  margin-bottom: awsui.$space-scaled-xxxl;
   padding: 0 awsui.$space-panel-side-right 0 awsui.$space-panel-nav-left;
+
+  &--last {
+    margin-bottom: awsui.$space-scaled-xxxl;
+  }
 }
 
 .list-variant-expandable-link-group {

--- a/src/test-utils/dom/side-navigation/index.ts
+++ b/src/test-utils/dom/side-navigation/index.ts
@@ -24,7 +24,10 @@ export default class SideNavigationWrapper extends ComponentWrapper {
   }
 
   findItemByIndex(index: number): SideNavigationItemWrapper | null {
-    return this.findComponent(`.${styles['list-variant-root']} > li:nth-child(${index})`, SideNavigationItemWrapper);
+    return this.findComponent(
+      `.${styles['list-variant-root']} > [data-itemid="item-${index}"]`,
+      SideNavigationItemWrapper
+    );
   }
 }
 
@@ -58,7 +61,7 @@ export class SideNavigationItemWrapper extends ElementWrapper {
   }
 
   findItemByIndex(index: number): SideNavigationItemWrapper | null {
-    return this.findComponent(`li:nth-child(${index})`, SideNavigationItemWrapper);
+    return this.findComponent(`[data-itemid="item-${index}"]`, SideNavigationItemWrapper);
   }
 
   findItems(): Array<SideNavigationItemWrapper> {


### PR DESCRIPTION
### Description

Follow-up for https://github.com/cloudscape-design/components/pull/613, https://github.com/cloudscape-design/components/pull/800

Dividers are used to split the list of items in side navigation into different `<ul>`. This will improve the perception of the side navigation for screenreader users.

Related links, issue #, if available: AWSUI-20463, AWSUI-20493

### How has this been tested?

New unit test added to cover more complex structure of the side nav

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
