### PR TITLE
chore: Add missing properties to documentation of Collection preferen…

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4092,10 +4092,14 @@ Object {
       "cancelable": false,
       "description": "Called when the user confirms a preference change using the confirm button in the modal footer.
 The event \`detail\` contains the following:
-- \`pageSize\` (number) - (Optional) The selected page size value. Available only if you specify the \`pageSizePreference\` property.
-- \`wrapLines\` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the \`wrapLinesPreference\` property.
-- \`visibleContent\` (ReadonlyArray<string>) - (Optional) The list of selected content \`id\`s. Available only if you specify the \`visibleContentPreference\` property.
+- \`contentDensity\` (boolean) - (Optional) The current content density preference value. Available only if you specify the \`contentDensityPreference\` property.
+- \`contentDisplay\` (ReadonlyArray<ContentDisplayItem>) - (Optional) The ordered list of table columns and their visibility. Available only if you specify the \`contentDisplayPreference\` property.
 - \`custom\` (CustomPreferenceType) - (Optional) The selected value for your custom preference.
+- \`pageSize\` (number) - (Optional) The selected page size value. Available only if you specify the \`pageSizePreference\` property.
+- \`stickyColumns\` (CollectionPreferencesProps.StickyColumns) - (Optional) The current sticky columns preference value. Available only if you specify the \`stickyColumnsPreference\` property.
+- \`stripedRows\` (boolean) - (Optional) The current striped rows preference value. Available only if you specify the \`stripedRowsPreference\` property.
+- \`visibleContent\` (ReadonlyArray<string>) - (Optional) The list of selected content \`id\`s. Available only if you specify the \`visibleContentPreference\` property.
+- \`wrapLines\` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the \`wrapLinesPreference\` property.
 
 The values for all configured preferences are present even if the user didn't change their values.
 ",

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -169,10 +169,14 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Called when the user confirms a preference change using the confirm button in the modal footer.
    *
    * The event `detail` contains the following:
-   * - `pageSize` (number) - (Optional) The selected page size value. Available only if you specify the `pageSizePreference` property.
-   * - `wrapLines` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the `wrapLinesPreference` property.
-   * - `visibleContent` (ReadonlyArray<string>) - (Optional) The list of selected content `id`s. Available only if you specify the `visibleContentPreference` property.
+   * - `contentDensity` (boolean) - (Optional) The current content density preference value. Available only if you specify the `contentDensityPreference` property.
+   * - `contentDisplay` (ReadonlyArray<ContentDisplayItem>) - (Optional) The ordered list of table columns and their visibility. Available only if you specify the `contentDisplayPreference` property.
    * - `custom` (CustomPreferenceType) - (Optional) The selected value for your custom preference.
+   * - `pageSize` (number) - (Optional) The selected page size value. Available only if you specify the `pageSizePreference` property.
+   * - `stickyColumns` (CollectionPreferencesProps.StickyColumns) - (Optional) The current sticky columns preference value. Available only if you specify the `stickyColumnsPreference` property.
+   * - `stripedRows` (boolean) - (Optional) The current striped rows preference value. Available only if you specify the `stripedRowsPreference` property.
+   * - `visibleContent` (ReadonlyArray<string>) - (Optional) The list of selected content `id`s. Available only if you specify the `visibleContentPreference` property.
+   * - `wrapLines` (boolean) - (Optional) The current line wrapping preference value. Available only if you specify the `wrapLinesPreference` property.
    *
    * The values for all configured preferences are present even if the user didn't change their values.
    */


### PR DESCRIPTION
…ces `onConfirm` event

### Description

Updates the [documentation](https://cloudscape.design/components/collection-preferences/?tabId=api#events) of the Collection preferences `onConfirm` event with attributes that were missing from the following recent feature additions:

- Content density (`contentDensity`)
- Column reordering (`contentDisplay`)
- Sticky columns (`stickyColumns`)
- Striped rows (`stripedRows`)

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
