### PR TITLE
fix: Options list to call on-load-more when status changes to pending

### DIFF
--- a/pages/options-list/simple.page.tsx
+++ b/pages/options-list/simple.page.tsx
@@ -36,7 +36,7 @@ export default function OptionsListScenario() {
         }
         onDropdownClose={toggleDropdown}
       >
-        <OptionsList onLoadMore={handleLoadMore} id={'list'} open={open}>
+        <OptionsList onLoadMore={handleLoadMore} id={'list'} open={open} statusType="pending">
           {[...Array(50)].map((_, index) => (
             <li key={index}>{`Option ${index}`}</li>
           ))}

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -197,6 +197,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
       dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null}
       dropdownContent={
         <AutosuggestOptionsList
+          statusType={statusType}
           autosuggestItemsState={autosuggestItemsState}
           autosuggestItemsHandlers={autosuggestItemsHandlers}
           highlightedOptionId={highlightedOptionId}

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -12,7 +12,7 @@ import { useAnnouncement } from '../select/utils/use-announcement';
 export interface AutosuggestOptionsListProps
   extends Pick<
     AutosuggestProps,
-    'enteredTextLabel' | 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive'
+    'enteredTextLabel' | 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive' | 'statusType'
   > {
   autosuggestItemsState: AutosuggestItemsState;
   autosuggestItemsHandlers: AutosuggestItemsHandlers;
@@ -34,6 +34,7 @@ const createMouseEventHandler = (handler: (index: number) => void) => (itemIndex
 };
 
 export default function AutosuggestOptionsList({
+  statusType,
   autosuggestItemsState,
   autosuggestItemsHandlers,
   highlightedOptionId,
@@ -77,6 +78,7 @@ export default function AutosuggestOptionsList({
         onMouseUp: handleMouseUp,
         onMouseMove: handleMouseMove,
         ariaDescribedby,
+        statusType: statusType || 'pending',
       }}
       screenReaderContent={announcement}
     />

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -12,8 +12,9 @@ import { useAnnouncement } from '../select/utils/use-announcement';
 export interface AutosuggestOptionsListProps
   extends Pick<
     AutosuggestProps,
-    'enteredTextLabel' | 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive' | 'statusType'
+    'enteredTextLabel' | 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive'
   > {
+  statusType: AutosuggestProps.StatusType;
   autosuggestItemsState: AutosuggestItemsState;
   autosuggestItemsHandlers: AutosuggestItemsHandlers;
   highlightedOptionId?: string;
@@ -78,7 +79,7 @@ export default function AutosuggestOptionsList({
         onMouseUp: handleMouseUp,
         onMouseMove: handleMouseMove,
         ariaDescribedby,
-        statusType: statusType || 'pending',
+        statusType,
       }}
       screenReaderContent={announcement}
     />

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -175,6 +175,7 @@ const InternalButtonDropdown = React.forwardRef(
             role="menu"
             decreaseTopMargin={true}
             ariaLabelledby={hasHeader ? headerId : undefined}
+            statusType="finished"
           >
             <ItemsList
               items={items}

--- a/src/internal/components/options-list/__tests__/options-list.test.tsx
+++ b/src/internal/components/options-list/__tests__/options-list.test.tsx
@@ -12,7 +12,7 @@ function renderList(jsx: React.ReactElement) {
 test('calls onMouseMove handler with item index', () => {
   const onMouseMove = jest.fn();
   const container = renderList(
-    <OptionsList open={true} onMouseMove={onMouseMove}>
+    <OptionsList open={true} statusType="pending" onMouseMove={onMouseMove}>
       <div data-testid="not-target">Not a target</div>
       <div data-mouse-target="1">One</div>
       <div data-mouse-target="2">Two</div>
@@ -31,7 +31,7 @@ test('calls onMouseMove handler with item index', () => {
 test('calls onMouseUp handler with item index', () => {
   const onMouseUp = jest.fn();
   const container = renderList(
-    <OptionsList open={true} onMouseUp={onMouseUp}>
+    <OptionsList open={true} statusType="pending" onMouseUp={onMouseUp}>
       <div data-testid="not-target">Not a target</div>
       <div data-mouse-target="1">One</div>
       <div data-mouse-target="2">Two</div>
@@ -49,7 +49,7 @@ test('calls onMouseUp handler with item index', () => {
 
 test('supports ariaLabelledby', () => {
   const container = renderList(
-    <OptionsList open={true} ariaLabelledby="someid">
+    <OptionsList open={true} statusType="pending" ariaLabelledby="someid">
       <div>Option</div>
     </OptionsList>
   );
@@ -59,7 +59,7 @@ test('supports ariaLabelledby', () => {
 test('onLoadMore fires when dropdown opens and its bottom is on the screen', () => {
   const onLoadMore = jest.fn();
   const { rerender } = render(
-    <OptionsList open={false} onLoadMore={onLoadMore}>
+    <OptionsList open={false} statusType="pending" onLoadMore={onLoadMore}>
       <div>Option</div>
     </OptionsList>
   );
@@ -67,7 +67,7 @@ test('onLoadMore fires when dropdown opens and its bottom is on the screen', () 
   expect(onLoadMore).not.toHaveBeenCalled();
 
   rerender(
-    <OptionsList open={true} onLoadMore={onLoadMore}>
+    <OptionsList open={true} statusType="pending" onLoadMore={onLoadMore}>
       <div>Option</div>
     </OptionsList>
   );
@@ -75,10 +75,37 @@ test('onLoadMore fires when dropdown opens and its bottom is on the screen', () 
   expect(onLoadMore).toHaveBeenCalledTimes(1);
 
   rerender(
-    <OptionsList open={true} onLoadMore={onLoadMore}>
+    <OptionsList open={true} statusType="pending" onLoadMore={onLoadMore}>
       <div>Option</div>
     </OptionsList>
   );
 
   expect(onLoadMore).toHaveBeenCalledTimes(1);
+});
+
+test('onLoadMore is called when dropdown is open and status type changes to "pending"', () => {
+  const onLoadMore = jest.fn();
+  const { rerender } = render(
+    <OptionsList open={true} statusType="pending" onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <OptionsList open={true} statusType="loading" onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <OptionsList open={true} statusType="pending" onLoadMore={onLoadMore}>
+      <div>Option</div>
+    </OptionsList>
+  );
+
+  expect(onLoadMore).toHaveBeenCalledTimes(2);
 });

--- a/src/internal/components/options-list/index.tsx
+++ b/src/internal/components/options-list/index.tsx
@@ -14,9 +14,11 @@ import {
 import { findUpUntil } from '../../utils/dom';
 import styles from './styles.css.js';
 import { useStableEventHandler } from '../../hooks/use-stable-event-handler';
+import { DropdownStatusProps } from '../dropdown-status';
 
 export interface OptionsListProps extends BaseComponentProps {
   open?: boolean;
+  statusType: DropdownStatusProps.StatusType;
   /**
    * Options list
    */
@@ -52,6 +54,7 @@ const getItemIndex = (containerRef: React.RefObject<HTMLElement>, event: React.M
 const OptionsList = (
   {
     open,
+    statusType,
     children,
     nativeAttributes = {},
     onKeyDown,
@@ -84,11 +87,10 @@ const OptionsList = (
   });
 
   useEffect(() => {
-    if (!open) {
-      return;
+    if (open && statusType === 'pending') {
+      handleScroll();
     }
-    handleScroll();
-  }, [open, handleScroll]);
+  }, [open, statusType, handleScroll]);
 
   const className = clsx(styles['options-list'], {
     [styles['decrease-top-margin']]: decreaseTopMargin,

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -163,6 +163,7 @@ const InternalMultiselect = React.forwardRef(
       fireLoadItems,
       setFilteringValue,
       useInteractiveGroups,
+      statusType,
     });
 
     const handleNativeSearch = useNativeSearch({

--- a/src/property-filter/__integ__/async-loading.test.ts
+++ b/src/property-filter/__integ__/async-loading.test.ts
@@ -120,7 +120,10 @@ const testCases: TestCase[] = [
       {
         command: 'type-in-filtering-input',
         param: 'label=',
-        result: [{ filteringProperty, filteringOperator: '=', filteringText: '', firstPage: true, samePage: false }],
+        result: [
+          { filteringText: 'l', firstPage: false, samePage: false },
+          { filteringProperty, filteringOperator: '=', filteringText: '', firstPage: true, samePage: false },
+        ],
       },
     ],
   ],

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -163,6 +163,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
     } else if (autosuggestItemsState.items.length > 0) {
       content = (
         <AutosuggestOptionsList
+          statusType={statusType}
           autosuggestItemsState={autosuggestItemsState}
           autosuggestItemsHandlers={autosuggestItemsHandlers}
           highlightedOptionId={highlightedOptionId}

--- a/src/select/__tests__/use-select.test.ts
+++ b/src/select/__tests__/use-select.test.ts
@@ -65,6 +65,7 @@ const initialProps = {
   filteringType: 'auto',
   fireLoadItems: () => {},
   setFilteringValue: () => {},
+  statusType: 'pending' as const,
 };
 
 describe('useSelect', () => {

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -187,6 +187,7 @@ const InternalSelect = React.forwardRef(
       onLoadMore: handleLoadMore,
       ariaLabelledby: joinStrings(selectAriaLabelId, controlId),
       ariaDescribedby: dropdownStatus.content ? footerId : undefined,
+      statusType: statusType,
     };
 
     const announcement = useAnnouncement({

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -122,6 +122,7 @@ const InternalSelect = React.forwardRef(
       externalRef,
       fireLoadItems,
       setFilteringValue,
+      statusType,
     });
 
     const handleNativeSearch = useNativeSearch({
@@ -187,7 +188,6 @@ const InternalSelect = React.forwardRef(
       onLoadMore: handleLoadMore,
       ariaLabelledby: joinStrings(selectAriaLabelId, controlId),
       ariaDescribedby: dropdownStatus.content ? footerId : undefined,
-      statusType: statusType,
     };
 
     const announcement = useAnnouncement({

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -17,8 +17,9 @@ import { ItemProps } from '../parts/item';
 import { usePrevious } from '../../internal/hooks/use-previous';
 import { BaseKeyDetail, NonCancelableEventHandler, fireNonCancelableEvent } from '../../internal/events';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
+import { DropdownStatusProps } from '../../internal/components/dropdown-status';
 
-export type MenuProps = Omit<OptionsListProps, 'children' | 'statusType'> & { ref: React.RefObject<HTMLUListElement> };
+export type MenuProps = Omit<OptionsListProps, 'children'> & { ref: React.RefObject<HTMLUListElement> };
 export type GetOptionProps = (option: DropdownOption, index: number) => ItemProps;
 
 interface UseSelectProps {
@@ -33,6 +34,7 @@ interface UseSelectProps {
   fireLoadItems: (filteringText: string) => void;
   setFilteringValue: (filteringText: string) => void;
   useInteractiveGroups?: boolean;
+  statusType: DropdownStatusProps.StatusType;
 }
 
 export interface SelectTriggerProps {
@@ -55,6 +57,7 @@ export function useSelect({
   fireLoadItems,
   setFilteringValue,
   useInteractiveGroups = false,
+  statusType,
 }: UseSelectProps) {
   const interactivityCheck = useInteractiveGroups ? isGroupInteractive : isInteractive;
 
@@ -193,6 +196,7 @@ export function useSelect({
           setHighlightedIndexWithMouse(itemIndex);
         }
       },
+      statusType,
     };
     if (!hasFilter) {
       menuProps.onKeyDown = activeKeyDownHandler;

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -18,7 +18,7 @@ import { usePrevious } from '../../internal/hooks/use-previous';
 import { BaseKeyDetail, NonCancelableEventHandler, fireNonCancelableEvent } from '../../internal/events';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
-export type MenuProps = Omit<OptionsListProps, 'children'> & { ref: React.RefObject<HTMLUListElement> };
+export type MenuProps = Omit<OptionsListProps, 'children' | 'statusType'> & { ref: React.RefObject<HTMLUListElement> };
 export type GetOptionProps = (option: DropdownOption, index: number) => ItemProps;
 
 interface UseSelectProps {


### PR DESCRIPTION
### Description

Fixes a bug introduced here: https://github.com/cloudscape-design/components/pull/1071

When dropdown is already open but the number of loaded options fits the screen height a second onLoadCall might be needed as can't rely on scroll.

Before:

https://github.com/cloudscape-design/components/assets/20790937/e1ee36c6-e9de-432a-bbbf-4321039238ec

After:

https://github.com/cloudscape-design/components/assets/20790937/fa1f616b-c2e4-4e02-874a-7583f1476fd1

### How has this been tested?

Manual testing, a new unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
