### PR TITLE
feat: AppLayout support for Beta testing toolsTriggers 

### DIFF
--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Button } from '~components';
+import Alert from '~components/alert';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import Link from '~components/link';
+import SpaceBetween from '~components/space-between';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import ScreenshotArea from '../utils/screenshot-area';
+import appLayoutLabels from './utils/labels';
+
+export default function () {
+  const [alertVisible, setVisible] = useState(true);
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        contentType="form"
+        ariaLabels={appLayoutLabels}
+        breadcrumbs={<Breadcrumbs />}
+        contentHeader={
+          <SpaceBetween size="m">
+            <Header
+              variant="h1"
+              info={<Link>Info</Link>}
+              description="When you create an Amazon CloudFront distribution."
+              actions={<Button variant="primary">Create distribution</Button>}
+            >
+              Create distribution
+            </Header>
+            {alertVisible && (
+              <Alert
+                statusIconAriaLabel="Info"
+                dismissible={true}
+                dismissAriaLabel="Close alert"
+                onDismiss={() => setVisible(false)}
+              >
+                Demo alert
+              </Alert>
+            )}
+          </SpaceBetween>
+        }
+        content={<Containers />}
+        {...{
+          toolsTriggers: [
+            {
+              ariaLabel: 'Open Expert Help',
+              iconName: 'settings',
+              iconSvg: (
+                <svg viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M8 15H1V5h14v3m-6.5 4.25H16M12.25 8.5V16M5 1h6v4H5V1Z"
+                    stroke="#fff"
+                    strokeWidth="2"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              ),
+              onClick: () => console.log('Open Expert Help'),
+            },
+          ],
+        }}
+      />
+    </ScreenshotArea>
+  );
+}

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -11,11 +11,12 @@ import HelpPanel from '~components/help-panel';
 import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
 import SpaceBetween from '~components/space-between';
