### PR TITLE
chore: Improve wrapping of buttons in the date range picker footer

### DIFF
--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -116,6 +116,10 @@ $calendar-header-color: awsui.$color-text-body-default;
 
 .footer-button-wrapper {
   padding-top: awsui.$space-s;
+
+  &:last-child {
+    margin-left: auto;
+  }
 }
 
 .icon-wrapper {


### PR DESCRIPTION
### Description

Improve the wrapping of the "Cancel" and "Apply" buttons in the footer of the date ranger picker component.

Related links, issue #, if available: AWSUI-17098

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
