### PR TITLE
feat: Expose runtime theming API for secondary themes

### DIFF
--- a/pages/theming/integration.page.tsx
+++ b/pages/theming/integration.page.tsx
@@ -34,26 +34,43 @@ const theme: Theme = {
 
 export default function () {
   const [themed, setThemed] = useState<boolean>(false);
+  const [secondaryTheme, setSecondaryTheme] = useState<boolean>(false);
 
   useEffect(() => {
     let reset: () => void = () => {};
     if (themed) {
-      const result = applyTheme({ theme });
+      const result = applyTheme({ theme, baseThemeId: secondaryTheme ? 'visual-refresh' : undefined });
       reset = result.reset;
     }
     return reset;
-  }, [themed]);
+  }, [themed, secondaryTheme]);
   return (
     <div style={{ padding: 15 }}>
       <h1>Theming Integration Page</h1>
       <p>Only for internal theme</p>
-      <button data-testid="change-theme" onClick={() => setThemed(!themed)}>
-        Change Theme
-      </button>
+      <label>
+        <input
+          type="checkbox"
+          data-testid="change-theme"
+          checked={themed}
+          onChange={evt => setThemed(evt.currentTarget.checked)}
+        />
+        <span style={{ marginLeft: 5 }}>Apply theme</span>
+      </label>
+      <label>
+        <input
+          style={{ marginLeft: 15 }}
+          type="checkbox"
+          data-testid="set-secondary"
+          checked={secondaryTheme}
+          onChange={evt => setSecondaryTheme(evt.currentTarget.checked)}
+        />
+        <span style={{ marginLeft: 5 }}>Secondary theme</span>
+      </label>
       <ScreenshotArea>
         <SpaceBetween direction="vertical" size="m">
           <Button variant="primary">Primary Button</Button>
-          <Link>Link</Link>
+          <Link href="#">Link</Link>
           <a data-testid="element-color-text-link-default" style={{ color: Tokens.colorTextLinkDefault }}>
             Anchor using colorTextLinkDefault
           </a>

--- a/pages/theming/styles.scss
+++ b/pages/theming/styles.scss
@@ -11,14 +11,8 @@
 
 .tile {
   color: white;
-  height: 4em;
-  line-height: 4em;
-  margin: 5px;
   flex: 1;
   padding: 4px;
+  margin: 2px;
   text-align: center;
-}
-
-.title {
-  color: black;
 }

--- a/pages/theming/tokens.page.tsx
+++ b/pages/theming/tokens.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Theme, applyTheme } from '~components/theming';
 import * as Tokens from '~design-tokens';
 import { preset } from '~components/internal/generated/theming';
