### PR TITLE
fix: Restore focus to the code editor tab button when pane is closed

### DIFF
--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -227,25 +227,6 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     setHighlightedAnnotation(undefined);
   }, []);
 
-  /**
-   * Ignore focus lock if focused element is the pane tab button or within editor tree.
-   * This check is required:
-   * - When closing the pane with `ESC` key: The panel closes asynchronously and its focus lock
-   *   still exists when trying to focus the tab button in higher-order component.
-   * - When clicking or hittin `Enter` on an annotation: The panel remains open but focus lock
-   *   deactivates asynchronously.
-   */
-  const shouldHandleFocus = useCallback(
-    (activeElement: HTMLElement): boolean => {
-      return (
-        activeElement !== errorsTabRef.current &&
-        activeElement !== warningsTabRef.current &&
-        !editor?.container.contains(activeElement)
-      );
-    },
-    [editor]
-  );
-
   const [isPreferencesModalVisible, setPreferencesModalVisible] = useState(false);
   const onPreferencesOpen = () => setPreferencesModalVisible(true);
   const onPreferencesConfirm = (p: CodeEditorProps.Preferences) => {
@@ -321,7 +302,6 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
               onAnnotationClick={onAnnotationClick}
               onAnnotationClear={onAnnotationClear}
               onClose={onPaneClose}
-              onAllowlist={shouldHandleFocus}
               cursorPositionLabel={i18nStrings.cursorPosition}
               closeButtonAriaLabel={i18nStrings.paneCloseButtonAriaLabel}
             />

--- a/src/code-editor/pane.tsx
+++ b/src/code-editor/pane.tsx
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
-import FocusLock from 'react-focus-lock';
 import { Ace } from 'ace-builds';
 
 import { KeyCode } from '../internal/keycode';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
+import FocusLock from '../internal/components/focus-lock';
 
 import { InternalButton } from '../button/internal';
 import { ResizableBox } from './resizable-box';
@@ -27,7 +27,6 @@ export interface PaneProps {
   cursorPositionLabel: (row: number, column: number) => string;
   closeButtonAriaLabel: string;
 
-  onAllowlist: (activeElement: HTMLElement) => boolean;
   onClose: () => void;
   onAnnotationClick: (annotation: Ace.Annotation) => void;
   onAnnotationClear: () => void;
@@ -38,7 +37,6 @@ export const Pane = ({
   visible,
   annotations,
   highlighted,
-  onAllowlist,
   onClose,
   onAnnotationClick,
   onAnnotationClear,
@@ -64,6 +62,12 @@ export const Pane = ({
     }
   }, [highlighted, annotations]);
 
+  useEffect(() => {
+    if (!visible) {
+      setFocusTrapActive(false);
+    }
+  }, [visible]);
+
   const onItemFocus = () => {
     setFocusTrapActive(true);
     onAnnotationClear();
@@ -73,6 +77,7 @@ export const Pane = ({
     setFocusTrapActive(false);
     onAnnotationClick(annotation);
   };
+
   const onItemKeyDown = (annotation: Ace.Annotation, event: React.KeyboardEvent) => {
     if (event.keyCode === KeyCode.enter || event.keyCode === KeyCode.space) {
       event.preventDefault();
@@ -96,13 +101,7 @@ export const Pane = ({
   return (
     <div id={id} className={styles.pane} onKeyDown={onEscKeyDown} role="tabpanel">
       <ResizableBox height={paneHeight} minHeight={MIN_HEIGHT} onResize={newHeight => setPaneHeight(newHeight)}>
-        <FocusLock
-          disabled={!isFocusTrapActive}
-          className={styles['focus-lock']}
-          autoFocus={false}
-          returnFocus={false}
-          whiteList={onAllowlist}
-        >
+        <FocusLock disabled={!isFocusTrapActive} className={styles['focus-lock']} autoFocus={true}>
           <div className={styles.pane__list} tabIndex={-1}>
             <table className={styles.pane__table} role="presentation">
               <colgroup>

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -13,14 +13,15 @@ interface StatusBarProps {
   languageLabel: string;
   cursorPosition: string;
   paneStatus: string;
-  errorsTabRef: React.RefObject<HTMLButtonElement>;
-  warningsTabRef: React.RefObject<HTMLButtonElement>;
   isTabFocused: boolean;
   paneId?: string;
   i18nStrings: CodeEditorProps.I18nStrings;
   errorCount: number;
   warningCount: number;
   isRefresh: boolean;
+
+  errorsTabRef?: React.RefObject<HTMLButtonElement>;
+  warningsTabRef?: React.RefObject<HTMLButtonElement>;
 
   onErrorPaneToggle: () => void;
   onWarningPaneToggle: () => void;
@@ -139,7 +140,7 @@ function InternalStatusBar({
   );
 }
 
-export const StatusBar = (props: StatusBarProps) => {
+export const StatusBar = ({ errorsTabRef, warningsTabRef, ...restProps }: StatusBarProps) => {
   // create a virtual status bar, in order to calculate the width with full tab button text
   // and decide if tab button text needs to be reduced
   const [realWidth, statusLeftBarRef] = useContainerQuery(rect => rect.width);
@@ -149,8 +150,15 @@ export const StatusBar = (props: StatusBarProps) => {
 
   return (
     <>
-      <InternalStatusBar isVirtual={false} {...props} leftBarRef={statusLeftBarRef} minifyCounters={minifyCounters} />
-      <InternalStatusBar isVirtual={true} {...props} leftBarRef={virtualStatusLeftBarRef} minifyCounters={false} />
+      <InternalStatusBar
+        {...restProps}
+        isVirtual={false}
+        leftBarRef={statusLeftBarRef}
+        errorsTabRef={errorsTabRef}
+        warningsTabRef={warningsTabRef}
+        minifyCounters={minifyCounters}
+      />
+      <InternalStatusBar {...restProps} isVirtual={true} leftBarRef={virtualStatusLeftBarRef} minifyCounters={false} />
     </>
   );
 };


### PR DESCRIPTION
### Description

Looks like we did have this in the past, but broke it after a refactor. Added a couple of integ tests to prevent that. Also replaced 'react-focus-lock' with our simpler more predictable internal one.

Related links, issue #, if available: AWSUI-20678

### How has this been tested?

Integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
