### PR TITLE
fix: FindSplitPanel selector returns true without splitpanel

### DIFF
--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -7,6 +7,7 @@ import SplitPanel from '../../../lib/components/split-panel';
 import { KeyCode } from '../../../lib/components/internal/keycode';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import { renderComponent, splitPanelI18nStrings } from './utils';
+import splitPanelStyles from '../../../lib/components/split-panel/styles.selectors.js';
 
 const defaultSplitPanel = (
   <SplitPanel i18nStrings={splitPanelI18nStrings} header="test header">
@@ -136,6 +137,12 @@ for (const theme of ['refresh', 'classic']) {
         expect(wrapper.findSplitPanel()!.findOpenButton()!.getElement()).toHaveFocus();
       });
     });
+    test(`should not render split panel when it is not defined in ${theme}`, () => {
+      const { wrapper, rerender } = renderComponent(<AppLayout splitPanel={defaultSplitPanel} />);
+      expect(wrapper.findSplitPanel()).toBeTruthy();
+      rerender(<AppLayout />);
+      expect(wrapper.findSplitPanel()).toBeFalsy();
+    });
   });
 }
 
@@ -205,7 +212,7 @@ describe('Visual refresh only features', () => {
 
   test('does not render open-button bar in default state', () => {
     const { wrapper } = renderComponent(<AppLayout />);
-    expect(wrapper.findSplitPanel()!.findOpenButton()).toBeFalsy();
+    expect(wrapper.find(`.${splitPanelStyles['open-button']}`)).toBeFalsy();
   });
 });
 

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -170,4 +170,6 @@ handleSplitPanelMaxWidth function in the context.
       z-index: 1;
     }
   }
+
+  @include styles.styles-reset;
 }

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -114,15 +114,11 @@ export default function Tools({ children }: ToolsProps) {
             <aside
               aria-hidden={!hasToolsForm ? true : false}
               aria-label={ariaLabels?.tools ?? undefined}
-              className={clsx(
-                styles['show-tools'],
-                {
-                  [styles.animating]: state === 'exiting',
-                  [styles['has-tools-form']]: hasToolsForm,
-                  [styles['has-tools-form-persistence']]: hasToolsFormPersistence,
-                },
-                splitPanelStyles.root
-              )}
+              className={clsx(styles['show-tools'], {
+                [styles.animating]: state === 'exiting',
+                [styles['has-tools-form']]: hasToolsForm,
+                [styles['has-tools-form-persistence']]: hasToolsFormPersistence,
+              })}
               ref={state === 'exiting' ? transitionEventsRef : undefined}
             >
               {!toolsHide && (

--- a/src/test-utils/dom/split-panel/index.ts
+++ b/src/test-utils/dom/split-panel/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import ButtonWrapper from '../button';
 import styles from '../../../split-panel/styles.selectors.js';
 
@@ -20,7 +20,8 @@ export default class SplitPanelWrapper extends ComponentWrapper {
   }
 
   findOpenButton(): ButtonWrapper | null {
-    return this.findComponent(`.${styles['open-button']}`, ButtonWrapper);
+    const wrapper = createWrapper();
+    return wrapper.findComponent(`.${styles['open-button']}`, ButtonWrapper);
   }
 
   findSlider(): ElementWrapper | null {


### PR DESCRIPTION
### Description

findSplitPanel() always return true in VR because `splitPanelStyles.root` is available in `aside` for tool and splitpanel toggle button. 
The fix is to remove this class from `aside`.
Also to change findOpenButton() not rely on SplitPanelWrapper because it is not always inside a split panel. 


Related links, issue #AWSUI-20594

### How has this been tested?

<!-- How did you test to verify your changes? --> Add unit test. Build succeed 6382342675

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
