### PR TITLE
fix: The AppBar should render when only drawers are present.

### DIFF
--- a/src/app-layout/visual-refresh/app-bar.tsx
+++ b/src/app-layout/visual-refresh/app-bar.tsx
@@ -34,7 +34,7 @@ export default function AppBar() {
     toolsRefs,
   } = useAppLayoutInternals();
 
-  if (navigationHide && !breadcrumbs && toolsHide) {
+  if (navigationHide && !breadcrumbs && toolsHide && !drawers) {
     return null;
   }
 


### PR DESCRIPTION
### Description

This is a follow up to #925 that resolves a minor error in the component logic. The application toolbar should not be suppressed if the drawers API is present. Currently it only checks the navigation, breadcrumbs, and tools. If the drawers API is used while all three of these are null then it will not be accessible in mobile viewports.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
