### PR TITLE
feat: Add ariaDescribedby to button

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2590,6 +2590,12 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
   "name": "Button",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-describedby\` to the button.",
+      "name": "ariaDescribedby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": " Adds aria-expanded to the button element. Use when the button controls an expandable element.",
       "name": "ariaExpanded",
       "optional": true,

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -106,7 +106,7 @@ const InternalAttributeEditor = React.forwardRef(
           onClick={onAddButtonClick}
           formAction="none"
           ref={addButtonRef}
-          __nativeAttributes={{ 'aria-describedby': infoAriaDescribedBy }}
+          ariaDescribedby={infoAriaDescribedBy}
         >
           {addButtonText}
         </InternalButton>

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -108,6 +108,18 @@ describe('Button Component', () => {
     });
   });
 
+  describe('ariaDescribedby property', () => {
+    test('adds aria-describedby property to button', () => {
+      const wrapper = renderButton({ ariaDescribedby: 'my-element' });
+      expect(wrapper.getElement()).toHaveAttribute('aria-describedby', 'my-element');
+    });
+
+    test("doesn't add an aria-describedby property if not provided", () => {
+      const wrapper = renderButton();
+      expect(wrapper.getElement()).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
   describe('iconUrl property', () => {
     const iconUrl = 'data:image/png;base64,aaaa';
     const iconAlt = 'Custom icon';
@@ -350,6 +362,7 @@ describe('Button Component', () => {
       expect(wrapper.getElement()).not.toHaveAttribute('aria-label');
     });
   });
+
   describe('form property', () => {
     test('should have form property when set', () => {
       const formId = 'form-id';

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -29,6 +29,7 @@ const Button = React.forwardRef(
       download,
       formAction = 'submit',
       ariaLabel,
+      ariaDescribedby,
       onClick,
       onFollow,
       ariaExpanded,
@@ -60,6 +61,7 @@ const Button = React.forwardRef(
         download={download}
         formAction={formAction}
         ariaLabel={ariaLabel}
+        ariaDescribedby={ariaDescribedby}
         onClick={onClick}
         onFollow={onFollow}
         ariaExpanded={ariaExpanded}

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -64,11 +64,18 @@ export interface ButtonProps extends BaseComponentProps {
    * The form action that is performed by a button click.
    */
   formAction?: ButtonProps.FormAction;
+
   /**
    * Adds `aria-label` to the button element. It should be used in buttons that don't have text in order to make
    * them accessible.
    */
   ariaLabel?: string;
+
+  /**
+   * Adds `aria-describedby` to the button.
+   */
+  ariaDescribedby?: string;
+
   /**
    * Applies button styling to a link. Use this property if you need a link styled as a button (`variant=link`).
    * For example, if you have a 'help' button that links to a documentation page.

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -42,6 +42,7 @@ export const InternalButton = React.forwardRef(
       download,
       formAction = 'submit',
       ariaLabel,
+      ariaDescribedby,
       ariaExpanded,
       __nativeAttributes,
       __internalRootRef = null,
@@ -88,6 +89,7 @@ export const InternalButton = React.forwardRef(
       // https://github.com/microsoft/TypeScript/issues/36659
       ref: useMergeRefs(buttonRef as any, __internalRootRef),
       'aria-label': ariaLabel,
+      'aria-describedby': ariaDescribedby,
       'aria-expanded': ariaExpanded,
       className: buttonClass,
       onClick: handleClick,


### PR DESCRIPTION
### Description

Pretty standard new property addition. I've seen this requested four or five times by this point, and the use cases get harder to push back each time. Developers can have a little custom attribute editor, as a treat.

New property description:

> **ariaDescribedby**: Adds `aria-describedby` to the button.


Related links, issue #, if available: AWSUI-21001

### How has this been tested?

Added unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
