### PR TITLE
chore: Revert update table column header appearance

### DIFF
--- a/pages/focus-lock.page.tsx
+++ b/pages/focus-lock.page.tsx
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef, useState } from 'react';
+import FocusLock, { FocusLockRef } from '~components/internal/components/focus-lock';
+import FormField from '~components/form-field';
+import Input from '~components/input';
+import Button from '~components/button';
+import Box from '~components/box';
+import SpaceBetween from '~components/space-between';
+
+export default function FocusLockPage() {
+  const ref = useRef<FocusLockRef>(null);
+  const [text, setText] = useState('');
+
+  return (
+    <Box padding="l">
+      <h1>FocusLock component</h1>
+      <FocusLock ref={ref} autoFocus={true}>
+        <SpaceBetween size="m">
+          <FormField label="First input">
+            <Input value={text} onChange={event => setText(event.detail.value)} />
+          </FormField>
+          <Button onClick={() => ref.current?.focusFirst()}>Focus first</Button>
+        </SpaceBetween>
+      </FocusLock>
+    </Box>
+  );
+}

--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -207,7 +207,7 @@ const Demo = forwardRef(
       let value = newValue;
       await new Promise(r => setTimeout(r, 1000));
       errorsMeta.delete(currentItem);
-      if (value === 'inline') {
+      if (typeof value === 'string' && value.includes('inline')) {
         errorsMeta.set(currentItem, 'Server does not accept this value, try another');
         throw new Error('Inline error');
       }

--- a/src/internal/components/focus-lock/__integ__/focus-lock.test.ts
+++ b/src/internal/components/focus-lock/__integ__/focus-lock.test.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper, { ElementWrapper } from '../../../../../lib/components/test-utils/selectors';
+
+function setupTest(testFn: (page: BasePageObject, wrapper: ElementWrapper) => Promise<void>) {
+  return useBrowser(async browser => {
+    await browser.url('#/light/focus-lock');
+    const page = new BasePageObject(browser);
+    const wrapper = createWrapper();
+    await page.waitForVisible(wrapper.findButton().toSelector());
+    await testFn(page, wrapper);
+  });
+}
+
+describe('FocusLock', () => {
+  test(
+    'focuses first element with autofocus',
+    setupTest(async (page, wrapper) => {
+      await expect(page.isFocused(wrapper.findInput().findNativeInput().toSelector())).resolves.toBe(true);
+    })
+  );
+
+  test(
+    'returns focus to first element with focusFirst function',
+    setupTest(async (page, wrapper) => {
+      // Make sure autofocus focused the first input
+      await expect(page.isFocused(wrapper.findInput().findNativeInput().toSelector())).resolves.toBe(true);
+
+      // Tab to the button
+      await page.keys('Tab');
+
+      // Activate the button
+      await page.keys('Enter');
+
+      // Focus moved back to the first element (the input)
+      await expect(page.isFocused(wrapper.findInput().findNativeInput().toSelector())).resolves.toBe(true);
+    })
+  );
+});

--- a/src/internal/components/focus-lock/index.tsx
+++ b/src/internal/components/focus-lock/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import TabTrap from '../tab-trap/index';
@@ -14,7 +14,23 @@ export interface FocusLockProps {
   children: React.ReactNode;
 }
 
-export default function FocusLock({ className, disabled, autoFocus, restoreFocus, children }: FocusLockProps) {
+export interface FocusLockRef {
+  /**
+   * Focuses the first element in the component.
+   */
+  focusFirst(): void;
+}
+
+function FocusLock(
+  { className, disabled, autoFocus, restoreFocus, children }: FocusLockProps,
+  ref: React.Ref<FocusLockRef>
+) {
+  useImperativeHandle(ref, () => {
+    return {
+      focusFirst,
+    };
+  });
+
   const returnFocusToRef = useRef<HTMLOrSVGElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -71,3 +87,5 @@ export default function FocusLock({ className, disabled, autoFocus, restoreFocus
     </>
   );
 }
+
+export default React.forwardRef(FocusLock);

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -77,3 +77,17 @@ test(
     await expect(page.isFocused(cellBelow$)).resolves.toBe(true);
   })
 );
+
+test(
+  'input is focused when the edit operation failed',
+  setupTest(async page => {
+    await page.click(cellRoot$);
+
+    // "inline" is a special keyword that causes a server-side error
+    await page.setValue(cellInputField$, 'inline');
+    await page.keys('Enter');
+
+    // after loading, the focus should be back on the input
+    await page.waitForAssertion(() => expect(page.isFocused(cellInputField$)).resolves.toBe(true));
+  })
+);

--- a/src/table/__integ__/table.test.ts
+++ b/src/table/__integ__/table.test.ts
@@ -38,10 +38,10 @@ test(
     const header = createWrapper().findContainer().findHeader().toSelector();
     await browser.url('#/light/table/full-page-variant?visualRefresh=true');
     const page = new BasePageObject(browser);
-    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '113px', marginBottom: '0px' });
+    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '115px', marginBottom: '0px' });
     await page.windowScrollTo({ top: 100 });
     await page.waitForJsTimers();
