### PR TITLE
feat: Add colorBackgroundPopover as public and themeable token

### DIFF
--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -104,7 +104,7 @@ const metadata: StyleDictionary.MetadataIndex = {
     themeable: true,
   },
   colorBackgroundLayoutMain: {
-    description: 'The background color of the main content area on a page. For example:  content area in app layout.',
+    description: 'The background color of the main content area on a page. For example: content area in app layout.',
     public: true,
     themeable: true,
   },
@@ -154,6 +154,11 @@ const metadata: StyleDictionary.MetadataIndex = {
   },
   colorBackgroundNotificationRed: {
     description: 'Background color for red notifications. For example: red badges and error flash messages.',
+    public: true,
+    themeable: true,
+  },
+  colorBackgroundPopover: {
+    description: 'Background color for the popover container component.',
     public: true,
     themeable: true,
   },


### PR DESCRIPTION
### Description

This PR adds the `colorBackgroundPopover` token to the public theme API.

This addresses the following customer feedback / request: https://github.com/cloudscape-design/components/discussions/956


### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
