### PR TITLE
chore: Add app layout runtime API

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  AppLayout,
+  ContentLayout,
+  Header,
+  HelpPanel,
+  NonCancelableCustomEvent,
+  SpaceBetween,
+  SplitPanel,
+  Toggle,
+} from '~components';
+import appLayoutLabels from './utils/labels';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import './utils/external-widget';
+
+export default function WithDrawers() {
+  const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
+  const [hasDrawers, setHasDrawers] = useState(true);
+  const [hasTools, setHasTools] = useState(false);
+  const [isToolsOpen, setIsToolsOpen] = useState(false);
+
+  const [widths, setWidths] = useState<{ [id: string]: number }>({
+    security: 500,
+    'pro-help': 280,
+  });
+
+  const drawers = !hasDrawers
+    ? null
+    : {
+        drawers: {
+          ariaLabel: 'Drawers',
+          activeDrawerId: activeDrawerId,
+          onResize: (event: NonCancelableCustomEvent<{ size: number; id: string }>) => {
+            const obj = widths;
+            obj[event.detail.id] = event.detail.size;
+            setWidths(obj);
+            console.log(widths.security);
+          },
+          items: [
+            {
+              ariaLabels: {
+                closeButton: 'ProHelp close button',
+                content: 'ProHelp drawer content',
+                triggerButton: 'ProHelp trigger button',
+                resizeHandle: 'ProHelp resize handle',
+              },
+              content: <ProHelp />,
+              id: 'pro-help',
+              trigger: {
+                iconName: 'contact',
+              },
+            },
+          ],
+          onChange: (event: NonCancelableCustomEvent<string>) => {
+            setActiveDrawerId(event.detail);
+          },
+        },
+      };
+
+  return (
+    <AppLayout
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="m">
+              <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
+                Testing Custom Drawers!
+              </Header>
+
+              <SpaceBetween size="xs">
+                <Toggle checked={hasTools} onChange={({ detail }) => setHasTools(detail.checked)}>
+                  Use Tools
+                </Toggle>
+
+                <Toggle checked={hasDrawers} onChange={({ detail }) => setHasDrawers(detail.checked)}>
+                  Use Drawers
+                </Toggle>
+              </SpaceBetween>
+            </SpaceBetween>
+          }
+        >
+          <Containers />
+        </ContentLayout>
+      }
+      splitPanel={
+        <SplitPanel
+          header="Split panel header"
+          i18nStrings={{
+            preferencesTitle: 'Preferences',
+            preferencesPositionLabel: 'Split panel position',
+            preferencesPositionDescription: 'Choose the default split panel position for the service.',
+            preferencesPositionSide: 'Side',
+            preferencesPositionBottom: 'Bottom',
+            preferencesConfirm: 'Confirm',
+            preferencesCancel: 'Cancel',
+            closeButtonAriaLabel: 'Close panel',
+            openButtonAriaLabel: 'Open panel',
+            resizeHandleAriaLabel: 'Slider',
+          }}
+        >
+          This is the Split Panel!
+        </SplitPanel>
+      }
+      onToolsChange={event => {
+        setIsToolsOpen(event.detail.open);
+      }}
+      tools={<Info />}
+      toolsOpen={isToolsOpen}
+      toolsHide={!hasTools}
+      {...drawers}
+    />
+  );
+}
+
+function Info() {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+}
+
+function ProHelp() {
+  return <HelpPanel header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</HelpPanel>;
+}

