### PR TITLE
fix: Table sticky scrollbar can be hidden globally

### DIFF
--- a/pages/table/sticky-scrollbar-custom.page.tsx
+++ b/pages/table/sticky-scrollbar-custom.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
-import { Box } from '~components';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Checkbox } from '~components';
 import styles from './styles.scss';
 import { generateItems, Instance } from './generate-data';
 import StickyScrollbar from '~components/table/sticky-scrollbar';
@@ -25,9 +25,18 @@ export default function Page() {
 
   const handleScroll = useScrollSync([wrapperRef, scrollbarRef]);
 
+  const [hideStickyScrollbar, setHideStickyScrollbar] = useState(false);
+
+  useEffect(() => {
+    document.body.setAttribute('data-awsui-hide-sticky-scrollbar', hideStickyScrollbar.toString());
+  }, [hideStickyScrollbar]);
+
   return (
     <Box margin="l">
       <h1>Sticky scrollbar with a custom table</h1>
+      <Checkbox checked={hideStickyScrollbar} onChange={event => setHideStickyScrollbar(event.detail.checked)}>
+        Hide sticky scrollbar
+      </Checkbox>
       <div ref={wrapperRef} onScroll={handleScroll} className={styles['custom-table']}>
         <table ref={tableRef} className={styles['custom-table-table']}>
           <thead>

--- a/pages/table/sticky-scrollbar-custom.page.tsx
+++ b/pages/table/sticky-scrollbar-custom.page.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef } from 'react';
+import SpaceBetween from '~components/space-between';
+import { Box } from '~components';
+import styles from './styles.scss';
+import { generateItems, Instance } from './generate-data';
+import StickyScrollbar from '~components/table/sticky-scrollbar';
+import { useScrollSync } from '~components/internal/hooks/use-scroll-sync';
+import { supportsStickyPosition } from '~components/internal/utils/dom';
+
+const items = generateItems(50);
+const columnDefinitions = [
+  { key: 'id', label: 'ID', render: (item: Instance) => item.id },
+  { key: 'state', label: 'State', render: (item: Instance) => item.state },
+  { key: 'type', label: 'Type', render: (item: Instance) => item.type },
+  { key: 'imageId', label: 'Image ID', render: (item: Instance) => item.imageId },
+  { key: 'dnsName', label: 'DNS name', render: (item: Instance) => item.dnsName },
+  { key: 'dnsName2', label: 'DNS name 2', render: (item: Instance) => item.dnsName + ':2' },
+  { key: 'dnsName3', label: 'DNS name 3', render: (item: Instance) => item.dnsName + ':3' },
+];
+
+export default function Page() {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const tableRef = useRef<HTMLTableElement>(null);
+  const scrollbarRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useScrollSync([wrapperRef, scrollbarRef], !supportsStickyPosition());
+
+  return (
+    <Box margin="l">
+      <SpaceBetween size="xl">
+        <h1>Sticky scrollbar with a custom table</h1>
+
+        <div ref={wrapperRef} onScroll={handleScroll} className={styles['custom-table']}>
+          <table ref={tableRef} className={styles['custom-table-table']}>
+            <thead>
+              <tr>
+                {columnDefinitions.map(column => (
+                  <th key={column.key} className={styles['custom-table-cell']}>
+                    {column.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(item => (
+                <tr key={item.id}>
+                  {columnDefinitions.map(column => (
+                    <td key={column.key} className={styles['custom-table-cell']}>
+                      {column.render(item)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <StickyScrollbar ref={scrollbarRef} wrapperRef={wrapperRef} tableRef={tableRef} onScroll={handleScroll} />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/table/sticky-scrollbar-custom.page.tsx
+++ b/pages/table/sticky-scrollbar-custom.page.tsx
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef } from 'react';
-import SpaceBetween from '~components/space-between';
 import { Box } from '~components';
 import styles from './styles.scss';
 import { generateItems, Instance } from './generate-data';
 import StickyScrollbar from '~components/table/sticky-scrollbar';
 import { useScrollSync } from '~components/internal/hooks/use-scroll-sync';
-import { supportsStickyPosition } from '~components/internal/utils/dom';
 
 const items = generateItems(50);
 const columnDefinitions = [
@@ -25,39 +23,36 @@ export default function Page() {
   const tableRef = useRef<HTMLTableElement>(null);
   const scrollbarRef = useRef<HTMLDivElement>(null);
 
-  const handleScroll = useScrollSync([wrapperRef, scrollbarRef], !supportsStickyPosition());
+  const handleScroll = useScrollSync([wrapperRef, scrollbarRef]);
 
   return (
     <Box margin="l">
-      <SpaceBetween size="xl">
-        <h1>Sticky scrollbar with a custom table</h1>
-
-        <div ref={wrapperRef} onScroll={handleScroll} className={styles['custom-table']}>
-          <table ref={tableRef} className={styles['custom-table-table']}>
-            <thead>
-              <tr>
+      <h1>Sticky scrollbar with a custom table</h1>
+      <div ref={wrapperRef} onScroll={handleScroll} className={styles['custom-table']}>
+        <table ref={tableRef} className={styles['custom-table-table']}>
+          <thead>
+            <tr>
+              {columnDefinitions.map(column => (
+                <th key={column.key} className={styles['custom-table-cell']}>
+                  {column.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(item => (
+              <tr key={item.id}>
                 {columnDefinitions.map(column => (
-                  <th key={column.key} className={styles['custom-table-cell']}>
-                    {column.label}
-                  </th>
+                  <td key={column.key} className={styles['custom-table-cell']}>
+                    {column.render(item)}
+                  </td>
                 ))}
               </tr>
-            </thead>
-            <tbody>
-              {items.map(item => (
-                <tr key={item.id}>
-                  {columnDefinitions.map(column => (
-                    <td key={column.key} className={styles['custom-table-cell']}>
-                      {column.render(item)}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <StickyScrollbar ref={scrollbarRef} wrapperRef={wrapperRef} tableRef={tableRef} onScroll={handleScroll} />
-      </SpaceBetween>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <StickyScrollbar ref={scrollbarRef} wrapperRef={wrapperRef} tableRef={tableRef} onScroll={handleScroll} />
     </Box>
   );
 }

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -1,0 +1,41 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '~design-tokens' as tokens;
+
+.custom-table {
+  box-sizing: border-box;
+  overflow-x: auto;
+  width: 100%;
+
+  &-table {
+    width: 100%;
+    box-sizing: border-box;
+    border-spacing: 0;
+  }
+
+  &-cell {
+    border-left: 1px solid tokens.$color-border-divider-default;
+    border-bottom: 1px solid tokens.$color-border-divider-default;
+    padding: 8px 16px;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background-color: tokens.$color-background-container-content;
+
+    &.sticky-cell {
+      position: sticky;
+
+      &-last-left {
+        border-right: 2px solid red;
+      }
+      &-last-right {
+        border-left: 2px solid red !important;
+      }
+    }
+  }
+}

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -26,16 +26,5 @@
     white-space: nowrap;
 
     background-color: tokens.$color-background-container-content;
-
-    &.sticky-cell {
-      position: sticky;
-
-      &-last-left {
-        border-right: 2px solid red;
-      }
-      &-last-right {
-        border-left: 2px solid red !important;
-      }
-    }
   }
 }

--- a/src/internal/hooks/use-scroll-sync/index.ts
+++ b/src/internal/hooks/use-scroll-sync/index.ts
@@ -1,16 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { RefObject, useRef } from 'react';
+import { supportsStickyPosition } from '../../utils/dom';
 
 /**
- * useScrollSync returns scroll event handler to be attached to synchronised scroll elements.
+ * useScrollSync returns scroll event handler to be attached to synchronized scroll elements.
  *
  * For example
  *    const handleScroll = useScrollSync([ref1, ref2]);
  *    <div ref={ref1} onScroll={handleScroll}/>
  *    <div ref={ref2} onScroll={handleScroll}/>
  */
-export function useScrollSync(refs: Array<RefObject<any>>, disabled = false) {
+export function useScrollSync(refs: Array<RefObject<any>>, disabled = !supportsStickyPosition()) {
   const activeElement = useRef<HTMLElement | null>(null);
   const onScroll = (event: React.UIEvent) => {
     const targetElement = event.target as HTMLElement;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -112,10 +112,7 @@ const InternalTable = React.forwardRef(
       []
     );
 
-    const handleScroll = useScrollSync(
-      [wrapperRefObject, scrollbarRef, secondaryWrapperRef],
-      !supportsStickyPosition()
-    );
+    const handleScroll = useScrollSync([wrapperRefObject, scrollbarRef, secondaryWrapperRef]);
 
     const { moveFocusDown, moveFocusUp, moveFocus } = useFocusMove(selectionType, items.length);
     const { onRowClickHandler, onRowContextMenuHandler } = useRowEvents({ onRowClick, onRowContextMenu });

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -156,7 +156,8 @@ filter search icon.
   &-content {
     height: 15px;
   }
-  &-visible {
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body:not([data-awsui-hide-sticky-scrollbar='true']) &-visible {
     display: block;
   }
 }

--- a/src/table/use-sticky-scrollbar.ts
+++ b/src/table/use-sticky-scrollbar.ts
@@ -124,10 +124,9 @@ export function useStickyScrollbar(
   }, [wrapperEl]);
 
   useEffect(() => {
-    if (supportsStickyPosition() && tableRef.current) {
-      const observer = new ResizeObserver(entries => {
+    if (supportsStickyPosition() && wrapperRef.current && tableRef.current) {
+      const observer = new ResizeObserver(() => {
         if (scrollbarContentRef.current) {
-          scrollbarContentRef.current.style.width = `${entries[0].borderBoxSize[0].inlineSize}px`;
           updatePosition(
             tableRef.current,
             wrapperRef.current,
@@ -138,39 +137,13 @@ export function useStickyScrollbar(
           );
         }
       });
+      // Scrollbar width must be in sync with wrapper width.
+      observer.observe(wrapperRef.current);
+      // Scrollbar content width must be in sync with table width.
       observer.observe(tableRef.current);
       return () => {
         observer.disconnect();
       };
     }
   }, [scrollbarContentRef, scrollbarRef, tableRef, wrapperRef, consideredFooterHeight, hasContainingBlock]);
-
-  useEffect(() => {
-    if (supportsStickyPosition()) {
-      const resizeHandler = () => {
-        updatePosition(
-          tableRef.current,
-          wrapperRef.current,
-          scrollbarRef.current,
-          scrollbarContentRef.current,
-          hasContainingBlock,
-          consideredFooterHeight
-        );
-      };
-      const pointerDownHandler = () => {
-        if (scrollbarRef.current) {
-          scrollbarRef.current.classList.remove(styles['sticky-scrollbar-visible']);
-        }
-      };
-      const pointerUpHandler = resizeHandler;
-      window.addEventListener('resize', resizeHandler);
-      window.addEventListener('pointerdown', pointerDownHandler);
-      window.addEventListener('pointerup', pointerUpHandler);
-      return () => {
-        window.removeEventListener('resize', resizeHandler);
-        window.removeEventListener('pointerdown', pointerDownHandler);
-        window.removeEventListener('pointerup', pointerUpHandler);
-      };
-    }
-  }, [tableRef, wrapperRef, scrollbarRef, scrollbarContentRef, hasContainingBlock, consideredFooterHeight]);
 }

--- a/src/table/use-sticky-scrollbar.ts
+++ b/src/table/use-sticky-scrollbar.ts
@@ -157,9 +157,19 @@ export function useStickyScrollbar(
           consideredFooterHeight
         );
       };
+      const pointerDownHandler = () => {
+        if (scrollbarRef.current) {
+          scrollbarRef.current.classList.remove(styles['sticky-scrollbar-visible']);
+        }
+      };
+      const pointerUpHandler = resizeHandler;
       window.addEventListener('resize', resizeHandler);
+      window.addEventListener('pointerdown', pointerDownHandler);
+      window.addEventListener('pointerup', pointerUpHandler);
       return () => {
         window.removeEventListener('resize', resizeHandler);
+        window.removeEventListener('pointerdown', pointerDownHandler);
+        window.removeEventListener('pointerup', pointerUpHandler);
       };
     }
   }, [tableRef, wrapperRef, scrollbarRef, scrollbarContentRef, hasContainingBlock, consideredFooterHeight]);


### PR DESCRIPTION
### Description

The table sticky scrollbar has fixed position and need to adjust every time the table updates its size or position. We can detect size changes with the resize observer but position detection is fairly limited. For example, in board-components the items can be repositioned with D&D. Moreover, when dragging, the container's position can be set to absolute. That leads to issues when the sticky scrollbar position not being updated or being updated incorrectly.

Proposed a global flag to hide all sticky scrollbars during interactions such as D&D that can result in table container being moved around.

Before fix:

https://user-images.githubusercontent.com/20790937/236244608-69b4c4f5-1e5c-4638-b1ba-fe6d4d0673f0.mov

After fix (requires a small adjustment to board components to set/unset the body attribute):

https://user-images.githubusercontent.com/20790937/236245054-267975af-c1ac-4848-b35d-4419c584b708.mov

### How has this been tested?

Manual testing with new custom table test page and board components.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