@@ -24,13 +24,39 @@ const tiles: Tile[] = themeableColorTokens
   .map((token: string) => ({ text: token, color: Tokens[token as keyof typeof Tokens] }));
 
 export default function () {
+  const [themed, setThemed] = useState<boolean>(false);
+  const [secondaryTheme, setSecondaryTheme] = useState<boolean>(false);
+
   useEffect(() => {
-    const { reset } = applyTheme({ theme });
+    let reset: () => void = () => {};
+    if (themed) {
+      const result = applyTheme({ theme, baseThemeId: secondaryTheme ? 'visual-refresh' : undefined });
+      reset = result.reset;
+    }
     return reset;
-  }, []);
+  }, [themed, secondaryTheme]);
   return (
     <div style={{ padding: 15, backgroundColor: 'white' }}>
       <h1 className={styles.title}>Color Token Mosaik</h1>
+      <label>
+        <input
+          type="checkbox"
+          data-testid="change-theme"
+          checked={themed}
+          onChange={evt => setThemed(evt.currentTarget.checked)}
+        />
+        <span style={{ marginLeft: 5 }}>Apply theme</span>
+      </label>
+      <label>
+        <input
+          style={{ marginLeft: 15 }}
+          type="checkbox"
+          data-testid="set-secondary"
+          checked={secondaryTheme}
+          onChange={evt => setSecondaryTheme(evt.currentTarget.checked)}
+        />
+        <span style={{ marginLeft: 5 }}>Secondary theme</span>
+      </label>
       <ScreenshotArea>
         <Mosaik tiles={tiles} />
       </ScreenshotArea>

--- a/src/__a11y__/a11y-refresh-dark.test.ts
+++ b/src/__a11y__/a11y-refresh-dark.test.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 import runA11yTests from './run-a11y-tests';
 
-runA11yTests('visual-refresh', 'dark', ['theming/tokens']);
+runA11yTests('visual-refresh', 'dark');

--- a/src/__a11y__/a11y-refresh-light.test.ts
+++ b/src/__a11y__/a11y-refresh-light.test.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 import runA11yTests from './run-a11y-tests';
 
-runA11yTests('visual-refresh', 'light', ['theming/tokens']);
+runA11yTests('visual-refresh', 'light');

--- a/src/__a11y__/run-a11y-tests.ts
+++ b/src/__a11y__/run-a11y-tests.ts
@@ -28,6 +28,7 @@ export default function runA11yTests(theme: Theme, mode: Mode, skip: string[] = 
       const testFunction =
         [
           ...skip,
+          'theming/tokens',
           // this page intentionally has issues to test the helper
           'undefined-texts',
         ].indexOf(inputUrl) === -1

--- a/src/theming/__integ__/index.test.ts
+++ b/src/theming/__integ__/index.test.ts
@@ -13,6 +13,9 @@ class ThemingPage extends BasePageObject {
   toggleDarkMode() {
     return this.click('#mode-toggle');
   }
+  setSecondaryTheme() {
+    return this.click('[data-testid="set-secondary"]');
+  }
   async getCSSProperty(selector: string, property: string) {
     const elem = await this.browser.$(selector);
     return this.browser.getElementCSSValue(elem.elementId, property);
@@ -28,10 +31,13 @@ class ThemingPage extends BasePageObject {
   }
 }
 
-const setupTest = (testFn: (page: ThemingPage) => Promise<void>) => {
+const setupTest = (testFn: (page: ThemingPage) => Promise<void>, vr?: boolean) => {
   return useBrowser(async browser => {
     const page = new ThemingPage(browser);
-    await browser.url('#/light/theming/integration?visualRefresh=false');
+    await browser.url(`#/light/theming/integration${!vr ? '?visualRefresh=false' : ''}`);
+    if (vr) {
+      await page.setSecondaryTheme();
+    }
     await testFn(page);
   });
 };
@@ -45,46 +51,47 @@ const linkTextColor = {
   light: 'rgba(255, 0, 0, 1)',
   dark: 'rgba(255, 165, 0, 1)',
 };
+[true, false].forEach(vr => {
+  test(
+    `applies theme to components${vr ? ' in Visual Refresh' : ''}`,
+    setupTest(async page => {
+      // Using a component is not ideal. Changes to the component will effect this test case.
+      await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.light);
+      await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.light);
 
-test(
-  'applies theme to components',
-  setupTest(async page => {
-    // Using a component is not ideal. Changes to the component will effect this test case.
-    await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.light);
-    await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.light);
+      await page.switchTheme();
 
-    await page.switchTheme();
+      await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.light);
+      await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.light);
 
-    await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.light);
-    await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.light);
+      await page.toggleDarkMode();
 
-    await page.toggleDarkMode();
+      await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.dark);
+      await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.dark);
 
-    await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.dark);
-    await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.dark);
+      await page.switchTheme();
 
-    await page.switchTheme();
+      await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.dark);
+      await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
+    }, vr)
+  );
 
-    await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.dark);
-    await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
-  })
-);
+  test(
+    `applies theme to design tokens${vr ? ' in Visual Refresh' : ''}`,
+    setupTest(async page => {
+      await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.light);
 
-test(
-  'applies theme to design tokens',
-  setupTest(async page => {
-    await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.light);
+      await page.switchTheme();
 
-    await page.switchTheme();
+      await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.light);
 
-    await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.light);
+      await page.toggleDarkMode();
 
-    await page.toggleDarkMode();
+      await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.dark);
 
-    await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.dark);
+      await page.switchTheme();
 
