### PR TITLE
fix: Fix app layout rendering when multiple drawers are open on mobile

### DIFF
--- a/pages/app-layout/all-panels-open.page.tsx
+++ b/pages/app-layout/all-panels-open.page.tsx
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Containers, Navigation, Tools, Breadcrumbs } from './utils/content-blocks';
+import labels from './utils/labels';
+
+export default function () {
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        breadcrumbs={<Breadcrumbs />}
+        navigationOpen={true}
+        navigation={<Navigation />}
+        toolsOpen={true}
+        tools={<Tools>On mobile, tools panel displayed above navigation</Tools>}
+        content={
+          <>
+            <div style={{ marginBottom: '1rem' }}>
+              <Header variant="h1" description="Basic demo">
+                Demo page
+              </Header>
+            </div>
+            <Containers />
+          </>
+        }
+      />
+    </ScreenshotArea>
+  );
+}

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -1,0 +1,144 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  AppLayout,
+  ContentLayout,
+  Header,
+  HelpPanel,
+  NonCancelableCustomEvent,
+  SpaceBetween,
+  SplitPanel,
+  Toggle,
+} from '~components';
+import appLayoutLabels from './utils/labels';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+
+export default function WithDrawers() {
+  const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
+  const [hasDrawers, setHasDrawers] = useState(true);
+  const [hasTools, setHasTools] = useState(false);
+  const [isToolsOpen, setIsToolsOpen] = useState(false);
+
+  const [widths, setWidths] = useState<{ [id: string]: number }>({
+    security: 500,
+    'pro-help': 280,
+  });
+
+  const drawers = !hasDrawers
+    ? null
+    : {
+        drawers: {
+          ariaLabel: 'Drawers',
+          activeDrawerId: activeDrawerId,
+          onResize: (event: NonCancelableCustomEvent<{ size: number; id: string }>) => {
+            const obj = widths;
+            obj[event.detail.id] = event.detail.size;
+            setWidths(obj);
+            console.log(widths.security);
+          },
+          items: [
+            {
+              ariaLabels: {
+                closeButton: 'Security close button',
+                content: 'Security drawer content',
+                triggerButton: 'Security trigger button',
+                resizeHandle: 'Security resize handle',
+              },
+              content: <Security />,
+              id: 'security',
+              resizable: true,
+              size: widths.security,
+
+              trigger: {
+                iconName: 'security',
+              },
+            },
+            {
+              ariaLabels: {
+                closeButton: 'ProHelp close button',
+                content: 'ProHelp drawer content',
+                triggerButton: 'ProHelp trigger button',
+                resizeHandle: 'ProHelp resize handle',
+              },
+              content: <ProHelp />,
+              id: 'pro-help',
+              trigger: {
+                iconName: 'contact',
+              },
+            },
+          ],
+          onChange: (event: NonCancelableCustomEvent<string>) => {
+            setActiveDrawerId(event.detail);
+          },
+        },
+      };
+
+  return (
+    <AppLayout
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
+                Testing Custom Drawers!
+              </Header>
+
+              <SpaceBetween size="xs">
+                <Toggle checked={hasTools} onChange={({ detail }) => setHasTools(detail.checked)}>
+                  Use Tools
+                </Toggle>
+
+                <Toggle checked={hasDrawers} onChange={({ detail }) => setHasDrawers(detail.checked)}>
+                  Use Drawers
+                </Toggle>
+              </SpaceBetween>
+            </SpaceBetween>
+          }
+        >
+          <Containers />
+        </ContentLayout>
+      }
+      splitPanel={
+        <SplitPanel
+          header="Split panel header"
+          i18nStrings={{
+            preferencesTitle: 'Preferences',
+            preferencesPositionLabel: 'Split panel position',
+            preferencesPositionDescription: 'Choose the default split panel position for the service.',
+            preferencesPositionSide: 'Side',
+            preferencesPositionBottom: 'Bottom',
+            preferencesConfirm: 'Confirm',
+            preferencesCancel: 'Cancel',
+            closeButtonAriaLabel: 'Close panel',
+            openButtonAriaLabel: 'Open panel',
+            resizeHandleAriaLabel: 'Slider',
+          }}
+        >
+          This is the Split Panel!
+        </SplitPanel>
+      }
+      onToolsChange={event => {
+        setIsToolsOpen(event.detail.open);
+      }}
+      tools={<Info />}
+      toolsOpen={isToolsOpen}
+      toolsHide={!hasTools}
+      {...drawers}
+    />
+  );
+}
+
+function Info() {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+}
+
+function Security() {
+  return <HelpPanel header={<h2>Security</h2>}>Everyone needs it.</HelpPanel>;
+}
+
+function ProHelp() {
+  return <HelpPanel header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</HelpPanel>;
+}

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -48,7 +48,7 @@ export default function Navigation() {
     }
   };
 
-  const isUnfocusable = hasDrawerViewportOverlay && isToolsOpen && !toolsHide;
+  const isUnfocusable = hasDrawerViewportOverlay && (!isNavigationOpen || (isToolsOpen && !toolsHide));
 
   return (
     <Transition in={isNavigationOpen}>

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -32,11 +32,9 @@ export default function Tools({ children }: ToolsProps) {
     hasDefaultToolsWidth,
     hasDrawerViewportOverlay,
     isMobile,
-    isNavigationOpen,
     isSplitPanelOpen,
     isToolsOpen,
     loseToolsFocus,
-    navigationHide,
     splitPanelDisplayed,
     splitPanelPosition,
     splitPanelRefs,
@@ -50,7 +48,7 @@ export default function Tools({ children }: ToolsProps) {
   const hasSplitPanel = getSplitPanelStatus(splitPanelDisplayed, splitPanelPosition);
   const hasToolsForm = getToolsFormStatus(hasSplitPanel, isMobile, isSplitPanelOpen, isToolsOpen, toolsHide);
   const hasToolsFormPersistence = getToolsFormPersistence(hasSplitPanel, isSplitPanelOpen, isToolsOpen, toolsHide);
-  const isUnfocusable = hasDrawerViewportOverlay && isNavigationOpen && !navigationHide;
+  const isUnfocusable = hasDrawerViewportOverlay && !isToolsOpen;
 
   /**
    * If the drawers property is defined the Tools and SplitPanel will be mounted and rendered


### PR DESCRIPTION
### Description

When both `navigationOpen` and `toolsOpen` are `true` same time, nothing is displayed.

This PR fixes it, making the tools taking precedence, same way as it works in Classic version

Related links, issue #, if available: AWSUI-20930

### How has this been tested?

* Added extra unit tests
* Added dev page for manual testing of the new drawers feature

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
