### PR TITLE
feat: Add findItemsByType to flashbar test-utils

### DIFF
--- a/src/flashbar/__tests__/collapsible.test.tsx
+++ b/src/flashbar/__tests__/collapsible.test.tsx
@@ -137,6 +137,43 @@ describe('Collapsible Flashbar', () => {
       expect(wrapper.findFlashbar()!.findItems()).toHaveLength(1);
       expect(findNotificationBar(wrapper.findFlashbar()!)).toBeTruthy();
     });
+
+    test('findItemsByType', () => {
+      {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar
+            stackItems={true}
+            items={[
+              { content: 'Flash', type: 'success' },
+              { content: 'Flash', type: 'warning' },
+            ]}
+          />
+        );
+        expect(wrapper.findItemsByType('success')).toHaveLength(1);
+        expect(wrapper.findItemsByType('warning')).toHaveLength(0);
+
+        findNotificationBar(wrapper)!.click();
+
+        expect(wrapper.findItemsByType('success')).toHaveLength(1);
+        expect(wrapper.findItemsByType('warning')).toHaveLength(1);
+      }
+      {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar
+            stackItems={true}
+            items={[
+              { content: 'Flash', type: 'warning' },
+              { content: 'Flash', type: 'warning' },
+            ]}
+          />
+        );
+        expect(wrapper.findItemsByType('warning')).toHaveLength(1);
+
+        findNotificationBar(wrapper)!.click();
+
+        expect(wrapper.findItemsByType('warning')).toHaveLength(2);
+      }
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -195,6 +195,26 @@ describe('Flashbar component', () => {
         }
       });
 
+      test('findItemsByType', () => {
+        const wrapper = createFlashbarWrapper(
+          <Flashbar
+            items={[
+              { content: 'Flash', type: 'success' },
+              { content: 'Flash', type: 'error' },
+              { content: 'Flash', type: 'error' },
+              { content: 'Flash', type: 'warning' },
+              { content: 'Flash', type: 'info' },
+              { content: 'Flash', type: 'warning', loading: true }, // assuming info
+              { content: 'Flash', loading: true }, // assuming info
+            ]}
+          />
+        );
+        expect(wrapper.findItemsByType('success')).toHaveLength(1);
+        expect(wrapper.findItemsByType('error')).toHaveLength(2);
+        expect(wrapper.findItemsByType('warning')).toHaveLength(1);
+        expect(wrapper.findItemsByType('info')).toHaveLength(3);
+      });
+
       test('correct aria-role', () => {
         const wrapper = createFlashbarWrapper(
           <Flashbar

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -17,6 +17,19 @@ export default class FlashbarWrapper extends ComponentWrapper {
   }
 
   /**
+   * Returns the individual flashes of this flashbar given the item type.
+   *
+   * If the items are stacked, only the item at the top of the stack is returned.
+   *
+   * If an item is loading assuming its type is "info".
+   */
+  findItemsByType(type: 'success' | 'warning' | 'info' | 'error'): Array<FlashWrapper> {
+    return this.findAll(`.${styles['flash-list-item']} .${styles[`flash-type-${type}`]}`).map(
+      item => new FlashWrapper(item.getElement())
+    );
+  }
+
+  /**
    * Returns the toggle button that expands and collapses stacked notifications.
    */
   findToggleButton(): ElementWrapper<HTMLButtonElement> | null {

--- a/src/test-utils/dom/flashbar/index.ts
+++ b/src/test-utils/dom/flashbar/index.ts
@@ -21,7 +21,7 @@ export default class FlashbarWrapper extends ComponentWrapper {
    *
    * If the items are stacked, only the item at the top of the stack is returned.
    *
-   * If an item is loading assuming its type is "info".
+   * If an item is loading its type is considered as "info".
    */
   findItemsByType(type: 'success' | 'warning' | 'info' | 'error'): Array<FlashWrapper> {
     return this.findAll(`.${styles['flash-list-item']} .${styles[`flash-type-${type}`]}`).map(


### PR DESCRIPTION
### Description

Added new test-util for flashbar to find flash items by type.

AWSUI-20204

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
