### PR TITLE
feat: Improve keyboard icon by making space bar narrower

### DIFF
--- a/themes/icons/keyboard.svg
+++ b/themes/icons/keyboard.svg
@@ -4,7 +4,7 @@
   <path d="M9 5H7"/>
   <path d="M12 5H10"/>
   <path d="M6 8H4"/>
-  <path d="M12 11H4"/>
+  <path d="M11 11H5"/>
   <path d="M9 8H7"/>
   <path d="M12 8H10"/>
 </svg>


### PR DESCRIPTION
### Description

The current keyboard icon is difficult to recognize, I propose making the space bar a bit narrower. 

Current:
![current keyboard image](https://user-images.githubusercontent.com/184182/235913355-84688258-94b7-4e25-bf0b-729dc145a6a1.png)
Proposed:
![proposed keyboard image](https://user-images.githubusercontent.com/184182/235914577-c7972cc3-44e8-4b77-9057-aab488475888.png)

Related links, issue #: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Icon can be visually inspected.

<!-- How can reviewers test these changes efficiently? -->
Reviewers can add `fill="#fff" stroke="#000000"` to SVG options to check the image.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
