### PR TITLE
fix: Fix autosuggest test indices to make findOptionInGroup work

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -399,3 +399,20 @@ describe('Ref', () => {
     expect(input.selectionEnd).toBe(2);
   });
 });
+
+test('findOptionInGroup', () => {
+  const { container } = render(
+    <Autosuggest
+      value=""
+      onChange={() => {}}
+      enteredTextLabel={() => 'Use value'}
+      options={[
+        { label: 'Group 1', options: [{ value: '1' }, { value: '2' }] },
+        { label: 'Group 2', options: [{ value: '3' }] },
+      ]}
+    />
+  );
+  const wrapper = createWrapper(container).findAutosuggest()!;
+  wrapper.findNativeInput().focus();
+  expect(wrapper.findDropdown().findOptionInGroup(1, 2)).toBeTruthy();
+});

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { AutosuggestItemsHandlers, AutosuggestItemsState, getParentGroup } from './options-controller';
+import { AutosuggestItemsHandlers, AutosuggestItemsState } from './options-controller';
 import { AutosuggestProps } from './interfaces';
 import VirtualList from './virtual-list';
 import PlainList from './plain-list';
 
 import { useAnnouncement } from '../select/utils/use-announcement';
-import { OptionGroup } from '../internal/components/option/interfaces';
 
 export interface AutosuggestOptionsListProps
   extends Pick<
@@ -58,7 +57,7 @@ export default function AutosuggestOptionsList({
   const announcement = useAnnouncement({
     announceSelected: autosuggestItemsState.highlightedOption?.value === highlightText,
     highlightedOption: autosuggestItemsState.highlightedOption,
-    getParent: option => getParentGroup(option)?.option as undefined | OptionGroup,
+    getParent: option => autosuggestItemsState.getItemGroup(option),
     selectedAriaLabel,
     renderHighlightedAriaLive,
   });

--- a/src/internal/components/options-list/utils/test-indexes.ts
+++ b/src/internal/components/options-list/utils/test-indexes.ts
@@ -11,14 +11,14 @@ interface TestIndexes {
 const testIndexMap = new WeakMap<ListItem, TestIndexes>();
 //retrieves the test indexes of the option for the findOption and findOptionInGroup test-utils
 export const getTestOptionIndexes = <T extends ListItem>(item: T) => testIndexMap.get(item);
-export const generateTestIndexes = <T extends ListItem>(
+export const generateTestIndexes = <T extends ListItem, Group extends object>(
   filteredItems: ReadonlyArray<T>,
-  getParentGroup: (item: T) => T | undefined
+  getParentGroup: (item: T) => Group | undefined
 ) => {
   let throughIndex = 1;
   let groupIndex = 0;
   let inGroupIndex = 1;
-  let currentGroup: T | null = null;
+  let currentGroup: Group | null = null;
   filteredItems.forEach(item => {
     if (!('type' in item)) {
       testIndexMap.set(item, { throughIndex: throughIndex++ });


### PR DESCRIPTION
### Description

The autosuggest items requires `data-test-index` and `data-in-group-index` attributes assigned to support test-utils (findOptionInGroup method). That didn't work because of a bug: the option parents comparison is done by reference but the references have been invalidated when writing the object's copy to the mapping.

Related links: AWSUI-20969

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
