### PR TITLE
feat: Add `rowHeader` to table column definitions

### DIFF
--- a/pages/table/compact-mode.page.tsx
+++ b/pages/table/compact-mode.page.tsx
@@ -164,6 +164,7 @@ export default function App() {
             {
               id: 'variable',
               header: 'Variable name',
+              rowHeader: true,
               minWidth: 176,
               cell: item => {
                 return item.name;

--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -48,6 +48,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
   {
     id: 'Id',
     header: 'Distribution ID',
+    rowHeader: true,
     sortingField: 'Id',
     width: 180,
     cell: (item: DistributionInfo) => <Link href={`/#/distributions/${item.Id}`}>{item.Id}</Link>,

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -41,6 +41,7 @@ const PROPERTY_COLUMNS: TableProps.ColumnDefinition<any>[] = [
   {
     id: 'variable',
     header: 'Property',
+    rowHeader: true,
     cell: item => <Link href="#">{item.name}</Link>,
   },
   {

--- a/pages/table/shared-configs.tsx
+++ b/pages/table/shared-configs.tsx
@@ -64,6 +64,7 @@ export const columnsConfig: TableProps.ColumnDefinition<Instance>[] = [
     cell: item => <Link href={`#${item.id}`}>{item.id}</Link>,
     ariaLabel: columnLabel('id'),
     sortingField: 'id',
+    rowHeader: true,
   },
   { id: 'type', header: 'Type', cell: item => item.type, ariaLabel: columnLabel('type'), sortingField: 'type' },
   {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11466,6 +11466,7 @@ add a meaningful description to the whole selection.
   to reorder the items. This property accepts a custom comparator that is used to compare two items.
   The comparator must implement ascending ordering, and the output is inverted automatically in case of descending order.
   If present, the \`sortingField\` property is ignored.
+* \`rowHeader\` (boolean) - Specifies that the content of this column is used as a header for each row. Sets \`scope=\\"row\\"\` for all of its cells.
 * \`editConfig\` (EditConfig) - Enables inline editing in column when present. The value is used to configure the editing behavior.
 * * \`editConfig.ariaLabel\` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
 * * \`editConfig.errorIconAriaLabel\` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -26,6 +26,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
   border-top: awsui.$border-divider-list-width solid transparent;
   word-wrap: break-word;
   border-bottom: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
+  font-weight: initial;
   &:not(.body-cell-wrap) {
     white-space: nowrap;
     overflow: hidden;

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -20,6 +20,7 @@ export interface TableTdElementProps {
   stripedRows?: boolean;
   hasSelection?: boolean;
   hasFooter?: boolean;
+  rowHeader?: boolean;
   isVisualRefresh?: boolean;
 }
 
@@ -42,11 +43,13 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       isVisualRefresh,
       hasSelection,
       hasFooter,
+      rowHeader = false,
     },
     ref
   ) => {
+    const TagName = rowHeader ? 'th' : 'td';
     return (
-      <td
+      <TagName
         style={style}
         className={clsx(
           className,
@@ -65,10 +68,11 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         )}
         onClick={onClick}
         ref={ref}
+        scope={rowHeader ? 'row' : undefined}
         {...nativeAttributes}
       >
         {children}
-      </td>
+      </TagName>
     );
   }
 );

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -47,6 +47,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
     },
     ref
   ) => {
+    // Row header cells need to be <th> for better screenreader support
     const TagName = rowHeader ? 'th' : 'td';
     return (
       <TagName

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -89,6 +89,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *   to reorder the items. This property accepts a custom comparator that is used to compare two items.
    *   The comparator must implement ascending ordering, and the output is inverted automatically in case of descending order.
    *   If present, the `sortingField` property is ignored.
+   * * `rowHeader` (boolean) - Specifies that the content of this column is used as a header for each row. Sets `scope="row"` for all of its cells.
    * * `editConfig` (EditConfig) - Enables inline editing in column when present. The value is used to configure the editing behavior.
    * * * `editConfig.ariaLabel` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
    * * * `editConfig.errorIconAriaLabel` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
@@ -338,6 +339,7 @@ export namespace TableProps {
     minWidth?: number | string;
     maxWidth?: number | string;
     editConfig?: EditConfig<ItemType>;
+    rowHeader?: boolean;
     cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -402,6 +402,7 @@ const InternalTable = React.forwardRef(
                               hasFooter={hasFooter}
                               stripedRows={stripedRows}
                               isEvenRow={isEven}
+                              rowHeader={!!column.rowHeader}
                               isVisualRefresh={isVisualRefresh}
                             />
                           );


### PR DESCRIPTION
### Description

Add `rowHeader` to table column definitions to allow the definition of row headers.

Related links, issue #, if available: AWSUI-20031

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
