### PR TITLE
fix: Pass through props for select in code editor preferences

### DIFF
--- a/pages/code-editor/base-props.ts
+++ b/pages/code-editor/base-props.ts
@@ -30,4 +30,8 @@ export const i18nStrings: CodeEditorProps.I18nStrings = {
   preferencesModalTheme: 'Theme',
   preferencesModalLightThemes: 'Light themes',
   preferencesModalDarkThemes: 'Dark themes',
+
+  preferencesModalThemeFilteringAriaLabel: 'Filter themes',
+  preferencesModalThemeFilteringClearAriaLabel: 'Clear',
+  preferencesModalThemeFilteringPlaceholder: 'Filter themes',
 };

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3914,6 +3914,21 @@ The object should contain, among others:
             "type": "string",
           },
           Object {
+            "name": "preferencesModalThemeFilteringAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "preferencesModalThemeFilteringClearAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "preferencesModalThemeFilteringPlaceholder",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "preferencesModalWrapLines",
             "optional": false,
             "type": "string",

--- a/src/code-editor/__tests__/common.ts
+++ b/src/code-editor/__tests__/common.ts
@@ -24,4 +24,8 @@ export const i18nStrings: CodeEditorProps.I18nStrings = {
   preferencesModalTheme: 'Theme',
   preferencesModalLightThemes: 'Light themes',
   preferencesModalDarkThemes: 'Dark themes',
+
+  preferencesModalThemeFilteringAriaLabel: 'Filter themes aria',
+  preferencesModalThemeFilteringClearAriaLabel: 'Clear',
+  preferencesModalThemeFilteringPlaceholder: 'Filter themes',
 };

--- a/src/code-editor/__tests__/preferences-modal.test.tsx
+++ b/src/code-editor/__tests__/preferences-modal.test.tsx
@@ -79,6 +79,18 @@ test('should allow limiting themes selection via property', () => {
   expect(select.findDropdown().findOptions()).toHaveLength(2);
 });
 
+test('should pass i18nStrings to theme select', () => {
+  const { wrapper } = renderCodeEditor();
+  wrapper.findSettingsButton()!.click();
+  const select = createWrapper().findModal()!.findContent().findSelect()!;
+  select.openDropdown();
+  const filteringInput = select.findFilteringInput()!;
+  expect(filteringInput.findNativeInput().getElement()).toHaveAccessibleName('Filter themes aria');
+  expect(filteringInput.findNativeInput().getElement()).toHaveAttribute('placeholder', 'Filter themes');
+  filteringInput.setInputValue('s');
+  expect(filteringInput.findClearButton()!.getElement()).toHaveAccessibleName('Clear');
+});
+
 test('should reset pending changes when modal dismisses', () => {
   const onPreferencesChange = jest.fn();
   const { wrapper } = renderCodeEditor({ onPreferencesChange: event => onPreferencesChange(event.detail) });

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -341,6 +341,9 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
                 theme: i18nStrings.preferencesModalTheme,
                 lightThemes: i18nStrings.preferencesModalLightThemes,
                 darkThemes: i18nStrings.preferencesModalDarkThemes,
+                themeFilteringAriaLabel: i18nStrings.preferencesModalThemeFilteringAriaLabel,
+                themeFilteringClearAriaLabel: i18nStrings.preferencesModalThemeFilteringClearAriaLabel,
+                themeFilteringPlaceholder: i18nStrings.preferencesModalThemeFilteringPlaceholder,
               }}
             />
           )}

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -154,6 +154,10 @@ export namespace CodeEditorProps {
     preferencesModalTheme: string;
     preferencesModalLightThemes: string;
     preferencesModalDarkThemes: string;
+
+    preferencesModalThemeFilteringPlaceholder?: string;
+    preferencesModalThemeFilteringAriaLabel?: string;
+    preferencesModalThemeFilteringClearAriaLabel?: string;
   }
   export interface ResizeDetail {
     height: number;

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -23,6 +23,9 @@ interface PreferencesModali18nStrings {
   theme: string;
   lightThemes: string;
   darkThemes: string;
+  themeFilteringPlaceholder?: string;
+  themeFilteringAriaLabel?: string;
+  themeFilteringClearAriaLabel?: string;
 }
 
 interface PreferencesModalProps {
@@ -97,6 +100,9 @@ export default (props: PreferencesModalProps) => {
               onChange={onThemeSelected}
               options={themeOptions}
               filteringType="auto"
+              filteringAriaLabel={props.i18nStrings.themeFilteringAriaLabel}
+              filteringClearAriaLabel={props.i18nStrings.themeFilteringClearAriaLabel}
+              filteringPlaceholder={props.i18nStrings.themeFilteringPlaceholder}
             />
           </InternalFormField>
         </div>


### PR DESCRIPTION
### Description

Ensure that all relevant Select props can be provided for the code editor theme picker 

Related links, issue #, if available: n/a

### How has this been tested?

New tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
