### PR TITLE
fix: Update button test util `isDisabled` logic for new loading state

### DIFF
--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -71,6 +71,7 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).toHaveAttribute('disabled');
       // In this case, aria-disabled would be redundant, so we don't set it
       expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
+      expect(wrapper.isDisabled()).toBe(true);
     });
 
     test('does not add the disabled attribute on link buttons', () => {
@@ -79,6 +80,7 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).toHaveClass(styles.disabled);
       expect(wrapper.getElement()).not.toHaveAttribute('disabled');
       expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+      expect(wrapper.isDisabled()).toBe(true);
     });
 
     test('adds a tab index -1 when button with link is disabled', () => {
@@ -298,6 +300,7 @@ describe('Button Component', () => {
       expect(wrapper.findLoadingIndicator()).not.toBeNull();
       expect(wrapper.getElement()).not.toHaveAttribute('disabled');
       expect(wrapper.getElement()).toHaveAttribute('aria-disabled');
+      expect(wrapper.isDisabled()).toBe(true);
       act(() => wrapper.click());
       expect(onClickSpy).not.toHaveBeenCalled();
     });
@@ -309,6 +312,7 @@ describe('Button Component', () => {
       // However, setting `disabled` does mean that the button can no longer be focused.
       expect(wrapper.getElement()).toHaveAttribute('disabled');
       expect(wrapper.getElement()).not.toHaveAttribute('aria-disabled');
+      expect(wrapper.isDisabled()).toBe(true);
     });
 
     test('adds a tab index -1 to the link button', () => {

--- a/src/test-utils/dom/button/index.ts
+++ b/src/test-utils/dom/button/index.ts
@@ -17,10 +17,6 @@ export default class ButtonWrapper extends ComponentWrapper<HTMLButtonElement> {
 
   @usesDom
   isDisabled(): boolean {
-    if (this.element.tagName === 'A') {
-      return this.element.getAttribute('aria-disabled') === 'true';
-    } else {
-      return this.element.disabled;
-    }
+    return this.element.disabled || this.element.getAttribute('aria-disabled') === 'true';
   }
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
