### PR TITLE
feat: Add info slot for link-group items in SideNavigation

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11244,6 +11244,8 @@ Object that represents a group of links.
 - \`type\`: \`'link-group'\`.
 - \`text\` (string) - Specifies the text of the group link.
 - \`href\` (string) - Specifies the \`href\` of the group link.
+- \`info\` (ReactNode) - Enables you to display content next to the link. Although it is technically possible to insert any content,
+    our UX guidelines allow only to add a Badge and/or a \\"New\\" label.
 - \`items\` (array) - Specifies the content of the section. You can use any valid item from this list.
     Although there is no technical limitation to the nesting level,
     our UX recommendation is to use only one level.

--- a/src/side-navigation/__tests__/side-navigation.test.tsx
+++ b/src/side-navigation/__tests__/side-navigation.test.tsx
@@ -646,6 +646,22 @@ describe('SideNavigation', () => {
 
       expect(wrapper.findItemByIndex(1)?.findLink()?.getElement()).toHaveAttribute('href', ABSOLUTE_HREF);
     });
+
+    it('has an additional info when "info" property is specified', () => {
+      const wrapper = renderSideNavigation({
+        items: [
+          {
+            type: 'link-group',
+            text: 'Link Group',
+            href: ABSOLUTE_HREF,
+            info: <span>Additional info</span>,
+            items: [{ type: 'link', text: 'Page 1', href: '/nested-content' }],
+          },
+        ],
+      });
+
+      expect(wrapper.findItemByIndex(1)?.find('span')?.getElement()).toHaveTextContent('Additional info');
+    });
   });
 
   describe('Expandable Link Group', () => {

--- a/src/side-navigation/interfaces.tsx
+++ b/src/side-navigation/interfaces.tsx
@@ -72,6 +72,8 @@ export interface SideNavigationProps extends BaseComponentProps {
    * - `type`: `'link-group'`.
    * - `text` (string) - Specifies the text of the group link.
    * - `href` (string) - Specifies the `href` of the group link.
+   * - `info` (ReactNode) - Enables you to display content next to the link. Although it is technically possible to insert any content,
+   *     our UX guidelines allow only to add a Badge and/or a "New" label.
    * - `items` (array) - Specifies the content of the section. You can use any valid item from this list.
    *     Although there is no technical limitation to the nesting level,
    *     our UX recommendation is to use only one level.
@@ -158,6 +160,7 @@ export namespace SideNavigationProps {
     type: 'link-group';
     text: string;
     href: string;
+    info?: React.ReactNode;
     items: ReadonlyArray<Item>;
   }
 

--- a/src/side-navigation/internal.tsx
+++ b/src/side-navigation/internal.tsx
@@ -332,7 +332,7 @@ function LinkGroup({ definition, activeHref, fireFollow, fireChange }: LinkGroup
   return (
     <>
       <Link
-        definition={{ type: 'link', href: definition.href, text: definition.text }}
+        definition={{ type: 'link', href: definition.href, text: definition.text, info: definition.info }}
         fireFollow={(_, event) => fireFollow(definition, event)}
         fireChange={fireChange}
         activeHref={activeHref}


### PR DESCRIPTION
### Description

Add `info` slot for `SideNavigation` item of type `link-group`. 
there is already an `info` slot for items of type `link` so `link-group` should be treated the same 

### How has this been tested?

added a unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
