### PR TITLE
fix: Improve hover contrast for multiselect group options

### DIFF
--- a/src/internal/components/option/index.tsx
+++ b/src/internal/components/option/index.tsx
@@ -48,7 +48,12 @@ const Option = ({
     });
   }
 
-  const className = clsx(styles.option, disabled && styles.disabled, isGroupOption && styles.parent);
+  const className = clsx(
+    styles.option,
+    disabled && styles.disabled,
+    isGroupOption && styles.parent,
+    highlightedOption && styles.highlighted
+  );
 
   const icon = option.__customIcon || (
     <OptionIcon

--- a/src/internal/components/option/styles.scss
+++ b/src/internal/components/option/styles.scss
@@ -23,7 +23,7 @@
   }
   &.parent {
     font-weight: bold;
-    &:not(.disabled) {
+    &:not(.disabled):not(.highlighted) {
       color: awsui.$color-text-dropdown-group-label;
     }
   }

--- a/src/internal/components/selectable-item/styles.scss
+++ b/src/internal/components/selectable-item/styles.scss
@@ -92,6 +92,9 @@
     &.interactiveGroups {
       padding: styles.$group-option-padding-with-border-placeholder-vertical
         calc(#{styles.$control-padding-horizontal} + #{awsui.$border-item-width});
+      &.highlighted {
+        color: awsui.$color-text-dropdown-item-highlighted;
+      }
       &.highlighted,
       &.selected {
         padding: styles.$group-option-padding-vertical styles.$control-padding-horizontal;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
