### PR TITLE
feat: Add label with results of filtering in select and multiselect

### DIFF
--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -28,7 +28,7 @@ export default function AutosuggestPage() {
         ariaLabel={'simple autosuggest'}
         selectedAriaLabel="Selected"
         empty={empty}
-        filteringResultsText={matchesCount => `${matchesCount} items found`}
+        filteringResultsText={matchesCount => `${matchesCount} items`}
       />
       <button id="remove-options" onClick={() => setHasOptions(false)}>
         set empty options

--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -28,6 +28,7 @@ export default function AutosuggestPage() {
         ariaLabel={'simple autosuggest'}
         selectedAriaLabel="Selected"
         empty={empty}
+        filteringResultsText={matchesCount => `${matchesCount} items found`}
       />
       <button id="remove-options" onClick={() => setHasOptions(false)}>
         set empty options

--- a/pages/multiselect/multiselect.async.example.page.tsx
+++ b/pages/multiselect/multiselect.async.example.page.tsx
@@ -77,6 +77,7 @@ class SecurityGroupMultiselect extends React.Component {
           filteringType="manual"
           filteringPlaceholder="Find security group"
           filteringAriaLabel="Filtering aria label"
+          filteringResultsText={matchesCount => `${matchesCount} items found`}
           statusType={status as any}
           placeholder="Choose a security group"
           loadingText="Loading security groups"

--- a/pages/multiselect/multiselect.async.example.page.tsx
+++ b/pages/multiselect/multiselect.async.example.page.tsx
@@ -67,11 +67,11 @@ class SecurityGroupMultiselect extends React.Component {
 
   showFilteredText = (matchesCount: number, totalCount: number) => {
     if (this.state.status === 'pending') {
-      return `${matchesCount}+ results displayed`;
+      return `${matchesCount}+ results`;
     }
 
     if (this.state.status === 'finished') {
-      return `${matchesCount} out of ${totalCount} matching results showing`;
+      return `${matchesCount} out of ${totalCount} results`;
     }
     return '';
   };

--- a/pages/multiselect/multiselect.async.example.page.tsx
+++ b/pages/multiselect/multiselect.async.example.page.tsx
@@ -65,6 +65,17 @@ class SecurityGroupMultiselect extends React.Component {
     });
   };
 
+  showFilteredText = (matchesCount: number, totalCount: number) => {
+    if (this.state.status === 'pending') {
+      return `${matchesCount}+ results displayed`;
+    }
+
+    if (this.state.status === 'finished') {
+      return `${matchesCount} out of ${totalCount} matching results showing`;
+    }
+    return '';
+  };
+
   render() {
     const { status, options, selectedOptions } = this.state;
     return (
@@ -77,7 +88,7 @@ class SecurityGroupMultiselect extends React.Component {
           filteringType="manual"
           filteringPlaceholder="Find security group"
           filteringAriaLabel="Filtering aria label"
-          filteringResultsText={matchesCount => `${matchesCount} items found`}
+          filteringResultsText={this.showFilteredText}
           statusType={status as any}
           placeholder="Choose a security group"
           loadingText="Loading security groups"

--- a/pages/multiselect/multiselect.sync.example.page.tsx
+++ b/pages/multiselect/multiselect.sync.example.page.tsx
@@ -76,6 +76,7 @@ export default function MultiselectPage() {
             filteringType="auto"
             filteringPlaceholder="Find equipment"
             filteringAriaLabel="Filtering aria label"
+            filteringResultsText={(matchesCount, totalCount) => `${matchesCount} out of ${totalCount} items`}
             options={options}
             name="choose_equipment"
             placeholder={'Choose equipment'}

--- a/pages/select/select.async.example.page.tsx
+++ b/pages/select/select.async.example.page.tsx
@@ -59,6 +59,17 @@ class SecurityGroupSingleSelect extends React.Component {
     });
   };
 
+  showFilteredText = (matchesCount: number, totalCount: number) => {
+    if (this.state.status === 'pending') {
+      return `${matchesCount}+ results displayed`;
+    }
+
+    if (this.state.status === 'finished') {
+      return `${matchesCount} out of ${totalCount} matching results showing`;
+    }
+    return '';
+  };
+
   render() {
     const { status, options, selectedOption } = this.state;
     return (
@@ -71,7 +82,7 @@ class SecurityGroupSingleSelect extends React.Component {
           filteringType="manual"
           filteringPlaceholder="Find security group"
           filteringAriaLabel="Filtering aria label"
-          filteringResultsText={(matchesCount, totalCount) => `${matchesCount} out of ${totalCount} items found`}
+          filteringResultsText={this.showFilteredText}
           statusType={status as any}
           placeholder="Choose a security group"
           loadingText="Loading security groups"

--- a/pages/select/select.async.example.page.tsx
+++ b/pages/select/select.async.example.page.tsx
@@ -71,7 +71,7 @@ class SecurityGroupSingleSelect extends React.Component {
           filteringType="manual"
           filteringPlaceholder="Find security group"
           filteringAriaLabel="Filtering aria label"
-          filteringResultsText={matchesCount => `${matchesCount} items found`}
+          filteringResultsText={(matchesCount, totalCount) => `${matchesCount} out of ${totalCount} items found`}
           statusType={status as any}
           placeholder="Choose a security group"
           loadingText="Loading security groups"

--- a/pages/select/select.async.example.page.tsx
+++ b/pages/select/select.async.example.page.tsx
@@ -71,6 +71,7 @@ class SecurityGroupSingleSelect extends React.Component {
           filteringType="manual"
           filteringPlaceholder="Find security group"
           filteringAriaLabel="Filtering aria label"
+          filteringResultsText={matchesCount => `${matchesCount} items found`}
           statusType={status as any}
           placeholder="Choose a security group"
           loadingText="Loading security groups"

--- a/pages/select/select.async.example.page.tsx
+++ b/pages/select/select.async.example.page.tsx
@@ -61,11 +61,11 @@ class SecurityGroupSingleSelect extends React.Component {
 
   showFilteredText = (matchesCount: number, totalCount: number) => {
     if (this.state.status === 'pending') {
-      return `${matchesCount}+ results displayed`;
+      return `${matchesCount}+ results`;
     }
 
     if (this.state.status === 'finished') {
-      return `${matchesCount} out of ${totalCount} matching results showing`;
+      return `${matchesCount} out of ${totalCount} results`;
     }
     return '';
   };

--- a/pages/select/select.sync.example.page.tsx
+++ b/pages/select/select.sync.example.page.tsx
@@ -65,6 +65,7 @@ export default function SelectPage() {
             filteringType="auto"
             filteringPlaceholder="Find equipment"
             filteringAriaLabel="Filtering aria label"
+            filteringResultsText={(matchesCount, totalCount) => `${matchesCount} out of ${totalCount} items`}
             options={options}
             name="choose_equipment"
             placeholder={'Choose equipment'}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1498,6 +1498,12 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
+      "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "name": "filteringResultsText",
+      "optional": true,
+      "type": "(matchesCount: number, totalCount: number) => string",
+    },
+    Object {
       "defaultValue": "'auto'",
       "description": "Determines how filtering is applied to the list of \`options\`:
 * \`auto\` - The component will automatically filter options based on user input.
@@ -8465,6 +8471,12 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "string",
     },
     Object {
+      "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "name": "filteringResultsText",
+      "optional": true,
+      "type": "(matchesCount: number, totalCount: number) => string",
+    },
+    Object {
       "defaultValue": "'none'",
       "description": "Determines how filtering is applied to the list of \`options\`:
 * \`auto\` - The component will automatically filter options based on user input.
@@ -10920,6 +10932,12 @@ in a slight, visible lag when scrolling complex pages.",
       "name": "filteringPlaceholder",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.",
+      "name": "filteringResultsText",
+      "optional": true,
+      "type": "(matchesCount: number, totalCount: number) => string",
     },
     Object {
       "defaultValue": "'none'",

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -78,6 +78,11 @@ export interface AutosuggestProps
   enteredTextLabel: AutosuggestProps.EnteredTextLabel;
 
   /**
+   * Displaying number of matched items while filtering
+   */
+  filteringResultsText?: (matchesCount: number, totalCount: number) => string;
+
+  /**
    * Specifies the text that's displayed when there aren't any suggestions to display.
    * This is displayed when `statusType` is set to `finished` or it's not set at all.
    */

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -78,7 +78,7 @@ export interface AutosuggestProps
   enteredTextLabel: AutosuggestProps.EnteredTextLabel;
 
   /**
-   * Displaying number of matched items while filtering
+   * Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.
    */
   filteringResultsText?: (matchesCount: number, totalCount: number) => string;
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -162,7 +162,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
   const isEmpty = !value && !autosuggestItemsState.items.length;
-  const isFiltered = value.length !== 0;
+  const isFiltered = !!value && value.length !== 0;
   const filteredText = isFiltered
     ? filteringResultsText?.(autosuggestItemsState.items.length, options?.length ?? 0)
     : undefined;

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -54,6 +54,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     ariaLabel,
     ariaRequired,
     enteredTextLabel,
+    filteringResultsText,
     onKeyDown,
     virtualScroll,
     expandToViewport,
@@ -161,12 +162,18 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
   const isEmpty = !value && !autosuggestItemsState.items.length;
+  const isFiltered = value.length !== 0;
+  const filteredText = isFiltered
+    ? filteringResultsText?.(autosuggestItemsState.items.length, options?.length ?? 0)
+    : undefined;
   const dropdownStatus = useDropdownStatus({
     ...props,
     isEmpty,
+    isFiltered,
     recoveryText,
     errorIconAriaLabel,
     onRecoveryClick: handleRecoveryClick,
+    filteringResultsText: filteredText,
   });
 
   return (

--- a/src/internal/components/dropdown-status/__tests__/dropdown-status.test.tsx
+++ b/src/internal/components/dropdown-status/__tests__/dropdown-status.test.tsx
@@ -112,4 +112,54 @@ describe('useDropdownStatus', () => {
     expect(getIcon()).toHaveAttribute('aria-label', 'error-icon');
     expect(getIcon()).toHaveAttribute('role', 'img');
   });
+
+  test('renders filtering text when filtered', () => {
+    const { getContent } = renderComponent({
+      statusType: 'pending',
+      filteringResultsText: '2 matches',
+      isFiltered: true,
+    });
+    expect(getContent()).toBe('2 matches');
+  });
+
+  test('does not render filtering text while loading', () => {
+    const { getContent } = renderComponent({
+      statusType: 'loading',
+      filteringResultsText: '2 matches',
+      isFiltered: true,
+      loadingText: 'Loading',
+    });
+    expect(getContent()).toBe('Loading');
+  });
+
+  test('does not render filtering text when error occurred', () => {
+    const { getContent } = renderComponent({
+      statusType: 'error',
+      filteringResultsText: '2 matches',
+      isFiltered: true,
+      errorText: 'We got a problem',
+      recoveryText: 'do not worry',
+    });
+    expect(getContent()).toBe('We got a problem do not worry');
+  });
+
+  test('render finished text when finished and not filtered', () => {
+    const { getContent } = renderComponent({
+      statusType: 'finished',
+      filteringResultsText: '10 out of 10 items',
+      isFiltered: false,
+      finishedText: 'End of results',
+    });
+    expect(getContent()).toBe('End of results');
+  });
+
+  test('render filtering text when finished and filtered', () => {
+    const { getContent } = renderComponent({
+      statusType: 'finished',
+      filteringResultsText: '10 out of 10 items',
+      isFiltered: true,
+      finishedText: 'End of results',
+    });
+    expect(getContent()).toBe('10 out of 10 items');
+  });
 });

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -15,7 +15,9 @@ export { DropdownStatusProps };
 export interface DropdownStatusPropsExtended extends DropdownStatusProps {
   isEmpty?: boolean;
   isNoMatch?: boolean;
+  isFiltered?: boolean;
   noMatch?: React.ReactNode;
+  filteringResultsText?: string;
   /**
    * Called when the user clicks the recovery button placed at the
    * bottom of the dropdown list in the error state. Use this to
@@ -34,10 +36,12 @@ type UseDropdownStatus = ({
   empty,
   loadingText,
   finishedText,
+  filteringResultsText,
   errorText,
   recoveryText,
   isEmpty,
   isNoMatch,
+  isFiltered,
   noMatch,
   onRecoveryClick,
 }: DropdownStatusPropsExtended) => DropdownStatusResult;
@@ -52,10 +56,12 @@ export const useDropdownStatus: UseDropdownStatus = ({
   empty,
   loadingText,
   finishedText,
+  filteringResultsText,
   errorText,
   recoveryText,
   isEmpty,
   isNoMatch,
+  isFiltered,
   noMatch,
   onRecoveryClick,
   errorIconAriaLabel,
@@ -90,6 +96,8 @@ export const useDropdownStatus: UseDropdownStatus = ({
     statusResult.content = empty;
   } else if (isNoMatch && noMatch) {
     statusResult.content = noMatch;
+  } else if (isFiltered && filteringResultsText) {
+    statusResult.content = filteringResultsText;
   } else if (statusType === 'finished' && finishedText) {
     statusResult.content = finishedText;
     statusResult.isSticky = false;

--- a/src/internal/components/option/utils/prepare-options.ts
+++ b/src/internal/components/option/utils/prepare-options.ts
@@ -13,5 +13,10 @@ export function prepareOptions(
   const { flatOptions, parentMap } = flattenOptions(options);
   const filteredOptions = filteringType !== 'auto' ? flatOptions : filterOptions(flatOptions, filteringText);
   generateTestIndexes(filteredOptions, parentMap.get.bind(parentMap));
-  return { filteredOptions, parentMap };
+  return {
+    filteredOptions,
+    parentMap,
+    totalCount: flatOptions.length,
+    matchesCount: filteredOptions.length,
+  };
 }

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -46,6 +46,7 @@ const InternalMultiselect = React.forwardRef(
       filteringPlaceholder,
       filteringAriaLabel,
       filteringClearAriaLabel,
+      filteringResultsText,
       ariaRequired,
       placeholder,
       disabled,
@@ -89,7 +90,11 @@ const InternalMultiselect = React.forwardRef(
     });
     const useInteractiveGroups = true;
     const [filteringValue, setFilteringValue] = useState('');
-    const { filteredOptions, parentMap } = prepareOptions(options, filteringType, filteringValue);
+    const { filteredOptions, parentMap, totalCount, matchesCount } = prepareOptions(
+      options,
+      filteringType,
+      filteringValue
+    );
 
     const updateSelectedOption = useCallback(
       (option: OptionDefinition | OptionGroup) => {
@@ -176,6 +181,9 @@ const InternalMultiselect = React.forwardRef(
 
     const isEmpty = !options || options.length === 0;
     const isNoMatch = filteredOptions && filteredOptions.length === 0;
+    const isFiltered =
+      filteringType !== 'none' && filteringValue.length > 0 && filteredOptions && filteredOptions.length > 0;
+    const filteredText = isFiltered ? filteringResultsText?.(matchesCount, totalCount) : undefined;
     const dropdownStatus = useDropdownStatus({
       statusType,
       empty,
@@ -186,6 +194,8 @@ const InternalMultiselect = React.forwardRef(
       isEmpty,
       isNoMatch,
       noMatch,
+      isFiltered,
+      filteringResultsText: filteredText,
       onRecoveryClick: handleRecoveryClick,
       errorIconAriaLabel: restProps.errorIconAriaLabel,
     });

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -34,7 +34,9 @@ import { joinStrings } from '../internal/utils/strings';
 const DROPDOWN_WIDTH_OPTIONS_LIST = 300;
 const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
 
-export interface PropertyFilterAutosuggestProps extends AutosuggestProps, InternalBaseComponentProps {
+export interface PropertyFilterAutosuggestProps
+  extends Omit<AutosuggestProps, 'filteringResultsText'>,
+    InternalBaseComponentProps {
   customForm?: React.ReactNode;
   filterText?: string;
   onOptionClick?: CancelableEventHandler<AutosuggestProps.Option>;
@@ -151,7 +153,11 @@ const PropertyFilterAutosuggest = React.forwardRef(
     const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
     const isEmpty = !value && !autosuggestItemsState.items.length;
-    const dropdownStatus = useDropdownStatus({ ...props, isEmpty, onRecoveryClick: handleRecoveryClick });
+    const dropdownStatus = useDropdownStatus({
+      ...props,
+      isEmpty,
+      onRecoveryClick: handleRecoveryClick,
+    });
 
     let content = null;
     if (customForm) {

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -305,26 +305,66 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     });
   });
 
-  test('shows filtering result text after typing', () => {
+  describe('Filtering results', () => {
     const options = [
       { label: 'First', value: '1' },
       { label: 'Second', value: '2' },
+      { label: 'Another', value: '3' },
     ];
-    const { wrapper } = renderSelect({
-      options,
-      expandToViewport: true,
-      statusType: 'pending',
-      filteringType: 'auto',
-      noMatch: 'No match',
-      filteringResultsText: (matchesCount, totalCount) => `${matchesCount}/${totalCount}`,
+    test('shows filtering result text after typing', () => {
+      const { wrapper } = renderSelect({
+        options,
+        expandToViewport: true,
+        statusType: 'pending',
+        filteringType: 'auto',
+        noMatch: 'No match',
+        filteringResultsText: (matchesCount, totalCount) => `${matchesCount}/${totalCount}`,
+      });
+      wrapper.openDropdown();
+      const statusIndicator = wrapper.findStatusIndicator({ expandToViewport })!;
+      expect(statusIndicator).toBeNull();
+      wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('First');
+      expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('1/3');
+      wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('Hey');
+      expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('No match');
     });
-    wrapper.openDropdown();
-    const statusIndicator = wrapper.findStatusIndicator({ expandToViewport })!;
-    expect(statusIndicator).toBeNull();
-    wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('First');
-    expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('1/2');
-    wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('Hey');
-    expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('No match');
+
+    test('Error and loading states have advantage over filtering text', () => {
+      const defaultParams: Partial<SelectProps> = {
+        options,
+        expandToViewport: true,
+        errorText: 'Error',
+        filteringType: 'auto',
+        finishedText: 'End of results',
+        filteringResultsText: (matchesCount, totalCount) => `${matchesCount}/${totalCount}`,
+        loadingText: 'Loading',
+        noMatch: 'No match',
+      };
+      const { wrapper, rerender } = renderSelect({
+        ...defaultParams,
+        statusType: 'pending',
+      });
+      wrapper.openDropdown();
+
+      wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('First');
+      rerender({
+        ...defaultParams,
+        statusType: 'loading',
+      });
+      expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('Loading');
+      rerender({
+        ...defaultParams,
+        statusType: 'pending',
+      });
+      expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('1/3');
+
+      wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('Another');
+      rerender({
+        ...defaultParams,
+        statusType: 'error',
+      });
+      expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('Error');
+    });
   });
 
   describe('Disabled state', () => {

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -305,6 +305,28 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     });
   });
 
+  test('shows filtering result text after typing', () => {
+    const options = [
+      { label: 'First', value: '1' },
+      { label: 'Second', value: '2' },
+    ];
+    const { wrapper } = renderSelect({
+      options,
+      expandToViewport: true,
+      statusType: 'pending',
+      filteringType: 'auto',
+      noMatch: 'No match',
+      filteringResultsText: (matchesCount, totalCount) => `${matchesCount}/${totalCount}`,
+    });
+    wrapper.openDropdown();
+    const statusIndicator = wrapper.findStatusIndicator({ expandToViewport })!;
+    expect(statusIndicator).toBeNull();
+    wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('First');
+    expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('1/2');
+    wrapper.findFilteringInput({ expandToViewport: true })!.setInputValue('Hey');
+    expect(wrapper.findStatusIndicator({ expandToViewport: true })!.getElement()).toHaveTextContent('No match');
+  });
+
   describe('Disabled state', () => {
     test('enabled by default', () => {
       const { wrapper } = renderSelect();

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -75,6 +75,11 @@ export interface BaseSelectProps
    * Specifies the placeholder to display in the filtering input if filtering is enabled.
    */
   filteringPlaceholder?: string;
+
+  /**
+   * Displaying number of matched items while filtering
+   */
+  filteringResultsText?: (matchesCount: number, totalCount: number) => string;
   /**
    * Adds an `aria-label` on the built-in filtering input if filtering is enabled.
    */

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -77,7 +77,7 @@ export interface BaseSelectProps
   filteringPlaceholder?: string;
 
   /**
-   * Displaying number of matched items while filtering
+   * Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.
    */
   filteringResultsText?: (matchesCount: number, totalCount: number) => string;
   /**

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -44,6 +44,7 @@ const InternalSelect = React.forwardRef(
       filteringPlaceholder,
       filteringAriaLabel,
       filteringClearAriaLabel,
+      filteringResultsText,
       ariaRequired,
       placeholder,
       disabled,
@@ -90,7 +91,11 @@ const InternalSelect = React.forwardRef(
 
     const [filteringValue, setFilteringValue] = useState('');
 
-    const { filteredOptions, parentMap } = prepareOptions(options, filteringType, filteringValue);
+    const { filteredOptions, parentMap, totalCount, matchesCount } = prepareOptions(
+      options,
+      filteringType,
+      filteringValue
+    );
 
     const rootRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLButtonElement>(null);
@@ -169,6 +174,10 @@ const InternalSelect = React.forwardRef(
 
     const isEmpty = !options || options.length === 0;
     const isNoMatch = filteredOptions && filteredOptions.length === 0;
+    const isFiltered =
+      filteringType !== 'none' && filteringValue.length > 0 && filteredOptions && filteredOptions.length > 0;
+    const filteredText = isFiltered ? filteringResultsText?.(matchesCount, totalCount) : undefined;
+
     const dropdownStatus = useDropdownStatus({
       statusType,
       empty,
@@ -179,6 +188,8 @@ const InternalSelect = React.forwardRef(
       isEmpty,
       isNoMatch,
       noMatch,
+      isFiltered,
+      filteringResultsText: filteredText,
       errorIconAriaLabel,
       onRecoveryClick: handleRecoveryClick,
     });


### PR DESCRIPTION
### Description

Adds new property to select, multiselect and autosuggest components to specify number of matches while filtering.
Resulted text is displayed in status field of dropdown.

Related links, issue #, if available: n/a

### How has this been tested?

New unit test added.
Try in 
* [select.sync with auto filtering](https://d21d5uik3ws71m.cloudfront.net/components/7c23f4ac91871261a188e9ffddce994f18455889/index.html#/light/select/select.sync.example)
* [select.async](https://d21d5uik3ws71m.cloudfront.net/components/7c23f4ac91871261a188e9ffddce994f18455889/index.html#/light/select/select.async.example)
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
