### PR TITLE
chore: Add findFilterSlot and findPropertyFilter test utils

### DIFF
--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import Table, { TableProps } from '../../../lib/components/table';
+import PropertyFilter from '../../../lib/components/property-filter';
+import Select from '../../../lib/components/select';
 import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
 import headerCellStyles from '../../../lib/components/table/header-cell/styles.css.js';
 
@@ -107,6 +109,37 @@ test('should render table with empty state when loading text is not set', () => 
   expect(wrapper.findRows()).toHaveLength(0);
   expect(wrapper.findEmptySlot()!.getElement()).toHaveTextContent('no content');
   expect(wrapper.findLoadingText()).toBeNull();
+});
+
+test('should render table with a property filter', () => {
+  const { wrapper } = renderTable(
+    <Table
+      columnDefinitions={defaultColumns}
+      items={defaultItems}
+      filter={
+        <PropertyFilter
+          onChange={() => {}}
+          query={{ tokens: [], operation: 'and' }}
+          i18nStrings={{ filteringAriaLabel: 'filter' }}
+          filteringProperties={[]}
+        />
+      }
+    />
+  );
+
+  expect(wrapper.findPropertyFilter()).not.toBeNull();
+});
+
+test('should render table with a select filter', () => {
+  const { wrapper } = renderTable(
+    <Table
+      columnDefinitions={defaultColumns}
+      items={defaultItems}
+      filter={<Select onChange={() => {}} selectedOption={{}} />}
+    />
+  );
+
+  expect(wrapper.findFilterSlot()?.findSelect()).not.toBeNull();
 });
 
 test('should render table with empty state when  loading text is defined', () => {

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -10,6 +10,7 @@ import CollectionPreferencesWrapper from '../collection-preferences';
 import ContainerWrapper from '../container';
 import PaginationWrapper from '../pagination';
 import TextFilterWrapper from '../text-filter';
+import PropertyFilterWrapper from '../property-filter';
 
 export default class TableWrapper extends ComponentWrapper {
   static rootSelector: string = styles.root;
@@ -121,11 +122,15 @@ export default class TableWrapper extends ComponentWrapper {
   findTextFilter(): TextFilterWrapper | null {
     return this.findComponent(`.${styles['tools-filtering']}`, TextFilterWrapper);
   }
-  //
-  // findPropertyFiltering(): TablePropertyFilteringWrapper {
-  //   return new TablePropertyFilteringWrapper(this.find('awsui-table-property-filtering').getElement());
-  // }
-  //
+
+  findPropertyFilter(): PropertyFilterWrapper | null {
+    return this.findComponent(`.${styles['tools-filtering']}`, PropertyFilterWrapper);
+  }
+
+  findFilterSlot(): ElementWrapper | null {
+    return this.findComponent(`.${styles['tools-filtering']}`, ElementWrapper);
+  }
+
   findCollectionPreferences(): CollectionPreferencesWrapper | null {
     return this.findComponent(`.${styles['tools-preferences']}`, CollectionPreferencesWrapper);
   }


### PR DESCRIPTION
### Description

We have a test util function for `TextFilter` but we don't have any for `PropertyFilter` or any other filter like: `Select`. 
this PR adds a generic function `findFilterSlot` and a `PropertyFilter` specific one.

Related links, issue #, if available: AWSUI-20754

### How has this been tested?

Added unit tests that uses these properties 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
