### PR TITLE
feat: Associate dropdown footers with the dropdown list element

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -202,6 +202,22 @@ describe('Dropdown states', () => {
     expect(statusIcon).toHaveAttribute('role', 'img');
   });
 
+  test('should associate the error status footer with the dropdown', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest {...defaultProps} statusType="error" errorText="Test error text" />
+    );
+    wrapper.focus();
+    expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription('Test error text');
+  });
+
+  test('should associate the finished status footer with the dropdown', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest {...defaultProps} statusType="finished" finishedText="Finished text" />
+    );
+    wrapper.focus();
+    expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription('Finished text');
+  });
+
   it('when no options is matched the dropdown is shown but aria-expanded is false', () => {
     const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} statusType="finished" value="free-text" />);
     wrapper.setInputValue('free-text');

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -154,6 +154,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
 
   const formFieldContext = useFormFieldContext(restProps);
   const selfControlId = useUniqueId('input');
+  const footerControlId = useUniqueId('footer');
   const controlId = formFieldContext.controlId ?? selfControlId;
   const listId = useUniqueId('list');
   const highlightedOptionIdSource = useUniqueId();
@@ -208,12 +209,19 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
           virtualScroll={virtualScroll}
           selectedAriaLabel={selectedAriaLabel}
           renderHighlightedAriaLive={renderHighlightedAriaLive}
-          listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+          listBottom={
+            !dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} id={footerControlId} /> : null
+          }
+          ariaDescribedby={dropdownStatus.content ? footerControlId : undefined}
         />
       }
       dropdownFooter={
         dropdownStatus.isSticky ? (
-          <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
+          <DropdownFooter
+            id={footerControlId}
+            content={dropdownStatus.content}
+            hasItems={autosuggestItemsState.items.length >= 1}
+          />
         ) : null
       }
       loopFocus={statusType === 'error' && !!recoveryText}

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -24,6 +24,7 @@ export interface AutosuggestOptionsListProps
   handleLoadMore: () => void;
   hasDropdownStatus?: boolean;
   listBottom?: React.ReactNode;
