### PR TITLE
fix: Fix constraint text for table inline editing

### DIFF
--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -29,6 +29,7 @@ const TestComponent = () => {
     editConfig: {
       ariaLabel: 'test-input',
       errorIconAriaLabel: 'error-icon',
+      constraintText: 'Requirement',
       validation: () => (thereBeErrors ? 'there be errors' : undefined),
       editingCell: (item: any, { currentValue, setValue }: TableProps.CellContext<string>) => (
         <input value={currentValue ?? item.test} onChange={() => setValue('test')} />
@@ -146,5 +147,11 @@ describe('InlineEditor', () => {
       expect(button.findLoadingIndicator()).toBeNull();
       expect(button).not.toHaveAttribute('disabled');
     });
+  });
+
+  it('should show constraint text', () => {
+    const { wrapper } = renderComponent(<TestComponent />);
+
+    expect(wrapper.findFormField()?.findConstraint()?.getElement()).toHaveTextContent('Requirement');
   });
 });

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -84,7 +84,13 @@ export function InlineEditor<ItemType>({
   }, [__onRender]);
 
   // asserting non-undefined editConfig here because this component is unreachable otherwise
-  const { ariaLabel = undefined, validation = noop, errorIconAriaLabel, editingCell } = column.editConfig!;
+  const {
+    ariaLabel = undefined,
+    validation = noop,
+    errorIconAriaLabel,
+    constraintText,
+    editingCell,
+  } = column.editConfig!;
 
   return (
     <form
@@ -96,6 +102,7 @@ export function InlineEditor<ItemType>({
       <FormField
         stretch={true}
         label={ariaLabel}
+        constraintText={constraintText}
         __hideLabel={true}
         __disableGutters={true}
         __useReactAutofocus={true}


### PR DESCRIPTION
### Description

The `editConfig.constraintText` API for table inline editing was not implemented.

Related links, issue #, if available: n/a

### How has this been tested?

Tested this manually and added a unit test. Visually this will also be covered by the new permutations in https://github.com/cloudscape-design/components/pull/857.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
