### PR TITLE
revert: Do not emit change events when use-entered option is selected

### DIFF
--- a/src/autosuggest/__integ__/events-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/events-autosuggest.test.ts
@@ -25,7 +25,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
   );
 
   test(
-    'should allow entering spaces after selecting an item',
+    'should fire change event when selecting suggestions with SPACE',
     setupTest(async page => {
       await page.focusInput();
       await page.keys(['opt']);
@@ -33,7 +33,6 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
 
       await page.keys(['ArrowDown', 'Space']);
       await page.assertEventsFired(['onChange']);
-      await expect(page.getAutosuggestValue()).resolves.toEqual('opt ');
     })
   );
 
@@ -102,7 +101,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
       await page.keys(['opt']);
       await page.clearEventList();
 
-      await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
+      await page.keys(['ArrowDown', 'Enter']);
       await page.focusOutsideInput();
       await page.assertEventsFired(['onChange', 'onBlur']);
     })

--- a/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
+++ b/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
@@ -20,7 +20,4 @@ export default class EventsAutosuggestPage extends AutosuggestPage {
   async focusOutsideInput() {
     await this.click('#focusable');
   }
-  getAutosuggestValue() {
-    return this.getValue(this.wrapper.findNativeInput().toSelector());
-  }
 }

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -133,7 +133,7 @@ describe('onSelect', () => {
     expect(onSelect).toHaveBeenCalledWith({ value: '1' });
   });
 
-  test('should not select `enteredText` option', () => {
+  test('should select `enteredText` option', () => {
     const onChange = jest.fn();
     const onSelect = jest.fn();
     const { wrapper } = renderAutosuggest(
@@ -145,11 +145,9 @@ describe('onSelect', () => {
       />
     );
     wrapper.focus();
-    expect(wrapper.findDropdown().findOpenDropdown()).toBeTruthy();
     wrapper.findEnteredTextOption()!.fireEvent(new MouseEvent('mouseup', { bubbles: true }));
-    expect(onChange).not.toHaveBeenCalled();
-    expect(onSelect).not.toHaveBeenCalled();
-    expect(wrapper.findDropdown().findOpenDropdown()).toBeFalsy();
+    expect(onChange).toHaveBeenCalledWith({ value: 'test' });
+    expect(onSelect).toHaveBeenCalledWith({ value: 'test' });
   });
 });
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -82,11 +82,9 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     filteringType,
     hideEnteredTextLabel: false,
     onSelectItem: (option: AutosuggestItem) => {
-      if (option.type !== 'use-entered') {
-        const value = option.value || '';
-        fireNonCancelableEvent(onChange, { value });
-        fireNonCancelableEvent(onSelect, { value });
-      }
+      const value = option.value || '';
+      fireNonCancelableEvent(onChange, { value });
+      fireNonCancelableEvent(onSelect, { value });
       autosuggestInputRef.current?.close();
     },
   });


### PR DESCRIPTION
This broke valid use-cases, so we need to revisit this approach

Reverts cloudscape-design/components#834