### PR TITLE
chore: Refactor table wrapper and selection elements

### DIFF
--- a/src/table/body-cell/td-selection-element.tsx
+++ b/src/table/body-cell/td-selection-element.tsx
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React, { KeyboardEventHandler } from 'react';
+import SelectionControl from '../selection-control/';
+import { TableProps } from '../interfaces.js';
+import { TableTdElementProps } from './td-element.js';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
+import styles from './styles.css.js';
+
+type TableBodySelectionCellProps = Omit<
+  TableTdElementProps,
+  'style' | 'nativeAttributes' | 'onClick' | 'tdRef' | 'hasSelection' | 'wrapLines' | 'columnId'
+> & {
+  selectionType?: 'single' | 'multi';
+  onFocusUp?: KeyboardEventHandler;
+  onFocusDown?: KeyboardEventHandler;
+  onShiftToggle: (value: boolean) => void;
+  itemSelectionProps: {
+    name: string;
+    selectionType: TableProps.SelectionType | undefined;
+    ariaLabel: string | undefined;
+    onChange: () => void;
+    checked: boolean;
+    disabled: boolean;
+  };
+};
+
+export function TableBodySelectionCell({
+  className,
+  isFirstRow,
+  isLastRow,
+  isSelected,
+  isNextSelected,
+  isPrevSelected,
+  isEvenRow,
+  stripedRows,
+  hasFooter,
+  selectionType,
+  onFocusDown,
+  onFocusUp,
+  onShiftToggle,
+  itemSelectionProps,
+}: TableBodySelectionCellProps) {
+  const isVisualRefresh = useVisualRefresh();
+  if (selectionType !== undefined) {
+    return (
+      <td
+        className={clsx(
+          className,
+          styles['body-cell'],
+          styles['has-selection'],
+          isFirstRow && styles['body-cell-first-row'],
+          isLastRow && styles['body-cell-last-row'],
+          isSelected && styles['body-cell-selected'],
+          isNextSelected && styles['body-cell-next-selected'],
+          isPrevSelected && styles['body-cell-prev-selected'],
+          !isEvenRow && stripedRows && styles['body-cell-shaded'],
+          stripedRows && styles['has-striped-rows'],
+          isVisualRefresh && styles['is-visual-refresh'],
+          hasFooter && styles['has-footer']
+        )}
+      >
+        <SelectionControl
+          onFocusDown={onFocusDown}
+          onFocusUp={onFocusUp}
+          onShiftToggle={onShiftToggle}
+          {...itemSelectionProps}
+        />
+      </td>
+    );
+  } else {
+    return null;
+  }
+}

--- a/src/table/header-cell/th-selection-element.tsx
+++ b/src/table/header-cell/th-selection-element.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React from 'react';
+import { TableProps } from '../interfaces';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
+import styles from '../styles.css.js';
+
+interface TableBodySelectionCellProps {
+  className?: string;
+  selectionType?: TableProps.SelectionType;
+  children: React.ReactNode;
+}
+
+export function TableHeaderSelectionCell({ children, selectionType, className }: TableBodySelectionCellProps) {
+  const isVisualRefresh = useVisualRefresh();
+  const selectionCellClass = clsx(
+    className,
+    styles['has-selection'],
+    styles['selection-control'],
+    styles['selection-control-header'],
+    isVisualRefresh && styles['is-visual-refresh']
+  );
+
+  if (selectionType !== undefined) {
+    return (
+      <th className={selectionCellClass} scope="col">
+        {children}
+      </th>
+    );
+  } else {
+    return null;
+  }
+}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -12,7 +12,6 @@ import { TableBodyCell } from './body-cell';
 import InternalStatusIndicator from '../status-indicator/internal';
 import { useContainerQuery } from '../internal/hooks/container-queries';
 import { supportsStickyPosition } from '../internal/utils/dom';
-import SelectionControl from './selection-control';
 import { checkSortingState, getColumnKey, getItemKey, toContainerVariant } from './utils';
 import { useRowEvents } from './use-row-events';
 import { focusMarkers, useFocusMove, useSelection } from './use-selection';
@@ -32,7 +31,9 @@ import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import LiveRegion from '../internal/components/live-region';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
-import { TableTdElement } from './body-cell/td-element';
+import TableWrapper from './table-wrapper';
+import { TableBodySelectionCell } from './body-cell/td-selection-element';
+
 type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
 
