### PR TITLE
fix: Fix top navigation text overflowing when provided with 100% w-h svgs

### DIFF
--- a/pages/top-navigation/logos/full-w-h-logo.svg
+++ b/pages/top-navigation/logos/full-w-h-logo.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100%" height="100%" viewBox="0 0 43 31" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(-31.000000, -12.000000)">
+            <g transform="translate(31.000000, 12.000000)">
+                <rect id="Rectangle" fill="#232f3e" stroke="#d5dbdb" x="0.5" y="0.5" width="42" height="30" rx="2"></rect>
+                <text font-family="AmazonEmber-Regular, Amazon Ember" font-size="12" fill="#FFFFFF">
+                    <tspan x="9" y="19">Logo</tspan>
+                </text>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/pages/top-navigation/simple.page.tsx
+++ b/pages/top-navigation/simple.page.tsx
@@ -7,6 +7,7 @@ import logo from './logos/simple-logo.svg';
 import longLogo from './logos/long-logo.svg';
 import narrowLogo from './logos/narrow-logo.svg';
 import tallLogo from './logos/tall-logo.svg';
+import fullHeightWidthLogo from './logos/full-w-h-logo.svg';
 import { I18N_STRINGS } from './common';
 
 export default function TopNavigationPage() {
@@ -60,6 +61,15 @@ export default function TopNavigationPage() {
           href: '#',
           logo: { src: tallLogo, alt: 'Only logo, no title' },
           title: 'Tall logo, resized to fit',
+        }}
+      />
+      <br />
+      <TopNavigation
+        i18nStrings={I18N_STRINGS}
+        identity={{
+          href: '#',
+          logo: { src: fullHeightWidthLogo, alt: 'Only logo, no title' },
+          title: '100% width and height logo, text should not overflow',
         }}
       />
     </article>

--- a/src/top-navigation/styles.scss
+++ b/src/top-navigation/styles.scss
@@ -84,7 +84,8 @@
   display: block;
   max-height: awsui.$space-xxl;
   margin-right: awsui.$space-s;
-  width: auto;
+  width: 100%;
+  max-width: fit-content;
   flex-shrink: 0;
 
   // Setting an arbitrary min-width here discourages browser from lazy rendering
@@ -180,6 +181,7 @@
   // Hide dividers around primary buttons.
   left: -1px;
   border-left: 1px solid awsui.$color-background-container-content;
+
   &::after {
     display: none;
   }


### PR DESCRIPTION
### Description
https://github.com/cloudscape-design/components/issues/704
If there is a provided svg to the top navigation component logo that has `100%` for height and width in the svg definition the top navigation title will always overflow and be cut.

To reproduce this, edit one of the sample svg logos in the test pages and make it have 100% height and width and check the page.
<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
