### PR TITLE
fix: Swap the order of the save and cancel buttons in table editing

### DIFF
--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -73,8 +73,8 @@ describe('Editable Table TestUtils', () => {
     const cellId0 = wrapper.findBodyCell(1, 1)!.getElement()!;
     fireEvent.click(cellId0);
     const buttons = getByTestId('id-editing-1').closest('form')!.querySelectorAll('button')!;
-    expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[0]);
-    expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[1]);
+    expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[0]);
+    expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[1]);
   });
 
   test('renders when items and labels types do not match', () => {

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -113,6 +113,13 @@ export function InlineEditor<ItemType>({
           {editingCell(item, cellContext)}
           <span className={styles['body-cell-editor-controls']}>
             <SpaceBetween direction="horizontal" size="xxs">
+              <Button
+                ariaLabel={ariaLabels?.submitEditLabel?.(column)}
+                formAction="submit"
+                iconName="check"
+                variant="inline-icon"
+                loading={currentEditLoading}
+              />
               {!currentEditLoading ? (
                 <Button
                   ariaLabel={ariaLabels?.cancelEditLabel?.(column)}
@@ -122,13 +129,6 @@ export function InlineEditor<ItemType>({
                   onClick={onCancel}
                 />
               ) : null}
-              <Button
-                ariaLabel={ariaLabels?.submitEditLabel?.(column)}
-                formAction="submit"
-                iconName="check"
-                variant="inline-icon"
-                loading={currentEditLoading}
-              />
             </SpaceBetween>
           </span>
         </div>

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -147,6 +147,6 @@ export default class TableWrapper extends ComponentWrapper {
   }
 
   findEditingCellCancelButton(): ElementWrapper | null {
-    return this._findEditingCellControls()?.find('button:first-child') ?? null;
+    return this._findEditingCellControls()?.find('button[type="button"]') ?? null;
   }
 }


### PR DESCRIPTION
### Description
This change swaps the order of the "Save" and "Cancel" buttons for table inline editing. This means that the Save button will now come first, and the Cancel button second.

The main motivation behind this change is 1) making the "green path" (saving) shorter, 2) avoid visual duplication of the X icon when an Autosuggest is used. The new order is also commonly found in other design system and component libraries.

| Before | After |
| ------------- | ------------- |
| ![Before](https://user-images.githubusercontent.com/2446349/229092924-80ea956f-1387-40c9-9e13-3d543247a2fc.png)  | ![After](https://user-images.githubusercontent.com/2446349/229092929-a8ca2fb5-8a7b-4313-95aa-097fe53d447c.png) |

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
