### PR TITLE
fix: Do not re-render table when app layout state changes

### DIFF
--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -12,6 +12,7 @@ import React, {
 } from 'react';
 import { applyDefaults } from '../defaults';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
+import { DynamicOverlapContext } from '../../internal/context/dynamic-overlap-context';
 import { AppLayoutProps } from '../interfaces';
 import { DrawersProps } from './drawers';
 import { fireNonCancelableEvent } from '../../internal/events';
@@ -60,7 +61,6 @@ interface AppLayoutInternals extends AppLayoutProps {
   notificationsElement: React.Ref<HTMLDivElement>;
   notificationsHeight: number;
   offsetBottom: number;
-  setDynamicOverlapHeight: (value: number) => void;
   setHasStickyBackground: (value: boolean) => void;
   setSplitPanelReportedSize: (value: number) => void;
   setSplitPanelReportedHeaderHeight: (value: number) => void;
@@ -601,7 +601,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           notificationsElement,
           notificationsHeight,
           offsetBottom,
-          setDynamicOverlapHeight,
           setHasStickyBackground,
           setSplitPanelReportedSize,
           setSplitPanelReportedHeaderHeight,
@@ -629,10 +628,9 @@ export const AppLayoutInternalsProvider = React.forwardRef(
             stickyOffsetTop: 0, // not used in this design. Sticky headers read a CSS-var instead
             hasBreadcrumbs: !!props.breadcrumbs,
             setHasStickyBackground,
-            setDynamicOverlapHeight,
           }}
         >
-          {children}
+          <DynamicOverlapContext.Provider value={setDynamicOverlapHeight}>{children}</DynamicOverlapContext.Provider>
         </AppLayoutContext.Provider>
       </AppLayoutInternalsContext.Provider>
     );

--- a/src/internal/context/app-layout-context.ts
+++ b/src/internal/context/app-layout-context.ts
@@ -7,7 +7,6 @@ export interface AppLayoutContextProps {
   stickyOffsetTop: number;
   hasBreadcrumbs: boolean;
   setHasStickyBackground?: (hasBackground: boolean) => void;
-  setDynamicOverlapHeight?: (height: number) => void;
 }
 
 export const AppLayoutContext = createContext<AppLayoutContextProps>({

--- a/src/internal/context/dynamic-overlap-context.ts
+++ b/src/internal/context/dynamic-overlap-context.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext } from 'react';
+
+export const DynamicOverlapContext = createContext<(overlapHeight: number) => void>(() => {});

--- a/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
+++ b/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { useDynamicOverlap } from '../../../../../lib/components/internal/hooks/use-dynamic-overlap';
-import { AppLayoutContext } from '../../../../../lib/components/internal/context/app-layout-context';
+import { DynamicOverlapContext } from '../../../../../lib/components/internal/context/dynamic-overlap-context';
 
 jest.mock('../../../../../lib/components/internal/hooks/container-queries/use-container-query', () => ({
   useContainerQuery: () => [800, () => {}],
@@ -16,12 +16,10 @@ function renderApp(children: React.ReactNode) {
   function App(props: { children: React.ReactNode }) {
     const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState<number | undefined>(0);
     return (
-      <AppLayoutContext.Provider
-        value={{ hasBreadcrumbs: false, stickyOffsetTop: 0, stickyOffsetBottom: 0, setDynamicOverlapHeight }}
-      >
+      <DynamicOverlapContext.Provider value={setDynamicOverlapHeight}>
         <div data-testid={testId}>{dynamicOverlapHeight}</div>
         {props.children}
-      </AppLayoutContext.Provider>
+      </DynamicOverlapContext.Provider>
     );
   }
 

--- a/src/internal/hooks/use-dynamic-overlap/index.ts
+++ b/src/internal/hooks/use-dynamic-overlap/index.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useLayoutEffect } from 'react';
+import { useContext, useLayoutEffect } from 'react';
 
-import { useAppLayoutContext } from '../../context/app-layout-context';
+import { DynamicOverlapContext } from '../../context/dynamic-overlap-context';
 import { useContainerQuery } from '../container-queries';
 
 export interface UseDynamicOverlapProps {
@@ -20,22 +20,22 @@ export interface UseDynamicOverlapProps {
  */
 export function useDynamicOverlap(props?: UseDynamicOverlapProps) {
   const disabled = props?.disabled ?? false;
-  const { setDynamicOverlapHeight } = useAppLayoutContext();
-  const [overlapContainerQuery, overlapElementRef] = useContainerQuery(rect => rect.height);
+  const setDynamicOverlapHeight = useContext(DynamicOverlapContext);
+  const [overlapHeight, overlapElementRef] = useContainerQuery(rect => rect.height);
 
   useLayoutEffect(
     function handleDynamicOverlapHeight() {
       if (!disabled) {
-        setDynamicOverlapHeight?.(overlapContainerQuery ?? 0);
+        setDynamicOverlapHeight(overlapHeight ?? 0);
       }
 
       return () => {
         if (!disabled) {
-          setDynamicOverlapHeight?.(0);
+          setDynamicOverlapHeight(0);
         }
       };
     },
-    [disabled, overlapContainerQuery, setDynamicOverlapHeight]
+    [disabled, overlapHeight, setDynamicOverlapHeight]
   );
 
   return overlapElementRef;


### PR DESCRIPTION
### Description

When a context changes, all its consumers get re-rendered. We use app layout context to communicate between app layout and some descendants, like content layout, but there is no need to re-render table, it only uses `setDynamicOverlapHeight` handler.

Extract this into separate context to allow better granularity of re-renders

Related links, issue #, if available: n/a

### How has this been tested?

* PR build passes
* Pushed the change to my dev-pipeline to reproduce the issue on _super heavy tables_, works fine now

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
