### PR TITLE
fix: Fixed visible focus outline for expandable section headers

### DIFF
--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -144,7 +144,7 @@ const ExpandableContainerHeader = ({
     <div id={id} className={className} onClick={onClick}>
       <Wrapper>
         <span
-          className={styles['header-container-button']}
+          className={isContainer ? styles['header-container-button'] : styles['header-button']}
           role="button"
           tabIndex={0}
           onKeyUp={onKeyUp}

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -99,6 +99,16 @@
     padding: 0;
   }
 
+  &-button {
+    box-sizing: border-box;
+    display: flex;
+
+    // Header buttons for non-container variants show the focus ring directly
+    @include focus-visible.when-visible {
+      @include styles.focus-highlight(0px);
+    }
+  }
+
   &-container {
     width: 100%;
     // The icon-container style is kept for variant='container' and header
@@ -106,17 +116,21 @@
       margin-top: awsui.$space-expandable-section-icon-offset-top;
     }
 
-    &[data-awsui-focus-visible='true']:focus-within {
+    // stylelint-disable-next-line selector-combinator-disallowed-list
+    body[data-awsui-focus-visible='true'] &:focus-within {
       outline: none;
       text-decoration: none;
       padding: container.$header-focus-visible-padding;
 
       @include styles.form-focus-element(awsui.$border-radius-control-default-focus-ring);
     }
+
+    // Header buttons that sit in a container should not show focus because the parent container has a focus ring already
     &-button {
       box-sizing: border-box;
       display: flex;
-      &:focus {
+
+      @include focus-visible.when-visible {
         outline: none;
         text-decoration: none;
       }


### PR DESCRIPTION
### Description
There was a problem with visible focus outlines not displaying correctly for expandable section headers that didn't use the `container` variant.

Related links, issue #, if available: AWSUI-21024, AWSUI-21013

### How has this been tested?
Tested manually.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
