### PR TITLE
chore: Use fake timer in progress-bar unit test

### DIFF
--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import ProgressBarWrapper from '../../../lib/components/test-utils/dom/progress-bar';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import ProgressBar, { ProgressBarProps } from '../../../lib/components/progress-bar';
@@ -173,28 +173,21 @@ standaloneAndKeyvalueVariants.forEach(variant => {
 });
 
 describe('Progress updates', () => {
-  const wait = (delay: number) => new Promise(resolve => setTimeout(resolve, delay));
-  jest.setTimeout(7000);
-  test('Announced progress value changes not more often then given interval', async () => {
+  test('Announced progress value changes not more often then given interval', () => {
+    jest.useFakeTimers(); // Mock timers
     const label = 'progress';
     const { container, rerender } = render(<ProgressBar label={label} value={0} />);
     const wrapper = createWrapper(container).findProgressBar()!;
 
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 0%`);
+    rerender(<ProgressBar label={label} value={1} />);
 
-    await act(async () => {
-      await wait(2000);
-      rerender(<ProgressBar label={label} value={1} />);
-    });
     // live region has an old value
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 0%`);
+    rerender(<ProgressBar label={label} value={2} />);
 
-    await act(async () => {
-      await wait(2000);
-      rerender(<ProgressBar label={label} value={2} />);
-      await wait(2000);
-    });
     // 6 seconds passed, live region has a new value
+    jest.advanceTimersByTime(6000);
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 2%`);
   });
 });


### PR DESCRIPTION
### Description

This update replaces the previous approach in the ProgressBar test that could cause time outs and delays between assertions. By incorporating Jest's fake timers, we now simulate time passage more effectively, enhancing test predictability and reducing time out occurrences.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Unit test still passes.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
