### PR TITLE
chore: Improve performance of table inline editing

### DIFF
--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -272,6 +272,7 @@ export default function () {
 
   return (
     <ScreenshotArea disableAnimations={true}>
+      <input data-testid="focus" aria-label="focus input" />
       <Demo setModalVisible={setModalVisible} ref={tableRef} />
       <Modal
         visible={modalVisible}

--- a/pages/table/performance.page.tsx
+++ b/pages/table/performance.page.tsx
@@ -51,6 +51,7 @@ export default function App() {
   const [isActive, setIsActive] = useState(false);
   return (
     <ScreenshotArea>
+      <h1>Table performance test</h1>
       {isActive ? (
         <Table
           columnDefinitions={columnDefinitions}

--- a/pages/table/performance.page.tsx
+++ b/pages/table/performance.page.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Button from '~components/button';
+import Box from '~components/box';
+import Header from '~components/header';
+import Input from '~components/input';
+import Table, { TableProps } from '~components/table';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const COLUMN_COUNT = 100;
+
+interface Item {
+  name: string;
+  alt?: string;
+  description?: string;
+  size?: string;
+  type?: string;
+}
+
+const ITEM_COUNT = 100;
+
+export const items: Array<Item> = [...new Array(ITEM_COUNT)].map((_, i) => ({
+  name: 'Item' + i,
+  alt: 'First',
+  description: 'This is the first item' + i,
+  type: '1A',
+  size: 'Small',
+}));
+
+const columnDefinitions: Array<TableProps.ColumnDefinition<Item>> = [...new Array(COLUMN_COUNT)].map((_, i) => ({
+  id: 'variable' + i,
+  header: 'Variable name' + i,
+  minWidth: 176,
+  cell: item => {
+    return item.name;
+  },
+  editConfig: {
+    ariaLabel: 'Name',
+    editIconAriaLabel: 'editable',
+    errorIconAriaLabel: 'Name Error',
+    editingCell: (item, { currentValue, setValue }) => {
+      return (
+        <Input autoFocus={true} value={currentValue ?? item.name} onChange={event => setValue(event.detail.value)} />
+      );
+    },
+  },
+}));
+
+export default function App() {
+  const [isActive, setIsActive] = useState(false);
+  return (
+    <ScreenshotArea>
+      {isActive ? (
+        <Table
+          columnDefinitions={columnDefinitions}
+          items={items}
+          loadingText="Loading resources"
+          submitEdit={async () => {
+            await new Promise(e => setTimeout(e, 1e3));
+          }}
+          resizableColumns={true}
+          empty={
+            <Box textAlign="center" color="inherit">
+              <b>No resources</b>
+              <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                No resources to display.
+              </Box>
+              <Button>Create resource</Button>
+            </Box>
+          }
+          header={<Header>Table with inline editing</Header>}
+        />
+      ) : (
+        <Button
+          onClick={() => {
+            setIsActive(true);
+            console.time('render');
+            requestAnimationFrame(() => console.timeEnd('render'));
+          }}
+        >
+          Render Table
+        </Button>
+      )}
+    </ScreenshotArea>
+  );
+}

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import range from 'lodash/range';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
@@ -31,6 +32,7 @@ const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
     await page.setWindowSize({ width: 1200, height: 800 });
     await browser.url('#/light/table/editable');
     await testFn(page);
+    await browser.saveScreenshot('table.png');
   });
 };
 
@@ -58,6 +60,46 @@ test(
     await page.click(cellRoot$);
     await page.click(cellSaveButton.toSelector());
     await expect(page.isFocused(cellEditButton$)).resolves.toBe(true);
+  })
+);
+
+test(
+  'can start editing with mouse',
+  setupTest(async page => {
+    await page.click(cellEditButton$);
+    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
+  })
+);
+
+test(
+  'can start editing with Enter key',
+  setupTest(async page => {
+    // Focus element before the table
+    await page.click('[data-testid="focus"]');
+
+    // Tab to the first editable column
+    await page.keys(range(11).map(() => 'Tab'));
+    await expect(page.isFocused(tableWrapper.findEditCellButton(1, 2).toSelector())).resolves.toBe(true);
+
+    // Activate with Enter
+    await page.keys(['Enter']);
+    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
+  })
+);
+
+test(
+  'can start editing with Space key',
+  setupTest(async page => {
+    // Focus element before the table
+    await page.click('[data-testid="focus"]');
+
+    // Tab to the first editable column
+    await page.keys(range(11).map(() => 'Tab'));
+    await expect(page.isFocused(tableWrapper.findEditCellButton(1, 2).toSelector())).resolves.toBe(true);
+
+    // Activate with Space
+    await page.keys(['Space']);
+    await expect(page.isDisplayed(cellSaveButton.toSelector())).resolves.toBe(true);
   })
 );
 

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -32,7 +32,6 @@ const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
     await page.setWindowSize({ width: 1200, height: 800 });
     await browser.url('#/light/table/editable');
     await testFn(page);
-    await browser.saveScreenshot('table.png');
   });
 };
 

