### PR TITLE
fix: Prevent modal sticky footer from hiding focused elements

### DIFF
--- a/pages/modal/scroll-padding.page.tsx
+++ b/pages/modal/scroll-padding.page.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import ScreenshotArea from '../utils/screenshot-area';
 import { Button, Modal } from '~components';
 
 export default function () {
@@ -13,28 +12,26 @@ export default function () {
       <Button data-testid="modal-trigger" onClick={() => setVisible(true)}>
         Show modal
       </Button>
-      <ScreenshotArea>
-        <Modal
-          header="Modal title"
-          visible={visible}
-          onDismiss={() => setVisible(false)}
-          closeAriaLabel="Close modal"
-          footer={
-            <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button variant="link">Cancel</Button>
-              <Button variant="primary">Delete</Button>
-            </span>
-          }
-        >
-          {Array(100)
-            .fill(0)
-            .map((value, index) => (
-              <div key={index}>
-                <input />
-              </div>
-            ))}
-        </Modal>
-      </ScreenshotArea>
+      <Modal
+        header="Modal title"
+        visible={visible}
+        onDismiss={() => setVisible(false)}
+        closeAriaLabel="Close modal"
+        footer={
+          <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button variant="link">Cancel</Button>
+            <Button variant="primary">Delete</Button>
+          </span>
+        }
+      >
+        {Array(100)
+          .fill(0)
+          .map((value, index) => (
+            <div key={index}>
+              <input />
+            </div>
+          ))}
+      </Modal>
     </article>
   );
 }

--- a/pages/modal/scroll-padding.page.tsx
+++ b/pages/modal/scroll-padding.page.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Button, Modal } from '~components';
+
+export default function () {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <article>
+      <h1>Scroll padding modal</h1>
+      <Button data-testid="modal-trigger" onClick={() => setVisible(true)}>
+        Show modal
+      </Button>
+      <ScreenshotArea>
+        <Modal
+          header="Modal title"
+          visible={visible}
+          onDismiss={() => setVisible(false)}
+          closeAriaLabel="Close modal"
+          footer={
+            <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button variant="link">Cancel</Button>
+              <Button variant="primary">Delete</Button>
+            </span>
+          }
+        >
+          {Array(100)
+            .fill(0)
+            .map((value, index) => (
+              <div key={index}>
+                <input />
+              </div>
+            ))}
+        </Modal>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -51,3 +51,30 @@ test(
     await expect(page.isFocused('body')).resolves.toBe(true);
   })
 );
