### PR TITLE
fix: Autosuggest input to not show dropdown when no content provided

### DIFF
--- a/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
+++ b/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
@@ -18,7 +18,9 @@ function render(jsx: React.ReactElement) {
 describe('imperative interface', () => {
   test('focuses input and opens dropdown', () => {
     const ref = React.createRef<AutosuggestInputRef>();
-    const { wrapper } = render(<AutosuggestInput ref={ref} value="" onChange={() => undefined} />);
+    const { wrapper } = render(
+      <AutosuggestInput ref={ref} value="" onChange={() => undefined} dropdownContent="..." />
+    );
     expect(wrapper.findInput().findNativeInput().getElement()).not.toHaveFocus();
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     ref.current!.focus();
@@ -28,7 +30,9 @@ describe('imperative interface', () => {
 
   test('focuses input and keeps dropdown closed', () => {
     const ref = React.createRef<AutosuggestInputRef>();
-    const { wrapper } = render(<AutosuggestInput ref={ref} value="" onChange={() => undefined} />);
+    const { wrapper } = render(
+      <AutosuggestInput ref={ref} value="" onChange={() => undefined} dropdownContent="..." />
+    );
     expect(wrapper.findInput().findNativeInput().getElement()).not.toHaveFocus();
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     ref.current!.focus({ preventDropdown: true });
@@ -51,7 +55,7 @@ describe('imperative interface', () => {
   test('opens and closes dropdown', () => {
     const ref = React.createRef<AutosuggestInputRef>();
     const onChange = jest.fn();
-    const { wrapper } = render(<AutosuggestInput ref={ref} value="123" onChange={onChange} />);
+    const { wrapper } = render(<AutosuggestInput ref={ref} value="123" onChange={onChange} dropdownContent="..." />);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     act(() => ref.current!.open());
     expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
@@ -62,7 +66,7 @@ describe('imperative interface', () => {
 
 describe('keyboard interactions', () => {
   test('closes dropdown on enter and opens it on arrow keys', () => {
-    const { wrapper } = render(<AutosuggestInput value="" onChange={() => undefined} />);
+    const { wrapper } = render(<AutosuggestInput value="" onChange={() => undefined} dropdownContent="..." />);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
 
     wrapper.findInput().findNativeInput().keydown(KeyCode.down);
@@ -76,7 +80,9 @@ describe('keyboard interactions', () => {
   });
 
   test('onPressEnter can prevent dropdown from closing', () => {
-    const { wrapper } = render(<AutosuggestInput value="" onChange={() => undefined} onPressEnter={() => true} />);
+    const { wrapper } = render(
+      <AutosuggestInput value="" onChange={() => undefined} onPressEnter={() => true} dropdownContent="..." />
+    );
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
 
     wrapper.findInput().findNativeInput().keydown(KeyCode.down);
@@ -88,7 +94,7 @@ describe('keyboard interactions', () => {
 
   test('closes dropdown and clears input on esc', () => {
     const onChange = jest.fn();
-    const { wrapper, rerender } = render(<AutosuggestInput value="1" onChange={onChange} />);
+    const { wrapper, rerender } = render(<AutosuggestInput value="1" onChange={onChange} dropdownContent="..." />);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
 
     wrapper.findInput().findNativeInput().keydown(KeyCode.down);
@@ -103,7 +109,7 @@ describe('keyboard interactions', () => {
     expect(onChange).toBeCalledTimes(1);
     expect(onChange).toBeCalledWith(expect.objectContaining({ detail: { value: '' } }));
 
-    rerender(<AutosuggestInput value="" onChange={onChange} />);
+    rerender(<AutosuggestInput value="" onChange={onChange} dropdownContent="..." />);
 
     wrapper.findInput().findNativeInput().keydown(KeyCode.escape);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
@@ -123,6 +129,7 @@ describe('keyboard interactions', () => {
         onPressArrowDown={onPressArrowDown}
         onPressEnter={onPressEnter}
         onKeyDown={onKeyDown}
+        dropdownContent="..."
       />
     );
 
@@ -160,7 +167,7 @@ describe('input events', () => {
 
   test('opens dropdown and calls onChange when input changes', () => {
     const onChange = jest.fn();
-    const { wrapper } = render(<AutosuggestInput value="1" onChange={onChange} />);
+    const { wrapper } = render(<AutosuggestInput value="1" onChange={onChange} dropdownContent="..." />);
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     act(() => wrapper.findInput().setInputValue('2'));
     expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
@@ -169,7 +176,9 @@ describe('input events', () => {
 
   test('opens dropdown and calls onFocus when input receives focus', () => {
     const onFocus = jest.fn();
-    const { wrapper } = render(<AutosuggestInput value="1" onChange={() => undefined} onFocus={onFocus} />);
+    const { wrapper } = render(
+      <AutosuggestInput value="1" onChange={() => undefined} onFocus={onFocus} dropdownContent="..." />
+    );
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     wrapper.findInput().findNativeInput().focus();
     expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
@@ -178,7 +187,9 @@ describe('input events', () => {
 
   test('opens dropdown and calls onFocus when input loses focus', () => {
     const onBlur = jest.fn();
-    const { wrapper } = render(<AutosuggestInput value="1" onChange={() => undefined} onBlur={onBlur} />);
+    const { wrapper } = render(
+      <AutosuggestInput value="1" onChange={() => undefined} onBlur={onBlur} dropdownContent="..." />
+    );
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     wrapper.findInput().findNativeInput().focus();
     wrapper.findInput().findNativeInput().blur();
@@ -190,7 +201,7 @@ describe('input events', () => {
     jest.useFakeTimers();
     const onDelayedInput = jest.fn();
     const { wrapper } = render(
-      <AutosuggestInput value="1" onChange={() => undefined} onDelayedInput={onDelayedInput} />
+      <AutosuggestInput value="1" onChange={() => undefined} onDelayedInput={onDelayedInput} dropdownContent="..." />
     );
     act(() => wrapper.findInput().setInputValue('2'));
     expect(onDelayedInput).not.toHaveBeenCalled();
@@ -212,7 +223,7 @@ describe('dropdown events', () => {
             onChange={() => undefined}
             onBlur={onBlur}
             dropdownContentFocusable={dropdownContentFocusable}
-            dropdownContent="content"
+            dropdownContent="..."
           />
         </div>
       );
@@ -231,7 +242,7 @@ describe('blur handling', () => {
     const { wrapper, getByTestId } = render(
       <div>
         <button data-testid="target">target</button>
-        <AutosuggestInput value="1" onChange={() => undefined} onBlur={onBlur} />
+        <AutosuggestInput value="1" onChange={() => undefined} onBlur={onBlur} dropdownContent="..." />
       </div>
     );
     wrapper.findInput().findNativeInput().focus();
@@ -266,6 +277,7 @@ describe('blur handling', () => {
           value="1"
           onChange={() => undefined}
           onBlur={onBlur}
+          dropdownContent="..."
           dropdownFooter={<button data-testid="target">target</button>}
         />
       </div>
@@ -275,4 +287,10 @@ describe('blur handling', () => {
     expect(onBlur).not.toBeCalled();
     expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
   });
+});
+
+test('dropdown is not shown when no content provided', () => {
+  const { wrapper } = render(<AutosuggestInput value="1" />);
+  act(() => wrapper.findInput().setInputValue('1'));
+  expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
 });

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -276,7 +276,7 @@ const AutosuggestInput = React.forwardRef(
             />
           }
           onMouseDown={handleDropdownMouseDown}
-          open={open}
+          open={open && !!dropdownContent}
           footer={
             dropdownFooterRef && (
               <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -988,11 +988,11 @@ describe('property filter parts', () => {
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
       expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Use: "free-text"');
     });
-    it('when free text filtering is not allowed and no property is matched dropdown is hidden but aria-expanded is false', () => {
+    it('when free text filtering is not allowed and no property is matched dropdown is not shown and aria-expanded is false', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering: true });
       wrapper.setInputValue('free-text');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
-      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('');
+      expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
     });
   });
 


### PR DESCRIPTION
### Description

When `disableFreeTextFiltering=true` the property filter can have no options matched and an empty dropdown is shown. We are still to decide if a dedicated no-match state is needed but for now the dropdown is to be hidden completely.

<img width="1440" alt="Screenshot 2023-04-27 at 14 47 32" src="https://user-images.githubusercontent.com/20790937/234866191-cc646135-e58a-486d-b09b-2859b5074666.png">


### How has this been tested?

Updated tests for property filter and autosuggest input. Added new unit test for autosuggest input

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
