### PR TITLE
fix: Pass new message when requesting new response

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -69,14 +69,19 @@ function CloudscapeAssistant() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [value, setValue] = useState('');
-  const [messages, setMessages] = useState([{ role: 'user', content: '#hello world' }]);
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      content: 'Hello there! Is there anything I can help you with?',
+    },
+  ]);
 
   const handleSend = () => {
     setLoading(true);
     fetch('http://localhost:3000', {
       method: 'post',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ messages }),
+      body: JSON.stringify({ messages: [...messages, { role: 'user', content: value }] }),
     })
       .then(async response => {
         if (response.status === 200) {
@@ -94,6 +99,7 @@ function CloudscapeAssistant() {
       })
       .finally(() => {
         setLoading(false);
+        setValue('');
       });
   };
 


### PR DESCRIPTION
### Description

Fixes the following:
- Submitted messages by the user were actually not passed to the request
- The conversation was being initialized with a dummy "#hello world" message which was prompting generic answers. Pass a welcoming message from the assistant instead
- Reset the input field value to empty string after submitting

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Manually tested

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
