### PR TITLE
revert: Revert "fix: Provide unique remove button label for each row in attribute editor and tag editor"

### DIFF
--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -394,10 +394,8 @@ describe('Attribute Editor', () => {
   });
 
   describe('a11y', () => {
-    let wrapper: AttributeEditorWrapper;
-
-    beforeEach(() => {
-      wrapper = renderAttributeEditor({
+    test('row has role group and aria-labelledby referring to first control label and content', () => {
+      const wrapper = renderAttributeEditor({
         ...defaultProps,
         definition: [
           {
@@ -412,9 +410,6 @@ describe('Attribute Editor', () => {
           },
         ],
       });
-    });
-
-    test('row has role group and aria-labelledby referring to first control label and content', () => {
       const [labelId, inputId] = wrapper
         .findRow(1)!
         .find('[role="group"]')!
@@ -426,20 +421,6 @@ describe('Attribute Editor', () => {
         ' ' +
         wrapper.getElement().querySelector(`#${inputId}`)!.getAttribute('value');
       expect(label).toBe('Key label k1');
-    });
-
-    test('remove button has an aria-labelledby pointing to the first control', () => {
-      const [labelId, inputId] = wrapper
-        .findRow(1)!
-        .findRemoveButton()!
-        .getElement()!
-        .getAttribute('aria-labelledby')!
-        .split(' ');
-
-      expect(document.getElementById(labelId)).toHaveTextContent('Remove');
-      expect(wrapper.findRow(1)!.findField(1)!.findControl()!.findInput()!.findNativeInput()!.getElement().id).toBe(
-        inputId
-      );
     });
   });
 });

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -57,7 +57,6 @@ export const Row = React.memo(
     }, [onRemoveButtonClick, index]);
 
     const firstControlId = useUniqueId('first-control-id-');
-    const removeButtonTextId = useUniqueId('remove-button-text-id-');
 
     return (
       <InternalBox className={styles.row} margin={{ bottom: 's' }}>
@@ -101,9 +100,8 @@ export const Row = React.memo(
                     removeButtonRefs[index] = ref ?? undefined;
                   }}
                   onClick={handleRemoveClick}
-                  __nativeAttributes={{ 'aria-labelledby': `${removeButtonTextId} ${firstControlId}` }}
                 >
-                  <span id={removeButtonTextId}>{removeButtonText}</span>
+                  {removeButtonText}
                 </InternalButton>
               </ButtonContainer>
             )}


### PR DESCRIPTION
Reverts cloudscape-design/components#975