### PR TITLE
chore: Update link API docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7379,9 +7379,10 @@ Object {
   "events": Array [
     Object {
       "cancelable": true,
-      "description": "Called when a link is clicked without any modifier keys.
-If you want to implement client-side routing yourself,
-use this event and prevent default browser navigation (by calling \`preventDefault\`).
+      "description": "Called when a link is clicked without any modifier keys. If the link has no \`href\` provided, it will be called on
+all clicks.
+If you want to implement client-side routing yourself, use this event and prevent default browser navigation
+(by calling \`preventDefault\`).
 ",
       "detailInlineType": Object {
         "name": "LinkProps.FollowDetail",

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -72,10 +72,11 @@ export interface LinkProps extends BaseComponentProps {
   externalIconAriaLabel?: string;
 
   /**
-   * Called when a link is clicked without any modifier keys.
+   * Called when a link is clicked without any modifier keys. If the link has no `href` provided, it will be called on
+   * all clicks.
    *
-   * If you want to implement client-side routing yourself,
-   * use this event and prevent default browser navigation (by calling `preventDefault`).
+   * If you want to implement client-side routing yourself, use this event and prevent default browser navigation
+   * (by calling `preventDefault`).
    */
   onFollow?: CancelableEventHandler<LinkProps.FollowDetail>;
 


### PR DESCRIPTION
### Description

When link component used without `href` prop, `onFollow` fires on all keys even with modifiers. 

Add this behavior to the documentation

Related links, issue #, if available: n/a

### How has this been tested?

Doc only change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
