### PR TITLE
fix: Improve announcement for flashbar content with JSX

### DIFF
--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -391,6 +391,26 @@ describe('Flashbar component', () => {
           expect(list).toBeTruthy();
           expect(list.getElement().getAttribute('aria-label')).toEqual(customAriaLabel);
         });
+
+        test.only('renders the label, header, and content in an aria-live region for ariaRole="status"', () => {
+          const { rerender, container } = reactRender(<Flashbar items={[]} />);
+          rerender(
+            <Flashbar
+              items={[
+                {
+                  id: '1',
+                  ariaRole: 'status',
+                  type: 'error',
+                  statusIconAriaLabel: 'Error',
+                  header: 'The header',
+                  content: 'The content',
+                },
+              ]}
+            />
+          );
+          // Render area of the LiveRegion component.
+          expect(container.querySelector('span[aria-hidden]')).toHaveTextContent('Error The header The content');
+        });
       });
     });
   }

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -392,7 +392,7 @@ describe('Flashbar component', () => {
           expect(list.getElement().getAttribute('aria-label')).toEqual(customAriaLabel);
         });
 
-        test.only('renders the label, header, and content in an aria-live region for ariaRole="status"', () => {
+        test('renders the label, header, and content in an aria-live region for ariaRole="status"', () => {
           const { rerender, container } = reactRender(<Flashbar items={[]} />);
           rerender(
             <Flashbar

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -112,8 +112,6 @@ export const Flash = React.forwardRef(
 
     const effectiveType = loading ? 'info' : type;
 
-    const announcement = [statusIconAriaLabel, header, content].filter(Boolean).join(' ');
-
     const handleDismiss: ButtonProps['onClick'] = event => {
       sendDismissMetric(effectiveType);
       onDismiss && onDismiss(event);
@@ -158,7 +156,11 @@ export const Flash = React.forwardRef(
           {button && <div className={styles['action-button-wrapper']}>{button}</div>}
         </div>
         {dismissible && dismissButton(dismissLabel, handleDismiss)}
-        {ariaRole === 'status' && <LiveRegion>{announcement}</LiveRegion>}
+        {ariaRole === 'status' && (
+          <LiveRegion>
+            {statusIconAriaLabel} {header} {content}
+          </LiveRegion>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### Description

We allow JSX in header and content, but we do a string join to come up with the live region announcement. Don't you just hate it when [Object object]

Related links, issue #, if available: AWSUI-21045

### How has this been tested?

Unit tests for LiveRegion content. The LiveRegion component takes it from there.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
