### PR TITLE
fix: Don't provide "" to modal closeAriaLabel by default

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -8107,7 +8107,6 @@ The event detail contains the \`reason\`, which can be any of the following:
       "type": "string",
     },
     Object {
-      "defaultValue": "\\"\\"",
       "description": "Adds an \`aria-label\` to the close button, for accessibility.",
       "name": "closeAriaLabel",
       "optional": true,

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -255,7 +255,7 @@ describe('Modal component', () => {
     describe('Close label property', () => {
       it('does not pass the label to the close button if not defined', () => {
         const wrapper = renderModal({ visible: true });
-        expect(wrapper.findDismissButton().getElement().getAttribute('aria-label')).toBe('');
+        expect(wrapper.findDismissButton().getElement().getAttribute('aria-label')).toBe(null);
       });
 
       it('passes the label to the close button if defined', () => {

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -8,9 +8,9 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 
 export { ModalProps };
 
-export default function Modal({ size = 'medium', closeAriaLabel = '', ...props }: ModalProps) {
+export default function Modal({ size = 'medium', ...props }: ModalProps) {
   const baseComponentProps = useBaseComponent('Modal');
-  return <InternalModal size={size} closeAriaLabel={closeAriaLabel} {...props} {...baseComponentProps} />;
+  return <InternalModal size={size} {...props} {...baseComponentProps} />;
 }
 
 applyDisplayName(Modal, 'Modal');

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -24,7 +24,7 @@ import FocusLock from '../internal/components/focus-lock';
 import { useInternalI18n } from '../internal/i18n/context';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
 
-type InternalModalProps = SomeRequired<ModalProps, 'size' | 'closeAriaLabel'> & InternalBaseComponentProps;
+type InternalModalProps = SomeRequired<ModalProps, 'size'> & InternalBaseComponentProps;
 
 export default function InternalModal({ modalRoot, ...rest }: InternalModalProps) {
   return (


### PR DESCRIPTION
### Description

When `closeAriaLabel` isn't provided, we're automatically defaulting to `""`, which isn't great. This messes with our i18n handler, makes it confusing for automated tools to check, and just feels wrong. Now the default is basically `undefined`, and it's even more clear when it's forgotten.

Related links, issue #, if available: n/a

### How has this been tested?

Changed a default value, so it was a manual check. Writing a test for this feels redundant.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
