### PR TITLE
fix: Add "title" attribute to table multi selection control

### DIFF
--- a/src/table/selection-control/index.tsx
+++ b/src/table/selection-control/index.tsx
@@ -100,6 +100,7 @@ export default function SelectionControl({
         htmlFor={controlId}
         className={clsx(styles.label, styles.root)}
         aria-label={ariaLabel}
+        title={ariaLabel}
       >
         {selector}
       </label>


### PR DESCRIPTION
### Description

Kind of an edge-casey accessibility concern. The "select all" control for tables has a screen reader label, and the visual affordance is pretty clear without necessitating an actual text label, but we still need a visual text label of some kind. So this is the low-impact middle ground we've arrived at.

Related links, issue #, if available: AWSUI-20043

### How has this been tested?

Manually, locally. No real way of testing "title" other than a unit test that tests the exact DOM structure I just added.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
