### PR TITLE
fix: Make tutorial panel downloadUrl optional

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13425,7 +13425,7 @@ Object {
     Object {
       "description": "The link to a file documenting all tutorials (usually a PDF).",
       "name": "downloadUrl",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {

--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -258,7 +258,6 @@ describe('URL sanitization', () => {
 
       const { container } = renderTutorialPanelWithContext({ tutorials, downloadUrl: undefined }, context);
       const wrapper = createWrapper(container).findTutorialPanel()!;
-      console.log(wrapper.findDownloadLink());
       expect(wrapper.findDownloadLink()).toBeFalsy();
     });
   });

--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -252,6 +252,15 @@ describe('URL sanitization', () => {
         `[AwsUi] [TutorialPanel] A javascript: URL was blocked as a security precaution. The URL was "javascript:alert('Hello from Download!')".`
       );
     });
+    test('does not show the download link when downloadUrl is not passed', () => {
+      const tutorials = getTutorials();
+      const context = getContext();
+
+      const { container } = renderTutorialPanelWithContext({ tutorials, downloadUrl: undefined }, context);
+      const wrapper = createWrapper(container).findTutorialPanel()!;
+      console.log(wrapper.findDownloadLink());
+      expect(wrapper.findDownloadLink()).toBeFalsy();
+    });
   });
   describe('a11y', () => {
     test('task list expandable section should have aria-label joining task title and total step label', () => {

--- a/src/tutorial-panel/components/tutorial-list/index.tsx
+++ b/src/tutorial-panel/components/tutorial-list/index.tsx
@@ -65,20 +65,21 @@ export default function TutorialList({
           </InternalBox>
         </InternalSpaceBetween>
         <InternalSpaceBetween size="l">
-          <a
-            {...focusVisible}
-            href={downloadUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles['download-link']}
-            aria-label={i18nStrings.labelTutorialListDownloadLink}
-          >
-            <InternalIcon name="download" />
-            <InternalBox padding={{ left: 'xs' }} color="inherit" fontWeight="bold" display="inline">
-              {i18nStrings.tutorialListDownloadLinkText}
-            </InternalBox>
-          </a>
-
+          {downloadUrl && (
+            <a
+              {...focusVisible}
+              href={downloadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles['download-link']}
+              aria-label={i18nStrings.labelTutorialListDownloadLink}
+            >
+              <InternalIcon name="download" />
+              <InternalBox padding={{ left: 'xs' }} color="inherit" fontWeight="bold" display="inline">
+                {i18nStrings.tutorialListDownloadLinkText}
+              </InternalBox>
+            </a>
+          )}
           {/*
           <FormField label="Filter tutorials">
             <Input type="search" value={searchTerm} placeholder="Filter tutorials" onChange={onSearchChangeCallback} />

--- a/src/tutorial-panel/interfaces.ts
+++ b/src/tutorial-panel/interfaces.ts
@@ -59,7 +59,7 @@ export interface TutorialPanelProps extends BaseComponentProps {
   /**
    * The link to a file documenting all tutorials (usually a PDF).
    */
-  downloadUrl: string;
+  downloadUrl?: string;
 
   /**
    * An object containing all the necessary localized strings required by the component.


### PR DESCRIPTION
### Description

Make download link in tutorial panel optional by not rendering the link when `downloadUrl` is not passed

Related links, issue #872 

### How has this been tested?

added a unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
