### PR TITLE
chore: Remove unnecessary ARIA code for default expandable section

### DIFF
--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -231,6 +231,14 @@ describe('Variant container with headerText', () => {
     const screenreaderElement = wrapper.findHeader().find(`#${headerButton}`)!.getElement();
     expect(screenreaderElement.textContent).toBe('Header component (5) Expand to see more content');
   });
+  test('does not set aria-labelledby for default variant', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'default',
+      headerText: 'Header component',
+    });
+    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+    expect(headerButton).not.toHaveAttribute('aria-labelledby');
+  });
   test('button should be under heading', () => {
     const wrapper = renderExpandableSection({
       variant: 'container',

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -127,22 +127,24 @@ const ExpandableContainerHeader = ({
 }: ExpandableContainerHeaderProps) => {
   const focusVisible = useFocusVisible();
   const screenreaderContentId = useUniqueId('expandable-section-header-content-');
-  const Wrapper =
-    variant === 'container'
-      ? ({ children }: { children: ReactNode }) => (
-          <InternalHeader
-            variant="h2"
-            description={headerDescription}
-            counter={headerCounter}
-            headingTagOverride={headingTagOverride}
-          >
-            {children}
-          </InternalHeader>
-        )
-      : ({ children }: { children: ReactNode }) => {
-          const Tag = headingTagOverride || 'div';
-          return <Tag className={styles['header-wrapper']}>{children}</Tag>;
-        };
+  const isContainer = variant === 'container';
+
+  const Wrapper = isContainer
+    ? ({ children }: { children: ReactNode }) => (
+        <InternalHeader
+          variant="h2"
+          description={headerDescription}
+          counter={headerCounter}
+          headingTagOverride={headingTagOverride}
+        >
+          {children}
+        </InternalHeader>
+      )
+    : ({ children }: { children: ReactNode }) => {
+        const Tag = headingTagOverride || 'div';
+        return <Tag className={styles['header-wrapper']}>{children}</Tag>;
+      };
+
   return (
     <div id={id} className={className} onClick={onClick} {...focusVisible}>
       <Wrapper>
@@ -154,7 +156,7 @@ const ExpandableContainerHeader = ({
           onKeyDown={onKeyDown}
           aria-label={ariaLabel}
           // Do not use aria-labelledby={id} but ScreenreaderOnly because safari+VO does not read headerText in this case.
-          aria-labelledby={ariaLabel ? undefined : screenreaderContentId}
+          aria-labelledby={ariaLabel || !isContainer ? undefined : screenreaderContentId}
           aria-controls={ariaControls}
           aria-expanded={expanded}
         >
@@ -162,9 +164,11 @@ const ExpandableContainerHeader = ({
           <span>{children}</span>
         </span>
       </Wrapper>
-      <ScreenreaderOnly id={screenreaderContentId}>
-        {children} {headerCounter} {headerDescription}
-      </ScreenreaderOnly>
+      {isContainer && (
+        <ScreenreaderOnly id={screenreaderContentId}>
+          {children} {headerCounter} {headerDescription}
+        </ScreenreaderOnly>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Description

A previous change introduced the ability to have different semantic headings for Expandable Sections that don't use the `container` variant (https://github.com/cloudscape-design/components/pull/919). However, this also added additional code for ARIA that is not needed for default variants, because these variants don't use `headerDescription` or `headerCounter`.

This PR removes the unnecessary code for these variants.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
