### PR TITLE
chore: Run more app layout tests for visual refresh

### DIFF
--- a/src/app-layout/__integ__/awsui-applayout.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout.test.ts
@@ -47,129 +47,125 @@ function setupTest(
   });
 }
 
-test(
-  'renders initial state with default content type',
-  setupTest({}, async page => {
-    await expect(page.isDisplayed(wrapper.findNavigationToggle().toSelector())).resolves.toBe(false);
-    await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
-    await expect(page.isDisplayed(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-    await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
-  })
-);
+for (const visualRefresh of [true, false]) {
+  test(
+    'renders initial state with default content type',
+    setupTest({ visualRefresh }, async page => {
+      await expect(page.isDisplayed(wrapper.findNavigationToggle().toSelector())).resolves.toBe(false);
+      await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+      await expect(page.isDisplayed(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
+      await expect(page.isDisplayed(wrapper.findSplitPanel().toSelector())).resolves.toBe(false);
+    })
+  );
 
-test(
-  'renders initial state with wizard content type',
-  setupTest({ pageName: 'with-wizard' }, async page => {
-    await expect(page.isDisplayed(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
-    await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
-    await expect(page.isDisplayed(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-    await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
-  })
-);
+  test(
+    'renders initial state with wizard content type',
+    setupTest({ pageName: 'with-wizard', visualRefresh }, async page => {
+      await expect(page.isDisplayed(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
+      await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
+      await expect(page.isDisplayed(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(false);
+    })
+  );
 
-test(
-  'switches between mobile and desktop modes',
-  setupTest({ viewport: viewports.desktop }, async page => {
-    await expect(page.isExisting(mobileSelector)).resolves.toBe(false);
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.isExisting(mobileSelector)).resolves.toBe(true);
-    await page.setWindowSize(viewports.desktop);
-    await expect(page.isExisting(mobileSelector)).resolves.toBe(false);
-  })
-);
+  test(
+    'switches between mobile and desktop modes',
+    setupTest({ viewport: viewports.desktop }, async page => {
+      await expect(page.isExisting(mobileSelector)).resolves.toBe(false);
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.isExisting(mobileSelector)).resolves.toBe(true);
+      await page.setWindowSize(viewports.desktop);
+      await expect(page.isExisting(mobileSelector)).resolves.toBe(false);
+    })
+  );
 
-test(
-  'preserves inner content state when switching between mobile and desktop',
-  setupTest({ viewport: viewports.desktop, pageName: 'stateful' }, async page => {
-    await page.click('#content-button');
-    await expect(page.getText('#content-text')).resolves.toBe('Clicked: 1');
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.getText('#content-text')).resolves.toBe('Clicked: 1');
-  })
-);
+  test(
+    'preserves inner content state when switching between mobile and desktop',
+    setupTest({ viewport: viewports.desktop, pageName: 'stateful' }, async page => {
+      await page.click('#content-button');
+      await expect(page.getText('#content-text')).resolves.toBe('Clicked: 1');
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.getText('#content-text')).resolves.toBe('Clicked: 1');
+    })
+  );
 
-test(
-  'does not preserve breadcrumbs state',
-  setupTest({ viewport: viewports.desktop, pageName: 'stateful' }, async page => {
-    await page.click('#breadcrumbs-button');
-    await expect(page.getText('#breadcrumbs-text')).resolves.toBe('Clicked: 1');
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.getText('#breadcrumbs-text')).resolves.toBe('Clicked: 0');
-  })
-);
+  test(
+    'does not preserve breadcrumbs state',
+    setupTest({ viewport: viewports.desktop, pageName: 'stateful' }, async page => {
+      await page.click('#breadcrumbs-button');
+      await expect(page.getText('#breadcrumbs-text')).resolves.toBe('Clicked: 1');
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.getText('#breadcrumbs-text')).resolves.toBe('Clicked: 0');
+    })
+  );
 
-test(
-  'preserves inner state when drawer closes and opens',
-  setupTest({ pageName: 'stateful' }, async page => {
-    await page.click('#navigation-button');
-    await expect(page.getText('#navigation-text')).resolves.toBe('Clicked: 1');
-    await page.click(wrapper.findNavigationClose().toSelector());
-    await page.click(wrapper.findNavigationToggle().toSelector());
-    await expect(page.getText('#navigation-text')).resolves.toBe('Clicked: 1');
-  })
-);
+  test(
+    'preserves inner state when drawer closes and opens',
+    setupTest({ pageName: 'stateful' }, async page => {
+      await page.click('#navigation-button');
+      await expect(page.getText('#navigation-text')).resolves.toBe('Clicked: 1');
+      await page.click(wrapper.findNavigationClose().toSelector());
+      await page.click(wrapper.findNavigationToggle().toSelector());
+      await expect(page.getText('#navigation-text')).resolves.toBe('Clicked: 1');
+    })
+  );
 
-test(
-  'keeps drawer open state when resizing the screen',
-  setupTest({}, async page => {
-    await page.click(wrapper.findToolsToggle().toSelector());
-    await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-  })
-);
+  test(
+    'keeps drawer open state when resizing the screen',
+    setupTest({}, async page => {
+      await page.click(wrapper.findToolsToggle().toSelector());
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+    })
+  );
 
-test(
-  'keeps drawer closed state when resizing the screen',
-  setupTest({}, async page => {
-    await page.click(wrapper.findNavigationClose().toSelector());
-    await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
-  })
-);
+  test(
+    'keeps drawer closed state when resizing the screen',
+    setupTest({}, async page => {
+      await page.click(wrapper.findNavigationClose().toSelector());
+      await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.isDisplayed(wrapper.findNavigationClose().toSelector())).resolves.toBe(false);
+    })
+  );
 
-test(
-  'scrolling content does not affect drawers',
-  setupTest({}, async page => {
-    const navBefore = await page.getNavPosition();
-    const contentBefore = await page.getContentPosition();
-    await page.windowScrollTo({ top: 100 });
-    await expect(page.getNavPosition()).resolves.toEqual(navBefore);
-    await expect(page.getContentPosition()).resolves.not.toEqual(contentBefore);
-  })
-);
+  test(
+    'scrolling content does not affect drawers',
+    setupTest({}, async page => {
+      const navBefore = await page.getNavPosition();
+      const contentBefore = await page.getContentPosition();
+      await page.windowScrollTo({ top: 100 });
+      await expect(page.getNavPosition()).resolves.toEqual(navBefore);
+      await expect(page.getContentPosition()).resolves.not.toEqual(contentBefore);
+    })
+  );
 
-test(
-  'scrolling drawer does not affect content',
-  setupTest({}, async page => {
-    const navBefore = await page.getNavPosition();
-    const contentBefore = await page.getContentPosition();
-    await page.elementScrollTo(wrapper.findNavigation().toSelector(), { top: 100 });
-    await expect(page.getNavPosition()).resolves.not.toEqual(navBefore);
-    await expect(page.getContentPosition()).resolves.toEqual(contentBefore);
-  })
-);
+  test(
+    'scrolling drawer does not affect content',
+    setupTest({}, async page => {
+      const navBefore = await page.getNavPosition();
+      const contentBefore = await page.getContentPosition();
+      await page.elementScrollTo(wrapper.findNavigation().toSelector(), { top: 100 });
+      await expect(page.getNavPosition()).resolves.not.toEqual(navBefore);
+      await expect(page.getContentPosition()).resolves.toEqual(contentBefore);
+    })
+  );
 
-test(
-  'preserves content scroll position when mobile drawer opens and closes',
-  setupTest({ viewport: viewports.mobile }, async page => {
-    const contentBefore = await page.getContentPosition();
-    await page.click(wrapper.findNavigationToggle().toSelector());
-    const navBefore = await page.getNavPosition();
-    await page.elementScrollTo(wrapper.findNavigation().toSelector(), { top: 100 });
-    await expect(page.getNavPosition()).resolves.not.toEqual(navBefore);
-    await page.click(wrapper.findNavigationClose().toSelector());
-    await expect(page.getContentPosition()).resolves.toEqual(contentBefore);
-  })
-);
-
-test(
-  'ResizeObserver errors are not thrown when changing screen size',
-  setupTest({ pageName: 'with-table', viewport: { width: 1200, height: 1200 } }, async page => {
-    await page.setWindowSize({ width: 600, height: 1200 });
-  })
-);
+  test(
+    'preserves content scroll position when mobile drawer opens and closes',
+    setupTest({ viewport: viewports.mobile }, async page => {
+      const contentBefore = await page.getContentPosition();
+      await page.click(wrapper.findNavigationToggle().toSelector());
+      const navBefore = await page.getNavPosition();
+      await page.elementScrollTo(wrapper.findNavigation().toSelector(), { top: 100 });
+      await expect(page.getNavPosition()).resolves.not.toEqual(navBefore);
+      await page.click(wrapper.findNavigationClose().toSelector());
+      await expect(page.getContentPosition()).resolves.toEqual(contentBefore);
+    })
+  );
+}
 
 test(
   'does not render notifications slot when it is empty',


### PR DESCRIPTION
### Description

Since refresh and classic are separate implementations it would be great to run the same test on both versions to ensure their compatibility

Related links, issue #, if available: The tests failed before https://github.com/cloudscape-design/components/pull/839 and pass now

### How has this been tested?

This is testing changes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
