### PR TITLE
feat: Allow headings in expandable-section

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -55,7 +55,10 @@ const permutations = createPermutations<ExpandableSectionProps>([
   {
     expanded: [true],
     variant: ['container'],
-    headerText: ['Container example header'],
+    headerText: [
+      'Container example header',
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
     children: [
       'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     ],
@@ -112,6 +115,13 @@ const permutations = createPermutations<ExpandableSectionProps>([
     variant: ['default', 'footer', 'navigation'],
     headerText: ['Header with ARIA label'],
     children: ['Sample content'],
+  },
+  {
+    expanded: [false],
+    variant: ['default', 'footer', 'navigation'],
+    headerText: ['Custom heading tag override'],
+    children: ['Sample content'],
+    headingTagOverride: [undefined, 'h2', 'h3'],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5535,8 +5535,9 @@ Behaves similar to the Header component counter.",
       "type": "string",
     },
     Object {
-      "description": "Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
-h2. Use with container variant.",
+      "description": "Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
+Use with container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
+works with the \`headerText\` slot (not with the deprecated \`header\`), and not with the navigation variant.",
       "inlineType": Object {
         "name": "ExpandableSectionProps.HeadingTag",
         "type": "union",

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -131,6 +131,43 @@ describe('Expandable Section', () => {
     });
   });
 });
+describe('headingTagOverride', () => {
+  test('container variant tag defaults to h2', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'container',
+      headerText: 'Header component',
+    });
+    expect(wrapper.findHeader().findAll('h2').length).toBe(1);
+  });
+  test('container variant tag can be overwritten', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'container',
+      headerText: 'Header component',
+      headingTagOverride: 'h3',
+    });
+    expect(wrapper.findHeader().findAll('h2').length).toBe(0);
+    expect(wrapper.findHeader().findAll('h3').length).toBe(1);
+  });
+  for (const variant of ['default', 'footer']) {
+    describe.each<ExpandableSectionProps.Variant>(['default', 'footer'])(`variant: ${variant}`, variant => {
+      test('tag defaults to div', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+        });
+        expect(wrapper.findHeader().findAll('h1,h2,h3,h4,h5,h6').length).toBe(0);
+      });
+      test('default variant tag can be overwritten', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+          headingTagOverride: 'h3',
+        });
+        expect(wrapper.findHeader().findAll('h3').length).toBe(1);
+      });
+    });
+  }
+});
 describe('Variant container with headerText', () => {
   test('validate a11y for container with headerText', async () => {
     const { container } = render(
@@ -200,6 +237,6 @@ describe('Variant container with headerText', () => {
       headerText: 'Header component',
     });
     expect(wrapper.findHeader().find('[role="button"]')!.findAll('h2')!.length).toBe(0);
-    expect(wrapper!.find('h2')!.find('[role="button"]')!.getElement()).toHaveTextContent('Header component');
+    expect(wrapper.find('h2')!.find('[role="button"]')!.getElement()).toHaveTextContent('Header component');
   });
 });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -23,6 +23,7 @@ interface ExpandableDefaultHeaderProps {
   onKeyDown: KeyboardEventHandler;
   onClick: MouseEventHandler;
   icon: JSX.Element;
+  variant: ExpandableSectionProps.Variant;
 }
 
 interface ExpandableNavigationHeaderProps extends Omit<ExpandableDefaultHeaderProps, 'onKeyUp' | 'onKeyDown'> {
@@ -56,6 +57,7 @@ const ExpandableDefaultHeader = ({
   icon,
   onKeyUp,
   onKeyDown,
+  variant,
 }: ExpandableDefaultHeaderProps) => {
   const focusVisible = useFocusVisible();
   return (
@@ -72,7 +74,7 @@ const ExpandableDefaultHeader = ({
       aria-expanded={expanded}
       {...focusVisible}
     >
-      <div className={styles['icon-container']}>{icon}</div>
+      <div className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</div>
       {children}
     </div>
   );
@@ -118,20 +120,32 @@ const ExpandableContainerHeader = ({
   icon,
   headerDescription,
   headerCounter,
+  variant,
   headingTagOverride,
   onKeyUp,
   onKeyDown,
 }: ExpandableContainerHeaderProps) => {
   const focusVisible = useFocusVisible();
   const screenreaderContentId = generateUniqueId('expandable-section-header-content-');
+  const Wrapper =
+    variant === 'container'
+      ? ({ children }: { children: ReactNode }) => (
+          <InternalHeader
+            variant="h2"
+            description={headerDescription}
+            counter={headerCounter}
+            headingTagOverride={headingTagOverride}
+          >
+            {children}
+          </InternalHeader>
+        )
+      : ({ children }: { children: ReactNode }) => {
+          const Tag = headingTagOverride || 'div';
+          return <Tag className={styles['header-wrapper']}>{children}</Tag>;
+        };
   return (
     <div id={id} className={className} onClick={onClick} {...focusVisible}>
-      <InternalHeader
-        variant={'h2'}
-        description={headerDescription}
-        counter={headerCounter}
-        headingTagOverride={headingTagOverride}
-      >
+      <Wrapper>
         <span
           className={styles['header-container-button']}
           role="button"
@@ -144,10 +158,10 @@ const ExpandableContainerHeader = ({
           aria-controls={ariaControls}
           aria-expanded={expanded}
         >
-          <span className={styles['icon-container']}>{icon}</span>
+          <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
           <span>{children}</span>
         </span>
-      </InternalHeader>
+      </Wrapper>
       <ScreenreaderOnly id={screenreaderContentId}>
         {children} {headerCounter} {headerDescription}
       </ScreenreaderOnly>
@@ -186,6 +200,7 @@ export const ExpandableSectionHeader = ({
     ariaControls: ariaControls,
     ariaLabel: ariaLabel,
     onClick: onClick,
+    variant,
   };
 
   const triggerClassName = clsx(styles.trigger, styles[`trigger-${variant}`], expanded && styles['trigger-expanded']);
@@ -201,7 +216,7 @@ export const ExpandableSectionHeader = ({
     );
   }
 
-  if (variant === 'container' && headerText) {
+  if (headerText) {
     return (
       <ExpandableContainerHeader
         className={clsx(className, triggerClassName, expanded && styles.expanded)}

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -67,8 +67,9 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   headerCounter?: string;
 
   /**
-   * Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
-   * h2. Use with container variant.
+   * Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
+   * Use with container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
+   * works with the `headerText` slot (not with the deprecated `header`), and not with the navigation variant.
    */
   headingTagOverride?: ExpandableSectionProps.HeadingTag;
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -29,6 +29,9 @@
   margin-left: calc((#{awsui.$font-body-m-line-height} - #{awsui.$size-icon-normal}) / -2);
   // For vertical alignment of text in side navigation items
   margin-right: calc(#{awsui.$space-xxs} + #{awsui.$border-divider-list-width});
+  &-container {
+    margin-right: awsui.$space-xs;
+  }
 }
 
 .trigger {
@@ -66,7 +69,6 @@
     @include styles.font-smoothing;
     font-size: awsui.$font-expandable-heading-size;
     letter-spacing: awsui.$font-heading-s-letter-spacing;
-
     &:hover {
       color: awsui.$color-text-expandable-section-hover;
     }
@@ -89,12 +91,19 @@
 .header {
   display: flex;
 
+  &-wrapper {
+    font-weight: inherit;
+    font-size: inherit;
+    letter-spacing: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
   &-container {
     width: 100%;
     // The icon-container style is kept for variant='container' and header
     > .icon-container {
       margin-top: awsui.$space-expandable-section-icon-offset-top;
-      margin-right: awsui.$space-xs;
     }
 
     &[data-awsui-focus-visible='true']:focus-within {
@@ -105,13 +114,11 @@
       @include styles.form-focus-element(awsui.$border-radius-control-default-focus-ring);
     }
     &-button {
+      box-sizing: border-box;
+      display: flex;
       &:focus {
         outline: none;
         text-decoration: none;
-      }
-      > .icon-container {
-        margin-top: awsui.$space-expandable-section-icon-offset-top;
-        margin-right: awsui.$space-xs;
       }
     }
   }

--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -269,7 +269,7 @@ describe('URL sanitization', () => {
       const wrapper = createWrapper(container).findTutorialPanel()!;
       const taskList = wrapper.findTaskList();
 
-      expect(taskList[0].findStepsTitle().getElement().getAttribute('aria-label')).toBe(
+      expect(taskList[0].findStepsTitle().find('[aria-label]')!.getElement().getAttribute('aria-label')).toBe(
         'TASK_1_FIRST_TASK_TEST TOTAL_STEPS_1'
       );
     });


### PR DESCRIPTION
### Description

Allow standard expandable sections to have a heading tag (rather than plain div) for accessibility/semantic purposes.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
