### PR TITLE
chore: Update docs for Multiselect and Select test utils

### DIFF
--- a/src/test-utils/dom/multiselect/index.ts
+++ b/src/test-utils/dom/multiselect/index.ts
@@ -24,7 +24,7 @@ export default class MultiselectWrapper extends DropdownHostComponentWrapper {
   }
 
   /**
-   * Returns the input that is used for filtering. Returns `null` if `enableFiltering` is not set to `true`.
+   * Returns the input that is used for filtering.
    * @param options
    * * expandToViewport (boolean) - Use this when the component under test is rendered with an `expandToViewport` flag.
    */

--- a/src/test-utils/dom/select/index.ts
+++ b/src/test-utils/dom/select/index.ts
@@ -30,7 +30,7 @@ export default class SelectWrapper extends DropdownHostComponentWrapper {
   }
 
   /**
-   * Returns the input that is used for filtering. Returns `null` if `enableFiltering` is not set to `true`.
+   * Returns the input that is used for filtering.
    * @param options
    * * expandToViewport (boolean) - Use this when the component under test is rendered with an `expandToViewport` flag.
    */


### PR DESCRIPTION
The documentation mentioned the `enableFiltering` flag,
which is no longer part of the two-component API.
It was left over from v2.1 migration.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
