### PR TITLE
chore: Move table A11Y unit test to integration test

### DIFF
--- a/pages/table/full-page-variant.page.tsx
+++ b/pages/table/full-page-variant.page.tsx
@@ -16,6 +16,7 @@ export default function App() {
       variant="full-page"
       columnDefinitions={columnsConfig}
       items={items}
+      ariaLabels={{ tableLabel: 'Full-page table' }}
     />
   );
 }

--- a/src/table/__integ__/table.test.ts
+++ b/src/table/__integ__/table.test.ts
@@ -57,3 +57,30 @@ test(
     expect(scrollLeft).toEqual(50);
   })
 );
+
+test(
+  'sets role=region and aria-label on scrollable wrapper when overflowing',
+  useBrowser(async browser => {
+    const tableWrapper = createWrapper().findTable();
+    const tableLabel = 'Full-page table';
+    await browser.url('#/light/table/full-page-variant?visualRefresh=true');
+    const page = new BasePageObject(browser);
+
+    // Find the scrollable wrapper element
+    const scrollableWrapperSelector = tableWrapper.findByClassName(styles.wrapper).toSelector();
+
+    let role, ariaLabel;
+    // Get the 'role' and 'aria-label' attributes of the scrollable wrapper
+    role = await page.getElementAttribute(scrollableWrapperSelector, 'role');
+    ariaLabel = await page.getElementAttribute(scrollableWrapperSelector, 'aria-label');
+
+    // Verify that the 'role' and 'aria-label' attributes are set correctly
+    await expect(role).toBeNull();
+    await expect(ariaLabel).toBeNull();
+    await page.setWindowSize({ width: 400, height: 800 });
+    role = await page.getElementAttribute(scrollableWrapperSelector, 'role');
+    ariaLabel = await page.getElementAttribute(scrollableWrapperSelector, 'aria-label');
+    await expect(role).toEqual('region');
+    await expect(ariaLabel).toEqual(tableLabel);
+  })
+);

--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -5,12 +5,7 @@ import React from 'react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
 import { render } from '@testing-library/react';
-import { useContainerQuery } from '../../../lib/components/internal/hooks/container-queries';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
-
-jest.mock('../../../lib/components/internal/hooks/container-queries', () => ({
-  useContainerQuery: jest.fn().mockReturnValue([800, { current: null }]),
-}));
 
 interface Item {
   id: number;
@@ -33,12 +28,6 @@ function renderTableWrapper(props?: Partial<TableProps>) {
   return createWrapper(container).findTable()!;
 }
 
-function mockSmallWrapper() {
-  // This is very brittle, bc we do not pass any identifying parameters to
-  // userContainerQuery. It relies on the call order inside the table.
-  (useContainerQuery as jest.MockedFn<typeof useContainerQuery>).mockReturnValueOnce([400, { current: null }]);
-}
-
 const tableLabel = 'Items';
 
 afterAll(() => {
@@ -56,15 +45,6 @@ describe('labels', () => {
       ariaLabels: { itemSelectionLabel: () => '', selectionGroupLabel: '', tableLabel },
     });
     expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-label')).toEqual(tableLabel);
-  });
-
-  test('sets role=region and aria-label on scrollable wrapper when overflowing', () => {
-    mockSmallWrapper();
-    const wrapper = renderTableWrapper({
-      ariaLabels: { itemSelectionLabel: () => '', selectionGroupLabel: '', tableLabel },
-    });
-
-    expect(wrapper.find('[role=region]')!.getElement().getAttribute('aria-label')).toEqual(tableLabel);
   });
 
   describe('rows', () => {


### PR DESCRIPTION
### Description

While working on https://github.com/cloudscape-design/components/pull/918, an A11Y unit test has been showing some flakiness depending on the code changes. This PR moves the unit to an integration test.

After further investigation it seems like there a couple of problems (TL;DR: call order dependency & lack of identifying parameters):

- `mockSmallWrapper()` is mocking the return value of `useContainerQuery` using `mockReturnValueOnce()`. This means that the test will only work correctly if the call order of `useContainerQuery` within the tested code is consistent with the mocked order in the test. If the call order changes (like it happened on the https://github.com/cloudscape-design/components/pull/918), the test may fail, even if the actual functionality remains correct. This makes the test sensitive to internal changes in the code, which is not ideal.

### How has this been tested?

The tests are the tests!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
