### PR TITLE
chore: Update custom page for sticky table columns to feature pad left

### DIFF
--- a/pages/table/sticky-columns-custom.page.tsx
+++ b/pages/table/sticky-columns-custom.page.tsx
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import SpaceBetween from '~components/space-between';
-import { Box, Link } from '~components';
+import { Box, Container, Link } from '~components';
 import { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from '~components/table/use-sticky-columns';
 import styles from './styles.scss';
 import { generateItems, Instance } from './generate-data';
 import clsx from 'clsx';
 
-const items = generateItems(10);
+const items = generateItems(50);
 const columnDefinitions = [
   { key: 'id', label: 'ID', render: (item: Instance) => item.id },
   { key: 'state', label: 'State', render: (item: Instance) => item.state },
-  { key: 'type', label: 'Type', render: (item: Instance) => item.type },
   { key: 'imageId', label: 'Image ID', render: (item: Instance) => <Link>{item.imageId}</Link> },
-  { key: 'dnsName', label: 'DNS name', render: (item: Instance) => item.dnsName },
+  { key: 'dnsName', label: 'DNS name', render: (item: Instance) => item.dnsName ?? 'none' },
+  { key: 'dnsName2', label: 'DNS name 2', render: (item: Instance) => (item.dnsName ?? 'none') + ':2' },
+  { key: 'type', label: 'Type', render: (item: Instance) => item.type },
 ];
 
 export default function Page() {
@@ -28,30 +29,32 @@ export default function Page() {
       <SpaceBetween size="xl">
         <h1>Sticky columns with a custom table</h1>
 
-        <div ref={stickyColumns.refs.wrapper} className={styles['custom-table']} style={stickyColumns.style.wrapper}>
-          <table ref={stickyColumns.refs.table} className={styles['custom-table-table']}>
-            <thead>
-              <tr>
-                {columnDefinitions.map(column => (
-                  <TableCell isHeader={true} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
-                    {column.label}
-                  </TableCell>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {items.map(item => (
-                <tr key={item.id}>
+        <Container disableContentPaddings={true}>
+          <div ref={stickyColumns.refs.wrapper} className={styles['custom-table']} style={stickyColumns.style.wrapper}>
+            <table ref={stickyColumns.refs.table} className={styles['custom-table-table']}>
+              <thead>
+                <tr>
                   {columnDefinitions.map(column => (
-                    <TableCell isHeader={false} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
-                      {column.render(item)}
+                    <TableCell isHeader={true} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
+                      {column.label}
                     </TableCell>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {items.map(item => (
+                  <tr key={item.id}>
+                    {columnDefinitions.map(column => (
+                      <TableCell isHeader={false} key={column.key} columnId={column.key} stickyColumns={stickyColumns}>
+                        {column.render(item)}
+                      </TableCell>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Container>
       </SpaceBetween>
     </Box>
   );
@@ -76,6 +79,7 @@ function TableCell({
       [styles['sticky-cell']]: !!props,
       [styles['sticky-cell-last-left']]: !!props?.lastLeft,
       [styles['sticky-cell-last-right']]: !!props?.lastRight,
+      [styles['sticky-cell-pad-left']]: !!props?.padLeft,
     }),
   });
   return (

--- a/pages/table/sticky-columns-custom.page.tsx
+++ b/pages/table/sticky-columns-custom.page.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
 import SpaceBetween from '~components/space-between';
-import { Box, Container, Link } from '~components';
+import { Box, Checkbox, Container, Link } from '~components';
 import { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from '~components/table/use-sticky-columns';
 import styles from './styles.scss';
 import { generateItems, Instance } from './generate-data';
@@ -19,6 +19,8 @@ const columnDefinitions = [
 ];
 
 export default function Page() {
+  // When wrapper paddings are used there is no need in dynamic padLeft.
+  const [useWrapperPaddings, setUseWrapperPaddings] = useState(false);
   const stickyColumns = useStickyColumns({
     visibleColumns: columnDefinitions.map(column => column.key),
     stickyColumnsFirst: 1,
@@ -29,9 +31,20 @@ export default function Page() {
       <SpaceBetween size="xl">
         <h1>Sticky columns with a custom table</h1>
 
+        <Checkbox checked={useWrapperPaddings} onChange={event => setUseWrapperPaddings(event.detail.checked)}>
+          Use wrapper paddings
+        </Checkbox>
+
         <Container disableContentPaddings={true}>
-          <div ref={stickyColumns.refs.wrapper} className={styles['custom-table']} style={stickyColumns.style.wrapper}>
-            <table ref={stickyColumns.refs.table} className={styles['custom-table-table']}>
+          <div
+            ref={stickyColumns.refs.wrapper}
+            className={clsx(styles['custom-table'], useWrapperPaddings && styles['use-wrapper-paddings'])}
+            style={stickyColumns.style.wrapper}
+          >
+            <table
+              ref={stickyColumns.refs.table}
+              className={clsx(styles['custom-table-table'], useWrapperPaddings && styles['use-wrapper-paddings'])}
+            >
               <thead>
                 <tr>
                   {columnDefinitions.map(column => (

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -10,11 +10,19 @@
   overflow-x: auto;
   width: 100%;
 
+  &.use-wrapper-paddings {
+    width: calc(100% - 64px);
+    margin: 0 32px;
+  }
+
   &-table {
     width: 100%;
     box-sizing: border-box;
     border-spacing: 0;
-    padding: 0 32px;
+
+    &:not(.use-wrapper-paddings) {
+      padding: 0 32px;
+    }
   }
 
   &-cell {

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -14,7 +14,7 @@
     width: 100%;
     box-sizing: border-box;
     border-spacing: 0;
-    padding: 0 16px;
+    padding: 0 32px;
   }
 
   &-cell {
@@ -46,7 +46,7 @@
         border-left: 2px solid red !important;
       }
       &-pad-left {
-        padding-left: 20px;
+        padding-left: 32px;
       }
     }
   }

--- a/pages/table/styles.scss
+++ b/pages/table/styles.scss
@@ -14,6 +14,7 @@
     width: 100%;
     box-sizing: border-box;
     border-spacing: 0;
+    padding: 0 16px;
   }
 
   &-cell {
@@ -27,6 +28,14 @@
 
     background-color: tokens.$color-background-container-content;
 
+    &:first-child {
+      padding-left: 2px;
+      border-left: none;
+    }
+    &:last-child {
+      padding-right: 2px;
+    }
+
     &.sticky-cell {
       position: sticky;
 
@@ -35,6 +44,9 @@
       }
       &-last-right {
         border-left: 2px solid red !important;
+      }
+      &-pad-left {
+        padding-left: 20px;
       }
     }
   }

--- a/src/table/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/__tests__/use-sticky-columns.test.tsx
@@ -53,7 +53,7 @@ test('isEnabled is true, wrapper styles is not empty and wrapper listener is att
   result.current.refs.wrapper(tableWrapper);
 
   expect(result.current.isEnabled).toBe(true);
-  expect(result.current.style.wrapper).toEqual({ scrollPaddingLeft: '0px', scrollPaddingRight: '0px' });
+  expect(result.current.style.wrapper).toEqual({ scrollPaddingLeft: 0, scrollPaddingRight: 0 });
   expect(addTableWrapperOnScrollSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
 });
 
@@ -118,7 +118,7 @@ test('generates non-empty sticky cell state', () => {
       2: null,
       3: null,
     },
-    scrollPadding: { left: 100, right: 0 },
+    wrapperState: { scrollPaddingLeft: 100, scrollPaddingRight: 0 },
   });
 });
 
@@ -137,7 +137,7 @@ test('generates empty cell state if wrapper is not scrollable', () => {
       2: null,
       3: null,
     },
-    scrollPadding: { left: 100, right: 0 },
+    wrapperState: { scrollPaddingLeft: 100, scrollPaddingRight: 0 },
   });
 });
 
@@ -156,7 +156,7 @@ test('generates empty sticky cell state if not enough scrollable space', () => {
       2: null,
       3: null,
     },
-    scrollPadding: { left: 200, right: 0 },
+    wrapperState: { scrollPaddingLeft: 200, scrollPaddingRight: 0 },
   });
 });
 
@@ -206,6 +206,7 @@ test('updates sticky cell styles', () => {
   getClassName.mockImplementation(() => ({ 'sticky-cell-updated': true }));
 
   // Trigger update
+  elements.wrapper.scrollLeft = 10;
   elements.wrapper.dispatchEvent(new UIEvent('scroll'));
 
   expect(elements.cells[0]).toHaveClass('sticky-cell-updated');

--- a/src/table/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/__tests__/use-sticky-columns.test.tsx
@@ -203,11 +203,41 @@ test('updates sticky cell styles', () => {
 
   expect(elements.cells[0]).toHaveClass('sticky-cell');
 
-  getClassName.mockImplementation(() => ({ 'sticky-cell-updated': true }));
+  getClassName.mockImplementation(() => ({ 'sticky-cell': false, 'sticky-cell-updated': true }));
+
+  // Trigger update w/o actual change
+  elements.wrapper.dispatchEvent(new UIEvent('scroll'));
+
+  expect(elements.cells[0]).toHaveClass('sticky-cell');
+  expect(elements.cells[0]).not.toHaveClass('sticky-cell-updated');
 
   // Trigger update
   elements.wrapper.scrollLeft = 10;
   elements.wrapper.dispatchEvent(new UIEvent('scroll'));
 
+  expect(elements.cells[0]).not.toHaveClass('sticky-cell');
   expect(elements.cells[0]).toHaveClass('sticky-cell-updated');
+});
+
+test('performs styles cleanup', () => {
+  const visibleColumns = ['1', '2', '3'];
+  const { result, rerender } = renderHook(useStickyColumns, {
+    initialProps: { visibleColumns, stickyColumnsFirst: 1, stickyColumnsLast: 0 },
+  });
+  const elements = createMockTable(result.current, 300, 500, 100, 200, 300);
+
+  const getClassName = jest.fn().mockImplementation(state => ({ 'sticky-cell': !!state }));
+  const { result: cellStylesResult } = renderHook(() =>
+    useStickyCellStyles({ stickyColumns: result.current, columnId: '1', getClassName })
+  );
+  cellStylesResult.current.ref(elements.cells[0]);
+
+  // Trigger update
+  elements.wrapper.dispatchEvent(new UIEvent('scroll'));
+
+  expect(elements.cells[0]).toHaveClass('sticky-cell');
+
+  rerender({ visibleColumns, stickyColumnsFirst: 0, stickyColumnsLast: 0 });
+
+  expect(elements.cells[0]).not.toHaveClass('sticky-cell');
 });

--- a/src/table/use-sticky-columns.ts
+++ b/src/table/use-sticky-columns.ts
@@ -36,7 +36,7 @@ export interface StickyColumnsModel {
 
 export interface StickyColumnsState {
   cellState: Record<ColumnId, null | StickyColumnsCellState>;
-  scrollPadding: ScrollPadding;
+  wrapperState: StickyColumnsWrapperState;
 }
 
 // Cell state is used to apply respective styles and offsets to sticky cells.
@@ -48,9 +48,9 @@ export interface StickyColumnsCellState {
 }
 
 // Scroll padding is applied to table's wrapper so that the table scrolls when focus goes behind sticky column.
-export interface ScrollPadding {
-  left: number;
-  right: number;
+export interface StickyColumnsWrapperState {
+  scrollPaddingLeft: number;
+  scrollPaddingRight: number;
 }
 
 export function useStickyColumns({
@@ -101,12 +101,12 @@ export function useStickyColumns({
       return;
     }
 
-    const selector = (state: StickyColumnsState) => state.scrollPadding;
+    const selector = (state: StickyColumnsState) => state.wrapperState;
 
-    const updateWrapperStyles = (state: ScrollPadding) => {
+    const updateWrapperStyles = (state: StickyColumnsWrapperState) => {
       if (wrapperRef.current) {
-        wrapperRef.current.style.scrollPaddingLeft = state.left + 'px';
-        wrapperRef.current.style.scrollPaddingRight = state.right + 'px';
+        wrapperRef.current.style.scrollPaddingLeft = state.scrollPaddingLeft + 'px';
+        wrapperRef.current.style.scrollPaddingRight = state.scrollPaddingRight + 'px';
       }
     };
 
@@ -144,12 +144,7 @@ export function useStickyColumns({
     store,
     style: {
       // Provide wrapper styles as props so that a re-render won't cause invalidation.
-      wrapper: hasStickyColumns
-        ? {
-            scrollPaddingLeft: store.get().scrollPadding.left + 'px',
-            scrollPaddingRight: store.get().scrollPadding.right + 'px',
-          }
-        : undefined,
+      wrapper: hasStickyColumns ? { ...store.get().wrapperState } : undefined,
     },
     refs: { wrapper: setWrapper, table: setTable, cell: setCell },
   };
@@ -242,7 +237,7 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
   private padLeft = false;
 
   constructor() {
-    super({ cellState: {}, scrollPadding: { left: 0, right: 0 } });
+    super({ cellState: {}, wrapperState: { scrollPaddingLeft: 0, scrollPaddingRight: 0 } });
   }
 
   public updateCellStyles(props: UpdateCellStylesProps) {
@@ -254,7 +249,7 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
       this.updateCellOffsets(props);
       this.set(() => ({
         cellState: this.generateCellStyles(props),
-        scrollPadding: { left: this.stickyWidthLeft, right: this.stickyWidthRight },
+        wrapperState: { scrollPaddingLeft: this.stickyWidthLeft, scrollPaddingRight: this.stickyWidthRight },
       }));
     }
   }


### PR DESCRIPTION
### Description

When the leading cells do not have paddings but the table does, the padding from the table should be applied to the first sticky column if it is stuck.

Refactored use-sticky-columns and proposed a solution for table padding. If applied on the table the padLeft property can be removed.

https://user-images.githubusercontent.com/20790937/236424385-ff4999f8-4a5b-4db6-b00a-e54402863c45.mov

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
