### PR TITLE
fix: Add role=group to token-group and property-filter tokens

### DIFF
--- a/pages/token-group/custom.page.tsx
+++ b/pages/token-group/custom.page.tsx
@@ -28,13 +28,11 @@ export default function GenericTokenGroupPage() {
     <Box padding="xl">
       <h1>Generic token group</h1>
       <SpaceBetween size="l" direction="vertical">
-        <div role="group" aria-label="Custom token">
-          <Token>Custom token</Token>
-        </div>
+        <Token ariaLabel="Standalone token">Standalone token</Token>
 
-        <div role="group" aria-label="Custom token" aria-disabled={true}>
-          <Token disabled={true}>Custom disabled token</Token>
-        </div>
+        <Token ariaLabel="Standalone disabled token" disabled={true}>
+          Standalone disabled token
+        </Token>
 
         <TokenList
           alignment="vertical"
@@ -43,6 +41,7 @@ export default function GenericTokenGroupPage() {
           limit={5}
           renderItem={(file, fileIndex) => (
             <Token
+              ariaLabel={`agreement-${file + 1}.pdf`}
               disabled={file === 0}
               dismissLabel={`Remove file ${fileIndex + 1}`}
               onDismiss={() => onDismiss(fileIndex)}
@@ -50,7 +49,6 @@ export default function GenericTokenGroupPage() {
               <FileOption file={file} />
             </Token>
           )}
-          itemAttributes={file => ({ 'aria-label': `agreement-${file + 1}.pdf`, 'aria-disabled': file === 0 })}
         />
       </SpaceBetween>
     </Box>
@@ -60,7 +58,7 @@ export default function GenericTokenGroupPage() {
 function FileOption({ file }: { file: number }) {
   const fileName = `agreement-${file + 1}.pdf`;
   return (
-    <Box className={styles['file-option']}>
+    <div className={styles['file-option']}>
       <Icon variant="success" name="status-positive" />
 
       <div className={styles['file-option-metadata']}>
@@ -83,6 +81,6 @@ function FileOption({ file }: { file: number }) {
           </Box>
         </SpaceBetween>
       </div>
-    </Box>
+    </div>
   );
 }

--- a/src/internal/components/filtering-token/index.tsx
+++ b/src/internal/components/filtering-token/index.tsx
@@ -14,6 +14,7 @@ export namespace FilteringTokenProps {
 }
 
 export interface FilteringTokenProps {
+  ariaLabel?: string;
   showOperation: boolean;
   operation: FilteringTokenProps.Operation;
   andText: string;
@@ -29,6 +30,7 @@ export interface FilteringTokenProps {
 }
 
 export default function FilteringToken({
+  ariaLabel,
   showOperation,
   operation,
   andText,
@@ -42,7 +44,7 @@ export default function FilteringToken({
 }: FilteringTokenProps) {
   const focusVisible = useFocusVisible();
   return (
-    <div className={styles.root}>
+    <div className={styles.root} role="group" aria-label={ariaLabel}>
       {showOperation && (
         <InternalSelect
           __inFilteringToken={true}

--- a/src/internal/components/token-list/index.tsx
+++ b/src/internal/components/token-list/index.tsx
@@ -14,7 +14,6 @@ export default function TokenList<Item>({
   items,
   alignment,
   renderItem,
-  itemAttributes,
   limit,
   after,
   i18nStrings,
@@ -51,7 +50,6 @@ export default function TokenList<Item>({
               <li
                 key={itemIndex}
                 className={styles['list-item']}
-                {...itemAttributes?.(item, itemIndex)}
                 aria-setsize={items.length}
                 aria-posinset={itemIndex + 1}
               >
@@ -75,7 +73,6 @@ export default function TokenList<Item>({
             <li
               key={itemIndex}
               className={styles['list-item']}
-              {...itemAttributes?.(item, itemIndex)}
               aria-setsize={items.length}
               aria-posinset={itemIndex + 1}
             >

--- a/src/internal/components/token-list/interfaces.ts
+++ b/src/internal/components/token-list/interfaces.ts
@@ -9,7 +9,6 @@ export interface TokenListProps<Item> {
   limit?: number;
   after?: React.ReactNode;
   renderItem: (item: Item, itemIndex: number) => React.ReactNode;
-  itemAttributes?: (item: Item, itemIndex: number) => React.HTMLAttributes<HTMLLIElement>;
   i18nStrings?: I18nStrings;
   removedItemIndex?: null | number;
 }

--- a/src/internal/components/token-list/token-focus-controller.tsx
+++ b/src/internal/components/token-list/token-focus-controller.tsx
@@ -21,7 +21,7 @@ export function useTokenFocusController({ removedItemIndex }: { removedItemIndex
 
     const activeItemIndices: number[] = [];
     for (let i = 0; i < tokenElements.length; i++) {
-      if (tokenElements[i].getAttribute('aria-disabled') !== 'true') {
+      if (!tokenElements[i].querySelector('[aria-disabled="true"]')) {
         activeItemIndices.push(i);
       }
     }

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -20,7 +20,6 @@ import {
   getAutosuggestOptions,
   getAllowedOperators,
   getExtendedOperator,
-  getFormattedToken,
 } from './controller';
 import { useLoadItems } from './use-load-items';
 import styles from './styles.css.js';
@@ -344,7 +343,6 @@ const PropertyFilter = React.forwardRef(
                     expandToViewport={expandToViewport}
                   />
                 )}
-                itemAttributes={token => ({ 'aria-label': getFormattedToken(filteringProperties, token).label })}
                 i18nStrings={{
                   limitShowFewer: i18nStrings.tokenLimitShowFewer,
                   limitShowMore: i18nStrings.tokenLimitShowMore,

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -61,6 +61,7 @@ export const TokenButton = ({
   const formattedToken = getFormattedToken(filteringProperties, token);
   return (
     <FilteringToken
+      ariaLabel={formattedToken.label}
       showOperation={!first && !hideOperations}
       operation={operation}
       andText={i18nStrings.operationAndText ?? ''}

--- a/src/token-group/__tests__/token-group.test.tsx
+++ b/src/token-group/__tests__/token-group.test.tsx
@@ -111,10 +111,7 @@ describe('TokenGroup', () => {
 
     test('sets aria-disabled on the token when disabled', () => {
       const wrapper = renderTokenGroup({ items: [{ ...items[0], disabled: true }], onDismiss });
-      expect(wrapper.findByClassName(tokenListSelectors['list-item'])!.getElement()).toHaveAttribute(
-        'aria-disabled',
-        'true'
-      );
+      expect(wrapper.findToken(1)!.getElement()).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('does not set aria-disabled on the token when not disabled', () => {

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -44,6 +44,7 @@ export default function InternalTokenGroup({
         limit={limit}
         renderItem={(item, itemIndex) => (
           <Token
+            ariaLabel={item.label}
             dismissLabel={item.dismissLabel}
             onDismiss={() => {
               fireNonCancelableEvent(onDismiss, { itemIndex });
@@ -54,7 +55,6 @@ export default function InternalTokenGroup({
             <Option option={item} isGenericGroup={false} />
           </Token>
         )}
-        itemAttributes={item => ({ 'aria-label': item.label, 'aria-disabled': item.disabled ? true : undefined })}
         i18nStrings={i18nStrings}
         removedItemIndex={removedItemIndex}
       />

--- a/src/token-group/token.tsx
+++ b/src/token-group/token.tsx
@@ -7,20 +7,22 @@ import clsx from 'clsx';
 import DismissButton from './dismiss-button';
 import styles from './styles.css.js';
 
-interface ItemAttributes {
+interface TokenProps {
   children: React.ReactNode;
+  ariaLabel?: string;
   dismissLabel?: string;
   onDismiss?: () => void;
   disabled?: boolean;
 }
 
-interface TokenProps extends ItemAttributes {
-  children: React.ReactNode;
-}
-
-export function Token({ disabled, dismissLabel, onDismiss, children }: TokenProps) {
+export function Token({ ariaLabel, disabled, dismissLabel, onDismiss, children }: TokenProps) {
   return (
-    <div className={clsx(styles.token, disabled && styles['token-disabled'])}>
+    <div
+      className={clsx(styles.token, disabled && styles['token-disabled'])}
+      role="group"
+      aria-label={ariaLabel}
+      aria-disabled={disabled}
+    >
       {children}
       {onDismiss && <DismissButton disabled={disabled} dismissLabel={dismissLabel} onDismiss={onDismiss} />}
     </div>


### PR DESCRIPTION
### Description

Although technically it works, having aria-label, aria-description or aria-disabled on li elements is not recommended and has been reported by html-validator. Instead it is possible to use role=group for the tokens that are directly nested under li  elements.

### How has this been tested?

Tested manually with VO and NVDA.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
