### PR TITLE
feat: Add stacked tabs variant

### DIFF
--- a/pages/table/variants.page.tsx
+++ b/pages/table/variants.page.tsx
@@ -12,68 +12,71 @@ import Modal from '~components/modal';
 import SpaceBetween from '~components/space-between';
 import Table, { TableProps } from '~components/table';
 import Tabs, { TabsProps } from '~components/tabs';
+import ScreenshotArea from '../utils/screenshot-area';
 
 export default function () {
   const [visible, setVisible] = useState(false);
   const [expanded, setExpanded] = useState(true);
   return (
-    <div style={{ padding: 10 }}>
+    <>
       <h1>Table Variants</h1>
-      <SpaceBetween size="s">
-        <Button onClick={() => setVisible(true)}>Open Modal</Button>
-        <Modal
-          visible={visible}
-          onDismiss={() => setVisible(false)}
-          header={'Embedded Table'}
-          closeAriaLabel="Close modal"
-          footer={
-            <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button variant="link" onClick={() => setVisible(false)}>
-                Cancel
-              </Button>
-              <Button variant="primary" onClick={() => setVisible(false)}>
-                Delete
-              </Button>
-            </span>
-          }
-        >
-          <EmbeddedTable />
-        </Modal>
-        <ExpandableSection
-          onChange={({ detail }) => setExpanded(detail.expanded)}
-          variant="container"
-          headerText="Expandable Section"
-          expanded={expanded}
-        >
-          <SpaceBetween direction="vertical" size="m">
-            <KeyValuePairs />
+      <ScreenshotArea disableAnimations={true}>
+        <SpaceBetween size="m">
+          <Button onClick={() => setVisible(true)}>Open Modal</Button>
+          <Modal
+            visible={visible}
+            onDismiss={() => setVisible(false)}
+            header={'Embedded Table'}
+            closeAriaLabel="Close modal"
+            footer={
+              <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button variant="link" onClick={() => setVisible(false)}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={() => setVisible(false)}>
+                  Delete
+                </Button>
+              </span>
+            }
+          >
             <EmbeddedTable />
-          </SpaceBetween>
-        </ExpandableSection>
-        <div>
-          <Container variant="stacked" header={<Header variant="h2">Stacked Container</Header>}>
-            <KeyValuePairs />
-          </Container>
-          <BaseTabs variant="stacked" />
-          <StackedTable />
-          <StackedTableWithFooter />
-        </div>
-        <div>
-          <Container header={<Header>Stacked Container (before migration)</Header>}>
-            <KeyValuePairs />
-          </Container>
-          <DefaultTable />
-          <BaseTabs variant="container" />
-        </div>
-        <div>
-          <Container header={<Header>Stacked Container (after migration)</Header>} variant="stacked">
-            <KeyValuePairs />
-          </Container>
-          <StackedTable />
-          <BaseTabs variant="stacked" />
-        </div>
-      </SpaceBetween>
-    </div>
+          </Modal>
+          <ExpandableSection
+            onChange={({ detail }) => setExpanded(detail.expanded)}
+            variant="container"
+            headerText="Expandable Section"
+            expanded={expanded}
+          >
+            <SpaceBetween direction="vertical" size="m">
+              <KeyValuePairs />
+              <EmbeddedTable />
+            </SpaceBetween>
+          </ExpandableSection>
+          <div>
+            <Container variant="stacked" header={<Header variant="h2">Stacked Container</Header>}>
+              <KeyValuePairs />
+            </Container>
+            <BaseTabs variant="stacked" />
+            <StackedTable />
+            <StackedTableWithFooter />
+          </div>
+          <div>
+            <Container header={<Header>Stacked Container (before migration)</Header>}>
+              <KeyValuePairs />
+            </Container>
+            <DefaultTable />
+            <BaseTabs variant="container" />
+          </div>
+          <div>
+            <Container header={<Header>Stacked Container (after migration)</Header>} variant="stacked">
+              <KeyValuePairs />
+            </Container>
+            <StackedTable />
+            <BaseTabs variant="stacked" />
+          </div>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </>
   );
 }
 

--- a/pages/table/variants.page.tsx
+++ b/pages/table/variants.page.tsx
@@ -11,6 +11,7 @@ import Link from '~components/link';
 import Modal from '~components/modal';
 import SpaceBetween from '~components/space-between';
 import Table, { TableProps } from '~components/table';
