### PR TITLE
fix: Primary button link in top navigation not firing in mobile view

### DIFF
--- a/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
@@ -82,7 +82,7 @@ describe('TopNavigation Overflow menu', () => {
 describe('UtilityMenuItem', () => {
   test.each(linkTargetExpectations)('"target" property %s', (props, expectation) => {
     const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
-    const linkWrapper = createWrapper(container).find('a')!;
+    const linkWrapper = createWrapper(container).find(`a, button`)!;
 
     expectation
       ? expect(linkWrapper.getElement()).toHaveAttribute('target', expectation)
@@ -91,19 +91,24 @@ describe('UtilityMenuItem', () => {
 
   test.each(linkRelExpectations)('"rel" property %s', (props, expectation) => {
     const { container } = render(<UtilityMenuItem type="button" index={0} {...props} />);
-    const linkWrapper = createWrapper(container).find('a')!;
+    const linkWrapper = createWrapper(container).find('a, button')!;
 
     expectation
       ? expect(linkWrapper.getElement()).toHaveAttribute('rel', expectation)
       : expect(linkWrapper.getElement()).not.toHaveAttribute('rel');
   });
 
-  it('fires onClick with empty detail', () => {
-    const onClick = jest.fn();
-    const { container } = render(<UtilityMenuItem type="button" index={0} href="#" onClick={onClick} />);
-    const linkWrapper = createWrapper(container).find('a')!;
-    linkWrapper.click();
+  test.each([undefined, 'link', 'primary-button'] as const)(
+    'fires onClick with empty detail for variant %s',
+    variant => {
+      const onClick = jest.fn();
+      const { container } = render(
+        <UtilityMenuItem type="button" index={0} href="#" variant={variant} onClick={onClick} />
+      );
+      const linkWrapper = createWrapper(container).find('a')!;
+      linkWrapper.click();
 
-    expect(onClick).toBeCalledWith(expect.objectContaining({ detail: {} }));
-  });
+      expect(onClick).toBeCalledWith(expect.objectContaining({ detail: {} }));
+    }
+  );
 });

--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -208,10 +208,24 @@ function utilityComponentFactory(
         fireCancelableEvent(utility.onClick, {}, event);
       };
 
-      if (utility.variant === 'primary-button') {
+      const content = (
+        <>
+          {label}
+          {utility.external && (
+            <>
+              {' '}
+              <span aria-label={utility.externalIconAriaLabel} role={utility.externalIconAriaLabel ? 'img' : undefined}>
+                <InternalIcon name="external" size="normal" />
+              </span>
+            </>
+          )}
+        </>
+      );
+
+      if (!utility.href) {
         return (
           <ButtonItem ref={ref} startIcon={startIcon} onFollow={handleClick} testId={`__${index}`}>
-            {label}
+            {content}
           </ButtonItem>
         );
       }
@@ -227,15 +241,7 @@ function utilityComponentFactory(
           testId={`__${index}`}
           onFollow={handleClick}
         >
-          {label}
-          {utility.external && (
-            <>
-              {' '}
-              <span aria-label={utility.externalIconAriaLabel} role={utility.externalIconAriaLabel ? 'img' : undefined}>
-                <InternalIcon name="external" size="normal" />
-              </span>
-            </>
-          )}
+          {content}
         </LinkItem>
       );
     }


### PR DESCRIPTION
### Description

Before this fix, a button that has `variant: "primary-button"` and an `href` would not trigger a navigation when the viewport is small enough for the content to move to the overflow menu. It also only shows the "external" icon when in desktop view.

With this code change, the navigation is triggered correctly on all screen sizes.  
In addition, the "external" icon is also shown in the mobile view.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: **AWSUI-20976**

### How has this been tested?

Manual local testing in the dev pages

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