--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -8,21 +8,20 @@ const DOMAIN_ERROR = 'Must be a valid domain name';
 const tableWrapper = createWrapper().findTable()!;
 
 // $ = selector
-const EDIT_BTN$ = 'button:first-child:last-child';
 
 const bodyCell = tableWrapper.findBodyCell(2, 2)!;
 const cellRoot$ = bodyCell.toSelector();
 const cellInputField$ = bodyCell.findFormField().find('input').toSelector();
-const cellEditButton$ = bodyCell.find(EDIT_BTN$).toSelector();
+const cellEditButton$ = tableWrapper.findEditCellButton(2, 2).toSelector();
 const cellSaveButton = tableWrapper.findEditingCellSaveButton();
 
 // for arrow key navigation
 const mainCell = tableWrapper.findBodyCell(4, 5);
 const mainCell$ = mainCell.toSelector();
-const leftCell$ = tableWrapper.findBodyCell(4, 4).find(EDIT_BTN$).toSelector();
-const rightCell$ = tableWrapper.findBodyCell(4, 6).find(EDIT_BTN$).toSelector();
-const cellAbove$ = tableWrapper.findBodyCell(3, 5).find(EDIT_BTN$).toSelector();
-const cellBelow$ = tableWrapper.findBodyCell(5, 5).find(EDIT_BTN$).toSelector();
+const leftCell$ = tableWrapper.findEditCellButton(4, 4).toSelector();
+const rightCell$ = tableWrapper.findEditCellButton(4, 6).toSelector();
+const cellAbove$ = tableWrapper.findEditCellButton(3, 5).toSelector();
+const cellBelow$ = tableWrapper.findEditCellButton(5, 5).toSelector();
 
 const bodyCellError = bodyCell.findFormField().findError().toSelector();
 

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -145,6 +145,38 @@ test('should render table header with icons to indicate editable columns', () =>
   });
 });
 
