### PR TITLE
fix: Empty search results result in extra padding

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -406,9 +406,16 @@ describe('property filter parts', () => {
   });
 
   describe('count text', () => {
-    test('is hidden when there are no filtering tokens', () => {
+    test('is not displayed when count text is empty', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        countText: '',
+        query: { tokens: [{ propertyKey: 'string', value: 'first', operator: ':' }], operation: 'or' },
+      });
+      expect(wrapper.findResultsCount()).toBe(null);
+    });
+    test('is not displayed when there are no filtering tokens', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({ countText: '5 matches' });
-      expect(wrapper.findResultsCount()!.getElement()).toBeEmptyDOMElement();
+      expect(wrapper.findResultsCount()).toBe(null);
     });
     test('is visible when there is at least 1 token', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -125,7 +125,7 @@ const PropertyFilter = React.forwardRef(
 
     useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
     const { tokens, operation } = query;
-    const showResults = tokens?.length && !disabled;
+    const showResults = !!tokens?.length && !disabled && !!countText;
     const { addToken, removeToken, setToken, setOperation, removeAllTokens } = getQueryActions(
       query,
       onChange,
@@ -312,9 +312,9 @@ const PropertyFilter = React.forwardRef(
             }
             hideEnteredTextOption={disableFreeTextFiltering && parsedText.step !== 'property'}
             clearAriaLabel={i18nStrings.clearAriaLabel}
-            searchResultsId={searchResultsId}
+            searchResultsId={showResults ? searchResultsId : undefined}
           />
-          {showResults && countText ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
+          {showResults ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
         </div>
         {tokens && tokens.length > 0 && (
           <div className={styles.tokens}>

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -9,7 +9,7 @@ import { getBaseProps } from '../internal/base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { KeyCode } from '../internal/keycode';
 import SelectToggle from '../token-group/toggle';
-import { generateUniqueId } from '../internal/hooks/use-unique-id/index';
+import { generateUniqueId, useUniqueId } from '../internal/hooks/use-unique-id/index';
 import { fireNonCancelableEvent } from '../internal/events';
 
 import { PropertyFilterOperator } from '@cloudscape-design/collection-hooks';
@@ -30,6 +30,7 @@ import { PropertyEditor } from './property-editor';
 import { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 import { matchTokenValue } from './utils';
 import { useInternalI18n } from '../internal/i18n/context';
+import { SearchResults } from '../text-filter/search-results';
 
 export { PropertyFilterProps };
 
@@ -266,6 +267,8 @@ const PropertyFilter = React.forwardRef(
       parsedText.step === 'property' &&
       getExtendedOperator(filteringProperties, parsedText.property.key, parsedText.operator)?.form;
 
+    const searchResultsId = useUniqueId('property-filter-search-results');
+
     return (
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <div className={styles['search-field']}>
@@ -309,14 +312,9 @@ const PropertyFilter = React.forwardRef(
             }
             hideEnteredTextOption={disableFreeTextFiltering && parsedText.step !== 'property'}
             clearAriaLabel={i18nStrings.clearAriaLabel}
+            searchResultsId={searchResultsId}
           />
-          <span
-            aria-live="polite"
-            aria-atomic="true"
-            className={clsx(styles.results, showResults && styles['results-visible'])}
-          >
-            {showResults ? countText : ''}
-          </span>
+          {showResults && countText ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
         </div>
         {tokens && tokens.length > 0 && (
           <div className={styles.tokens}>

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -38,6 +38,7 @@ export interface PropertyFilterAutosuggestProps extends AutosuggestProps, Intern
   filterText?: string;
   onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
   hideEnteredTextOption?: boolean;
+  searchResultsId?: string;
 }
 
 const PropertyFilterAutosuggest = React.forwardRef(
@@ -61,6 +62,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
       filterText,
       onOptionClick,
       hideEnteredTextOption,
+      searchResultsId,
       ...rest
     } = props;
     const highlightText = filterText === undefined ? value : filterText;
@@ -190,6 +192,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         expandToViewport={expandToViewport}
         ariaControls={listId}
         ariaActivedescendant={highlightedOptionId}
+        ariaDescribedby={searchResultsId}
         dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null || !!customForm}
         dropdownContentKey={customForm ? 'custom' : 'options'}
         dropdownContent={content}

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -91,16 +91,6 @@
   flex: 1;
 }
 
-.results {
-  color: awsui.$color-text-form-label;
-  display: inline-block;
-  box-sizing: border-box;
-  white-space: nowrap;
-  &-visible {
-    padding-left: awsui.$space-s;
-  }
-}
-
 .separator {
   margin: 0px awsui.$space-scaled-m;
   height: 100%;

--- a/src/s3-resource-selector/s3-modal/__tests__/buckets-table.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/buckets-table.test.tsx
@@ -139,7 +139,7 @@ test('filtering buckets', async () => {
   expect(wrapper.findTextFilter()!.findResultsCount().getElement()).toHaveTextContent('0 matches');
   wrapper.findEmptySlot()!.findButton()!.click();
   expect(wrapper.findRows()).toHaveLength(2);
-  expect(wrapper.findTextFilter()!.findResultsCount().getElement()).toHaveTextContent('');
+  expect(wrapper.findTextFilter()!.findResultsCount()).toBe(null);
 });
 
 test('paginating buckets', async () => {

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -3,6 +3,7 @@
 import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import styles from '../../../property-filter/styles.selectors.js';
+import textFilterStyles from '../../../text-filter/styles.selectors.js';
 
 import AutosuggestWrapper from '../autosuggest';
 
@@ -12,7 +13,7 @@ export default class PropertyFilterWrapper extends AutosuggestWrapper {
   static rootSelector = styles.root;
 
   findResultsCount(): ElementWrapper {
-    return this.findByClassName(styles.results)!;
+    return this.findByClassName(textFilterStyles.results)!;
   }
 
   findTokens(): Array<FilteringTokenWrapper> {

--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -94,14 +94,14 @@ test('has autocomplete turned off', () => {
 });
 
 describe('countText', () => {
-  test('is empty if no value was given', () => {
+  test('not displayed if no value was given', () => {
     const { wrapper } = renderTextFilter(<TextFilter filteringText="" />);
-    expect(wrapper.findResultsCount().getElement().textContent).toEqual('');
+    expect(wrapper.findResultsCount()).toBe(null);
   });
 
   test('not displayed when filtering text is empty', () => {
     const { wrapper } = renderTextFilter(<TextFilter filteringText="" countText="0 matches" />);
-    expect(wrapper.findResultsCount().getElement().textContent).toEqual('');
+    expect(wrapper.findResultsCount()).toBe(null);
   });
 
   test('displays the text when all conditions met', () => {

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -9,11 +9,8 @@ import { fireNonCancelableEvent } from '../internal/events';
 import styles from './styles.css.js';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { TextFilterProps } from './interfaces';
-import LiveRegion from '../internal/components/live-region';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
-
-// Debounce delay for live region (based on testing with VoiceOver)
-const LIVE_REGION_DELAY = 2000;
+import { SearchResults } from './search-results';
 
 type InternalTextFilterProps = TextFilterProps & InternalBaseComponentProps;
 
@@ -37,7 +34,7 @@ const InternalTextFilter = React.forwardRef(
     const inputRef = useRef<HTMLInputElement>(null);
     useForwardFocus(ref, inputRef);
 
-    const countTextId = useUniqueId('text-filter');
+    const searchResultsId = useUniqueId('text-filter-search-results');
     const showResults = filteringText && countText && !disabled;
 
     return (
@@ -51,16 +48,12 @@ const InternalTextFilter = React.forwardRef(
           value={filteringText}
           disabled={disabled}
           autoComplete={false}
-          ariaDescribedby={countTextId}
+          ariaDescribedby={searchResultsId}
           clearAriaLabel={filteringClearAriaLabel}
           onChange={event => fireNonCancelableEvent(onChange, { filteringText: event.detail.value })}
           __onDelayedInput={event => fireNonCancelableEvent(onDelayedChange, { filteringText: event.detail.value })}
         />
-        <span className={clsx(styles.results, showResults && styles['results-visible'])}>
-          <LiveRegion delay={LIVE_REGION_DELAY} visible={true}>
-            <span id={countTextId}>{showResults ? countText : ''}</span>
-          </LiveRegion>
-        </span>
+        {showResults && countText ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
       </div>
     );
   }

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -48,12 +48,12 @@ const InternalTextFilter = React.forwardRef(
           value={filteringText}
           disabled={disabled}
           autoComplete={false}
-          ariaDescribedby={searchResultsId}
+          ariaDescribedby={showResults ? searchResultsId : undefined}
           clearAriaLabel={filteringClearAriaLabel}
           onChange={event => fireNonCancelableEvent(onChange, { filteringText: event.detail.value })}
           __onDelayedInput={event => fireNonCancelableEvent(onDelayedChange, { filteringText: event.detail.value })}
         />
-        {showResults && countText ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
+        {showResults ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
       </div>
     );
   }

--- a/src/text-filter/search-results.tsx
+++ b/src/text-filter/search-results.tsx
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import styles from './styles.css.js';
+import LiveRegion from '../internal/components/live-region';
+
+// Debounce delay for live region (based on testing with VoiceOver)
+const LIVE_REGION_DELAY = 2000;
+
+interface SearchResultsProps {
+  id: string;
+  children: string;
+}
+
+export function SearchResults({ id, children }: SearchResultsProps) {
+  return (
+    <span className={styles.results}>
+      <LiveRegion delay={LIVE_REGION_DELAY} visible={true}>
+        <span id={id}>{children}</span>
+      </LiveRegion>
+    </span>
+  );
+}

--- a/src/text-filter/styles.scss
+++ b/src/text-filter/styles.scss
@@ -23,7 +23,5 @@
   display: inline-block;
   box-sizing: border-box;
   white-space: nowrap;
-  &-visible {
-    padding-left: awsui.$space-s;
-  }
+  padding-left: awsui.$space-s;
 }


### PR DESCRIPTION
### Description

Fixed an issue (AWSUI-20714) with property-filter countText resulting in an extra padding when undefined. Additionally, aligned search results handling between property-filter and text-filter based on the recent change to the latter: https://github.com/cloudscape-design/components/pull/782.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