+import Tabs, { TabsProps } from '~components/tabs';
 
 export default function () {
   const [visible, setVisible] = useState(false);
@@ -53,6 +54,7 @@ export default function () {
           <Container variant="stacked" header={<Header variant="h2">Stacked Container</Header>}>
             <KeyValuePairs />
           </Container>
+          <BaseTabs variant="stacked" />
           <StackedTable />
           <StackedTableWithFooter />
         </div>
@@ -61,12 +63,14 @@ export default function () {
             <KeyValuePairs />
           </Container>
           <DefaultTable />
+          <BaseTabs variant="container" />
         </div>
         <div>
           <Container header={<Header>Stacked Container (after migration)</Header>} variant="stacked">
             <KeyValuePairs />
           </Container>
           <StackedTable />
+          <BaseTabs variant="stacked" />
         </div>
       </SpaceBetween>
     </div>
@@ -150,3 +154,36 @@ function BaseTable(props: Partial<TableProps>) {
     />
   );
 }
+
+const tabs: Array<TabsProps.Tab> = [
+  {
+    label: 'First tab',
+    id: 'first',
+    content:
+      'Diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+  },
+  {
+    label: 'Second tab',
+    id: 'second',
+    content:
+      'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+  },
+  {
+    label: 'Third tab',
+    id: 'third',
+    content: '',
+  },
+];
+
+const BaseTabs = ({ variant }: { variant: TabsProps.Variant }) => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0].id);
+  return (
+    <Tabs
+      tabs={tabs}
+      variant={variant}
+      activeTabId={selectedTab}
+      onChange={event => setSelectedTab(event.detail.activeTabId)}
+      i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+    />
+  );
+};

--- a/pages/tabs/permutations.page.tsx
+++ b/pages/tabs/permutations.page.tsx
@@ -38,7 +38,7 @@ const permutations = createPermutations<TabsProps>([
     ],
   },
   {
-    variant: ['default', 'container'],
+    variant: ['default', 'container', 'stacked'],
     tabs: [
       ['first', 'second', 'third', 'fourth', 'fifth', 'sixth', 'seventh', 'eight'].map(id => ({
         label: `${id} tab`,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12326,13 +12326,15 @@ Don't use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "defaultValue": "\\"default\\"",
       "description": "The possible visual variants of tabs are the following:
 * \`default\` - Use in any context.
-* \`container\` - A variant with borders, for use alongside other containers.",
+* \`container\` - Use this variant to have the tabs displayed within a container header.
+* \`stacked\` - Use this variant directly adjacent to other stacked containers (such as a container, table).",
       "inlineType": Object {
         "name": "TabsProps.Variant",
         "type": "union",
         "values": Array [
           "default",
           "container",
+          "stacked",
         ],
       },
       "name": "variant",

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -77,7 +77,9 @@ export default function Tabs({
     return (
       <div
         className={clsx(
-          variant === 'container' ? styles['tabs-container-content-wrapper'] : styles['tabs-content-wrapper'],
+          variant === 'container' || variant === 'stacked'
+            ? styles['tabs-container-content-wrapper']
+            : styles['tabs-content-wrapper'],
           {
             [styles['with-paddings']]: !disableContentPaddings,
           }
@@ -104,7 +106,7 @@ export default function Tabs({
     />
   );
 
-  if (variant === 'container') {
+  if (variant === 'container' || variant === 'stacked') {
     return (
       <InternalContainer
         header={header}
@@ -113,6 +115,7 @@ export default function Tabs({
         className={clsx(baseProps.className, styles.root)}
         __internalRootRef={__internalRootRef}
         disableContentPaddings={true}
+        variant={variant === 'stacked' ? 'stacked' : 'default'}
       >
         {content()}
       </InternalContainer>

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -22,7 +22,8 @@ export interface TabsProps extends BaseComponentProps {
   /**
    * The possible visual variants of tabs are the following:
    * * `default` - Use in any context.
-   * * `container` - A variant with borders, for use alongside other containers.
+   * * `container` - Use this variant to have the tabs displayed within a container header.
+   * * `stacked` - Use this variant directly adjacent to other stacked containers (such as a container, table).
    */
   variant?: TabsProps.Variant;
 
@@ -63,7 +64,7 @@ export interface TabsProps extends BaseComponentProps {
   i18nStrings?: TabsProps.I18nStrings;
 }
 export namespace TabsProps {
-  export type Variant = 'default' | 'container';
+  export type Variant = 'default' | 'container' | 'stacked';
 
   export interface Tab {
     /**


### PR DESCRIPTION
### Description

Adds `stacked` variant to tabs, so they can be used alongside other stacked containers, and maintain compatibility with classic.

In VR, we introduced stacked containers and tables. During tiger teams, we noticed a need for a backwards compatible version for stacked tabs as well.

![Screen Shot 2023-05-02 at 7 56 05 AM](https://user-images.githubusercontent.com/15003460/236038634-095f3431-bb33-4c46-bbc1-e30e7d1d197a.png)

Related links, issue #, if available: CR-90767732

### How has this been tested?

Added stacked variant page to integ screenshot tests (CR-90767732).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
