### PR TITLE
feat: Added `borderless` table variant

### DIFF
--- a/pages/table/variants.page.tsx
+++ b/pages/table/variants.page.tsx
@@ -53,6 +53,11 @@ export default function () {
             </SpaceBetween>
           </ExpandableSection>
           <div>
+            <Container disableContentPaddings={true} header={<Header>Container with borderless table</Header>}>
+              <BorderlessTable />
+            </Container>
+          </div>
+          <div>
             <Container variant="stacked" header={<Header variant="h2">Stacked Container</Header>}>
               <KeyValuePairs />
             </Container>
@@ -93,6 +98,7 @@ const StackedTableWithFooter = () => (
 );
 const StackedTable = () => <BaseTable variant="stacked" header={<Header>Stacked</Header>} />;
 const EmbeddedTable = () => <BaseTable variant="embedded" />;
+const BorderlessTable = () => <BaseTable variant="borderless" header={null} />;
 const DefaultTable = () => <BaseTable variant="container" header={<Header>Default</Header>} />;
 
 const ValueWithLabel = ({ label, children }: { label: string; children: string }) => (

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12252,6 +12252,8 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
       "defaultValue": "'container'",
       "description": "Specify a table variant with one of the following:
 * \`container\` - Use this variant to have the table displayed within a container.
+* \`borderless\` - Use this variant when the table should have no outer borders or shadows
+                 (for example in a dashboard item container).
 * \`embedded\` - Use this variant within a parent container (such as a modal, expandable
                section, container or split panel).
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,
@@ -12264,6 +12266,7 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
         "values": Array [
           "container",
           "embedded",
+          "borderless",
           "stacked",
           "full-page",
         ],
@@ -12271,7 +12274,7 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
       "name": "variant",
       "optional": true,
       "type": "string",
-      "visualRefreshTag": "\`stacked\` and \`full-page\` variants",
+      "visualRefreshTag": "\`embedded\`, \`stacked\`, and \`full-page\` variants",
     },
     Object {
       "description": "Specifies an array containing the \`id\`s of visible columns. If not set, all columns are displayed.

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12252,8 +12252,8 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
       "defaultValue": "'container'",
       "description": "Specify a table variant with one of the following:
 * \`container\` - Use this variant to have the table displayed within a container.
-* \`borderless\` - Use this variant when the table should have no outer borders or shadows
-                 (for example in a dashboard item container).
+* \`borderless\` - Use this variant when the table should have no outer borders or shadow
+                 (such as in a dashboard item container).
 * \`embedded\` - Use this variant within a parent container (such as a modal, expandable
                section, container or split panel).
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12271,7 +12271,7 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
       "name": "variant",
       "optional": true,
       "type": "string",
-      "visualRefreshTag": "\`embedded\`, \`stacked\`, and \`full-page\` variants",
+      "visualRefreshTag": "\`stacked\` and \`full-page\` variants",
     },
     Object {
       "description": "Specifies an array containing the \`id\`s of visible columns. If not set, all columns are displayed.

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -276,13 +276,15 @@ export interface TableProps<T = any> extends BaseComponentProps {
   /**
    * Specify a table variant with one of the following:
    * * `container` - Use this variant to have the table displayed within a container.
+   * * `borderless` - Use this variant when the table should have no outer borders or shadows
+   *                  (for example in a dashboard item container).
    * * `embedded` - Use this variant within a parent container (such as a modal, expandable
    *                section, container or split panel).
    * * `stacked` - Use this variant adjacent to other stacked containers (such as a container,
    *               table).
    * * `full-page` – Use this variant when the table is the entire content of a page. Full page variants
    *                 implement the high contrast header and content behavior automatically.
-   * @visualrefresh `stacked` and `full-page` variants
+   * @visualrefresh `embedded`, `stacked`, and `full-page` variants
    */
   variant?: TableProps.Variant;
 
@@ -374,7 +376,7 @@ export namespace TableProps {
   }
 
   export type SelectionType = 'single' | 'multi';
-  export type Variant = 'container' | 'embedded' | 'stacked' | 'full-page';
+  export type Variant = 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page';
   export interface SelectionState<T> {
     selectedItems: ReadonlyArray<T>;
   }

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -276,8 +276,8 @@ export interface TableProps<T = any> extends BaseComponentProps {
   /**
    * Specify a table variant with one of the following:
    * * `container` - Use this variant to have the table displayed within a container.
-   * * `borderless` - Use this variant when the table should have no outer borders or shadows
-   *                  (for example in a dashboard item container).
+   * * `borderless` - Use this variant when the table should have no outer borders or shadow
+   *                  (such as in a dashboard item container).
    * * `embedded` - Use this variant within a parent container (such as a modal, expandable
    *                section, container or split panel).
    * * `stacked` - Use this variant adjacent to other stacked containers (such as a container,

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -282,7 +282,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *               table).
    * * `full-page` – Use this variant when the table is the entire content of a page. Full page variants
    *                 implement the high contrast header and content behavior automatically.
-   * @visualrefresh `embedded`, `stacked`, and `full-page` variants
+   * @visualrefresh `stacked` and `full-page` variants
    */
   variant?: TableProps.Variant;
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -142,7 +142,11 @@ const InternalTable = React.forwardRef(
     }
 
     const isVisualRefresh = useVisualRefresh();
-    const computedVariant = !isVisualRefresh && variant === 'full-page' ? 'container' : variant;
+    const computedVariant = isVisualRefresh
+      ? variant
+      : ['embedded', 'full-page'].indexOf(variant) > -1
+      ? 'container'
+      : variant;
     const hasHeader = !!(header || filter || pagination || preferences);
     const hasSelection = !!selectionType;
     const hasFooter = !!footer;

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -142,11 +142,7 @@ const InternalTable = React.forwardRef(
     }
 
     const isVisualRefresh = useVisualRefresh();
-    const computedVariant = isVisualRefresh
-      ? variant
-      : ['embedded', 'full-page'].indexOf(variant) > -1
-      ? 'container'
-      : variant;
+    const computedVariant = !isVisualRefresh && variant === 'full-page' ? 'container' : variant;
     const hasHeader = !!(header || filter || pagination || preferences);
     const hasSelection = !!selectionType;
     const hasFooter = !!footer;

--- a/src/table/utils.ts
+++ b/src/table/utils.ts
@@ -32,7 +32,7 @@ export const getColumnKey = <T>(column: TableProps.ColumnDefinition<T>, index: n
 
 export const toContainerVariant = (variant: TableProps.Variant | undefined): InternalContainerProps['variant'] => {
   const isDefaultVariant = !variant || variant === 'container';
-  return isDefaultVariant ? 'default' : variant;
+  return isDefaultVariant ? 'default' : variant === 'borderless' ? 'embedded' : variant;
 };
 
 export function checkSortingState<T>(


### PR DESCRIPTION
### Description

This change adds a new variant (`borderless`) to the Table component. This variant removes any outer borders and shadows from the table, just like the `embedded` variant. However, unlike `embedded`, `borderless` works in both Classic and Visual Refresh.

The `borderless` variant is recommended for use-cases where the table shouldn't have any outer borders, regardless of theme or mode. For example, for tables inside dashboard widget containers. Previously, this required additional CSS to hide the shadows, see [embedded-table-wrapper/styles.module.scss](https://github.com/cloudscape-design/demos/blob/e5b10d2329593ab1f20613d7d45e6ff93d4721d7/src/pages/dashboard/components/embedded-table-wrapper/styles.module.scss).

Related links, issue #, if available: AWSUI-20338

![Screenshot 2023-05-25 at 15 20 29](https://github.com/cloudscape-design/components/assets/2446349/d6c2be11-c101-4b32-890a-ba6e8407b062)


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
