### PR TITLE
fix: Fix classic app layout calling onNavigationToggle and onToolsToggle twice on desktop

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -52,7 +52,7 @@ describeEachAppLayout(() => {
     },
   ].forEach(({ openProp, hideProp, handler, findElement, findLandmarks, findToggle, findClose }) => {
     describe(`${openProp} prop`, () => {
-      test(`Should call handler once on open`, () => {
+      test(`Should call handler once on open when toggle is clicked`, () => {
         const onToggle = jest.fn();
         const props = {
           [openProp]: false,
@@ -61,6 +61,20 @@ describeEachAppLayout(() => {
         const { wrapper } = renderComponent(<AppLayout {...props} />);
 
         findToggle(wrapper).click();
+        expect(onToggle).toHaveBeenCalledTimes(1);
+        expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
+      });
+
+      test(`Should call handler once on open when span inside toggle is clicked`, () => {
+        const onToggle = jest.fn();
+        const props = {
+          [openProp]: false,
+          [handler]: onToggle,
+        };
+        const { wrapper } = renderComponent(<AppLayout {...props} />);
+
+        // Chrome bubbles up events from specific elements inside <button>s.
+        findToggle(wrapper).find('span')!.click();
         expect(onToggle).toHaveBeenCalledTimes(1);
         expect(onToggle).toHaveBeenCalledWith(expect.objectContaining({ detail: { open: true } }));
       });

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React from 'react';
+import React, { useRef } from 'react';
 import { AppLayoutButton, CloseButton, togglesConfig } from '../toggles';
 import { AppLayoutProps } from '../interfaces';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -64,9 +64,10 @@ export function Drawer({
   const { mainLabel, closeLabel, openLabel } = getLabels(ariaLabels);
   const drawerContentWidthOpen = isMobile ? undefined : width;
   const drawerContentWidth = isOpen ? drawerContentWidthOpen : undefined;
+  const openButtonWrapperRef = useRef<HTMLElement | null>(null);
 
   const regularOpenButton = (
-    <TagName aria-label={mainLabel} className={styles.toggle} aria-hidden={isOpen}>
+    <TagName ref={openButtonWrapperRef} aria-label={mainLabel} className={styles.toggle} aria-hidden={isOpen}>
       <AppLayoutButton
         ref={toggleRefs.toggle}
         className={toggleClassName}
@@ -102,7 +103,10 @@ export function Drawer({
 
         if (!isOpen) {
           // to prevent calling onToggle from the drawer when it's called from the toggle button
-          if ((event.target as Element).tagName !== 'BUTTON') {
+          if (
+            openButtonWrapperRef.current === event.target ||
+            !openButtonWrapperRef.current?.contains(event.target as Node)
+          ) {
             onToggle(true);
           }
         }


### PR DESCRIPTION
### Description

It turns out I did fix this issue earlier, but it was only raised for mobile toggles. I don't _love_ this fix (or the original code), but I guess it was what we had to do when we put clickable elements inside clickable elements.

Related links, issue #, if available: AWSUI-20745

### How has this been tested?

Added a new unit test for this case.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
