### PR TITLE
chore: Update VR resizable columns handle color

### DIFF
--- a/src/__integ__/__snapshots__/themes.test.ts.snap
+++ b/src/__integ__/__snapshots__/themes.test.ts.snap
@@ -2513,7 +2513,7 @@ Object {
   "color-border-control-disabled": "#d1d5db",
   "color-border-divider-active": "#000716",
   "color-border-divider-default": "#e9ebed",
-  "color-border-divider-interactive-default": "#414d5c",
+  "color-border-divider-interactive-default": "#7d8998",
   "color-border-divider-panel-bottom": "#e9ebed",
   "color-border-divider-panel-side": "#e9ebed",
   "color-border-dropdown-container": "#9ba7b6",

--- a/style-dictionary/visual-refresh/colors.ts
+++ b/style-dictionary/visual-refresh/colors.ts
@@ -121,7 +121,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBorderStatusInfo: { light: '{colorBlue600}', dark: '{colorBlue500}' },
   colorBorderStatusSuccess: { light: '{colorGreen600}', dark: '{colorGreen500}' },
   colorBorderStatusWarning: { light: '{colorGrey500}', dark: '{colorGrey450}' },
-  colorBorderDividerInteractiveDefault: '{colorTextInteractiveDefault}',
+  colorBorderDividerInteractiveDefault: { light: '{colorGrey500}', dark: '{colorGrey300}' },
   colorBorderTabsDivider: { light: '{colorGrey200}', dark: '{colorGrey600}' },
   colorBorderTabsShadow: '{colorGreyTransparent}',
   colorBorderTabsUnderline: '{colorTextAccent}',


### PR DESCRIPTION
### Description

Update the VR resize handle color, to adhere to the new design decision.

Before:
<img width="225" alt="Before" src="https://user-images.githubusercontent.com/29541876/236323531-4686b796-0357-4b26-8bdb-894e208bd549.png">

After:
<img width="210" alt="After" src="https://user-images.githubusercontent.com/29541876/236323580-460c7073-241f-4d48-985d-decb39faa908.png">


Related to https://github.com/cloudscape-design/components/pull/918

### How has this been tested?

Visual regression tests in pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