-    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '103px', marginBottom: '10px' });
+    await expect(browser.execute(extractHeight, header)).resolves.toEqual({ height: '105px', marginBottom: '10px' });
   })
 );
 

--- a/src/table/__tests__/inline-editor.test.tsx
+++ b/src/table/__tests__/inline-editor.test.tsx
@@ -17,9 +17,9 @@ const handleEditEnd = jest.fn();
 let thereBeErrors = false;
 
 function renderComponent(jsx: React.ReactElement) {
-  const { container, rerender, getByTestId, queryByTestId } = render(jsx);
+  const { container, rerender, getByTestId, queryByTestId, getByRole } = render(jsx);
   const wrapper = createWrapper(container).find('[data-testid="inline-editor"]')!;
-  return { wrapper, rerender, getByTestId, queryByTestId };
+  return { wrapper, rerender, getByTestId, queryByTestId, getByRole };
 }
 
 const TestComponent = () => {
@@ -42,6 +42,7 @@ const TestComponent = () => {
     <div data-testid="inline-editor">
       <InlineEditor
         ariaLabels={{
+          activateEditLabel: () => 'edit cell',
           submitEditLabel: () => 'save edit',
           cancelEditLabel: () => 'cancel edit',
         }}
@@ -68,6 +69,11 @@ describe('InlineEditor', () => {
   it('should render', () => {
     const { getByTestId } = renderComponent(<TestComponent />);
     expect(getByTestId('inline-editor')).toBeInTheDocument();
+  });
+
+  it('should render as a dialog', () => {
+    const { getByRole } = renderComponent(<TestComponent />);
+    expect(getByRole('dialog')).toHaveAttribute('aria-label', 'edit cell');
   });
 
   it('should show error', () => {

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Button from '../../button/internal';
 import FormField from '../../form-field/internal';
 import SpaceBetween from '../../space-between/internal';
@@ -8,6 +8,7 @@ import { useClickAway } from './click-away';
 import { TableProps } from '../interfaces';
 import styles from './styles.css.js';
 import { Optional } from '../../internal/types';
+import FocusLock, { FocusLockRef } from '../../internal/components/focus-lock';
 
 // A function that does nothing
 const noop = () => undefined;
@@ -31,6 +32,8 @@ export function InlineEditor<ItemType>({
 }: InlineEditorProps<ItemType>) {
   const [currentEditLoading, setCurrentEditLoading] = useState(false);
   const [currentEditValue, setCurrentEditValue] = useState<Optional<any>>();
+
+  const focusLockRef = useRef<FocusLockRef>(null);
 
   const cellContext = {
     currentValue: currentEditValue,
@@ -58,6 +61,7 @@ export function InlineEditor<ItemType>({
       finishEdit();
     } catch (e) {
       setCurrentEditLoading(false);
+      focusLockRef.current?.focusFirst();
     }
   }
 
@@ -93,45 +97,49 @@ export function InlineEditor<ItemType>({
   } = column.editConfig!;
 
   return (
-    <form
-      ref={clickAwayRef}
-      onSubmit={onSubmitClick}
-      onKeyDown={handleEscape}
-      className={styles['body-cell-editor-form']}
-    >
-      <FormField
-        stretch={true}
-        label={ariaLabel}
-        constraintText={constraintText}
-        __hideLabel={true}
-        __disableGutters={true}
-        i18nStrings={{ errorIconAriaLabel }}
-        errorText={validation(item, currentEditValue)}
+    <FocusLock restoreFocus={true} ref={focusLockRef}>
+      <div
+        role="dialog"
+        ref={clickAwayRef}
+        aria-label={ariaLabels?.activateEditLabel?.(column)}
+        onKeyDown={handleEscape}
       >
-        <div className={styles['body-cell-editor-row']}>
-          {editingCell(item, cellContext)}
-          <span className={styles['body-cell-editor-controls']}>
-            <SpaceBetween direction="horizontal" size="xxs">
-              {!currentEditLoading ? (
-                <Button
-                  ariaLabel={ariaLabels?.cancelEditLabel?.(column)}
-                  formAction="none"
-                  iconName="close"
-                  variant="inline-icon"
-                  onClick={onCancel}
-                />
-              ) : null}
-              <Button
-                ariaLabel={ariaLabels?.submitEditLabel?.(column)}
-                formAction="submit"
-                iconName="check"
-                variant="inline-icon"
-                loading={currentEditLoading}
-              />
-            </SpaceBetween>
-          </span>
-        </div>
-      </FormField>
-    </form>
+        <form onSubmit={onSubmitClick} className={styles['body-cell-editor-form']}>
+          <FormField
+            stretch={true}
+            label={ariaLabel}
+            constraintText={constraintText}
+            __hideLabel={true}
+            __disableGutters={true}
+            i18nStrings={{ errorIconAriaLabel }}
+            errorText={validation(item, currentEditValue)}
+          >
+            <div className={styles['body-cell-editor-row']}>
+              {editingCell(item, cellContext)}
+              <span className={styles['body-cell-editor-controls']}>
+                <SpaceBetween direction="horizontal" size="xxs">
+                  {!currentEditLoading ? (
+                    <Button
+                      ariaLabel={ariaLabels?.cancelEditLabel?.(column)}
+                      formAction="none"
+                      iconName="close"
+                      variant="inline-icon"
+                      onClick={onCancel}
+                    />
+                  ) : null}
+                  <Button
+                    ariaLabel={ariaLabels?.submitEditLabel?.(column)}
+                    formAction="submit"
+                    iconName="check"
+                    variant="inline-icon"
+                    loading={currentEditLoading}
+                  />
+                </SpaceBetween>
+              </span>
+            </div>
+          </FormField>
+        </form>
+      </div>
+    </FocusLock>
   );
 }

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -32,13 +32,11 @@
   }
 
   &:not(:last-child):before {
-    $gap: calc(#{awsui.$space-xs} + #{awsui.$space-xxxs});
-
     content: '';
     position: absolute;
     right: 0;
-    bottom: $gap;
-    top: $gap;
+    bottom: 25%;
+    height: 50%;
     border-left: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
     box-sizing: border-box;
   }
@@ -50,8 +48,7 @@
 
 .sorting-icon {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: awsui.$space-scaled-xxs;
   right: awsui.$space-xxs;
   color: awsui.$color-text-column-sorting-icon;
 }
@@ -103,11 +100,6 @@
 }
 
 .header-cell-text {
-  line-height: awsui.$font-heading-xs-line-height;
-
-  padding-top: calc(#{awsui.$space-xxxs} / 2);
-  padding-bottom: calc(#{awsui.$space-xxxs} / 2);
-
   &:not(.header-cell-text-wrap) {
     white-space: nowrap;
     overflow: hidden;

--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -35,13 +35,11 @@ $active-separator-width: 2px;
     &:hover,
     &-active {
       &::before {
-        $gap: calc(#{awsui.$space-xs} + #{awsui.$space-xxxs});
-
         content: '';
         position: absolute;
         left: calc(#{$handle-width} / 2 - #{$active-separator-width});
-        bottom: $gap;
-        top: $gap;
+        bottom: 25%;
+        height: 50%;
         box-sizing: border-box;
         border-left: $active-separator-width solid awsui.$color-border-divider-active;
       }


### PR DESCRIPTION
This reverts commit 1c3d3084e5a3256671ff7c9a26d777d4e89cafd7.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
