### PR TITLE
revert: Changed container bottom spacing for fit height mode (#766)

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -89,9 +89,7 @@ export default function InternalContainer({
         styles.root,
         styles[`variant-${variant}`],
         fitHeight && styles['fit-height'],
-        isSticky && [styles['sticky-enabled']],
-        !disableContentPaddings && styles['with-content-paddings'],
-        footer && styles['with-footer']
+        isSticky && [styles['sticky-enabled']]
       )}
       ref={mergedRef}
     >
@@ -118,7 +116,13 @@ export default function InternalContainer({
           </div>
         </StickyHeaderContext.Provider>
       )}
-      <div className={styles.content}>{children}</div>
+      <div
+        className={clsx(styles.content, {
+          [styles['with-paddings']]: !disableContentPaddings,
+        })}
+      >
+        {children}
+      </div>
       {footer && (
         <div
           className={clsx(styles.footer, {

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -155,18 +155,12 @@ the default white background of the container component.
     flex: 1;
     overflow: auto;
   }
-  .with-content-paddings > & {
+  &.with-paddings {
     padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
-  }
-  .with-content-paddings > .header + & {
-    padding-top: awsui.$space-container-content-top;
-  }
-}
 
-.fit-height.with-content-paddings:not(.with-footer) {
-  padding-bottom: awsui.$space-scaled-l;
-  & > .content {
-    padding-bottom: 0;
+    .header + & {
+      padding-top: awsui.$space-container-content-top;
+    }
   }
 }
 


### PR DESCRIPTION
This partially reverts commit e66b674ba1e2c6c5629d0ff1e9abb004ce77ccaf.

The dev pages changes stay, the source code changes revert

### Description

Reverting the change because it caused issues for static dashboard demo https://cloudscape.design/examples/react/dashboard.html

This vertical scrollbar is a bug

<img width="887" alt="image" src="https://user-images.githubusercontent.com/812240/228543261-2aac38e5-4d0f-4276-9c14-f00630a4857d.png">


Related links, issue #, if available: n/a

### How has this been tested?

This behavior is not reproducible on demo pages (needs negative margins to show up). Will be tested later in the pipeline with the demo pages build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
