### PR TITLE
fix: Remove sticky styles from container on mobile

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -9,6 +9,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
 import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import { useMobile } from '../internal/hooks/use-mobile';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
 
@@ -51,6 +52,7 @@ export default function InternalContainer({
   __disableStickyMobile = true,
   ...restProps
 }: InternalContainerProps) {
+  const isMobile = useMobile();
   const baseProps = getBaseProps(restProps);
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -97,7 +99,7 @@ export default function InternalContainer({
         styles.root,
         styles[`variant-${variant}`],
         fitHeight && styles['fit-height'],
-        isSticky && [styles['sticky-enabled']]
+        isSticky && !isMobile && [styles['sticky-enabled']]
       )}
       ref={mergedRef}
     >

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -91,6 +91,10 @@ export default function InternalContainer({
     };
   }, [isSticky, setHasStickyBackground, variant]);
 
+  // The container is only sticky on mobile if it is the header for the table.
+  // In this case we don't want the container to have sticky styles, as only the table header row will show as stuck on scroll.
+  const shouldHaveStickyStyles = isSticky && !isMobile;
+
   return (
     <div
       {...baseProps}
@@ -99,7 +103,7 @@ export default function InternalContainer({
         styles.root,
         styles[`variant-${variant}`],
         fitHeight && styles['fit-height'],
-        isSticky && !isMobile && [styles['sticky-enabled']]
+        shouldHaveStickyStyles && [styles['sticky-enabled']]
       )}
       ref={mergedRef}
     >


### PR DESCRIPTION
### Description

This PR fixes a regression caused by https://github.com/cloudscape-design/components/pull/1040, where the container would get the sticky styles (a box shadow) on mobile even though only the table header was sticky.

### How has this been tested?

Existing screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
