### PR TITLE
fix: Adds higher specificity to css properties in drawers

### DIFF
--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -64,7 +64,7 @@ $drawer-z-index-mobile: 1001;
 }
 
 .trigger {
-  .drawer-triggers > & {
+  .drawer-content > .drawer-triggers > & {
     padding: constants.$drawers-padding;
     margin: 1px constants.$drawers-padding-horizontal;
     border-radius: 0;
@@ -82,7 +82,8 @@ $drawer-z-index-mobile: 1001;
       }
     }
 
-    &.selected {
+    &.selected,
+    &.selected:hover {
       padding: constants.$drawers-padding-vertical awsui.$space-s;
       margin: 0;
       border-top: 1px solid awsui.$color-background-layout-panel-trigger-active;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Outside of the Cloudscape testing environment, due to a difference in loading and bundling, CSS rules of the same specificity were being applied in a different order, causing unintended effects.

This PR increases the specificity of the correct CSS rules so that no matter what order the bundle is loaded, the correct styles are applied.

### How has this been tested?

This was tested inside the management console using a local branch, so we know it works.
