### PR TITLE
fix: Improve table inline editing focus highlighting for assitive technology

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -5,7 +5,6 @@
 
 @use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
-@use '../../internal/hooks/focus-visible' as focus-visible;
 
 $cell-vertical-padding: awsui.$space-scaled-xs;
 // Calculate padding to prevent a shift in content after selection due to the difference
@@ -206,6 +205,19 @@ $border-placeholder: awsui.$border-item-width solid transparent;
       & > .body-cell-editor {
         opacity: 0;
       }
+      // We don't use our focus-visible polyfill here because it doesn't work properly with screen readers.
+      // These edit buttons are special because they are visually hidden (opacity: 0), but exposed to assistive technology.
+      // It's therefore important to display the focus outline, even when a keyboard user wasn't detected.
+      // For example, when an edit button is selected from the VoiceOver rotor menu.
+      &:focus-within {
+        @include focused-editor-styles;
+        @include styles.focus-highlight(
+          (
+            'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),
+            'horizontal': calc(-1 * #{awsui.$space-scaled-xxs}),
+          )
+        );
+      }
       &:hover {
         position: relative;
         background-color: awsui.$color-background-dropdown-item-hover;
@@ -232,16 +244,6 @@ $border-placeholder: awsui.$border-item-width solid transparent;
           padding-top: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
           padding-bottom: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
         }
-      }
-      // stylelint-disable-next-line selector-combinator-disallowed-list
-      body[data-awsui-focus-visible='true'] &:focus-within {
-        @include focused-editor-styles;
-        @include styles.focus-highlight(
-          (
-            'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),
-            'horizontal': calc(-1 * #{awsui.$space-scaled-xxs}),
-          )
-        );
       }
     }
   }


### PR DESCRIPTION
### Description

The edit buttons for table inline editing are visually hidden (`opacity: 0`) but are exposed to assistive technology.
This makes it critical that focus outlines are displayed correctly when these cells receive focus. Unfortunately, our focus-visible polyfill doesn't detect screen reader users correctly, which means that edit buttons are not always displayed correctly when focused by a screen reader. For example, when focusing a edit using the VoiceOver rotor menu (VO+U).

To mitigate this problem, we're replacing the focus visible polyfill with a native `:focus-within` selector **for table inline editing only.** This is a special case and there is no need to apply these changes elsewhere.

Related links, issue #, if available: AWSUI-20149

### How has this been tested?

Tested manually with Chrome, Firefox, Safari, and VoiceOver.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
