### PR TITLE
feat: Add target and rel attributes to top-nav utilities

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13366,6 +13366,8 @@ The following properties are supported across all utility types:
 
 * \`variant\` ('primary-button' | 'link') - The visual appearance of the button. The default value is 'link'.
 * \`href\` (string) - Specifies the \`href\` for a link styled as a button.
+* \`target\` (string) - Specifies where to open the linked URL (for example, to open in a new browser window or tab use \`_blank\`). This property only applies when an \`href\` is provided.
+* \`rel\` (string) - Adds a \`rel\` attribute to the link. By default, the component sets the \`rel\` attribute to \\"noopener noreferrer\\" when \`target\` is \`\\"_blank\\"\`. If the \`rel\` property is provided, it overrides the default behavior.
 * \`external\` (boolean) - Marks the link as external by adding an icon after the text. When clicked, the link opens in a new tab.
 * \`externalIconAriaLabel\` (string) - Adds an \`aria-label\` for the external icon.
 * \`onClick\` (() => void) - Specifies the event handler called when the utility is clicked.

--- a/src/__tests__/target-rel-test-helper.ts
+++ b/src/__tests__/target-rel-test-helper.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface ButtonProps {
+  href: undefined | string;
+  target: undefined | string;
+  rel: undefined | string;
+}
+
+export interface LinkProps extends ButtonProps {
+  external: boolean;
+}
+
+export const buttonTargetExpectations: [props: ButtonProps, expectedTarget: undefined | string][] = [
+  [{ href: undefined, target: 'custom', rel: undefined }, undefined],
+  [{ href: '#', target: undefined, rel: undefined }, undefined],
+  [{ href: '#', target: 'custom', rel: undefined }, 'custom'],
+];
+
+export const buttonRelExpectations: [props: ButtonProps, expectedTarget: undefined | string][] = [
+  [{ href: undefined, target: '_blank', rel: undefined }, undefined],
+  [{ href: '#', target: 'custom', rel: undefined }, undefined],
+  [{ href: '#', target: '_blank', rel: undefined }, 'noopener noreferrer'],
+  [{ href: '#', target: undefined, rel: 'custom' }, 'custom'],
+  [{ href: '#', target: '_blank', rel: 'custom' }, 'custom'],
+];
+
+export const linkTargetExpectations: [props: LinkProps, expectedTarget: undefined | string][] = [
+  [{ href: undefined, external: false, target: 'custom', rel: undefined }, undefined],
+  [{ href: '#', external: false, target: undefined, rel: undefined }, undefined],
+  [{ href: '#', external: true, target: undefined, rel: undefined }, '_blank'],
+  [{ href: '#', external: false, target: 'custom', rel: undefined }, 'custom'],
+  [{ href: '#', external: true, target: 'custom', rel: undefined }, 'custom'],
+];
+
+export const linkRelExpectations: [props: LinkProps, expectedRel: undefined | string][] = [
+  [{ href: undefined, external: false, target: undefined, rel: 'custom' }, undefined],
+  [{ href: '#', external: false, target: undefined, rel: undefined }, undefined],
+  [{ href: '#', external: true, target: undefined, rel: undefined }, 'noopener noreferrer'],
+  [{ href: '#', external: false, target: 'custom', rel: undefined }, undefined],
+  [{ href: '#', external: false, target: '_blank', rel: undefined }, 'noopener noreferrer'],
+  [{ href: '#', external: true, target: undefined, rel: 'custom' }, 'custom'],
+  [{ href: '#', external: false, target: '_blank', rel: 'custom' }, 'custom'],
+];

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -5,6 +5,7 @@ import { act, render } from '@testing-library/react';
 import Button, { ButtonProps } from '../../../lib/components/button';
 import createWrapper, { ButtonWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/button/styles.css.js';
+import { buttonRelExpectations, buttonTargetExpectations } from '../../__tests__/target-rel-test-helper';
 
 function renderWrappedButton(props: ButtonProps = {}) {
   const onClickSpy = jest.fn();
@@ -364,25 +365,18 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).toHaveAttribute('href', 'https://amazon.com');
     });
 
-    test('can add a target attribute if it is a link', () => {
-      let wrapper = renderButton({ target: '_blank' });
-      expect(wrapper.getElement()).not.toHaveAttribute('target');
-      wrapper = renderButton({ href: 'https://amazon.com', target: '_blank' });
-      expect(wrapper.getElement()).toHaveAttribute('target', '_blank');
-      wrapper = renderButton({ href: 'https://amazon.com' });
-      expect(wrapper.getElement()).not.toHaveAttribute('target');
+    test.each(buttonTargetExpectations)('"target" property %s', (props, expectation) => {
+      const wrapper = renderButton({ ...props });
+      expectation
+        ? expect(wrapper.getElement()).toHaveAttribute('target', expectation)
+        : expect(wrapper.getElement()).not.toHaveAttribute('target');
     });
 
-    test('when target is blank, adds respective rel attribute', () => {
-      let wrapper = renderButton({ href: 'https://amazon.com', target: '_blank' });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
-      wrapper = renderButton({ href: 'https://amazon.com', target: '_self' });
-      expect(wrapper.getElement()).not.toHaveAttribute('rel');
-    });
-
-    test('does not set the default "rel" attribute for "target=_blank" if a "rel" prop is provided', () => {
-      const wrapper = renderButton({ href: 'https://amazon.com', target: '_blank', rel: 'nofollow' });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'nofollow');
+    test.each(buttonRelExpectations)('"rel" property %s', (props, expectation) => {
+      const wrapper = renderButton({ ...props });
+      expectation
+        ? expect(wrapper.getElement()).toHaveAttribute('rel', expectation)
+        : expect(wrapper.getElement()).not.toHaveAttribute('rel');
     });
 
     test('can add a download attribute if it is a link', () => {

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import Link, { LinkProps } from '../../../lib/components/link';
 import styles from '../../../lib/components/link/styles.css.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
+import { linkRelExpectations, linkTargetExpectations } from '../../__tests__/target-rel-test-helper';
 
 function renderLink(props: LinkProps = {}) {
   const renderResult = render(<Link {...props} />);
@@ -43,43 +44,25 @@ describe('Link component', () => {
     });
   });
 
-  describe('"_target" property', () => {
-    test('sets the "rel" attribute to "noopener noreferrer" if target is _blank', () => {
-      const wrapper = renderLink({ href: '#', target: '_blank' });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
-    });
-
-    test('does not set the "rel" attribute if another "rel" is provided', () => {
-      const wrapper = renderLink({ href: '#', target: '_blank', rel: 'nofollow' });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'nofollow');
-    });
-  });
-
   describe('"external" property', () => {
     test('renders an icon', () => {
       const wrapper = renderLink({ external: true });
       expect(createWrapper(wrapper.getElement()).findIcon()).not.toBeNull();
     });
+  });
 
-    test('sets the "rel" attribute to "noopener noreferrer" on anchors', () => {
-      const wrapper = renderLink({ href: '#', external: true });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
-    });
+  test.each(linkTargetExpectations)('"target" property %s', (props, expectation) => {
+    const wrapper = renderLink({ ...props });
+    expectation
+      ? expect(wrapper.getElement()).toHaveAttribute('target', expectation)
+      : expect(wrapper.getElement()).not.toHaveAttribute('target');
+  });
 
-    test('does not set the "rel" attribute if another "rel" is provided', () => {
-      const wrapper = renderLink({ href: '#', external: true, rel: 'nofollow' });
-      expect(wrapper.getElement()).toHaveAttribute('rel', 'nofollow');
-    });
-
-    test('sets the "target" attribute to "_blank" if type is anchor and target is not provided', () => {
-      const wrapper = renderLink({ href: '#', external: true });
-      expect(wrapper.getElement()).toHaveAttribute('target', '_blank');
-    });
-
-    test('does not override "target" if one is provided', () => {
-      const wrapper = renderLink({ href: '#', external: true, target: 'iframe1' });
-      expect(wrapper.getElement()).toHaveAttribute('target', 'iframe1');
-    });
+  test.each(linkRelExpectations)('"rel" property %s', (props, expectation) => {
+    const wrapper = renderLink({ ...props });
+    expectation
+      ? expect(wrapper.getElement()).toHaveAttribute('rel', expectation)
+      : expect(wrapper.getElement()).not.toHaveAttribute('rel');
   });
 
   describe('"href" property', () => {

--- a/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { TopNavigationProps } from '../../../lib/components/top-navigation/interfaces';
 import { transformUtility } from '../../../lib/components/top-navigation/1.0-beta/parts/overflow-menu';
+import { UtilityMenuItem } from '../../../lib/components/top-navigation/parts/overflow-menu/menu-item';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { linkRelExpectations, linkTargetExpectations } from '../../__tests__/target-rel-test-helper';
+import { createWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 const buttonUtility: TopNavigationProps.ButtonUtility = {
   type: 'button',
@@ -71,5 +76,25 @@ describe('TopNavigation Overflow menu', () => {
         { id: '3__2', text: 'Option 2' },
       ],
     });
+  });
+});
+
+describe('UtilityMenuItem', () => {
+  test.each(linkTargetExpectations)('"target" property %s', (props, expectation) => {
+    const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
+    const wrapper = createWrapper(container);
+
+    expectation
+      ? expect(wrapper.find('a')!.getElement()).toHaveAttribute('target', expectation)
+      : expect(wrapper.find('a')!.getElement()).not.toHaveAttribute('target');
+  });
+
+  test.each(linkRelExpectations)('"rel" property %s', (props, expectation) => {
+    const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
+    const wrapper = createWrapper(container);
+
+    expectation
+      ? expect(wrapper.find('a')!.getElement()).toHaveAttribute('rel', expectation)
+      : expect(wrapper.find('a')!.getElement()).not.toHaveAttribute('rel');
   });
 });

--- a/src/top-navigation/__tests__/top-navigation-utility.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-utility.test.tsx
@@ -84,6 +84,62 @@ describe('TopNavigation Utility part', () => {
       }).findButtonLinkType()!;
       expect(buttonWrapper.findByClassName('test-svg')).toBeTruthy();
     });
+
+    it('target is undefined by default if external=false', () => {
+      const buttonWrapper = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA' },
+      }).findButtonLinkType()!;
+
+      expect(buttonWrapper.getElement()).not.toHaveAttribute('target');
+    });
+
+    it('target is set to "_blank" by default if external=true', () => {
+      const buttonWrapper = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external: true },
+      }).findButtonLinkType()!;
+
+      expect(buttonWrapper.getElement()).toHaveAttribute('target', '_blank');
+    });
+
+    it.each([false, true])('target can be overridden for external=%s', external => {
+      const buttonWrapper = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external, target: 'custom' },
+      }).findButtonLinkType()!;
+
+      expect(buttonWrapper.getElement()).toHaveAttribute('target', 'custom');
+    });
+
+    it('rel is set to "noopener noreferrer" by default if target is "_blank"', () => {
+      const buttonExternal = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external: true },
+      }).findButtonLinkType()!;
+      const buttonCustomTarget = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', target: '_blank' },
+      }).findButtonLinkType()!;
+
+      expect(buttonExternal.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(buttonCustomTarget.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('rel undefined by default when target is not "_blank"', () => {
+      const buttonDefault = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA' },
+      }).findButtonLinkType()!;
+      const buttonCustomTarget = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', target: 'custom' },
+      }).findButtonLinkType()!;
+
+      expect(buttonDefault.getElement()).not.toHaveAttribute('rel');
+      expect(buttonCustomTarget.getElement()).not.toHaveAttribute('rel');
+    });
+
+    it.each([false, true])('rel can be overridden for external=%s', external => {
+      const buttonWrapper = renderUtility({
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external, rel: 'custom' },
+      }).findButtonLinkType()!;
+
+      expect(buttonWrapper.getElement()).toHaveAttribute('rel', 'custom');
+    });
   });
 
   describe('Primary button', () => {

--- a/src/top-navigation/__tests__/top-navigation-utility.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-utility.test.tsx
@@ -85,60 +85,13 @@ describe('TopNavigation Utility part', () => {
       expect(buttonWrapper.findByClassName('test-svg')).toBeTruthy();
     });
 
-    it('target is undefined by default if external=false', () => {
+    it('target and rel can be set', () => {
       const buttonWrapper = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA' },
+        definition: { type: 'button', href: '#', ariaLabel: 'ARIA label', target: 'target', rel: 'rel' },
       }).findButtonLinkType()!;
 
-      expect(buttonWrapper.getElement()).not.toHaveAttribute('target');
-    });
-
-    it('target is set to "_blank" by default if external=true', () => {
-      const buttonWrapper = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external: true },
-      }).findButtonLinkType()!;
-
-      expect(buttonWrapper.getElement()).toHaveAttribute('target', '_blank');
-    });
-
-    it.each([false, true])('target can be overridden for external=%s', external => {
-      const buttonWrapper = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external, target: 'custom' },
-      }).findButtonLinkType()!;
-
-      expect(buttonWrapper.getElement()).toHaveAttribute('target', 'custom');
-    });
-
-    it('rel is set to "noopener noreferrer" by default if target is "_blank"', () => {
-      const buttonExternal = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external: true },
-      }).findButtonLinkType()!;
-      const buttonCustomTarget = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', target: '_blank' },
-      }).findButtonLinkType()!;
-
-      expect(buttonExternal.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
-      expect(buttonCustomTarget.getElement()).toHaveAttribute('rel', 'noopener noreferrer');
-    });
-
-    it('rel undefined by default when target is not "_blank"', () => {
-      const buttonDefault = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA' },
-      }).findButtonLinkType()!;
-      const buttonCustomTarget = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', target: 'custom' },
-      }).findButtonLinkType()!;
-
-      expect(buttonDefault.getElement()).not.toHaveAttribute('rel');
-      expect(buttonCustomTarget.getElement()).not.toHaveAttribute('rel');
-    });
-
-    it.each([false, true])('rel can be overridden for external=%s', external => {
-      const buttonWrapper = renderUtility({
-        definition: { type: 'button', href: '#', ariaLabel: 'ARIA', external, rel: 'custom' },
-      }).findButtonLinkType()!;
-
-      expect(buttonWrapper.getElement()).toHaveAttribute('rel', 'custom');
+      expect(buttonWrapper.getElement()).toHaveAttribute('target', 'target');
+      expect(buttonWrapper.getElement()).toHaveAttribute('rel', 'rel');
     });
   });
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -43,6 +43,8 @@ export interface TopNavigationProps extends BaseComponentProps {
    *
    * * `variant` ('primary-button' | 'link') - The visual appearance of the button. The default value is 'link'.
    * * `href` (string) - Specifies the `href` for a link styled as a button.
+   * * `target` (string) - Specifies where to open the linked URL (for example, to open in a new browser window or tab use `_blank`). This property only applies when an `href` is provided.
+   * * `rel` (string) - Adds a `rel` attribute to the link. By default, the component sets the `rel` attribute to "noopener noreferrer" when `target` is `"_blank"`. If the `rel` property is provided, it overrides the default behavior.
    * * `external` (boolean) - Marks the link as external by adding an icon after the text. When clicked, the link opens in a new tab.
    * * `externalIconAriaLabel` (string) - Adds an `aria-label` for the external icon.
    * * `onClick` (() => void) - Specifies the event handler called when the utility is clicked.
@@ -100,6 +102,8 @@ export namespace TopNavigationProps {
     variant?: 'primary-button' | 'link';
     onClick?: CancelableEventHandler;
     href?: string;
+    target?: string;
+    rel?: string;
     external?: boolean;
     externalIconAriaLabel?: string;
   }

--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -45,9 +45,9 @@ const LinkItem = forwardRef(
     const anchorRel = rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
 
     const anchorProps = {
-      rel,
+      href,
       target: anchorTarget,
-      href: anchorRel,
+      rel: anchorRel,
       onClick(event: React.MouseEvent) {
         if (isPlainLeftClick(event)) {
           onFollow?.(event);
@@ -230,6 +230,8 @@ function utilityComponentFactory(
           startIcon={startIcon}
           href={utility.href}
           external={utility.external}
+          target={utility.target}
+          rel={utility.rel}
           testId={`__${index}`}
           onFollow={handleClick}
         >

--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -33,21 +33,21 @@ const ListItem = ({ children, startIcon, endIcon }: ListItemProps) => {
   );
 };
 
-interface LinkItemProps extends ButtonItemProps, Pick<LinkProps, 'href' | 'external'> {}
+interface LinkItemProps extends ButtonItemProps, Pick<LinkProps, 'href' | 'external' | 'target' | 'rel'> {}
 
 const LinkItem = forwardRef(
   (
-    { children, external, href, startIcon, endIcon, onFollow, context, testId }: LinkItemProps,
+    { children, external, href, target, rel, startIcon, endIcon, onFollow, context, testId }: LinkItemProps,
     ref: React.Ref<HTMLAnchorElement>
   ) => {
     const focusVisible = useFocusVisible();
-    const rel = external ? 'noopener noreferrer' : undefined;
-    const target = external ? '_blank' : undefined;
+    const anchorTarget = target ?? (external ? '_blank' : undefined);
+    const anchorRel = rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
 
     const anchorProps = {
       rel,
-      target,
-      href,
+      target: anchorTarget,
+      href: anchorRel,
       onClick(event: React.MouseEvent) {
         if (isPlainLeftClick(event)) {
           onFollow?.(event);

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -64,18 +64,15 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
           </InternalButton>
         </span>
       );
-    }
-    // Link
-    else {
-      const anchorTarget = definition.target ?? (definition.external ? '_blank' : undefined);
-      const anchorRel = definition.rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
+    } else {
+      // Link
       return (
         <span className={styles[`offset-right-${offsetRight}`]}>
           <InternalLink
             variant="top-navigation"
             href={definition.href}
-            target={anchorTarget}
-            rel={anchorRel}
+            target={definition.target}
+            rel={definition.rel}
             external={definition.external}
             onFollow={definition.onClick}
             ariaLabel={ariaLabel}

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -64,13 +64,18 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
           </InternalButton>
         </span>
       );
-    } else {
-      // Link
+    }
+    // Link
+    else {
+      const anchorTarget = definition.target ?? (definition.external ? '_blank' : undefined);
+      const anchorRel = definition.rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
       return (
         <span className={styles[`offset-right-${offsetRight}`]}>
           <InternalLink
             variant="top-navigation"
             href={definition.href}
+            target={anchorTarget}
+            rel={anchorRel}
             external={definition.external}
             onFollow={definition.onClick}
             ariaLabel={ariaLabel}


### PR DESCRIPTION
### Description

Added "target" and "rel" attributes for top-nav link utilities. We support these attributes for buttons and links.

Ticket: 20785

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