+  ariaDescribedby?: string;
 }
 
 const createMouseEventHandler = (handler: (index: number) => void) => (itemIndex: number) => {
@@ -47,6 +48,7 @@ export default function AutosuggestOptionsList({
   selectedAriaLabel,
   renderHighlightedAriaLive,
   listBottom,
+  ariaDescribedby,
 }: AutosuggestOptionsListProps) {
   const handleMouseUp = createMouseEventHandler(autosuggestItemsHandlers.selectVisibleOptionWithMouse);
   const handleMouseMove = createMouseEventHandler(autosuggestItemsHandlers.highlightVisibleOptionWithMouse);
@@ -70,7 +72,13 @@ export default function AutosuggestOptionsList({
       enteredTextLabel={enteredTextLabel}
       highlightedA11yProps={highlightedOptionId ? { id: highlightedOptionId } : {}}
       hasDropdownStatus={hasDropdownStatus}
-      menuProps={{ id: listId, ariaLabelledby: controlId, onMouseUp: handleMouseUp, onMouseMove: handleMouseMove }}
+      menuProps={{
+        id: listId,
+        ariaLabelledby: controlId,
+        onMouseUp: handleMouseUp,
+        onMouseMove: handleMouseMove,
+        ariaDescribedby,
+      }}
       screenReaderContent={announcement}
     />
   );

--- a/src/internal/components/dropdown-footer/index.tsx
+++ b/src/internal/components/dropdown-footer/index.tsx
@@ -10,11 +10,12 @@ import LiveRegion from '../live-region/index.js';
 interface DropdownFooter {
   content?: React.ReactNode | null;
   hasItems?: boolean;
+  id?: string;
 }
 
-const DropdownFooter: React.FC<DropdownFooter> = ({ content, hasItems = true }: DropdownFooter) => (
+const DropdownFooter: React.FC<DropdownFooter> = ({ content, id, hasItems = true }: DropdownFooter) => (
   <div className={clsx(styles.root, { [styles.hidden]: content === null, [styles['no-items']]: !hasItems })}>
-    <LiveRegion visible={true} tagName="div">
+    <LiveRegion visible={true} tagName="div" id={id}>
       {content && <DropdownStatus>{content}</DropdownStatus>}
     </LiveRegion>
   </div>

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -14,6 +14,7 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
   visible?: boolean;
   tagName?: 'span' | 'div';
   children: React.ReactNode;
+  id?: string;
 }
 
 /**
@@ -57,6 +58,7 @@ function LiveRegion({
   visible = false,
   tagName: TagName = 'span',
   children,
+  id,
   ...restProps
 }: LiveRegionProps) {
   const sourceRef = useRef<HTMLSpanElement & HTMLDivElement>(null);
@@ -103,7 +105,11 @@ function LiveRegion({
 
   return (
     <>
-      {visible && <TagName ref={sourceRef}>{children}</TagName>}
+      {visible && (
+        <TagName ref={sourceRef} id={id}>
+          {children}
+        </TagName>
+      )}
 
       <ScreenreaderOnly {...restProps} className={clsx(styles.root, restProps.className)}>
         {!visible && (

--- a/src/internal/components/options-list/index.tsx
+++ b/src/internal/components/options-list/index.tsx
@@ -33,6 +33,7 @@ export interface OptionsListProps extends BaseComponentProps {
   position?: React.CSSProperties['position'];
   role?: 'listbox' | 'list' | 'menu';
   ariaLabelledby?: string;
+  ariaDescribedby?: string;
   decreaseTopMargin?: boolean;
 }
 
@@ -62,6 +63,7 @@ const OptionsList = (
     role = 'listbox',
     decreaseTopMargin = false,
     ariaLabelledby,
+    ariaDescribedby,
     ...restProps
   }: OptionsListProps,
   ref: React.Ref<HTMLUListElement>
@@ -109,6 +111,7 @@ const OptionsList = (
       onFocus={() => fireNonCancelableEvent(onFocus)}
       tabIndex={-1}
       aria-labelledby={ariaLabelledby}
+      aria-describedby={ariaDescribedby}
     >
       {open && children}
     </ul>

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -262,6 +262,17 @@ describe('Dropdown states', () => {
       expect(Boolean(dropdown.findByClassName(selectPartsStyles['list-bottom']))).toBe(!isSticky);
     });
 
+    test(`should associate ${statusType} status text as ${
+      isSticky ? 'sticky' : 'non-sticky'
+    } footer to the dropdown element`, () => {
+      const statusText = { [`${statusType}Text`]: `Test ${statusType} text` };
+      const { wrapper } = renderMultiselect(
+        <Multiselect selectedOptions={[]} options={defaultOptions} statusType={statusType as any} {...statusText} />
+      );
+      wrapper.openDropdown();
+      expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription(`Test ${statusType} text`);
+    });
+
     test(`check a11y for ${statusType} and ${isSticky ? 'sticky' : 'non-sticky'} footer`, async () => {
       const statusText = { [`${statusType}Text`]: `Test ${statusType} text` };
       const { container, wrapper } = renderMultiselect(

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -136,6 +136,8 @@ const InternalMultiselect = React.forwardRef(
 
     const multiSelectAriaLabelId = useUniqueId('multiselect-arialabel-');
 
+    const footerId = useUniqueId('footer');
+
     const scrollToIndex = useRef<SelectListProps.SelectListRef>(null);
     const {
       isOpen,
@@ -216,6 +218,7 @@ const InternalMultiselect = React.forwardRef(
       ...getMenuProps(),
       onLoadMore: handleLoadMore,
       ariaLabelledby: joinStrings(multiSelectAriaLabelId, controlId),
+      ariaDescribedby: dropdownStatus.content ? footerId : undefined,
     };
 
     const announcement = useAnnouncement({
@@ -284,12 +287,18 @@ const InternalMultiselect = React.forwardRef(
           trigger={trigger}
           header={filter}
           onMouseDown={handleMouseDown}
-          footer={dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null}
+          footer={
+            dropdownStatus.isSticky ? (
+              <DropdownFooter content={isOpen ? dropdownStatus.content : null} id={footerId} />
+            ) : null
+          }
           expandToViewport={expandToViewport}
         >
           <ListComponent
             listBottom={
-              !dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null
+              !dropdownStatus.isSticky ? (
+                <DropdownFooter content={isOpen ? dropdownStatus.content : null} id={footerId} />
+              ) : null
             }
             menuProps={menuProps}
             getOptionProps={getOptionProps}

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -799,6 +799,45 @@ describe('property filter parts', () => {
     expect(wrapper.findNativeInput().getElement()).toHaveValue('string != ');
   });
 
+  describe('status indicators', () => {
+    test('displays error status', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringStatusType: 'error',
+        filteringErrorText: 'Error text',
+      });
+      wrapper.findNativeInput().focus();
+      wrapper.setInputValue('string');
+      expect(wrapper.findStatusIndicator()!.getElement()).toHaveTextContent('Error text');
+    });
+    test('links error status to dropdown', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringStatusType: 'error',
+        filteringErrorText: 'Error text',
+      });
+      wrapper.findNativeInput().focus();
+      wrapper.setInputValue('string');
+      expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription(`Error text`);
+    });
+    test('displays finished status', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringStatusType: 'finished',
+        filteringFinishedText: 'Finished text',
+      });
+      wrapper.findNativeInput().focus();
+      wrapper.setInputValue('string');
+      expect(wrapper.findStatusIndicator()!.getElement()).toHaveTextContent('Finished text');
+    });
+    test('links finished status to dropdown', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringStatusType: 'finished',
+        filteringFinishedText: 'Finished text',
+      });
+      wrapper.findNativeInput().focus();
+      wrapper.setInputValue('string');
+      expect(wrapper.findDropdown().find('ul')!.getElement()).toHaveAccessibleDescription(`Finished text`);
+    });
+  });
+
   describe('extended operators', () => {
     const indexProperty: FilteringProperty = {
       key: 'index',

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -145,6 +145,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const selfControlId = useUniqueId('input');
     const controlId = rest.controlId ?? selfControlId;
     const listId = useUniqueId('list');
+    const footerId = useUniqueId('footer');
     const highlightedOptionIdSource = useUniqueId();
     const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
@@ -171,7 +172,10 @@ const PropertyFilterAutosuggest = React.forwardRef(
           handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
           hasDropdownStatus={dropdownStatus.content !== null}
           virtualScroll={virtualScroll}
-          listBottom={!dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} /> : null}
+          listBottom={
+            !dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} id={footerId} /> : null
+          }
+          ariaDescribedby={dropdownStatus.content ? footerId : undefined}
         />
       );
     }
@@ -199,7 +203,11 @@ const PropertyFilterAutosuggest = React.forwardRef(
         dropdownContent={content}
         dropdownFooter={
           dropdownStatus.isSticky ? (
-            <DropdownFooter content={dropdownStatus.content} hasItems={autosuggestItemsState.items.length >= 1} />
+            <DropdownFooter
+              content={dropdownStatus.content}
+              hasItems={autosuggestItemsState.items.length >= 1}
+              id={footerId}
+            />
           ) : null
         }
         dropdownWidth={customForm ? DROPDOWN_WIDTH_CUSTOM_FORM : DROPDOWN_WIDTH_OPTIONS_LIST}

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -264,6 +264,17 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
         expect(Boolean(dropdown.findByClassName(selectPartsStyles['list-bottom']))).toBe(!isSticky);
       });
 
+      test(`should link ${statusType} status text in ${
+        isSticky ? 'sticky' : 'non-sticky'
+      } footer to dropdown list`, () => {
+        const statusText = { [`${statusType}Text`]: `Test ${statusType} text` };
+        const { wrapper } = renderSelect({ statusType: statusType as any, ...statusText });
+        wrapper.openDropdown();
+        expect(wrapper.findDropdown({ expandToViewport }).find('ul')!.getElement()).toHaveAccessibleDescription(
+          `Test ${statusType} text`
+        );
+      });
+
       test(`check a11y for ${statusType} and ${isSticky ? 'sticky' : 'non-sticky'} footer`, async () => {
         const statusText = { [`${statusType}Text`]: `Test ${statusType} text` };
         const { container, wrapper } = renderSelect({

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -132,6 +132,7 @@ const InternalSelect = React.forwardRef(
     });
 
     const selectAriaLabelId = useUniqueId('select-arialabel-');
+    const footerId = useUniqueId('footer');
 
     useEffect(() => {
       scrollToIndex.current?.(highlightedIndex);
@@ -165,12 +166,6 @@ const InternalSelect = React.forwardRef(
       />
     );
 
-    const menuProps = {
-      ...getMenuProps(),
-      onLoadMore: handleLoadMore,
-      ariaLabelledby: joinStrings(selectAriaLabelId, controlId),
-    };
-
     const isEmpty = !options || options.length === 0;
     const isNoMatch = filteredOptions && filteredOptions.length === 0;
     const dropdownStatus = useDropdownStatus({
@@ -186,6 +181,13 @@ const InternalSelect = React.forwardRef(
       errorIconAriaLabel,
       onRecoveryClick: handleRecoveryClick,
     });
+
+    const menuProps = {
+      ...getMenuProps(),
+      onLoadMore: handleLoadMore,
+      ariaLabelledby: joinStrings(selectAriaLabelId, controlId),
+      ariaDescribedby: dropdownStatus.content ? footerId : undefined,
+    };
 
     const announcement = useAnnouncement({
       announceSelected,
@@ -222,12 +224,18 @@ const InternalSelect = React.forwardRef(
           trigger={trigger}
           header={filter}
           onMouseDown={handleMouseDown}
-          footer={dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null}
+          footer={
+            dropdownStatus.isSticky ? (
+              <DropdownFooter content={isOpen ? dropdownStatus.content : null} id={footerId} />
+            ) : null
+          }
           expandToViewport={expandToViewport}
         >
           <ListComponent
             listBottom={
-              !dropdownStatus.isSticky ? <DropdownFooter content={isOpen ? dropdownStatus.content : null} /> : null
+              !dropdownStatus.isSticky ? (
+                <DropdownFooter content={isOpen ? dropdownStatus.content : null} id={footerId} />
+              ) : null
             }
             menuProps={menuProps}
             getOptionProps={getOptionProps}


### PR DESCRIPTION
### Description

Associate dropdown footer with the actual list element using `aria-describedby` to give more persistent visibility of the message (it's currently aria-live announced, but then hard to re-discover).

Related links, issue #, if available: AWSUI-20604

### How has this been tested?

New/updated tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
