### PR TITLE
fix: Internal component imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,10 @@
         {
           "pattern": "./src/*/index.tsx",
           "message": "Disallowed import '{{ path }}'. Use the internal component for composition or the interface directly."
+        },
+        {
+          "pattern": "./src/*/index.js",
+          "message": "Disallowed import '{{ path }}'. Use the internal component for composition or the interface directly."
         }
       ]
     ],

--- a/src/annotation-context/index.tsx
+++ b/src/annotation-context/index.tsx
@@ -10,23 +10,9 @@ import { fireNonCancelableEvent } from '../internal/events';
 import { HotspotProps } from '../hotspot/interfaces';
 import { useTelemetry } from '../internal/hooks/use-telemetry';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { getStepInfo } from './utils';
 
 export { AnnotationContextProps };
-
-export function getStepInfo(annotations: readonly AnnotationContextProps.Task[], index: number) {
-  if (index >= 0) {
-    let taskIndex = 0;
-    for (const task of annotations) {
-      if (task.steps.length <= index) {
-        index -= task.steps.length;
-        taskIndex++;
-        continue;
-      }
-      return { task, step: task.steps[index], localIndex: index, taskIndex };
-    }
-  }
-  return { task: undefined, step: undefined, localIndex: 0, taskIndex: 0 };
-}
 
 // constant empty array to keep hook dependency stable
 const emptyTasks: ReadonlyArray<AnnotationContextProps.Task> = [];

--- a/src/annotation-context/utils.ts
+++ b/src/annotation-context/utils.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnnotationContextProps } from './interfaces';
+
+export function getStepInfo(annotations: readonly AnnotationContextProps.Task[], index: number) {
+  if (index >= 0) {
+    let taskIndex = 0;
+    for (const task of annotations) {
+      if (task.steps.length <= index) {
+        index -= task.steps.length;
+        taskIndex++;
+        continue;
+      }
+      return { task, step: task.steps[index], localIndex: index, taskIndex };
+    }
+  }
+  return { task: undefined, step: undefined, localIndex: 0, taskIndex: 0 };
+}

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -8,7 +8,7 @@ import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import FocusLock from '../internal/components/focus-lock';
 import InternalBox from '../box/internal';
-import SpaceBetween from '../space-between/index.js';
+import InternalSpaceBetween from '../space-between/internal';
 
 import styles from './styles.css.js';
 import RelativeRangePicker from './relative-range';
@@ -149,9 +149,9 @@ export function DateRangePickerDropdown({
               [styles['one-grid']]: isSingleGrid,
             })}
           >
-            <SpaceBetween size="l">
+            <InternalSpaceBetween size="l">
               <InternalBox padding={{ top: 'm', horizontal: 'l' }}>
-                <SpaceBetween direction="vertical" size="s">
+                <InternalSpaceBetween direction="vertical" size="s">
                   {rangeSelectorMode === 'default' && (
                     <ModeSwitcher
                       mode={rangeSelectionMode}
@@ -188,7 +188,7 @@ export function DateRangePickerDropdown({
                       i18nStrings={i18nStrings}
                     />
                   )}
-                </SpaceBetween>
+                </InternalSpaceBetween>
 
                 <InternalBox
                   className={styles['validation-section']}
@@ -224,7 +224,7 @@ export function DateRangePickerDropdown({
                   </div>
                 )}
                 <div className={styles['footer-button-wrapper']}>
-                  <SpaceBetween size="xs" direction="horizontal">
+                  <InternalSpaceBetween size="xs" direction="horizontal">
                     <InternalButton
                       onClick={closeDropdown}
                       className={styles['cancel-button']}
@@ -242,10 +242,10 @@ export function DateRangePickerDropdown({
                     >
                       {i18nStrings.applyButtonLabel}
                     </InternalButton>
-                  </SpaceBetween>
+                  </InternalSpaceBetween>
                 </div>
               </div>
-            </SpaceBetween>
+            </InternalSpaceBetween>
           </div>
         </div>
       </FocusLock>

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -28,7 +28,8 @@ import { checkOptionValueField } from '../select/utils/check-option-value-field.
 import Filter from '../select/parts/filter';
 import Trigger from '../select/parts/trigger';
 
-import TokenGroup, { TokenGroupProps } from '../token-group/index.js';
+import InternalTokenGroup from '../token-group/internal';
+import { TokenGroupProps } from '../token-group/interfaces';
 
 import { MultiselectProps } from './interfaces';
 import styles from './styles.css.js';
@@ -303,7 +304,8 @@ const InternalMultiselect = React.forwardRef(
           />
         </Dropdown>
         {showTokens && (
-          <TokenGroup
+          <InternalTokenGroup
+            alignment="horizontal"
             limit={tokenLimit}
             items={tokens}
             onDismiss={handleTokenDismiss}

--- a/src/tutorial-panel/components/tutorial-detail-view/task-list.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/task-list.tsx
@@ -8,7 +8,7 @@ import InternalBox from '../../../box/internal';
 import InternalSpaceBetween from '../../../space-between/internal';
 import { HotspotContext } from '../../../annotation-context/context';
 import { Task } from './task';
-import { getStepInfo } from '../../../annotation-context/index.js';
+import { getStepInfo } from '../../../annotation-context/utils';
 
 export interface TaskListProps {
   tasks: ReadonlyArray<TutorialPanelProps.Task>;


### PR DESCRIPTION
### Description

Components can use other components internally but importing from `index.tsx` is disallowed.
However, there were three imports that violate the rule because of having `/index.js` path which was probably auto-inserted by the IDE.

### How has this been tested?

Runner `npm run lint` with updated rule configuration.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
