### PR TITLE
fix: Allow to skip optional i18n strings on split panel

### DIFF
--- a/pages/app-layout/dashboard-content-type.page.tsx
+++ b/pages/app-layout/dashboard-content-type.page.tsx
@@ -9,7 +9,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 import { Containers, Navigation, Tools, Breadcrumbs } from './utils/content-blocks';
 import * as toolsContent from './utils/tools-content';
 import labels from './utils/labels';
-import { splitPaneli18nStrings } from './utils/strings';
+import { discreetSplitPanelI18nStrings } from './utils/strings';
 
 export default function () {
   const [splitPanelOpen, setSplitPanelOpen] = useState(false);
@@ -34,7 +34,7 @@ export default function () {
             header="Add something"
             closeBehavior="hide"
             hidePreferencesButton={true}
-            i18nStrings={splitPaneli18nStrings}
+            i18nStrings={discreetSplitPanelI18nStrings}
           >
             Hello!
           </SplitPanel>

--- a/pages/app-layout/utils/strings.ts
+++ b/pages/app-layout/utils/strings.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { SplitPanelProps } from '~components/split-panel';
 
+export const discreetSplitPanelI18nStrings: SplitPanelProps.I18nStrings = {
+  closeButtonAriaLabel: 'Close panel',
+  resizeHandleAriaLabel: 'Slider',
+};
+
 export const splitPaneli18nStrings: SplitPanelProps.I18nStrings = {
+  ...discreetSplitPanelI18nStrings,
+  openButtonAriaLabel: 'Open panel',
   preferencesTitle: 'Preferences',
   preferencesPositionLabel: 'Split panel position',
   preferencesPositionDescription: 'Choose the default split panel position for the service.',
@@ -10,7 +17,4 @@ export const splitPaneli18nStrings: SplitPanelProps.I18nStrings = {
   preferencesPositionBottom: 'Bottom',
   preferencesConfirm: 'Confirm',
   preferencesCancel: 'Cancel',
-  closeButtonAriaLabel: 'Close panel',
-  openButtonAriaLabel: 'Open panel',
-  resizeHandleAriaLabel: 'Slider',
 };

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11078,42 +11078,42 @@ Object {
           },
           Object {
             "name": "openButtonAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesCancel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesConfirm",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesPositionBottom",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesPositionDescription",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesPositionLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesPositionSide",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesTitle",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -36,14 +36,14 @@ export interface SplitPanelProps extends BaseComponentProps {
 export namespace SplitPanelProps {
   export interface I18nStrings {
     closeButtonAriaLabel: string;
-    openButtonAriaLabel: string;
-    preferencesTitle: string;
-    preferencesPositionLabel: string;
-    preferencesPositionDescription: string;
-    preferencesPositionSide: string;
-    preferencesPositionBottom: string;
-    preferencesConfirm: string;
-    preferencesCancel: string;
+    openButtonAriaLabel?: string;
+    preferencesTitle?: string;
+    preferencesPositionLabel?: string;
+    preferencesPositionDescription?: string;
+    preferencesPositionSide?: string;
+    preferencesPositionBottom?: string;
+    preferencesConfirm?: string;
+    preferencesCancel?: string;
     resizeHandleAriaLabel: string;
   }
 }

--- a/src/split-panel/preferences-modal.tsx
+++ b/src/split-panel/preferences-modal.tsx
@@ -16,13 +16,13 @@ import bottomPositionIconRefresh from './icons/bottom-icon-refresh';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 interface PreferencesModali18nStrings {
-  header: string;
-  cancel: string;
-  confirm: string;
-  positionLabel: string;
-  positionDescription: string;
-  positionBottom: string;
-  positionSide: string;
+  header?: string;
+  cancel?: string;
+  confirm?: string;
+  positionLabel?: string;
+  positionDescription?: string;
+  positionBottom?: string;
+  positionSide?: string;
 }
 
 interface PreferencesModalProps extends InternalBaseComponentProps {
@@ -57,7 +57,7 @@ export default (props: PreferencesModalProps) => {
       visible={props.visible}
       onDismiss={props.onDismiss}
       header={props.i18nStrings.header}
-      closeAriaLabel={props.i18nStrings.cancel}
+      closeAriaLabel={props.i18nStrings.cancel!}
       footer={
         <InternalBox float="right">
           <InternalSpaceBetween direction="horizontal" size="xs">


### PR DESCRIPTION
### Description

When `hidePreferences` button is used, there is no point in passing strings for the modal, because it will never show. Additionally, when `closeBehavior` is `hide`, open button is also not displayed.

Related links, issue #, if available: n/a

### How has this been tested?

Updated the demo where we use this property to only include required strings

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
