### PR TITLE
fix: Standardize focus behavior when removing tags

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1027,6 +1027,13 @@ The event \`detail\` contains the index of the corresponding item.",
   ],
   "functions": Array [
     Object {
+      "description": "Focuses the 'add' button. Use this, for example, after a user removes the last row.",
+      "name": "focusAddButton",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+    Object {
+      "description": "Focuses the remove button for the given row index.",
       "name": "focusRemoveButton",
       "parameters": Array [
         Object {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1033,7 +1033,7 @@ The event \`detail\` contains the index of the corresponding item.",
       "returnType": "void",
     },
     Object {
-      "description": "Focuses the remove button for the given row index.",
+      "description": "Focuses the 'remove' button for the given row index.",
       "name": "focusRemoveButton",
       "parameters": Array [
         Object {

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -386,6 +386,11 @@ describe('Attribute Editor', () => {
         expect(wrapper.findRow(row)!.findRemoveButton()!.getElement()).not.toHaveFocus();
       }
     });
+
+    it('can focus add button', () => {
+      ref.focusAddButton();
+      expect(wrapper.findAddButton().getElement()).toHaveFocus();
+    });
   });
 
   describe('a11y', () => {

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -38,7 +38,7 @@ export namespace AttributeEditorProps {
 
   export interface Ref {
     /**
-     * Focuses the remove button for the given row index.
+     * Focuses the 'remove' button for the given row index.
      */
     focusRemoveButton(itemIndex: number): void;
     /**

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -37,7 +37,14 @@ export namespace AttributeEditorProps {
   }
 
   export interface Ref {
+    /**
+     * Focuses the remove button for the given row index.
+     */
     focusRemoveButton(itemIndex: number): void;
+    /**
+     * Focuses the 'add' button. Use this, for example, after a user removes the last row.
+     */
+    focusAddButton(): void;
   }
 
   export interface I18nStrings {

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -45,6 +45,7 @@ const InternalAttributeEditor = React.forwardRef(
   ) => {
     const [breakpoint, breakpointRef] = useContainerBreakpoints(['default', 'xxs', 'xs']);
     const removeButtonRefs = useRef<Array<ButtonProps.Ref | undefined>>([]);
+    const addButtonRef = useRef<ButtonProps.Ref>(null);
     const wasNonEmpty = useRef<boolean>(false);
     const [removalAnnouncement, setRemovalAnnouncement] = useState<string>('');
 
@@ -56,6 +57,9 @@ const InternalAttributeEditor = React.forwardRef(
     useImperativeHandle(ref, () => ({
       focusRemoveButton(rowIndex: number) {
         removeButtonRefs.current[rowIndex]?.focus();
+      },
+      focusAddButton() {
+        addButtonRef.current?.focus();
       },
     }));
 
@@ -101,6 +105,7 @@ const InternalAttributeEditor = React.forwardRef(
           disabled={disableAddButton}
           onClick={onAddButtonClick}
           formAction="none"
+          ref={addButtonRef}
           __nativeAttributes={{ 'aria-describedby': infoAriaDescribedBy }}
         >
           {addButtonText}

--- a/src/tag-editor/__integ__/tag-editor.test.ts
+++ b/src/tag-editor/__integ__/tag-editor.test.ts
@@ -108,6 +108,7 @@ describe('Tag Editor', () => {
         // 2. Add new tag -> Remove added tag -> Add new tag
         await page.addTag();
         await page.removeTag(5);
+        page.focusTagEditor();
         await page.addTag();
 
         // 3. Remove existing tag -> Undo remove -> Remove existing tag

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -131,7 +131,26 @@ const TagEditor = React.forwardRef(
           };
         } else {
           keyDirtyStateRef.current.splice(detail.itemIndex, 1);
-          keyInputRefs.current[detail.itemIndex]?.focus();
+          const nextKey = keyInputRefs.current[detail.itemIndex + 1];
+          if (nextKey) {
+            // if next key is present, focus _current_ key which will be replaced by next after state update
+            keyInputRefs.current[detail.itemIndex]?.focus();
+          } else if (detail.itemIndex > 0) {
+            // otherwise focus previous key/value/undo button
+            const previousIsExisting = tags[detail.itemIndex - 1].existing;
+            if (previousIsExisting) {
+              if (tags[detail.itemIndex - 1].markedForRemoval) {
+                undoButtonRefs.current[detail.itemIndex - 1]?.focus();
+              } else {
+                valueInputRefs.current[detail.itemIndex - 1]?.focus();
+              }
+            } else {
+              keyInputRefs.current[detail.itemIndex - 1]?.focus();
+            }
+          } else {
+            // or the 'add' button
+            attributeEditorRef.current?.focusAddButton();
+          }
         }
       }
     );


### PR DESCRIPTION
### Description

Standardize focus handling when removing tags in TagEditor: focus another tag when possible, otherwise the 'Add tag' button.

Related links, issue #, if available: AWSUI-20696

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
