### PR TITLE
chore: Add unit tests for sticky columns

### DIFF
--- a/src/table/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/__tests__/use-sticky-columns.test.tsx
@@ -1,0 +1,183 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  useStickyColumns,
+  StickyColumnsModel,
+  useStickyCellStyles,
+} from '../../../lib/components/table/use-sticky-columns';
+import { renderHook } from '../../__tests__/render-hook';
+
+function createElementWithWidth(tag: string, width = 0) {
+  const element = document.createElement(tag);
+  jest.spyOn(element, 'getBoundingClientRect').mockImplementation(() => ({ width } as DOMRect));
+  return element;
+}
+
+function createMockTable(
+  stickyColumns: StickyColumnsModel,
+  wrapperWidth: number,
+  tableWidth: number,
+  ...cellWidths: number[]
+) {
+  const wrapper = createElementWithWidth('div', wrapperWidth);
+  const table = createElementWithWidth('table', tableWidth);
+  const cells = cellWidths.map(width => createElementWithWidth('td', width));
+
+  stickyColumns.refs.wrapper(wrapper);
+  stickyColumns.refs.table(table);
+  cells.forEach((cell, index) => stickyColumns.refs.cell((index + 1).toString(), cell));
+}
+
+test('isEnabled is false, wrapper styles is empty and wrapper listener is not attached when feature is off', () => {
+  const tableWrapper = document.createElement('div');
+  const addTableWrapperOnScrollSpy = jest.spyOn(tableWrapper, 'addEventListener');
+  const { result } = renderHook(() =>
+    useStickyColumns({ visibleColumns: [], stickyColumnsFirst: 0, stickyColumnsLast: 0 })
+  );
+  result.current.refs.wrapper(tableWrapper);
+
+  expect(result.current.isEnabled).toBe(false);
+  expect(result.current.style.wrapper).not.toBeDefined();
+  expect(addTableWrapperOnScrollSpy).not.toHaveBeenCalled();
+});
+
+test('isEnabled is true, wrapper styles is not empty and wrapper listener is attached when feature is on', () => {
+  const tableWrapper = document.createElement('div');
+  const addTableWrapperOnScrollSpy = jest.spyOn(tableWrapper, 'addEventListener');
+  const { result } = renderHook(() =>
+    useStickyColumns({ visibleColumns: [], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+  );
+  result.current.refs.wrapper(tableWrapper);
+
+  expect(result.current.isEnabled).toBe(true);
+  expect(result.current.style.wrapper).toEqual({ scrollPaddingLeft: '0px', scrollPaddingRight: '0px' });
+  expect(addTableWrapperOnScrollSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+});
+
+test('styles update when sticky column properties change', () => {
+  const tableWrapper = document.createElement('div');
+  const table = document.createElement('table');
+  const { result, rerender } = renderHook(() =>
+    useStickyColumns({ visibleColumns: [], stickyColumnsFirst: 0, stickyColumnsLast: 0 })
+  );
+  result.current.refs.wrapper(tableWrapper);
+  result.current.refs.table(table);
+  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles');
+
+  expect(updateCellStylesSpy).not.toHaveBeenCalled();
+
+  rerender({ visibleColumns: [], stickyColumnsFirst: 1, stickyColumnsLast: 0 });
+  expect(updateCellStylesSpy).toHaveBeenCalledTimes(1);
+
+  rerender({ visibleColumns: [], stickyColumnsFirst: 1, stickyColumnsLast: 1 });
+  expect(updateCellStylesSpy).toHaveBeenCalledTimes(2);
+
+  rerender({ visibleColumns: ['new'], stickyColumnsFirst: 1, stickyColumnsLast: 1 });
+  expect(updateCellStylesSpy).toHaveBeenCalledTimes(3);
+
+  expect(result.current.store.get()).toEqual({ cellState: {}, scrollPadding: { left: 0, right: 0 } });
+});
+
+test('styles update when wrapper scrolls', () => {
+  const tableWrapper = document.createElement('div');
+  const table = document.createElement('table');
+  const { result } = renderHook(() =>
+    useStickyColumns({ visibleColumns: [], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+  );
+  result.current.refs.wrapper(tableWrapper);
+  result.current.refs.table(table);
+  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles');
+
+  expect(updateCellStylesSpy).not.toHaveBeenCalled();
+
+  tableWrapper.dispatchEvent(new UIEvent('scroll'));
+  expect(updateCellStylesSpy).toHaveBeenCalledTimes(1);
+});
+
+test('generates non-empty styles for sticky cells', () => {
+  const { result, rerender } = renderHook(() =>
+    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+  );
+  createMockTable(result.current, 300, 500, 100, 200, 300);
+
+  // Wait for effect
+  rerender({});
+
+  expect(result.current.store.get()).toEqual({
+    cellState: {
+      1: {
+        lastLeft: false,
+        lastRight: false,
+        padLeft: false,
+        offset: { left: 0 },
+      },
+      2: null,
+      3: null,
+    },
+    scrollPadding: { left: 100, right: 0 },
+  });
+});
+
+test('generates empty cell styles if wrapper is not scrollable', () => {
+  const { result, rerender } = renderHook(() =>
+    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+  );
+  createMockTable(result.current, 500, 500, 100, 200, 300);
+
+  // Wait for effect
+  rerender({});
+
+  expect(result.current.store.get()).toEqual({
+    cellState: {
+      1: null,
+      2: null,
+      3: null,
+    },
+    scrollPadding: { left: 100, right: 0 },
+  });
+});
+
+test('generates empty cell styles if not enough scrollable space', () => {
+  const { result, rerender } = renderHook(() =>
+    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+  );
+  createMockTable(result.current, 300, 500, 200, 300, 100);
+
+  // Wait for effect
+  rerender({});
+
+  expect(result.current.store.get()).toEqual({
+    cellState: {
+      1: null,
+      2: null,
+      3: null,
+    },
+    scrollPadding: { left: 200, right: 0 },
+  });
+});
+
+test('generates non-empty styles for sticky cells', () => {
+  const { result, rerender } = renderHook(() =>
+    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 0, stickyColumnsLast: 1 })
+  );
+  createMockTable(result.current, 300, 500, 300, 200, 100);
+
+  const getClassName = jest.fn().mockImplementation(() => 'sticky-cell');
+  const { result: cellStylesResult, rerender: rerenderCellStyles } = renderHook(() =>
+    useStickyCellStyles({ stickyColumns: result.current, columnId: '3', getClassName })
+  );
+
+  // Wait for effect
+  rerender({});
+  rerenderCellStyles({});
+
+  expect(getClassName).toHaveBeenCalledWith({
+    lastLeft: false,
+    lastRight: false,
+    padLeft: false,
+    offset: { right: 0 },
+  });
+  expect(cellStylesResult.current.className).toBe('sticky-cell');
+  expect(cellStylesResult.current.style).toEqual({ right: 0 });
+});


### PR DESCRIPTION
### Description

Add test coverage for use-sticky-columns

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
