### PR TITLE
test: Add test for flashbar data-attributes propagation

### DIFF
--- a/src/flashbar/__tests__/data-attributes.test.tsx
+++ b/src/flashbar/__tests__/data-attributes.test.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import Flashbar from '../../../lib/components/flashbar';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { FlashbarProps } from '../interfaces';
+
+const i18nStrings = {
+  ariaLabel: 'Notifications',
+  notificationBarText: 'Notifications',
+  notificationBarAriaLabel: 'View all notifications',
+  errorIconAriaLabel: 'Error',
+  warningIconAriaLabel: 'Warning',
+  successIconAriaLabel: 'Success',
+  infoIconAriaLabel: 'Information',
+  inProgressIconAriaLabel: 'In progress',
+};
+
+function createDataAttributes(items: readonly FlashbarProps.MessageDefinition[]) {
+  const itemsByType = {
+    progress: 0,
+    success: 0,
+    warning: 0,
+    error: 0,
+    info: 0,
+  };
+  items.forEach(item => {
+    if (item.loading) {
+      itemsByType.progress++;
+    } else if (item.type) {
+      itemsByType[item.type]++;
+    }
+  });
+  return Object.fromEntries(Object.entries(itemsByType).map(([key, value]) => [`data-items-${key}`, value]));
+}
+
+test.each([false, true])('data attributes are assigned for flashbar with stackItems=%s', stackItems => {
+  const items = [
+    { type: 'error', header: 'Error 1' },
+    { type: 'error', header: 'Error 2' },
+    { type: 'warning', header: 'Warning 1' },
+  ] as const;
+
+  const { container } = render(
+    <Flashbar
+      stackItems={stackItems}
+      i18nStrings={i18nStrings}
+      items={[
+        { type: 'error', header: 'Error 1' },
+        { type: 'error', header: 'Error 2' },
+        { type: 'warning', header: 'Warning 1' },
+      ]}
+      {...createDataAttributes(items)}
+    />
+  );
+
+  expect({ ...createWrapper(container).findFlashbar()!.getElement().dataset }).toEqual({
+    itemsProgress: '0',
+    itemsSuccess: '0',
+    itemsWarning: '1',
+    itemsError: '2',
+    itemsInfo: '0',
+  });
+});


### PR DESCRIPTION
### Description

The test validates if the data- attributes are assigned to the flashbar root node and serves as an example of how the flashbar state can be checked in both unit- and integration tests. We can support a test-utils for the same matter but only for unit tests.

AWSUI-20204

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
