### PR TITLE
feat: Allow cards list/group label to be overridden

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3234,6 +3234,8 @@ scroll parent up to reveal the first card or row of cards.",
       "description": "Adds labels to the selection components (checkboxes and radio buttons) as follows:
 * \`itemSelectionLabel\` ((SelectionState, Item) => string) - Determines the label for an item.
 * \`selectionGroupLabel\` (string) - Specifies the label for the group selection control.
+* \`cardsLabel\` (string) - Provides alternative text for the cards list.
+                           By default the contents of the \`header\` are used.
 You can use the first arguments of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The label function for individual
 items also receives the corresponding  \`Item\` object. You can use the group label to
@@ -3242,6 +3244,11 @@ add a meaningful description to the whole selection.
       "inlineType": Object {
         "name": "CardsProps.AriaLabels",
         "properties": Array [
+          Object {
+            "name": "cardsLabel",
+            "optional": true,
+            "type": "string",
+          },
           Object {
             "name": "itemSelectionLabel",
             "optional": false,

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -171,11 +171,21 @@ describe('Cards', () => {
 
     it('maintains logical relationship between header and cards', () => {
       wrapper = renderCards(<Cards<Item> cardDefinition={{}} items={defaultItems} header="abcedefg" />).wrapper;
-      const headerElement = wrapper.findHeader()!.getElement();
-      expect(headerElement).toHaveAttribute('id');
       const cardsOrderedList = getCard(0).getElement().parentElement;
-      expect(cardsOrderedList).toHaveAttribute('aria-labelledby', headerElement!.getAttribute('id'));
-      expect(cardsOrderedList).toHaveAttribute('aria-describedby', headerElement!.getAttribute('id'));
+      expect(cardsOrderedList).toHaveAccessibleName('abcedefg');
+    });
+
+    it('allows label to be overridden', () => {
+      wrapper = renderCards(
+        <Cards<Item>
+          cardDefinition={{}}
+          items={defaultItems}
+          header="abcedefg"
+          ariaLabels={{ itemSelectionLabel: () => 'Item', selectionGroupLabel: 'Group', cardsLabel: 'Custom label' }}
+        />
+      ).wrapper;
+      const cardsOrderedList = getCard(0).getElement().parentElement;
+      expect(cardsOrderedList).toHaveAccessibleName('Custom label');
     });
   });
 

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -151,8 +151,8 @@ const Cards = React.forwardRef(function <T = any>(
               visibleSections={visibleSections}
               updateShiftToggle={updateShiftToggle}
               onFocus={onCardFocus}
-              ariaDescribedby={cardsHeaderId}
-              ariaLabelledby={cardsHeaderId}
+              ariaLabel={ariaLabels?.cardsLabel}
+              ariaLabelledby={ariaLabels?.cardsLabel ? undefined : cardsHeaderId}
             />
           )}
         </div>
@@ -175,13 +175,14 @@ const CardsList = <T,>({
   updateShiftToggle,
   onFocus,
   ariaLabelledby,
-  ariaDescribedby,
+  ariaLabel,
 }: Pick<CardsProps<T>, 'items' | 'cardDefinition' | 'trackBy' | 'selectionType' | 'visibleSections'> & {
   columns: number | null;
   isItemSelected: (item: T) => boolean;
   getItemSelectionProps: (item: T) => SelectionControlProps;
   updateShiftToggle: (state: boolean) => void;
   onFocus: FocusEventHandler<HTMLElement>;
+  ariaLabel?: string;
   ariaLabelledby?: string;
   ariaDescribedby?: string;
 }) => {
@@ -209,7 +210,7 @@ const CardsList = <T,>({
       className={clsx(styles.list, styles[`list-grid-${columns || 1}`])}
       role={listRole}
       aria-labelledby={ariaLabelledby}
-      aria-describedby={ariaDescribedby}
+      aria-label={ariaLabel}
       {...(focusMarkers && focusMarkers.root)}
     >
       {items.map((item, index) => (

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -150,6 +150,8 @@ export interface CardsProps<T = any> extends BaseComponentProps {
    * Adds labels to the selection components (checkboxes and radio buttons) as follows:
    * * `itemSelectionLabel` ((SelectionState, Item) => string) - Determines the label for an item.
    * * `selectionGroupLabel` (string) - Specifies the label for the group selection control.
+   * * `cardsLabel` (string) - Provides alternative text for the cards list.
+   *                            By default the contents of the `header` are used.
    *
    * You can use the first arguments of type `SelectionState` to access the current selection
    * state of the component (for example, the `selectedItems` list). The label function for individual
@@ -225,6 +227,7 @@ export namespace CardsProps {
   export interface AriaLabels<T> {
     itemSelectionLabel: (data: CardsProps.SelectionState<T>, row: T) => string;
     selectionGroupLabel: string;
+    cardsLabel?: string;
   }
   export interface Ref {
     /**


### PR DESCRIPTION
### Description

Allow a custom label for cards group. The default behavior of aria-labelledby the header slot can be too verbose.

Related links, issue #, if available: AWSUI-20957

### How has this been tested?

Unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
