### PR TITLE
feat: Add row data information to the `activateEditLabel` function for table

### DIFF
--- a/pages/table/compact-mode.page.tsx
+++ b/pages/table/compact-mode.page.tsx
@@ -276,7 +276,7 @@ export default function App() {
           }}
           ariaLabels={{
             tableLabel: 'Distributions',
-            activateEditLabel: column => `Edit ${column.header}`,
+            activateEditLabel: (column, item) => `Edit ${item.name} ${column.header}`,
             cancelEditLabel: column => `Cancel editing ${column.header}`,
             submitEditLabel: column => `Submit edit ${column.header}`,
           }}

--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -21,7 +21,7 @@ const DOMAIN_NAME = /^\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[
 
 export const ariaLabels: TableProps.AriaLabels<DistributionInfo> = {
   tableLabel: 'Distributions',
-  activateEditLabel: column => `Edit ${column.header}`,
+  activateEditLabel: (column, item) => `Edit ${item.Id} ${column.header}`,
   cancelEditLabel: column => `Cancel editing ${column.header}`,
   submitEditLabel: column => `Submit edit ${column.header}`,
 };

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11678,7 +11678,7 @@ You can use the first argument of type \`SelectionState\` to access the current 
 state of the component (for example, the \`selectedItems\` list). The \`itemSelectionLabel\` for individual
 items also receives the corresponding  \`Item\` object. You can use the \`selectionGroupLabel\` to
 add a meaningful description to the whole selection.
-* \`activateEditLabel\` (EditableColumnDefinition) => string -
+* \`activateEditLabel\` (EditableColumnDefinition, Item) => string -
                      Specifies an alternative text for the edit button in editable cells.
 * \`cancelEditLabel\` (EditableColumnDefinition) => string -
                      Specifies an alternative text for the cancel button in editable cells.
@@ -11691,7 +11691,7 @@ add a meaningful description to the whole selection.
           Object {
             "name": "activateEditLabel",
             "optional": true,
-            "type": "(column: TableProps.ColumnDefinition<any>) => string",
+            "type": "(column: TableProps.ColumnDefinition<any>, item: T) => string",
           },
           Object {
             "name": "allItemsSelectionLabel",

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -6,7 +6,7 @@ import { TableBodyCell } from '../../../lib/components/table/body-cell';
 import { TableProps } from '../interfaces';
 
 const testItem = {
-  test: 'test',
+  test: 'testData',
 };
 
 const column: TableProps.ColumnDefinition<typeof testItem> = {
@@ -37,7 +37,7 @@ const TestComponent = ({ isEditing = false }) => {
             onEditStart={onEditStart}
             onEditEnd={onEditEnd}
             ariaLabels={{
-              activateEditLabel: () => 'activate edit',
+              activateEditLabel: (column, item) => `Edit ${item.test} ${column.id}`,
               cancelEditLabel: () => 'cancel edit',
               submitEditLabel: () => 'submit edit',
             }}
@@ -93,7 +93,7 @@ describe('TableBodyCell', () => {
 
   it('should call onEditStart', () => {
     render(<TestComponent />);
-    fireEvent.click(screen.getByRole('button', { name: 'activate edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit testData test' }));
     expect(onEditStart).toHaveBeenCalled();
   });
 

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -78,7 +78,7 @@ function TableCellEditable<ItemType>({
           {column.cell(item)}
           <button
             className={styles['body-cell-editor']}
-            aria-label={ariaLabels?.activateEditLabel?.(column)}
+            aria-label={ariaLabels?.activateEditLabel?.(column, item)}
             ref={editActivateRef}
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -101,7 +101,7 @@ export function InlineEditor<ItemType>({
       <div
         role="dialog"
         ref={clickAwayRef}
-        aria-label={ariaLabels?.activateEditLabel?.(column)}
+        aria-label={ariaLabels?.activateEditLabel?.(column, item)}
         onKeyDown={handleEscape}
       >
         <form onSubmit={onSubmitClick} className={styles['body-cell-editor-form']}>

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -166,7 +166,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * items also receives the corresponding  `Item` object. You can use the `selectionGroupLabel` to
    * add a meaningful description to the whole selection.
    *
-   * * `activateEditLabel` (EditableColumnDefinition) => string -
+   * * `activateEditLabel` (EditableColumnDefinition, Item) => string -
    *                      Specifies an alternative text for the edit button in editable cells.
    * * `cancelEditLabel` (EditableColumnDefinition) => string -
    *                      Specifies an alternative text for the cancel button in editable cells.
@@ -357,7 +357,7 @@ export namespace TableProps {
     tableLabel?: string;
     // do not use <T> to prevent overly strict validation on consumer end
     // it works, practically, we are only interested in `id` and `header` properties only
-    activateEditLabel?: (column: ColumnDefinition<any>) => string;
+    activateEditLabel?: (column: ColumnDefinition<any>, item: T) => string;
     cancelEditLabel?: (column: ColumnDefinition<any>) => string;
     submitEditLabel?: (column: ColumnDefinition<any>) => string;
   }


### PR DESCRIPTION
### Description
To provide more context for edit buttons in table cells, we pass information about the current row's item data to the `activateEditLabel` function.

Related links, issue #, if available: AWSUI-20154

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
