### PR TITLE
fix: Update keys calculation for virtual dropdown lists

### DIFF
--- a/src/autosuggest/__tests__/virtual-scroll.test.tsx
+++ b/src/autosuggest/__tests__/virtual-scroll.test.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import Autosuggest, { AutosuggestProps } from '../../../lib/components/autosuggest';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const defaultProps: AutosuggestProps = {
+  options: [
+    { value: '1', label: 'One' },
+    { value: '2', lang: 'Two' },
+    { value: '3', lang: 'Three' },
+  ],
+  virtualScroll: true,
+  enteredTextLabel: () => 'Use value',
+  value: '',
+  onChange: () => {},
+};
+
+function renderWithWrapper(ui: React.ReactElement) {
+  const { container } = render(ui);
+  return createWrapper(container).findAutosuggest()!;
+}
+
+describe('Virtual scroll support', () => {
+  test('should render plain virtual list', () => {
+    const wrapper = renderWithWrapper(<Autosuggest {...defaultProps} />);
+    wrapper.findNativeInput().focus();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(3);
+  });
+
+  test('should render a subset of items in virtual list', () => {
+    const wrapper = renderWithWrapper(
+      <Autosuggest
+        {...defaultProps}
+        options={Array.from({ length: 100 }, (_, index) => ({ value: `Option ${index}` }))}
+      />
+    );
+    wrapper.findNativeInput().focus();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(6);
+  });
+
+  test('should render virtual list with groups', () => {
+    const wrapper = renderWithWrapper(
+      <Autosuggest
+        {...defaultProps}
+        options={[
+          { label: 'Group 1', options: [{ value: '1' }, { value: '2' }] },
+          { label: 'Group 2', options: [{ value: '3' }] },
+        ]}
+      />
+    );
+    wrapper.findNativeInput().focus();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(3);
+    expect(wrapper.findDropdown().findOptionInGroup(1, 1)).toBeTruthy();
+    expect(wrapper.findDropdown().findOptionInGroup(2, 1)).toBeTruthy();
+  });
+
+  test('should select an option in virtual list', () => {
+    const onChange = jest.fn();
+    const wrapper = renderWithWrapper(<Autosuggest {...defaultProps} onChange={event => onChange(event.detail)} />);
+    wrapper.findNativeInput().focus();
+    wrapper.selectSuggestionByValue('2');
+    expect(onChange).toHaveBeenCalledWith({ value: '2' });
+  });
+});

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -4,7 +4,9 @@ import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'reac
 import { useVirtual } from 'react-virtual';
 
 import OptionsList from '../internal/components/options-list';
+import { optionKeyExtractor } from '../internal/components/option/utils/key-extractor';
 import { useContainerQuery } from '../internal/hooks/container-queries';
+import { useStableEventHandler } from '../internal/hooks/use-stable-event-handler';
 
 import AutosuggestOption from './autosuggest-option';
 import { getOptionProps, ListProps } from './plain-list';
@@ -28,6 +30,7 @@ const VirtualList = ({
   const rowVirtualizer = useVirtual({
     size: autosuggestItemsState.items.length,
     parentRef: scrollRef,
+    keyExtractor: useStableEventHandler(index => optionKeyExtractor(autosuggestItemsState.items[index], index)),
     // estimateSize is a dependency of measurements memo. We update it to force full recalculation
     // when the height of any option could have changed:
     // 1: because the component got resized (width property got updated)

--- a/src/internal/components/option/utils/key-extractor.ts
+++ b/src/internal/components/option/utils/key-extractor.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DropdownOption } from '../interfaces';
+
+export function optionKeyExtractor(option: DropdownOption | undefined, index: number) {
+  if (option && 'value' in option.option && option.option.value) {
+    // prepend with type to have unique ids for "use-entered" and normal options
+    return `${option.type}_${option.option.value}`;
+  }
+  // fallback to index if value does not exist
+  return index;
+}

--- a/src/select/__tests__/virtual-scroll.test.tsx
+++ b/src/select/__tests__/virtual-scroll.test.tsx
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import Select, { SelectProps } from '../../../lib/components/select';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+const defaultProps: SelectProps = {
+  options: [
+    { value: '1', label: 'One' },
+    { value: '2', lang: 'Two' },
+    { value: '3', lang: 'Three' },
+  ],
+  virtualScroll: true,
+  selectedOption: null,
+  onChange: () => {},
+};
+
+function renderWithWrapper(ui: React.ReactElement) {
+  const { container } = render(ui);
+  return createWrapper(container).findSelect()!;
+}
+
+describe('Virtual scroll support', () => {
+  test('should render plain virtual list', () => {
+    const wrapper = renderWithWrapper(<Select {...defaultProps} />);
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(3);
+  });
+
+  test('should render a subset of items in virtual list', () => {
+    const wrapper = renderWithWrapper(
+      <Select {...defaultProps} options={Array.from({ length: 100 }, (_, index) => ({ value: `Option ${index}` }))} />
+    );
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(11);
+  });
+
+  test('should render virtual list with groups', () => {
+    const wrapper = renderWithWrapper(
+      <Select
+        {...defaultProps}
+        options={[
+          { label: 'Group 1', options: [{ value: '1' }, { value: '2' }] },
+          { label: 'Group 2', options: [{ value: '3' }] },
+        ]}
+      />
+    );
+    wrapper.openDropdown();
+    expect(wrapper.findDropdown().findOptions()).toHaveLength(3);
+    expect(wrapper.findDropdown().findOptionInGroup(1, 1)).toBeTruthy();
+    expect(wrapper.findDropdown().findOptionInGroup(2, 1)).toBeTruthy();
+  });
+
+  test('should select an option in virtual list', () => {
+    const onChange = jest.fn();
+    const wrapper = renderWithWrapper(<Select {...defaultProps} onChange={event => onChange(event.detail)} />);
+    wrapper.openDropdown();
+    wrapper.selectOptionByValue('2');
+    expect(onChange).toHaveBeenCalledWith({ selectedOption: defaultProps.options![1] });
+  });
+});

--- a/src/select/parts/virtual-list.tsx
+++ b/src/select/parts/virtual-list.tsx
@@ -3,10 +3,12 @@
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import OptionsList from '../../internal/components/options-list';
+import { optionKeyExtractor } from '../../internal/components/option/utils/key-extractor';
 import { renderOptions } from '../utils/render-options';
 import { useVirtual } from 'react-virtual';
 import { SelectListProps } from './plain-list';
 import { useContainerQuery } from '../../internal/hooks/container-queries';
+import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
 
 import styles from './styles.css.js';
 
@@ -38,6 +40,7 @@ const VirtualListOpen = forwardRef(
     const { virtualItems, totalSize, scrollToIndex } = useVirtual({
       size: filteredOptions.length,
       parentRef: menuRefObject,
+      keyExtractor: useStableEventHandler(index => optionKeyExtractor(filteredOptions[index], index)),
       // estimateSize is a dependency of measurements memo. We update it to force full recalculation
       // when the height of any option could have changed:
       // 1: because the component got resized (width property got updated)


### PR DESCRIPTION
### Description

Add this property according to [react-virtual docs](https://react-virtual-v2.tanstack.com/docs/api#options)

> keyExtractor: Function(index) => String | Integer
This function should be passed whenever dynamic measurement rendering is enabled and the size or order of items in the list changes.

We have variable size of the items, so it is our case.

Related links, issue #, if available: AWSUI-20777

### How has this been tested?

* Pushed to my dev pipeline for cross-browser tests
* Added unit tests on virtual scroll mode in general, because we missed unit test coverage on this feature completely

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
