### PR TITLE
fix: Ensure FormFieldContext doesn't leak into modal-style components

### DIFF
--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -11,7 +11,6 @@ import InternalModal from '../modal/internal';
 import { SelectProps } from '../select/interfaces';
 import InternalSelect from '../select/internal';
 import InternalSpaceBetween from '../space-between/internal';
-import { FormFieldContext } from '../internal/context/form-field-context';
 import { NonCancelableCustomEvent } from '../internal/events';
 import { LightThemes, DarkThemes } from './ace-themes';
 import { CodeEditorProps } from './interfaces';
@@ -68,42 +67,40 @@ export default (props: PreferencesModalProps) => {
   };
 
   return (
-    <FormFieldContext.Provider value={{}}>
-      <InternalModal
-        size="medium"
-        visible={true}
-        onDismiss={props.onDismiss}
-        header={props.i18nStrings.header}
-        closeAriaLabel={props.i18nStrings.cancel}
-        footer={
-          <InternalBox float="right">
-            <InternalSpaceBetween direction="horizontal" size="xs">
-              <InternalButton onClick={props.onDismiss}>{props.i18nStrings.cancel}</InternalButton>
-              <InternalButton onClick={() => props.onConfirm({ wrapLines, theme })} variant="primary">
-                {props.i18nStrings.confirm}
-              </InternalButton>
-            </InternalSpaceBetween>
-          </InternalBox>
-        }
-      >
-        <InternalColumnLayout columns={2} variant="text-grid">
-          <div>
-            <InternalCheckbox checked={wrapLines} onChange={e => setWrapLines(e.detail.checked)}>
-              {props.i18nStrings.wrapLines}
-            </InternalCheckbox>
-          </div>
-          <div>
-            <InternalFormField label={props.i18nStrings.theme}>
-              <InternalSelect
-                selectedOption={selectedThemeOption}
-                onChange={onThemeSelected}
-                options={themeOptions}
-                filteringType="auto"
-              />
-            </InternalFormField>
-          </div>
-        </InternalColumnLayout>
-      </InternalModal>
-    </FormFieldContext.Provider>
+    <InternalModal
+      size="medium"
+      visible={true}
+      onDismiss={props.onDismiss}
+      header={props.i18nStrings.header}
+      closeAriaLabel={props.i18nStrings.cancel}
+      footer={
+        <InternalBox float="right">
+          <InternalSpaceBetween direction="horizontal" size="xs">
+            <InternalButton onClick={props.onDismiss}>{props.i18nStrings.cancel}</InternalButton>
+            <InternalButton onClick={() => props.onConfirm({ wrapLines, theme })} variant="primary">
+              {props.i18nStrings.confirm}
+            </InternalButton>
+          </InternalSpaceBetween>
+        </InternalBox>
+      }
+    >
+      <InternalColumnLayout columns={2} variant="text-grid">
+        <div>
+          <InternalCheckbox checked={wrapLines} onChange={e => setWrapLines(e.detail.checked)}>
+            {props.i18nStrings.wrapLines}
+          </InternalCheckbox>
+        </div>
+        <div>
+          <InternalFormField label={props.i18nStrings.theme}>
+            <InternalSelect
+              selectedOption={selectedThemeOption}
+              onChange={onThemeSelected}
+              options={themeOptions}
+              filteringType="auto"
+            />
+          </InternalFormField>
+        </div>
+      </InternalColumnLayout>
+    </InternalModal>
   );
 };

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -14,6 +14,7 @@ import InternalHeader from '../header/internal';
 import Portal from '../internal/components/portal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { FormFieldContext } from '../internal/context/form-field-context';
 
 import { disableBodyScrolling, enableBodyScrolling } from './body-scroll';
 import { ModalProps } from './interfaces';
