### PR TITLE
fix: Make on-load-more stable

### DIFF
--- a/src/internal/components/options-list/__tests__/options-list.test.tsx
+++ b/src/internal/components/options-list/__tests__/options-list.test.tsx
@@ -55,3 +55,30 @@ test('supports ariaLabelledby', () => {
   );
   expect(container.querySelector('ul')).toHaveAttribute('aria-labelledby', 'someid');
 });
+
+test('onLoadMore fires when dropdown opens and its bottom is on the screen', () => {
+  const onLoadMore = jest.fn();
+  const { rerender } = render(
+    <OptionsList open={false} onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).not.toHaveBeenCalled();
+
+  rerender(
+    <OptionsList open={true} onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <OptionsList open={true} onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).toHaveBeenCalledTimes(1);
+});

--- a/src/internal/components/options-list/index.tsx
+++ b/src/internal/components/options-list/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../events';
 import { findUpUntil } from '../../utils/dom';
 import styles from './styles.css.js';
+import { useStableEventHandler } from '../../hooks/use-stable-event-handler';
 
 export interface OptionsListProps extends BaseComponentProps {
   open?: boolean;
@@ -71,7 +72,7 @@ const OptionsList = (
   const baseProps = getBaseProps(restProps);
   const menuRef = useRef<HTMLUListElement>(null);
 
-  const handleScroll = () => {
+  const handleScroll = useStableEventHandler(() => {
     const scrollContainer = menuRef?.current;
     if (scrollContainer) {
       const bottomEdgePosition = scrollContainer.scrollTop + scrollContainer.clientHeight;
@@ -80,14 +81,14 @@ const OptionsList = (
         fireNonCancelableEvent(onLoadMore);
       }
     }
-  };
+  });
 
   useEffect(() => {
     if (!open) {
       return;
     }
     handleScroll();
-  });
+  }, [open, handleScroll]);
 
   const className = clsx(styles['options-list'], {
     [styles['decrease-top-margin']]: decreaseTopMargin,

--- a/src/property-filter/__integ__/async-loading.test.ts
+++ b/src/property-filter/__integ__/async-loading.test.ts
@@ -30,7 +30,6 @@ class AsyncPropertyFilterPage extends BasePageObject {
     await this.waitForAssertion(async () => {
       const loadItemsCalls = await this.browser.execute(() => {
         const loadItemsCalls = window.loadItemsCalls;
-        window.loadItemsCalls = [];
         return loadItemsCalls;
       });
       expect(loadItemsCalls).toEqual(expected);
@@ -105,7 +104,10 @@ const testCases: TestCase[] = [
       {
         command: 'type-in-filtering-input',
         param: '1',
-        result: [{ firstPage: true, samePage: false, filteringText: '1' }],
+        result: [
+          { firstPage: true, samePage: false, filteringText: '' },
+          { firstPage: true, samePage: false, filteringText: '1' },
+        ],
       },
     ],
   ],
@@ -118,10 +120,7 @@ const testCases: TestCase[] = [
       {
         command: 'type-in-filtering-input',
         param: 'label=',
-        result: [
-          { filteringText: 'l', firstPage: false, samePage: false },
-          { filteringProperty, filteringOperator: '=', filteringText: '', firstPage: true, samePage: false },
-        ],
+        result: [{ filteringProperty, filteringOperator: '=', filteringText: '', firstPage: true, samePage: false }],
       },
     ],
   ],


### PR DESCRIPTION
### Description

Calling onLoadMore in an effect w/o dependencies can produce an infinite loop.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
