### PR TITLE
feat: Use native useId hook if available

### DIFF
--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -11,7 +11,7 @@ import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/e
 import InternalGrid from '../grid/internal';
 import { InternalButton } from '../button/internal';
 import clsx from 'clsx';
-import { generateUniqueId } from '../internal/hooks/use-unique-id';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 const Divider = () => <InternalBox className={styles.divider} padding={{ top: 'l' }} />;
 
@@ -56,7 +56,7 @@ export const Row = React.memo(
       fireNonCancelableEvent(onRemoveButtonClick, { itemIndex: index });
     }, [onRemoveButtonClick, index]);
 
-    const firstControlId = generateUniqueId('first-control-id-');
+    const firstControlId = useUniqueId('first-control-id-');
 
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -10,13 +10,6 @@ import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
 
-let uniqueId = 1;
-
-jest.mock('../../../lib/components/internal/hooks/use-unique-id', () => ({
-  useUniqueId: () => 'random-' + uniqueId++,
-  generateUniqueId: () => 'random-' + uniqueId++,
-}));
-
 const defaultOptions: AutosuggestProps.Options = [
   { value: '1', label: 'One' },
   { value: '2', lang: 'fr' },
@@ -239,8 +232,8 @@ describe('a11y props', () => {
     const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} options={[]} />);
     const input = wrapper.findNativeInput().getElement();
     wrapper.findNativeInput().focus();
-    expect(input).toHaveAttribute('aria-controls', expect.stringContaining('random-'));
-    expect(input).toHaveAttribute('aria-owns', expect.stringContaining('random-'));
+    expect(input).toHaveAttribute('aria-controls', expect.any(String));
+    expect(input).toHaveAttribute('aria-owns', expect.any(String));
   });
 
   test('adds correct aria properties to input when expanded', () => {
@@ -261,7 +254,7 @@ describe('a11y props', () => {
     wrapper.findNativeInput().keydown(KeyCode.down);
     const input = wrapper.findNativeInput().getElement();
     const highlightedOption = wrapper.findDropdown().findHighlightedOption()!.getElement();
-    expect(highlightedOption).toHaveAttribute('id', expect.stringContaining('random-'));
+    expect(highlightedOption).toHaveAttribute('id', expect.any(String));
     expect(input).toHaveAttribute('aria-activedescendant', highlightedOption.getAttribute('id'));
   });
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -10,7 +10,7 @@ import { AutosuggestItem, AutosuggestProps } from './interfaces';
 import { useDropdownStatus } from '../internal/components/dropdown-status';
 import DropdownFooter from '../internal/components/dropdown-footer';
 
-import { generateUniqueId, useUniqueId } from '../internal/hooks/use-unique-id';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import {
   BaseKeyDetail,
   fireCancelableEvent,
@@ -156,7 +156,8 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const selfControlId = useUniqueId('input');
   const controlId = formFieldContext.controlId ?? selfControlId;
   const listId = useUniqueId('list');
-  const highlightedOptionId = autosuggestItemsState.highlightedOption ? generateUniqueId() : undefined;
+  const highlightedOptionIdSource = useUniqueId();
+  const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
   const isEmpty = !value && !autosuggestItemsState.items.length;
   const dropdownStatus = useDropdownStatus({

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx';
 import styles from './styles.css.js';
 import InternalHeader from '../header/internal';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
-import { generateUniqueId } from '../internal/hooks/use-unique-id';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '../internal/logging';
 
@@ -126,7 +126,7 @@ const ExpandableContainerHeader = ({
   onKeyDown,
 }: ExpandableContainerHeaderProps) => {
   const focusVisible = useFocusVisible();
-  const screenreaderContentId = generateUniqueId('expandable-section-header-content-');
+  const screenreaderContentId = useUniqueId('expandable-section-header-content-');
   const Wrapper =
     variant === 'container'
       ? ({ children }: { children: ReactNode }) => (

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -1,16 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 
 let counter = 0;
-export function generateUniqueId(prefix?: string) {
-  return `${prefix ? prefix : ''}${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
-}
-
-export function useUniqueId(prefix?: string) {
+const useIdFallback = () => {
   const idRef = useRef<string | null>(null);
   if (!idRef.current) {
-    idRef.current = generateUniqueId(prefix);
+    idRef.current = `${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
   }
   return idRef.current;
+};
+
+const useId: typeof useIdFallback = (React as any).useId ?? useIdFallback;
+
+export function useUniqueId(prefix?: string) {
+  return `${prefix ? prefix : ''}` + useId();
 }

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -9,7 +9,7 @@ import { AutosuggestItem, AutosuggestProps } from '../autosuggest/interfaces';
 import { useDropdownStatus } from '../internal/components/dropdown-status';
 import DropdownFooter from '../internal/components/dropdown-footer';
 
-import { generateUniqueId, useUniqueId } from '../internal/hooks/use-unique-id';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import {
   fireNonCancelableEvent,
   CancelableEventHandler,
@@ -145,7 +145,8 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const selfControlId = useUniqueId('input');
     const controlId = rest.controlId ?? selfControlId;
     const listId = useUniqueId('list');
-    const highlightedOptionId = autosuggestItemsState.highlightedOption ? generateUniqueId() : undefined;
+    const highlightedOptionIdSource = useUniqueId();
+    const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
     const isEmpty = !value && !autosuggestItemsState.items.length;
     const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 import clsx from 'clsx';
 import ButtonTrigger from '../../internal/components/button-trigger';
@@ -9,7 +9,7 @@ import styles from './styles.css.js';
 import { OptionDefinition } from '../../internal/components/option/interfaces';
 import { FormFieldValidationControlProps } from '../../internal/context/form-field-context';
 import Option from '../../internal/components/option';
-import { generateUniqueId } from '../../internal/hooks/use-unique-id';
+import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { SelectTriggerProps } from '../utils/use-select';
 import { joinStrings } from '../../internal/utils/strings';
 
@@ -40,8 +40,9 @@ const Trigger = React.forwardRef(
     }: TriggerProps,
     ref: React.Ref<HTMLButtonElement>
   ) => {
-    const id = useMemo(() => controlId ?? generateUniqueId(), [controlId]);
-    const triggerContentId = generateUniqueId('trigger-content-');
+    const generatedId = useUniqueId();
+    const id = controlId ?? generatedId;
+    const triggerContentId = useUniqueId('trigger-content-');
 
     let triggerContent = null;
     if (!selectedOption) {


### PR DESCRIPTION
### Description

Revived version of #233

Native hook produces deterministic ids in server-side rendering, which is useful feature and not possible to adopt without changes in our components

Related links, issue #, if available: n/a

### How has this been tested?

* Our demos package uses React 18, so it will cover that condition
* Also deployed to my dev pipeline to have a closer look at all demos

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
