### PR TITLE
chore: Use codecov upload token

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@codecov-upload-token
+    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
     secrets: inherit
     with:
       artifact-path: lib/static-default

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
+    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@codecov-upload-token
     with:
       artifact-path: lib/static-default
       artifact-name: dev-pages

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   build:
     uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@codecov-upload-token
+    secrets: inherit
     with:
       artifact-path: lib/static-default
       artifact-name: dev-pages


### PR DESCRIPTION
### Description

Allow the build workflow to inherit secrets so that the `CODECOV_TOKEN` can be access by the codecov action. See https://github.com/cloudscape-design/.github/pull/48.

Related links, issue #, if available: AWSUI-20481

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
