### PR TITLE
chore: State in API docs that charts with bars should use `categorica…

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2057,7 +2057,8 @@ When controlling this directly, make sure to update the value based on filtering
     },
     Object {
       "defaultValue": "\\"linear\\"",
-      "description": "Determines the type of scale for values on the x axis.",
+      "description": "Determines the type of scale for values on the x axis.
+Use \`categorical\` for bar charts.",
       "inlineType": Object {
         "name": "ScaleType",
         "type": "union",
@@ -8050,7 +8051,8 @@ When controlling this directly, make sure to update the value based on filtering
     },
     Object {
       "defaultValue": "\\"linear\\"",
-      "description": "Determines the type of scale for values on the x axis.",
+      "description": "Determines the type of scale for values on the x axis.
+Use \`categorical\` for charts with bars.",
       "inlineType": Object {
         "name": "ScaleType",
         "type": "union",

--- a/src/bar-chart/interfaces.ts
+++ b/src/bar-chart/interfaces.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CartesianChartProps } from '../internal/components/cartesian-chart/interfaces';
+import { CartesianChartProps, ScaleType } from '../internal/components/cartesian-chart/interfaces';
 import { ChartDataTypes, MixedLineBarChartProps } from '../mixed-line-bar-chart/interfaces';
 
 type BarSeries<T> = MixedLineBarChartProps.BarDataSeries<T> | MixedLineBarChartProps.ThresholdSeries<T>;
@@ -35,6 +35,12 @@ export interface BarChartProps<T extends ChartDataTypes>
    * See the usage guidelines for more details.
    */
   emphasizeBaselineAxis?: boolean;
+
+  /**
+   * Determines the type of scale for values on the x axis.
+   * Use `categorical` for bar charts.
+   */
+  xScaleType?: ScaleType;
 }
 
 // W/o this documenter injects CartesianChartProps namespace properties into BarChartProps definition.

--- a/src/mixed-line-bar-chart/interfaces.ts
+++ b/src/mixed-line-bar-chart/interfaces.ts
@@ -45,6 +45,12 @@ export interface MixedLineBarChartProps<T extends ChartDataTypes>
    * See the usage guidelines for more details.
    */
   emphasizeBaselineAxis?: boolean;
+
+  /**
+   * Determines the type of scale for values on the x axis.
+   * Use `categorical` for charts with bars.
+   */
+  xScaleType?: ScaleType;
 }
 
 export namespace MixedLineBarChartProps {


### PR DESCRIPTION
…l` value for `xScaleType` prop

### Description

Minimal change to state in the API that customers should use `categorical` value for the `xScaleType` prop in bar charts and mixed line and bar charts.

I think it would be preferable to change the API e.g, to restrict the values to accept only `categorical` in these cases (and/or deprecate the prop as in #1080), but this is not possible right now without running into issues (for example, `linear` is used in empty, loading and error states for Bar chart by at least one customer and even [in our own examples](https://cloudscape.aws.dev/components/bar-chart/?tabId=playground&example=loading). We should change that first).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related issue: AWSUI-19806

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
