### PR TITLE
feat: Internal generic token group component

### DIFF
--- a/pages/token-group/generic.page.tsx
+++ b/pages/token-group/generic.page.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { range } from 'lodash';
+import { TokenGroupProps } from '~components/token-group';
+import GenericTokenGroup from '~components/token-group/generic-token-group';
+import Box from '~components/box';
+import SpaceBetween from '~components/space-between';
+import Icon from '~components/icon';
+import styles from './styles.scss';
+
+const i18nStrings: TokenGroupProps.I18nStrings = {
+  limitShowMore: 'Show more chosen options',
+  limitShowFewer: 'Show fewer chosen options',
+};
+
+export default function GenericTokenGroupPage() {
+  const [files, setFiles] = useState(range(0, 4));
+
+  const onDismiss = (itemIndex: number) => {
+    const newItems = [...files];
+    newItems.splice(itemIndex, 1);
+    setFiles(newItems);
+  };
+
+  return (
+    <Box padding="xl">
+      <h1>Generic token group</h1>
+      <GenericTokenGroup
+        alignment="vertical"
+        items={files}
+        i18nStrings={i18nStrings}
+        limit={5}
+        renderItem={file => <FileOption file={file} />}
+        getItemAttributes={(item, itemIndex) => ({
+          disabled: item === 0,
+          dismissLabel: 'Remove file',
+          onDismiss: () => onDismiss(itemIndex),
+        })}
+      />
+    </Box>
+  );
+}
+
+function FileOption({ file }: { file: number }) {
+  const fileName = `agreement-${file + 1}.pdf`;
+  return (
+    <Box className={styles['file-option']}>
+      <Icon variant="success" name="status-positive" />
+
+      <div className={styles['file-option-metadata']}>
+        <SpaceBetween direction="vertical" size="xxxs">
+          {
+            <div className={styles['file-option-name']}>
+              <div className={styles['file-option-name-label']} title={fileName}>
+                {fileName}
+              </div>
+            </div>
+          }
+          <Box fontSize="body-s" color="text-body-secondary">
+            application/pdf
+          </Box>
+          <Box fontSize="body-s" color="text-body-secondary">
+            313.03 KB
+          </Box>
+          <Box fontSize="body-s" color="text-body-secondary">
+            2022-01-01T12:02:02
+          </Box>
+        </SpaceBetween>
+      </div>
+    </Box>
+  );
+}