@@ -93,56 +94,58 @@ export default function InternalModal({
 
   return (
     <Portal container={modalRoot}>
-      <div
-        {...baseProps}
-        className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
-        role="dialog"
-        aria-modal={true}
-        aria-labelledby={headerId}
-        onMouseDown={onOverlayMouseDown}
-        onClick={onOverlayClick}
-        ref={mergedRef}
-      >
-        <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
-          <div
-            className={clsx(
-              styles.dialog,
-              styles[size],
-              styles[`breakpoint-${breakpoint}`],
-              isRefresh && styles.refresh
-            )}
-            onKeyDown={escKeyHandler}
-            tabIndex={-1}
-          >
-            <div className={styles.container}>
-              <div className={styles.header}>
-                <InternalHeader
-                  variant="h2"
-                  __disableActionsWrapping={true}
-                  actions={
-                    <InternalButton
-                      ariaLabel={closeAriaLabel}
-                      className={styles['dismiss-control']}
-                      variant="modal-dismiss"
-                      iconName="close"
-                      formAction="none"
-                      onClick={onCloseButtonClick}
-                    />
-                  }
-                >
-                  <span id={headerId} className={styles['header--text']}>
-                    {header}
-                  </span>
-                </InternalHeader>
+      <FormFieldContext.Provider value={{}}>
+        <div
+          {...baseProps}
+          className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
+          role="dialog"
+          aria-modal={true}
+          aria-labelledby={headerId}
+          onMouseDown={onOverlayMouseDown}
+          onClick={onOverlayClick}
+          ref={mergedRef}
+        >
+          <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
+            <div
+              className={clsx(
+                styles.dialog,
+                styles[size],
+                styles[`breakpoint-${breakpoint}`],
+                isRefresh && styles.refresh
+              )}
+              onKeyDown={escKeyHandler}
+              tabIndex={-1}
+            >
+              <div className={styles.container}>
+                <div className={styles.header}>
+                  <InternalHeader
+                    variant="h2"
+                    __disableActionsWrapping={true}
+                    actions={
+                      <InternalButton
+                        ariaLabel={closeAriaLabel}
+                        className={styles['dismiss-control']}
+                        variant="modal-dismiss"
+                        iconName="close"
+                        formAction="none"
+                        onClick={onCloseButtonClick}
+                      />
+                    }
+                  >
+                    <span id={headerId} className={styles['header--text']}>
+                      {header}
+                    </span>
+                  </InternalHeader>
+                </div>
+                <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
+                  {children}
+                </div>
+                {footer && <div className={styles.footer}>{footer}</div>}
               </div>
-              <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
-                {children}
-              </div>
-              {footer && <div className={styles.footer}>{footer}</div>}
             </div>
-          </div>
-        </FocusLock>
-      </div>
+          </FocusLock>
+        </div>
+      </FormFieldContext.Provider>
     </Portal>
   );
 }

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { KeyCode } from '../internal/keycode';
 import { getBaseProps } from '../internal/base-component';
 import useFocusVisible from '../internal/hooks/focus-visible';
+import { FormFieldContext } from '../internal/context/form-field-context';
 
 import Arrow from './arrow';
 import Portal from '../internal/components/portal';
@@ -148,25 +149,27 @@ function InternalPopover(
   const mergedRef = useMergeRefs(popoverRef, __internalRootRef);
 
   return (
-    <div
-      {...baseProps}
-      className={clsx(styles.root, baseProps.className)}
-      ref={mergedRef}
-      onMouseDown={() => {
-        // Indicate there was a click inside popover recently, including nested portals.
-        clickFrameId.current = requestAnimationFrame(() => {
-          clickFrameId.current = null;
-        });
-      }}
-    >
-      {triggerType === 'text' ? (
-        <button {...triggerProps} type="button" aria-haspopup="dialog" {...focusVisible}>
-          <span className={styles['trigger-inner-text']}>{children}</span>
-        </button>
-      ) : (
-        <span {...triggerProps}>{children}</span>
-      )}
-      {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
-    </div>
+    <FormFieldContext.Provider value={{}}>
+      <div
+        {...baseProps}
+        className={clsx(styles.root, baseProps.className)}
+        ref={mergedRef}
+        onMouseDown={() => {
+          // Indicate there was a click inside popover recently, including nested portals.
+          clickFrameId.current = requestAnimationFrame(() => {
+            clickFrameId.current = null;
+          });
+        }}
+      >
+        {triggerType === 'text' ? (
+          <button {...triggerProps} type="button" aria-haspopup="dialog" {...focusVisible}>
+            <span className={styles['trigger-inner-text']}>{children}</span>
+          </button>
+        ) : (
+          <span {...triggerProps}>{children}</span>
+        )}
+        {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
+      </div>
+    </FormFieldContext.Provider>
   );
 }


### PR DESCRIPTION
### Description

Previously, inputs within a Modal were getting auto-labelled/described by a parent FormField of the Modal component. This prevents that from happening.

Related links, issue #, if available: AWSUI-20621

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
