### PR TITLE
chore: Improve unit test APIs for Input & TextArea ElementWrappers by exposing getters for value property

### DIFF
--- a/src/input/__tests__/input.test.tsx
+++ b/src/input/__tests__/input.test.tsx
@@ -104,6 +104,10 @@ describe('Input', () => {
       const { input } = renderInput({ value: 'value' });
       expect(input).toHaveAttribute('value', 'value');
     });
+    test('can be obtained through getInputValue API', () => {
+      const { wrapper } = renderInput({ value: 'value' });
+      expect(wrapper.getInputValue()).toBe('value');
+    });
   });
 
   describe('placeholder', () => {

--- a/src/test-utils/dom/input/base-input.ts
+++ b/src/test-utils/dom/input/base-input.ts
@@ -26,6 +26,15 @@ export default abstract class BaseInputWrapper extends ComponentWrapper {
   }
 
   /**
+   * Gets the value of the component.
+   *
+   * @returns current value of selected textarea.
+   */
+  @usesDom getTextareaValue(): string {
+    return this.findNativeInput().getElement().value;
+  }
+
+  /**
    * Sets the value of the component and calls the `onChange` handler
    *
    * @param value The value the input is set to.

--- a/src/test-utils/dom/input/base-input.ts
+++ b/src/test-utils/dom/input/base-input.ts
@@ -28,7 +28,7 @@ export default abstract class BaseInputWrapper extends ComponentWrapper {
   /**
    * Gets the value of the component.
    *
-   * @returns current value of selected textarea.
+   * Returns the current value of the input.
    */
   @usesDom getInputValue(): string {
     return this.findNativeInput().getElement().value;

--- a/src/test-utils/dom/input/base-input.ts
+++ b/src/test-utils/dom/input/base-input.ts
@@ -30,7 +30,7 @@ export default abstract class BaseInputWrapper extends ComponentWrapper {
    *
    * @returns current value of selected textarea.
    */
-  @usesDom getTextareaValue(): string {
+  @usesDom getInputValue(): string {
     return this.findNativeInput().getElement().value;
   }
 

--- a/src/test-utils/dom/textarea/index.ts
+++ b/src/test-utils/dom/textarea/index.ts
@@ -12,6 +12,15 @@ export default class TextareaWrapper extends ComponentWrapper<HTMLTextAreaElemen
   }
 
   /**
+   * Gets the value of the component.
+   *
+   * @returns current value of selected textarea.
+   */
+  @usesDom getTextareaValue(): string {
+    return this.findNativeTextarea().getElement().value;
+  }
+
+  /**
    * Sets the value of the component and calls the onChange handler.
    *
    * @param value value to set the textarea to.

--- a/src/test-utils/dom/textarea/index.ts
+++ b/src/test-utils/dom/textarea/index.ts
@@ -14,7 +14,7 @@ export default class TextareaWrapper extends ComponentWrapper<HTMLTextAreaElemen
   /**
    * Gets the value of the component.
    *
-   * @returns current value of selected textarea.
+   * Returns the current value of the textarea.
    */
   @usesDom getTextareaValue(): string {
     return this.findNativeTextarea().getElement().value;

--- a/src/textarea/__tests__/textarea.test.tsx
+++ b/src/textarea/__tests__/textarea.test.tsx
@@ -31,6 +31,10 @@ describe('Textarea', () => {
       const { textarea } = renderTextarea({ value: 'value' });
       expect(textarea).toHaveTextContent('value');
     });
+    test('can be obtained through getTextareaValue API', () => {
+      const { textareaWrapper } = renderTextarea({ value: 'value' });
+      expect(textareaWrapper.getTextareaValue()).toBe('value');
+    });
   });
 
   describe('placeholder', () => {


### PR DESCRIPTION
### Description

**Include a summary of the changes and the related issue:** This change introduces getters for `Input` & `TextArea` ElementWrappers to support string validation in unit tests.

**Also include relevant motivation and context:** This was motivated by an internal AWS discussion.

Related links, issue #, if available: AWSUI-21062

### How has this been tested?

**How did you test to verify your changes?** I added unit tests.

**How can reviewers test these changes efficiently?** Running the unit tests locally or validating via an integration test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
