### PR TITLE
fix: Adjust heading hierarchy in s3 selector

### DIFF
--- a/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
@@ -29,6 +29,14 @@ test('renders correct strings and aria labels', async () => {
   expect(modal.findDismissButton().getElement()).toHaveAttribute('aria-label', i18nStrings.labelModalDismiss);
 });
 
+test('modal has valid hierarchy of headings', async () => {
+  const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
+  const modal = wrapper.findModal()!;
+  expect(modal.findHeader().findAll('h2').length).toBe(1);
+  const table = wrapper.findTable()!;
+  expect(table.findHeaderSlot()!.findAll('h3').length).toBe(1);
+});
+
 test('renders alert content when provided', async () => {
   const wrapper = await renderModal(<S3Modal {...modalDefaultProps} alert={<div data-testid="test-alert" />} />);
   expect(wrapper.findModal()!.findContent().find('[data-testid="test-alert"]')).toBeTruthy();

--- a/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
@@ -34,7 +34,8 @@ test('modal has valid hierarchy of headings', async () => {
   const modal = wrapper.findModal()!;
   expect(modal.findHeader().findAll('h2').length).toBe(1);
   const table = wrapper.findTable()!;
-  expect(table.findHeaderSlot()!.findAll('h3').length).toBe(1);
+  await waitForFetch();
+  expect(table.findHeaderSlot()!.findHeader()!.findAll('h3').length).toBe(1);
 });
 
 test('renders alert content when provided', async () => {

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -129,6 +129,7 @@ export function BasicS3Table<T>({
       header={
         <InternalHeader
           variant={isVisualRefresh ? 'h3' : 'h2'}
+          headingTagOverride={'h3'}
           actions={<InternalButton iconName="refresh" ariaLabel={i18nStrings.labelRefresh} onClick={loadData} />}
           counter={selectedItem ? `(1/${allItems.length})` : `(${allItems.length})`}
         >


### PR DESCRIPTION
### Description

S3 selector modal has inaccurate heading hierarchy in classic mode. Specifically, both modal header and table header are h2.

Related links, issue #, if available: n/a

### How has this been tested?
Go to [S3 selector page](https://d21d5uik3ws71m.cloudfront.net/components/05d92d1f7d46a94b73b3b88f92dcc5832ff80fd0/index.html#/light/s3-resource-selector/main/?visualRefresh=false), open modal, inspect Table heading.


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
