### PR TITLE
refactor: Update use-sticky-columns code style and replace useReactio…

### DIFF
--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -85,7 +85,6 @@ export default function () {
             filter={
               <PropertyFilter
                 {...propertyFilterProps}
-                disableFreeTextFiltering={true}
                 filteringOptions={filteringOptions}
                 virtualScroll={true}
                 countText={`${items.length} matches`}

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -85,6 +85,7 @@ export default function () {
             filter={
               <PropertyFilter
                 {...propertyFilterProps}
+                disableFreeTextFiltering={true}
                 filteringOptions={filteringOptions}
                 virtualScroll={true}
                 countText={`${items.length} matches`}

--- a/pages/table/sticky-columns-custom.page.tsx
+++ b/pages/table/sticky-columns-custom.page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import SpaceBetween from '~components/space-between';
 import { Box, Link } from '~components';
-import { useStickyState, StickyStateModel, useStickyStyles } from '~components/table/sticky-state-model';
+import { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from '~components/table/use-sticky-columns';
 import styles from './styles.scss';
 import { generateItems, Instance } from './generate-data';
 import clsx from 'clsx';
@@ -18,7 +18,7 @@ const columnDefinitions = [
 ];
 
 export default function Page() {
-  const stickyState = useStickyState({
+  const stickyColumns = useStickyColumns({
     visibleColumns: columnDefinitions.map(column => column.key),
     stickyColumnsFirst: 1,
     stickyColumnsLast: 1,
@@ -28,12 +28,12 @@ export default function Page() {
       <SpaceBetween size="xl">
         <h1>Sticky columns with a custom table</h1>
 
-        <div ref={stickyState.refs.wrapper} className={styles['custom-table']} style={stickyState.style.wrapper}>
-          <table ref={stickyState.refs.table} className={styles['custom-table-table']}>
+        <div ref={stickyColumns.refs.wrapper} className={styles['custom-table']} style={stickyColumns.style.wrapper}>
+          <table ref={stickyColumns.refs.table} className={styles['custom-table-table']}>
             <thead>
               <tr>
                 {columnDefinitions.map(column => (
-                  <TableCell isHeader={true} key={column.key} columnId={column.key} stickyState={stickyState}>
+                  <TableCell isHeader={true} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
                     {column.label}
                   </TableCell>
                 ))}
@@ -43,7 +43,7 @@ export default function Page() {
               {items.map(item => (
                 <tr key={item.id}>
                   {columnDefinitions.map(column => (
-                    <TableCell isHeader={false} key={column.key} columnId={column.key} stickyState={stickyState}>
+                    <TableCell isHeader={false} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
                       {column.render(item)}
                     </TableCell>
                   ))}
@@ -59,19 +59,19 @@ export default function Page() {
 
 function TableCell({
   columnId,
-  stickyState,
+  stickyColumns,
   children,
   isHeader,
 }: {
   columnId: string;
-  stickyState: StickyStateModel;
+  stickyColumns: StickyColumnsModel;
   children: React.ReactNode;
   isHeader: boolean;
 }) {
   const Tag = isHeader ? 'th' : 'td';
-  const stickyStyles = useStickyStyles({
+  const stickyStyles = useStickyCellStyles({
     columnId,
-    stickyState,
+    stickyColumns,
     getClassName: props => ({
       [styles['sticky-cell']]: !!props,
       [styles['sticky-cell-last-left']]: !!props?.lastLeft,


### PR DESCRIPTION
…n with custom subscriptions

### Description

The purpose of the refactoring is to make code better readable and also avoid unnecessary subscriptions when the feature is disabled.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
