### PR TITLE
fix: Correctly break words in wizard navigation step title

### DIFF
--- a/pages/wizard/wizard-screenshot.page.tsx
+++ b/pages/wizard/wizard-screenshot.page.tsx
@@ -18,7 +18,7 @@ const steps: WizardProps.Step[] = [
     description: 'Description of the step',
   },
   {
-    title: 'Step 2',
+    title: 'Step 2 - reallylongsteptitlewithoutspacestowraptonextline',
     content: (
       <>
         <p>{repeat('Really long text to wrap. ', 10)}</p>

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -176,6 +176,7 @@
     margin: 0;
 
     > li {
+      @include styles.text-wrapping;
       padding-bottom: awsui.$space-scaled-m;
       padding-top: 0;
     }


### PR DESCRIPTION
### Description

Long step title names overflow the wizard navigation. Refresh has the mixin correctly applied, but classic has its own component for navigation.

Related links, issue #, if available: AWSUI-21035

### How has this been tested?

Updated screenshot test page.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
