### PR TITLE
feat: Buttons in loading state can now be focused for better screen reader experience

### DIFF
--- a/pages/button/tab-navigation.page.tsx
+++ b/pages/button/tab-navigation.page.tsx
@@ -12,6 +12,7 @@ export default function TabNavigationPage() {
       <Button href="#" disabled={true}>
         Disabled with href
       </Button>{' '}
+      <Button loading={true}>Loading</Button>{' '}
       <Button href="#" loading={true}>
         Loading with href
       </Button>{' '}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2769,7 +2769,7 @@ If you set both \`iconUrl\` and \`iconSvg\`, \`iconSvg\` will take precedence.
     Object {
       "defaultValue": "false",
       "description": "Renders the button as being in a loading state. It takes precedence over the \`disabled\` if both are set to \`true\`.
-It prevents users from clicking the button.",
+It prevents users from clicking the button, but it can still be focused.",
       "name": "loading",
       "optional": true,
       "type": "boolean",

--- a/src/button/__integ__/button.test.ts
+++ b/src/button/__integ__/button.test.ts
@@ -38,6 +38,8 @@ describe('Button', () => {
       await expect(page.getFocusedElementText()).resolves.toBe('Active with href');
       await page.keys('Tab');
       // disabled button in the middle should be skipped
+      await expect(page.getFocusedElementText()).resolves.toBe('Loading');
+      await page.keys('Tab');
       await expect(page.getFocusedElementText()).resolves.toBe('Last button');
     })
   );

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -68,7 +68,8 @@ describe('Button Component', () => {
       expect(wrapper.isDisabled()).toEqual(true);
       expect(wrapper.getElement()).toHaveClass(styles.disabled);
       expect(wrapper.getElement()).toHaveAttribute('disabled');
-      expect(wrapper.getElement()).toHaveAttribute('aria-disabled', 'true');
+      // In this case, aria-disabled would be redundant, so we don't set it
+      expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
     });
 
     test('does not add the disabled attribute on link buttons', () => {
@@ -302,9 +303,11 @@ describe('Button Component', () => {
 
     test('gives loading precendence over disabled', () => {
       const wrapper = renderButton({ loading: true, disabled: true });
+      // Loading indicator is shown even when the button is also disabled.
       expect(wrapper.findLoadingIndicator()).not.toBeNull();
+      // However, setting `disabled` does mean that the button can no longer be focused.
       expect(wrapper.getElement()).toHaveAttribute('disabled');
-      expect(wrapper.getElement()).toHaveAttribute('aria-disabled', 'true');
+      expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
     });
 
     test('adds a tab index -1 to the link button', () => {

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -68,7 +68,7 @@ describe('Button Component', () => {
       expect(wrapper.isDisabled()).toEqual(true);
       expect(wrapper.getElement()).toHaveClass(styles.disabled);
       expect(wrapper.getElement()).toHaveAttribute('disabled');
-      expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
+      expect(wrapper.getElement()).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('does not add the disabled attribute on link buttons', () => {
@@ -290,11 +290,12 @@ describe('Button Component', () => {
   });
 
   describe('Loading property', () => {
-    test("should disable the button when in 'loading' status", () => {
+    test("should disable the button with aria-disabled when in 'loading' status", () => {
       const onClickSpy = jest.fn();
       const wrapper = renderButton({ onClick: onClickSpy, loading: true });
       expect(wrapper.findLoadingIndicator()).not.toBeNull();
-      expect(wrapper.getElement()).toHaveAttribute('disabled');
+      expect(wrapper.getElement()).not.toHaveAttribute('disabled');
+      expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
       act(() => wrapper.click());
       expect(onClickSpy).not.toHaveBeenCalled();
     });
@@ -303,6 +304,7 @@ describe('Button Component', () => {
       const wrapper = renderButton({ loading: true, disabled: true });
       expect(wrapper.findLoadingIndicator()).not.toBeNull();
       expect(wrapper.getElement()).toHaveAttribute('disabled');
+      expect(wrapper.getElement()).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('adds a tab index -1 to the link button', () => {

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -12,7 +12,7 @@ export interface ButtonProps extends BaseComponentProps {
   disabled?: boolean;
   /**
    * Renders the button as being in a loading state. It takes precedence over the `disabled` if both are set to `true`.
-   * It prevents users from clicking the button.
+   * It prevents users from clicking the button, but it can still be focused.
    */
   loading?: boolean;
   /**

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -56,7 +56,7 @@ export const InternalButton = React.forwardRef(
     checkSafeUrl('Button', href);
     const focusVisible = useFocusVisible();
     const isAnchor = Boolean(href);
-    const isDisabled = loading || disabled;
+    const isNotInteractive = loading || disabled;
     const shouldHaveContent =
       children && ['icon', 'inline-icon', 'flashbar-icon', 'modal-dismiss'].indexOf(variant) === -1;
 
@@ -65,7 +65,7 @@ export const InternalButton = React.forwardRef(
 
     const handleClick = useCallback(
       (event: React.MouseEvent) => {
-        if (isDisabled) {
+        if (isNotInteractive) {
           return event.preventDefault();
         }
 
@@ -76,11 +76,11 @@ export const InternalButton = React.forwardRef(
         const { altKey, button, ctrlKey, metaKey, shiftKey } = event;
         fireCancelableEvent(onClick, { altKey, button, ctrlKey, metaKey, shiftKey }, event);
       },
-      [isAnchor, isDisabled, onClick, onFollow]
+      [isAnchor, isNotInteractive, onClick, onFollow]
     );
 
     const buttonClass = clsx(props.className, styles.button, styles[`variant-${variant}`], {
-      [styles.disabled]: isDisabled,
+      [styles.disabled]: isNotInteractive,
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
       [styles['is-activated']]: __activated,
@@ -127,8 +127,8 @@ export const InternalButton = React.forwardRef(
             target={target}
             // security recommendation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target
             rel={rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined)}
-            tabIndex={isDisabled ? -1 : undefined}
-            aria-disabled={isDisabled ? true : undefined}
+            tabIndex={isNotInteractive ? -1 : undefined}
+            aria-disabled={isNotInteractive ? true : undefined}
             download={download}
           >
             {buttonContent}

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -143,7 +143,7 @@ export const InternalButton = React.forwardRef(
           {...buttonProps}
           type={formAction === 'none' ? 'button' : 'submit'}
           disabled={disabled}
-          aria-disabled={isDisabled ? true : undefined}
+          aria-disabled={loading && !disabled ? true : undefined}
         >
           {buttonContent}
         </button>

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -65,7 +65,7 @@ export const InternalButton = React.forwardRef(
 
     const handleClick = useCallback(
       (event: React.MouseEvent) => {
-        if (isAnchor && isDisabled) {
+        if (isDisabled) {
           return event.preventDefault();
         }
 
@@ -139,7 +139,12 @@ export const InternalButton = React.forwardRef(
     }
     return (
       <>
-        <button {...buttonProps} type={formAction === 'none' ? 'button' : 'submit'} disabled={isDisabled}>
+        <button
+          {...buttonProps}
+          type={formAction === 'none' ? 'button' : 'submit'}
+          disabled={disabled}
+          aria-disabled={isDisabled ? true : undefined}
+        >
           {buttonContent}
         </button>
         {loading && loadingText && <LiveRegion>{loadingText}</LiveRegion>}

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -503,7 +503,7 @@ test('disables all navigation while a step is loading', () => {
   expect(wrapper.findPreviousButton()!.getElement()).toBeDisabled();
   expect(wrapper.findSkipToButton()!.getElement()).toBeDisabled();
   expect(wrapper.findCancelButton()!.getElement()).toBeEnabled();
-  expect(wrapper.findPrimaryButton()!.getElement()).toBeDisabled();
+  expect(wrapper.findPrimaryButton()!.getElement()).toHaveAttribute('aria-disabled', 'true');
 
   expect(wrapper.findMenuNavigationLink(1, 'disabled')).not.toBeNull();
   expect(wrapper.findMenuNavigationLink(2, 'active')).not.toBeNull();

--- a/src/wizard/wizard-actions.tsx
+++ b/src/wizard/wizard-actions.tsx
@@ -86,7 +86,6 @@ export default function WizardActions({
           formAction="none"
           onClick={onPrimaryClick}
           loading={isPrimaryLoading}
-          loadingText="Loading next step"
         >
           {primaryButtonText}
         </InternalButton>

--- a/src/wizard/wizard-actions.tsx
+++ b/src/wizard/wizard-actions.tsx
@@ -86,6 +86,7 @@ export default function WizardActions({
           formAction="none"
           onClick={onPrimaryClick}
           loading={isPrimaryLoading}
+          loadingText="Loading next step"
         >
           {primaryButtonText}
         </InternalButton>


### PR DESCRIPTION
### Description

This change makes buttons with `loading={true}` focusable by only setting the `aria-disabled` attribute but not `disabled`.

Buttons are usually not in a loading state from the beginning. Users activate a button, which starts some kind of background process and turns on the loading state to visually indicate this. However, a `<button>` element with the attribute `disabled` cannot be focused. So if a keyboard user activates a button which then turns into a loading state, the keyboard focus is lost and goes to the document body.

This can be a frustrating experience for pattern like Wizard flows where the next step is loaded asynchronously, or during table inline editing.

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually with keyboard and VoiceOver. Also did a successful dry-run.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
