### PR TITLE
fix: Provide unique remove button label for each row in attribute editor and tag editor

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -394,8 +394,10 @@ describe('Attribute Editor', () => {
   });
 
   describe('a11y', () => {
-    test('row has role group and aria-labelledby referring to first control label and content', () => {
-      const wrapper = renderAttributeEditor({
+    let wrapper: AttributeEditorWrapper;
+
+    beforeEach(() => {
+      wrapper = renderAttributeEditor({
         ...defaultProps,
         definition: [
           {
@@ -410,6 +412,9 @@ describe('Attribute Editor', () => {
           },
         ],
       });
+    });
+
+    test('row has role group and aria-labelledby referring to first control label and content', () => {
       const [labelId, inputId] = wrapper
         .findRow(1)!
         .find('[role="group"]')!
@@ -421,6 +426,20 @@ describe('Attribute Editor', () => {
         ' ' +
         wrapper.getElement().querySelector(`#${inputId}`)!.getAttribute('value');
       expect(label).toBe('Key label k1');
+    });
+
+    test('remove button has an aria-labelledby pointing to the first control', () => {
+      const [labelId, inputId] = wrapper
+        .findRow(1)!
+        .findRemoveButton()!
+        .getElement()!
+        .getAttribute('aria-labelledby')!
+        .split(' ');
+
+      expect(document.getElementById(labelId)).toHaveTextContent('Remove');
+      expect(wrapper.findRow(1)!.findField(1)!.findControl()!.findInput()!.findNativeInput()!.getElement().id).toBe(
+        inputId
+      );
     });
   });
 });

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -57,6 +57,7 @@ export const Row = React.memo(
     }, [onRemoveButtonClick, index]);
 
     const firstControlId = useUniqueId('first-control-id-');
+    const removeButtonTextId = useUniqueId('remove-button-text-id-');
 
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>
@@ -100,8 +101,9 @@ export const Row = React.memo(
                     removeButtonRefs[index] = ref ?? undefined;
                   }}
                   onClick={handleRemoveClick}
+                  __nativeAttributes={{ 'aria-labelledby': `${removeButtonTextId} ${firstControlId}` }}
                 >
-                  {removeButtonText}
+                  <span id={removeButtonTextId}>{removeButtonText}</span>
                 </InternalButton>
               </ButtonContainer>
             )}


### PR DESCRIPTION
### Description

A common accessibility violation is that the "Remove" buttons for the components have the same accessible text every time, which makes it confusing for assistive technology users. This adds an aria-labelledby pointing to the first input, exactly the same way each row is labelled. We made it less of an issue when we labelled each row, but the original issue is going to keep coming up, so...

Related links, issue #, if available: AWSUI-19472

### How has this been tested?

Unit test added.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
