### PR TITLE
fix: Remove spacing around null SpaceBetween children

### DIFF
--- a/pages/space-between/permutations.page.tsx
+++ b/pages/space-between/permutations.page.tsx
@@ -8,35 +8,55 @@ import ScreenshotArea from '../utils/screenshot-area';
 import styles from './styles.scss';
 import Container from '~components/container';
 
-const ExampleContent = () => <div className={styles.box}>This is some text.</div>;
+const ExampleContent = ({ renderNull }: { renderNull?: boolean }) =>
+  renderNull ? null : <div className={styles.box}>This is some text.</div>;
 
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
   {
     size: ['xxxs', 'xs', 's', 'm', 'l', 'xl', 'xxl'],
     direction: ['vertical', 'horizontal'],
-    children: [[<ExampleContent />, <ExampleContent />, <ExampleContent />]],
+    children: [
+      [
+        <ExampleContent renderNull={true} />,
+        <ExampleContent />,
+        <ExampleContent renderNull={true} />,
+        <ExampleContent />,
+        <ExampleContent />,
+        <ExampleContent renderNull={true} />,
+      ],
+    ],
   },
   {
     size: ['xs', 'xl'],
     direction: ['horizontal', 'vertical'],
     children: [
       [
+        () => null,
         <SpaceBetween size="s">
+          <ExampleContent renderNull={true} />
+          <ExampleContent />
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
-          <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
+        () => null,
         <SpaceBetween size="l">
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
           <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
         <SpaceBetween size="xxl">
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
           <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
+        () => null,
       ],
     ],
     note: ['nested vertical'],
@@ -46,21 +66,31 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
     direction: ['horizontal', 'vertical'],
     children: [
       [
+        () => null,
         <SpaceBetween size="s" direction="horizontal">
+          <ExampleContent renderNull={true} />
+          <ExampleContent />
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
-          <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
+        () => null,
         <SpaceBetween size="l" direction="horizontal">
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
           <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
         <SpaceBetween size="xxl" direction="horizontal">
+          <ExampleContent renderNull={true} />
           <ExampleContent />
           <ExampleContent />
           <ExampleContent />
+          <ExampleContent renderNull={true} />
         </SpaceBetween>,
+        () => null,
       ],
     ],
     note: ['nested horizontal'],

--- a/pages/space-between/permutations.page.tsx
+++ b/pages/space-between/permutations.page.tsx
@@ -32,7 +32,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
     direction: ['horizontal', 'vertical'],
     children: [
       [
-        () => null,
+        <ExampleContent renderNull={true} />,
         <SpaceBetween size="s">
           <ExampleContent renderNull={true} />
           <ExampleContent />
@@ -41,7 +41,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
           <ExampleContent />
           <ExampleContent renderNull={true} />
         </SpaceBetween>,
-        () => null,
+        <ExampleContent renderNull={true} />,
         <SpaceBetween size="l">
           <ExampleContent renderNull={true} />
           <ExampleContent />
@@ -56,7 +56,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
           <ExampleContent />
           <ExampleContent renderNull={true} />
         </SpaceBetween>,
-        () => null,
+        <ExampleContent renderNull={true} />,
       ],
     ],
     note: ['nested vertical'],
@@ -66,7 +66,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
     direction: ['horizontal', 'vertical'],
     children: [
       [
-        () => null,
+        <ExampleContent renderNull={true} />,
         <SpaceBetween size="s" direction="horizontal">
           <ExampleContent renderNull={true} />
           <ExampleContent />
@@ -75,7 +75,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
           <ExampleContent />
           <ExampleContent renderNull={true} />
         </SpaceBetween>,
-        () => null,
+        <ExampleContent renderNull={true} />,
         <SpaceBetween size="l" direction="horizontal">
           <ExampleContent renderNull={true} />
           <ExampleContent />
@@ -90,7 +90,7 @@ const permutations = createPermutations<SpaceBetweenProps & { note?: string }>([
           <ExampleContent />
           <ExampleContent renderNull={true} />
         </SpaceBetween>,
-        () => null,
+        <ExampleContent renderNull={true} />,
       ],
     ],
     note: ['nested horizontal'],

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -111,7 +111,7 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
     visibleData: visibleSeries,
     statusType,
   });
-  const showFilters = statusType === 'finished' && (!isEmpty || isNoMatch);
+  const showFilters = statusType === 'finished' && (!isEmpty || isNoMatch) && (additionalFilters || !hideFilter);
   const showLegend = !hideLegend && !isEmpty && statusType === 'finished';
   const reserveLegendSpace = !showChart && !hideLegend;
   const reserveFilterSpace = !showChart && !isNoMatch && (!hideFilter || additionalFilters);

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -732,9 +732,9 @@ describe('Filter', () => {
     expect(wrapper.findDefaultFilter()).not.toBeNull();
   });
 
-  test('is rendered when hideFilter is set but does not contain the default filter', () => {
+  test('is not rendered when hideFilter is set', () => {
     const { wrapper } = renderMixedChart(<MixedLineBarChart series={[lineSeries]} hideFilter={true} />);
-    expect(wrapper.findFilterContainer()).not.toBeNull();
+    expect(wrapper.findFilterContainer()).toBeNull();
     expect(wrapper.findDefaultFilter()).toBeNull();
   });
 

--- a/src/mixed-line-bar-chart/internal.tsx
+++ b/src/mixed-line-bar-chart/internal.tsx
@@ -197,7 +197,7 @@ export default function InternalMixedLineBarChart<T extends number | string | Da
     visibleData: visibleSeries || [],
     statusType,
   });
-  const showFilters = statusType === 'finished' && (!isEmpty || isNoMatch);
+  const showFilters = statusType === 'finished' && (!isEmpty || isNoMatch) && (additionalFilters || !hideFilter);
   const showLegend = !hideLegend && !isEmpty && statusType === 'finished';
   const reserveLegendSpace = !showChart && !hideLegend;
   const reserveFilterSpace = !showChart && !isNoMatch && (!hideFilter || additionalFilters);

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -183,9 +183,9 @@ describe('Filter container', () => {
     expect(wrapper.findDefaultFilter()).not.toBeNull();
   });
 
-  test('is rendered when hideFilter is set but does not contain the default filter', () => {
+  test('is not rendered when hideFilter is set', () => {
     const { wrapper } = renderPieChart(<PieChart data={defaultData} hideFilter={true} />);
-    expect(wrapper.findFilterContainer()).not.toBeNull();
+    expect(wrapper.findFilterContainer()).toBeNull();
     expect(wrapper.findDefaultFilter()).toBeNull();
   });
 

--- a/src/pie-chart/index.tsx
+++ b/src/pie-chart/index.tsx
@@ -134,7 +134,7 @@ const PieChart = function PieChart<T extends PieChartProps.Datum = PieChartProps
 
   return (
     <div {...containerAttr} ref={mergedRef} onBlur={onBlur}>
-      {statusType === 'finished' && !isEmpty && (
+      {statusType === 'finished' && !isEmpty && (additionalFilters || !hideFilter) && (
         <InternalBox className={styles['filter-container']} margin={{ bottom: 'l' }}>
           <InternalSpaceBetween
             size="l"

--- a/src/space-between/__tests__/space-between.test.tsx
+++ b/src/space-between/__tests__/space-between.test.tsx
@@ -44,7 +44,7 @@ describe('SpaceBetween', () => {
         </SpaceBetween>
       );
 
-      expect(container.firstChild!.firstChild).toHaveClass(styles['child-vertical-s']);
+      expect(container.firstChild).toHaveClass(styles['vertical-s']);
     }
     {
       const { container } = render(
@@ -54,7 +54,7 @@ describe('SpaceBetween', () => {
         </SpaceBetween>
       );
 
-      expect(container.firstChild!.firstChild).toHaveClass(styles['child-vertical-m']);
+      expect(container.firstChild).toHaveClass(styles['vertical-m']);
     }
     {
       const { container } = render(
@@ -64,7 +64,7 @@ describe('SpaceBetween', () => {
         </SpaceBetween>
       );
 
-      expect(container.firstChild!.firstChild).toHaveClass(styles['child-vertical-xxl']);
+      expect(container.firstChild).toHaveClass(styles['vertical-xxl']);
     }
   });
 

--- a/src/space-between/internal.tsx
+++ b/src/space-between/internal.tsx
@@ -36,7 +36,7 @@ export default function InternalSpaceBetween({
         const key = (child as any).key;
 
         return (
-          <div key={key} className={clsx(styles.child, styles[`child-${direction}-${size}`])}>
+          <div key={key} className={styles.child}>
             {child}
           </div>
         );

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -50,20 +50,8 @@ $sizes-vertical: (
 
   @each $name, $size in $sizes-horizontal {
     &-#{$name} {
-      // This cancels out the margins of the children in the first row / in the first column.
-      margin-left: calc(-1 * #{$size});
-      margin-bottom: calc(-1 * #{$size});
+      gap: $size;
     }
-  }
-}
-
-@each $name, $size in $sizes-horizontal {
-  .child-horizontal-#{$name} {
-    margin-left: $size;
-    margin-bottom: $size;
-
-    // This is a fix for IE11. It prevents the content from overflowing.
-    min-width: 1px;
   }
 }
 
@@ -73,10 +61,11 @@ $sizes-vertical: (
 
 .vertical {
   flex-direction: column;
-}
 
-@each $name, $size in $sizes-vertical {
-  .child-vertical-#{$name}:not(:last-child) {
-    margin-bottom: $size;
+  @each $name, $size in $sizes-vertical {
+    &-#{$name} {
+      // This cancels out the margins of the children in the first row / in the first column.
+      gap: $size;
+    }
   }
 }

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -64,8 +64,7 @@ $sizes-vertical: (
 
   @each $name, $size in $sizes-vertical {
     &-#{$name} {
-      // This cancels out the margins of the children in the first row / in the first column.
-      gap: $size;
+      row-gap: $size;
     }
   }
 }

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -39,7 +39,7 @@ export default function InternalTokenGroup({
   const slicedItems = hasHiddenItems && !expanded ? items.slice(0, limit) : items;
 
   const baseProps = getBaseProps(props);
-  const className = clsx(baseProps.className, styles.root, hasItems && styles['has-items']);
+  const className = clsx(baseProps.className, styles.root, hasItems && slicedItems.length && styles['has-items']);
 
   return (
     <div {...baseProps} className={className} ref={__internalRootRef}>


### PR DESCRIPTION
### Description

Ensure that conditionally-rendered (and therefore potentially null/empty) children are handled by SpaceBetween. Also take the opportunity to modernize the approach (as we no longer need to support IE11).

Related links, issue #, if available: AWSUI-20570

### How has this been tested?

Screenshot tests run in dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
