### PR TITLE
chore: Add permutations for table inline editor

### DIFF
--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { TableBodyCell } from '~components/table/body-cell';
 import { TableProps } from '~components/table';
-import SpaceBetween from '~components/space-between';
 import Input from '~components/input';
 import Multiselect from '~components/multiselect';
 import createPermutations from '../utils/permutations';
@@ -20,7 +19,7 @@ const editPermutations = createPermutations<TableProps.EditConfig<unknown>>([
     editIconAriaLabel: ['editable'],
     errorIconAriaLabel: ['Error'],
     editingCell: [
-      () => <Input value="editing" />,
+      () => <Input value="editing" onChange={() => {}} />,
       () => (
         <Multiselect
           options={options}
@@ -40,33 +39,37 @@ export default function InlineEditorPermutations() {
     <>
       <h1>Table inline editor permutations</h1>
       <ScreenshotArea>
-        <SpaceBetween size="xs">
-          <PermutationsView
-            permutations={editPermutations}
-            render={permutation => (
-              <TableBodyCell
-                ariaLabels={{
-                  activateEditLabel: column => `Edit ${column.header}`,
-                  cancelEditLabel: column => `Cancel editing ${column.header}`,
-                  submitEditLabel: column => `Submit edit ${column.header}`,
-                }}
-                item={{}}
-                column={{ ...baseColumnDefinition, editConfig: permutation }}
-                isEditing={true}
-                isEditable={true}
-                isFirstRow={false}
-                isLastRow={false}
-                isNextSelected={false}
-                isPrevSelected={false}
-                isSelected={false}
-                onEditStart={() => {}}
-                onEditEnd={() => {}}
-                wrapLines={false}
-                {...permutation}
-              />
-            )}
-          />
-        </SpaceBetween>
+        <PermutationsView
+          permutations={editPermutations}
+          render={permutation => (
+            <table>
+              <tbody>
+                <tr>
+                  <TableBodyCell
+                    ariaLabels={{
+                      activateEditLabel: column => `Edit ${column.header}`,
+                      cancelEditLabel: column => `Cancel editing ${column.header}`,
+                      submitEditLabel: column => `Submit edit ${column.header}`,
+                    }}
+                    item={{}}
+                    column={{ ...baseColumnDefinition, editConfig: permutation }}
+                    isEditing={true}
+                    isEditable={true}
+                    isFirstRow={false}
+                    isLastRow={false}
+                    isNextSelected={false}
+                    isPrevSelected={false}
+                    isSelected={false}
+                    onEditStart={() => {}}
+                    onEditEnd={() => {}}
+                    wrapLines={false}
+                    {...permutation}
+                  />
+                </tr>
+              </tbody>
+            </table>
+          )}
+        />
       </ScreenshotArea>
     </>
   );

--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -21,7 +21,14 @@ const editPermutations = createPermutations<TableProps.EditConfig<unknown>>([
     errorIconAriaLabel: ['Error'],
     editingCell: [
       () => <Input value="editing" />,
-      () => <Multiselect options={options} selectedOptions={[options[2]]} placeholder="Choose an option" />,
+      () => (
+        <Multiselect
+          options={options}
+          selectedOptions={[options[2]]}
+          placeholder="Choose an option"
+          deselectAriaLabel={() => 'Dismiss'}
+        />
+      ),
     ],
     constraintText: [undefined, 'This requirement needs to be met.'],
     validation: [undefined, () => 'There was an error!'],

--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { TableBodyCell } from '~components/table/body-cell';
+import { TableProps } from '~components/table';
+import SpaceBetween from '~components/space-between';
+import Input from '~components/input';
+import Multiselect from '~components/multiselect';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const baseColumnDefinition = { cell: () => 'Cell content', header: 'Column header' };
+
+const options = ['A', 'B', 'C', 'D', 'E', 'F'].map(value => ({ value, label: `Option ${value}` }));
+
+const editPermutations = createPermutations<TableProps.EditConfig<unknown>>([
+  {
+    ariaLabel: ['Editable column'],
+    editIconAriaLabel: ['editable'],
+    errorIconAriaLabel: ['Error'],
+    editingCell: [
+      () => <Input value="editing" />,
+      () => <Multiselect options={options} selectedOptions={[options[2]]} placeholder="Choose an option" />,
+    ],
+    constraintText: [undefined, 'This requirement needs to be met.'],
+    validation: [undefined, () => 'There was an error!'],
+  },
+]);
+
+export default function InlineEditorPermutations() {
+  return (
+    <>
+      <h1>Table inline editor permutations</h1>
+      <ScreenshotArea>
+        <SpaceBetween size="xs">
+          <PermutationsView
+            permutations={editPermutations}
+            render={permutation => (
+              <TableBodyCell
+                ariaLabels={{
+                  activateEditLabel: column => `Edit ${column.header}`,
+                  cancelEditLabel: column => `Cancel editing ${column.header}`,
+                  submitEditLabel: column => `Submit edit ${column.header}`,
+                }}
+                item={{}}
+                column={{ ...baseColumnDefinition, editConfig: permutation }}
+                isEditing={true}
+                isEditable={true}
+                isFirstRow={false}
+                isLastRow={false}
+                isNextSelected={false}
+                isPrevSelected={false}
+                isSelected={false}
+                onEditStart={() => {}}
+                onEditEnd={() => {}}
+                wrapLines={false}
+                {...permutation}
+              />
+            )}
+          />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
+  );
+}


### PR DESCRIPTION
### Description

Adds a permutation page that displays the table inline editor component in various states. Used for visual regression testing.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
