### PR TITLE
fix: Change `start` to `flex-start` in collection preferences.

### DIFF
--- a/src/collection-preferences/content-display/sortable-item.scss
+++ b/src/collection-preferences/content-display/sortable-item.scss
@@ -44,7 +44,7 @@ $border-radius: awsui.$border-radius-item;
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  align-items: start;
+  align-items: flex-start;
   padding-top: awsui.$space-xs;
   padding-bottom: awsui.$space-xs;
   padding-right: 0;


### PR DESCRIPTION
### Description

Fixes warning:
```
autoprefixer: start value has mixed support, consider using flex-start 
instead
```

Related links, issue #, if available: n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