-    await page.switchTheme();
-
-    await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
-  })
-);
+      await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
+    }, vr)
+  );
+});

--- a/src/theming/__integ__/tokens.test.ts
+++ b/src/theming/__integ__/tokens.test.ts
@@ -21,6 +21,12 @@ class ColorTokensMosaikPage extends BasePageObject {
     });
     return map;
   }
+  switchTheme() {
+    return this.click('[data-testid="change-theme"]');
+  }
+  setSecondaryTheme() {
+    return this.click('[data-testid="set-secondary"]');
+  }
   toggleDarkMode() {
     return this.click('#mode-toggle');
   }
@@ -30,17 +36,16 @@ class ColorTokensMosaikPage extends BasePageObject {
   toggleDisabledMotion() {
     return this.click('#disabled-motion-toggle');
   }
-  toggleVisualRefresh() {
-    return this.click('#visual-refresh-toggle');
-  }
 }
 
-const setupTest = (testFn: (page: ColorTokensMosaikPage) => Promise<void>) => {
+const setupTest = (testFn: (page: ColorTokensMosaikPage) => Promise<void>, vr?: boolean) => {
   return useBrowser(async browser => {
     const page = new ColorTokensMosaikPage(browser);
-    await browser.url('#/light/theming/tokens');
-    // The default theme is VR by default, so we toggle once to go to classic mode
-    await page.toggleVisualRefresh();
+    await browser.url(`#/light/theming/tokens${!vr ? '?visualRefresh=false' : ''}`);
+    await page.switchTheme();
+    if (vr) {
+      await page.setSecondaryTheme();
+    }
     await testFn(page);
   });
 };
@@ -87,17 +92,6 @@ test(
     expect(actual).toMatchObject(defaultMap);
   })
 );
-// TODO: re-enable test after implementing theming in visual refresh
-test.skip(
-  'applies theming in visual refresh',
-  setupTest(async page => {
-    await page.toggleVisualRefresh();
-
-    const actual = await page.getCustomPropertyMap();
-
-    expect(actual).toMatchObject(defaultMap);
-  })
-);
 test(
   'applies theming in dark mode',
   setupTest(async page => {
@@ -130,15 +124,21 @@ test(
     expect(actual).toMatchObject(darkMap);
   })
 );
-// TODO: re-enable test after implementing theming in visual refresh
-test.skip(
+test(
+  'applies theming in visual refresh',
+  setupTest(async page => {
+    const actual = await page.getCustomPropertyMap();
+
+    expect(actual).toMatchObject(defaultMap);
+  }, true)
+);
+test(
   'applies theming in dark mode + visual refresh',
   setupTest(async page => {
     await page.toggleDarkMode();
-    await page.toggleVisualRefresh();
 
     const actual = await page.getCustomPropertyMap();
 
     expect(actual).toMatchObject(darkMap);
-  })
+  }, true)
 );

--- a/src/theming/index.ts
+++ b/src/theming/index.ts
@@ -6,15 +6,17 @@ import { preset, TypedOverride } from '../internal/generated/theming';
 export type Theme = TypedOverride;
 export interface ApplyThemeParams {
   theme: Theme;
+  baseThemeId?: string;
 }
 
 export interface ApplyThemeResult {
   reset: () => void;
 }
 
-export function applyTheme({ theme }: ApplyThemeParams): ApplyThemeResult {
+export function applyTheme({ theme, baseThemeId }: ApplyThemeParams): ApplyThemeResult {
   return coreApplyTheme({
     override: theme,
     preset,
+    baseThemeId,
   });
 }


### PR DESCRIPTION
### Description

Expose API introduced in https://github.com/cloudscape-design/theming-core/pull/37

Additional fix pending merge: https://github.com/cloudscape-design/theming-core/pull/39


### How has this been tested?

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ Not yet. Updates to website will be published at a later stage
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ Confirmed
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ No. The feature is fully tested in the theming-core package.
- _Changes are covered with new/existing integration tests?_ Yes

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
