### PR TITLE
feat: Allow table columns to be specified as row headers

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -42,6 +42,7 @@ const PROPERTY_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     id: 'variable',
     header: 'Property',
     cell: item => <Link href="#">{item.name}</Link>,
+    isRowHeader: true,
   },
   {
     id: 'type',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11879,7 +11879,8 @@ add a meaningful description to the whole selection.
        You receive the current table row \`item\` and a \`cellContext\` object as arguments.
        The \`cellContext\` object contains the following properties:
  *  * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
- *  * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.",
+ *  * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
+ * \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.",
       "name": "columnDefinitions",
       "optional": false,
       "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",

--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -36,7 +36,7 @@ function Counter({ id }: { id: number | string }) {
 }
 
 const defaultColumns: TableProps.ColumnDefinition<Item>[] = [
-  { header: 'id', cell: item => item.id },
+  { header: 'id', cell: item => item.id, isRowHeader: true },
   { header: 'name', cell: item => item.name },
 ];
 const defaultColumnsWithIds: TableProps.ColumnDefinition<Item>[] = [
@@ -167,6 +167,15 @@ test('should render table with accessible headers', () => {
   const columnHeaders = wrapper.findColumnHeaders();
   columnHeaders.forEach(header => {
     expect(header.getElement()).toHaveAttribute('scope', 'col');
+  });
+});
+
+test('should render row headers if defined', () => {
+  const { wrapper } = renderTable(<Table columnDefinitions={defaultColumns} items={defaultItems} />);
+  defaultItems.forEach((item, index) => {
+    const cellElement = wrapper.findBodyCell(index + 1, 1)?.getElement();
+    expect(cellElement?.tagName).toBe('TH');
+    expect(cellElement).toHaveAttribute('scope', 'row');
   });
 });
 

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -25,6 +25,7 @@ $border-placeholder: awsui.$border-item-width solid transparent;
   border-top: awsui.$border-divider-list-width solid transparent;
   word-wrap: break-word;
   border-bottom: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
+  font-weight: inherit;
   &:not(.body-cell-wrap) {
     white-space: nowrap;
     overflow: hidden;

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -8,12 +8,16 @@ export interface TableTdElementProps {
   className?: string;
   style?: React.CSSProperties;
   wrapLines: boolean | undefined;
+  isRowHeader?: boolean;
   isFirstRow: boolean;
   isLastRow: boolean;
   isSelected: boolean;
   isNextSelected: boolean;
   isPrevSelected: boolean;
-  nativeAttributes?: Omit<React.HTMLAttributes<HTMLTableCellElement>, 'style' | 'className' | 'onClick'>;
+  nativeAttributes?: Omit<
+    React.TdHTMLAttributes<HTMLTableCellElement> | React.ThHTMLAttributes<HTMLTableCellElement>,
+    'style' | 'className' | 'onClick'
+  >;
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -32,6 +36,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       style,
       children,
       wrapLines,
+      isRowHeader,
       isFirstRow,
       isLastRow,
       isSelected,
@@ -49,8 +54,16 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
     },
     ref
   ) => {
+    let Element: 'th' | 'td' = 'td';
+    if (isRowHeader) {
+      Element = 'th';
+      nativeAttributes = {
+        ...nativeAttributes,
+        scope: 'row',
+      };
+    }
     return (
-      <td
+      <Element
         style={style}
         className={clsx(
           className,
@@ -74,7 +87,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         {...nativeAttributes}
       >
         {children}
-      </td>
+      </Element>
     );
   }
 );

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -102,6 +102,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *        The `cellContext` object contains the following properties:
    *  *  * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
    *  *  * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
+   *  * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
   /**
@@ -352,6 +353,7 @@ export namespace TableProps {
     minWidth?: number | string;
     maxWidth?: number | string;
     editConfig?: EditConfig<ItemType>;
+    isRowHeader?: boolean;
     cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -391,6 +391,7 @@ const InternalTable = React.forwardRef(
                               wrapLines={wrapLines}
                               isEditable={isEditable}
                               isEditing={isEditing}
+                              isRowHeader={column.isRowHeader}
                               isFirstRow={firstVisible}
                               isLastRow={lastVisible}
                               isSelected={isSelected}

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -61,7 +61,9 @@ export default class TableWrapper extends ComponentWrapper {
    * @param columnIndex 1-based index of the column of the cell to select.
    */
   findBodyCell(rowIndex: number, columnIndex: number): ElementWrapper | null {
-    return this.findNativeTable().find(`tbody tr:nth-child(${rowIndex}) td:nth-child(${columnIndex})`);
+    return this.findNativeTable().find(
+      `tbody tr:nth-child(${rowIndex}) .${bodyCellStyles['body-cell']}:nth-child(${columnIndex})`
+    );
   }
 
   findRows(): Array<ElementWrapper> {


### PR DESCRIPTION
### Description

Allow individual columns to be marked as row headers for improved table semantics

Related links, issue #, if available: AWSUI-20031

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
