### PR TITLE
fix: z-index of content display options in Collection preferences whi…

### DIFF
--- a/src/collection-preferences/content-display/content-display-option.scss
+++ b/src/collection-preferences/content-display/content-display-option.scss
@@ -40,7 +40,6 @@ $border-radius: awsui.$border-radius-item;
   border-top: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
   &:not(.placeholder).sorting {
     @include animated;
-    z-index: 1;
   }
   &.placeholder {
     > .content-display-option-content {


### PR DESCRIPTION
…le dragging

### Description

<!-- Include a summary of the changes and the related issue. -->

#1072 introduced an unintended behavior where the list items are rendered on top of the other modal elements when dragging is active:

https://github.com/cloudscape-design/components/assets/1257272/a1f451d3-d8de-4cd8-8bec-42c242b7491c

This is happening when using the mouse as well as the keyboard.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Manually tested in Chrome, Firefox and Safari, with mouse and keyboard
- Visual regression test will be introduced to cover lists with scroll

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
