### PR TITLE
feat: Token group tokens use role group and can support list rendering

### DIFF
--- a/pages/token-group/generic.page.tsx
+++ b/pages/token-group/generic.page.tsx
@@ -30,13 +30,15 @@ export default function GenericTokenGroupPage() {
         alignment="vertical"
         items={files}
         i18nStrings={i18nStrings}
+        asList={true}
         limit={5}
         renderItem={file => <FileOption file={file} />}
-        getItemAttributes={(item, itemIndex) => ({
-          disabled: item === 0,
+        getItemAttributes={(file, fileIndex) => ({
+          name: `agreement-${file + 1}.pdf`,
+          disabled: file === 0,
           dismiss: {
-            label: 'Remove file',
-            onDismiss: () => onDismiss(itemIndex),
+            label: `Remove file ${fileIndex + 1}`,
+            onDismiss: () => onDismiss(fileIndex),
           },
         })}
       />

--- a/src/space-between/internal.tsx
+++ b/src/space-between/internal.tsx
@@ -8,12 +8,16 @@ import flattenChildren from 'react-keyed-flatten-children';
 import { SpaceBetweenProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
-type InternalSpaceBetweenProps = SpaceBetweenProps & InternalBaseComponentProps;
+type InternalSpaceBetweenProps = SpaceBetweenProps &
+  InternalBaseComponentProps & {
+    asList?: boolean;
+  };
 
 export default function InternalSpaceBetween({
   direction = 'vertical',
   size,
   children,
+  asList,
   __internalRootRef,
   ...props
 }: InternalSpaceBetweenProps) {
@@ -24,8 +28,11 @@ export default function InternalSpaceBetween({
    */
   const flattenedChildren = flattenChildren(children);
 
+  const ParentTag = asList ? 'ul' : 'div';
+  const ChildTag = asList ? 'li' : 'div';
+
   return (
-    <div
+    <ParentTag
       {...baseProps}
       className={clsx(baseProps.className, styles.root, styles[direction], styles[`${direction}-${size}`])}
       ref={__internalRootRef}
@@ -36,11 +43,11 @@ export default function InternalSpaceBetween({
         const key = (child as any).key;
 
         return (
-          <div key={key} className={clsx(styles.child, styles[`child-${direction}-${size}`])}>
+          <ChildTag key={key} className={clsx(styles.child, styles[`child-${direction}-${size}`])}>
             {child}
-          </div>
+          </ChildTag>
         );
       })}
-    </div>
+    </ParentTag>
   );
 }

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -31,6 +31,11 @@ $sizes-vertical: (
 .root {
   display: flex;
 }
+ul.root {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
 
 .child {
   /* used in test-utils */

--- a/src/token-group/__tests__/generic-token-group.test.tsx
+++ b/src/token-group/__tests__/generic-token-group.test.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GenericTokenGroup, { GenericTokenGroupProps } from '../../../lib/components/token-group/generic-token-group';
+import createWrapper, { TokenGroupWrapper } from '../../../lib/components/test-utils/dom';
+
+interface Item {
+  name: string;
+}
+
+const defaultProps: GenericTokenGroupProps<Item> = {
+  items: generateItems(5),
+  alignment: 'horizontal',
+  renderItem: item => item.name,
+  getItemAttributes: item => ({ name: item.name }),
+};
+
+function renderTokenGroup(props: Partial<GenericTokenGroupProps<Item>> = {}): TokenGroupWrapper {
+  const { container } = render(<GenericTokenGroup {...defaultProps} {...props} />);
+  return createWrapper(container).findTokenGroup()!;
+}
+
+function generateItems(count: number) {
+  return [...new Array(count)].map((_, index) => ({ name: `name-${index}` }));
+}
+
+describe('GenericTokenGroup', () => {
+  test('tokens have role="group" and aria-label set', async () => {
+    renderTokenGroup();
+
+    await expect(screen.findByRole('group', { name: 'name-0' })).resolves.toBeDefined();
+  });
+
+  test('tokens do not have role and aria-label set when `asList` is used', async () => {
+    renderTokenGroup({ asList: true });
+
+    await expect(screen.findByRole('group', { name: 'name-0' })).rejects.toBeDefined();
+  });
+});

--- a/src/token-group/__tests__/token-group.test.tsx
+++ b/src/token-group/__tests__/token-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import TokenGroup, { TokenGroupProps } from '../../../lib/components/token-group';
 import createWrapper, { TokenGroupWrapper, IconWrapper } from '../../../lib/components/test-utils/dom';
 
@@ -167,6 +167,12 @@ describe('TokenGroup', () => {
 
       const icon = wrapper.findTokenToggle()!.find('svg');
       expect(icon!.getElement()).toContainHTML(icons['treeview-collapse']);
+    });
+
+    test('has role="group" and aria-label set', async () => {
+      renderTokenGroup({ items: generateItems(5) });
+
+      await expect(screen.findByRole('group', { name: 'label-0' })).resolves.toBeDefined();
     });
   });
 });

--- a/src/token-group/generic-token-group.tsx
+++ b/src/token-group/generic-token-group.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { BaseComponentProps, getBaseProps } from '../internal/base-component';
 
-import SpaceBetween from '../space-between/internal';
+import InternalSpaceBetween from '../space-between/internal';
 
 import { TokenGroupProps } from './interfaces';
 import DismissButton from './dismiss-button';
@@ -16,6 +16,7 @@ import SelectToggle from './toggle';
 import styles from './styles.css.js';
 
 interface ItemAttributes {
+  name: string;
   disabled?: boolean;
   dismiss?: {
     label?: string;
@@ -23,8 +24,9 @@ interface ItemAttributes {
   };
 }
 
-interface GenericTokenGroupProps<Item> extends BaseComponentProps {
+export interface GenericTokenGroupProps<Item> extends BaseComponentProps {
   items: readonly Item[];
+  asList?: boolean;
   limit?: number;
   alignment: TokenGroupProps.Alignment;
   renderItem: (item: Item, itemIndex: number) => React.ReactNode;
@@ -37,7 +39,7 @@ export default forwardRef(GenericTokenGroup) as <T>(
 ) => ReturnType<typeof GenericTokenGroup>;
 
 function GenericTokenGroup<Item>(
-  { items, alignment, renderItem, getItemAttributes, limit, ...props }: GenericTokenGroupProps<Item>,
+  { items, alignment, renderItem, getItemAttributes, asList, limit, ...props }: GenericTokenGroupProps<Item>,
   ref: React.Ref<HTMLDivElement>
 ) {
   const [expanded, setExpanded] = useState(false);
@@ -53,13 +55,13 @@ function GenericTokenGroup<Item>(
   return (
     <div {...baseProps} className={className} ref={ref}>
       {hasItems && (
-        <SpaceBetween id={controlId} direction={alignment} size="xs">
+        <InternalSpaceBetween id={controlId} direction={alignment} asList={asList} size="xs">
           {slicedItems.map((item, itemIndex) => (
-            <GenericToken key={itemIndex} {...getItemAttributes(item, itemIndex)}>
+            <GenericToken asGroup={!asList} key={itemIndex} {...getItemAttributes(item, itemIndex)}>
               {renderItem(item, itemIndex)}
             </GenericToken>
           ))}
-        </SpaceBetween>
+        </InternalSpaceBetween>
       )}
       {hasHiddenItems && (
         <SelectToggle
@@ -76,12 +78,15 @@ function GenericTokenGroup<Item>(
 }
 
 interface GenericTokenProps extends ItemAttributes {
+  asGroup: boolean;
   children: React.ReactNode;
 }
 
-function GenericToken({ disabled, dismiss, children }: GenericTokenProps) {
+function GenericToken({ asGroup, name, disabled, dismiss, children }: GenericTokenProps) {
+  const groupProps = asGroup ? { role: 'group', 'aria-label': name } : {};
   return (
     <div
+      {...groupProps}
       className={clsx(styles.token, disabled && styles['token-disabled'])}
       aria-disabled={disabled ? 'true' : undefined}
     >

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -24,6 +24,7 @@ export default function InternalTokenGroup({ items, onDismiss, __internalRootRef
       items={items}
       renderItem={item => <Option option={item} />}
       getItemAttributes={(item, itemIndex) => ({
+        name: item.label ?? '',
         disabled: item.disabled,
         dismiss: {
           label: item.dismissLabel,


### PR DESCRIPTION
### Description

Internal generic token group supports rendering as list (required for file upload and can potentially be made public).

When rendering as list is not used all token group tokens receive role="group" for improved navaigation.

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
