### PR TITLE
fix: Adjust offsetTop value for drawers when disableBodyScroll is enabled

### DIFF
--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -38,8 +38,18 @@
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     position: fixed;
     right: 0;
-    top: var(#{custom-props.$offsetTop});
     z-index: 1001;
+
+    /*
+    When disableBodyScroll is true the offsetTop will be relative to the 
+    app layout and not the body. However, the drawer position changes 
+    to fixed in mobile viewports. The top value needs to include the 
+    header because fixed position switches the top value so it is now 
+    relative to the body.
+    */
+    &.disable-body-scroll {
+      top: var(#{custom-props.$headerHeight});
+    }
   }
 }
 

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -51,7 +51,7 @@ namespace DrawersProps {
  * do not exist then the Tools and SplitPanel will be handled by the Tools component.
  */
 export default function Drawers() {
-  const { drawers, hasDrawerViewportOverlay, hasOpenDrawer, isNavigationOpen, navigationHide } =
+  const { disableBodyScroll, drawers, hasDrawerViewportOverlay, hasOpenDrawer, isNavigationOpen, navigationHide } =
     useAppLayoutInternals();
 
   const isUnfocusable = hasDrawerViewportOverlay && isNavigationOpen && !navigationHide;
@@ -63,6 +63,7 @@ export default function Drawers() {
   return (
     <div
       className={clsx(styles['drawers-container'], {
+        [styles['disable-body-scroll']]: disableBodyScroll,
         [styles['has-open-drawer']]: hasOpenDrawer,
         [styles.unfocusable]: isUnfocusable,
       })}

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -36,8 +36,18 @@
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     left: 0;
     position: fixed;
-    top: var(#{custom-props.$offsetTop});
     z-index: 1001;
+
+    /*
+    When disableBodyScroll is true the offsetTop will be relative to the 
+    app layout and not the body. However, the drawer position changes 
+    to fixed in mobile viewports. The top value needs to include the 
+    header because fixed position switches the top value so it is now 
+    relative to the body.
+    */
+    &.disable-body-scroll {
+      top: var(#{custom-props.$headerHeight});
+    }
   }
 }
 

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -21,6 +21,7 @@ import customCssProps from '../../internal/generated/custom-css-properties';
 export default function Navigation() {
   const {
     ariaLabels,
+    disableBodyScroll,
     handleNavigationClick,
     hasDrawerViewportOverlay,
     isMobile,
@@ -55,8 +56,9 @@ export default function Navigation() {
       {(state, transitionEventsRef) => (
         <div
           className={clsx(styles['navigation-container'], {
-            [testutilStyles['drawer-closed']]: !isNavigationOpen,
+            [styles['disable-body-scroll']]: disableBodyScroll,
             [styles.unfocusable]: isUnfocusable,
+            [testutilStyles['drawer-closed']]: !isNavigationOpen,
           })}
           // Overwrite the default nav width (depends on breakpoints) only when the `navigationWidth` property is set.
           style={{ ...(navigationWidth && { [customCssProps.navigationWidth]: `${navigationWidth}px` }) }}

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -44,8 +44,18 @@ viewport size and state of the Tools drawer.
     #{custom-props.$toolsWidth}: auto;
     position: fixed;
     right: 0;
-    top: var(#{custom-props.$offsetTop});
     z-index: 1001;
+
+    /*
+    When disableBodyScroll is true the offsetTop will be relative to the 
+    app layout and not the body. However, the drawer position changes 
+    to fixed in mobile viewports. The top value needs to include the 
+    header because fixed position switches the top value so it is now 
+    relative to the body.
+    */
+    &.disable-body-scroll {
+      top: var(#{custom-props.$headerHeight});
+    }
   }
 }
 

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -26,6 +26,7 @@ interface ToolsProps {
 export default function Tools({ children }: ToolsProps) {
   const {
     ariaLabels,
+    disableBodyScroll,
     drawers,
     handleSplitPanelClick,
     handleToolsClick,
@@ -63,8 +64,9 @@ export default function Tools({ children }: ToolsProps) {
       {(state, transitionEventsRef) => (
         <div
           className={clsx(styles['tools-container'], {
-            [testutilStyles['drawer-closed']]: !isToolsOpen,
+            [styles['disable-body-scroll']]: disableBodyScroll,
             [styles.unfocusable]: isUnfocusable,
+            [testutilStyles['drawer-closed']]: !isToolsOpen,
           })}
           style={{
             [customCssProps.toolsAnimationStartingOpacity]: `${hasSplitPanel && isSplitPanelOpen ? 1 : 0}`,


### PR DESCRIPTION
This PR resolves an issue with the `AppLayout` `navigation`, `drawers`, and `tools` in mobile viewports when the deprecated `disableBodyScroll` property is enabled. Using `disableBodyScroll` sets the internal `offsetTop` value to `0` because sticky elements will be relative to the `AppLayout` root element and not the document `body`. However, `sticky` drawers are changed to `fixed` position in mobile viewports. This makes the `top` value incorrect because it is now relative to the document `body` and does not account for the height of the `header` element.

Before:

https://user-images.githubusercontent.com/438181/233471296-a49bc2a8-7402-43f6-960b-11a17fcce31c.mov

After:

https://user-images.githubusercontent.com/438181/233471331-e4bb9f81-5d31-4456-9b65-2d5be16ff133.mov

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
