### PR TITLE
fix: Remove uses of useCallback from internal i18n hook

### DIFF
--- a/src/internal/i18n/context.ts
+++ b/src/internal/i18n/context.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useContext } from 'react';
+import React, { useContext } from 'react';
 
 export type CustomHandler<T> = (formatFn: (args: Record<string, string | number>) => string) => T;
 
@@ -23,15 +23,12 @@ export interface ComponentFormatFunction {
   <T>(key: string, provided: T, handler?: CustomHandler<T>): T;
 }
 
-export function useInternalI18n(componentName: string) {
+export function useInternalI18n(componentName: string): ComponentFormatFunction {
   // HACK: useContext should return the default value if a provider
   // isn't present, but some consumers mock out React.useContext globally
   // in their tests, so we can't rely on this assumption.
   const format = useContext(InternalI18nContext) || defaultFormatFunction;
-  return useCallback<ComponentFormatFunction>(
-    <T>(key: string, provided: T, customHandler?: CustomHandler<T>) => {
-      return format<T>('@cloudscape-design/components', componentName, key, provided, customHandler);
-    },
-    [format, componentName]
-  );
+  return <T>(key: string, provided: T, customHandler?: CustomHandler<T>) => {
+    return format<T>('@cloudscape-design/components', componentName, key, provided, customHandler);
+  };
 }


### PR DESCRIPTION
### Description

Let's say, hypothetically, some consumers also mock out useCallback. It's also unnecessary now, since the function it relies on isn't stable anymore.

Related links, issue #, if available: n/a

### How has this been tested?

I can send you the failed build to validate.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
