### PR TITLE
chore: Allow onboarding page to be used in screenshot tests

### DIFF
--- a/pages/onboarding/with-app-layout.page.tsx
+++ b/pages/onboarding/with-app-layout.page.tsx
@@ -6,6 +6,7 @@ import { Button, Header, NonCancelableCustomEvent, SpaceBetween, Tabs } from '~c
 import AnnotationContext from '~components/annotation-context';
 import AppLayout, { AppLayoutProps } from '~components/app-layout';
 import TutorialPanel, { TutorialPanelProps } from '~components/tutorial-panel';
+import ScreenshotArea from '../utils/screenshot-area';
 import tutorialData from './tutorials';
 
 import { PageOne } from './pages/page1';
@@ -108,40 +109,42 @@ export default function OnboardingDemoPage() {
       onFinish={onFinish}
       i18nStrings={annotationContextStrings}
     >
-      <AppLayout
-        ariaLabels={labels}
-        navigationHide={true}
-        toolsOpen={toolsPanelVisible}
-        onToolsChange={onToolsChange}
-        toolsWidth={330}
-        tools={
-          <Tabs
-            activeTabId="tutorials-panel"
-            tabs={[
-              { id: 'help-panel', label: 'Info', content: null },
-              {
-                id: 'tutorials-panel',
-                label: 'Tutorials',
-                content: (
-                  <TutorialPanel
-                    i18nStrings={tutorialPanelStrings}
-                    tutorials={tutorials}
-                    onFeedbackClick={onFeedbackClick}
-                    downloadUrl={window.location.href}
-                  />
-                ),
-              },
-            ]}
-            i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
-          />
-        }
-        content={
-          <SpaceBetween size="l">
-            {currentPage > 0 && <Button onClick={loadPreviousPage}>Back to page {currentPage}</Button>}
-            {routingContent}
-          </SpaceBetween>
-        }
-      />
+      <ScreenshotArea>
+        <AppLayout
+          ariaLabels={labels}
+          navigationHide={true}
+          toolsOpen={toolsPanelVisible}
+          onToolsChange={onToolsChange}
+          toolsWidth={330}
+          tools={
+            <Tabs
+              activeTabId="tutorials-panel"
+              tabs={[
+                { id: 'help-panel', label: 'Info', content: null },
+                {
+                  id: 'tutorials-panel',
+                  label: 'Tutorials',
+                  content: (
+                    <TutorialPanel
+                      i18nStrings={tutorialPanelStrings}
+                      tutorials={tutorials}
+                      onFeedbackClick={onFeedbackClick}
+                      downloadUrl={window.location.href}
+                    />
+                  ),
+                },
+              ]}
+              i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+            />
+          }
+          content={
+            <SpaceBetween size="l">
+              {currentPage > 0 && <Button onClick={loadPreviousPage}>Back to page {currentPage}</Button>}
+              {routingContent}
+            </SpaceBetween>
+          }
+        />
+      </ScreenshotArea>
     </AnnotationContext>
   );
 }


### PR DESCRIPTION
### Description

Allow onboarding page to be used in screenshots, to catch possible regressions sooner in our pipeline.

Related links, issue #, if available: n/a

### How has this been tested?

Will add integration tests once merged.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
