### PR TITLE
feat: Add `findToggleButton` test utility to Flashbar

### DIFF
--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -180,24 +180,24 @@ describe('Collapsible Flashbar', () => {
           notificationBarAriaLabel: customToggleButtonAriaLabel,
         },
       });
-      const button = findToggleButton(flashbar);
+      const button = flashbar.findToggleButton()?.getElement();
       expect(button).toHaveAttribute('aria-label', customToggleButtonAriaLabel);
     });
 
     it('applies aria-expanded attribute to toggle button', () => {
       const flashbar = renderFlashbar();
-      const button = findToggleButton(flashbar)!;
-      expect(button).toHaveAttribute('aria-expanded', 'false');
+      const button = flashbar.findToggleButton()!;
+      expect(button?.getElement()).toHaveAttribute('aria-expanded', 'false');
 
       button.click();
-      expect(button).toHaveAttribute('aria-expanded', 'true');
+      expect(button?.getElement()).toHaveAttribute('aria-expanded', 'true');
     });
 
     it('applies aria-controls attribute to toggle button referring to the unordered list', () => {
       const flashbar = renderFlashbar();
       const listId = findList(flashbar)!.getElement().id;
       expect(listId).toBeTruthy();
-      const button = findToggleButton(flashbar);
+      const button = flashbar.findToggleButton()?.getElement();
       expect(button).toHaveAttribute('aria-controls', listId);
     });
 
@@ -225,7 +225,7 @@ describe('Collapsible Flashbar', () => {
       const flashbar = renderFlashbar();
       const itemCounterElementId = findOuterCounter(flashbar)!.id;
       expect(itemCounterElementId).toBeTruthy();
-      const toggleButton = findToggleButton(flashbar);
+      const toggleButton = flashbar.findToggleButton()?.getElement();
       expect(toggleButton).toHaveAttribute('aria-describedby', itemCounterElementId);
     });
 
@@ -285,11 +285,6 @@ function findNotificationBar(flashbar: FlashbarWrapper): HTMLElement | undefined
   if (element) {
     return element as HTMLElement;
   }
-}
-
-// Actual <button/> element inside the toggle element
-function findToggleButton(flashbar: FlashbarWrapper): HTMLElement | undefined {
-  return findNotificationBar(flashbar)?.querySelector('button') || undefined;
 }
 
 // Item counter including the header

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -19,7 +19,7 @@ export default class FlashbarWrapper extends ComponentWrapper {
   /**
    * Returns the toggle button that expands and collapses stacked notifications.
    */
-  findToggleButton(): ElementWrapper | null {
+  findToggleButton(): ElementWrapper<HTMLButtonElement> | null {
     return this.findByClassName(styles['notification-bar'])?.find('button') ?? null;
   }
 }

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import styles from '../../../flashbar/styles.selectors.js';
 import FlashWrapper from './flash';
 
@@ -14,5 +14,12 @@ export default class FlashbarWrapper extends ComponentWrapper {
    */
   findItems(): Array<FlashWrapper> {
     return this.findAllByClassName(styles['flash-list-item']).map(item => new FlashWrapper(item.getElement()));
+  }
+
+  /**
+   * Returns the toggle button that expands and collapses stacked notifications.
+   */
+  findToggleButton(): ElementWrapper | null {
+    return this.findByClassName(styles['notification-bar'])?.find('button') ?? null;
   }
 }


### PR DESCRIPTION
### Description
This adds a new test util to Flashbar which lets teams target the toggle button for stacked notifications. This enables them to expand stacked notifications.

Related links, issue #, if available: AWSUI-20428, AWSUI-20787

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