@@ -256,14 +257,14 @@ const InternalTable = React.forwardRef(
           __stickyOffset={stickyHeaderVerticalOffset}
           {...focusMarkers.root}
         >
-          <div
-            ref={wrapperRef}
+          <TableWrapper
+            wrapperRef={wrapperRef}
             className={clsx(styles.wrapper, styles[`variant-${computedVariant}`], {
               [styles['has-footer']]: hasFooter,
               [styles['has-header']]: hasHeader,
             })}
             onScroll={handleScroll}
-            {...wrapperProps}
+            wrapperProps={wrapperProps}
           >
             {!!renderAriaLive && !!firstIndex && (
               <LiveRegion>
@@ -338,29 +339,22 @@ const InternalTable = React.forwardRef(
                         onContextMenu={onRowContextMenuHandler && onRowContextMenuHandler.bind(null, rowIndex, item)}
                         aria-rowindex={firstIndex ? firstIndex + rowIndex + 1 : undefined}
                       >
-                        {selectionType !== undefined && (
-                          <TableTdElement
-                            className={clsx(styles['selection-control'])}
-                            isVisualRefresh={isVisualRefresh}
-                            isFirstRow={firstVisible}
-                            isLastRow={lastVisible}
-                            isSelected={isSelected}
-                            isNextSelected={isNextSelected}
-                            isPrevSelected={isPrevSelected}
-                            wrapLines={false}
-                            isEvenRow={isEven}
-                            stripedRows={stripedRows}
-                            hasSelection={hasSelection}
-                            hasFooter={hasFooter}
-                          >
-                            <SelectionControl
-                              onFocusDown={moveFocusDown}
-                              onFocusUp={moveFocusUp}
-                              onShiftToggle={updateShiftToggle}
-                              {...getItemSelectionProps(item)}
-                            />
-                          </TableTdElement>
-                        )}
+                        <TableBodySelectionCell
+                          className={clsx(styles['selection-control'])}
+                          isFirstRow={firstVisible}
+                          isLastRow={lastVisible}
+                          isSelected={isSelected}
+                          isNextSelected={isNextSelected}
+                          isPrevSelected={isPrevSelected}
+                          isEvenRow={isEven}
+                          stripedRows={stripedRows}
+                          hasFooter={hasFooter}
+                          selectionType={selectionType}
+                          onFocusDown={moveFocusDown}
+                          onFocusUp={moveFocusUp}
+                          onShiftToggle={updateShiftToggle}
+                          itemSelectionProps={getItemSelectionProps(item)}
+                        />
                         {visibleColumnDefinitions.map((column, colIndex) => {
                           const isEditing =
                             !!currentEditCell && currentEditCell[0] === rowIndex && currentEditCell[1] === colIndex;
@@ -410,7 +404,7 @@ const InternalTable = React.forwardRef(
               </tbody>
             </table>
             {resizableColumns && <ResizeTracker />}
-          </div>
+          </TableWrapper>
           <StickyScrollbar
             ref={scrollbarRef}
             wrapperRef={wrapperRefObject}

--- a/src/table/table-wrapper.tsx
+++ b/src/table/table-wrapper.tsx
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+export interface TableWrapperProps {
+  children: React.ReactNode;
+  className: string;
+  wrapperRef: React.RefCallback<any> | null;
+  onScroll?: React.UIEventHandler<HTMLDivElement>;
+  wrapperProps: any;
+}
+
+const TableWrapper = ({ children, className, wrapperRef, onScroll, wrapperProps }: TableWrapperProps) => {
+  return (
+    <div ref={wrapperRef} className={className} onScroll={onScroll} {...wrapperProps}>
+      {children}
+    </div>
+  );
+};
+
+export default TableWrapper;

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -10,6 +10,7 @@ import { getColumnKey } from './utils';
 import { TableHeaderCell } from './header-cell';
 import { useColumnWidths } from './use-column-widths';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { TableHeaderSelectionCell } from './header-cell/th-selection-element';
 import styles from './styles.css.js';
 import headerCellStyles from './header-cell/styles.css.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
@@ -38,7 +39,6 @@ export interface TheadProps {
   stuck?: boolean;
   singleSelectionHeaderAriaLabel?: string;
   stripedRows?: boolean;
-
   focusedComponent?: InteractiveComponent | null;
   onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
 }
@@ -81,41 +81,30 @@ const Thead = React.forwardRef(
       isVisualRefresh && headerCellStyles['is-visual-refresh']
     );
 
-    const selectionCellClass = clsx(
-      styles['selection-control'],
-      styles['selection-control-header'],
-      isVisualRefresh && styles['is-visual-refresh']
-    );
-
     const { columnWidths, totalWidth, updateColumn } = useColumnWidths();
 
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
         <tr {...focusMarkers.all} ref={outerRef} aria-rowindex={1}>
-          {selectionType === 'multi' && (
-            <th
-              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
-              scope="col"
-            >
-              <SelectionControl
-                onFocusDown={event => {
-                  onFocusMove!(event.target as HTMLElement, -1, +1);
-                }}
-                focusedComponent={focusedComponent}
-                onFocusedComponentChange={onFocusedComponentChange}
-                {...selectAllProps}
-                {...(sticky ? { tabIndex: -1 } : {})}
-              />
-            </th>
-          )}
-          {selectionType === 'single' && (
-            <th
-              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
-              scope="col"
-            >
-              <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>
-            </th>
-          )}
+          <TableHeaderSelectionCell
+            selectionType={selectionType}
+            className={clsx(headerCellClass, hidden && headerCellStyles['header-cell-hidden'])}
+          >
+            <>
+              {selectionType === 'single' && <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>}
+              {selectionType === 'multi' && (
+                <SelectionControl
+                  onFocusDown={event => {
+                    onFocusMove!(event.target as HTMLElement, -1, +1);
+                  }}
+                  focusedComponent={focusedComponent}
+                  onFocusedComponentChange={onFocusedComponentChange}
+                  {...selectAllProps}
+                  {...(sticky ? { tabIndex: -1 } : {})}
+                />
+              )}
+            </>
+          </TableHeaderSelectionCell>
           {columnDefinitions.map((column, colIndex) => {
             let widthOverride;
             if (resizableColumns) {


### PR DESCRIPTION
### Description

This PR addresses the need to utilize hooks within our previously native table wrapper and selection cell components. By converting them to function components, we will be able to take advantage of hooks, in preparation for the sticky columns feature: https://github.com/cloudscape-design/components/pull/918


### How has this been tested?

Existing unit, integration and screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
