### PR TITLE
fix: Top navigation utility clicks event details misalignment

### DIFF
--- a/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
@@ -3,10 +3,10 @@
 import { TopNavigationProps } from '../../../lib/components/top-navigation/interfaces';
 import { transformUtility } from '../../../lib/components/top-navigation/1.0-beta/parts/overflow-menu';
 import { UtilityMenuItem } from '../../../lib/components/top-navigation/parts/overflow-menu/menu-item';
+import createWrapper from '../../../lib/components/test-utils/dom';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { linkRelExpectations, linkTargetExpectations } from '../../__tests__/target-rel-test-helper';
-import { createWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 const buttonUtility: TopNavigationProps.ButtonUtility = {
   type: 'button',
@@ -82,19 +82,28 @@ describe('TopNavigation Overflow menu', () => {
 describe('UtilityMenuItem', () => {
   test.each(linkTargetExpectations)('"target" property %s', (props, expectation) => {
     const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
-    const wrapper = createWrapper(container);
+    const linkWrapper = createWrapper(container).find('a')!;
 
     expectation
-      ? expect(wrapper.find('a')!.getElement()).toHaveAttribute('target', expectation)
-      : expect(wrapper.find('a')!.getElement()).not.toHaveAttribute('target');
+      ? expect(linkWrapper.getElement()).toHaveAttribute('target', expectation)
+      : expect(linkWrapper.getElement()).not.toHaveAttribute('target');
   });
 
   test.each(linkRelExpectations)('"rel" property %s', (props, expectation) => {
     const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
-    const wrapper = createWrapper(container);
+    const linkWrapper = createWrapper(container).find('a')!;
 
     expectation
-      ? expect(wrapper.find('a')!.getElement()).toHaveAttribute('rel', expectation)
-      : expect(wrapper.find('a')!.getElement()).not.toHaveAttribute('rel');
+      ? expect(linkWrapper.getElement()).toHaveAttribute('rel', expectation)
+      : expect(linkWrapper.getElement()).not.toHaveAttribute('rel');
+  });
+
+  it('fires onClick with empty detail', () => {
+    const onClick = jest.fn();
+    const { container } = render(<UtilityMenuItem type="button" index={0} href="#" onClick={onClick} />);
+    const linkWrapper = createWrapper(container).find('a')!;
+    linkWrapper.click();
+
+    expect(onClick).toBeCalledWith(expect.objectContaining({ detail: {} }));
   });
 });

--- a/src/top-navigation/__tests__/top-navigation-utility.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-utility.test.tsx
@@ -93,6 +93,14 @@ describe('TopNavigation Utility part', () => {
       expect(buttonWrapper.getElement()).toHaveAttribute('target', 'target');
       expect(buttonWrapper.getElement()).toHaveAttribute('rel', 'rel');
     });
+
+    it('fires onClick with empty detail', () => {
+      const onClick = jest.fn();
+      const buttonWrapper = renderUtility({ definition: { type: 'button', onClick } }).findButtonLinkType()!;
+      buttonWrapper.click();
+
+      expect(onClick).toBeCalledWith(expect.objectContaining({ detail: {} }));
+    });
   });
 
   describe('Primary button', () => {

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -13,6 +13,7 @@ import { TopNavigationProps } from '../interfaces';
 import styles from '../styles.css.js';
 import { checkSafeUrl } from '../../internal/utils/check-safe-url';
 import { joinStrings } from '../../internal/utils/strings';
+import { fireCancelableEvent } from '../../internal/events';
 
 export interface UtilityProps {
   hideText: boolean;
@@ -74,7 +75,7 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
             target={definition.target}
             rel={definition.rel}
             external={definition.external}
-            onFollow={event => definition.onClick?.({ ...event, detail: {} })}
+            onFollow={() => fireCancelableEvent(definition.onClick, {})}
             ariaLabel={ariaLabel}
           >
             {hasIcon && (

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -74,7 +74,7 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
             target={definition.target}
             rel={definition.rel}
             external={definition.external}
-            onFollow={definition.onClick}
+            onFollow={event => definition.onClick?.({ ...event, detail: {} })}
             ariaLabel={ariaLabel}
           >
             {hasIcon && (


### PR DESCRIPTION
### Description

The events fired when the utility button is clicked from the header and from the overflow menu must be the same. The utilities of type="button" are not expected to have any attributes in the detail object.

Closes https://github.com/cloudscape-design/components/issues/915

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
