### PR TITLE
fix: Use correct message pack path for pagination labels

### DIFF
--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -92,12 +92,13 @@ export default function InternalPagination({
 
   const i18n = useInternalI18n('pagination');
 
-  const nextPageLabel = i18n('nextPageLabel', ariaLabels?.nextPageLabel) ?? defaultAriaLabels.nextPageLabel;
-  const paginationLabel = i18n('paginationLabel', ariaLabels?.paginationLabel) ?? defaultAriaLabels.paginationLabel;
+  const nextPageLabel = i18n('ariaLabels.nextPageLabel', ariaLabels?.nextPageLabel) ?? defaultAriaLabels.nextPageLabel;
+  const paginationLabel =
+    i18n('ariaLabels.paginationLabel', ariaLabels?.paginationLabel) ?? defaultAriaLabels.paginationLabel;
   const previousPageLabel =
-    i18n('previousPageLabel', ariaLabels?.previousPageLabel) ?? defaultAriaLabels.previousPageLabel;
+    i18n('ariaLabels.previousPageLabel', ariaLabels?.previousPageLabel) ?? defaultAriaLabels.previousPageLabel;
   const pageNumberLabelFn =
-    i18n('pageLabel', ariaLabels?.pageLabel, format => pageNumber => format({ pageNumber })) ??
+    i18n('ariaLabels.pageLabel', ariaLabels?.pageLabel, format => pageNumber => format({ pageNumber })) ??
     defaultAriaLabels.pageLabel;
 
   function handlePrevPageClick(requestedPageIndex: number) {


### PR DESCRIPTION
### Description

Previous identifier was incorrect, this should allow the correct strings to be picked up.

https://github.com/cloudscape-design/components/blob/main/src/internal/i18n/messages/all.en.json#L40-L42

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
