### PR TITLE
fix: Ensure breadcrumb group test utils work for short lists

### DIFF
--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -99,6 +99,14 @@ describe('BreadcrumbGroup Component', () => {
       }
     });
 
+    test('test-utils findBreadcrumbLink selector properly finds non-link items in short lists', () => {
+      const { container } = render(<BreadcrumbGroup items={[items[0], items[1]]} />);
+      const breadcrumbs = createWrapper(container).findBreadcrumbGroup()!;
+
+      expect(breadcrumbs.findBreadcrumbLink(1)?.getElement()).toHaveTextContent(items[0].text);
+      expect(breadcrumbs.findBreadcrumbLink(2)?.getElement()).toHaveTextContent(items[1].text);
+    });
+
     // Test for AWSUI-6738
     test('all the icons stay visible when changing the items', () => {
       const { container, rerender } = render(<BreadcrumbGroup items={items} />);

--- a/src/breadcrumb-group/internal.tsx
+++ b/src/breadcrumb-group/internal.tsx
@@ -113,7 +113,7 @@ export default function InternalBreadcrumbGroup<T extends BreadcrumbGroupProps.I
   };
 
   // Add ellipsis
-  if (breadcrumbItems.length >= 3) {
+  if (breadcrumbItems.length >= 2) {
     const dropdownItems: Array<LinkItem> = items
       .slice(1, items.length - 1)
       .map((item: BreadcrumbGroupProps.Item, index: number) => ({
@@ -138,7 +138,12 @@ export default function InternalBreadcrumbGroup<T extends BreadcrumbGroupProps.I
   return (
     <nav
       {...baseProps}
-      className={clsx(styles['breadcrumb-group'], isMobile && styles.mobile, baseProps.className)}
+      className={clsx(
+        styles['breadcrumb-group'],
+        isMobile && styles.mobile,
+        items.length <= 2 && styles['mobile-short'],
+        baseProps.className
+      )}
       aria-label={ariaLabel || undefined}
       ref={__internalRootRef}
     >

--- a/src/breadcrumb-group/styles.scss
+++ b/src/breadcrumb-group/styles.scss
@@ -61,4 +61,14 @@
       }
     }
   }
+
+  // Test utils rely on the ellipsis being present even if there are
+  // only 2 items in the list, so we display but hide it.
+  &.mobile-short {
+    > .breadcrumb-group-list {
+      > .ellipsis {
+        display: none;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Description

Ensure breadcrumb group test utils work for short lists

Related links, issue #, if available: AWSUI-20701

### How has this been tested?

Updated unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
