### PR TITLE
chore: Update app layout docs to recommend providing null to splitPanel

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -628,7 +628,7 @@ Conceived to contain notifications (flash messages).
     },
     Object {
       "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
-Note: This property must be set to \`null\` if a split panel should not be rendered.
+Note: If provided, this property should be set to \`null\` or \`undefined\` if a split panel should not be rendered.
 ",
       "isDefault": false,
       "name": "splitPanel",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -627,7 +627,9 @@ Conceived to contain notifications (flash messages).
       "name": "notifications",
     },
     Object {
-      "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.",
+      "description": "Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
+Note: This property must be set to \`null\` if a split panel should not be rendered.
+",
       "isDefault": false,
       "name": "splitPanel",
     },

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -162,7 +162,7 @@ export interface AppLayoutProps extends BaseComponentProps {
   /**
    * Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
    *
-   * Note: This property must be set to `null` if a split panel should not be rendered.
+   * Note: If provided, this property should be set to `null` or `undefined` if a split panel should not be rendered.
    */
   splitPanel?: React.ReactNode;
 

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -158,8 +158,11 @@ export interface AppLayoutProps extends BaseComponentProps {
    * Fired when the tools drawer is toggled.
    */
   onToolsChange?: NonCancelableEventHandler<AppLayoutProps.ChangeDetail>;
+
   /**
    * Use this slot to add the [split panel component](/components/split-panel/) to the app layout.
+   *
+   * Note: This property must be set to `null` if a split panel should not be rendered.
    */
   splitPanel?: React.ReactNode;
 


### PR DESCRIPTION
### Description

We've had a number of situations in the past where people provided a react node (e.g. empty node or something) for split panel even when no content should be rendered - so we can't know when split panel is present. This makes it clear that it's either split panel or `null`.

Related links, issue #, if available: AWSUI-20807

### How has this been tested?

Just a docs change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
