### PR TITLE
chore: Fix visual regression for table inline editing

### DIFF
--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -135,8 +135,8 @@ export function InlineEditor<ItemType>({
                     variant="inline-icon"
                     loading={currentEditLoading}
                   />
-                  <LiveRegion>{currentEditLoading ? ariaLabels?.submittingEditText?.(column) : ''}</LiveRegion>
                 </SpaceBetween>
+                <LiveRegion>{currentEditLoading ? ariaLabels?.submittingEditText?.(column) : ''}</LiveRegion>
               </span>
             </div>
           </FormField>


### PR DESCRIPTION
### Description
Fixes a visual regression introduced in https://github.com/cloudscape-design/components/pull/941 regarding the use of `LiveRegion` inside `SpaceBetween`.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
