### PR TITLE
fix: Invalid html markup in property filter

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -20,6 +20,7 @@ import {
   PropertyFilterProps,
   Ref,
 } from '../../../lib/components/property-filter/interfaces';
+import '../../__a11y__/to-validate-a11y';
 
 const states: Record<string, string> = {
   0: 'Stopped',
@@ -1241,5 +1242,10 @@ describe('property filter parts', () => {
   test('property filter input can be found with styles.input', () => {
     const { container } = renderComponent();
     expect(createWrapper(container).findByClassName(styles.input)!.getElement()).not.toBe(null);
+  });
+
+  test('check a11y', async () => {
+    const { container } = render(<PropertyFilter {...defaultProps} />);
+    await expect(container).toValidateA11y();
   });
 });

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -208,7 +208,7 @@ const PropertyFilter = React.forwardRef(
       getExtendedOperator(filteringProperties, parsedText.property.key, parsedText.operator)?.form;
 
     return (
-      <span {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
+      <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <div className={styles['search-field']}>
           {customControl && <div className={styles['custom-control']}>{customControl}</div>}
           <PropertyFilterAutosuggest
@@ -306,7 +306,7 @@ const PropertyFilter = React.forwardRef(
             </InternalSpaceBetween>
           </div>
         )}
-      </span>
+      </div>
     );
   }
 );


### PR DESCRIPTION
### Description

Property Filter has div as child element of span.
AWSUI-20592

### How has this been tested?

<!-- How did you test to verify your changes? --> Added a11y test.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
