### PR TITLE
feat: Add labelling properties to PropertyFilter

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -9146,6 +9146,31 @@ Object {
   "name": "PropertyFilter",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for each element that you want to use as a description
+and set the property to a string of each ID separated by spaces (for example, \`\\"id1 id2 id3\\"\`).
+",
+      "name": "ariaDescribedby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
+      "name": "ariaLabelledby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Set \`asyncProperties\` if you need to load \`filteringProperties\` asynchronousely. This would cause extra \`onLoadMore\`
 events to fire calling for more properties.",
       "name": "asyncProperties",
@@ -9156,6 +9181,16 @@ events to fire calling for more properties.",
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies the ID of the native form element. You can use it to relate
+a label element's \`for\` attribute to this control.
+It defaults to an automatically generated ID that
+is provided by its parent form field component.
+",
+      "name": "controlId",
       "optional": true,
       "type": "string",
     },

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -187,6 +187,16 @@ describe('property filter parts', () => {
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('disabled');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-label', 'your choice');
     });
+    test('recieves `ariaLabelledby`, `ariaDescribedby` and `controlId` properties passed to the component', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        ariaLabelledby: 'label-by-id',
+        ariaDescribedby: 'described-by-id',
+        controlId: 'control-id',
+      });
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-labelledby', 'label-by-id');
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-describedby', 'described-by-id');
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('id', 'control-id');
+    });
     describe('typing experience: ', () => {
       test('provides relevant suggestions depending on the currently entered string', () => {
         const { propertyFilterWrapper: wrapper } = renderComponent();

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -275,6 +275,9 @@ const PropertyFilter = React.forwardRef(
             enteredTextLabel={i18nStrings.enteredTextLabel ?? (value => value)}
             ariaLabel={i18nStrings.filteringAriaLabel}
             placeholder={i18nStrings.filteringPlaceholder}
+            ariaLabelledby={rest.ariaLabelledby}
+            ariaDescribedby={rest.ariaDescribedby}
+            controlId={rest.controlId}
             value={filteringText}
             disabled={disabled}
             onKeyDown={handleKeyDown}

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -7,6 +7,7 @@ import { NonCancelableEventHandler } from '../internal/events';
 import { DropdownStatusProps } from '../internal/components/dropdown-status';
 import { AutosuggestProps } from '../autosuggest/interfaces';
 import { ExpandToViewport } from '../internal/components/dropdown/interfaces';
+import { FormFieldControlProps } from '../internal/context/form-field-context';
 import {
   PropertyFilterOperation,
   PropertyFilterOperator,
@@ -19,7 +20,7 @@ import {
   PropertyFilterToken,
 } from '@cloudscape-design/collection-hooks';
 
-export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewport {
+export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewport, FormFieldControlProps {
   /**
    * If set to `true`, the filtering input will be disabled.
    * Use it, for example, if you are fetching new items upon filtering change

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -29,6 +29,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import clsx from 'clsx';
 import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 import { filterOptions } from './filter-options';
+import { joinStrings } from '../internal/utils/strings';
 
 const DROPDOWN_WIDTH_OPTIONS_LIST = 300;
 const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
@@ -193,7 +194,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         expandToViewport={expandToViewport}
         ariaControls={listId}
         ariaActivedescendant={highlightedOptionId}
-        ariaDescribedby={[searchResultsId, rest.ariaDescribedby].filter(id => !!id).join(' ')}
+        ariaDescribedby={joinStrings(searchResultsId, rest.ariaDescribedby)}
         dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null || !!customForm}
         dropdownContentKey={customForm ? 'custom' : 'options'}
         dropdownContent={content}

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -193,7 +193,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         expandToViewport={expandToViewport}
         ariaControls={listId}
         ariaActivedescendant={highlightedOptionId}
-        ariaDescribedby={searchResultsId}
+        ariaDescribedby={[searchResultsId, rest.ariaDescribedby].filter(id => !!id).join(' ')}
         dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null || !!customForm}
         dropdownContentKey={customForm ? 'custom' : 'options'}
         dropdownContent={content}


### PR DESCRIPTION
### Description

PropertyFilter input can already accept these via FormFieldContext, so allow them also
to be overridden for custom use-cases.

Related links, issue #, if available: AWSUI-20256

### How has this been tested?

Unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
