### PR TITLE
fix: Adjust the stacking order of drawers content

### DIFF
--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -113,6 +113,7 @@
   > .drawer-close-button {
     grid-column: 2;
     grid-row: 2;
+    z-index: 1;
   }
 
   > .drawer-content {


### PR DESCRIPTION
This PR resolves an issue with the `AppLayout` `drawers` implementation regarding the stacking order of the contents and the close button. If `drawers` is used with contents other than a `HelpPanel` (such as a `Container`) the close button will be obscured and unusable. The resolution is to lift the stacking context of the close button similar to the original `tools` implementation.

Before:

https://user-images.githubusercontent.com/438181/233476013-6fc1fb12-557e-4083-aa79-1bf2a962648b.mov

After: 

https://user-images.githubusercontent.com/438181/233476047-f7f09c2e-2cf1-4d74-b900-8c66991b1a6e.mov

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
