### PR TITLE
chore: Improve shell compatibility in husky scripts

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -3,7 +3,7 @@
 
 # Section for git-secrets
 
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,7 @@ npx --no-install lint-staged
 
 # Section for git-secrets
 
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -5,7 +5,7 @@
 
 # Section for git-secrets
 
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
The &> operator is a shorthand used in Bash and some other shells to redirect both stdout and stderr to the same location. However not all shells support this operator and the script can then fail. This change maintains the same functionality but improves compatibility. 

<!-- Also include relevant motivation and context. -->
Reason for change is I was running into issues with my current shell where I have git-secrets installed but was unable to commit my changes due to these scripts failing.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
I am now able to make commits again.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
