### PR TITLE
feat: Add lang property to option types

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1553,6 +1553,7 @@ The options can be grouped using \`OptionGroup\` objects.
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 - \`label\` (string) - (Optional) Option text displayed to the user.
+- \`lang\` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
 - \`description\` (string) - (Optional) Further information about the option that appears below the label.
 - \`disabled\` (boolean) - (Optional) Determines whether the option is disabled.
 - \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
@@ -2979,6 +2980,8 @@ in a slight, visible lag when scrolling complex pages.",
 - \`id\` (string) - allows to identify the item that the user clicked on. Mandatory for individual items, optional for categories.
 
 - \`text\` (string) - description shown in the menu for this item. Mandatory for individual items, optional for categories.
+
+- \`lang\` (string) - (Optional) The language of the item, provided as a BCP 47 language tag.
 
 - \`disabled\` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
 
@@ -8110,6 +8113,7 @@ The options can be grouped using \`OptionGroup\` objects.
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 - \`label\` (string) - (Optional) Option text displayed to the user.
+- \`lang\` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
 - \`description\` (string) - (Optional) Further information about the option that appears below the label.
 - \`disabled\` (boolean) - (Optional) Determines whether the option is disabled.
 - \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
@@ -10492,6 +10496,7 @@ The options can be grouped using \`OptionGroup\` objects.
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
 - \`label\` (string) - (Optional) Option text displayed to the user.
+- \`lang\` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
 - \`description\` (string) - (Optional) Further information about the option that appears below the label.
 - \`disabled\` (boolean) - (Optional) Determines whether the option is disabled.
 - \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -17,7 +17,10 @@ jest.mock('../../../lib/components/internal/hooks/use-unique-id', () => ({
   generateUniqueId: () => 'random-' + uniqueId++,
 }));
 
-const defaultOptions: AutosuggestProps.Options = [{ value: '1', label: 'One' }, { value: '2' }];
+const defaultOptions: AutosuggestProps.Options = [
+  { value: '1', label: 'One' },
+  { value: '2', lang: 'fr' },
+];
 const defaultProps: AutosuggestProps = {
   enteredTextLabel: () => 'Use value',
   value: '',
@@ -37,6 +40,12 @@ test('renders correct labels when focused', () => {
   wrapper.focus();
   expect(wrapper.findDropdown().findOptionByValue('1')!.getElement()).toHaveTextContent('One');
   expect(wrapper.findDropdown().findOptionByValue('2')!.getElement()).toHaveTextContent('2');
+});
+
+test('renders lang on options', () => {
+  const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+  wrapper.focus();
+  expect(wrapper.findDropdown()!.findOptionByValue('2')!.getElement()).toHaveAttribute('lang', 'fr');
 });
 
 test('option can be selected', () => {

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -28,6 +28,7 @@ export interface AutosuggestProps
    * #### Option
    * - `value` (string) - The returned value of the option when selected.
    * - `label` (string) - (Optional) Option text displayed to the user.
+   * - `lang` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
    * - `description` (string) - (Optional) Further information about the option that appears below the label.
    * - `disabled` (boolean) - (Optional) Determines whether the option is disabled.
    * - `labelTag` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -53,6 +53,12 @@ const checkElementItem = (renderedItem: ElementWrapper, item: ButtonDropdownProp
     }
   }
 
+  if (item.lang) {
+    expect(element.children[0]).toHaveAttribute('lang', item.lang);
+  } else {
+    expect(element.children[0]).not.toHaveAttribute('lang');
+  }
+
   if (disabled) {
     expect(element).toHaveClass(`${itemStyles.disabled}`);
     expect(element.children[0]).toHaveAttribute('aria-disabled', 'true');
@@ -164,6 +170,27 @@ const items: ButtonDropdownProps.Items = [
       const wrapper = renderButtonDropdown({ ...props, items: disabledCategory });
       wrapper.openDropdown();
       checkRenderedItems(wrapper.findOpenDropdown()!, disabledCategory);
+    });
+
+    test('should render lang on items', () => {
+      const items = [
+        {
+          id: 'i0',
+          text: 'Deutsch',
+          lang: 'de',
+        },
+        {
+          text: 'category',
+          disabled: true,
+          items: [
+            { id: 'i1', disabled: true, text: 'English', lang: 'en' },
+            { id: 'i2', text: 'item2' },
+          ],
+        },
+      ];
+      const wrapper = renderButtonDropdown({ ...props, items });
+      wrapper.openDropdown();
+      checkRenderedItems(wrapper.findOpenDropdown()!, items);
     });
 
     test('should render mixed list of items and categories', () => {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -14,6 +14,8 @@ export interface ButtonDropdownProps extends BaseComponentProps {
 
    * - `text` (string) - description shown in the menu for this item. Mandatory for individual items, optional for categories.
 
+   * - `lang` (string) - (Optional) The language of the item, provided as a BCP 47 language tag.
+
    * - `disabled` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
 
    * - `disabledReason` (string) - (Optional) Displays text near the `text` property when item is disabled. Use to provide additional context.
@@ -103,6 +105,7 @@ export namespace ButtonDropdownProps {
   export interface Item {
     id: string;
     text: string;
+    lang?: string;
     disabled?: boolean;
     disabledReason?: string;
     description?: string;

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -73,7 +73,7 @@ interface MenuItemProps {
 }
 
 function MenuItem({ item, disabled, highlighted }: MenuItemProps) {
-  const menuItemRef = useRef<HTMLSpanElement | HTMLAnchorElement>(null);
+  const menuItemRef = useRef<(HTMLSpanElement & HTMLAnchorElement) | null>(null);
 
   useEffect(() => {
     if (highlighted && menuItemRef.current) {
@@ -83,8 +83,9 @@ function MenuItem({ item, disabled, highlighted }: MenuItemProps) {
 
   const isDisabledWithReason = disabled && item.disabledReason;
   const { targetProps, descriptionEl } = useHiddenDescription(item.disabledReason);
-  const menuItemProps: React.HTMLProps<HTMLSpanElement | HTMLAnchorElement> = {
+  const menuItemProps: React.HTMLAttributes<HTMLSpanElement & HTMLAnchorElement> = {
     className: styles['menu-item'],
+    lang: item.lang,
     ref: menuItemRef,
     // We are using the roving tabindex technique to manage the focus state of the dropdown.
     // The current element will always have tabindex=0 which means that it can be tabbed to,
@@ -93,9 +94,10 @@ function MenuItem({ item, disabled, highlighted }: MenuItemProps) {
     ...getMenuItemProps({ disabled }),
     ...(isDisabledWithReason ? targetProps : {}),
   };
+
   const menuItem = isLinkItem(item) ? (
     <a
-      {...(menuItemProps as React.HTMLProps<HTMLAnchorElement>)}
+      {...menuItemProps}
       href={!disabled ? item.href : undefined}
       target={getItemTarget(item)}
       rel={item.external ? 'noopener noreferrer' : undefined}

--- a/src/internal/components/option/index.tsx
+++ b/src/internal/components/option/index.tsx
@@ -65,6 +65,7 @@ const Option = ({
       data-value={option.value}
       className={className}
       aria-disabled={disabled}
+      lang={option.lang}
       {...baseProps}
     >
       {icon}

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -11,6 +11,7 @@ export interface BaseOption {
 
 export interface OptionDefinition extends BaseOption {
   value?: string;
+  lang?: string;
   labelTag?: string;
   description?: string;
   iconAlt?: string;

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -12,7 +12,7 @@ import statusIconStyles from '../../../lib/components/status-indicator/styles.se
 const defaultOptions: MultiselectProps.Options = [
   { label: 'First', value: '1' },
   { label: 'Second', value: '2' },
-  { label: 'Third', value: '3' },
+  { label: 'Third', value: '3', lang: 'es' },
   { label: 'Fourth', value: '4' },
 ];
 const groupOptions: MultiselectProps.Options = [
@@ -76,6 +76,12 @@ test('does not open dropdown when disabled', () => {
   expect(wrapper.isDisabled()).toEqual(true);
   wrapper.openDropdown();
   expect(wrapper.findDropdown().findOpenDropdown()).toEqual(null);
+});
+
+test('renders lang on options', () => {
+  const { wrapper } = renderMultiselect(<Multiselect selectedOptions={[]} options={defaultOptions} />);
+  wrapper.openDropdown();
+  expect(wrapper.findDropdown()!.findOptionByValue('3')!.getElement()).toHaveAttribute('lang', 'es');
 });
 
 test('filtering state stays unchanged when an item is selected', () => {

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -19,6 +19,7 @@ const defaultOptions: SelectProps.Options = [
       {
         label: 'Third',
         value: '3',
+        lang: 'de',
       },
       {
         label: 'Forth',
@@ -93,6 +94,15 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     const { wrapper } = renderSelect();
     wrapper.openDropdown();
     expect(wrapper.findDropdown({ expandToViewport })!.findOptionByValue(VALUE_WITH_SPECIAL_CHARS)).toBeTruthy();
+  });
+
+  test('renders lang on options', () => {
+    const { wrapper } = renderSelect();
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown({ expandToViewport })!.findOptionByValue('3')!.getElement()).toHaveAttribute(
+      'lang',
+      'de'
+    );
   });
 
   test('throws an error when attempting to select an option with closed dropdown', () => {

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -24,6 +24,7 @@ export interface BaseSelectProps
    * #### Option
    * - `value` (string) - The returned value of the option when selected.
    * - `label` (string) - (Optional) Option text displayed to the user.
+   * - `lang` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
    * - `description` (string) - (Optional) Further information about the option that appears below the label.
    * - `disabled` (boolean) - (Optional) Determines whether the option is disabled.
    * - `labelTag` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.


### PR DESCRIPTION
### Description

We signed this off a while ago - just got confirmation on some accessibility-related things today, got the descriptions approved, and we're good to ship.

Related links, issue #, if available: AWSUI-19568 and AWSUI-20461

### How has this been tested?

Added unit tests for all affected components.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
