### PR TITLE
fix: Remove `aria-disabled` from non-sortable columns

### DIFF
--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -108,9 +108,8 @@ export function TableHeaderCell<ItemType>({
               })
             : undefined
         }
-        {...(sortingDisabled || !sortingStatus
-          ? { ['aria-disabled']: 'true' }
-          : {
+        {...(sortingStatus && !sortingDisabled
+          ? {
               onKeyPress: handleKeyPress,
               tabIndex: tabIndex,
               role: 'button',
@@ -118,7 +117,8 @@ export function TableHeaderCell<ItemType>({
               onClick: handleClick,
               onFocus: () => onFocusedComponentChange?.({ type: 'column', col: colIndex }),
               onBlur: () => onFocusedComponentChange?.(null),
-            })}
+            }
+          : {})}
       >
         <div className={clsx(styles['header-cell-text'], wrapLines && styles['header-cell-text-wrap'])} id={headerId}>
           {column.header}


### PR DESCRIPTION
### Description

This attribute is only valid on certain roles (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled#associated_roles) so it's incorrect to use it here on a plain `div`.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
