### PR TITLE
feat: Add disabled callback for table cell

### DIFF
--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -60,6 +60,7 @@ const columns: TableProps.ColumnDefinition<DistributionInfo>[] = [
       ariaLabel: 'Domain name',
       editIconAriaLabel: 'editable',
       errorIconAriaLabel: 'Domain Name Error',
+      disabled: item => item.DomainName !== initialItems[4].DomainName,
       validation(item, value: string) {
         const currentValue = value ?? item.DomainName;
         if (!DOMAIN_NAME.test(currentValue)) {

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -145,6 +145,23 @@ test('should render table header with icons to indicate editable columns', () =>
   });
 });
 
+test('should render table with disabled editable cell', () => {
+  const columnDefinitions: TableProps.ColumnDefinition<Item>[] = [
+    {
+      header: 'id',
+      cell: (item: Item) => item.id,
+      editConfig: { editingCell: item => item.id, disabled: item => item.id === defaultItems[0].id },
+    },
+    { header: 'name', cell: (item: Item) => item.name, editConfig: { editingCell: item => item.name } },
+  ];
+  const { wrapper } = renderTable(<Table columnDefinitions={columnDefinitions} items={defaultItems} />);
+  const disabledBodyCell = wrapper.findBodyCell(1, 1)!;
+  expect(disabledBodyCell.findButton(`[type="button"]`)?.getElement()).toBeUndefined();
+
+  const editableBodyCell = wrapper.findBodyCell(2, 1)!;
+  expect(editableBodyCell.findButton(`[type="button"]`)?.getElement()).toBeInTheDocument();
+});
+
 test('should cancel edit using ref imperative method', async () => {
   const ref = React.createRef<any>();
   const { wrapper } = renderTable(

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -325,6 +325,12 @@ export namespace TableProps {
     validation?: (item: T, value: Optional<V>) => Optional<string>;
 
     /**
+     * A function that allows you to disable editing of the cell
+     * @param item - The item that is being edited.
+     */
+    disabled?: (item: T) => boolean;
+
+    /**
      * Determines the display of a cell's content when inline edit is active.
      */
     editingCell(item: T, ctx: TableProps.CellContext<any>): React.ReactNode;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -367,7 +367,8 @@ const InternalTable = React.forwardRef(
                         {visibleColumnDefinitions.map((column, colIndex) => {
                           const isEditing =
                             !!currentEditCell && currentEditCell[0] === rowIndex && currentEditCell[1] === colIndex;
-                          const isEditable = !!column.editConfig && !currentEditLoading;
+                          const isEditable =
+                            !!column.editConfig && !currentEditLoading && !column.editConfig?.disabled?.(item);
                           return (
                             <TableBodyCell
                               key={getColumnKey(column, colIndex)}


### PR DESCRIPTION
### Description

Added ability to disable cell editing with `disabled` function.

#854

### How has this been tested?

Tested locally, added new unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
