### PR TITLE
chore: Make sure focus outline in table editing is not hidden by mouse hover

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -217,7 +217,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
         left: 0;
         right: 0;
       }
-      &[data-awsui-focus-visible='true']:not(:hover):focus-within {
+      &[data-awsui-focus-visible='true']:focus-within {
         @include styles.focus-highlight(
           (
             'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),


### PR DESCRIPTION
### Description
Editable table cells can be focused with a keyboard, and they have a special visual state when hovering over them with your mouse. This change fixes a problem where the keyboard focus outline on a cell would become invisible when the user also hovers over the cell.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