--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect } from 'react';
+import ReactDOM, { unmountComponentAtNode } from 'react-dom';
+import HelpPanel from '~components/help-panel';
+import awsuiPlugins from '~components/internal/plugins';
+
+function Content() {
+  useEffect(() => {
+    console.log('mounted');
+    return () => console.log('unmounted');
+  }, []);
+  return <HelpPanel header={<h2>Security</h2>}>I am runtime drawer</HelpPanel>;
+}
+
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'security',
+
+  ariaLabels: {
+    closeButton: 'Security close button',
+    content: 'Security drawer content',
+    triggerButton: 'Security trigger button',
+    resizeHandle: 'Security resize handle',
+  },
+
+  trigger: {
+    iconName: 'security',
+  },
+
+  resizable: true,
+  defaultSize: 320,
+
+  onResize: newSize => {
+    console.log('resize', newSize);
+  },
+
+  mountContent: container => {
+    ReactDOM.render(<Content />, container);
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import AppLayout from '../../../lib/components/app-layout';
+import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
+import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import { DrawerConfig } from '../../../lib/components/internal/plugins/drawers-controller';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+beforeEach(() => {
+  awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+});
+
+async function renderComponent(jsx: React.ReactElement) {
+  const { container, rerender } = render(jsx);
+  const wrapper = createWrapper(container).findAppLayout()!;
+  await delay();
+  return { wrapper, rerender };
+}
+
+function delay() {
+  return act(() => new Promise(resolve => setTimeout(resolve)));
+}
+
+const drawerDefaults: DrawerConfig = {
+  id: 'test',
+  ariaLabels: {},
+  trigger: {},
+  mountContent: () => {},
+  unmountContent: () => {},
+};
+
+describe('Runtime drawers', () => {
+  test('does not render runtime drawers when it is explicitly disabled', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper } = await renderComponent(<AppLayout {...({ __disableRuntimeDrawers: true } as any)} />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
+  });
+
+  test('runtime drawers integration can be dynamically enabled and disabled', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper, rerender } = await renderComponent(<AppLayout />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    rerender(<AppLayout {...({ __disableRuntimeDrawers: true } as any)} />);
+    await delay();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
+    rerender(<AppLayout />);
+    await delay();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+  });
+
+  test('renders drawers via runtime config', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper } = await renderComponent(<AppLayout />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+  });
+
+  test('accepts drawers registration after initial rendering', async () => {
+    const { wrapper } = await renderComponent(<AppLayout />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    await delay();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+  });
+
+  test('persists drawer config between mounts/unmounts', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper, rerender } = await renderComponent(<AppLayout key="first" />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    rerender(<AppLayout key="second" />);
+    await delay();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+  });
+
+  test('drawer content lifecycle', async () => {
+    const mountContent = jest.fn();
+    const unmountContent = jest.fn();
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      mountContent,
+      unmountContent,
+    });
+    const { wrapper } = await renderComponent(<AppLayout />);
+    expect(mountContent).toHaveBeenCalledTimes(0);
+    wrapper.findDrawersTriggers()[0].click();
+    expect(mountContent).toHaveBeenCalledTimes(1);
+    expect(unmountContent).toHaveBeenCalledTimes(0);
+    wrapper.findActiveDrawerCloseButton()!.click();
+    expect(mountContent).toHaveBeenCalledTimes(1);
+    expect(unmountContent).toHaveBeenCalledTimes(1);
+  });
+
+  test('drawer content updates when switching active drawers', async () => {
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      id: 'first',
+      mountContent: container => (container.textContent = 'first drawer content'),
+    });
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      id: 'second',
+      mountContent: container => (container.textContent = 'second drawer content'),
+    });
+    const { wrapper } = await renderComponent(<AppLayout />);
+    wrapper.findDrawersTriggers()[0].click();
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('first drawer content');
+    wrapper.findDrawersTriggers()[1].click();
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('second drawer content');
+  });
+
+  describe('ordering', () => {
+    test('renders multiple drawers in alphabetical order by default', async () => {
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'bbb', ariaLabels: { triggerButton: 'bbb' } });
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'aaa', ariaLabels: { triggerButton: 'aaa' } });
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'ccc', ariaLabels: { triggerButton: 'ccc' } });
+      const { wrapper } = await renderComponent(<AppLayout />);
+      expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'aaa',
+        'bbb',
+        'ccc',
+      ]);
+    });
+
+    test('renders multiple drawers according to order priority when it is set', async () => {
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'ddd', ariaLabels: { triggerButton: 'ddd' } });
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'bbb', ariaLabels: { triggerButton: 'bbb' } });
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'aaa',
+        ariaLabels: { triggerButton: 'aaa' },
+        orderPriority: 1,
+      });
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'ccc',
+        ariaLabels: { triggerButton: 'ccc' },
+        orderPriority: 10,
+      });
+      const { wrapper } = await renderComponent(<AppLayout />);
+      expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'ccc',
+        'aaa',
+        'bbb',
+        'ddd',
+      ]);
+    });
+
+    test('allows mixing static and runtime drawers', async () => {
+      awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'aaa', ariaLabels: { triggerButton: 'aaa' } });
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'bbb',
+        ariaLabels: { triggerButton: 'bbb' },
+        orderPriority: 1,
+      });
+      awsuiPlugins.appLayout.registerDrawer({
+        ...drawerDefaults,
+        id: 'ccc',
+        ariaLabels: { triggerButton: 'ccc' },
+        orderPriority: -1,
+      });
+      const drawers: InternalDrawerProps = {
+        drawers: {
+          items: [{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd' } }],
+        },
+      };
+      const { wrapper } = await renderComponent(<AppLayout {...(drawers as any)} />);
+      expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'bbb',
+        'ddd',
+        'aaa',
+        'ccc',
+      ]);
+    });
+  });
+});

