### PR TITLE
fix: drawer widths

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -14,6 +14,7 @@ import {
 import appLayoutLabels from './utils/labels';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
 import ScreenshotArea from '../utils/screenshot-area';
+import type { DrawerItem } from '~components/app-layout/drawer/interfaces';
 
 export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
@@ -21,19 +22,12 @@ export default function WithDrawers() {
   const [hasTools, setHasTools] = useState(false);
   const [isToolsOpen, setIsToolsOpen] = useState(false);
 
-  const [widths, setWidths] = useState<{ [id: string]: number }>({
-    security: 500,
-  });
-
   const drawers = !hasDrawers
     ? null
     : {
         drawers: {
           ariaLabel: 'Drawers',
           activeDrawerId: activeDrawerId,
-          onResize: (event: NonCancelableCustomEvent<{ size: number; id: string }>) => {
-            setWidths({ ...widths, [event.detail.id]: event.detail.size });
-          },
           items: [
             {
               ariaLabels: {
@@ -45,7 +39,13 @@ export default function WithDrawers() {
               content: <Security />,
               id: 'security',
               resizable: true,
-              size: widths.security,
+              defaultSize: 500,
+              onResize: ({ detail: { size } }) => {
+                // A drawer implementer may choose to listen to THEIR drawer's
+                // resize event,should they want to persist, or otherwise respond
+                // to their drawer being resized.
+                console.log('Security Drawer is now: ', size);
+              },
               trigger: {
                 iconName: 'security',
               },
@@ -63,7 +63,7 @@ export default function WithDrawers() {
                 iconName: 'contact',
               },
             },
-          ],
+          ] as DrawerItem[],
           onChange: (event: NonCancelableCustomEvent<string>) => {
             setActiveDrawerId(event.detail);
           },

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -40,67 +40,7 @@ describe('Classic only features', () => {
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveFocus();
   });
 
-  test('should change drawers size in controlled mode', () => {
-    const onResize = jest.fn();
-
-    const drawersSize300 = {
-      drawers: {
-        onResize: onResize,
-        items: [
-          {
-            ariaLabels: {
-              closeButton: 'Security close button',
-              content: 'Security drawer content',
-              triggerButton: 'Security trigger button',
-              resizeHandle: 'Security resize handle',
-            },
-            content: <span>Security</span>,
-            resizable: true,
-            size: 300,
-            id: 'security',
-            trigger: {
-              iconName: 'security',
-            },
-          },
-        ],
-      },
-    };
-
-    const drawersSize310 = {
-      drawers: {
-        onResize: onResize,
-        items: [
-          {
-            ariaLabels: {
-              closeButton: 'Security close button',
-              content: 'Security drawer content',
-              triggerButton: 'Security trigger button',
-              resizeHandle: 'Security resize handle',
-            },
-            content: <span>Security</span>,
-            resizable: true,
-            size: 310,
-            id: 'security',
-            trigger: {
-              iconName: 'security',
-            },
-          },
-        ],
-      },
-    };
-
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" {...drawersSize300} />);
-    act(() => wrapper.findDrawersTriggers()![0].click());
-    act(() => wrapper.findDrawersSlider()!.keydown(KeyCode.left));
-    expect(getComputedStyle(wrapper.findActiveDrawer()!.getElement()).width).toBe('300px');
-
-    rerender(<AppLayout contentType="form" {...drawersSize310} />);
-
-    act(() => wrapper.findDrawersTriggers()![0].click());
-    expect(getComputedStyle(wrapper.findActiveDrawer()!.getElement()).width).toBe('310px');
-  });
-
-  test('should change size in uncontrolled mode', () => {
+  test('should change size via keyboard events on slider handle', async () => {
     const drawersOpen = {
       drawers: {
         activeDrawerId: 'security',
@@ -109,6 +49,14 @@ describe('Classic only features', () => {
     };
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersOpen} />);
     act(() => wrapper.findDrawersSlider()!.keydown(KeyCode.left));
-    expect(getComputedStyle(wrapper.findActiveDrawer()!.getElement()).width).toBe('290px');
+    await act(async () => {
+      await requestAnimationFramePromise();
+    });
+    // Drawer grows after a left keydown (10px increments)
+    expect(wrapper.findActiveDrawer()!.getElement().style.width).toBe('300px');
   });
 });
+
+function requestAnimationFramePromise() {
+  return new Promise(resolve => requestAnimationFrame(resolve));
+}

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -75,7 +75,8 @@ export interface DrawerItem {
   };
   ariaLabels: DrawerItemAriaLabels;
   resizable?: boolean;
-  size?: number;
+  defaultSize?: number;
+  onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
 }
 
 export interface SizeControlProps {

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -23,7 +23,7 @@ export const ResizableDrawer = ({
 }: ResizableDrawerProps) => {
   const { isOpen, children, isMobile } = props;
 
-  const MIN_WIDTH = activeDrawer?.size && activeDrawer.size < 280 ? activeDrawer?.size : 280;
+  const MIN_WIDTH = activeDrawer?.defaultSize && activeDrawer.defaultSize < 280 ? activeDrawer?.defaultSize : 280;
   const [relativeSize, setRelativeSize] = useState(0);
 
   useEffect(() => {

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import { useControllable } from '../internal/hooks/use-controllable';
 import { useMobile } from '../internal/hooks/use-mobile';
@@ -269,31 +269,29 @@ const OldAppLayout = React.forwardRef(
       }
     );
 
-    const sizes = (() => {
+    const drawerItems = useMemo(() => drawers?.items || [], [drawers?.items]);
+
+    const getDrawerItemSizes = useCallback(() => {
       const sizes: { [id: string]: number } = {};
-      if (!drawers) {
+      if (!drawerItems) {
         return {};
       }
 
-      for (const item of drawers.items) {
-        if (item.size) {
-          sizes[item.id] = item.size;
+      for (const item of drawerItems) {
+        if (item.defaultSize) {
+          sizes[item.id] = item.defaultSize || toolsWidth;
         }
       }
-
       return sizes;
-    })();
+    }, [drawerItems, toolsWidth]);
 
-    const [drawerSizes = {}, setDrawerSizes] = useControllable(
-      Object.keys(sizes).length > 0 ? sizes : undefined,
-      drawers?.onResize,
-      {},
-      {
-        componentName: 'AppLayout',
-        controlledProp: 'drawers.items[].size',
-        changeHandler: 'drawers.onResize',
-      }
-    );
+    const [drawerSizes, setDrawerSizes] = useState(() => getDrawerItemSizes());
+
+    useEffect(() => {
+      // Ensure we only set new drawer items by performing a shallow merge
+      // of the latest drawer item sizes, and previous drawer item sizes.
+      setDrawerSizes(prev => ({ ...getDrawerItemSizes(), ...prev }));
+    }, [getDrawerItemSizes]);
 
     const drawerSize =
       selectedDrawer?.id && drawerSizes[selectedDrawer?.id] ? drawerSizes[selectedDrawer?.id] : toolsWidth;
@@ -378,6 +376,7 @@ const OldAppLayout = React.forwardRef(
       // so we subtract space-scaled-2x-xxxl * 2 for left and right padding
       const contentPadding = disableContentPaddings ? 80 : 0;
       const spaceAvailable = width - defaults.minContentWidth - contentPadding;
+
       const spaceTaken = finalSplitPanePosition === 'side' ? splitPanelSize : 0;
       return Math.max(0, spaceTaken + spaceAvailable);
     });
@@ -387,7 +386,9 @@ const OldAppLayout = React.forwardRef(
         return NaN;
       }
 
-      const width = parseInt(getComputedStyle(mainContentRef.current).width);
+      // Either use the computed width of the drawer or the drawerSize as defined.
+      const width = parseInt(getComputedStyle(mainContentRef.current).width || `${drawerSize}`);
+
       // when disableContentPaddings is true there is less available space,
       // so we subtract space-scaled-2x-xxxl * 2 for left and right padding
       const contentPadding = disableContentPaddings ? 80 : 0;
@@ -733,6 +734,10 @@ const OldAppLayout = React.forwardRef(
                   size={!isResizeInvalid ? drawerSize : toolsWidth}
                   onResize={changeDetail => {
                     fireNonCancelableEvent(drawers.onResize, changeDetail);
+                    const drawerItem = drawerItems.find(({ id }) => id === changeDetail.id);
+                    if (drawerItem?.onResize) {
+                      fireNonCancelableEvent(drawerItem.onResize, changeDetail);
+                    }
                     setDrawerSizes({ ...drawerSizes, [changeDetail.id]: changeDetail.size });
                   }}
                   refs={drawerRefs}


### PR DESCRIPTION
### Description

Removed `controlled/uncontrolled` concept and allowed resize handling to be controlled, with a callback to provide the ability to persist the last value. Changing `size` to initialSize to indicate that we only use this value as... an initial size.

### How has this been tested?

Tested locally using `with-drawers.page.tsx`, and included writing `onResize` value to local storage, and restoring to initialState. I also enabled, disabled drawers, added drawers dynamically and more!

#### Correctness
It is correct.

#### Security
It is secure.

#### Testing
It has been tested

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
