### PR TITLE
fix: Don't unset form field context around popover trigger

### DIFF
--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -98,7 +98,7 @@ describe('Dismiss button', () => {
       const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', renderWithPortal });
       wrapper.findTrigger().click();
       act(() => {
-        document.dispatchEvent(new MouseEvent('mousedown'));
+        document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
       });
       expect(wrapper.findBody({ renderWithPortal })).toBeNull();
     });
@@ -107,7 +107,10 @@ describe('Dismiss button', () => {
       const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', renderWithPortal });
       wrapper.findTrigger().click();
       act(() => {
-        wrapper.findBody({ renderWithPortal })!.getElement().dispatchEvent(new MouseEvent('mousedown'));
+        wrapper
+          .findBody({ renderWithPortal })!
+          .getElement()
+          .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
       });
       expect(wrapper.findBody({ renderWithPortal })).toBeTruthy();
     });
@@ -116,7 +119,10 @@ describe('Dismiss button', () => {
       const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', renderWithPortal });
       wrapper.findTrigger().click();
       act(() => {
-        wrapper.findTrigger().getElement().dispatchEvent(new MouseEvent('mousedown'));
+        wrapper
+          .findTrigger()
+          .getElement()
+          .dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
       });
       expect(wrapper.findBody({ renderWithPortal })).toBeTruthy();
     });

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -150,27 +150,27 @@ function InternalPopover(
   const mergedRef = useMergeRefs(popoverRef, __internalRootRef);
 
   return (
-    <FormFieldContext.Provider value={{}}>
-      <span
-        {...baseProps}
-        className={clsx(styles.root, baseProps.className)}
-        ref={mergedRef}
-        onMouseDown={() => {
-          // Indicate there was a click inside popover recently, including nested portals.
-          clickFrameId.current = requestAnimationFrame(() => {
-            clickFrameId.current = null;
-          });
-        }}
-      >
-        {triggerType === 'text' ? (
-          <button {...triggerProps} type="button" aria-haspopup="dialog">
-            <span className={styles['trigger-inner-text']}>{children}</span>
-          </button>
-        ) : (
-          <span {...triggerProps}>{children}</span>
-        )}
+    <span
+      {...baseProps}
+      className={clsx(styles.root, baseProps.className)}
+      ref={mergedRef}
+      onMouseDown={() => {
+        // Indicate there was a click inside popover recently, including nested portals.
+        clickFrameId.current = requestAnimationFrame(() => {
+          clickFrameId.current = null;
+        });
+      }}
+    >
+      {triggerType === 'text' ? (
+        <button {...triggerProps} type="button" aria-haspopup="dialog">
+          <span className={styles['trigger-inner-text']}>{children}</span>
+        </button>
+      ) : (
+        <span {...triggerProps}>{children}</span>
+      )}
+      <FormFieldContext.Provider value={{}}>
         {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
-      </span>
-    </FormFieldContext.Provider>
+      </FormFieldContext.Provider>
+    </span>
   );
 }


### PR DESCRIPTION
### Description

We added a wrapper unsetting form field context around dialog components like modal and popover in #850. That was a little over-eager with popover and also reset it around the trigger, not just the dialog. This moves the context provider to wrap just the content.

Related links, issue #, if available: AWSUI-21042

### How has this been tested?

One-time manual check. Not a use case I want to, uh, endorse.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
