### PR TITLE
refactor: Remove useContext hack from i18n context

### DIFF
--- a/src/internal/i18n/context.ts
+++ b/src/internal/i18n/context.ts
@@ -11,11 +11,9 @@ export interface FormatFunction {
   <T>(namespace: string, component: string, key: string, provided: T, handler?: CustomHandler<T>): T;
 }
 
-function defaultFormatFunction<T>(_namespace: string, _component: string, _key: string, provided: T) {
-  return provided;
-}
-
-export const InternalI18nContext = React.createContext<FormatFunction>(defaultFormatFunction);
+export const InternalI18nContext = React.createContext<FormatFunction>(
+  <T>(_namespace: string, _component: string, _key: string, provided: T) => provided
+);
 
 export interface ComponentFormatFunction {
   (key: string, provided: string): string;
@@ -24,10 +22,7 @@ export interface ComponentFormatFunction {
 }
 
 export function useInternalI18n(componentName: string): ComponentFormatFunction {
-  // HACK: useContext should return the default value if a provider
-  // isn't present, but some consumers mock out React.useContext globally
-  // in their tests, so we can't rely on this assumption.
-  const format = useContext(InternalI18nContext) || defaultFormatFunction;
+  const format = useContext(InternalI18nContext);
   return <T>(key: string, provided: T, customHandler?: CustomHandler<T>) => {
     return format<T>('@cloudscape-design/components', componentName, key, provided, customHandler);
   };


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
