### PR TITLE
chore: Make sticky columns test page configurable

### DIFF
--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -1,269 +1,261 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import Table, { TableProps } from '~components/table';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
 import Input from '~components/input';
 import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
-import CollectionPreferences, { CollectionPreferencesProps } from '~components/collection-preferences';
 import { columnsConfig } from './shared-configs';
-import { generateItems } from './generate-data';
+import { generateItems, Instance } from './generate-data';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import { Checkbox, FormField, Select } from '~components';
+import AppContext, { AppContextType } from '../app/app-context';
 
-const tableItems = generateItems(10);
+type DemoContext = React.Context<
+  AppContextType<{
+    resizableColumns: boolean;
+    stickyHeader: boolean;
+    sortingDisabled: boolean;
+    selectionType: undefined | 'single' | 'multi';
+    stickyColumnsFirst: string;
+    stickyColumnsLast: string;
+  }>
+>;
 
-const COLUMN_DEFINITIONS: TableProps.ColumnDefinition<any>[] = [
+interface ExtendedInstance extends Instance {
+  name: string;
+  alt: string;
+  description: string;
+}
+
+const alts = ['First', 'Second', 'Third', 'Fourth', '-', 'Sixth', '-', '-', '-', '-'];
+
+const descriptions = [
+  'This is the first item',
+  'This is the second item',
+  '-',
+  'This is the fourth item',
+  'This is the fifth item with a longer description',
+  'This is the sixth item',
+  '-',
+  '-',
+  '-',
+  '-',
+];
+
+const tableItems: ExtendedInstance[] = generateItems(10).map((it, index) => ({
+  ...it,
+  name: `Item ${index + 1}`,
+  alt: alts[index],
+  description: descriptions[index],
+}));
+
+const COLUMN_DEFINITIONS: TableProps.ColumnDefinition<ExtendedInstance>[] = [
   {
     id: 'variable',
     header: 'Simple table',
     minWidth: 200,
     cell: item => {
-      return item.name;
+      return item.id;
     },
+    sortingField: 'variable',
   },
   {
     id: 'description',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-2',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-3',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-4',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-5',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-6',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-7',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-8',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-9',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-10',
     header: 'Description',
     cell: item => <Link href="#">Link: {item.description}</Link> || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-11',
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
   {
     id: 'description-12',
     minWidth: 200,
     header: 'Description',
     cell: item => item.description || '-',
+    sortingField: 'description',
   },
 ];
 
-const ITEMS = [
-  {
-    name: 'Item 1',
-    alt: 'First',
-    description: 'This is the first item',
-    type: '1A',
-    size: 'Small',
+const ariaLabels: TableProps<ExtendedInstance>['ariaLabels'] = {
+  selectionGroupLabel: 'group label',
+  activateEditLabel: column => `Edit ${column.header}`,
+  cancelEditLabel: column => `Cancel editing ${column.header}`,
+  submitEditLabel: column => `Submit edit ${column.header}`,
+  allItemsSelectionLabel: ({ selectedItems }) =>
+    `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
+  itemSelectionLabel: ({ selectedItems }, item) => {
+    const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
+    return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
   },
-  {
-    name: 'Item 2',
-    alt: 'Second',
-    description: 'This is the second item',
-    type: '1B',
-    size: 'Large',
-  },
-  {
-    name: 'Item 3',
-    alt: 'Third',
-    description: '-',
-    type: '1A',
-    size: 'Large',
-  },
-  {
-    name: 'Item 4',
-    alt: 'Fourth',
-    description: 'This is the fourth item',
-    type: '2A',
-    size: 'Small',
-  },
-  {
-    name: 'Item 5',
-    alt: '-',
-    description: 'This is the fifth item with a longer description',
-    type: '2A',
-    size: 'Large',
-  },
-  {
-    name: 'Item 6',
-    alt: 'Sixth',
-    description: 'This is the sixth item',
-    type: '1A',
-    size: 'Small',
-  },
-];
+  tableLabel: 'Demo table',
+};
+
+const selectionTypeOptions = [{ value: 'none' }, { value: 'single' }, { value: 'multi' }];
+
+const stickyColumnsOptions = [{ value: '0' }, { value: '1' }, { value: '2' }, { value: '3' }];
 
 export default () => {
-  const [preferences, setPreferences] = React.useState<CollectionPreferencesProps.Preferences>({
-    stickyColumns: { first: 1, last: 1 },
-  });
-
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const [selectedItems, setSelectedItems] = useState<any>([]);
+  const { items, collectionProps } = useCollection(tableItems, { pagination: {}, sorting: {} });
   return (
     <ScreenshotArea>
       <h1>Sticky columns</h1>
       <SpaceBetween size="xl">
+        <SpaceBetween direction="horizontal" size="m">
+          <FormField label="Table flags">
+            <Checkbox
+              checked={urlParams.resizableColumns}
+              onChange={event => setUrlParams({ resizableColumns: event.detail.checked })}
+            >
+              Resizable columns
+            </Checkbox>
+
+            <Checkbox
+              checked={urlParams.stickyHeader}
+              onChange={event => setUrlParams({ stickyHeader: event.detail.checked })}
+            >
+              Sticky header
+            </Checkbox>
+
+            <Checkbox
+              checked={urlParams.sortingDisabled}
+              onChange={event => setUrlParams({ sortingDisabled: event.detail.checked })}
+            >
+              Sorting disabled
+            </Checkbox>
+          </FormField>
+
+          <FormField label="Selection type">
+            <Select
+              selectedOption={
+                selectionTypeOptions.find(option => option.value === urlParams.selectionType) ?? selectionTypeOptions[0]
+              }
+              options={selectionTypeOptions}
+              onChange={event =>
+                setUrlParams({
+                  selectionType:
+                    event.detail.selectedOption.value === 'single' || event.detail.selectedOption.value === 'multi'
+                      ? event.detail.selectedOption.value
+                      : undefined,
+                })
+              }
+            />
+          </FormField>
+
+          <FormField label="Sticky columns first">
+            <Select
+              selectedOption={
+                stickyColumnsOptions.find(option => option.value === urlParams.stickyColumnsFirst) ??
+                stickyColumnsOptions[0]
+              }
+              options={stickyColumnsOptions}
+              onChange={event => setUrlParams({ stickyColumnsFirst: event.detail.selectedOption.value })}
+            />
+          </FormField>
+
+          <FormField label="Sticky columns last">
+            <Select
+              selectedOption={
+                stickyColumnsOptions.find(option => option.value === urlParams.stickyColumnsLast) ??
+                stickyColumnsOptions[0]
+              }
+              options={stickyColumnsOptions}
+              onChange={event => setUrlParams({ stickyColumnsLast: event.detail.selectedOption.value })}
+            />
+          </FormField>
+        </SpaceBetween>
+
         <Table
-          data-test-id="simple"
-          stickyColumns={{ first: 1, last: 1 }}
+          {...collectionProps}
+          data-test-id="small-table"
+          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          {...urlParams}
           columnDefinitions={columnsConfig}
-          resizableColumns={true}
-          items={tableItems}
-          sortingDisabled={true}
-          ariaLabels={{
-            tableLabel: 'simple',
-          }}
+          selectedItems={selectedItems}
+          onSelectionChange={({ detail: { selectedItems } }) => setSelectedItems(selectedItems)}
+          items={items}
+          ariaLabels={ariaLabels}
           header={<Header>Simple table</Header>}
         />
         <Table
-          data-test-id="with-collection-preferences"
-          stickyColumns={preferences.stickyColumns}
-          stickyHeader={true}
-          resizableColumns={true}
-          preferences={
-            <CollectionPreferences
-              title="Preferences"
-              confirmLabel="Confirm"
-              cancelLabel="Cancel"
-              onConfirm={({ detail }) => setPreferences(detail)}
-              preferences={preferences}
-              stickyColumnsPreference={{
-                firstColumns: {
-                  title: 'Stick first column(s)',
-                  description: 'Keep the first column(s) visible while horizontally scrolling table content.',
-                  options: [
-                    { label: 'None', value: 0 },
-                    { label: 'First column', value: 1 },
-                    { label: 'First two columns', value: 2 },
-                    { label: 'Three two columns', value: 3 },
-                  ],
-                },
-                lastColumns: {
-                  title: 'Stick last column',
-                  description: 'Keep the last column visible while horizontally scrolling table content.',
-                  options: [
-                    { label: 'None', value: 0 },
-                    { label: 'Last column', value: 1 },
-                    { label: 'Last two columns', value: 2 },
-                    { label: 'Last three columns', value: 3 },
-                  ],
-                },
-              }}
-            />
-          }
-          ariaLabels={{
-            selectionGroupLabel: 'Items selection',
-            allItemsSelectionLabel: ({ selectedItems }) =>
-              `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-            itemSelectionLabel: ({ selectedItems }, item) => {
-              const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-              return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-            },
-            tableLabel: 'With collection preferences',
-          }}
+          {...collectionProps}
+          data-test-id="large-table"
+          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          {...urlParams}
+          ariaLabels={ariaLabels}
           columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          header={<Header>Simple table with collection preferences & sticky-header</Header>}
+          selectedItems={selectedItems}
+          onSelectionChange={({ detail: { selectedItems } }) => setSelectedItems(selectedItems)}
+          items={items}
+          header={<Header>Large table</Header>}
         />
         <Table
-          data-test-id="resizable"
-          resizableColumns={true}
-          stickyColumns={{ first: 1, last: 1 }}
-          columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          ariaLabels={{
-            tableLabel: 'Resizable',
-          }}
-          header={<Header>Resizable columns</Header>}
-        />
-        <Table
-          data-test-id="with-collection-preferences"
-          stickyColumns={preferences.stickyColumns}
-          stickyHeader={true}
-          preferences={
-            <CollectionPreferences
-              title="Preferences"
-              confirmLabel="Confirm"
-              cancelLabel="Cancel"
-              onConfirm={({ detail }) => setPreferences(detail)}
-              preferences={preferences}
-              stickyColumnsPreference={{
-                firstColumns: {
-                  title: 'Stick first column(s)',
-                  description: 'Keep the first column(s) visible while horizontally scrolling table content.',
-                  options: [
-                    { label: 'None', value: 0 },
-                    { label: 'First column', value: 1 },
-                    { label: 'First two columns', value: 2 },
-                  ],
-                },
-                lastColumns: {
-                  title: 'Stick last column',
-                  description: 'Keep the last column visible while horizontally scrolling table content.',
-                  options: [
-                    { label: 'None', value: 0 },
-                    { label: 'Last column', value: 1 },
-                  ],
-                },
-              }}
-            />
-          }
-          ariaLabels={{
-            selectionGroupLabel: 'Items selection',
-            allItemsSelectionLabel: ({ selectedItems }) =>
-              `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-            itemSelectionLabel: ({ selectedItems }, item) => {
-              const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-              return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-            },
-            tableLabel: 'With collection preferences',
-          }}
-          columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          header={<Header>Simple table with collection preferences & sticky-header</Header>}
-        />
-        <Table
-          data-test-id="inline-editing"
-          stickyColumns={{ first: 1, last: 1 }}
+          {...collectionProps}
+          data-test-id="inline-editing-table"
+          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          {...urlParams}
           columnDefinitions={[
             {
               id: 'inline-edit-start',
@@ -306,67 +298,11 @@ export default () => {
               },
             },
           ]}
-          items={ITEMS}
-          ariaLabels={{
-            activateEditLabel: column => `Edit ${column.header}`,
-            cancelEditLabel: column => `Cancel editing ${column.header}`,
-            submitEditLabel: column => `Submit edit ${column.header}`,
-            allItemsSelectionLabel: ({ selectedItems }) =>
-              `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-            itemSelectionLabel: ({ selectedItems }, item) => {
-              const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-              return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-            },
-            tableLabel: 'Inline editing',
-          }}
-          sortingDisabled={true}
-          header={<Header>Inline editing columns</Header>}
-        />
-        <Table
-          data-test-id="selection-single"
-          selectionType="single"
-          stickyColumns={{ first: 1, last: 1 }}
-          columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          ariaLabels={{
-            selectionGroupLabel: 'Items selection',
-            allItemsSelectionLabel: ({ selectedItems }) =>
-              `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-            itemSelectionLabel: ({ selectedItems }, item) => {
-              const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-              return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-            },
-            tableLabel: 'Selection type single',
-          }}
-          header={<Header>Selection type single</Header>}
-        />
-        <Table
-          data-test-id="selection-multi"
-          selectionType="multi"
-          stickyColumns={{ first: 1, last: 1 }}
-          columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          ariaLabels={{
-            selectionGroupLabel: 'Items selection',
-            allItemsSelectionLabel: ({ selectedItems }) =>
-              `${selectedItems.length} ${selectedItems.length === 1 ? 'item' : 'items'} selected`,
-            itemSelectionLabel: ({ selectedItems }, item) => {
-              const isItemSelected = selectedItems.filter(i => i.name === item.name).length;
-              return `${item.name} is ${isItemSelected ? '' : 'not'} selected`;
-            },
-            tableLabel: 'With 5 sticky columns',
-          }}
-          header={<Header>Selection type multi</Header>}
-        />
-        <Table
-          data-test-id="focusable-element"
-          stickyColumns={{ first: 3, last: 2 }}
-          columnDefinitions={COLUMN_DEFINITIONS}
-          items={ITEMS}
-          sortingDisabled={true}
-          header={<Header>With 5 sticky columns</Header>}
+          selectedItems={selectedItems}
+          onSelectionChange={({ detail: { selectedItems } }) => setSelectedItems(selectedItems)}
+          items={items}
+          ariaLabels={ariaLabels}
+          header={<Header>Large table with inline editing</Header>}
         />
       </SpaceBetween>
     </ScreenshotArea>


### PR DESCRIPTION
### Description

Simplify sticky columns test page and make it configurable with url params.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
