### PR TITLE
fix: Keep focus on header button after expanding/collapsing

### DIFF
--- a/pages/expandable-section/test.page.tsx
+++ b/pages/expandable-section/test.page.tsx
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import ExpandableSection from '~components/expandable-section';
+
+export default function ExpandableSectionTestPage() {
+  return (
+    <article>
+      <h1>Expandable Section Test Page</h1>
+
+      <button id="focus-target">Focus target</button>
+
+      <ExpandableSection headerText="Static website hosting">
+        After you enable your S3 bucket for static website hosting, web browsers can access your content through the
+        Amazon S3 website endpoint for the bucket.
+      </ExpandableSection>
+    </article>
+  );
+}

--- a/src/expandable-section/__integ__/expandable-section.test.ts
+++ b/src/expandable-section/__integ__/expandable-section.test.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const focusTargetSelector = '#focus-target';
+
+const expandableSectionWrapper = createWrapper().findExpandableSection();
+const headerButtonSelector = expandableSectionWrapper.findHeader().find('[role="button"]').toSelector();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/expandable-section/test');
+    await page.waitForVisible(expandableSectionWrapper.toSelector());
+    await testFn(page);
+  });
+};
+
+describe('Expandable Section', () => {
+  test(
+    'keeps focus on header button after expanding/collapsing',
+    setupTest(async page => {
+      await page.click(focusTargetSelector);
+
+      // Open expandable section
+      await page.keys(['Tab', 'Space']);
+      await expect(page.isExisting(expandableSectionWrapper.findExpandedContent().toSelector())).resolves.toBe(true);
+      await expect(page.isFocused(headerButtonSelector)).resolves.toBe(true);
+
+      // Close expandable section
+      await page.keys(['Space']);
+      await expect(page.isExisting(expandableSectionWrapper.findExpandedContent().toSelector())).resolves.toBe(false);
+      await expect(page.isFocused(headerButtonSelector)).resolves.toBe(true);
+    })
+  );
+});

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -29,7 +29,7 @@ interface ExpandableNavigationHeaderProps extends Omit<ExpandableDefaultHeaderPr
   ariaLabelledBy?: string;
 }
 
-interface ExpandableContainerHeaderProps extends ExpandableDefaultHeaderProps {
+interface ExpandableHeaderTextWrapperProps extends ExpandableDefaultHeaderProps {
   headerDescription?: ReactNode;
   headerCounter?: string;
   headingTagOverride?: ExpandableSectionProps.HeadingTag;
@@ -105,7 +105,7 @@ const ExpandableNavigationHeader = ({
   );
 };
 
-const ExpandableContainerHeader = ({
+const ExpandableHeaderTextWrapper = ({
   id,
   className,
   onClick,
@@ -120,45 +120,42 @@ const ExpandableContainerHeader = ({
   headingTagOverride,
   onKeyUp,
   onKeyDown,
-}: ExpandableContainerHeaderProps) => {
+}: ExpandableHeaderTextWrapperProps) => {
   const screenreaderContentId = useUniqueId('expandable-section-header-content-');
   const isContainer = variant === 'container';
+  const HeadingTag = headingTagOverride || 'div';
+  const headerButton = (
+    <span
+      className={isContainer ? styles['header-container-button'] : styles['header-button']}
+      role="button"
+      tabIndex={0}
+      onKeyUp={onKeyUp}
+      onKeyDown={onKeyDown}
+      aria-label={ariaLabel}
+      // Do not use aria-labelledby={id} but ScreenreaderOnly because safari+VO does not read headerText in this case.
+      aria-labelledby={ariaLabel || !isContainer ? undefined : screenreaderContentId}
+      aria-controls={ariaControls}
+      aria-expanded={expanded}
+    >
+      <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
+      <span>{children}</span>
+    </span>
+  );
 
-  const Wrapper = isContainer
-    ? ({ children }: { children: ReactNode }) => (
+  return (
+    <div id={id} className={className} onClick={onClick}>
+      {isContainer ? (
         <InternalHeader
           variant="h2"
           description={headerDescription}
           counter={headerCounter}
           headingTagOverride={headingTagOverride}
         >
-          {children}
+          {headerButton}
         </InternalHeader>
-      )
-    : ({ children }: { children: ReactNode }) => {
-        const Tag = headingTagOverride || 'div';
-        return <Tag className={styles['header-wrapper']}>{children}</Tag>;
-      };
-
-  return (
-    <div id={id} className={className} onClick={onClick}>
-      <Wrapper>
-        <span
-          className={isContainer ? styles['header-container-button'] : styles['header-button']}
-          role="button"
-          tabIndex={0}
-          onKeyUp={onKeyUp}
-          onKeyDown={onKeyDown}
-          aria-label={ariaLabel}
-          // Do not use aria-labelledby={id} but ScreenreaderOnly because safari+VO does not read headerText in this case.
-          aria-labelledby={ariaLabel || !isContainer ? undefined : screenreaderContentId}
-          aria-controls={ariaControls}
-          aria-expanded={expanded}
-        >
-          <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
-          <span>{children}</span>
-        </span>
-      </Wrapper>
+      ) : (
+        <HeadingTag className={styles['header-wrapper']}>{headerButton}</HeadingTag>
+      )}
       {isContainer && (
         <ScreenreaderOnly id={screenreaderContentId}>
           {children} {headerCounter} {headerDescription}
@@ -217,7 +214,7 @@ export const ExpandableSectionHeader = ({
 
   if (headerText) {
     return (
-      <ExpandableContainerHeader
+      <ExpandableHeaderTextWrapper
         className={clsx(className, triggerClassName, expanded && styles.expanded)}
         headerDescription={headerDescription}
         headerCounter={headerCounter}
@@ -227,7 +224,7 @@ export const ExpandableSectionHeader = ({
         {...defaultHeaderProps}
       >
         {headerText}
-      </ExpandableContainerHeader>
+      </ExpandableHeaderTextWrapper>
     );
   }
 
@@ -245,7 +242,7 @@ export const ExpandableSectionHeader = ({
       onKeyDown={onKeyDown}
       {...defaultHeaderProps}
     >
-      {headerText ?? header}
+      {header}
     </ExpandableDefaultHeader>
   );
 };


### PR DESCRIPTION
### Description

Expanding/collapsing the header seemed to remount the React tree around the header, which kicks focus back out to the body. I spent a while looking around for a `"key"`, and figured out what was actually happening. Of course, **[Boris got there first](https://github.com/cloudscape-design/components/pull/919#discussion_r1162554339)**  😛

Related links, issue #, if available: AWSUI-21024

### How has this been tested?

Added an integration test (and a dev page to match).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
