### PR TITLE
fix: Fix html validity in popover and expandable section

### DIFF
--- a/pages/popover/text-align.page.tsx
+++ b/pages/popover/text-align.page.tsx
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import ScreenshotArea from '../utils/screenshot-area';
+import React from 'react';
+import Box from '~components/box';
+import Popover from '~components/popover';
+
+export default function () {
+  const content = 'Nothing to see here';
+  return (
+    <>
+      <h1>Popover rendered inside inline text</h1>
+      <ScreenshotArea>
+        <Box variant="p">
+          Very{' '}
+          <Popover content={content} renderWithPortal={true} dismissButton={false}>
+            important
+          </Popover>{' '}
+          message.
+        </Box>
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -96,6 +96,7 @@ const ExpandableNavigationHeader = ({
         aria-label={ariaLabel}
         aria-controls={ariaControls}
         aria-expanded={expanded}
+        type="button"
       >
         {icon}
       </button>

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { act, render } from '@testing-library/react';
 import createWrapper, { ElementWrapper, PopoverWrapper } from '../../../lib/components/test-utils/dom';
 import Popover, { PopoverProps } from '../../../lib/components/popover';
+import '../../__a11y__/to-validate-a11y';
 
 import styles from '../../../lib/components/popover/styles.selectors.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
@@ -249,5 +250,29 @@ describe('ARIA labels', () => {
     const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', dismissButton: false });
     wrapper.findTrigger().click();
     expect(wrapper.findBody()!.getElement()).not.toHaveAttribute('role', 'dialog');
+  });
+
+  it('accessibility validation basic popover', async () => {
+    const wrapper = renderPopover({
+      children: 'Trigger',
+      content: 'Popover',
+      dismissButton: false,
+      renderWithPortal: true,
+    });
+    wrapper.findTrigger().click();
+    await expect(document.body).toValidateA11y();
+  });
+
+  it('accessibility validation for popover with dismiss button and header', async () => {
+    const wrapper = renderPopover({
+      children: 'Trigger',
+      header: 'Popover',
+      content: 'Content',
+      dismissButton: true,
+      dismissAriaLabel: 'Dismiss',
+      renderWithPortal: true,
+    });
+    wrapper.findTrigger().click();
+    await expect(document.body).toValidateA11y();
   });
 });

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -151,7 +151,7 @@ function InternalPopover(
 
   return (
     <FormFieldContext.Provider value={{}}>
-      <div
+      <span
         {...baseProps}
         className={clsx(styles.root, baseProps.className)}
         ref={mergedRef}
@@ -170,7 +170,7 @@ function InternalPopover(
           <span {...triggerProps}>{children}</span>
         )}
         {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
-      </div>
+      </span>
     </FormFieldContext.Provider>
   );
 }

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -15,7 +15,6 @@
 .root {
   @include styles.styles-reset;
   color: inherit;
-  display: inline;
 }
 
 .trigger {

--- a/src/side-navigation/__tests__/complex-side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/complex-side-navigation.test.tsx
@@ -2,22 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import Badge from '../../../lib/components/badge';
+import Popover from '../../../lib/components/popover';
 import SideNavigation, { SideNavigationProps } from '../../../lib/components/side-navigation';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { SideNavigationItemWrapper } from '../../../lib/components/test-utils/dom/side-navigation';
+import '../../__a11y__/to-validate-a11y';
 
 function renderSideNavigation(props: SideNavigationProps = {}) {
   const { container } = render(<SideNavigation {...props} />);
   return createWrapper(container).findSideNavigation()!;
 }
 
-it('Side navigation with all possible items', () => {
+it('Side navigation with all possible items', async () => {
   const wrapper = renderSideNavigation({
     items: [
       {
         type: 'link',
         text: 'Page 1',
         href: '#/page1',
+        info: <Badge>1</Badge>,
       },
       {
         type: 'divider',
@@ -30,11 +34,18 @@ it('Side navigation with all possible items', () => {
             type: 'link',
             text: 'Page 2',
             href: '#/page2',
+            info: (
+              <Popover content="very new feature" renderWithPortal={true}>
+                new
+              </Popover>
+            ),
           },
           {
             type: 'link',
             text: 'Page 3',
             href: '#/page3',
+            external: true,
+            externalIconAriaLabel: 'Opens in a new tab',
           },
           { type: 'divider' },
           {
@@ -218,4 +229,5 @@ it('Side navigation with all possible items', () => {
   expect(wrapper.findItemByIndex(8)!.findDivider()).toBeTruthy();
 
   expect(wrapper.findItemByIndex(9)!.findLink()!.getElement()).toHaveTextContent('Notifications');
+  await expect(wrapper.getElement()).toValidateA11y();
 });


### PR DESCRIPTION
### Description

Prevent block elements to appear inside inline

Related links, issue #, if available: AWSUI-20955

### How has this been tested?

Added extra tests to affected components

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
