### PR TITLE
fix: Update mobile touch targets

### DIFF
--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -122,12 +122,7 @@ export function MobileToolbar({
         >
           {drawers.items.map((item: DrawerItem, index: number) => (
             <AppLayoutButton
-              className={clsx(
-                styles.trigger,
-                styles['trigger-drawer'],
-                drawers.activeDrawerId === item.id && styles.selected,
-                testutilStyles['drawers-trigger']
-              )}
+              className={clsx(styles['mobile-trigger-with-drawers'], testutilStyles['drawers-trigger'])}
               key={`drawer-trigger-${index}`}
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}

--- a/src/app-layout/mobile-toolbar/styles.scss
+++ b/src/app-layout/mobile-toolbar/styles.scss
@@ -32,6 +32,12 @@
   margin-right: awsui.$space-m;
 }
 
+.mobile-trigger-with-drawers {
+  width: constants.$sidebar-size-closed;
+  display: flex;
+  justify-content: center;
+}
+
 .mobile-toggle {
   box-sizing: border-box;
   cursor: pointer;
@@ -41,7 +47,7 @@
   &:first-child {
     border-right: 1px solid awsui.$color-border-layout;
   }
-  &:last-child {
+  &:last-child:not(.mobile-toggle-with-drawers) {
     border-left: 1px solid awsui.$color-border-layout;
   }
   &:hover:not(.mobile-toggle-with-drawers) {
@@ -51,5 +57,13 @@
   &-with-drawers {
     display: flex;
     width: auto;
+    padding: 0;
+    height: 100%;
+
+    > .mobile-trigger-with-drawers {
+      border-left: 1px solid awsui.$color-border-layout;
+      display: flex;
+      align-items: center;
+    }
   }
 }

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -5,6 +5,7 @@
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 @use '../../internal/styles' as styles;
+@use '../constants.scss' as constants;
 
 .drawers-container {
   background-color: transparent;
@@ -102,6 +103,13 @@
       transition: opacity awsui.$motion-duration-refresh-only-medium;
       transition-delay: calc(awsui.$motion-duration-refresh-only-fast / 1.5);
     }
+  }
+}
+
+.drawers-trigger {
+  @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
+    width: constants.$sidebar-size-closed;
+    text-align: right;
   }
 }
 

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -315,7 +315,7 @@ export function MobileTriggers() {
         <InternalButton
           ariaExpanded={item.id === activeDrawerId}
           ariaLabel={item.ariaLabels?.triggerButton}
-          className={testutilStyles['drawers-trigger']}
+          className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
           disabled={hasDrawerViewportOverlay}
           formAction="none"
           iconName={item.trigger.iconName}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Our mobile touch targets for drawers are too small, and were called out during a Drawers design review. Updating them to be `40px`, which is what the current width is for the navigation and tools icons on mobile.

Note: We should follow-up on these targets, as we may want to expand these even further.

Before:
![image](https://user-images.githubusercontent.com/9701338/236299800-a857a88f-b950-47b4-a5f5-b6626166a104.png)
![image](https://user-images.githubusercontent.com/9701338/236299743-71f58e08-5726-4d27-955c-1d5a172a5efc.png)

After:
![image](https://user-images.githubusercontent.com/9701338/236299511-4f38484f-e320-4cde-b90a-5b0b3bb52cac.png)
![image](https://user-images.githubusercontent.com/9701338/236299550-06ef8da1-ec1a-43d7-ae15-f83d8d7541de.png)


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
