### PR TITLE
feat: added progress to alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/test-utils/dom/index.ts
 src/test-utils/selectors
 src/internal/generated/custom-css-properties/index.*
 vendor/generated-third-party-licenses.txt
+# vscode
+.vscode

--- a/pages/alert/permutations.page.tsx
+++ b/pages/alert/permutations.page.tsx
@@ -10,7 +10,7 @@ import PermutationsView from '../utils/permutations-view';
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<AlertProps>([
   {
-    type: ['warning', 'info', 'success', 'error'],
+    type: ['warning', 'info', 'success', 'error', 'spinner'],
     children: [
       'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -84,7 +84,7 @@ describe('Alert Component', () => {
       expect(wrapper.getElement()).toBeVisible();
     });
     it('displays correct type', () => {
-      (['error', 'warning', 'info', 'success'] as AlertProps.Type[]).forEach(alertType => {
+      (['error', 'warning', 'info', 'success', 'progress'] as AlertProps.Type[]).forEach(alertType => {
         const { wrapper } = renderAlert({ type: alertType });
         expect(wrapper.findRootElement().getElement()).toHaveClass(styles[`type-${alertType}`]);
       });

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -5,7 +5,7 @@ import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
 export namespace AlertProps {
-  export type Type = 'success' | 'error' | 'warning' | 'info' | 'progress';
+  export type Type = 'success' | 'error' | 'warning' | 'info' | 'spinner';
 }
 
 export interface AlertProps extends BaseComponentProps {

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -5,7 +5,7 @@ import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
 export namespace AlertProps {
-  export type Type = 'success' | 'error' | 'warning' | 'info';
+  export type Type = 'success' | 'error' | 'warning' | 'info' | 'progress';
 }
 
 export interface AlertProps extends BaseComponentProps {

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -22,6 +22,7 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
   warning: 'status-warning',
   success: 'status-positive',
   info: 'status-info',
+  progress: 'status-in-progress',
 };
 
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps;

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -16,13 +16,14 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
 import { useInternalI18n } from '../internal/i18n/context';
+import Spinner from '../spinner/internal';
 
 const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
   error: 'status-negative',
   warning: 'status-warning',
   success: 'status-positive',
   info: 'status-info',
-  progress: 'status-in-progress',
+  spinner: 'status-in-progress',
 };
 
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps;
@@ -78,7 +79,7 @@ export default function InternalAlert({
       <VisualContext contextName="alert">
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
           <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
-            <InternalIcon name={typeToIcon[type]} size={size} />
+            <InternalIcon name={typeToIcon[type]} size={size} {...(type === 'spinner' && { svg: <Spinner /> })} />
           </div>
           <div className={styles.body}>
             <div className={clsx(styles.message, styles.text)}>

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -102,7 +102,7 @@ $_border-colors: (
   'warning': awsui.$color-border-status-warning,
   'success': awsui.$color-border-status-success,
   'info': awsui.$color-border-status-info,
-  'progress': awsui.$color-border-status-warning,
+  'spinner': awsui.$color-border-status-warning,
 );
 
 $_background-colors: (
@@ -110,7 +110,7 @@ $_background-colors: (
   'warning': awsui.$color-background-status-warning,
   'success': awsui.$color-background-status-success,
   'info': awsui.$color-background-status-info,
-  'progress': awsui.$color-background-status-warning,
+  'spinner': awsui.$color-background-status-warning,
 );
 
 $_text-colors: (
@@ -118,7 +118,7 @@ $_text-colors: (
   'warning': awsui.$color-text-status-warning,
   'success': awsui.$color-text-status-success,
   'info': awsui.$color-text-status-info,
-  'progress': awsui.$color-text-status-warning,
+  'spinner': awsui.$color-text-status-inactive,
 );
 
 @each $type in map.keys($_text-colors) {

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -102,6 +102,7 @@ $_border-colors: (
   'warning': awsui.$color-border-status-warning,
   'success': awsui.$color-border-status-success,
   'info': awsui.$color-border-status-info,
+  'progress': awsui.$color-border-status-warning,
 );
 
 $_background-colors: (
@@ -109,6 +110,7 @@ $_background-colors: (
   'warning': awsui.$color-background-status-warning,
   'success': awsui.$color-background-status-success,
   'info': awsui.$color-background-status-info,
+  'progress': awsui.$color-background-status-warning,
 );
 
 $_text-colors: (
@@ -116,6 +118,7 @@ $_text-colors: (
   'warning': awsui.$color-text-status-warning,
   'success': awsui.$color-text-status-success,
   'info': awsui.$color-text-status-info,
+  'progress': awsui.$color-text-status-warning,
 );
 
 @each $type in map.keys($_text-colors) {

--- a/src/icon/interfaces.ts
+++ b/src/icon/interfaces.ts
@@ -123,6 +123,7 @@ export namespace IconProps {
     | 'settings'
     | 'share'
     | 'shrink'
+    | 'spinner'
     | 'status-in-progress'
     | 'status-info'
     | 'status-negative'


### PR DESCRIPTION
### Description

We have a use case where the `<Alert />` component is on the stage while a backend validation call occurs. This might be a long call round trip and we would like to persist the `<Alert />` component with an `status-in-progress` icon.

> What was added

* `progress` typeToIcon
* `progress` to tests
* `progress` to styles