+test('should show edit icon on hover', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+
+  // No icon by default
+  const editButton = wrapper.findEditCellButton(1, 1);
+  expect(editButton?.findIcon()).toBeNull();
+
+  // Show icon on hover
+  fireEvent.mouseEnter(editButton!.getElement());
+  expect(editButton?.findIcon()).not.toBeNull();
+
+  // Remove icon when mouse moves away
+  fireEvent.mouseLeave(editButton!.getElement());
+  expect(editButton?.findIcon()).toBeNull();
+});
+
+test('should show edit icon on focus', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
+
+  // No icon by default
+  const editButton = wrapper.findEditCellButton(1, 1);
+  expect(editButton?.findIcon()).toBeNull();
+
+  // Show icon on focus
+  editButton?.focus();
+  expect(editButton?.findIcon()).not.toBeNull();
+
+  // Remove icon on blur
+  editButton?.blur();
+  expect(editButton?.findIcon()).toBeNull();
+});
+
 test('should cancel edit using ref imperative method', async () => {
   const ref = React.createRef<any>();
   const { wrapper } = renderTable(

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -158,8 +158,7 @@ test('should cancel edit using ref imperative method', async () => {
     />
   );
 
-  const bodyCell = wrapper.findBodyCell(2, 2)!;
-  const button = bodyCell.findButton(`[type="button"]`)!;
+  const button = wrapper.findEditCellButton(2, 2)!;
 
   fireEvent.click(button.getElement());
   act(() => {
@@ -316,7 +315,7 @@ test('should submit edits successfully', async () => {
   );
 
   const bodyCell = wrapper.find('td');
-  const button = bodyCell?.findButton(`[aria-label="activate-edit"]`);
+  const button = wrapper.findEditCellButton(1, 1);
 
   // activate edit
   fireEvent.click(button!.getElement()!);

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
 import styles from './styles.css.js';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
 import Icon from '../../icon/internal';
 import { TableProps } from '../interfaces';
@@ -46,6 +46,11 @@ function TableCellEditable<ItemType>({
     }
   }, [isEditing]);
 
+  // To improve the initial page render performance we only show the edit icon when necessary.
+  const [hasHover, setHasHover] = useState(false);
+  const [hasFocus, setHasFocus] = useState(false);
+  const showIcon = hasHover || hasFocus;
+
   return (
     <TableTdElement
       {...rest}
@@ -57,6 +62,8 @@ function TableCellEditable<ItemType>({
         isVisualRefresh && styles['is-visual-refresh']
       )}
       onClick={!isEditing ? onEditStart : undefined}
+      onMouseEnter={() => setHasHover(true)}
+      onMouseLeave={() => setHasHover(false)}
     >
       {isEditing ? (
         <InlineEditor
@@ -75,8 +82,10 @@ function TableCellEditable<ItemType>({
             role="button"
             tabIndex={0}
             ref={editActivateRef}
+            onFocus={() => setHasFocus(true)}
+            onBlur={() => setHasFocus(false)}
           >
-            <Icon name="edit" />
+            {showIcon && <Icon name="edit" />}
           </span>
         </>
       )}

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -4,8 +4,7 @@ import clsx from 'clsx';
 import styles from './styles.css.js';
 import React, { useRef } from 'react';
 import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
-import Button from '../../button/internal';
-import { ButtonProps } from '../../button/interfaces';
+import Icon from '../../icon/internal';
 import { TableProps } from '../interfaces';
 import { TableTdElement, TableTdElementProps } from './td-element';
 import { InlineEditor } from './inline-editor';
@@ -36,7 +35,7 @@ function TableCellEditable<ItemType>({
   isVisualRefresh,
   ...rest
 }: TableBodyCellProps<ItemType>) {
-  const editActivateRef = useRef<ButtonProps.Ref>(null);
+  const editActivateRef = useRef<HTMLSpanElement>(null);
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
   };
@@ -70,15 +69,14 @@ function TableCellEditable<ItemType>({
       ) : (
         <>
           {column.cell(item)}
-          <span className={styles['body-cell-editor']}>
-            <Button
-              __forcedFocusState="none"
-              __internalRootRef={editActivateRef}
-              ariaLabel={ariaLabels?.activateEditLabel?.(column)}
-              formAction="none"
-              iconName="edit"
-              variant="inline-icon"
-            />
+          <span
+            className={styles['body-cell-editor']}
+            aria-label={ariaLabels?.activateEditLabel?.(column)}
+            role="button"
+            tabIndex={0}
+            ref={editActivateRef}
+          >
+            <Icon name="edit" />
           </span>
         </>
       )}

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -79,7 +79,6 @@ function TableCellEditable<ItemType>({
           <button
             className={styles['body-cell-editor']}
             aria-label={ariaLabels?.activateEditLabel?.(column)}
-            role="button"
             ref={editActivateRef}
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -35,7 +35,7 @@ function TableCellEditable<ItemType>({
   isVisualRefresh,
   ...rest
 }: TableBodyCellProps<ItemType>) {
-  const editActivateRef = useRef<HTMLSpanElement>(null);
+  const editActivateRef = useRef<HTMLButtonElement>(null);
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
   };
@@ -76,17 +76,16 @@ function TableCellEditable<ItemType>({
       ) : (
         <>
           {column.cell(item)}
-          <span
+          <button
             className={styles['body-cell-editor']}
             aria-label={ariaLabels?.activateEditLabel?.(column)}
             role="button"
-            tabIndex={0}
             ref={editActivateRef}
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}
           >
             {showIcon && <Icon name="edit" />}
-          </span>
+          </button>
         </>
       )}
     </TableTdElement>

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -145,7 +145,23 @@ $border-placeholder: awsui.$border-item-width solid transparent;
     align-items: center;
     justify-content: flex-end;
 
-    padding-right: awsui.$space-xs;
+    // Reset some native <button> styles
+    cursor: pointer;
+    outline: 0;
+    background: 0;
+    border: 0;
+    padding: 0;
+
+    // Additional xxs padding that would normally come from the Inline Icon Button
+    padding-right: calc(#{awsui.$space-xs} + #{awsui.$space-xxs});
+    color: awsui.$color-text-button-normal-default;
+
+    &:hover {
+      color: awsui.$color-text-button-normal-hover;
+    }
+    &:active {
+      color: awsui.$color-text-button-normal-active;
+    }
 
     &-form {
       margin: calc(-1 * #{awsui.$space-xs}) calc(-1.5 * #{awsui.$space-xs});
@@ -189,17 +205,6 @@ $border-placeholder: awsui.$border-item-width solid transparent;
       }
       & > .body-cell-editor {
         opacity: 0;
-        outline: 0;
-        background: 0;
-        border: 0;
-        color: awsui.$color-text-button-normal-default;
-
-        &:hover {
-          color: awsui.$color-text-button-normal-hover;
-        }
-        &:active {
-          color: awsui.$color-text-button-normal-active;
-        }
       }
       &:hover {
         position: relative;
@@ -213,7 +218,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
           right: 0;
         }
         & > .body-cell-editor {
-          padding-right: calc(#{awsui.$space-xs} - (2 * #{awsui.$border-divider-list-width}));
+          padding-right: calc(#{awsui.$space-xs} + #{awsui.$space-xxs} - (2 * #{awsui.$border-divider-list-width}));
         }
         &.body-cell-last-row.body-cell-selected,
         &.body-cell-next-selected {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -189,6 +189,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
       }
       & > .body-cell-editor {
         opacity: 0;
+        outline: 0;
       }
       &:hover {
         position: relative;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -190,6 +190,14 @@ $border-placeholder: awsui.$border-item-width solid transparent;
       & > .body-cell-editor {
         opacity: 0;
         outline: 0;
+        color: awsui.$color-text-button-normal-default;
+
+        &:hover {
+          color: awsui.$color-text-button-normal-hover;
+        }
+        &:active {
+          color: awsui.$color-text-button-normal-active;
+        }
       }
       &:hover {
         position: relative;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -190,6 +190,8 @@ $border-placeholder: awsui.$border-item-width solid transparent;
       & > .body-cell-editor {
         opacity: 0;
         outline: 0;
+        background: 0;
+        border: 0;
         color: awsui.$color-text-button-normal-default;
 
         &:hover {

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -15,6 +15,8 @@ export interface TableTdElementProps {
   isPrevSelected: boolean;
   nativeAttributes?: Omit<React.HTMLAttributes<HTMLTableCellElement>, 'style' | 'className' | 'onClick'>;
   onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   children?: React.ReactNode;
   isEvenRow?: boolean;
   stripedRows?: boolean;
@@ -37,6 +39,8 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       isPrevSelected,
       nativeAttributes,
       onClick,
+      onMouseEnter,
+      onMouseLeave,
       isEvenRow,
       stripedRows,
       isVisualRefresh,
@@ -64,6 +68,8 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
           hasFooter && styles['has-footer']
         )}
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         ref={ref}
         {...nativeAttributes}
       >

--- a/src/table/use-table-focus-navigation.ts
+++ b/src/table/use-table-focus-navigation.ts
@@ -49,7 +49,7 @@ function useTableFocusNavigation<T extends { editConfig?: TableProps.EditConfig<
       if (tableRoot?.current) {
         iterateTableCells(tableRoot.current, (cell, rIndex, cIndex) => {
           if (rIndex === rowIndex && cIndex === columnIndex) {
-            const editButton = cell.querySelector('button:last-child') as HTMLButtonElement | null;
+            const editButton = cell.querySelector('[role=button]:last-child') as HTMLButtonElement | null;
 
             if (editButton) {
               editButton.focus?.();

--- a/src/table/use-table-focus-navigation.ts
+++ b/src/table/use-table-focus-navigation.ts
@@ -49,7 +49,7 @@ function useTableFocusNavigation<T extends { editConfig?: TableProps.EditConfig<
       if (tableRoot?.current) {
         iterateTableCells(tableRoot.current, (cell, rIndex, cIndex) => {
           if (rIndex === rowIndex && cIndex === columnIndex) {
-            const editButton = cell.querySelector('[role=button]:last-child') as HTMLButtonElement | null;
+            const editButton = cell.querySelector('button:last-child') as HTMLButtonElement | null;
 
             if (editButton) {
               editButton.focus?.();

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -134,6 +134,16 @@ export default class TableWrapper extends ComponentWrapper {
     return this.findComponent(`.${styles['tools-pagination']}`, PaginationWrapper);
   }
 
+  /**
+   * Returns the button that activates inline editing for a table cell based on given row and column indices.
+   *
+   * @param rowIndex 1-based index of the row of the cell to select.
+   * @param columnIndex 1-based index of the column of the cell to select.
+   */
+  findEditCellButton(rowIndex: number, columnIndex: number): ElementWrapper | null {
+    return this.findBodyCell(rowIndex, columnIndex)?.findByClassName(bodyCellStyles['body-cell-editor']) ?? null;
+  }
+
   findEditingCell(): ElementWrapper | null {
     return this.findNativeTable().findByClassName(bodyCellStyles['body-cell-edit-active']);
   }


### PR DESCRIPTION
### Description
When a table has editable cells, it renders a few more elements in every cell to make them clickable and editable. These additional elements can cause performance regressions when compared to a table that doesn't have inline editing enabled.

This change attempts to improve the performance of editable tables by removing the amount and complexity of additional elements:

* The `<Button>` is replaced with a `<button>`
* The edit icon is rendered conditionally when the cell is hovered or focus

Related links, issue #, if available: Dry run build 6431111657.

### How has this been tested?

This table contains some explorations to improve the rendering performance of tables with inline editing.

The measurements use a Cloudscape table with 100 columns and 100 rows, with all cells being editable. First time render performance is measured in production mode and React 16.14. The browser is Chrome on an M1 Pro MacBook.

The time to render is measured by measuring the time between the requested table render and the next `requestAnimationFrame`.

| Theme | Edit button | Edit icon | Time to render (ms) | Compared to current | Compared to no editing | Notes |
| - | - | - | - | - | - | - |
| VR | `<InternalButton>` | `<InternalButton>` | 1646.4 | 0.00% | 275.89% | Current implementation |
| VR | `<span role=button>` | `<InternalIcon>` | 1358 | -17.52% | 210.05% |  |
| VR | `<span role=button>` | `<SimpleIcon>` | 1254.66667 | -23.79% | 186.45% | SimpleIcon is a "lite" version of the Icon component |
| VR | `<span role=button>` | inline svg icon | 1255.8 | -23.72% | 186.71% |  |
| VR | `<span>` | ✏️ | 860.57143 | -47.73% | 96.48% |  just an experiment |
| VR | `<span role=button>` | conditional `<InternalIcon>` | 765.8 | -53.49% | 74.84% | Only show icon on hover/focus. **Proposed solution.** | 
| Classic | No inline editing |  | 451.5 | -72.58% | 0.00% |  | Reference table with no inline editing |
| VR | No inline editing |  | 438 | -73.40% | 0.00% |  | 



<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
