### PR TITLE
chore: Improve border radius for table inline editing cells in refresh

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -257,12 +257,12 @@ $border-placeholder: awsui.$border-item-width solid transparent;
   }
   &-editable.is-visual-refresh:not(.body-cell-edit-active):hover {
     &:first-child {
-      border-top-left-radius: awsui.$border-radius-control-default-focus-ring;
-      border-bottom-left-radius: awsui.$border-radius-control-default-focus-ring;
+      border-top-left-radius: awsui.$border-radius-item;
+      border-bottom-left-radius: awsui.$border-radius-item;
     }
     &:last-child {
-      border-top-right-radius: awsui.$border-radius-control-default-focus-ring;
-      border-bottom-right-radius: awsui.$border-radius-control-default-focus-ring;
+      border-top-right-radius: awsui.$border-radius-item;
+      border-bottom-right-radius: awsui.$border-radius-item;
     }
     &.body-cell-first-row > .body-cell-editor {
       padding-top: awsui.$border-divider-list-width;


### PR DESCRIPTION
### Description
The cell hover effect was using the wrong border radius in VR.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