--- a/src/app-layout/__tests__/warnings.test.tsx
+++ b/src/app-layout/__tests__/warnings.test.tsx
@@ -20,10 +20,10 @@ const noop = () => undefined;
  */
 describe('AppLayout component', () => {
   test('warns when toolsOpen and toolsHide are both set', () => {
-    render(<AppLayout toolsHide={true} toolsOpen={false} onToolsChange={noop} />);
+    const { rerender } = render(<AppLayout toolsHide={true} toolsOpen={false} onToolsChange={noop} />);
     expect(console.warn).not.toHaveBeenCalled();
 
-    render(<AppLayout toolsHide={true} toolsOpen={true} onToolsChange={noop} />);
+    rerender(<AppLayout toolsHide={true} toolsOpen={true} onToolsChange={noop} />);
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(

--- a/src/app-layout/runtime-api.tsx
+++ b/src/app-layout/runtime-api.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef } from 'react';
+import { DrawerConfig as RuntimeDrawerConfig } from '../internal/plugins/drawers-controller';
+import { DrawerItem } from './drawer/interfaces';
+
+interface RuntimeContentWrapperProps {
+  mountContent: RuntimeDrawerConfig['mountContent'];
+  unmountContent: RuntimeDrawerConfig['unmountContent'];
+}
+
+function RuntimeContentWrapper({ mountContent, unmountContent }: RuntimeContentWrapperProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = ref.current!;
+    mountContent(container);
+    return () => unmountContent(container);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <div ref={ref}></div>;
+}
+
+export interface DrawersLayout {
+  before: Array<DrawerItem>;
+  after: Array<DrawerItem>;
+}
+
+export function convertRuntimeDrawers(drawers: Array<RuntimeDrawerConfig>): DrawersLayout {
+  const converted = drawers.map(({ mountContent, unmountContent, ...runtimeDrawer }) => ({
+    ...runtimeDrawer,
+    content: (
+      <RuntimeContentWrapper key={runtimeDrawer.id} mountContent={mountContent} unmountContent={unmountContent} />
+    ),
+  }));
+  converted.sort((a, b) => {
+    if (b.orderPriority !== a.orderPriority) {
+      return Math.sign((b.orderPriority ?? 0) - (a.orderPriority ?? 0));
+    }
+    return b.id < a.id ? 1 : -1;
+  });
+  return {
+    before: converted.filter(item => (item.orderPriority ?? 0) > 0),
+    after: converted.filter(item => (item.orderPriority ?? 0) <= 0),
+  };
+}

--- a/src/internal/plugins/__tests__/drawers-controller.test.ts
+++ b/src/internal/plugins/__tests__/drawers-controller.test.ts
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DrawerConfig, DrawersController } from '../../../../lib/components/internal/plugins/drawers-controller';
+
+const drawerA = { id: 'drawerA' } as DrawerConfig;
+const drawerB = { id: 'drawerB' } as DrawerConfig;
+
+function delay() {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
+test('notifies about registered drawers initially', async () => {
+  const onDrawersRegistered = jest.fn();
+  const drawers = new DrawersController();
+  drawers.onDrawersRegistered(onDrawersRegistered);
+  drawers.registerDrawer(drawerA);
+  drawers.registerDrawer(drawerB);
+  expect(onDrawersRegistered).not.toHaveBeenCalled();
+  await delay();
+  expect(onDrawersRegistered).toHaveBeenCalledWith([drawerA, drawerB]);
+});
+
+test('returns empty array when no drawers registered', async () => {
+  const onDrawersRegistered = jest.fn();
+  const drawers = new DrawersController();
+  drawers.onDrawersRegistered(onDrawersRegistered);
+  await delay();
+  expect(onDrawersRegistered).toHaveBeenCalledWith([]);
+});
+
+test('notifies about late added drawers', async () => {
+  const onDrawersRegistered = jest.fn();
+  const drawers = new DrawersController();
+  drawers.registerDrawer(drawerA);
+  drawers.onDrawersRegistered(onDrawersRegistered);
+  await delay();
+  onDrawersRegistered.mockReset();
+  drawers.registerDrawer(drawerB);
+  await delay();
+  expect(onDrawersRegistered).toHaveBeenCalledWith([drawerA, drawerB]);
+});
+
+test('change listener is not called after cleanup', async () => {
+  const onDrawersRegistered = jest.fn();
+  const drawers = new DrawersController();
+  const cleanup = drawers.onDrawersRegistered(onDrawersRegistered);
+  await delay();
+  onDrawersRegistered.mockReset();
+  cleanup();
+  drawers.registerDrawer(drawerA);
+  await delay();
+  expect(onDrawersRegistered).not.toHaveBeenCalled();
+});
+
+describe('console warnings', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  test('warns if multiple change listeners attempted to register', () => {
+    const drawers = new DrawersController();
+    drawers.onDrawersRegistered(() => {});
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    drawers.onDrawersRegistered(() => {});
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringMatching(/multiple app layout instances detected/));
+  });
+});

--- a/src/internal/plugins/api.ts
+++ b/src/internal/plugins/api.ts
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DrawerConfig, DrawersController, DrawersRegistrationListener } from './drawers-controller';
+
+const storageKey = Symbol.for('awsui-plugin-api');
+
+interface AwsuiPluginApiPublic {
+  appLayout: {
+    registerDrawer(config: DrawerConfig): void;
+  };
+}
+interface AwsuiPluginApiInternal {
+  appLayout: {
+    clearRegisteredDrawers(): void;
+    onDrawersRegistered(listener: DrawersRegistrationListener): () => void;
+  };
+}
+
+interface AwsuiApi {
+  awsuiPlugins: AwsuiPluginApiPublic;
+  awsuiPluginsInternal: AwsuiPluginApiInternal;
+}
+
+interface WindowWithApi extends Window {
+  [storageKey]: AwsuiApi;
+}
+
+function findUpApi(currentWindow: WindowWithApi): AwsuiApi | undefined {
+  try {
+    if (currentWindow?.[storageKey]) {
+      return currentWindow[storageKey];
+    }
+
+    if (!currentWindow || currentWindow.parent === currentWindow) {
+      // When the window has no more parents, it references itself
+      return undefined;
+    }
+
+    return findUpApi(currentWindow.parent as WindowWithApi);
+  } catch (ex) {
+    // Most likely a cross-origin access error
+    return undefined;
+  }
+}
+
+function loadApi() {
+  if (typeof window === 'undefined') {
+    return createApi();
+  }
+  const win = window as unknown as WindowWithApi;
+  const api = findUpApi(win);
+  if (api) {
+    return api;
+  }
+  win[storageKey] = createApi();
+  return win[storageKey];
+}
+
+export const { awsuiPlugins, awsuiPluginsInternal } = loadApi();
+
+function createApi(): AwsuiApi {
+  const drawers = new DrawersController();
+
+  return {
+    awsuiPlugins: {
+      appLayout: {
+        registerDrawer: drawers.registerDrawer,
+      },
+    },
+    awsuiPluginsInternal: {
+      appLayout: {
+        clearRegisteredDrawers: drawers.clearRegisteredDrawers,
+        onDrawersRegistered: drawers.onDrawersRegistered,
+      },
+    },
+  };
+}

--- a/src/internal/plugins/drawers-controller.ts
+++ b/src/internal/plugins/drawers-controller.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DrawerItem } from '../../app-layout/drawer/interfaces';
+
+export type DrawerConfig = Omit<DrawerItem, 'content'> & {
+  orderPriority?: number;
+  mountContent: (container: HTMLElement) => void;
+  unmountContent: (container: HTMLElement) => void;
+};
+export type DrawersRegistrationListener = (drawers: Array<DrawerConfig>) => void;
+
+export class DrawersController {
+  private drawers: Array<DrawerConfig> = [];
+  private drawersRegistrationListener: DrawersRegistrationListener | null = null;
+  private updateTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  private scheduleUpdate() {
+    if (this.updateTimeout) {
+      clearTimeout(this.updateTimeout);
+    }
+    this.updateTimeout = setTimeout(() => {
+      this.drawersRegistrationListener?.(this.drawers);
+    });
+  }
+
+  registerDrawer = (config: DrawerConfig) => {
+    this.drawers = this.drawers.concat(config);
+    this.scheduleUpdate();
+  };
+
+  onDrawersRegistered = (listener: DrawersRegistrationListener) => {
+    if (this.drawersRegistrationListener !== null) {
+      console.warn('[AwsUi] [runtime plugins] multiple app layout instances detected');
+    }
+    this.drawersRegistrationListener = listener;
+    this.scheduleUpdate();
+    return () => {
+      this.drawersRegistrationListener = null;
+    };
+  };
+
+  clearRegisteredDrawers = () => {
+    this.drawers = [];
+  };
+}

--- a/src/internal/plugins/index.ts
+++ b/src/internal/plugins/index.ts
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export { awsuiPlugins as default } from './api';

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -63,7 +63,7 @@ export default class AppLayoutWrapper extends ComponentWrapper {
     return this.findByClassName(testutilStyles['drawers-mobile-triggers-container']);
   }
 
-  findDrawersTriggers(): ElementWrapper<HTMLButtonElement>[] | null {
+  findDrawersTriggers(): ElementWrapper<HTMLButtonElement>[] {
     return this.findAllByClassName<HTMLButtonElement>(testutilStyles['drawers-trigger']);
   }
 


### PR DESCRIPTION
### Description

Adding new API for configuring app layout outside React tree. Detailed proposal: https://tiny.amazon.com/tjbskv2t/quipK3xL


### How has this been tested?

* Added unit tests
* Tested on integration POC (links in the proposal)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
