### PR TITLE
fix: Remove unwanted `clearInputLabel` from input elements that do not support it

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4655,12 +4655,6 @@ scrolled out of the viewport.",
       "type": "string",
     },
     Object {
-      "description": "Adds an \`aria-label\` to the clear button inside the search input.",
-      "name": "clearAriaLabel",
-      "optional": true,
-      "type": "string",
-    },
-    Object {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
 It defaults to an automatically generated ID that
@@ -12560,12 +12554,6 @@ scrolled out of the viewport.",
       "type": "string",
     },
     Object {
-      "description": "Adds an \`aria-label\` to the clear button inside the search input.",
-      "name": "clearAriaLabel",
-      "optional": true,
-      "type": "string",
-    },
-    Object {
       "description": "Specifies the ID of the native form element. You can use it to relate
 a label element's \`for\` attribute to this control.
 It defaults to an automatically generated ID that
@@ -12909,12 +12897,6 @@ scrolled out of the viewport.",
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",
-      "optional": true,
-      "type": "string",
-    },
-    Object {
-      "description": "Adds an \`aria-label\` to the clear button inside the search input.",
-      "name": "clearAriaLabel",
       "optional": true,
       "type": "string",
     },

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -10,7 +10,7 @@ import {
   OptionsFilteringType,
 } from '../internal/components/dropdown/interfaces';
 import { DropdownStatusProps } from '../internal/components/dropdown-status';
-import { BaseInputProps, InputAutoCorrect, InputKeyEvents, InputProps } from '../input/interfaces';
+import { BaseInputProps, InputAutoCorrect, InputClearLabel, InputKeyEvents, InputProps } from '../input/interfaces';
 import { NonCancelableEventHandler } from '../internal/events';
 
 export interface AutosuggestProps
@@ -19,6 +19,7 @@ export interface AutosuggestProps
     InputAutoCorrect,
     BaseDropdownHostProps,
     InputKeyEvents,
+    InputClearLabel,
     FormFieldValidationControlProps,
     DropdownStatusProps {
   /**

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -54,11 +54,6 @@ export interface BaseInputProps {
   ariaLabel?: string;
 
   /**
-   * Adds an `aria-label` to the clear button inside the search input.
-   */
-  clearAriaLabel?: string;
-
-  /**
    * Specifies whether to add `aria-required` to the native control.
    */
   ariaRequired?: boolean;
@@ -133,6 +128,13 @@ export interface InputKeyEvents {
   onKeyUp?: CancelableEventHandler<InputProps.KeyDetail>;
 }
 
+export interface InputClearLabel {
+  /**
+   * Adds an `aria-label` to the clear button inside the search input.
+   */
+  clearAriaLabel?: string;
+}
+
 export interface InputProps
   extends BaseComponentProps,
     BaseInputProps,
@@ -140,6 +142,7 @@ export interface InputProps
     InputAutoCorrect,
     InputAutoComplete,
     InputSpellcheck,
+    InputClearLabel,
     FormFieldValidationControlProps {
   /**
    * Specifies the type of control to render.

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -9,7 +9,13 @@ import { FormFieldValidationControlProps, useFormFieldContext } from '../../cont
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
 import InternalInput from '../../../input/internal';
-import { BaseChangeDetail, BaseInputProps, InputAutoCorrect, InputKeyEvents } from '../../../input/interfaces';
+import {
+  BaseChangeDetail,
+  BaseInputProps,
+  InputAutoCorrect,
+  InputClearLabel,
+  InputKeyEvents,
+} from '../../../input/interfaces';
 import { AutosuggestProps } from '../../../autosuggest/interfaces';
 import { ExpandToViewport } from '../dropdown/interfaces';
 import { InternalBaseComponentProps } from '../../hooks/use-base-component';
@@ -22,12 +28,12 @@ export interface AutosuggestInputProps
     BaseInputProps,
     InputAutoCorrect,
     InputKeyEvents,
+    InputClearLabel,
     FormFieldValidationControlProps,
     ExpandToViewport,
     InternalBaseComponentProps {
   ariaControls?: string;
   ariaActivedescendant?: string;
-  clearAriaLabel?: string;
   dropdownExpanded?: boolean;
   dropdownContentKey?: string;
   dropdownContentFocusable?: boolean;


### PR DESCRIPTION
### Description

This was accidentally added to the BaseInputProps interface, hopefully no-one has started using it yet...

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
