### PR TITLE
feat: Add aria-controls to checkbox, toggle, and tiles

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3589,6 +3589,13 @@ Object {
   "name": "Checkbox",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-controls\` attribute to the component.
+If the component controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.",
+      "name": "ariaControls",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
 Use this property if the component isn't surrounded by a form field, or you want to override the value
@@ -13130,6 +13137,13 @@ Object {
   "name": "Tiles",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-controls\` attribute to the component.
+If the component controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.",
+      "name": "ariaControls",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
 Use this property if the component isn't surrounded by a form field, or you want to override the value
@@ -13481,6 +13495,13 @@ Object {
   ],
   "name": "Toggle",
   "properties": Array [
+    Object {
+      "description": "Adds \`aria-controls\` attribute to the component.
+If the component controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.",
+      "name": "ariaControls",
+      "optional": true,
+      "type": "string",
+    },
     Object {
       "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.

--- a/src/checkbox/__tests__/common-tests.tsx
+++ b/src/checkbox/__tests__/common-tests.tsx
@@ -98,6 +98,14 @@ export function createCommonTests(Component: React.ComponentType<BaseCheckboxPro
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-describedby', 'my-custom-id');
     });
 
+    test('aria-controls can be set', () => {
+      const { wrapper, rerender } = renderComponent(<Component checked={false} />);
+      expect(wrapper.findNativeInput().getElement()).not.toHaveAttribute('aria-controls');
+
+      rerender(<Component checked={false} ariaControls="aria-controls-value" />);
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-controls', 'aria-controls-value');
+    });
+
     test('disables native control when disabled', () => {
       const { wrapper, rerender } = renderComponent(<Component checked={false} disabled={false} />);
       const labelElement = wrapper.findLabel().getElement();

--- a/src/checkbox/base-checkbox.tsx
+++ b/src/checkbox/base-checkbox.tsx
@@ -52,4 +52,10 @@ export interface BaseCheckboxProps extends BaseComponentProps, FormFieldControlP
    * Description that appears below the label.
    */
   description?: React.ReactNode;
+
+  /**
+   * Adds `aria-controls` attribute to the component.
+   * If the component controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.
+   */
+  ariaControls?: string;
 }

--- a/src/checkbox/internal.tsx
+++ b/src/checkbox/internal.tsx
@@ -34,6 +34,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
       onChange,
       tabIndex,
       showOutline,
+      ariaControls,
       __internalRootRef,
       ...rest
     },
@@ -63,6 +64,7 @@ const InternalCheckbox = React.forwardRef<CheckboxProps.Ref, InternalProps>(
         ariaLabel={ariaLabel}
         ariaLabelledby={ariaLabelledby}
         ariaDescribedby={ariaDescribedby}
+        ariaControls={ariaControls}
         showOutline={showOutline}
         nativeControl={nativeControlProps => (
           <input

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -20,6 +20,7 @@ export interface AbstractSwitchProps extends React.HTMLAttributes<HTMLElement>, 
   ariaLabel?: string;
   ariaLabelledby?: string;
   ariaDescribedby?: string;
+  ariaControls?: string;
   onClick: () => void;
 }
 
@@ -41,6 +42,7 @@ export default function AbstractSwitch({
   ariaLabel,
   ariaLabelledby,
   ariaDescribedby,
+  ariaControls,
   onClick,
   __internalRootRef,
   ...rest
@@ -59,12 +61,12 @@ export default function AbstractSwitch({
     ariaLabelledByIds.push(ariaLabelledby);
   }
 
-  const ariaDescriptons = [];
+  const ariaDescriptions = [];
   if (ariaDescribedby) {
-    ariaDescriptons.push(ariaDescribedby);
+    ariaDescriptions.push(ariaDescribedby);
   }
   if (description) {
-    ariaDescriptons.push(descriptionId);
+    ariaDescriptions.push(descriptionId);
   }
 
   return (
@@ -80,9 +82,10 @@ export default function AbstractSwitch({
             id,
             disabled,
             className: styles['native-input'],
-            'aria-describedby': ariaDescriptons.length ? joinString(ariaDescriptons) : undefined,
+            'aria-describedby': ariaDescriptions.length ? joinString(ariaDescriptions) : undefined,
             'aria-labelledby': ariaLabelledByIds.length ? joinString(ariaLabelledByIds) : undefined,
             'aria-label': ariaLabel,
+            'aria-controls': ariaControls,
           })}
           <span className={clsx(styles.outline, outlineClassName, showOutline && styles['show-outline'])} />
         </span>

--- a/src/tiles/__tests__/tiles.test.tsx
+++ b/src/tiles/__tests__/tiles.test.tsx
@@ -37,12 +37,14 @@ test('renders attributes for assistive technology when set', function () {
   const ariaLabelledby = 'something';
   const ariaDescribedby = 'something else';
   const ariaLabel = 'the last one';
+  const ariaControls = 'aria controls';
 
   const { wrapper } = renderTiles(
     <Tiles
       ariaLabelledby={ariaLabelledby}
       ariaDescribedby={ariaDescribedby}
       ariaLabel={ariaLabel}
+      ariaControls={ariaControls}
       value={null}
       items={defaultItems}
     />
@@ -51,6 +53,7 @@ test('renders attributes for assistive technology when set', function () {
   expect(rootElement).toHaveAttribute('aria-labelledby', ariaLabelledby);
   expect(rootElement).toHaveAttribute('aria-describedby', ariaDescribedby);
   expect(rootElement).toHaveAttribute('aria-label', ariaLabel);
+  expect(rootElement).toHaveAttribute('aria-controls', ariaControls);
 });
 
 test('does not render attributes for assistive technology when not set', function () {

--- a/src/tiles/interfaces.ts
+++ b/src/tiles/interfaces.ts
@@ -48,6 +48,12 @@ export interface TilesProps extends BaseComponentProps, FormFieldControlProps {
    * Called when the user selects a different tile.
    */
   onChange?: NonCancelableEventHandler<TilesProps.ChangeDetail>;
+
+  /**
+   * Adds `aria-controls` attribute to the component.
+   * If the component controls any secondary content (for example, another form field), use this to provide an ID referring to the secondary content.
+   */
+  ariaControls?: string;
 }
 
 export namespace TilesProps {

--- a/src/tiles/internal.tsx
+++ b/src/tiles/internal.tsx
@@ -21,7 +21,17 @@ type InternalTilesProps = TilesProps & InternalBaseComponentProps;
 
 const InternalTiles = React.forwardRef(
   (
-    { value, items, ariaLabel, ariaRequired, columns, onChange, __internalRootRef = null, ...rest }: InternalTilesProps,
+    {
+      value,
+      items,
+      ariaLabel,
+      ariaRequired,
+      ariaControls,
+      columns,
+      onChange,
+      __internalRootRef = null,
+      ...rest
+    }: InternalTilesProps,
     ref: React.Ref<TilesProps.Ref>
   ) => {
     const baseProps = getBaseProps(rest);
@@ -41,6 +51,7 @@ const InternalTiles = React.forwardRef(
         aria-labelledby={ariaLabelledby}
         aria-describedby={ariaDescribedby}
         aria-required={ariaRequired}
+        aria-controls={ariaControls}
         {...baseProps}
         className={clsx(baseProps.className, styles.root)}
         ref={mergedRef}

--- a/src/toggle/internal.tsx
+++ b/src/toggle/internal.tsx
@@ -23,6 +23,7 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
       children,
       description,
       ariaLabel,
+      ariaControls,
       onFocus,
       onBlur,
       onChange,
@@ -53,6 +54,7 @@ const InternalToggle = React.forwardRef<ToggleProps.Ref, InternalToggleProps>(
         ariaLabel={ariaLabel}
         ariaLabelledby={ariaLabelledby}
         ariaDescribedby={ariaDescribedby}
+        ariaControls={ariaControls}
         nativeControl={nativeControlProps => (
           <input
             {...nativeControlProps}


### PR DESCRIPTION
### Description

Added aria-controls to Checkbox, Tiles and Toggle component APIs. The same has been previously added to the RadioGroup (see https://github.com/cloudscape-design/components/pull/659).

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
