### PR TITLE
fix: Remove unnecessary progress aria attributes

### DIFF
--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -34,8 +34,6 @@ export const Progress = ({ value, isInFlash, labelId }: ProgressProps) => {
           progressValue >= MAX_VALUE && styles.complete,
           isInFlash && styles['progress-in-flash']
         )}
-        aria-valuenow={progressValue}
-        aria-valuemin={0}
         max={MAX_VALUE}
         value={progressValue}
         aria-labelledby={labelId}


### PR DESCRIPTION
### Description

Use only the standard HTML `progress` element attributes, as the additional `aria-` properties are not necessary.

(In the past it seems that these were necessary, for example in VO+Chrome, but testing now suggests the underlying Chrome issue has been resolved)

Related links, issue #, if available: AWSUI-21037

### How has this been tested?

Local testing with VO+Chrome, VO+Safari, NVDA+Firefox

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
