### PR TITLE
chore: Update documentation of Link's `onFollow` event to be more clear

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7141,8 +7141,9 @@ Object {
     Object {
       "cancelable": true,
       "description": "Called when a link is clicked without any modifier keys.
-Use this event if you want to prevent default browser navigation
-(by calling \`preventDefault\`) and implement client-side routing yourself.",
+If you want to implement client-side routing yourself,
+use this event and prevent default browser navigation (by calling \`preventDefault\`)
+",
       "detailInlineType": Object {
         "name": "LinkProps.FollowDetail",
         "properties": Array [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7142,7 +7142,7 @@ Object {
       "cancelable": true,
       "description": "Called when a link is clicked without any modifier keys.
 If you want to implement client-side routing yourself,
-use this event and prevent default browser navigation (by calling \`preventDefault\`)
+use this event and prevent default browser navigation (by calling \`preventDefault\`).
 ",
       "detailInlineType": Object {
         "name": "LinkProps.FollowDetail",

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -73,8 +73,9 @@ export interface LinkProps extends BaseComponentProps {
 
   /**
    * Called when a link is clicked without any modifier keys.
-   * Use this event if you want to prevent default browser navigation
-   * (by calling `preventDefault`) and implement client-side routing yourself.
+   *
+   * If you want to implement client-side routing yourself,
+   * use this event and prevent default browser navigation (by calling `preventDefault`)
    */
   onFollow?: CancelableEventHandler<LinkProps.FollowDetail>;
 

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -75,7 +75,7 @@ export interface LinkProps extends BaseComponentProps {
    * Called when a link is clicked without any modifier keys.
    *
    * If you want to implement client-side routing yourself,
-   * use this event and prevent default browser navigation (by calling `preventDefault`)
+   * use this event and prevent default browser navigation (by calling `preventDefault`).
    */
   onFollow?: CancelableEventHandler<LinkProps.FollowDetail>;
 


### PR DESCRIPTION
### Description
This change slightly rephrases the documentation text of Link's `onFollow` event. We received feedback that this is a little unclear for button-variant links.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