+
+test(
+  'should not let the sticky footer cover focused elements',
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/modal/scroll-padding');
+
+    // Open modal
+    await page.click('[data-testid="modal-trigger"]');
+    const modal = createWrapper().findModal();
+    const modalContent = modal.findContent();
+    const footerSelector = modal.findFooter().toSelector();
+    for (let i = 0; i < 100; i++) {
+      page.keys('Tab');
+      const input = modalContent
+        .findAll('div')
+        .get(i + 1)
+        .find('input');
+      const inputSelector = input.toSelector();
+      expect(await page.isFocused(inputSelector)).toBe(true);
+      const inputBox = await page.getBoundingBox(inputSelector);
+      const footerBox = await page.getBoundingBox(footerSelector);
+      const inputCenter = inputBox.top + inputBox.height / 2;
+      expect(inputCenter).toBeLessThan(footerBox.top);
+    }
+  })
+);

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -108,7 +108,8 @@ function InnerModal({
   // to detect when the user has scrolled to the bottom.
   const { ref: stickySentinelRef, isIntersecting: footerStuck } = useIntersectionObserver();
 
-  // Add extra scroll padding when the footer is sticky, to prevent it from covering potentially focused elements.
+  // Add extra scroll padding to account for the height of the sticky footer,
+  // to prevent it from covering focused elements.
   const [footerHeight, footerRef] = useContainerQuery(rect => rect.borderBoxHeight);
 
   return (
@@ -122,7 +123,7 @@ function InnerModal({
         onMouseDown={onOverlayMouseDown}
         onClick={onOverlayClick}
         ref={mergedRef}
-        style={!footerStuck && footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
+        style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
       >
         <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
           <div

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -34,7 +34,8 @@ export default function InternalModal({ modalRoot, ...rest }: InternalModalProps
   );
 }
 
-// Separate component to prevent the Portal from getting in the way of refs being null because of extra initial rendering
+// Separate component to prevent the Portal from getting in the way of refs, as it needs extra cycles to render the inner components.
+// useContainerQuery needs its targeted element to exist on the first render in order to work properly.
 function InnerModal({
   size,
   visible,

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -12,7 +12,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { InternalButton } from '../button/internal';
 import InternalHeader from '../header/internal';
 import Portal from '../internal/components/portal';
-import { useContainerBreakpoints } from '../internal/hooks/container-queries';
+import { useContainerBreakpoints, useContainerQuery } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { FormFieldContext } from '../internal/context/form-field-context';
 
@@ -26,7 +26,16 @@ import { useIntersectionObserver } from '../internal/hooks/use-intersection-obse
 
 type InternalModalProps = SomeRequired<ModalProps, 'size' | 'closeAriaLabel'> & InternalBaseComponentProps;
 
-export default function InternalModal({
+export default function InternalModal({ modalRoot, ...rest }: InternalModalProps) {
+  return (
+    <Portal container={modalRoot}>
+      <InnerModal {...rest} />
+    </Portal>
+  );
+}
+
+// Separate component to prevent the Portal from getting in the way of refs being null because of extra initial rendering
+function InnerModal({
   size,
   visible,
   header,
@@ -34,7 +43,6 @@ export default function InternalModal({
   footer,
   disableContentPaddings,
   onDismiss,
-  modalRoot,
   __internalRootRef = null,
   ...rest
 }: InternalModalProps) {
@@ -100,61 +108,67 @@ export default function InternalModal({
   // to detect when the user has scrolled to the bottom.
   const { ref: stickySentinelRef, isIntersecting: footerStuck } = useIntersectionObserver();
 
+  // Add extra scroll padding when the footer is sticky, to prevent it from covering potentially focused elements.
+  const [footerHeight, footerRef] = useContainerQuery(rect => rect.borderBoxHeight);
+
   return (
-    <Portal container={modalRoot}>
-      <FormFieldContext.Provider value={{}}>
-        <div
-          {...baseProps}
-          className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
-          role="dialog"
-          aria-modal={true}
-          aria-labelledby={headerId}
-          onMouseDown={onOverlayMouseDown}
-          onClick={onOverlayClick}
-          ref={mergedRef}
-        >
-          <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
-            <div
-              className={clsx(
-                styles.dialog,
-                styles[size],
-                styles[`breakpoint-${breakpoint}`],
-                isRefresh && styles.refresh
-              )}
-              onKeyDown={escKeyHandler}
-              tabIndex={-1}
-            >
-              <div className={styles.container}>
-                <div className={styles.header}>
-                  <InternalHeader
-                    variant="h2"
-                    __disableActionsWrapping={true}
-                    actions={
-                      <InternalButton
-                        ariaLabel={closeAriaLabel}
-                        className={styles['dismiss-control']}
-                        variant="modal-dismiss"
-                        iconName="close"
-                        formAction="none"
-                        onClick={onCloseButtonClick}
-                      />
-                    }
-                  >
-                    <span id={headerId} className={styles['header--text']}>
-                      {header}
-                    </span>
-                  </InternalHeader>
-                </div>
-                <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
-                  {children}
-                  <div ref={stickySentinelRef} />
-                </div>
-                {footer && <div className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>{footer}</div>}
+    <FormFieldContext.Provider value={{}}>
+      <div
+        {...baseProps}
+        className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
+        role="dialog"
+        aria-modal={true}
+        aria-labelledby={headerId}
+        onMouseDown={onOverlayMouseDown}
+        onClick={onOverlayClick}
+        ref={mergedRef}
+        style={!footerStuck && footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
+      >
+        <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
+          <div
+            className={clsx(
+              styles.dialog,
+              styles[size],
+              styles[`breakpoint-${breakpoint}`],
+              isRefresh && styles.refresh
+            )}
+            onKeyDown={escKeyHandler}
+            tabIndex={-1}
+          >
+            <div className={styles.container}>
+              <div className={styles.header}>
+                <InternalHeader
+                  variant="h2"
+                  __disableActionsWrapping={true}
+                  actions={
+                    <InternalButton
+                      ariaLabel={closeAriaLabel}
+                      className={styles['dismiss-control']}
+                      variant="modal-dismiss"
+                      iconName="close"
+                      formAction="none"
+                      onClick={onCloseButtonClick}
+                    />
+                  }
+                >
+                  <span id={headerId} className={styles['header--text']}>
+                    {header}
+                  </span>
+                </InternalHeader>
               </div>
+              <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
+                {children}
+                <div ref={stickySentinelRef} />
+              </div>
+              {footer && (
+                <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
+                  {footer}
+                </div>
+              )}
             </div>
-          </FocusLock>
-        </div>
-      </FormFieldContext.Provider>
-    </Portal>
+          </div>
+        </FocusLock>
+      </div>
+    </FormFieldContext.Provider>
   );
 }


### PR DESCRIPTION
### Description
A typical problem of sticky headers and footers is that they can cover other elements in an undesired way. In our modal component, the sticky footer can eventually cover focused elements when navigating with the keyboard:

https://user-images.githubusercontent.com/1257272/233566051-15abd309-b2ef-49a2-bae4-6c636de60e1c.mov

This PR fixes this by adding a bottom [scroll padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) equivalent to the footer height.

Now the modal scrolls as needed as soon as the focused element meets the footer's position (not the modal's bottom):

https://user-images.githubusercontent.com/1257272/233566062-8c24c29d-5d71-4cee-876e-bce75f8c7e97.mov

### How has this been tested?

- Added integration test
- Manually tested

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
