### PR TITLE
fix: Use `header` slot of ExpandableSection for tutorial steps

### DIFF
--- a/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
+++ b/src/tutorial-panel/__tests__/tutorial-panel.test.tsx
@@ -278,7 +278,7 @@ describe('URL sanitization', () => {
       const wrapper = createWrapper(container).findTutorialPanel()!;
       const taskList = wrapper.findTaskList();
 
-      expect(taskList[0].findStepsTitle().find('[aria-label]')!.getElement().getAttribute('aria-label')).toBe(
+      expect(taskList[0].findStepsTitle().getElement().getAttribute('aria-label')).toBe(
         'TASK_1_FIRST_TASK_TEST TOTAL_STEPS_1'
       );
     });

--- a/src/tutorial-panel/components/tutorial-detail-view/task.tsx
+++ b/src/tutorial-panel/components/tutorial-detail-view/task.tsx
@@ -58,7 +58,7 @@ export function Task({ task, taskIndex, currentTaskIndex, expanded, onToggleExpa
 
         <div className={styles['expandable-section-wrapper']}>
           <InternalExpandableSection
-            headerText={
+            header={
               <span className={styles['expandable-section-header']}>
                 {i18nStrings.labelTotalSteps(task.steps.length)}
               </span>


### PR DESCRIPTION
### Description

The `headerText` slot is designed only for plain text, so applying styling within it causes unexpected side-effects, but that styling is necessary for 

Related links, issue #, if available: n/a

### How has this been tested?

Tested locally, will follow-up with improved screenshot test coverage

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
