### PR TITLE
fix: Fix SSR support in I18nProvider

### DIFF
--- a/src/internal/i18n/__tests__/i18n.test.tsx
+++ b/src/internal/i18n/__tests__/i18n.test.tsx
@@ -3,52 +3,8 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { useInternalI18n } from '../context';
-import { I18nProvider, I18nProviderProps } from '../provider';
-
-interface TestComponentProps {
-  topLevelString?: string;
-  topLevelFunction?: (type: 'function') => string;
-  nested?: {
-    nestedString?: string;
-    nestedFunction?: (props: { type: 'function' }) => string;
-  };
-}
-
-const MESSAGES: I18nProviderProps.Messages = {
-  '@cloudscape-design/components': {
-    en: {
-      'test-component': {
-        topLevelString: 'top level string',
-        topLevelFunction: 'top level {type}',
-        'nested.nestedString': 'nested string',
-        'nested.nestedFunction': 'nested {type}',
-      },
-    },
-  },
-};
-
-function TestComponent(props: TestComponentProps) {
-  const i18n = useInternalI18n('test-component');
-
-  return (
-    <ul>
-      <li id="top-level-string">{i18n('topLevelString', props.topLevelString)}</li>
-      <li id="top-level-function">
-        {i18n('topLevelFunction', props.topLevelFunction, format => type => format({ type }))?.('function')}
-      </li>
-
-      <li id="nested-string">{i18n('nested.nestedString', props.nested?.nestedString)}</li>
-      <li id="nested-function">
-        {i18n(
-          'nested.nestedFunction',
-          props.nested?.nestedFunction,
-          format => props => format(props)
-        )?.({ type: 'function' })}
-      </li>
-    </ul>
-  );
-}
+import { I18nProvider, I18nProviderProps } from '../../../../lib/components/internal/i18n';
+import { MESSAGES, TestComponent } from './test-component';
 
 describe('with custom "lang" on <html>', () => {
   afterEach(() => {
@@ -83,6 +39,17 @@ describe('with custom "lang" on <html>', () => {
 it('provides top-level and dot-notation values for static strings', () => {
   const { container } = render(
     <I18nProvider messages={[MESSAGES]} locale="en">
+      <TestComponent />
+    </I18nProvider>
+  );
+
+  expect(container.querySelector('#top-level-string')).toHaveTextContent('top level string');
+  expect(container.querySelector('#nested-string')).toHaveTextContent('nested string');
+});
+
+it('falls back to "en" if no locale is provided', () => {
+  const { container } = render(
+    <I18nProvider messages={[MESSAGES]}>
       <TestComponent />
     </I18nProvider>
   );

--- a/src/internal/i18n/__tests__/ssr.test.ts
+++ b/src/internal/i18n/__tests__/ssr.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable header/header */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nProvider, I18nProviderProps } from '../../../../lib/components/internal/i18n';
+import { TestComponent, MESSAGES } from './test-component';
+
+let consoleWarnSpy: jest.SpyInstance;
+beforeEach(() => {
+  consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+});
+afterEach(() => {
+  consoleWarnSpy?.mockRestore();
+});
+
+test(`not running in DOM`, () => {
+  expect(typeof document).toBe('undefined');
+});
+
+test(`renders nested components with correct strings in SSR`, () => {
+  const content = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      // Casting because props expects children to be present, but children shouldn't be provided in props.
+      { messages: [MESSAGES], locale: 'en' } as unknown as I18nProviderProps,
+      React.createElement(TestComponent, null)
+    )
+  );
+
+  expect(content).toContain(`<li id="top-level-string">top level string</li>`);
+  expect(content).toContain(`<li id="top-level-function">top level function</li>`);
+  expect(content).toContain(`<li id="nested-string">nested string</li>`);
+  expect(content).toContain(`<li id="nested-function">nested function</li>`);
+});
+
+test(`outputs a warning if a locale wasn't provided during server rendering`, () => {
+  const content = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      // Casting because props expects children to be present, but children shouldn't be provided in props.
+      { messages: [MESSAGES] } as unknown as I18nProviderProps,
+      React.createElement(TestComponent, null)
+    )
+  );
+
+  // A fallback to "en" should still happen.
+  expect(content).toContain(`<li id="top-level-string">top level string</li>`);
+
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(console.warn).toHaveBeenCalledWith(
+    '[AwsUi] [I18nProvider] An explicit locale was not provided during server rendering. This can lead to a hydration mismatch on the client.'
+  );
+});

--- a/src/internal/i18n/__tests__/test-component.tsx
+++ b/src/internal/i18n/__tests__/test-component.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { I18nProviderProps } from '../../../../lib/components/internal/i18n';
+import { useInternalI18n } from '../../../../lib/components/internal/i18n/context';
+
+interface TestComponentProps {
+  topLevelString?: string;
+  topLevelFunction?: (type: 'function') => string;
+  nested?: {
+    nestedString?: string;
+    nestedFunction?: (props: { type: 'function' }) => string;
+  };
+}
+
+export const MESSAGES: I18nProviderProps.Messages = {
+  '@cloudscape-design/components': {
+    en: {
+      'test-component': {
+        topLevelString: 'top level string',
+        topLevelFunction: 'top level {type}',
+        'nested.nestedString': 'nested string',
+        'nested.nestedFunction': 'nested {type}',
+      },
+    },
+  },
+};
+
+export function TestComponent(props: TestComponentProps) {
+  const i18n = useInternalI18n('test-component');
+
+  return (
+    <ul>
+      <li id="top-level-string">{i18n('topLevelString', props.topLevelString)}</li>
+      <li id="top-level-function">
+        {i18n('topLevelFunction', props.topLevelFunction, format => type => format({ type }))?.('function')}
+      </li>
+
+      <li id="nested-string">{i18n('nested.nestedString', props.nested?.nestedString)}</li>
+      <li id="nested-function">
+        {i18n(
+          'nested.nestedFunction',
+          props.nested?.nestedFunction,
+          format => props => format(props)
+        )?.({ type: 'function' })}
+      </li>
+    </ul>
+  );
+}

--- a/src/internal/i18n/provider.tsx
+++ b/src/internal/i18n/provider.tsx
@@ -6,6 +6,7 @@ import IntlMessageFormat from 'intl-messageformat';
 import { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
 
 import { InternalI18nContext, FormatFunction, CustomHandler } from './context';
+import { warnOnce } from '../logging';
 
 export interface I18nProviderProps {
   messages: ReadonlyArray<I18nProviderProps.Messages>;
@@ -33,15 +34,31 @@ export namespace I18nProviderProps {
 const I18nMessagesContext = React.createContext<I18nProviderProps.Messages>({});
 
 export function I18nProvider({ messages: messagesArray, locale: providedLocale, children }: I18nProviderProps) {
+  if (typeof document === 'undefined' && !providedLocale) {
+    warnOnce(
+      'I18nProvider',
+      'An explicit locale was not provided during server rendering. This can lead to a hydration mismatch on the client.'
+    );
+  }
+
   // The provider accepts an array of configs. We merge parent messages and
   // flatten the tree early on so that accesses by key are simpler and faster.
   const parentMessages = useContext(I18nMessagesContext);
   const messages = mergeMessages([parentMessages, ...messagesArray]);
 
-  // If a locale isn't provided, we can try and guess from the html lang,
-  // and lastly default to English. Locales have a recommended case, but are
-  // matched case-insensitively, so we lowercase it internally.
-  const locale = (providedLocale || document?.documentElement.lang || 'en').toLowerCase();
+  let locale: string;
+  if (providedLocale) {
+    // If a locale is explicitly provided, use the string directly.
+    // Locales have a recommended case, but are matched case-insensitively,
+    // so we lowercase it internally.
+    locale = providedLocale.toLowerCase();
+  } else if (typeof document !== 'undefined' && document.documentElement.lang) {
+    // Otherwise, use the value provided in the HTML tag.
+    locale = document.documentElement.lang.toLowerCase();
+  } else {
+    // Lastly, fall back to English.
+    locale = 'en';
+  }
 
   const format: FormatFunction = <T,>(
     namespace: string,


### PR DESCRIPTION
### Description

Whoops. This one's on me. Thought optional chaining on `document` would save me here, but I would still need to explicitly check that the variable is even defined in SSR. 

Related links, issue #, if available: n/a

### How has this been tested?

Wrote an SSR test to make sure this doesn't break.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
