### PR TITLE
fix: Improve browser support of Content display preference

### DIFF
--- a/src/collection-preferences/content-display/sortable-item.scss
+++ b/src/collection-preferences/content-display/sortable-item.scss
@@ -42,9 +42,7 @@ $border-radius: awsui.$border-radius-item;
 .sortable-item-content {
   border-top: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
   display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-items: start;
+  align-items: flex-start;
   padding-top: awsui.$space-xs;
   padding-bottom: awsui.$space-xs;
   padding-right: 0;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Replaces `align-items: start` with `align-items: flex-start`.

Also removes two CSS rules that are unnecessary.

### Why?

`align-items: start` is not supported by all 3 latest major versions of Safari, only since 15.4 (see [caniuse](https://caniuse.com/mdn-css_properties_align-items_flex_context_start_end)). Besides, this is causing build failures on two consumer packages that are set to fail on warnings when `process.env.CI = true`, because autoprefixer issues the following warning:

```
autoprefixer: start value has mixed support, consider using flex-start instead
```

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Ran through my pipeline successfully, including visual regression tests
- Ran dry-run build successfully

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
