### PR TITLE
feat: Add removeButtonAriaLabel to attribute editor and tag editor i18nStrings

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1094,12 +1094,17 @@ A maximum of four fields are supported.
             "optional": true,
             "type": "string",
           },
+          Object {
+            "name": "removeButtonAriaLabel",
+            "optional": true,
+            "type": "(item: T) => string",
+          },
         ],
         "type": "object",
       },
       "name": "i18nStrings",
       "optional": true,
-      "type": "AttributeEditorProps.I18nStrings",
+      "type": "AttributeEditorProps.I18nStrings<T>",
     },
     Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
@@ -12483,6 +12488,11 @@ character validation. You should use this property only when absolutely necessar
             "name": "removeButton",
             "optional": false,
             "type": "string",
+          },
+          Object {
+            "name": "removeButtonAriaLabel",
+            "optional": true,
+            "type": "(item: TagEditorProps.Tag) => string",
           },
           Object {
             "name": "tagLimit",

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -190,6 +190,22 @@ describe('Attribute Editor', () => {
       });
     });
 
+    test('renders `ariaLabel` on remove button using `removeButtonAriaLabel` on all rows', () => {
+      const removeButtonAriaLabel = (item: Item) => `Remove ${item.key}`;
+      const wrapper = renderAttributeEditor({
+        ...defaultProps,
+        i18nStrings: { ...defaultProps.i18nStrings, removeButtonAriaLabel },
+      });
+      defaultProps.items!.forEach((item, index) => {
+        expect(
+          wrapper
+            .findRow(index + 1)!
+            .findRemoveButton()!
+            .getElement()
+        ).toHaveAccessibleName(`Remove ${item.key}`);
+      });
+    });
+
     test('conditionally renders `remove` button depending on isItemRemovable return value', () => {
       const isItemRemovable = (item: Item) => item.key !== 'k1';
       const wrapper = renderAttributeEditor({ ...defaultProps, isItemRemovable });

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -47,10 +47,10 @@ export namespace AttributeEditorProps {
     focusAddButton(): void;
   }
 
-  export interface I18nStrings {
+  export interface I18nStrings<T = any> {
     errorIconAriaLabel?: string;
-
     itemRemovedAriaLive?: string;
+    removeButtonAriaLabel?: (item: T) => string;
   }
 }
 
@@ -120,5 +120,5 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
   /**
    * An object containing all the necessary localized strings required by the component.
    */
-  i18nStrings?: AttributeEditorProps.I18nStrings;
+  i18nStrings?: AttributeEditorProps.I18nStrings<T>;
 }

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -99,6 +99,7 @@ export const Row = React.memo(
                   ref={ref => {
                     removeButtonRefs[index] = ref ?? undefined;
                   }}
+                  ariaLabel={i18nStrings.removeButtonAriaLabel?.(item)}
                   onClick={handleRemoveClick}
                 >
                   {removeButtonText}

--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -352,6 +352,22 @@ describe('Tag Editor component', () => {
         })
       );
     });
+
+    test('renders `ariaLabel` on remove button using `removeButtonAriaLabel` on all rows', () => {
+      const removeButtonAriaLabel = (item: TagEditorProps.Tag) => `Remove ${item.key}`;
+      const { wrapper } = renderTagEditor({
+        tags: [{ key: 'test key', value: 'value', existing: false }],
+        i18nStrings: { ...defaultProps.i18nStrings, removeButtonAriaLabel },
+      });
+      defaultProps.tags!.forEach((item, index) => {
+        expect(
+          wrapper
+            .findRow(index + 1)!
+            .findRemoveButton()!
+            .getElement()
+        ).toHaveAccessibleName(`Remove test key`);
+      });
+    });
   });
 
   test('should render itemRemovedAriaLive when a tag is removed', async () => {

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -255,6 +255,16 @@ const TagEditor = React.forwardRef(
       [i18nStrings, keysRequest, onKeyChange, onKeyBlur, valuesRequest, onValueChange, onUndoRemoval]
     );
 
+    const forwardedI18nStrings = useMemo<AttributeEditorProps.I18nStrings<InternalTag>>(
+      () => ({
+        errorIconAriaLabel: i18nStrings?.errorIconAriaLabel,
+        itemRemovedAriaLive: i18nStrings?.itemRemovedAriaLive,
+        removeButtonAriaLabel:
+          i18nStrings.removeButtonAriaLabel && (({ tag }) => i18nStrings.removeButtonAriaLabel!(tag)),
+      }),
+      [i18nStrings]
+    );
+
     if (loading) {
       return (
         <div className={styles.root} ref={baseComponentProps.__internalRootRef}>
@@ -292,7 +302,7 @@ const TagEditor = React.forwardRef(
           )
         }
         definition={definition}
-        i18nStrings={i18nStrings}
+        i18nStrings={forwardedI18nStrings}
       />
     );
   }

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -127,6 +127,7 @@ export namespace TagEditorProps {
     tagLimitExceeded: (tagLimit: number) => string;
     enteredKeyLabel: (enteredText: string) => string;
     enteredValueLabel: (enteredText: string) => string;
+    removeButtonAriaLabel?: (item: TagEditorProps.Tag) => string;
   }
 
   export interface ChangeDetail {


### PR DESCRIPTION
### Description

The remove button has the same text for each row, which could end up confusing a lot of screen reader users, especially if we have many rows. We tried to do this automagically for everyone in #975, but that ended up breaking a lot of people's tests since many selected buttons by their accessible name, which changed from "Remove" to "Remove [tag name]".

This approach is a little more opt-in. It adds `removeButtonAriaLabel?: (item: T) => string` to i18nStrings for attribute editor and tag editor. This PR is small enough to act as the API proposal for itself :)

Related links, issue #, if available: AWSUI-19472

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
