### PR TITLE
feat: Add extra detail to autosuggest onSelect handler

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1319,6 +1319,11 @@ Instead, use \`onSelect\` in combination with the \`onChange\` handler only as a
         "name": "AutosuggestProps.SelectDetail",
         "properties": Array [
           Object {
+            "name": "selectedOption",
+            "optional": true,
+            "type": "AutosuggestProps.Option",
+          },
+          Object {
             "name": "value",
             "optional": false,
             "type": "string",

--- a/src/autosuggest/__integ__/events-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/events-autosuggest.test.ts
@@ -25,7 +25,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
   );
 
   test(
-    'should fire change event when selecting suggestions with SPACE',
+    'should allow entering spaces after focusing a dropdown item',
     setupTest(async page => {
       await page.focusInput();
       await page.keys(['opt']);
@@ -33,6 +33,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
 
       await page.keys(['ArrowDown', 'Space']);
       await page.assertEventsFired(['onChange']);
+      await expect(page.getAutosuggestValue()).resolves.toEqual('opt ');
     })
   );
 

--- a/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
+++ b/src/autosuggest/__integ__/page-objects/events-autosuggest-page.ts
@@ -20,4 +20,7 @@ export default class EventsAutosuggestPage extends AutosuggestPage {
   async focusOutsideInput() {
     await this.click('#focusable');
   }
+  getAutosuggestValue() {
+    return this.getValue(this.wrapper.findNativeInput().toSelector());
+  }
 }

--- a/src/autosuggest/__tests__/autosuggest-and-token-group.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest-and-token-group.test.tsx
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import Autosuggest from '../../../lib/components/autosuggest';
+import TokenGroup from '../../../lib/components/token-group';
+
+const wrapper = createWrapper();
+
+function getSelectedTokens() {
+  return wrapper
+    .findTokenGroup()!
+    .findTokens()
+    .map(token => token.findLabel().getElement().textContent!.trim());
+}
+
+function Demo() {
+  const options = ['apple', 'banana', 'orange'];
+  const enteredTextLabel = (value: string) => `Use: ${value}`;
+  const empty = <span>Nothing found</span>;
+  const [pendingValue, setPendingValue] = useState('');
+  const [tokens, setTokens] = useState<Array<string>>([]);
+  return (
+    <>
+      <Autosuggest
+        value={pendingValue}
+        options={options.filter(option => !tokens.includes(option)).map(option => ({ value: option }))}
+        enteredTextLabel={enteredTextLabel}
+        ariaLabel="Multi-suggest"
+        selectedAriaLabel="Selected"
+        empty={empty}
+        onChange={event => setPendingValue(event.detail.value)}
+        onSelect={event => {
+          setTokens(tokens => [...tokens, event.detail.value]);
+          setPendingValue('');
+        }}
+      />
+      <TokenGroup
+        items={tokens.map(token => ({ label: token }))}
+        onDismiss={event => setTokens(tokens => tokens.filter((token, index) => event.detail.itemIndex !== index))}
+      />
+    </>
+  );
+}
+
+test('Adding tokens from the dropdown', () => {
+  render(<Demo />);
+  wrapper.findAutosuggest()!.focus();
+  wrapper.findAutosuggest()!.selectSuggestion(1);
+  expect(wrapper.findAutosuggest()!.findNativeInput().getElement()).toHaveValue('');
+  expect(getSelectedTokens()).toEqual(['apple']);
+});
+
+test('Adding custom tokens', () => {
+  render(<Demo />);
+  wrapper.findAutosuggest()!.setInputValue('custom');
+  wrapper.findAutosuggest()!.focus();
+  wrapper
+    .findAutosuggest()!
+    .findEnteredTextOption()!
+    .fireEvent(new MouseEvent('mouseup', { bubbles: true }));
+  expect(wrapper.findAutosuggest()!.findNativeInput().getElement()).toHaveValue('');
+  expect(getSelectedTokens()).toEqual(['custom']);
+});
+
+test('Removing tokens', () => {
+  render(<Demo />);
+  wrapper.findAutosuggest()!.focus();
+  wrapper.findAutosuggest()!.selectSuggestion(1);
+  expect(getSelectedTokens()).toEqual(['apple']);
+  wrapper.findTokenGroup()!.findToken(1)!.findDismiss().click();
+  expect(getSelectedTokens()).toEqual([]);
+});

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -130,7 +130,7 @@ describe('onSelect', () => {
     wrapper.focus();
     wrapper.selectSuggestion(1);
     expect(onChange).toHaveBeenCalledWith({ value: '1' });
-    expect(onSelect).toHaveBeenCalledWith({ value: '1' });
+    expect(onSelect).toHaveBeenCalledWith({ value: '1', selectedOption: defaultOptions[0] });
   });
 
   test('should select `enteredText` option', () => {
@@ -147,7 +147,8 @@ describe('onSelect', () => {
     wrapper.focus();
     wrapper.findEnteredTextOption()!.fireEvent(new MouseEvent('mouseup', { bubbles: true }));
     expect(onChange).toHaveBeenCalledWith({ value: 'test' });
-    expect(onSelect).toHaveBeenCalledWith({ value: 'test' });
+    expect(onSelect).toHaveBeenCalledWith({ value: 'test', selectedOption: undefined });
+    expect(wrapper.findDropdown().findOpenDropdown()).toBeFalsy();
   });
 });
 
@@ -309,7 +310,9 @@ describe('keyboard interactions', () => {
     wrapper.findNativeInput().keydown(KeyCode.down);
     wrapper.findNativeInput().keydown(KeyCode.enter);
     expect(onChange).toBeCalledWith(expect.objectContaining({ detail: { value: '1' } }));
-    expect(onSelect).toBeCalledWith(expect.objectContaining({ detail: { value: '1' } }));
+    expect(onSelect).toBeCalledWith(
+      expect.objectContaining({ detail: { value: '1', selectedOption: defaultOptions[0] } })
+    );
   });
 
   test('closes dropdown on enter and opens it on arrow keys', () => {

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -122,6 +122,7 @@ export namespace AutosuggestProps {
   export type StatusType = DropdownStatusProps.StatusType;
   export interface SelectDetail {
     value: string;
+    selectedOption?: Option;
   }
 
   export interface ContainingOptionAndGroupString {

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -84,7 +84,10 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     onSelectItem: (option: AutosuggestItem) => {
       const value = option.value || '';
       fireNonCancelableEvent(onChange, { value });
-      fireNonCancelableEvent(onSelect, { value });
+      fireNonCancelableEvent(onSelect, {
+        value,
+        selectedOption: option.type !== 'use-entered' ? option.option : undefined,
+      });
       autosuggestInputRef.current?.close();
     },
   });


### PR DESCRIPTION
### Description

Follow up for https://github.com/cloudscape-design/components/pull/834. Another attempt to resolve AWSUI-20591, but this time in a backward compatible way

Related links, issue #, if available: AWSUI-20591

### How has this been tested?

Added extra tests 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