+import SplitPanel from '~components/split-panel';
 
 export default function () {
   const [alertVisible, setVisible] = useState(true);
   const [isToolsOpen, setIsToolsOpen] = useState(false);
-  const [toolsContent, setToolsContent] = useState(<Info />);
+  const [toolsContent, setToolsContent] = useState('info');
 
   return (
     <ScreenshotArea gutters={false}>
@@ -30,8 +31,8 @@ export default function () {
               info={
                 <Link
                   onFollow={() => {
-                    setToolsContent(<Info />);
-                    setIsToolsOpen(!isToolsOpen);
+                    setToolsContent('info');
+                    setIsToolsOpen(true);
                   }}
                 >
                   Info
@@ -59,7 +60,31 @@ export default function () {
         onToolsChange={({ detail }) => {
           setIsToolsOpen(detail.open);
         }}
-        tools={toolsContent}
+        splitPanel={
+          <SplitPanel
+            header="Split panel header"
+            i18nStrings={{
+              preferencesTitle: 'Preferences',
+              preferencesPositionLabel: 'Split panel position',
+              preferencesPositionDescription: 'Choose the default split panel position for the service.',
+              preferencesPositionSide: 'Side',
+              preferencesPositionBottom: 'Bottom',
+              preferencesConfirm: 'Confirm',
+              preferencesCancel: 'Cancel',
+              closeButtonAriaLabel: 'Close panel',
+              openButtonAriaLabel: 'Open panel',
+              resizeHandleAriaLabel: 'Slider',
+            }}
+          >
+            This is the Split Panel!
+          </SplitPanel>
+        }
+        tools={
+          <>
+            {toolsContent === 'info' && <Info />}
+            {toolsContent === 'proHelp' && <ProHelp />}
+          </>
+        }
         toolsOpen={isToolsOpen}
         {...{
           toolsTriggers: [
@@ -67,17 +92,19 @@ export default function () {
               ariaLabel: 'View Info content',
               iconName: 'status-info',
               onClick: () => {
-                setToolsContent(<Info />);
-                setIsToolsOpen(!isToolsOpen);
+                setToolsContent('info');
+                setIsToolsOpen(true);
               },
+              selected: isToolsOpen && toolsContent === 'info',
             },
             {
               ariaLabel: 'View Pro Help content',
               iconSvg: <IconBriefcase />,
               onClick: () => {
-                setToolsContent(<ProHelp />);
-                setIsToolsOpen(!isToolsOpen);
+                setToolsContent('proHelp');
+                setIsToolsOpen(true);
               },
+              selected: isToolsOpen && toolsContent === 'proHelp',
             },
           ],
         }}

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -4,15 +4,19 @@ import React, { useState } from 'react';
 import { Button } from '~components';
 import Alert from '~components/alert';
 import AppLayout from '~components/app-layout';
-import Header from '~components/header';
-import Link from '~components/link';
-import SpaceBetween from '~components/space-between';
-import { Breadcrumbs, Containers } from './utils/content-blocks';
-import ScreenshotArea from '../utils/screenshot-area';
 import appLayoutLabels from './utils/labels';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import Header from '~components/header';
+import HelpPanel from '~components/help-panel';
+import Link from '~components/link';
+import ScreenshotArea from '../utils/screenshot-area';
+import SpaceBetween from '~components/space-between';
 
 export default function () {
   const [alertVisible, setVisible] = useState(true);
+  const [isToolsOpen, setIsToolsOpen] = useState(false);
+  const [toolsContent, setToolsContent] = useState(<Info />);
+
   return (
     <ScreenshotArea gutters={false}>
       <AppLayout
@@ -22,19 +26,29 @@ export default function () {
         contentHeader={
           <SpaceBetween size="m">
             <Header
-              variant="h1"
-              info={<Link>Info</Link>}
-              description="When you create an Amazon CloudFront distribution."
               actions={<Button variant="primary">Create distribution</Button>}
+              info={
+                <Link
+                  onFollow={() => {
+                    setToolsContent(<Info />);
+                    setIsToolsOpen(!isToolsOpen);
+                  }}
+                >
+                  Info
+                </Link>
+              }
+              description="When you create an Amazon CloudFront distribution."
+              variant="h1"
             >
               Create distribution
             </Header>
+
             {alertVisible && (
               <Alert
-                statusIconAriaLabel="Info"
-                dismissible={true}
                 dismissAriaLabel="Close alert"
+                dismissible={true}
                 onDismiss={() => setVisible(false)}
+                statusIconAriaLabel="Info"
               >
                 Demo alert
               </Alert>
@@ -42,26 +56,54 @@ export default function () {
           </SpaceBetween>
         }
         content={<Containers />}
+        onToolsChange={({ detail }) => {
+          console.log('onToolsChange');
+          setIsToolsOpen(detail.open);
+        }}
+        tools={toolsContent}
+        toolsOpen={isToolsOpen}
         {...{
           toolsTriggers: [
             {
-              ariaLabel: 'Open Expert Help',
-              iconName: 'settings',
-              iconSvg: (
-                <svg viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M8 15H1V5h14v3m-6.5 4.25H16M12.25 8.5V16M5 1h6v4H5V1Z"
-                    stroke="#fff"
-                    strokeWidth="2"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              ),
-              onClick: () => console.log('Open Expert Help'),
+              ariaLabel: 'View Info content',
+              iconName: 'status-info',
+              onClick: () => {
+                setToolsContent(<Info />);
+                setIsToolsOpen(!isToolsOpen);
+              },
+            },
+            {
+              ariaLabel: 'View Pro Help content',
+              iconSvg: <IconBriefcase />,
+              onClick: () => {
+                setToolsContent(<ProHelp />);
+                setIsToolsOpen(!isToolsOpen);
+              },
             },
           ],
         }}
       />
     </ScreenshotArea>
   );
+}
+
+function Info() {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+}
+
+function IconBriefcase() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none">
+      <path
+        d="M8 15H1V5h14v3m-6.5 4.25H16M12.25 8.5V16M5 1h6v4H5V1Z"
+        stroke="#fff"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ProHelp() {
+  return <HelpPanel header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</HelpPanel>;
 }

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -89,6 +89,7 @@ export default function () {
         {...{
           toolsTriggers: [
             {
+              ariaExpanded: isToolsOpen,
               ariaLabel: 'View Info content',
               iconName: 'status-info',
               onClick: () => {
@@ -98,6 +99,7 @@ export default function () {
               selected: isToolsOpen && toolsContent === 'info',
             },
             {
+              ariaExpanded: isToolsOpen,
               ariaLabel: 'View Pro Help content',
               iconSvg: <IconBriefcase />,
               onClick: () => {

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -1,22 +1,53 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import { Button } from '~components';
-import Alert from '~components/alert';
-import AppLayout from '~components/app-layout';
+import { AppLayout, Header, HelpPanel, Link, SegmentedControl, SpaceBetween, SplitPanel } from '~components';
 import appLayoutLabels from './utils/labels';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
-import Header from '~components/header';
-import HelpPanel from '~components/help-panel';
-import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
-import SpaceBetween from '~components/space-between';
-import SplitPanel from '~components/split-panel';
 
 export default function () {
-  const [alertVisible, setVisible] = useState(true);
   const [isToolsOpen, setIsToolsOpen] = useState(false);
   const [toolsContent, setToolsContent] = useState('info');
+  const [triggerStatus, setTriggerStatus] = useState('custom-triggers');
+  const [splitPanelStatus, setSplitPanelStatus] = useState('show-split-panel');
+
+  const customTriggers =
+    triggerStatus !== 'custom-triggers'
+      ? null
+      : {
+          toolsTriggers: [
+            {
+              ariaExpanded: isToolsOpen,
+              ariaLabel: 'View Info content',
+              iconName: 'status-info',
+
+              onClick: () => {
+                if (isToolsOpen && toolsContent === 'info') {
+                  setIsToolsOpen(false);
+                } else {
+                  setToolsContent('info');
+                  setIsToolsOpen(true);
+                }
+              },
+              selected: isToolsOpen && toolsContent === 'info',
+            },
+            {
+              ariaExpanded: isToolsOpen,
+              ariaLabel: 'View Pro Help content',
+              iconSvg: <IconBriefcase />,
+              onClick: () => {
+                if (isToolsOpen && toolsContent === 'proHelp') {
+                  setIsToolsOpen(false);
+                } else {
+                  setToolsContent('proHelp');
+                  setIsToolsOpen(true);
+                }
+              },
+              selected: isToolsOpen && toolsContent === 'proHelp',
+            },
+          ],
+        };
 
   return (
     <ScreenshotArea gutters={false}>
@@ -27,7 +58,6 @@ export default function () {
         contentHeader={
           <SpaceBetween size="m">
             <Header
-              actions={<Button variant="primary">Create distribution</Button>}
               info={
                 <Link
                   onFollow={() => {
@@ -38,46 +68,61 @@ export default function () {
                   Info
                 </Link>
               }
-              description="When you create an Amazon CloudFront distribution."
+              description="Sometimes you need custom triggers to get the job done."
               variant="h1"
             >
-              Create distribution
+              Custom Trigger Testing!
             </Header>
 
-            {alertVisible && (
-              <Alert
-                dismissAriaLabel="Close alert"
-                dismissible={true}
-                onDismiss={() => setVisible(false)}
-                statusIconAriaLabel="Info"
-              >
-                Demo alert
-              </Alert>
-            )}
+            <SegmentedControl
+              label="Trigger Status"
+              onChange={({ detail }) => setTriggerStatus(detail.selectedId)}
+              options={[
+                { text: 'Custom Triggers', id: 'custom-triggers' },
+                { text: 'Default Trigger', id: 'default-trigger' },
+                { text: 'Hide Tools', id: 'hide-tools' },
+              ]}
+              selectedId={triggerStatus}
+            />
+
+            <SegmentedControl
+              label="Split Panel Status"
+              onChange={({ detail }) => setSplitPanelStatus(detail.selectedId)}
+              options={[
+                { text: 'Show SplitPanel', id: 'show-split-panel' },
+                { text: 'Hide SplitPanel', id: 'hide-split-panel' },
+              ]}
+              selectedId={splitPanelStatus}
+            />
           </SpaceBetween>
         }
         content={<Containers />}
         onToolsChange={({ detail }) => {
           setIsToolsOpen(detail.open);
         }}
+        splitPanelPreferences={{
+          position: 'side',
+        }}
         splitPanel={
-          <SplitPanel
-            header="Split panel header"
-            i18nStrings={{
-              preferencesTitle: 'Preferences',
-              preferencesPositionLabel: 'Split panel position',
-              preferencesPositionDescription: 'Choose the default split panel position for the service.',
-              preferencesPositionSide: 'Side',
-              preferencesPositionBottom: 'Bottom',
-              preferencesConfirm: 'Confirm',
-              preferencesCancel: 'Cancel',
-              closeButtonAriaLabel: 'Close panel',
-              openButtonAriaLabel: 'Open panel',
-              resizeHandleAriaLabel: 'Slider',
-            }}
-          >
-            This is the Split Panel!
-          </SplitPanel>
+          splitPanelStatus === 'show-split-panel' && (
+            <SplitPanel
+              header="Split panel header"
+              i18nStrings={{
+                preferencesTitle: 'Preferences',
+                preferencesPositionLabel: 'Split panel position',
+                preferencesPositionDescription: 'Choose the default split panel position for the service.',
+                preferencesPositionSide: 'Side',
+                preferencesPositionBottom: 'Bottom',
+                preferencesConfirm: 'Confirm',
+                preferencesCancel: 'Cancel',
+                closeButtonAriaLabel: 'Close panel',
+                openButtonAriaLabel: 'Open panel',
+                resizeHandleAriaLabel: 'Slider',
+              }}
+            >
+              This is the Split Panel!
+            </SplitPanel>
+          )
         }
         tools={
           <>
@@ -85,31 +130,9 @@ export default function () {
             {toolsContent === 'proHelp' && <ProHelp />}
           </>
         }
+        toolsHide={triggerStatus === 'hide-tools' ? true : false}
         toolsOpen={isToolsOpen}
-        {...{
-          toolsTriggers: [
-            {
-              ariaExpanded: isToolsOpen,
-              ariaLabel: 'View Info content',
-              iconName: 'status-info',
-              onClick: () => {
-                setToolsContent('info');
-                setIsToolsOpen(true);
-              },
-              selected: isToolsOpen && toolsContent === 'info',
-            },
-            {
-              ariaExpanded: isToolsOpen,
-              ariaLabel: 'View Pro Help content',
-              iconSvg: <IconBriefcase />,
-              onClick: () => {
-                setToolsContent('proHelp');
-                setIsToolsOpen(true);
-              },
-              selected: isToolsOpen && toolsContent === 'proHelp',
-            },
-          ],
-        }}
+        {...customTriggers}
       />
     </ScreenshotArea>
   );

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -10,7 +10,6 @@ export default function () {
   const [isToolsOpen, setIsToolsOpen] = useState(false);
   const [toolsContent, setToolsContent] = useState('info');
   const [triggerStatus, setTriggerStatus] = useState('custom-triggers');
-  const [splitPanelStatus, setSplitPanelStatus] = useState('show-split-panel');
 
   const customTriggers =
     triggerStatus !== 'custom-triggers'
@@ -19,18 +18,18 @@ export default function () {
           toolsTriggers: [
             {
               ariaExpanded: isToolsOpen,
-              ariaLabel: 'View Info content',
-              iconName: 'status-info',
+              ariaLabel: 'View Security content',
+              iconName: 'security',
 
               onClick: () => {
-                if (isToolsOpen && toolsContent === 'info') {
+                if (isToolsOpen && toolsContent === 'security') {
                   setIsToolsOpen(false);
                 } else {
-                  setToolsContent('info');
+                  setToolsContent('security');
                   setIsToolsOpen(true);
                 }
               },
-              selected: isToolsOpen && toolsContent === 'info',
+              selected: isToolsOpen && toolsContent === 'security',
             },
             {
               ariaExpanded: isToolsOpen,
@@ -84,16 +83,6 @@ export default function () {
               ]}
               selectedId={triggerStatus}
             />
-
-            <SegmentedControl
-              label="Split Panel Status"
-              onChange={({ detail }) => setSplitPanelStatus(detail.selectedId)}
-              options={[
-                { text: 'Show SplitPanel', id: 'show-split-panel' },
-                { text: 'Hide SplitPanel', id: 'hide-split-panel' },
-              ]}
-              selectedId={splitPanelStatus}
-            />
           </SpaceBetween>
         }
         content={<Containers />}
@@ -104,30 +93,29 @@ export default function () {
           position: 'side',
         }}
         splitPanel={
-          splitPanelStatus === 'show-split-panel' && (
-            <SplitPanel
-              header="Split panel header"
-              i18nStrings={{
-                preferencesTitle: 'Preferences',
-                preferencesPositionLabel: 'Split panel position',
-                preferencesPositionDescription: 'Choose the default split panel position for the service.',
-                preferencesPositionSide: 'Side',
-                preferencesPositionBottom: 'Bottom',
-                preferencesConfirm: 'Confirm',
-                preferencesCancel: 'Cancel',
-                closeButtonAriaLabel: 'Close panel',
-                openButtonAriaLabel: 'Open panel',
-                resizeHandleAriaLabel: 'Slider',
-              }}
-            >
-              This is the Split Panel!
-            </SplitPanel>
-          )
+          <SplitPanel
+            header="Split panel header"
+            i18nStrings={{
+              preferencesTitle: 'Preferences',
+              preferencesPositionLabel: 'Split panel position',
+              preferencesPositionDescription: 'Choose the default split panel position for the service.',
+              preferencesPositionSide: 'Side',
+              preferencesPositionBottom: 'Bottom',
+              preferencesConfirm: 'Confirm',
+              preferencesCancel: 'Cancel',
+              closeButtonAriaLabel: 'Close panel',
+              openButtonAriaLabel: 'Open panel',
+              resizeHandleAriaLabel: 'Slider',
+            }}
+          >
+            This is the Split Panel!
+          </SplitPanel>
         }
         tools={
           <>
-            {toolsContent === 'info' && <Info />}
-            {toolsContent === 'proHelp' && <ProHelp />}
+            {(triggerStatus === 'default-trigger' || toolsContent === 'info') && <Info />}
+            {triggerStatus === 'custom-triggers' && toolsContent === 'proHelp' && <ProHelp />}
+            {triggerStatus === 'custom-triggers' && toolsContent === 'security' && <Security />}
           </>
         }
         toolsHide={triggerStatus === 'hide-tools' ? true : false}
@@ -153,6 +141,10 @@ function IconBriefcase() {
       />
     </svg>
   );
+}
+
+function Security() {
+  return <HelpPanel header={<h2>Security</h2>}>Keep your passwords secret!</HelpPanel>;
 }
 
 function ProHelp() {

--- a/pages/app-layout/with-custom-triggers.page.tsx
+++ b/pages/app-layout/with-custom-triggers.page.tsx
@@ -57,7 +57,6 @@ export default function () {
         }
         content={<Containers />}
         onToolsChange={({ detail }) => {
-          console.log('onToolsChange');
           setIsToolsOpen(detail.open);
         }}
         tools={toolsContent}

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -23,12 +23,13 @@ export default function AppBar() {
     handleToolsClick,
     hasNotificationsContent,
     hasStickyBackground,
+    isAnyPanelOpen,
     isMobile,
-    navigationHide,
     isNavigationOpen,
     isToolsOpen,
+    navigationHide,
     toolsHide,
-    isAnyPanelOpen,
+    toolsTriggers,
   } = useAppLayoutInternals();
   const { refs: focusRefsNav } = useFocusControl(isNavigationOpen);
   const { refs: focusRefsTools } = useFocusControl(isToolsOpen, true);
@@ -89,6 +90,21 @@ export default function AppBar() {
           aria-hidden={isToolsOpen}
           aria-label={ariaLabels?.tools ?? undefined}
         >
+          {toolsTriggers &&
+            toolsTriggers.map((trigger: any, key) => (
+              <InternalButton
+                ariaLabel={trigger.ariaLabel}
+                disabled={isAnyPanelOpen}
+                key={key}
+                iconName={trigger.iconName}
+                iconSvg={trigger.iconSvg}
+                formAction="none"
+                onClick={trigger.onClick}
+                variant="icon"
+                __nativeAttributes={{ 'aria-haspopup': true }}
+              />
+            ))}
+
           <InternalButton
             className={testutilStyles['tools-toggle']}
             ariaExpanded={isToolsOpen}

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -112,9 +112,9 @@ export default function AppBar() {
                 ariaLabel={trigger.ariaLabel}
                 disabled={isAnyPanelOpen}
                 formAction="none"
-                key={key}
                 iconName={trigger.iconName}
                 iconSvg={trigger.iconSvg}
+                key={key}
                 onClick={trigger.onClick}
                 variant="icon"
                 __nativeAttributes={{ 'aria-haspopup': true }}

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -90,6 +90,21 @@ export default function AppBar() {
           aria-hidden={isToolsOpen}
           aria-label={ariaLabels?.tools ?? undefined}
         >
+          {!toolsTriggers && (
+            <InternalButton
+              className={testutilStyles['tools-toggle']}
+              ariaExpanded={isToolsOpen}
+              disabled={isAnyPanelOpen}
+              ariaLabel={ariaLabels?.toolsToggle ?? undefined}
+              iconName="status-info"
+              formAction="none"
+              onClick={() => handleToolsClick(true)}
+              variant="icon"
+              ref={focusRefsTools.toggle}
+              __nativeAttributes={{ 'aria-haspopup': true }}
+            />
+          )}
+
           {toolsTriggers &&
             toolsTriggers.map((trigger: any, key) => (
               <InternalButton
@@ -104,19 +119,6 @@ export default function AppBar() {
                 __nativeAttributes={{ 'aria-haspopup': true }}
               />
             ))}
-
-          <InternalButton
-            className={testutilStyles['tools-toggle']}
-            ariaExpanded={isToolsOpen}
-            disabled={isAnyPanelOpen}
-            ariaLabel={ariaLabels?.toolsToggle ?? undefined}
-            iconName="status-info"
-            formAction="none"
-            onClick={() => handleToolsClick(true)}
-            variant="icon"
-            ref={focusRefsTools.toggle}
-            __nativeAttributes={{ 'aria-haspopup': true }}
-          />
         </aside>
       )}
     </section>

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -108,7 +108,7 @@ export default function AppBar() {
           {toolsTriggers &&
             toolsTriggers.map((trigger: any, key) => (
               <InternalButton
-                ariaExpanded={isToolsOpen}
+                ariaExpanded={trigger.ariaExpanded}
                 ariaLabel={trigger.ariaLabel}
                 disabled={isAnyPanelOpen}
                 formAction="none"
@@ -116,7 +116,6 @@ export default function AppBar() {
                 iconName={trigger.iconName}
                 iconSvg={trigger.iconSvg}
                 onClick={trigger.onClick}
-                ref={focusRefsTools.toggle}
                 variant="icon"
                 __nativeAttributes={{ 'aria-haspopup': true }}
               />

--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -108,13 +108,15 @@ export default function AppBar() {
           {toolsTriggers &&
             toolsTriggers.map((trigger: any, key) => (
               <InternalButton
+                ariaExpanded={isToolsOpen}
                 ariaLabel={trigger.ariaLabel}
                 disabled={isAnyPanelOpen}
+                formAction="none"
                 key={key}
                 iconName={trigger.iconName}
                 iconSvg={trigger.iconSvg}
-                formAction="none"
                 onClick={trigger.onClick}
+                ref={focusRefsTools.toggle}
                 variant="icon"
                 __nativeAttributes={{ 'aria-haspopup': true }}
               />

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -64,6 +64,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   setSplitPanelToggle: (toggle: SplitPanelSideToggleProps) => void;
   splitPanelDisplayed: boolean;
   toolsFocusControl: FocusControlState;
+  toolsTriggers: Array<any>;
 }
 
 /**
@@ -180,6 +181,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
      * useControllable hook and also fire the onToolsChange function to
      * emit the state change.
      */
+    const toolsTriggers = (props as any).toolsTriggers;
     const toolsWidth = props.toolsWidth ?? 290;
     const hasDefaultToolsWidth = props.toolsWidth === undefined;
 
@@ -521,6 +523,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           setSplitPanelToggle,
           toolsHide,
           toolsOpen: isToolsOpen,
+          toolsTriggers,
           toolsWidth,
           toolsFocusControl,
         }}

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -171,6 +171,12 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     );
 
     /**
+     * The toolsTriggers property will override the default behavior of the
+     * tools drawer. This property will provide an array of trigger buttons
+     * that must be manually connected to the tools drawer with a controlled
+     * state. If the toolsHide property is set to true it will suppress the
+     * toolsTriggers similar to the default behavior.
+     *
      * The useControllable hook will set the default value and manage either
      * the controlled or uncontrolled state of the Tools drawer. The logic
      * for determining the default state is colocated with the Tools component.

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -25,6 +25,7 @@ import { FocusControlState, useFocusControl } from '../utils/use-focus-control';
 import { useObservedElement } from '../utils/use-observed-element';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
+import { TriggerButtonProps } from './trigger-button';
 
 interface AppLayoutInternals extends AppLayoutProps {
   dynamicOverlapHeight: number;
@@ -64,7 +65,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   setSplitPanelToggle: (toggle: SplitPanelSideToggleProps) => void;
   splitPanelDisplayed: boolean;
   toolsFocusControl: FocusControlState;
-  toolsTriggers: Array<any>;
+  toolsTriggers: Array<TriggerButtonProps>;
 }
 
 /**

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -29,11 +29,10 @@ viewport size and state of the Tools drawer.
   grid-row: 1 / span 5;
   height: var(#{custom-props.$contentHeight});
   max-width: var(#{custom-props.$toolsMaxWidth});
+  pointer-events: none;
   position: sticky;
   top: var(#{custom-props.$offsetTop});
   z-index: 830;
-
-  pointer-events: none;
 
   @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
     #{custom-props.$toolsWidth}: 360px;

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -29,19 +29,20 @@ export default function Tools({ children }: ToolsProps) {
     handleSplitPanelClick,
     handleToolsClick,
     hasDefaultToolsWidth,
+    isAnyPanelOpen,
     isNavigationOpen,
     isMobile,
     isSplitPanelOpen,
     isToolsOpen,
-    splitPanelDisplayed,
-    tools,
-    toolsHide,
-    toolsWidth,
-    isAnyPanelOpen,
     navigationHide,
-    toolsFocusControl,
+    splitPanelDisplayed,
     splitPanelPosition,
     splitPanelToggle,
+    tools,
+    toolsFocusControl,
+    toolsHide,
+    toolsTriggers,
+    toolsWidth,
   } = useAppLayoutInternals();
 
   const hasSplitPanel = getSplitPanelStatus(splitPanelDisplayed, splitPanelPosition);
@@ -131,6 +132,17 @@ export default function Tools({ children }: ToolsProps) {
                   ref={focusRefs.toggle}
                 />
               )}
+
+              {toolsTriggers &&
+                toolsTriggers.map((trigger: any, key) => (
+                  <TriggerButton
+                    ariaLabel={trigger.ariaLabel}
+                    key={key}
+                    iconName={trigger.iconName}
+                    iconSvg={trigger.iconSvg}
+                    onClick={trigger.onClick}
+                  />
+                ))}
 
               {hasSplitPanel && splitPanelToggle.displayed && (
                 <TriggerButton

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -46,8 +46,21 @@ export default function Tools({ children }: ToolsProps) {
   } = useAppLayoutInternals();
 
   const hasSplitPanel = getSplitPanelStatus(splitPanelDisplayed, splitPanelPosition);
-  const hasToolsForm = getToolsFormStatus(hasSplitPanel, isMobile, isSplitPanelOpen, isToolsOpen, toolsHide);
-  const hasToolsFormPersistence = getToolsFormPersistence(hasSplitPanel, isSplitPanelOpen, isToolsOpen, toolsHide);
+  const toolsTriggerCount = getToolsTriggerCount(hasSplitPanel, toolsTriggers, toolsHide);
+  const hasToolsForm = getToolsFormStatus(
+    hasSplitPanel,
+    toolsTriggerCount,
+    isMobile,
+    isSplitPanelOpen,
+    isToolsOpen,
+    toolsHide
+  );
+  const hasToolsFormPersistence = getToolsFormPersistence(
+    hasSplitPanel,
+    toolsTriggerCount,
+    isSplitPanelOpen,
+    isToolsOpen
+  );
 
   const { refs: focusRefs } = toolsFocusControl;
 
@@ -200,6 +213,7 @@ function getSplitPanelStatus(splitPanelDisplayed: boolean, splitPanelPosition: s
  */
 function getToolsFormStatus(
   hasSplitPanel: boolean,
+  toolsTriggerCount: number,
   isMobile: boolean,
   isSplitPanelOpen?: boolean,
   isToolsOpen?: boolean,
@@ -222,6 +236,11 @@ function getToolsFormStatus(
     if (!hasSplitPanel && !toolsHide && !isToolsOpen) {
       hasToolsForm = true;
     }
+
+    //
+    if (toolsTriggerCount > 1) {
+      hasToolsForm = true;
+    }
   }
 
   return hasToolsForm;
@@ -237,16 +256,41 @@ function getToolsFormStatus(
  */
 function getToolsFormPersistence(
   hasSplitPanel: boolean,
+  toolsTriggerCount: number,
   isSplitPanelOpen?: boolean,
-  isToolsOpen?: boolean,
-  toolsHide?: boolean
+  isToolsOpen?: boolean
 ) {
   let hasToolsFormPersistence = false;
 
   // Both Tools and Split Panel exist and one or both is open
-  if (hasSplitPanel && !toolsHide && (isSplitPanelOpen || isToolsOpen)) {
+  if (toolsTriggerCount > 1 && ((hasSplitPanel && isSplitPanelOpen) || isToolsOpen)) {
     hasToolsFormPersistence = true;
   }
 
   return hasToolsFormPersistence;
+}
+
+/**
+ *
+ */
+function getToolsTriggerCount(
+  hasSplitPanel: boolean,
+  toolsTriggers: Array<Record<string, unknown>>,
+  toolsHide?: boolean
+) {
+  let toolsTriggerCount = 0;
+
+  if (hasSplitPanel) {
+    toolsTriggerCount++;
+  }
+
+  if (!toolsHide && !toolsTriggers) {
+    toolsTriggerCount++;
+  }
+
+  if (!toolsHide && toolsTriggers) {
+    toolsTriggerCount += toolsTriggers.length;
+  }
+
+  return toolsTriggerCount;
 }

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -123,26 +123,30 @@ export default function Tools({ children }: ToolsProps) {
               ref={state === 'exiting' ? transitionEventsRef : undefined}
             >
               {!toolsHide && (
-                <TriggerButton
-                  ariaLabel={ariaLabels?.toolsToggle}
-                  iconName="status-info"
-                  onClick={() => handleToolsClick(!isToolsOpen)}
-                  selected={hasSplitPanel && isToolsOpen}
-                  className={testutilStyles['tools-toggle']}
-                  ref={focusRefs.toggle}
-                />
-              )}
+                <>
+                  {!toolsTriggers && (
+                    <TriggerButton
+                      ariaLabel={ariaLabels?.toolsToggle}
+                      iconName="status-info"
+                      onClick={() => handleToolsClick(!isToolsOpen)}
+                      selected={hasSplitPanel && isToolsOpen}
+                      className={testutilStyles['tools-toggle']}
+                      ref={focusRefs.toggle}
+                    />
+                  )}
 
-              {toolsTriggers &&
-                toolsTriggers.map((trigger: any, key) => (
-                  <TriggerButton
-                    ariaLabel={trigger.ariaLabel}
-                    key={key}
-                    iconName={trigger.iconName}
-                    iconSvg={trigger.iconSvg}
-                    onClick={trigger.onClick}
-                  />
-                ))}
+                  {toolsTriggers &&
+                    toolsTriggers.map((trigger: any, key) => (
+                      <TriggerButton
+                        ariaLabel={trigger.ariaLabel}
+                        key={key}
+                        iconName={trigger.iconName}
+                        iconSvg={trigger.iconSvg}
+                        onClick={trigger.onClick}
+                      />
+                    ))}
+                </>
+              )}
 
               {hasSplitPanel && splitPanelToggle.displayed && (
                 <TriggerButton

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
+import customCssProps from '../../internal/generated/custom-css-properties';
 import { InternalButton } from '../../button/internal';
-import { useAppLayoutInternals } from './context';
-import TriggerButton from './trigger-button';
-import styles from './styles.css.js';
 import splitPanelStyles from '../../split-panel/styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 import { Transition } from '../../internal/components/transition';
-import customCssProps from '../../internal/generated/custom-css-properties';
+import TriggerButton, { TriggerButtonProps } from './trigger-button';
+import { useAppLayoutInternals } from './context';
+import styles from './styles.css.js';
 
 interface ToolsProps {
   children: React.ReactNode;
@@ -61,14 +61,12 @@ export default function Tools({ children }: ToolsProps) {
     isSplitPanelOpen,
     isToolsOpen
   );
-
   const { refs: focusRefs } = toolsFocusControl;
+  const isUnfocusable = isMobile && isAnyPanelOpen && isNavigationOpen && !navigationHide;
 
   if (toolsHide && !hasSplitPanel) {
     return null;
   }
-
-  const isUnfocusable = isMobile && isAnyPanelOpen && isNavigationOpen && !navigationHide;
 
   return (
     <Transition in={isToolsOpen ?? false}>
@@ -149,7 +147,7 @@ export default function Tools({ children }: ToolsProps) {
                   )}
 
                   {toolsTriggers &&
-                    toolsTriggers.map((trigger: any, key) => (
+                    toolsTriggers.map((trigger: TriggerButtonProps, key) => (
                       <TriggerButton
                         ariaLabel={trigger.ariaLabel}
                         iconName={trigger.iconName}
@@ -206,7 +204,7 @@ function getSplitPanelStatus(splitPanelDisplayed: boolean, splitPanelPosition: s
 }
 
 /**
- * By default the Tools form is styled as display: none; This behavior should
+ * By default the Tools form is styled as display: none. This behavior should
  * be unchanged in mobile viewports where the Tools form is always suppressed.
  * In large viewports, however the Tools form and its corresponding buttons
  * should be present in the UI under the below circumstances.
@@ -237,7 +235,7 @@ function getToolsFormStatus(
       hasToolsForm = true;
     }
 
-    //
+    // The Form is required any time there are 2 or more buttons
     if (toolsTriggerCount > 1) {
       hasToolsForm = true;
     }
@@ -271,13 +269,11 @@ function getToolsFormPersistence(
 }
 
 /**
- *
+ * Compute the number of triggers that are rendered next to the Tools drawer.
+ * This number will vary based on the suppression of the drawer, the use of a
+ * SplitPanel in the side position, and the existence of custom trigger buttons.
  */
-function getToolsTriggerCount(
-  hasSplitPanel: boolean,
-  toolsTriggers: Array<Record<string, unknown>>,
-  toolsHide?: boolean
-) {
+function getToolsTriggerCount(hasSplitPanel: boolean, toolsTriggers: Array<TriggerButtonProps>, toolsHide?: boolean) {
   let toolsTriggerCount = 0;
 
   if (hasSplitPanel) {

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -143,6 +143,7 @@ export default function Tools({ children }: ToolsProps) {
                         iconSvg={trigger.iconSvg}
                         key={key}
                         onClick={trigger.onClick}
+                        selected={trigger.selected}
                       />
                     ))}
                 </>

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -127,11 +127,11 @@ export default function Tools({ children }: ToolsProps) {
                   {!toolsTriggers && (
                     <TriggerButton
                       ariaLabel={ariaLabels?.toolsToggle}
+                      className={testutilStyles['tools-toggle']}
                       iconName="status-info"
                       onClick={() => handleToolsClick(!isToolsOpen)}
-                      selected={hasSplitPanel && isToolsOpen}
-                      className={testutilStyles['tools-toggle']}
                       ref={focusRefs.toggle}
+                      selected={hasSplitPanel && isToolsOpen}
                     />
                   )}
 
@@ -139,9 +139,9 @@ export default function Tools({ children }: ToolsProps) {
                     toolsTriggers.map((trigger: any, key) => (
                       <TriggerButton
                         ariaLabel={trigger.ariaLabel}
-                        key={key}
                         iconName={trigger.iconName}
                         iconSvg={trigger.iconSvg}
+                        key={key}
                         onClick={trigger.onClick}
                       />
                     ))}

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -8,7 +8,7 @@ import styles from './styles.css.js';
 import { ButtonProps } from '../../button/interfaces';
 import { IconProps } from '../../icon/interfaces';
 
-interface TriggerButtonProps {
+export interface TriggerButtonProps {
   ariaLabel?: string;
   className?: string;
   iconName?: IconProps.Name;
@@ -36,8 +36,8 @@ function TriggerButton(
         className
       )}
       onClick={onClick}
-      type="button"
       ref={ref as React.Ref<HTMLButtonElement>}
+      type="button"
       {...focusVisible}
     >
       {iconName && !iconSvg && <Icon name={iconName} />}

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -10,14 +10,15 @@ import { IconProps } from '../../icon/interfaces';
 
 interface TriggerButtonProps {
   ariaLabel?: string;
-  iconName: IconProps.Name;
+  className?: string;
+  iconName?: IconProps.Name;
+  iconSvg?: React.ReactNode;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   selected?: boolean;
-  className?: string;
 }
 
 function TriggerButton(
-  { ariaLabel, iconName, onClick, selected = false, className }: TriggerButtonProps,
+  { ariaLabel, className, iconName, iconSvg, onClick, selected = false }: TriggerButtonProps,
   ref: React.Ref<ButtonProps.Ref>
 ) {
   const focusVisible = useFocusVisible();
@@ -39,7 +40,8 @@ function TriggerButton(
       ref={ref as React.Ref<HTMLButtonElement>}
       {...focusVisible}
     >
-      <Icon name={iconName} />
+      {iconName && !iconSvg && <Icon name={iconName} />}
+      {iconSvg}
     </button>
   );
 }

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -9,6 +9,7 @@ import { ButtonProps } from '../../button/interfaces';
 import { IconProps } from '../../icon/interfaces';
 
 export interface TriggerButtonProps {
+  ariaExpanded?: boolean;
   ariaLabel?: string;
   className?: string;
   iconName?: IconProps.Name;
@@ -25,9 +26,9 @@ function TriggerButton(
 
   return (
     <button
-      aria-label={ariaLabel}
       aria-expanded={false}
       aria-haspopup={true}
+      aria-label={ariaLabel}
       className={clsx(
         styles.trigger,
         {


### PR DESCRIPTION
### Description

This PR adds the ability to for users to create custom trigger buttons in the slot adjacent to the tools panel. There are no changes to the interface in order to prevent widespread awareness and adoption during the feature testing window.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
