### PR TITLE
refactor: Remove internal force focus prop from button

### DIFF
--- a/pages/file-upload/test.page.tsx
+++ b/pages/file-upload/test.page.tsx
@@ -14,6 +14,9 @@ export default function FileUploadTestPage() {
   return (
     <SpaceBetween size="m">
       <Header variant="h1">File upload integration test page</Header>
+      <button type="button" id="focus-target">
+        focus target
+      </button>
       <FileUpload
         multiple={true}
         value={contractFiles}

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -17,7 +17,7 @@ type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   __nativeAttributes?: Record<string, any>;
   __iconClass?: string;
   __activated?: boolean;
-  __forcedFocusState?: 'none' | 'focused';
+  __forcedFocusState?: 'focused';
 } & InternalBaseComponentProps;
 
 export const InternalButton = React.forwardRef(
@@ -82,7 +82,6 @@ export const InternalButton = React.forwardRef(
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
       [styles['is-activated']]: __activated,
-      [styles['hide-focus-outline']]: __forcedFocusState === 'none',
       [styles['force-focus-outline']]: __forcedFocusState === 'focused',
     });
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -17,7 +17,6 @@ type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   __nativeAttributes?: Record<string, any>;
   __iconClass?: string;
   __activated?: boolean;
-  __forcedFocusState?: 'focused';
 } & InternalBaseComponentProps;
 
 export const InternalButton = React.forwardRef(
@@ -44,7 +43,6 @@ export const InternalButton = React.forwardRef(
       formAction = 'submit',
       ariaLabel,
       ariaExpanded,
-      __forcedFocusState,
       __nativeAttributes,
       __internalRootRef = null,
       __activated = false,
@@ -82,7 +80,6 @@ export const InternalButton = React.forwardRef(
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
       [styles['is-activated']]: __activated,
-      [styles['force-focus-outline']]: __forcedFocusState === 'focused',
     });
 
     const buttonProps = {

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -38,10 +38,8 @@
     text-decoration: none;
   }
 
-  &:not(.hide-focus-outline) {
-    @include focus-visible.when-visible {
-      @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
-    }
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
   }
   // stylelint-disable-next-line selector-combinator-disallowed-list
   body[data-awsui-focus-visible='true'] &.force-focus-outline {
@@ -59,7 +57,7 @@
       );
     }
   }
-  &.variant-inline-icon:not(.hide-focus-outline) {
+  &.variant-inline-icon {
     @include focus-visible.when-visible {
       @include styles.focus-highlight(awsui.$space-button-inline-icon-focus-outline-gutter);
     }

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -41,10 +41,6 @@
   @include focus-visible.when-visible {
     @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
   }
-  // stylelint-disable-next-line selector-combinator-disallowed-list
-  body[data-awsui-focus-visible='true'] &.force-focus-outline {
-    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
-  }
   &.variant-icon,
   &.variant-modal-dismiss,
   &.variant-flashbar-icon {

--- a/src/file-upload/__integ__/file-upload.test.ts
+++ b/src/file-upload/__integ__/file-upload.test.ts
@@ -7,9 +7,18 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 
 const wrapper = createWrapper().findFileUpload();
 
-const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+class FileUploadPageObject extends BasePageObject {
+  hasOutline(selector: string) {
+    return this.browser.execute(selector => {
+      const element = document.querySelector(selector);
+      return !!element && getComputedStyle(element).outline.includes('2px');
+    }, selector);
+  }
+}
+
+const setupTest = (testFn: (page: FileUploadPageObject) => Promise<void>) => {
   return useBrowser(async browser => {
-    const page = new BasePageObject(browser);
+    const page = new FileUploadPageObject(browser);
     await browser.url('/#/light/file-upload/test');
     await testFn(page);
   });
@@ -27,5 +36,15 @@ test(
     await page.click(wrapper.findFileToken(1).findRemoveButton().toSelector());
 
     await expect(page.getElementsCount(wrapper.findFileTokens().toSelector())).resolves.toBe(0);
+  })
+);
+
+test(
+  'focus outline is forced on the upload button',
+  setupTest(async page => {
+    await page.click('#focus-target');
+    await page.keys('Tab');
+
+    await expect(page.hasOutline(wrapper.findUploadButton().toSelector())).resolves.toBe(true);
   })
 );

--- a/src/file-upload/file-input/index.tsx
+++ b/src/file-upload/file-input/index.tsx
@@ -12,6 +12,7 @@ import { joinStrings } from '../../internal/utils/strings';
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { FileUploadProps } from '../interfaces';
 import useForwardFocus from '../../internal/hooks/forward-focus';
+import clsx from 'clsx';
 
 interface FileInputProps extends FormFieldValidationControlProps {
   accept?: string;
@@ -95,9 +96,8 @@ function FileInput(
         iconName="upload"
         formAction="none"
         onClick={onUploadButtonClick}
-        className={styles['upload-button']}
+        className={clsx(styles['upload-button'], isFocused && styles['force-focus-outline'])}
         __nativeAttributes={{ tabIndex: -1, 'aria-hidden': true }}
-        __forcedFocusState={isFocused ? 'focused' : undefined}
       >
         {children}
       </InternalButton>

--- a/src/file-upload/file-input/styles.scss
+++ b/src/file-upload/file-input/styles.scss
@@ -4,6 +4,7 @@
 */
 
 @use '../../internal/styles/tokens' as awsui;
+@use '../../internal/styles' as styles;
 
 .upload-button,
 .upload-input {
@@ -17,4 +18,11 @@
 .upload-input {
   position: absolute;
   clip: rect(0, 0, 0, 0);
+}
+
+.upload-button {
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body[data-awsui-focus-visible='true'] &.force-focus-outline {
+    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+  }
 }


### PR DESCRIPTION
### Description

This should reduce the risk of abusing this workaround.

AWSUI-20966

### How has this been tested?

Added new integ test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
