### PR TITLE
chore: Add i18n to autosuggest, date picker, and wizard

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3147,13 +3147,13 @@ Supported values and formats are listed in the
     Object {
       "description": "Specifies an \`aria-label\` for the 'next month' button.",
       "name": "nextMonthAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
       "description": "Specifies an \`aria-label\` for the 'previous month' button.",
       "name": "previousMonthAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -3166,7 +3166,7 @@ By default the starting day of the week is defined by the locale, but you can us
     Object {
       "description": "Used as part of the \`aria-label\` for today's date in the calendar.",
       "name": "todayAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4902,7 +4902,7 @@ Supported values and formats are listed in the
     Object {
       "description": "Specifies an \`aria-label\` for the 'next month' button.",
       "name": "nextMonthAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4934,7 +4934,7 @@ a human-readable localised string representing the current value of the input.
     Object {
       "description": "Specifies an \`aria-label\` for the 'previous month' button.",
       "name": "previousMonthAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4958,7 +4958,7 @@ By default the starting day of the week is defined by the locale, but you can us
     Object {
       "description": "Used as part of the \`aria-label\` for today's date in the calendar.",
       "name": "todayAriaLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -13705,7 +13705,7 @@ Defaults to \`false\`.
         "properties": Array [
           Object {
             "name": "cancelButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -13720,7 +13720,7 @@ Defaults to \`false\`.
           },
           Object {
             "name": "nextButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -13730,7 +13730,7 @@ Defaults to \`false\`.
           },
           Object {
             "name": "previousButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -13740,7 +13740,7 @@ Defaults to \`false\`.
           },
           Object {
             "name": "collapsedStepsLabel",
-            "optional": false,
+            "optional": true,
             "type": "(stepNumber: number, stepsCount: number) => string",
           },
           Object {
@@ -13750,7 +13750,7 @@ Defaults to \`false\`.
           },
           Object {
             "name": "stepNumberLabel",
-            "optional": false,
+            "optional": true,
             "type": "(stepNumber: number) => string",
           },
         ],

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { Ref, useImperativeHandle, useRef } from 'react';
+import clsx from 'clsx';
 
 import { useAutosuggestItems } from './options-controller';
 import { AutosuggestItem, AutosuggestProps } from './interfaces';
@@ -17,7 +18,6 @@ import {
   NonCancelableCustomEvent,
 } from '../internal/events';
 import { BaseChangeDetail } from '../input/interfaces';
-import styles from './styles.css.js';
 import { checkOptionValueField } from '../select/utils/check-option-value-field';
 import checkControlled from '../internal/hooks/check-controlled';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -26,7 +26,9 @@ import { useAutosuggestLoadMore } from './load-more-controller';
 import { OptionsLoadItemsDetail } from '../internal/components/dropdown/interfaces';
 import AutosuggestInput, { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 import { useFormFieldContext } from '../contexts/form-field';
-import clsx from 'clsx';
+import { useInternalI18n } from '../internal/i18n/context';
+
+import styles from './styles.css.js';
 
 export interface InternalAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {}
 
@@ -56,7 +58,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     virtualScroll,
     expandToViewport,
     onSelect,
-    selectedAriaLabel,
     renderHighlightedAriaLive,
     __internalRootRef,
     ...restProps
@@ -74,6 +75,10 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     }),
     []
   );
+
+  const i18n = useInternalI18n('autosuggest');
+  const errorIconAriaLabel = i18n('errorIconAriaLabel', restProps.errorIconAriaLabel);
+  const selectedAriaLabel = i18n('selectedAriaLabel', restProps.selectedAriaLabel);
 
   const [autosuggestItemsState, autosuggestItemsHandlers] = useAutosuggestItems({
     options: options || [],
@@ -154,7 +159,13 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const highlightedOptionId = autosuggestItemsState.highlightedOption ? generateUniqueId() : undefined;
 
   const isEmpty = !value && !autosuggestItemsState.items.length;
-  const dropdownStatus = useDropdownStatus({ ...props, isEmpty, recoveryText, onRecoveryClick: handleRecoveryClick });
+  const dropdownStatus = useDropdownStatus({
+    ...props,
+    isEmpty,
+    recoveryText,
+    errorIconAriaLabel,
+    onRecoveryClick: handleRecoveryClick,
+  });
 
   return (
     <AutosuggestInput

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -39,7 +39,7 @@ export interface GridProps {
   onFocusDate: (date: null | Date) => void;
   onChangeMonth: (date: Date) => void;
   startOfWeek: DayIndex;
-  todayAriaLabel: string;
+  todayAriaLabel?: string;
   selectedDate: Date | null;
   ariaLabelledby: string;
 }

--- a/src/calendar/header/header-button.tsx
+++ b/src/calendar/header/header-button.tsx
@@ -7,7 +7,7 @@ import styles from '../styles.css.js';
 import { addMonths } from 'date-fns';
 
 interface HeaderButtonProps {
-  ariaLabel: string;
+  ariaLabel?: string;
   baseDate: Date;
   onChangeMonth: (date: Date) => void;
 }

--- a/src/calendar/header/index.tsx
+++ b/src/calendar/header/index.tsx
@@ -9,8 +9,8 @@ interface CalendarHeaderProps {
   baseDate: Date;
   locale: string;
   onChangeMonth: (date: Date) => void;
-  previousMonthLabel: string;
-  nextMonthLabel: string;
+  previousMonthLabel?: string;
+  nextMonthLabel?: string;
   headingId: string;
 }
 

--- a/src/calendar/interfaces.ts
+++ b/src/calendar/interfaces.ts
@@ -51,17 +51,17 @@ export interface CalendarProps extends BaseComponentProps {
   /**
    * Used as part of the `aria-label` for today's date in the calendar.
    */
-  todayAriaLabel: string;
+  todayAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'next month' button.
    */
-  nextMonthAriaLabel: string;
+  nextMonthAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'previous month' button.
    */
-  previousMonthAriaLabel: string;
+  previousMonthAriaLabel?: string;
 
   /**
    * Called whenever a user changes the input value (by typing, pasting, or selecting a value).

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -17,6 +17,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { getBaseDate } from './utils/navigation';
 import { useDateCache } from '../internal/hooks/use-date-cache/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id/index.js';
+import { useInternalI18n } from '../internal/i18n/context.js';
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -28,9 +29,6 @@ export default function Calendar({
   ariaLabel,
   ariaLabelledby,
   ariaDescribedby,
-  todayAriaLabel,
-  nextMonthAriaLabel,
-  previousMonthAriaLabel,
   onChange,
   __internalRootRef,
   ...rest
@@ -53,6 +51,11 @@ export default function Calendar({
   const [displayedDate, setDisplayedDate] = useState(defaultDisplayedDate);
 
   const headingId = useUniqueId('calendar-heading');
+
+  const i18n = useInternalI18n('calendar');
+  const nextMonthAriaLabel = i18n('nextMonthAriaLabel', rest.nextMonthAriaLabel);
+  const previousMonthAriaLabel = i18n('previousMonthAriaLabel', rest.previousMonthAriaLabel);
+  const todayAriaLabel = i18n('todayAriaLabel', rest.todayAriaLabel);
 
   // Update displayed date if value changes.
   useEffect(() => {

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -27,6 +27,7 @@ import useFocusVisible from '../internal/hooks/focus-visible/index.js';
 import { parseDate } from '../internal/utils/date-time';
 import LiveRegion from '../internal/components/live-region';
 import { useFormFieldContext } from '../contexts/form-field.js';
+import { useInternalI18n } from '../internal/i18n/context.js';
 
 export { DatePickerProps };
 
@@ -36,9 +37,6 @@ const DatePicker = React.forwardRef(
       locale = '',
       startOfWeek,
       isDateEnabled,
-      nextMonthAriaLabel,
-      previousMonthAriaLabel,
-      todayAriaLabel,
       placeholder = '',
       value = '',
       readOnly = false,
@@ -54,18 +52,23 @@ const DatePicker = React.forwardRef(
       invalid,
       openCalendarAriaLabel,
       expandToViewport,
-      ...rest
+      ...restProps
     }: DatePickerProps,
     ref: Ref<DatePickerProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent('DatePicker');
     checkControlled('DatePicker', 'value', value, 'onChange', onChange);
 
-    const baseProps = getBaseProps(rest);
+    const i18n = useInternalI18n('date-picker');
+    const nextMonthAriaLabel = i18n('nextMonthAriaLabel', restProps.nextMonthAriaLabel);
+    const previousMonthAriaLabel = i18n('previousMonthAriaLabel', restProps.previousMonthAriaLabel);
+    const todayAriaLabel = i18n('todayAriaLabel', restProps.todayAriaLabel);
+
+    const baseProps = getBaseProps(restProps);
     const [isDropDownOpen, setIsDropDownOpen] = useState<boolean>(false);
     const normalizedLocale = normalizeLocale('DatePicker', locale);
     const focusVisible = useFocusVisible();
-    const { ariaLabelledby, ariaDescribedby } = useFormFieldContext(rest);
+    const { ariaLabelledby, ariaDescribedby } = useFormFieldContext(restProps);
 
     const internalInputRef = useRef<HTMLInputElement>(null);
     const buttonRef = useRef<ButtonProps.Ref>(null);

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -27,7 +27,7 @@ import useFocusVisible from '../internal/hooks/focus-visible/index.js';
 import { parseDate } from '../internal/utils/date-time';
 import LiveRegion from '../internal/components/live-region';
 import { useFormFieldContext } from '../contexts/form-field.js';
-import { useInternalI18n } from '../internal/i18n/context.js';
+import { useInternalI18n, useLocale } from '../internal/i18n/context.js';
 
 export { DatePickerProps };
 
@@ -64,9 +64,11 @@ const DatePicker = React.forwardRef(
     const previousMonthAriaLabel = i18n('previousMonthAriaLabel', restProps.previousMonthAriaLabel);
     const todayAriaLabel = i18n('todayAriaLabel', restProps.todayAriaLabel);
 
+    const contextLocale = useLocale();
+    const normalizedLocale = normalizeLocale('DatePicker', locale || contextLocale);
+
     const baseProps = getBaseProps(restProps);
     const [isDropDownOpen, setIsDropDownOpen] = useState<boolean>(false);
-    const normalizedLocale = normalizeLocale('DatePicker', locale);
     const focusVisible = useFocusVisible();
     const { ariaLabelledby, ariaDescribedby } = useFormFieldContext(restProps);
 

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -27,7 +27,7 @@ import useFocusVisible from '../internal/hooks/focus-visible/index.js';
 import { parseDate } from '../internal/utils/date-time';
 import LiveRegion from '../internal/components/live-region';
 import { useFormFieldContext } from '../contexts/form-field.js';
-import { useInternalI18n, useLocale } from '../internal/i18n/context.js';
+import { useLocale } from '../internal/i18n/context.js';
 
 export { DatePickerProps };
 
@@ -37,6 +37,9 @@ const DatePicker = React.forwardRef(
       locale = '',
       startOfWeek,
       isDateEnabled,
+      nextMonthAriaLabel,
+      previousMonthAriaLabel,
+      todayAriaLabel,
       placeholder = '',
       value = '',
       readOnly = false,
@@ -58,11 +61,6 @@ const DatePicker = React.forwardRef(
   ) => {
     const { __internalRootRef } = useBaseComponent('DatePicker');
     checkControlled('DatePicker', 'value', value, 'onChange', onChange);
-
-    const i18n = useInternalI18n('date-picker');
-    const nextMonthAriaLabel = i18n('nextMonthAriaLabel', restProps.nextMonthAriaLabel);
-    const previousMonthAriaLabel = i18n('previousMonthAriaLabel', restProps.previousMonthAriaLabel);
-    const todayAriaLabel = i18n('todayAriaLabel', restProps.todayAriaLabel);
 
     const contextLocale = useLocale();
     const normalizedLocale = normalizeLocale('DatePicker', locale || contextLocale);

--- a/src/internal/i18n/context.ts
+++ b/src/internal/i18n/context.ts
@@ -11,9 +11,19 @@ export interface FormatFunction {
   <T>(namespace: string, component: string, key: string, provided: T, handler?: CustomHandler<T>): T;
 }
 
-export const InternalI18nContext = React.createContext<FormatFunction>(
-  <T>(_namespace: string, _component: string, _key: string, provided: T) => provided
-);
+export interface InternalI18nContextProps {
+  locale: string | null;
+  format: FormatFunction;
+}
+
+export const InternalI18nContext = React.createContext<InternalI18nContextProps>({
+  locale: null,
+  format: <T>(_namespace: string, _component: string, _key: string, provided: T) => provided,
+});
+
+export function useLocale(): string | null {
+  return useContext(InternalI18nContext).locale;
+}
 
 export interface ComponentFormatFunction {
   (key: string, provided: string): string;
@@ -22,7 +32,7 @@ export interface ComponentFormatFunction {
 }
 
 export function useInternalI18n(componentName: string): ComponentFormatFunction {
-  const format = useContext(InternalI18nContext);
+  const { format } = useContext(InternalI18nContext);
   return <T>(key: string, provided: T, customHandler?: CustomHandler<T>) => {
     return format<T>('@cloudscape-design/components', componentName, key, provided, customHandler);
   };

--- a/src/internal/i18n/messages/all.de.json
+++ b/src/internal/i18n/messages/all.de.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Warnung verwerfen" },
-  "autosuggest": {
-    "stepNumberLabel": "Schritt {stepNumber}",
-    "collapsedStepsLabel": "Schritt {stepNumber} von {stepsCount}",
-    "cancelButton": "Abbrechen",
-    "previousButton": "Zurück",
-    "nextButton": "Weiter",
-    "optional": "optional"
+  "alert": {
+    "dismissAriaLabel": "Warnung verwerfen"
   },
   "app-layout": {
     "ariaLabels.navigation": "Seitennavigation",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Hilfebereich",
     "ariaLabels.toolsClose": "Hilfebereich öffnen",
     "ariaLabels.toolsToggle": "Hilfebereich schließen"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Fehler",
+    "selectedAriaLabel": "Ausgewählt"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Nächster Monat",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Erfolg",
     "i18nStrings.warningIconAriaLabel": "Warnung"
   },
-  "form": { "errorIconAriaLabel": "Fehler" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Fehler" },
-  "input": { "clearAriaLabel": "Löschen" },
-  "modal": { "closeAriaLabel": "Modal schließen" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Fehler"
+  },
+  "form": {
+    "errorIconAriaLabel": "Fehler"
+  },
+  "input": {
+    "clearAriaLabel": "Löschen"
+  },
+  "modal": {
+    "closeAriaLabel": "Modal schließen"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Nächste Seite",
     "ariaLabels.pageLabel": "Seite {pageNumber} aller Seiten",
     "ariaLabels.previousPageLabel": "Vorherige Seite"
   },
-  "popover": { "dismissAriaLabel": "Popover schließen" },
+  "popover": {
+    "dismissAriaLabel": "Popover schließen"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Alle Eigenschaften",
     "i18nStrings.applyActionText": "Anwenden",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Wert",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Filter entfernen, {token__propertyKey} ist gleich {token__value}} not_equals {Filter entfernen, {token__propertyKey} ist nicht gleich {token__value}} greater_than {Filter entfernen, {token__propertyKey} ist größer als {token__value}} greater_than_equal {Filter entfernen, {token__propertyKey} ist größer oder gleich {token__value}} less_than {Filter entfernen, {token__propertyKey} ist kleiner als {token__value}} less_than_equal {Filter entfernen, {token__propertyKey} ist kleiner als oder gleich {token__value}} contains {Filter entfernen, {token__propertyKey} enthält {token__value}} not_contains {Filter entfernen, {token__propertyKey} enthält nicht {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Fehler", "selectedAriaLabel": "Ausgewählt" },
-  "wizard": { "errorIconAriaLabel": "Fehler", "selectedAriaLabel": "Ausgewählt" }
+  "select": {
+    "errorIconAriaLabel": "Fehler",
+    "selectedAriaLabel": "Ausgewählt"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Schritt {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Schritt {stepNumber} von {stepsCount}",
+    "i18nStrings.cancelButton": "Abbrechen",
+    "i18nStrings.previousButton": "Zurück",
+    "i18nStrings.nextButton": "Weiter",
+    "i18nStrings.optional": "optional"
+  }
 }

--- a/src/internal/i18n/messages/all.de.json
+++ b/src/internal/i18n/messages/all.de.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Fehler",
     "selectedAriaLabel": "Ausgewählt"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Nächster Monat",
     "previousMonthAriaLabel": "Vorheriger Monat",
     "todayAriaLabel": "Heute"

--- a/src/internal/i18n/messages/all.en-GB.json
+++ b/src/internal/i18n/messages/all.en-GB.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Dismiss alert" },
-  "autosuggest": {
-    "stepNumberLabel": "Step {stepNumber}",
-    "collapsedStepsLabel": "Step {stepNumber} of {stepsCount}",
-    "cancelButton": "Cancel",
-    "previousButton": "Previous",
-    "nextButton": "Next",
-    "optional": "optional"
+  "alert": {
+    "dismissAriaLabel": "Dismiss alert"
   },
   "app-layout": {
     "ariaLabels.navigation": "Side navigation",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Help panel",
     "ariaLabels.toolsClose": "Open help panel",
     "ariaLabels.toolsToggle": "Close help panel"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Selected"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Next month",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Success",
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
-  "form": { "errorIconAriaLabel": "Error" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Error" },
-  "input": { "clearAriaLabel": "Clear" },
-  "modal": { "closeAriaLabel": "Close modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
+  },
+  "input": {
+    "clearAriaLabel": "Clear"
+  },
+  "modal": {
+    "closeAriaLabel": "Close modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Next page",
     "ariaLabels.pageLabel": "Page {pageNumber} of all pages",
     "ariaLabels.previousPageLabel": "Previous page"
   },
-  "popover": { "dismissAriaLabel": "Close pop-over" },
+  "popover": {
+    "dismissAriaLabel": "Close pop-over"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "All properties",
     "i18nStrings.applyActionText": "Apply",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Value",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyKey} equals {token__value}} not_equals {Remove filter, {token__propertyKey} does not equal {token__value}} greater_than {Remove filter, {token__propertyKey} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyKey} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyKey} is less than {token__value}} less_than_equal {Remove filter, {token__propertyKey} is less than or equal to {token__value}} contains {Remove filter, {token__propertyKey} contains {token__value}} not_contains {Remove filter, {token__propertyKey} does not contain {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Selected" },
-  "wizard": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Selected" }
+  "select": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Selected"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Step {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Step {stepNumber} of {stepsCount}",
+    "i18nStrings.cancelButton": "Cancel",
+    "i18nStrings.previousButton": "Previous",
+    "i18nStrings.nextButton": "Next",
+    "i18nStrings.optional": "optional"
+  }
 }

--- a/src/internal/i18n/messages/all.en-GB.json
+++ b/src/internal/i18n/messages/all.en-GB.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Error",
     "selectedAriaLabel": "Selected"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",
     "todayAriaLabel": "Today"

--- a/src/internal/i18n/messages/all.en.json
+++ b/src/internal/i18n/messages/all.en.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Dismiss alert" },
-  "autosuggest": {
-    "stepNumberLabel": "Step {stepNumber}",
-    "collapsedStepsLabel": "Step {stepNumber} of {stepsCount}",
-    "cancelButton": "Cancel",
-    "previousButton": "Previous",
-    "nextButton": "Next",
-    "optional": "optional"
+  "alert": {
+    "dismissAriaLabel": "Dismiss alert"
   },
   "app-layout": {
     "ariaLabels.navigation": "Side navigation",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Help panel",
     "ariaLabels.toolsClose": "Open help panel",
     "ariaLabels.toolsToggle": "Close help panel"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Selected"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Next month",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Success",
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
-  "form": { "errorIconAriaLabel": "Error" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Error" },
-  "input": { "clearAriaLabel": "Clear" },
-  "modal": { "closeAriaLabel": "Close modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
+  },
+  "input": {
+    "clearAriaLabel": "Clear"
+  },
+  "modal": {
+    "closeAriaLabel": "Close modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Next page",
     "ariaLabels.pageLabel": "Page {pageNumber} of all pages",
     "ariaLabels.previousPageLabel": "Previous page"
   },
-  "popover": { "dismissAriaLabel": "Close popover" },
+  "popover": {
+    "dismissAriaLabel": "Close popover"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "All properties",
     "i18nStrings.applyActionText": "Apply",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Value",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyKey} equals {token__value}} not_equals {Remove filter, {token__propertyKey} does not equal {token__value}} greater_than {Remove filter, {token__propertyKey} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyKey} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyKey} is less than {token__value}} less_than_equal {Remove filter, {token__propertyKey} is less than or equal to {token__value}} contains {Remove filter, {token__propertyKey} contains {token__value}} not_contains {Remove filter, {token__propertyKey} does not contain {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Selected" },
-  "wizard": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Selected" }
+  "select": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Selected"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Step {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Step {stepNumber} of {stepsCount}",
+    "i18nStrings.cancelButton": "Cancel",
+    "i18nStrings.previousButton": "Previous",
+    "i18nStrings.nextButton": "Next",
+    "i18nStrings.optional": "optional"
+  }
 }

--- a/src/internal/i18n/messages/all.en.json
+++ b/src/internal/i18n/messages/all.en.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Error",
     "selectedAriaLabel": "Selected"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",
     "todayAriaLabel": "Today"

--- a/src/internal/i18n/messages/all.es.json
+++ b/src/internal/i18n/messages/all.es.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Error",
     "selectedAriaLabel": "Seleccionado"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Próximo mes",
     "previousMonthAriaLabel": "Mes anterior",
     "todayAriaLabel": "Hoy"

--- a/src/internal/i18n/messages/all.es.json
+++ b/src/internal/i18n/messages/all.es.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Descartar alerta" },
-  "autosuggest": {
-    "stepNumberLabel": "Paso {stepNumber}",
-    "collapsedStepsLabel": "Paso {stepNumber} de {stepsCount}",
-    "cancelButton": "Cancelar",
-    "previousButton": "Anterior",
-    "nextButton": "Siguiente",
-    "optional": "opcional"
+  "alert": {
+    "dismissAriaLabel": "Descartar alerta"
   },
   "app-layout": {
     "ariaLabels.navigation": "Navegación lateral",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Panel de ayuda",
     "ariaLabels.toolsClose": "Abrir panel de ayuda",
     "ariaLabels.toolsToggle": "Cerrar panel de ayuda"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Seleccionado"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Próximo mes",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Éxito",
     "i18nStrings.warningIconAriaLabel": "Advertencia"
   },
-  "form": { "errorIconAriaLabel": "Error" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Error" },
-  "input": { "clearAriaLabel": "Borrar" },
-  "modal": { "closeAriaLabel": "Cerrar modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
+  },
+  "input": {
+    "clearAriaLabel": "Borrar"
+  },
+  "modal": {
+    "closeAriaLabel": "Cerrar modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Página siguiente",
     "ariaLabels.pageLabel": "Página {pageNumber} de todas las páginas",
     "ariaLabels.previousPageLabel": "Página anterior"
   },
-  "popover": { "dismissAriaLabel": "Cerrar ventana emergente" },
+  "popover": {
+    "dismissAriaLabel": "Cerrar ventana emergente"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Todas las propiedades",
     "i18nStrings.applyActionText": "Aplicar",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Valor",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Eliminar filtro, {token__propertyKey} igual a {token__value}} not_equals {Eliminar filtro, {token__propertyKey} no es igual a {token__value}} greater_than {Eliminar filtro, {token__propertyKey} es mayor que {token__value}} greater_than_equal {Eliminar filtro, {token__propertyKey} es mayor o igual que {token__value}} less_than {Eliminar filtro, {token__propertyKey} es menor que {token__value}} less_than_equal {Eliminar filtro, {token__propertyKey} es menor o igual que {token__value}} contains {Eliminar filtro, {token__propertyKey} contiene {token__value}} not_contains {Eliminar filtro, {token__propertyKey} no contiene {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Seleccionado" },
-  "wizard": { "errorIconAriaLabel": "Error", "selectedAriaLabel": "Seleccionado" }
+  "select": {
+    "errorIconAriaLabel": "Error",
+    "selectedAriaLabel": "Seleccionado"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Paso {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Paso {stepNumber} de {stepsCount}",
+    "i18nStrings.cancelButton": "Cancelar",
+    "i18nStrings.previousButton": "Anterior",
+    "i18nStrings.nextButton": "Siguiente",
+    "i18nStrings.optional": "opcional"
+  }
 }

--- a/src/internal/i18n/messages/all.fr.json
+++ b/src/internal/i18n/messages/all.fr.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Ignorer l'alerte" },
-  "autosuggest": {
-    "stepNumberLabel": "Étape {stepNumber}",
-    "collapsedStepsLabel": "Étape {stepNumber} de {stepsCount}",
-    "cancelButton": "Annuler",
-    "previousButton": "Précédent",
-    "nextButton": "Suivant",
-    "optional": "facultatif"
+  "alert": {
+    "dismissAriaLabel": "Ignorer l'alerte"
   },
   "app-layout": {
     "ariaLabels.navigation": "Navigation latérale",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Volet d'aide",
     "ariaLabels.toolsClose": "Ouvrir le volet d'aide",
     "ariaLabels.toolsToggle": "Fermer le volet d'aide"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Erreur",
+    "selectedAriaLabel": "Sélectionné"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Mois suivant",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Réussite",
     "i18nStrings.warningIconAriaLabel": "Avertissement"
   },
-  "form": { "errorIconAriaLabel": "Erreur" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Erreur" },
-  "input": { "clearAriaLabel": "Effacer" },
-  "modal": { "closeAriaLabel": "Fermer le modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Erreur"
+  },
+  "form": {
+    "errorIconAriaLabel": "Erreur"
+  },
+  "input": {
+    "clearAriaLabel": "Effacer"
+  },
+  "modal": {
+    "closeAriaLabel": "Fermer le modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Page suivante",
     "ariaLabels.pageLabel": "Page {pageNumber} de toutes les pages",
     "ariaLabels.previousPageLabel": "Page précédente"
   },
-  "popover": { "dismissAriaLabel": "Fermer la fenêtre contextuelle" },
+  "popover": {
+    "dismissAriaLabel": "Fermer la fenêtre contextuelle"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Toutes les propriétés",
     "i18nStrings.applyActionText": "Appliquer",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Valeur",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Supprimer le filtre, {token__propertyKey} égal à {token__value}} not_equals {Supprimer le filtre, {token__propertyKey} n'est pas égal à {token__value}} greater_than {Supprimer le filtre, {token__propertyKey} est supérieur à {token__value}} greater_than_equal {Supprimer le filtre, {token__propertyKey} est supérieur ou égal à {token__value}} less_than {Supprimer le filtre, {token__propertyKey} est inférieur à {token__value}} less_than_equal {Supprimer le filtre, {token__propertyKey} est inférieur ou égal à {token__value}} contains {Supprimer le filtre, {token__propertyKey} contient {token__value}} not_contains {Supprimer le filtre, {token__propertyKey} ne contient pas {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Erreur", "selectedAriaLabel": "Sélectionné" },
-  "wizard": { "errorIconAriaLabel": "Erreur", "selectedAriaLabel": "Sélectionné" }
+  "select": {
+    "errorIconAriaLabel": "Erreur",
+    "selectedAriaLabel": "Sélectionné"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Étape {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Étape {stepNumber} de {stepsCount}",
+    "i18nStrings.cancelButton": "Annuler",
+    "i18nStrings.previousButton": "Précédent",
+    "i18nStrings.nextButton": "Suivant",
+    "i18nStrings.optional": "facultatif"
+  }
 }

--- a/src/internal/i18n/messages/all.fr.json
+++ b/src/internal/i18n/messages/all.fr.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Erreur",
     "selectedAriaLabel": "Sélectionné"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Mois suivant",
     "previousMonthAriaLabel": "Mois précédent",
     "todayAriaLabel": "Aujourd'hui"

--- a/src/internal/i18n/messages/all.id.json
+++ b/src/internal/i18n/messages/all.id.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Kesalahan",
     "selectedAriaLabel": "Dipilih"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Bulan berikutnya",
     "previousMonthAriaLabel": "Bulan sebelumnya",
     "todayAriaLabel": "Hari ini"

--- a/src/internal/i18n/messages/all.id.json
+++ b/src/internal/i18n/messages/all.id.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Abaikan pemberitahuan" },
-  "autosuggest": {
-    "stepNumberLabel": "Langkah {stepNumber}",
-    "collapsedStepsLabel": "Langkah {stepNumber} dari {stepsCount}",
-    "cancelButton": "Batalkan",
-    "previousButton": "Sebelumnya",
-    "nextButton": "Berikutnya",
-    "optional": "opsional"
+  "alert": {
+    "dismissAriaLabel": "Abaikan pemberitahuan"
   },
   "app-layout": {
     "ariaLabels.navigation": "Navigasi samping",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Panel bantuan",
     "ariaLabels.toolsClose": "Buka panel bantuan",
     "ariaLabels.toolsToggle": "Tutup panel bantuan"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Kesalahan",
+    "selectedAriaLabel": "Dipilih"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Bulan berikutnya",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Berhasil",
     "i18nStrings.warningIconAriaLabel": "Peringatan"
   },
-  "form": { "errorIconAriaLabel": "Kesalahan" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Kesalahan" },
-  "input": { "clearAriaLabel": "Hapus" },
-  "modal": { "closeAriaLabel": "Tutup modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Kesalahan"
+  },
+  "form": {
+    "errorIconAriaLabel": "Kesalahan"
+  },
+  "input": {
+    "clearAriaLabel": "Hapus"
+  },
+  "modal": {
+    "closeAriaLabel": "Tutup modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Halaman berikutnya",
     "ariaLabels.pageLabel": "Halaman {pageNumber} dari semua halaman",
     "ariaLabels.previousPageLabel": "Halaman sebelumnya"
   },
-  "popover": { "dismissAriaLabel": "Tutup popover" },
+  "popover": {
+    "dismissAriaLabel": "Tutup popover"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Semua properti",
     "i18nStrings.applyActionText": "Terapkan",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Nilai",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Hapus filter, {token__propertyKey} sama dengan {token__value}} not_equals {Hapus filter, {token__propertyKey} tidak sama dengan {token__value}} greater_than {Hapus filter, {token__propertyKey} lebih besar dari {token__value}} greater_than_equal {Hapus filter, {token__propertyKey} lebih besar dari atau sama dengan {token__value}} less_than {Hapus filter, {token__propertyKey} kurang dari {token__value}} less_than_equal {Hapus filter, {token__propertyKey} kurang dari atau sama dengan {token__value}} contains {Hapus filter, {token__propertyKey} berisi {token__value}} not_contains {Hapus filter, {token__propertyKey} tidak berisi {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Kesalahan", "selectedAriaLabel": "Dipilih" },
-  "wizard": { "errorIconAriaLabel": "Kesalahan", "selectedAriaLabel": "Dipilih" }
+  "select": {
+    "errorIconAriaLabel": "Kesalahan",
+    "selectedAriaLabel": "Dipilih"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Langkah {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Langkah {stepNumber} dari {stepsCount}",
+    "i18nStrings.cancelButton": "Batalkan",
+    "i18nStrings.previousButton": "Sebelumnya",
+    "i18nStrings.nextButton": "Berikutnya",
+    "i18nStrings.optional": "opsional"
+  }
 }

--- a/src/internal/i18n/messages/all.it.json
+++ b/src/internal/i18n/messages/all.it.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Avviso di disattivazione" },
-  "autosuggest": {
-    "stepNumberLabel": "Fase {stepNumber}",
-    "collapsedStepsLabel": "Fase {stepNumber} di {stepsCount}",
-    "cancelButton": "Annulla",
-    "previousButton": "Precedente",
-    "nextButton": "Successivo",
-    "optional": "facoltativo"
+  "alert": {
+    "dismissAriaLabel": "Avviso di disattivazione"
   },
   "app-layout": {
     "ariaLabels.navigation": "Navigazione laterale",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Pannello di aiuto",
     "ariaLabels.toolsClose": "Apri il pannello di aiuto",
     "ariaLabels.toolsToggle": "Chiudere il pannello di aiuto"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Errore",
+    "selectedAriaLabel": "Selezionato"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Mese successivo",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Esito positivo",
     "i18nStrings.warningIconAriaLabel": "Avviso"
   },
-  "form": { "errorIconAriaLabel": "Errore" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Errore" },
-  "input": { "clearAriaLabel": "Cancella" },
-  "modal": { "closeAriaLabel": "Chiudi modale" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Errore"
+  },
+  "form": {
+    "errorIconAriaLabel": "Errore"
+  },
+  "input": {
+    "clearAriaLabel": "Cancella"
+  },
+  "modal": {
+    "closeAriaLabel": "Chiudi modale"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Pagina successiva",
     "ariaLabels.pageLabel": "Pagina {pageNumber} di tutte le pagine",
     "ariaLabels.previousPageLabel": "Pagina precedente"
   },
-  "popover": { "dismissAriaLabel": "Chiudi popover" },
+  "popover": {
+    "dismissAriaLabel": "Chiudi popover"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Tutte le proprietà",
     "i18nStrings.applyActionText": "Applica",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Valore",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Rimuovi filtro {token__propertyKey}, uguale a {token__value}} not_equals {Rimuovi filtro, {token__propertyKey} non è uguale a {token__value}} greater_than {Rimuovi filtro, {token__propertyKey} è maggiore di {token__value}} greater_than_equal {Rimuovi filtro, {token__propertyKey} è maggiore o uguale a {token__value}} less_than {Rimuovi filtro, {token__propertyKey} è inferiore a {token__value}} less_than_equal {Rimuovi filtro, {token__propertyKey} è minore o uguale a {token__value}} contains {Rimuovi filtro, {token__propertyKey} contiene {token__value}} not_contains {Rimuovi filtro, {token__propertyKey} non contiene {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Errore", "selectedAriaLabel": "Selezionato" },
-  "wizard": { "errorIconAriaLabel": "Errore", "selectedAriaLabel": "Selezionato" }
+  "select": {
+    "errorIconAriaLabel": "Errore",
+    "selectedAriaLabel": "Selezionato"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Fase {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Fase {stepNumber} di {stepsCount}",
+    "i18nStrings.cancelButton": "Annulla",
+    "i18nStrings.previousButton": "Precedente",
+    "i18nStrings.nextButton": "Successivo",
+    "i18nStrings.optional": "facoltativo"
+  }
 }

--- a/src/internal/i18n/messages/all.it.json
+++ b/src/internal/i18n/messages/all.it.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Errore",
     "selectedAriaLabel": "Selezionato"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Mese successivo",
     "previousMonthAriaLabel": "Mese precedente",
     "todayAriaLabel": "Oggi"

--- a/src/internal/i18n/messages/all.ja.json
+++ b/src/internal/i18n/messages/all.ja.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "エラー",
     "selectedAriaLabel": "選択済み"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "来月",
     "previousMonthAriaLabel": "前月",
     "todayAriaLabel": "今日"

--- a/src/internal/i18n/messages/all.ja.json
+++ b/src/internal/i18n/messages/all.ja.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "アラートを閉じる" },
-  "autosuggest": {
-    "stepNumberLabel": "ステップ {stepNumber}",
-    "collapsedStepsLabel": "ステップ {stepNumber}/{stepsCount}",
-    "cancelButton": "キャンセル",
-    "previousButton": "戻る",
-    "nextButton": "次へ",
-    "optional": "オプション"
+  "alert": {
+    "dismissAriaLabel": "アラートを閉じる"
   },
   "app-layout": {
     "ariaLabels.navigation": "サイドナビゲーション",
@@ -17,7 +11,15 @@
     "ariaLabels.toolsClose": "ヘルプパネルを開く",
     "ariaLabels.toolsToggle": "ヘルプパネルを閉じる"
   },
-  "date-picker": { "nextMonthAriaLabel": "来月", "previousMonthAriaLabel": "前月", "todayAriaLabel": "今日" },
+  "autosuggest": {
+    "errorIconAriaLabel": "エラー",
+    "selectedAriaLabel": "選択済み"
+  },
+  "date-picker": {
+    "nextMonthAriaLabel": "来月",
+    "previousMonthAriaLabel": "前月",
+    "todayAriaLabel": "今日"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "エラー",
@@ -28,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": { "errorIconAriaLabel": "エラー" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "エラー" },
-  "input": { "clearAriaLabel": "クリア" },
-  "modal": { "closeAriaLabel": "モーダルを閉じる" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "エラー"
+  },
+  "form": {
+    "errorIconAriaLabel": "エラー"
+  },
+  "input": {
+    "clearAriaLabel": "クリア"
+  },
+  "modal": {
+    "closeAriaLabel": "モーダルを閉じる"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "次のページ",
     "ariaLabels.pageLabel": "全ページ中 {pageNumber} ページ",
     "ariaLabels.previousPageLabel": "前のページ"
   },
-  "popover": { "dismissAriaLabel": "ポップオーバーを閉じる" },
+  "popover": {
+    "dismissAriaLabel": "ポップオーバーを閉じる"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "すべてのプロパティ",
     "i18nStrings.applyActionText": "適用",
@@ -64,6 +76,16 @@
     "i18nStrings.valueText": "値",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {フィルターを削除、{token__propertyKey} は {token__value} と等しい} not_equals {フィルターを削除、{token__propertyKey} は {token__value} と等しくない} greater_than {フィルターを削除、{token__propertyKey} は {token__value} より大きい} greater_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以上} less_than {フィルターを削除、{token__propertyKey} は {token__value} 未満} less_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以下} contains {フィルターを削除、{token__propertyKey} は {token__value} を含む} not_contains {フィルターを削除、{token__propertyKey} は {token__value} を含まない} other {}}"
   },
-  "select": { "errorIconAriaLabel": "エラー", "selectedAriaLabel": "選択済み" },
-  "wizard": { "errorIconAriaLabel": "エラー", "selectedAriaLabel": "選択済み" }
+  "select": {
+    "errorIconAriaLabel": "エラー",
+    "selectedAriaLabel": "選択済み"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "ステップ {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "ステップ {stepNumber}/{stepsCount}",
+    "i18nStrings.cancelButton": "キャンセル",
+    "i18nStrings.previousButton": "戻る",
+    "i18nStrings.nextButton": "次へ",
+    "i18nStrings.optional": "オプション"
+  }
 }

--- a/src/internal/i18n/messages/all.ko.json
+++ b/src/internal/i18n/messages/all.ko.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "알림 무시" },
-  "autosuggest": {
-    "stepNumberLabel": "{stepNumber}단계",
-    "collapsedStepsLabel": "{stepNumber}/{stepsCount} 단계",
-    "cancelButton": "취소",
-    "previousButton": "이전",
-    "nextButton": "다음",
-    "optional": "선택 사항"
+  "alert": {
+    "dismissAriaLabel": "알림 무시"
   },
   "app-layout": {
     "ariaLabels.navigation": "측면 탐색",
@@ -17,7 +11,15 @@
     "ariaLabels.toolsClose": "도움말 창 열기",
     "ariaLabels.toolsToggle": "도움말 창 닫기"
   },
-  "date-picker": { "nextMonthAriaLabel": "다음 달", "previousMonthAriaLabel": "이전 달", "todayAriaLabel": "오늘" },
+  "autosuggest": {
+    "errorIconAriaLabel": "오류",
+    "selectedAriaLabel": "선택됨"
+  },
+  "date-picker": {
+    "nextMonthAriaLabel": "다음 달",
+    "previousMonthAriaLabel": "이전 달",
+    "todayAriaLabel": "오늘"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "알림",
     "i18nStrings.errorIconAriaLabel": "오류",
@@ -28,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "성공",
     "i18nStrings.warningIconAriaLabel": "경고"
   },
-  "form": { "errorIconAriaLabel": "오류" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "오류" },
-  "input": { "clearAriaLabel": "지우기" },
-  "modal": { "closeAriaLabel": "모달 닫기" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "오류"
+  },
+  "form": {
+    "errorIconAriaLabel": "오류"
+  },
+  "input": {
+    "clearAriaLabel": "지우기"
+  },
+  "modal": {
+    "closeAriaLabel": "모달 닫기"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "다음 페이지",
     "ariaLabels.pageLabel": "전체 페이지 중 {pageNumber}페이지",
     "ariaLabels.previousPageLabel": "이전 페이지"
   },
-  "popover": { "dismissAriaLabel": "팝오버 닫기" },
+  "popover": {
+    "dismissAriaLabel": "팝오버 닫기"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "모든 속성",
     "i18nStrings.applyActionText": "적용",
@@ -64,6 +76,16 @@
     "i18nStrings.valueText": "값",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {{token__propertyKey}이(가) {token__value}과(와) 같음 필터 제거} not_equals {{token__propertyKey}이(가) {token__value}과(와) 같지 않음 필터 제거} greater_than {{token__propertyKey}이(가) {token__value}보다 큼 필터 제거} greater_than_equal {{token__propertyKey}이(가) {token__value}보다 크거나 같음 필터 제거} less_than {{token__propertyKey}이(가) {token__value}보다 작음 필터 제거} less_than_equal {{token__propertyKey}이(가) {token__value}보다 작거나 같음 필터 제거} contains {{token__propertyKey}이(가) {token__value}을(를) 포함함 필터 제거} not_contains {{token__propertyKey}이(가) {token__value}을(를) 포함하지 않음 필터 제거} other {}}"
   },
-  "select": { "errorIconAriaLabel": "오류", "selectedAriaLabel": "선택됨" },
-  "wizard": { "errorIconAriaLabel": "오류", "selectedAriaLabel": "선택됨" }
+  "select": {
+    "errorIconAriaLabel": "오류",
+    "selectedAriaLabel": "선택됨"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "{stepNumber}단계",
+    "i18nStrings.collapsedStepsLabel": "{stepNumber}/{stepsCount} 단계",
+    "i18nStrings.cancelButton": "취소",
+    "i18nStrings.previousButton": "이전",
+    "i18nStrings.nextButton": "다음",
+    "i18nStrings.optional": "선택 사항"
+  }
 }

--- a/src/internal/i18n/messages/all.ko.json
+++ b/src/internal/i18n/messages/all.ko.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "오류",
     "selectedAriaLabel": "선택됨"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "다음 달",
     "previousMonthAriaLabel": "이전 달",
     "todayAriaLabel": "오늘"

--- a/src/internal/i18n/messages/all.pt-BR.json
+++ b/src/internal/i18n/messages/all.pt-BR.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "Erro",
     "selectedAriaLabel": "Selecionado"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "Próximo mês",
     "previousMonthAriaLabel": "Mês anterior",
     "todayAriaLabel": "Hoje"

--- a/src/internal/i18n/messages/all.pt-BR.json
+++ b/src/internal/i18n/messages/all.pt-BR.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "Descartar alerta" },
-  "autosuggest": {
-    "stepNumberLabel": "Etapa {stepNumber}",
-    "collapsedStepsLabel": "Etapa {stepNumber} de {stepsCount}",
-    "cancelButton": "Cancelar",
-    "previousButton": "Anterior",
-    "nextButton": "Próximo",
-    "optional": "opcional"
+  "alert": {
+    "dismissAriaLabel": "Descartar alerta"
   },
   "app-layout": {
     "ariaLabels.navigation": "Navegação lateral",
@@ -16,6 +10,10 @@
     "ariaLabels.tools": "Painel de ajuda",
     "ariaLabels.toolsClose": "Abrir o painel de ajuda",
     "ariaLabels.toolsToggle": "Fechar o painel de ajuda"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "Erro",
+    "selectedAriaLabel": "Selecionado"
   },
   "date-picker": {
     "nextMonthAriaLabel": "Próximo mês",
@@ -32,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "Com êxito",
     "i18nStrings.warningIconAriaLabel": "Aviso"
   },
-  "form": { "errorIconAriaLabel": "Erro" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "Erro" },
-  "input": { "clearAriaLabel": "Limpar" },
-  "modal": { "closeAriaLabel": "Fechar modal" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "Erro"
+  },
+  "form": {
+    "errorIconAriaLabel": "Erro"
+  },
+  "input": {
+    "clearAriaLabel": "Limpar"
+  },
+  "modal": {
+    "closeAriaLabel": "Fechar modal"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Próxima página",
     "ariaLabels.pageLabel": "Página {pageNumber} de todas as páginas",
     "ariaLabels.previousPageLabel": "Página anterior"
   },
-  "popover": { "dismissAriaLabel": "Fechar pop-over" },
+  "popover": {
+    "dismissAriaLabel": "Fechar pop-over"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "Todas as propriedades",
     "i18nStrings.applyActionText": "Aplicar",
@@ -68,6 +76,16 @@
     "i18nStrings.valueText": "Valor",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remover filtro, {token__propertyKey} igual a {token__value}} not_equals {Remover filtro, {token__propertyKey} diferente de {token__value}} greater_than {Remover filtro, {token__propertyKey} é maior que {token__value}} greater_than_equal {Remover filtro, {token__propertyKey} é maior que ou igual a {token__value}} less_than {Remover filtro, {token__propertyKey} é menor que {token__value}} less_than_equal {Remover filtro, {token__propertyKey} é menor que ou igual a {token__value}} contains {Remove filtro, {token__propertyKey} contém {token__value}} not_contains {Remover filtro, {token__propertyKey} não contém {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "Erro", "selectedAriaLabel": "Selecionado" },
-  "wizard": { "errorIconAriaLabel": "Erro", "selectedAriaLabel": "Selecionado" }
+  "select": {
+    "errorIconAriaLabel": "Erro",
+    "selectedAriaLabel": "Selecionado"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "Etapa {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "Etapa {stepNumber} de {stepsCount}",
+    "i18nStrings.cancelButton": "Cancelar",
+    "i18nStrings.previousButton": "Anterior",
+    "i18nStrings.nextButton": "Próximo",
+    "i18nStrings.optional": "opcional"
+  }
 }

--- a/src/internal/i18n/messages/all.zh-CN.json
+++ b/src/internal/i18n/messages/all.zh-CN.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "错误",
     "selectedAriaLabel": "已选定"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "下个月",
     "previousMonthAriaLabel": "上个月",
     "todayAriaLabel": "今天"

--- a/src/internal/i18n/messages/all.zh-CN.json
+++ b/src/internal/i18n/messages/all.zh-CN.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "退出提示" },
-  "autosuggest": {
-    "stepNumberLabel": "第 {stepNumber} 步",
-    "collapsedStepsLabel": "第 {stepNumber} 步，共 {stepsCount} 步",
-    "cancelButton": "取消",
-    "previousButton": "上一步",
-    "nextButton": "下一步",
-    "optional": "可选"
+  "alert": {
+    "dismissAriaLabel": "退出提示"
   },
   "app-layout": {
     "ariaLabels.navigation": "侧导航",
@@ -17,7 +11,15 @@
     "ariaLabels.toolsClose": "打开帮助面板",
     "ariaLabels.toolsToggle": "关闭帮助面板"
   },
-  "date-picker": { "nextMonthAriaLabel": "下个月", "previousMonthAriaLabel": "上个月", "todayAriaLabel": "今天" },
+  "autosuggest": {
+    "errorIconAriaLabel": "错误",
+    "selectedAriaLabel": "已选定"
+  },
+  "date-picker": {
+    "nextMonthAriaLabel": "下个月",
+    "previousMonthAriaLabel": "上个月",
+    "todayAriaLabel": "今天"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "错误",
@@ -28,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": { "errorIconAriaLabel": "错误" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "错误" },
-  "input": { "clearAriaLabel": "清除" },
-  "modal": { "closeAriaLabel": "关闭模态" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "错误"
+  },
+  "form": {
+    "errorIconAriaLabel": "错误"
+  },
+  "input": {
+    "clearAriaLabel": "清除"
+  },
+  "modal": {
+    "closeAriaLabel": "关闭模态"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "下一页",
     "ariaLabels.pageLabel": "第 {pageNumber} 页",
     "ariaLabels.previousPageLabel": "上一页"
   },
-  "popover": { "dismissAriaLabel": "关闭弹出框" },
+  "popover": {
+    "dismissAriaLabel": "关闭弹出框"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "所有属性",
     "i18nStrings.applyActionText": "应用",
@@ -64,6 +76,16 @@
     "i18nStrings.valueText": "值",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {删除筛选条件，{token__propertyKey}等于{token__value}} not_equals {删除筛选条件，{token__propertyKey}不等于{token__value}} greater_than {删除筛选条件，{token__propertyKey}大于{token__value}} greater_than_equal {删除筛选条件，{token__propertyKey}大于或等于{token__value}} less_than {删除筛选条件，{token__propertyKey}小于{token__value}} less_than_equal {删除筛选条件，{token__propertyKey}小于或等于{token__value}} contains {删除筛选条件，{token__propertyKey}包含{token__value}} not_contains {删除筛选条件，{token__propertyKey}不包含{token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "错误", "selectedAriaLabel": "已选定" },
-  "wizard": { "errorIconAriaLabel": "错误", "selectedAriaLabel": "已选定" }
+  "select": {
+    "errorIconAriaLabel": "错误",
+    "selectedAriaLabel": "已选定"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "第 {stepNumber} 步",
+    "i18nStrings.collapsedStepsLabel": "第 {stepNumber} 步，共 {stepsCount} 步",
+    "i18nStrings.cancelButton": "取消",
+    "i18nStrings.previousButton": "上一步",
+    "i18nStrings.nextButton": "下一步",
+    "i18nStrings.optional": "可选"
+  }
 }

--- a/src/internal/i18n/messages/all.zh-TW.json
+++ b/src/internal/i18n/messages/all.zh-TW.json
@@ -15,7 +15,7 @@
     "errorIconAriaLabel": "錯誤",
     "selectedAriaLabel": "已選取"
   },
-  "date-picker": {
+  "calendar": {
     "nextMonthAriaLabel": "下個月",
     "previousMonthAriaLabel": "上個月",
     "todayAriaLabel": "今天"

--- a/src/internal/i18n/messages/all.zh-TW.json
+++ b/src/internal/i18n/messages/all.zh-TW.json
@@ -1,12 +1,6 @@
 {
-  "alert": { "dismissAriaLabel": "關閉提醒" },
-  "autosuggest": {
-    "stepNumberLabel": "步驟 {stepNumber}",
-    "collapsedStepsLabel": "步驟 {stepNumber}，共 {stepsCount} 步",
-    "cancelButton": "取消",
-    "previousButton": "上一步",
-    "nextButton": "下一步",
-    "optional": "選用"
+  "alert": {
+    "dismissAriaLabel": "關閉提醒"
   },
   "app-layout": {
     "ariaLabels.navigation": "側邊導覽",
@@ -17,7 +11,15 @@
     "ariaLabels.toolsClose": "開啟說明面板",
     "ariaLabels.toolsToggle": "關閉說明面板"
   },
-  "date-picker": { "nextMonthAriaLabel": "下個月", "previousMonthAriaLabel": "上個月", "todayAriaLabel": "今天" },
+  "autosuggest": {
+    "errorIconAriaLabel": "錯誤",
+    "selectedAriaLabel": "已選取"
+  },
+  "date-picker": {
+    "nextMonthAriaLabel": "下個月",
+    "previousMonthAriaLabel": "上個月",
+    "todayAriaLabel": "今天"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "錯誤",
@@ -28,16 +30,26 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": { "errorIconAriaLabel": "錯誤" },
-  "form-field": { "i18nStrings.errorIconAriaLabel": "錯誤" },
-  "input": { "clearAriaLabel": "清除" },
-  "modal": { "closeAriaLabel": "關閉強制回應" },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "錯誤"
+  },
+  "form": {
+    "errorIconAriaLabel": "錯誤"
+  },
+  "input": {
+    "clearAriaLabel": "清除"
+  },
+  "modal": {
+    "closeAriaLabel": "關閉強制回應"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "下一頁",
     "ariaLabels.pageLabel": "所有頁面中的第 {pageNumber} 頁",
     "ariaLabels.previousPageLabel": "上一頁"
   },
-  "popover": { "dismissAriaLabel": "關閉彈出視窗" },
+  "popover": {
+    "dismissAriaLabel": "關閉彈出視窗"
+  },
   "property-filter": {
     "i18nStrings.allPropertiesLabel": "所有屬性",
     "i18nStrings.applyActionText": "套用",
@@ -64,6 +76,16 @@
     "i18nStrings.valueText": "值",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {移除篩選條件，{token__propertyKey} 等於 {token__value}} not_equals {移除篩選條件，{token__propertyKey} 不等於 {token__value}} greater_than {移除篩選條件，{token__propertyKey} 大於 {token__value}} greater_than_equal {移除篩選條件，{token__propertyKey} 大於或等於 {token__value}} less_than {移除篩選條件，{token__propertyKey} 小於 {token__value}} less_than_equal {移除篩選條件，{token__propertyKey} 小於或等於 {token__value}} contains {移除篩選條件，{token__propertyKey} 包含 {token__value}} not_contains {移除篩選條件，{token__propertyKey} 不包含 {token__value}} other {}}"
   },
-  "select": { "errorIconAriaLabel": "錯誤", "selectedAriaLabel": "已選取" },
-  "wizard": { "errorIconAriaLabel": "錯誤", "selectedAriaLabel": "已選取" }
+  "select": {
+    "errorIconAriaLabel": "錯誤",
+    "selectedAriaLabel": "已選取"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "步驟 {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "步驟 {stepNumber}，共 {stepsCount} 步",
+    "i18nStrings.cancelButton": "取消",
+    "i18nStrings.previousButton": "上一步",
+    "i18nStrings.nextButton": "下一步",
+    "i18nStrings.optional": "選用"
+  }
 }

--- a/src/internal/i18n/provider.tsx
+++ b/src/internal/i18n/provider.tsx
@@ -100,7 +100,7 @@ export function I18nProvider({ messages: messagesArray, locale: providedLocale, 
   };
 
   return (
-    <InternalI18nContext.Provider value={format}>
+    <InternalI18nContext.Provider value={{ locale, format }}>
       <I18nMessagesContext.Provider value={messages}>{children}</I18nMessagesContext.Provider>
     </InternalI18nContext.Provider>
   );

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -78,7 +78,7 @@ const PropertyFilter = React.forwardRef(
     const baseProps = getBaseProps(rest);
 
     const i18n = useInternalI18n('property-filter');
-    const i18nStrings = {
+    const i18nStrings: PropertyFilterProps.I18nStrings = {
       ...rest.i18nStrings,
       allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings.allPropertiesLabel),
       applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings.applyActionText),

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -94,19 +94,19 @@ describe('i18nStrings', () => {
       );
 
       wrapper.findAllByClassName(styles['navigation-link-label']).forEach((label, index) => {
-        const expectedTitle = i18nStrings.stepNumberLabel(index + 1);
+        const expectedTitle = i18nStrings.stepNumberLabel!(index + 1);
         const expectedLabel = DEFAULT_STEPS[index].isOptional
           ? `${expectedTitle} - ${i18nStrings.optional}`
           : expectedTitle;
         expect(label?.getElement()).toHaveTextContent(expectedLabel);
       });
 
-      expect(wrapper.findCancelButton().getElement()).toHaveTextContent(i18nStrings.cancelButton);
-      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(i18nStrings.nextButton);
+      expect(wrapper.findCancelButton().getElement()).toHaveTextContent(i18nStrings.cancelButton!);
+      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(i18nStrings.nextButton!);
 
       // navigate to next step
       wrapper.findPrimaryButton().click();
-      const expectedCollapsedSteps = `${i18nStrings.collapsedStepsLabel(2, DEFAULT_STEPS.length)}`;
+      const expectedCollapsedSteps = `${i18nStrings.collapsedStepsLabel!(2, DEFAULT_STEPS.length)}`;
       expect(wrapper.findByClassName(styles['collapsed-steps'])!.getElement()).toHaveTextContent(
         expectedCollapsedSteps
       );
@@ -114,7 +114,7 @@ describe('i18nStrings', () => {
       const expectedFormTitle = `${DEFAULT_STEPS[1].title} - ${i18nStrings.optional}`;
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent(expectedFormTitle);
 
-      expect(wrapper.findPreviousButton()!.getElement()).toHaveTextContent(i18nStrings.previousButton);
+      expect(wrapper.findPreviousButton()!.getElement()).toHaveTextContent(i18nStrings.previousButton!);
 
       // navigate to next step
       wrapper.findPrimaryButton().click();
@@ -250,7 +250,7 @@ describe('Primary button', () => {
     const [wrapper] = renderDefaultWizard();
     DEFAULT_STEPS.forEach((step, index) => {
       if (index < DEFAULT_STEPS.length - 1) {
-        expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].nextButton);
+        expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].nextButton!);
       } else {
         expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].submitButton);
       }

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -24,13 +24,13 @@ import {
   trackEndWizard,
   trackCancel,
 } from './internal/analytics';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export { WizardProps };
 
 export default function Wizard({
   steps,
   activeStepIndex: controlledActiveStepIndex,
-  i18nStrings,
   isLoadingNextStep = false,
   allowSkipTo = false,
   secondaryActions,
@@ -80,6 +80,17 @@ export default function Wizard({
     } else {
       navigationEvent(actualActiveStepIndex + 1, 'next');
     }
+  };
+
+  const i18n = useInternalI18n('wizard');
+  const i18nStrings: WizardProps.I18nStrings = {
+    ...rest.i18nStrings,
+    stepNumberLabel: i18n('i18nStrings.stepNumberLabel', rest.i18nStrings.stepNumberLabel),
+    collapsedStepsLabel: i18n('i18nStrings.collapsedStepsLabel', rest.i18nStrings.collapsedStepsLabel),
+    cancelButton: i18n('i18nStrings.cancelButton', rest.i18nStrings.cancelButton),
+    previousButton: i18n('i18nStrings.previousButton', rest.i18nStrings.previousButton),
+    nextButton: i18n('i18nStrings.nextButton', rest.i18nStrings.nextButton),
+    optional: i18n('i18nStrings.optional', rest.i18nStrings.optional),
   };
 
   if (activeStepIndex && activeStepIndex >= steps.length) {

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -112,14 +112,14 @@ export namespace WizardProps {
   }
 
   export interface I18nStrings {
-    stepNumberLabel(stepNumber: number): string;
-    collapsedStepsLabel(stepNumber: number, stepsCount: number): string;
+    stepNumberLabel?(stepNumber: number): string;
+    collapsedStepsLabel?(stepNumber: number, stepsCount: number): string;
     skipToButtonLabel?(targetStep: WizardProps.Step, targetStepNumber: number): string;
     navigationAriaLabel?: string;
     errorIconAriaLabel?: string;
-    cancelButton: string;
-    previousButton: string;
-    nextButton: string;
+    cancelButton?: string;
+    previousButton?: string;
+    nextButton?: string;
     submitButton: string;
     optional?: string;
   }

--- a/src/wizard/wizard-actions.tsx
+++ b/src/wizard/wizard-actions.tsx
@@ -8,13 +8,13 @@ import { ButtonProps } from '../button/interfaces';
 import Unmount from './unmount';
 
 interface WizardActionsProps {
-  cancelButtonText: string;
+  cancelButtonText?: string;
   onCancelClick: () => void;
   isPrimaryLoading: boolean;
-  primaryButtonText: string;
+  primaryButtonText?: string;
   onPrimaryClick: () => void;
   showPrevious: boolean;
-  previousButtonText: string;
+  previousButtonText?: string;
   onPreviousClick: () => void;
   showSkipTo: boolean;
   skipToButtonText?: string;

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -71,7 +71,7 @@ export default function WizardForm({
             isVisualRefresh && isMobile && styles['collapsed-steps-extra-padding']
           )}
         >
-          {i18nStrings.collapsedStepsLabel(activeStepIndex + 1, steps.length)}
+          {i18nStrings.collapsedStepsLabel?.(activeStepIndex + 1, steps.length)}
         </div>
         <InternalHeader className={styles['form-header-component']} variant="h1" description={description} info={info}>
           <span className={styles['form-header-component-wrapper']} tabIndex={-1} ref={stepHeaderRef} {...focusVisible}>


### PR DESCRIPTION
### Description

Because the messages came back after the implementation, I missed a few components that should've been included in the latest batch of translation strings.

The translation files were also wrong because they swapped wizard and autosuggest. So I switched them out, sorted them alphabetically, and spaced them out so they looked nice and maintainable.

Related links, issue #, if available: n/a

### How has this been tested?

Existing unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
