### PR TITLE
fix: Passthrough preventDefault on top navigation link utility clicks

### DIFF
--- a/pages/top-navigation/integ.page.tsx
+++ b/pages/top-navigation/integ.page.tsx
@@ -53,7 +53,11 @@ export default function () {
             ariaLabel: 'Notifications',
             iconName: 'notification',
             disableUtilityCollapse: true,
-            onClick: onUtilityClick,
+            href: '/should-not-navigate',
+            onClick: evt => {
+              evt.preventDefault();
+              onUtilityClick(evt);
+            },
           },
           {
             type: 'menu-dropdown',

--- a/src/top-navigation/__integ__/top-navigation.test.ts
+++ b/src/top-navigation/__integ__/top-navigation.test.ts
@@ -8,10 +8,16 @@ import TopNavigationWrapper from '../../../lib/components/test-utils/selectors/t
 
 const wrapper = new TopNavigationWrapper(`.${TopNavigationWrapper.rootSelector}`);
 
-const setupTest = (pageWidth: number, testFn: (page: BasePageObject) => Promise<void>) => {
+class TopNavigationPage extends BasePageObject {
+  getLocation() {
+    return this.browser.getUrl();
+  }
+}
+
+const setupTest = (pageWidth: number, testFn: (page: TopNavigationPage) => Promise<void>) => {
   return useBrowser(async browser => {
     await browser.url('#/light/top-navigation/integ');
-    const page = new BasePageObject(browser);
+    const page = new TopNavigationPage(browser);
     await page.setWindowSize({ width: pageWidth, height: 600 });
     await page.waitForVisible(wrapper.toSelector());
     await testFn(page);
@@ -28,6 +34,15 @@ describe('Top navigation', () => {
         await expect(page.getText(wrapper.findUtility(1).toSelector())).resolves.toBe('New thing');
         await expect(page.getText(wrapper.findUtility(2).toSelector())).resolves.toBe('Docs ');
         await expect(page.getText(wrapper.findUtility(4).toSelector())).resolves.toBe('John Doe');
+      })
+    );
+
+    test(
+      'respects preventDefault on button onClick handler',
+      setupTest(pageWidth, async page => {
+        const previousLocation = await page.getLocation();
+        await page.click(wrapper.findUtility(3).toSelector());
+        await expect(page.getLocation()).resolves.toBe(previousLocation);
       })
     );
 

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -75,7 +75,7 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
             target={definition.target}
             rel={definition.rel}
             external={definition.external}
-            onFollow={() => fireCancelableEvent(definition.onClick, {})}
+            onFollow={evt => fireCancelableEvent(definition.onClick, {}, evt)}
             ariaLabel={ariaLabel}
           >
             {hasIcon && (


### PR DESCRIPTION
### Description

We broke this in a recent PR to update the click detail but borked it in the process.

Related links, issue #, if available: n/a

### How has this been tested?

Painstakingly integ tested.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
