### PR TITLE
chore: Add ScreenshotArea to inline editing page

### DIFF
--- a/pages/table/editable-with-app-layout.page.tsx
+++ b/pages/table/editable-with-app-layout.page.tsx
@@ -14,6 +14,7 @@ import Multiselect, { MultiselectProps } from '~components/multiselect';
 import { Link, Box, Button, Modal, SpaceBetween } from '~components';
 import { initialItems, DistributionInfo, tlsVersions, originSuggestions, tagOptions } from './editable-data';
 import { HelpContent } from './editable-utils';
+import ScreenshotArea from '../utils/screenshot-area';
 
 let __editStateDirty = false;
 
@@ -275,60 +276,62 @@ export default function () {
   });
 
   return (
-    <AppLayout
-      contentType="table"
-      navigationHide={true}
-      breadcrumbs={
-        <BreadcrumbGroup
-          items={[
-            { text: 'AWS-UI Demos', href: '#' },
-            { text: 'Editable table', href: '#' },
-          ]}
-        />
-      }
-      ariaLabels={{
-        navigation: 'Side navigation',
-        navigationToggle: 'Open navigation',
-        navigationClose: 'Close navigation',
-        notifications: 'Notifications',
-        tools: 'Tools',
-        toolsToggle: 'Open tools',
-        toolsClose: 'Close tools',
-      }}
-      tools={<HelpContent />}
-      content={
-        <>
-          <Demo setModalVisible={setModalVisible} ref={tableRef} />
-          <Modal
-            visible={modalVisible}
-            header="Discard changes"
-            closeAriaLabel="Close modal"
-            onDismiss={withCleanState(() => setModalVisible(false))}
-            footer={
-              <Box float="right">
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button variant="link" onClick={withCleanState(() => setModalVisible(false))}>
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    onClick={withCleanState(() => {
-                      setModalVisible(false);
-                      tableRef.current?.cancelEdit?.();
-                    })}
-                  >
-                    Discard
-                  </Button>
-                </SpaceBetween>
-              </Box>
-            }
-          >
-            <Alert type="warning" statusIconAriaLabel="Warning">
-              Are you sure you want to discard any unsaved changes?
-            </Alert>
-          </Modal>
-        </>
-      }
-    />
+    <ScreenshotArea disableAnimations={true}>
+      <AppLayout
+        contentType="table"
+        navigationHide={true}
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'AWS-UI Demos', href: '#' },
+              { text: 'Editable table', href: '#' },
+            ]}
+          />
+        }
+        ariaLabels={{
+          navigation: 'Side navigation',
+          navigationToggle: 'Open navigation',
+          navigationClose: 'Close navigation',
+          notifications: 'Notifications',
+          tools: 'Tools',
+          toolsToggle: 'Open tools',
+          toolsClose: 'Close tools',
+        }}
+        tools={<HelpContent />}
+        content={
+          <>
+            <Demo setModalVisible={setModalVisible} ref={tableRef} />
+            <Modal
+              visible={modalVisible}
+              header="Discard changes"
+              closeAriaLabel="Close modal"
+              onDismiss={withCleanState(() => setModalVisible(false))}
+              footer={
+                <Box float="right">
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Button variant="link" onClick={withCleanState(() => setModalVisible(false))}>
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      onClick={withCleanState(() => {
+                        setModalVisible(false);
+                        tableRef.current?.cancelEdit?.();
+                      })}
+                    >
+                      Discard
+                    </Button>
+                  </SpaceBetween>
+                </Box>
+              }
+            >
+              <Alert type="warning" statusIconAriaLabel="Warning">
+                Are you sure you want to discard any unsaved changes?
+              </Alert>
+            </Modal>
+          </>
+        }
+      />
+    </ScreenshotArea>
   );
 }


### PR DESCRIPTION
### Description

Add ScreenshotArea to inline editing page for visual regression testing.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
