### PR TITLE
fix: Do not emit change events when use-entered option is selected

### DIFF
--- a/src/autosuggest/__integ__/events-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/events-autosuggest.test.ts
@@ -25,7 +25,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
   );
 
   test(
-    'should fire change event when selecting suggestions with SPACE',
+    'should allow entering spaces after selecting an item',
     setupTest(async page => {
       await page.focusInput();
       await page.keys(['opt']);
@@ -33,6 +33,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
 
       await page.keys(['ArrowDown', 'Space']);
       await page.assertEventsFired(['onChange']);
+      await expect(page.getAutosuggestValue()).resolves.toEqual('opt ');
     })
   );
 
@@ -101,7 +102,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
       await page.keys(['opt']);
       await page.clearEventList();
 
-      await page.keys(['ArrowDown', 'Enter']);
+      await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
       await page.focusOutsideInput();
       await page.assertEventsFired(['onChange', 'onBlur']);
     })

--- a/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
+++ b/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
@@ -20,4 +20,7 @@ export default class EventsAutosuggestPage extends AutosuggestPage {
   async focusOutsideInput() {
     await this.click('#focusable');
   }
+  getAutosuggestValue() {
+    return this.getValue(this.wrapper.findNativeInput().toSelector());
+  }
 }

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -133,7 +133,7 @@ describe('onSelect', () => {
     expect(onSelect).toHaveBeenCalledWith({ value: '1' });
   });
 
-  test('should select `enteredText` option', () => {
+  test('should not select `enteredText` option', () => {
     const onChange = jest.fn();
     const onSelect = jest.fn();
     const { wrapper } = renderAutosuggest(
@@ -145,9 +145,11 @@ describe('onSelect', () => {
       />
     );
     wrapper.focus();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBeTruthy();
     wrapper.findEnteredTextOption()!.fireEvent(new MouseEvent('mouseup', { bubbles: true }));
-    expect(onChange).toHaveBeenCalledWith({ value: 'test' });
-    expect(onSelect).toHaveBeenCalledWith({ value: 'test' });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(wrapper.findDropdown().findOpenDropdown()).toBeFalsy();
   });
 });
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -82,9 +82,11 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     filteringType,
     hideEnteredTextLabel: false,
     onSelectItem: (option: AutosuggestItem) => {
-      const value = option.value || '';
-      fireNonCancelableEvent(onChange, { value });
-      fireNonCancelableEvent(onSelect, { value });
+      if (option.type !== 'use-entered') {
+        const value = option.value || '';
+        fireNonCancelableEvent(onChange, { value });
+        fireNonCancelableEvent(onSelect, { value });
+      }
       autosuggestInputRef.current?.close();
     },
   });


### PR DESCRIPTION
### Description

This option actually does nothing, because the value is already there. It basically operates like a "close dropdown" button

Related links, issue #, if available: AWSUI-20591

### How has this been tested?

* Updated related test
* Running compatibility tests in my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