--- a/pages/token-group/generic.page.tsx
+++ b/pages/token-group/generic.page.tsx
@@ -34,8 +34,10 @@ export default function GenericTokenGroupPage() {
         renderItem={file => <FileOption file={file} />}
         getItemAttributes={(item, itemIndex) => ({
           disabled: item === 0,
-          dismissLabel: 'Remove file',
-          onDismiss: () => onDismiss(itemIndex),
+          dismiss: {
+            label: 'Remove file',
+            onDismiss: () => onDismiss(itemIndex),
+          },
         })}
       />
     </Box>

--- a/pages/token-group/styles.scss
+++ b/pages/token-group/styles.scss
@@ -1,0 +1,24 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '~design-tokens' as awsui;
+
+.file-option {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  gap: awsui.$space-scaled-xs;
+}
+
+.file-option-metadata {
+  width: 100%;
+  overflow: hidden;
+}
+
+.file-option-name-label {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/src/token-group/generic-token-group.tsx
+++ b/src/token-group/generic-token-group.tsx
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { forwardRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { BaseComponentProps, getBaseProps } from '../internal/base-component';
+
+import SpaceBetween from '../space-between/internal';
+
+import { TokenGroupProps } from './interfaces';
+import DismissButton from './dismiss-button';
+import SelectToggle from './toggle';
+
+import styles from './styles.css.js';
+
+interface ItemAttributes {
+  disabled?: boolean;
+  dismissLabel?: string;
+  onDismiss?: () => void;
+}
+
+interface GenericTokenGroupProps<Item> extends BaseComponentProps {
+  items: readonly Item[];
+  limit?: number;
+  alignment: TokenGroupProps.Alignment;
+  renderItem: (item: Item, itemIndex: number) => React.ReactNode;
+  getItemAttributes: (item: Item, itemIndex: number) => ItemAttributes;
+  i18nStrings?: TokenGroupProps.I18nStrings;
+}
+
+export default forwardRef(GenericTokenGroup) as <T>(
+  props: GenericTokenGroupProps<T> & { ref?: React.ForwardedRef<HTMLDivElement> }
+) => ReturnType<typeof GenericTokenGroup>;
+
+function GenericTokenGroup<Item>(
+  { items, alignment, renderItem, getItemAttributes, limit, ...props }: GenericTokenGroupProps<Item>,
+  ref: React.Ref<HTMLDivElement>
+) {
+  const [expanded, setExpanded] = useState(false);
+  const controlId = useUniqueId();
+
+  const hasItems = items.length > 0;
+  const hasHiddenItems = hasItems && limit !== undefined && items.length > limit;
+  const slicedItems = hasHiddenItems && !expanded ? items.slice(0, limit) : items;
+
+  const baseProps = getBaseProps(props);
+  const className = clsx(baseProps.className, styles.root, hasItems && styles['has-items']);
+
+  return (
+    <div {...baseProps} className={className} ref={ref}>
+      {hasItems && (
+        <SpaceBetween id={controlId} direction={alignment} size="xs">
+          {slicedItems.map((item, itemIndex) => (
+            <GenericToken key={itemIndex} {...getItemAttributes(item, itemIndex)}>
+              {renderItem(item, itemIndex)}
+            </GenericToken>
+          ))}
+        </SpaceBetween>
+      )}
+      {hasHiddenItems && (
+        <SelectToggle
+          controlId={controlId}
+          allHidden={limit === 0}
+          expanded={expanded}
+          numberOfHiddenOptions={items.length - slicedItems.length}
+          i18nStrings={props.i18nStrings}
+          onClick={() => setExpanded(!expanded)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface GenericTokenProps extends ItemAttributes {
+  children: React.ReactNode;
+  onDismiss?: () => void;
+}
+
+function GenericToken({ disabled, dismissLabel, onDismiss, children }: GenericTokenProps) {
+  return (
+    <div
+      className={clsx(styles.token, disabled && styles['token-disabled'])}
+      aria-disabled={disabled ? 'true' : undefined}
+    >
+      {children}
+      {onDismiss && <DismissButton disabled={disabled} dismissLabel={dismissLabel} onDismiss={onDismiss} />}
+    </div>
+  );
+}

--- a/src/token-group/generic-token-group.tsx
+++ b/src/token-group/generic-token-group.tsx
@@ -17,8 +17,10 @@ import styles from './styles.css.js';
 
 interface ItemAttributes {
   disabled?: boolean;
-  dismissLabel?: string;
-  onDismiss?: () => void;
+  dismiss?: {
+    label?: string;
+    onDismiss: () => void;
+  };
 }
 
 interface GenericTokenGroupProps<Item> extends BaseComponentProps {
@@ -75,17 +77,16 @@ function GenericTokenGroup<Item>(
 
 interface GenericTokenProps extends ItemAttributes {
   children: React.ReactNode;
-  onDismiss?: () => void;
 }
 
-function GenericToken({ disabled, dismissLabel, onDismiss, children }: GenericTokenProps) {
+function GenericToken({ disabled, dismiss, children }: GenericTokenProps) {
   return (
     <div
       className={clsx(styles.token, disabled && styles['token-disabled'])}
       aria-disabled={disabled ? 'true' : undefined}
     >
       {children}
-      {onDismiss && <DismissButton disabled={disabled} dismissLabel={dismissLabel} onDismiss={onDismiss} />}
+      {dismiss && <DismissButton disabled={disabled} dismissLabel={dismiss.label} onDismiss={dismiss.onDismiss} />}
     </div>
   );
 }

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -25,8 +25,10 @@ export default function InternalTokenGroup({ items, onDismiss, __internalRootRef
       renderItem={item => <Option option={item} />}
       getItemAttributes={(item, itemIndex) => ({
         disabled: item.disabled,
-        dismissLabel: item.dismissLabel,
-        onDismiss: () => fireNonCancelableEvent(onDismiss, { itemIndex }),
+        dismiss: {
+          label: item.dismissLabel,
+          onDismiss: () => fireNonCancelableEvent(onDismiss, { itemIndex }),
+        },
       })}
     />
   );

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -1,86 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
-import clsx from 'clsx';
+import React from 'react';
 
 import Option from '../internal/components/option';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { getBaseProps } from '../internal/base-component';
-
-import SpaceBetween from '../space-between/internal';
 
 import { TokenGroupProps } from './interfaces';
-import DismissButton from './dismiss-button';
-import SelectToggle from './toggle';
 
-import styles from './styles.css.js';
 import { SomeRequired } from '../internal/types';
+import GenericTokenGroup from './generic-token-group';
 
 type InternalTokenGroupProps = SomeRequired<TokenGroupProps, 'items' | 'alignment'> & InternalBaseComponentProps;
 
-export default function InternalTokenGroup({
-  items,
-  alignment,
-  onDismiss,
-  __internalRootRef,
-  limit,
-  ...props
-}: InternalTokenGroupProps) {
+export default function InternalTokenGroup({ items, onDismiss, __internalRootRef, ...props }: InternalTokenGroupProps) {
   checkControlled('TokenGroup', 'items', items, 'onDismiss', onDismiss);
 
-  const [expanded, setExpanded] = useState(false);
-  const controlId = useUniqueId();
-
-  const hasItems = items.length > 0;
-  const hasHiddenItems = hasItems && limit !== undefined && items.length > limit;
-  const slicedItems = hasHiddenItems && !expanded ? items.slice(0, limit) : items;
-
-  const baseProps = getBaseProps(props);
-  const className = clsx(baseProps.className, styles.root, hasItems && styles['has-items']);
-
   return (
-    <div {...baseProps} className={className} ref={__internalRootRef}>
-      {hasItems && (
-        <SpaceBetween id={controlId} direction={alignment} size="xs">
-          {slicedItems.map((item: TokenGroupProps.Item, itemIndex) => (
-            <Token key={itemIndex} {...item} onDismiss={() => fireNonCancelableEvent(onDismiss, { itemIndex })} />
-          ))}
-        </SpaceBetween>
-      )}
-      {hasHiddenItems && (
-        <SelectToggle
-          controlId={controlId}
-          allHidden={limit === 0}
-          expanded={expanded}
-          numberOfHiddenOptions={items.length - slicedItems.length}
-          i18nStrings={props.i18nStrings}
-          onClick={() => setExpanded(!expanded)}
-        />
-      )}
-    </div>
-  );
-}
-
-interface TokenProps extends TokenGroupProps.Item {
-  onDismiss?: () => void;
-}
-
-export function Token({ disabled, dismissLabel, onDismiss, ...props }: TokenProps) {
-  return (
-    <div
-      className={clsx(styles.token, disabled && styles['token-disabled'])}
-      aria-disabled={disabled ? 'true' : undefined}
-    >
-      <Option
-        option={{
-          ...props,
-          disabled,
-        }}
-      />
-      <DismissButton disabled={disabled} dismissLabel={dismissLabel} onDismiss={onDismiss} />
-    </div>
+    <GenericTokenGroup
+      ref={__internalRootRef}
+      {...props}
+      items={items}
+      renderItem={item => <Option option={item} />}
+      getItemAttributes={(item, itemIndex) => ({
+        disabled: item.disabled,
+        dismissLabel: item.dismissLabel,
+        onDismiss: () => fireNonCancelableEvent(onDismiss, { itemIndex }),
+      })}
+    />
   );
 }


### PR DESCRIPTION
### Description

The generic token group is an internal component to reuse token group for arbitrary content. It is needed to support the addition of file upload component, see https://github.com/cloudscape-design/components/pull/829.

### How has this been tested?

Relying on the existing tests because the new component is an excerpt from the internal token group.

Added new test page to be used as dev. reference/playground.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
