### PR TITLE
chore: Update set source map's sourceRoot path

### DIFF
--- a/build-tools/tasks/typescript.js
+++ b/build-tools/tasks/typescript.js
@@ -19,6 +19,8 @@ function compileTypescript(theme) {
         '--declarationMap',
         '--sourceMap',
         '--inlineSources',
+        '--sourceRoot',
+        `lib/${theme.name}`,
       ],
       {
         stdio: 'inherit',


### PR DESCRIPTION
### Description

Before this change, the sources pointed to the relative path outside of the code package. This is fine during development but points to a wrong path when consuming the built artifacts. See screenshot which illustrates the wrong mapping:

<img width="1536" alt="Screenshot 2023-03-29 at 11 58 28" src="https://user-images.githubusercontent.com/569011/228787188-e73805c0-37b8-4cf7-aef1-87110c3fd90e.png">

Setting the `sourceRoot` fixes that and points to the correct location in dev mode and when consuming the
artifacts.

AWSUI-20467

### How has this been tested?

Verified in a vite and webpack project. Also in components local dev env.

You can test the changes when checking out this PR and browse through the devtools sources tree.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
