### PR TITLE
feat: Make table header row sticky on mobile

### DIFF
--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -15,13 +15,13 @@ import InternalContainer from '../container/internal';
 import InternalStatusIndicator from '../status-indicator/internal';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import stickyScrolling from '../table/sticky-scrolling';
-import { useSupportsStickyHeader } from '../container/use-sticky-header';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import LiveRegion from '../internal/components/live-region';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
+import { useMobile } from '../internal/hooks/use-mobile';
 
 export { CardsProps };
 
@@ -79,8 +79,9 @@ const Cards = React.forwardRef(function <T = any>(
   });
   const hasToolsHeader = header || filter || pagination || preferences;
   const headerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useMobile();
   const { scrollToTop, scrollToItem } = stickyScrolling(refObject, headerRef);
-  stickyHeader = useSupportsStickyHeader() && stickyHeader;
+  stickyHeader = !isMobile && stickyHeader;
   const onCardFocus: FocusEventHandler<HTMLElement> = event => {
     // When an element inside card receives focus we want to adjust the scroll.
     // However, that behavior is unwanted when the focus is received as result of a click

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -22,6 +22,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import LiveRegion from '../internal/components/live-region';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { useMobile } from '../internal/hooks/use-mobile';
+import { supportsStickyPosition } from '../internal/utils/dom';
 
 export { CardsProps };
 
@@ -81,7 +82,7 @@ const Cards = React.forwardRef(function <T = any>(
   const headerRef = useRef<HTMLDivElement>(null);
   const isMobile = useMobile();
   const { scrollToTop, scrollToItem } = stickyScrolling(refObject, headerRef);
-  stickyHeader = !isMobile && stickyHeader;
+  stickyHeader = supportsStickyPosition() && !isMobile && stickyHeader;
   const onCardFocus: FocusEventHandler<HTMLElement> = event => {
     // When an element inside card receives focus we want to adjust the scroll.
     // However, that behavior is unwanted when the focus is received as result of a click

--- a/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
+++ b/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
@@ -11,6 +11,7 @@ const appLayoutWrapper = createWrapper().findAppLayout();
 const containerWrapper = appLayoutWrapper.findContentRegion().findContainer();
 const containerHeaderSelector = containerWrapper.findHeader().toSelector();
 const flashBarSelector = createWrapper().findFlashbar().toSelector();
+const demoHeaderSelector = '#h';
 
 const CLASSIC_STICKY_OFFSET_SPACE = 0; // No borders on flashbars or additional padding below
 const VISUAL_REFRESH_STICKY_OFFSET_SPACE = 4; // space-xxs - from $offsetTopWithNotifications additional padding
@@ -59,13 +60,14 @@ describe.each([
   );
 
   test(
-    'Does not stick in narrow viewports',
+    'Sticky header is scrolled out of view in mobile viewports',
     setupTest({ viewport: viewports.mobile }, async page => {
+      const { height: demoPageHeaderHeight } = await page.getBoundingBox(demoHeaderSelector);
       const { top: topBefore } = await page.getBoundingBox(containerHeaderSelector);
-      expect(topBefore).toBeGreaterThan(0);
+      expect(topBefore).toBeGreaterThan(demoPageHeaderHeight);
       await page.scrollTo({ top: 400 });
       const { top: topAfter } = await page.getBoundingBox(containerHeaderSelector);
-      expect(topAfter).toBeLessThan(0);
+      expect(topAfter).toBeLessThan(demoPageHeaderHeight);
     })
   );
 });

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -21,6 +21,7 @@ export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>,
   __headerRef?: React.RefObject<HTMLDivElement>;
   __headerId?: string;
   __darkHeader?: boolean;
+  __disableStickyMobile?: boolean;
   /**
    * Additional internal variant:
    * * `embedded` - Use this variant within a parent container (such as a modal,
@@ -47,12 +48,19 @@ export default function InternalContainer({
   __headerRef,
   __headerId,
   __darkHeader = false,
+  __disableStickyMobile = true,
   ...restProps
 }: InternalContainerProps) {
   const baseProps = getBaseProps(restProps);
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const { isSticky, isStuck, stickyStyles } = useStickyHeader(rootRef, headerRef, __stickyHeader, __stickyOffset);
+  const { isSticky, isStuck, stickyStyles } = useStickyHeader(
+    rootRef,
+    headerRef,
+    __stickyHeader,
+    __stickyOffset,
+    __disableStickyMobile
+  );
   const { setHasStickyBackground } = useAppLayoutContext();
   const isRefresh = useVisualRefresh();
 

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -54,7 +54,7 @@ export const useStickyHeader = (
    * to the default offset calculated in AppLayoutDomContext.
    */
   let computedOffset = `${effectiveStickyOffset}px`;
-  if (isRefresh && !hasInnerOverflowParents) {
+  if (isRefresh && !hasInnerOverflowParents && !isMobile) {
     computedOffset = `var(${customCssProps.offsetTopWithNotifications}, ${computedOffset})`;
   }
 

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RefObject, useState, useLayoutEffect, useCallback, useEffect, createContext } from 'react';
 import { useAppLayoutContext } from '../internal/context/app-layout-context';
-import { findUpUntil } from '../internal/utils/dom';
+import { findUpUntil, supportsStickyPosition } from '../internal/utils/dom';
 import { getOverflowParents } from '../internal/utils/scrollable-containers';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import customCssProps from '../internal/generated/custom-css-properties';
@@ -26,7 +26,7 @@ export const useStickyHeader = (
   // of other sticky elements positioned on top of the view.
   const { stickyOffsetTop } = useAppLayoutContext();
   const disableSticky = isMobile && __disableMobile;
-  const isSticky = !disableSticky && !!__stickyHeader;
+  const isSticky = supportsStickyPosition() && !disableSticky && !!__stickyHeader;
   const isRefresh = useVisualRefresh();
 
   // If it has overflow parents inside the app layout, we shouldn't apply a sticky offset.

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RefObject, useState, useLayoutEffect, useCallback, useEffect, createContext } from 'react';
 import { useAppLayoutContext } from '../internal/context/app-layout-context';
-import { useMobile } from '../internal/hooks/use-mobile';
-import { findUpUntil, supportsStickyPosition } from '../internal/utils/dom';
+import { findUpUntil } from '../internal/utils/dom';
 import { getOverflowParents } from '../internal/utils/scrollable-containers';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import customCssProps from '../internal/generated/custom-css-properties';
@@ -23,7 +22,7 @@ export const useStickyHeader = (
   // We reach into AppLayoutContext in case sticky header needs to be offset down by the height
   // of other sticky elements positioned on top of the view.
   const { stickyOffsetTop } = useAppLayoutContext();
-  const isSticky = useSupportsStickyHeader() && !!__stickyHeader;
+  const isSticky = !!__stickyHeader;
   const isRefresh = useVisualRefresh();
 
   // If it has overflow parents inside the app layout, we shouldn't apply a sticky offset.
@@ -92,8 +91,3 @@ export const useStickyHeader = (
     stickyStyles,
   };
 };
-
-export function useSupportsStickyHeader() {
-  const isMobile = useMobile();
-  return supportsStickyPosition() && !isMobile;
-}

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -6,6 +6,7 @@ import { findUpUntil } from '../internal/utils/dom';
 import { getOverflowParents } from '../internal/utils/scrollable-containers';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import customCssProps from '../internal/generated/custom-css-properties';
+import { useMobile } from '../internal/hooks/use-mobile';
 
 interface StickyHeaderContextProps {
   isStuck: boolean;
@@ -17,12 +18,15 @@ export const useStickyHeader = (
   rootRef: RefObject<HTMLDivElement>,
   headerRef: RefObject<HTMLDivElement>,
   __stickyHeader?: boolean,
-  __stickyOffset?: number
+  __stickyOffset?: number,
+  __disableMobile = true
 ) => {
+  const isMobile = useMobile();
   // We reach into AppLayoutContext in case sticky header needs to be offset down by the height
   // of other sticky elements positioned on top of the view.
   const { stickyOffsetTop } = useAppLayoutContext();
-  const isSticky = !!__stickyHeader;
+  const disableSticky = isMobile && __disableMobile;
+  const isSticky = !disableSticky && !!__stickyHeader;
   const isRefresh = useVisualRefresh();
 
   // If it has overflow parents inside the app layout, we shouldn't apply a sticky offset.

--- a/src/table/__integ__/sticky-header.test.ts
+++ b/src/table/__integ__/sticky-header.test.ts
@@ -157,14 +157,19 @@ describe('Sticky header', () => {
   );
 
   test(
-    'sticky feature is disabled on mobile',
+    'sticky header does not get sticky on mobile but table header row does',
     setupTest(async page => {
       await page.setWindowSize(mobileSize);
       await page.elementScrollTo(scrollContainerSelector, { top: 200 });
-      const { top: oldOffset } = await page.getBoundingBox(tableWrapper.findHeaderSlot().toSelector());
+      const { top: headerOldOffset } = await page.getBoundingBox(tableWrapper.findHeaderSlot().toSelector());
       await page.elementScrollTo(scrollContainerSelector, { top: 400 });
-      const { top: newOffset } = await page.getBoundingBox(tableWrapper.findHeaderSlot().toSelector());
-      expect(oldOffset).not.toEqual(newOffset);
+      const { top: headerNewOffset } = await page.getBoundingBox(tableWrapper.findHeaderSlot().toSelector());
+      expect(headerOldOffset).not.toEqual(headerNewOffset);
+
+      const { top: tableHeaderRowOldOffset } = await page.getBoundingBox(headerSecondary.toSelector());
+      await page.elementScrollTo(scrollContainerSelector, { top: 600 });
+      const { top: tableHeaderRowNewOffset } = await page.getBoundingBox(headerSecondary.toSelector());
+      expect(tableHeaderRowOldOffset).toEqual(tableHeaderRowNewOffset);
     })
   );
 

--- a/src/table/__integ__/sticky-header.test.ts
+++ b/src/table/__integ__/sticky-header.test.ts
@@ -157,7 +157,7 @@ describe('Sticky header', () => {
   );
 
   test(
-    'sticky header does not get sticky on mobile but table header row does',
+    'sticky header does not get stuck on mobile but table header row does',
     setupTest(async page => {
       await page.setWindowSize(mobileSize);
       await page.elementScrollTo(scrollContainerSelector, { top: 200 });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -33,6 +33,8 @@ import LiveRegion from '../internal/components/live-region';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
 import { TableTdElement } from './body-cell/td-element';
+import { useMobile } from '../internal/hooks/use-mobile';
+
 type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps;
 
@@ -82,7 +84,7 @@ const InternalTable = React.forwardRef(
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseProps = getBaseProps(rest);
-    stickyHeader = stickyHeader && supportsStickyPosition();
+    const isMobile = useMobile();
 
     const [containerWidth, wrapperMeasureRef] = useContainerQuery<number>(({ width }) => width);
     const wrapperRefObject = useRef(null);
@@ -202,8 +204,12 @@ const InternalTable = React.forwardRef(
 
     const hasDynamicHeight = computedVariant === 'full-page';
     const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
-
     useTableFocusNavigation(selectionType, tableRefObject, visibleColumnDefinitions, items?.length);
+
+    const toolsHeaderWrapper = useRef(null);
+    // If is mobile we subtract the tools wrapper height so only the table header is sticky
+    const mobileStickyOffset =
+      (toolsHeaderWrapper?.current as HTMLDivElement | null)?.getBoundingClientRect().height ?? 0;
 
     return (
       <ColumnWidthsProvider
@@ -223,7 +229,10 @@ const InternalTable = React.forwardRef(
                   ref={overlapElement}
                   className={clsx(hasDynamicHeight && [styles['dark-header'], 'awsui-context-content-header'])}
                 >
-                  <div className={clsx(styles['header-controls'], styles[`variant-${computedVariant}`])}>
+                  <div
+                    ref={toolsHeaderWrapper}
+                    className={clsx(styles['header-controls'], styles[`variant-${computedVariant}`])}
+                  >
                     <ToolsHeader header={header} filter={filter} pagination={pagination} preferences={preferences} />
                   </div>
                 </div>
@@ -257,7 +266,9 @@ const InternalTable = React.forwardRef(
             )
           }
           __stickyHeader={stickyHeader}
-          __stickyOffset={stickyHeaderVerticalOffset}
+          __stickyOffset={
+            isMobile ? (stickyHeaderVerticalOffset ?? 0) - mobileStickyOffset : stickyHeaderVerticalOffset
+          }
           {...focusMarkers.root}
         >
           <div

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -85,6 +85,7 @@ const InternalTable = React.forwardRef(
   ) => {
     const baseProps = getBaseProps(rest);
     const isMobile = useMobile();
+    stickyHeader = stickyHeader && supportsStickyPosition();
 
     const [containerWidth, wrapperMeasureRef] = useContainerQuery<number>(({ width }) => width);
     const wrapperRefObject = useRef(null);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -258,6 +258,7 @@ const InternalTable = React.forwardRef(
           variant={toContainerVariant(computedVariant)}
           __disableFooterPaddings={true}
           __disableFooterDivider={true}
+          __disableStickyMobile={false}
           footer={
             footer && (
               <div className={clsx(styles['footer-wrapper'], styles[`variant-${computedVariant}`])}>


### PR DESCRIPTION
### Description

Description:
This PR updates the table component to make only the table header row sticky on mobile devices, instead of the entire header container. This improves the user experience on mobile devices by preserving the sticky behavior of the table header row, while allowing other header elements, such as title, filters or buttons, to scroll out of view.

Changes:
- Updated the sticky behavior in `src/container/internal.tsx` to take into account the new internal `__disableStickyMobile` prop.
- Added the prop to the sticky header in `src/container/use-sticky-header.ts` and made it disable the sticky feature on mobile devices by default (status-quo).
- Updated the sticky header test in `src/table/__integ__/sticky-header.test.ts` to reflect the new behavior on mobile devices.
- Added a `toolsHeaderWrapper` ref and calculated the `mobileStickyOffset` in `src/table/internal.tsx` to correctly offset the sticky table header row when on a mobile device and passed the new `__disableStickyMobile` as `false`.

### How has this been tested?

Existing and newly updated integration test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
