### PR TITLE
fix: Allow placing semantic block elements inside card definition header

### DIFF
--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -225,9 +225,9 @@ const CardsList = <T,>({
         >
           <div className={styles['card-inner']}>
             <div className={styles['card-header']}>
-              <span className={styles['card-header-inner']}>
+              <div className={styles['card-header-inner']}>
                 {cardDefinition.header ? cardDefinition.header(item) : ''}
-              </span>
+              </div>
               {selectable && (
                 <div className={styles['selection-control']}>
                   <SelectionControl


### PR DESCRIPTION
### Description

Users can't place a div inside the card header because the wrapper is a span. Normally, it's designed to hold text (like a table), but it's being used in a situation with some layout elements. Given the scope of the change, we decided we might as well do it to unblock them.

Related links, issue #, if available: AWSUI-20694

### How has this been tested?

I changed an element that already has `display: inline-block` styling. No tests. Sue me.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
