### PR TITLE
feat: Add keyboard accessibility to fold controls in code editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.20.0",
+        "ace-builds": "^1.23.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -2763,9 +2763,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.20.0.tgz",
-      "integrity": "sha512-JUvWbRXz7tL3EkcM5CpVyyuu9mvVRo594ZRgwHzb9arb9s2o5gTg94Lrk3zQZzM1udq6fRSDnmU2RClJPt9aNw=="
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.0.tgz",
+      "integrity": "sha512-PKRuQaQkjIhg1zeqJPW1QFtJO2fx13Nlv7N/VLhQS/kIQ/2aGAgWvYVcE9X64gbSiLzPdY3jcxv5wJJpLj1gLw=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -20551,9 +20551,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.20.0.tgz",
-      "integrity": "sha512-JUvWbRXz7tL3EkcM5CpVyyuu9mvVRo594ZRgwHzb9arb9s2o5gTg94Lrk3zQZzM1udq6fRSDnmU2RClJPt9aNw=="
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.0.tgz",
+      "integrity": "sha512-PKRuQaQkjIhg1zeqJPW1QFtJO2fx13Nlv7N/VLhQS/kIQ/2aGAgWvYVcE9X64gbSiLzPdY3jcxv5wJJpLj1gLw=="
     },
     "acorn": {
       "version": "8.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.4.13",
+        "ace-builds": "^1.20.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -2763,8 +2763,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.13.1",
-      "license": "BSD-3-Clause"
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.20.0.tgz",
+      "integrity": "sha512-JUvWbRXz7tL3EkcM5CpVyyuu9mvVRo594ZRgwHzb9arb9s2o5gTg94Lrk3zQZzM1udq6fRSDnmU2RClJPt9aNw=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -20550,7 +20551,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.13.1"
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.20.0.tgz",
+      "integrity": "sha512-JUvWbRXz7tL3EkcM5CpVyyuu9mvVRo594ZRgwHzb9arb9s2o5gTg94Lrk3zQZzM1udq6fRSDnmU2RClJPt9aNw=="
     },
     "acorn": {
       "version": "8.8.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.4.13",
+    "ace-builds": "^1.20.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.20.0",
+    "ace-builds": "^1.23.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",

--- a/pages/code-editor/controllable-height.page.tsx
+++ b/pages/code-editor/controllable-height.page.tsx
@@ -15,6 +15,9 @@ export default function () {
   useEffect(() => {
     import('ace-builds').then(ace => {
       ace.config.set('basePath', './ace/');
+      ace.config.set('themePath', './ace/');
+      ace.config.set('modePath', './ace/');
+      ace.config.set('workerPath', './ace/');
       ace.config.set('useStrictCSP', true);
       setAce(ace);
       setLoading(false);

--- a/pages/code-editor/simple.page.tsx
+++ b/pages/code-editor/simple.page.tsx
@@ -36,6 +36,9 @@ export default class App extends React.PureComponent<null, IState> {
 
     import('ace-builds').then(ace => {
       ace.config.set('basePath', './ace/');
+      ace.config.set('themePath', './ace/');
+      ace.config.set('modePath', './ace/');
+      ace.config.set('workerPath', './ace/');
       ace.config.set('useStrictCSP', true);
       this.setState({ ace, loading: false });
     });

--- a/pages/code-editor/vertical-scroll.page.tsx
+++ b/pages/code-editor/vertical-scroll.page.tsx
@@ -18,6 +18,9 @@ export default function () {
   useEffect(() => {
     import('ace-builds').then(ace => {
       ace.config.set('basePath', './ace/');
+      ace.config.set('themePath', './ace/');
+      ace.config.set('modePath', './ace/');
+      ace.config.set('workerPath', './ace/');
       ace.config.set('useStrictCSP', true);
       setAce(ace);
       setLoading(false);

--- a/pages/code-editor/with-errors-no-warnings.page.tsx
+++ b/pages/code-editor/with-errors-no-warnings.page.tsx
@@ -46,6 +46,9 @@ sdsdasd
 
     import('ace-builds').then(ace => {
       ace.config.set('basePath', './ace/');
+      ace.config.set('themePath', './ace/');
+      ace.config.set('modePath', './ace/');
+      ace.config.set('workerPath', './ace/');
       ace.config.set('useStrictCSP', true);
       this.setState({ ace, loading: false });
     });

--- a/src/code-editor/__integ__/code-editor.test.ts
+++ b/src/code-editor/__integ__/code-editor.test.ts
@@ -172,10 +172,10 @@ test(
     // Open errors pane
     await page.click(codeEditorWrapper.findErrorsTab().toSelector());
     // Tab to close button
-    await page.keys(['Tab', 'Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab']);
     await expect(page.isFocused(codeEditorWrapper.findPane().findButton().toSelector())).resolves.toBe(true);
     // Loop around again
-    await page.keys(['Tab', 'Tab', 'Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab']);
     await expect(page.isFocused(codeEditorWrapper.findPane().findButton().toSelector())).resolves.toBe(true);
   })
 );

--- a/src/code-editor/__integ__/code-editor.test.ts
+++ b/src/code-editor/__integ__/code-editor.test.ts
@@ -172,10 +172,10 @@ test(
     // Open errors pane
     await page.click(codeEditorWrapper.findErrorsTab().toSelector());
     // Tab to close button
-    await page.keys(['Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab', 'Tab']);
     await expect(page.isFocused(codeEditorWrapper.findPane().findButton().toSelector())).resolves.toBe(true);
     // Loop around again
-    await page.keys(['Tab', 'Tab']);
+    await page.keys(['Tab', 'Tab', 'Tab', 'Tab']);
     await expect(page.isFocused(codeEditorWrapper.findPane().findButton().toSelector())).resolves.toBe(true);
   })
 );
@@ -187,8 +187,8 @@ test(
     await page.waitForVisible(codeEditorWrapper.findErrorsTab().toSelector() + ':not(:disabled)');
     // Open errors pane
     await page.click(codeEditorWrapper.findErrorsTab().toSelector());
-    // Activate close button (Tab, Shift+Tab, Enter)
-    await page.keys(['Tab', 'Shift', 'Tab', 'Shift', 'Enter']);
+    // Activate close button (Shift+Tab, Enter)
+    await page.keys(['Shift', 'Tab', 'Shift', 'Enter']);
     await expect(page.isFocused(codeEditorWrapper.findErrorsTab().toSelector())).resolves.toBe(true);
   })
 );

--- a/src/code-editor/__integ__/code-editor.test.ts
+++ b/src/code-editor/__integ__/code-editor.test.ts
@@ -141,6 +141,8 @@ test(
     await page.keys('Tab');
     await expect(page.isFocused(codeEditorWrapper.findEditor().toSelector())).resolves.toBe(true);
 
+    await page.keys('Tab'); // Tab into gutter
+    await page.keys('Tab'); // Tab into editor area
     await page.keys('Tab');
     await expect(page.isFocused(codeEditorWrapper.findSettingsButton().toSelector())).resolves.toBe(true);
 

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -401,7 +401,7 @@ describe('Code editor component', () => {
     expect(wrapper.findPane()).toBeNull();
   });
 
-  it('highlights annotation when clicked in gutter', () => {
+  it('focuses annotation when clicked in gutter', () => {
     let gutterClickCallback: (event: any) => void;
     editorMock.on = jest.fn((name: string, _callback: (event: any) => void) => {
       if (name === 'gutterclick') {
@@ -419,7 +419,7 @@ describe('Code editor component', () => {
     expect(wrapper.findPane()).not.toBeNull(); // Pane should open
 
     const [item] = findPaneItems(wrapper.findPane()!);
-    expect(item.getElement().classList).toContain(styles['pane__item--highlighted']);
+    expect(document.activeElement).toBe(item.getElement());
 
     editorMock.on.mockRestore();
   });

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -424,6 +424,29 @@ describe('Code editor component', () => {
     editorMock.on.mockRestore();
   });
 
+  it('focuses annotation when annotation is activated with keyboard in gutter', () => {
+    let gutterKeydownCallback: (event: any) => void;
+    editorMock.on = jest.fn((name: string, _callback: (event: any) => void) => {
+      if (name === 'gutterkeydown') {
+        gutterKeydownCallback = _callback;
+      }
+    });
+    editorMock.session.getAnnotations.mockReturnValue([{ type: 'error', row: 1, column: 1 }]);
+    const { wrapper } = renderCodeEditor();
+
+    act(() => {
+      emulateAceAnnotationEvent!();
+      gutterKeydownCallback!({ isInAnnotationLane: () => true, getKey: () => 'return', getRow: () => 1 }); // emulate gutter keydown
+    });
+
+    expect(wrapper.findPane()).not.toBeNull(); // Pane should open
+
+    const [item] = findPaneItems(wrapper.findPane()!);
+    expect(document.activeElement).toBe(item.getElement());
+
+    editorMock.on.mockRestore();
+  });
+
   it('displays settings button', () => {
     const { wrapper } = renderCodeEditor();
     expect(wrapper.findSettingsButton()).not.toBeNull();

--- a/src/code-editor/__tests__/util.test.ts
+++ b/src/code-editor/__tests__/util.test.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { supportsKeyboardAccessibility } from '../../../lib/components/code-editor/util';
+
+describe('supportsKeyboardAccessibility', () => {
+  it('returns false for old versions of ace', () => {
+    expect(supportsKeyboardAccessibility({ version: '1.0.0' })).toBe(false);
+  });
+
+  it('returns true for versions of ace with enableKeyboardAccessibility', () => {
+    expect(supportsKeyboardAccessibility({ version: '1.23.0' })).toBe(true);
+  });
+
+  it('returns false if version is not provided or is invalid', () => {
+    expect(() => supportsKeyboardAccessibility({})).not.toThrow();
+    expect(() => supportsKeyboardAccessibility({ version: '1.0.0-alpha.100' })).not.toThrow();
+    expect(() => supportsKeyboardAccessibility({ version: 'testing' })).not.toThrow();
+  });
+});

--- a/src/code-editor/__tests__/util.test.ts
+++ b/src/code-editor/__tests__/util.test.ts
@@ -13,8 +13,8 @@ describe('supportsKeyboardAccessibility', () => {
   });
 
   it('returns false if version is not provided or is invalid', () => {
-    expect(() => supportsKeyboardAccessibility({})).not.toThrow();
-    expect(() => supportsKeyboardAccessibility({ version: '1.0.0-alpha.100' })).not.toThrow();
-    expect(() => supportsKeyboardAccessibility({ version: 'testing' })).not.toThrow();
+    expect(supportsKeyboardAccessibility({})).toBe(false);
+    expect(supportsKeyboardAccessibility({ version: '1.0.0-alpha.100' })).toBe(false);
+    expect(supportsKeyboardAccessibility({ version: 'testing' })).toBe(false);
   });
 });

--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -3,8 +3,10 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
+@use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use './background-inline-svg.scss' as utils;
+@use '../internal/hooks/focus-visible' as focus-visible;
 
 /* stylelint-disable selector-combinator-disallowed-list, @cloudscape-design/no-implicit-descendant */
 
@@ -52,7 +54,20 @@
     margin-right: -$gutter-padding-right + 1px; // leave 1px margin on each side
     background-color: transparent;
     border: none;
+  }
+
+  .ace_gutter_annotation {
+    // To align our custom icon with the annotation clickable/focus area.
+    // Based on -19px in ace's default stylesheet.
+    margin-left: -21px;
+  }
+
+  .ace_fold-widget,
+  .ace_gutter_annotation {
     box-shadow: none;
+    @include focus-visible.when-visible {
+      @include styles.focus-highlight(-2px);
+    }
   }
 
   $active-line-border-color-light: awsui.$color-border-code-editor-ace-active-line-light-theme;
@@ -73,6 +88,13 @@
   .ace_gutter {
     background-color: awsui.$color-background-code-editor-gutter-default;
     color: awsui.$color-text-code-editor-gutter-default;
+  }
+
+  .ace_gutter,
+  .ace_scroller {
+    @include focus-visible.when-visible {
+      box-shadow: inset 0 0 0 2px awsui.$color-border-item-focused;
+    }
   }
 
   .ace_fold-widget.ace_open {
@@ -110,6 +132,17 @@
   .ace_gutter-active-line {
     background-color: awsui.$color-background-code-editor-gutter-active-line-default;
     color: awsui.$color-text-code-editor-gutter-active-line;
+
+    .ace_fold-widget,
+    .ace_gutter_annotation {
+      @include focus-visible.when-visible {
+        @include styles.focus-highlight(
+          -2px,
+          awsui.$border-radius-control-default-focus-ring,
+          0 0 0 2px awsui.$color-text-code-editor-gutter-active-line
+        );
+      }
+    }
 
     & > .ace_fold-widget.ace_open {
       @include utils.background-inline-svg(

--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -10,6 +10,15 @@
 
 /* stylelint-disable selector-combinator-disallowed-list, @cloudscape-design/no-implicit-descendant */
 
+.code-editor-refresh :global .ace_editor {
+  .ace_gutter {
+    border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  }
+  .ace_scroller {
+    border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  }
+}
+
 .code-editor :global .ace_editor {
   font-family: Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace;
   font-size: 14px;
@@ -92,7 +101,8 @@
 
   .ace_gutter,
   .ace_scroller {
-    @include focus-visible.when-visible {
+    &:focus {
+      // Inset focus visible styling that works with ace regions.
       box-shadow: inset 0 0 0 2px awsui.$color-border-item-focused;
     }
   }
@@ -226,15 +236,6 @@
         }
       }
     }
-  }
-}
-
-.code-editor-refresh :global .ace_editor {
-  .ace_gutter {
-    border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
-  }
-  .ace_scroller {
-    border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
   }
 }
 

--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -66,7 +66,7 @@
   .ace_gutter_annotation {
     box-shadow: none;
     @include focus-visible.when-visible {
-      @include styles.focus-highlight(-2px);
+      @include styles.focus-highlight(-1px);
     }
   }
 

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -208,15 +208,9 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     setPaneStatus(paneStatus !== 'warning' ? 'warning' : 'hidden');
   }, [paneStatus]);
 
-  const onPaneClose = useCallback(() => {
-    if (paneStatus === 'error' && errorsTabRef.current) {
-      errorsTabRef.current.focus();
-    }
-    if (paneStatus === 'warning' && warningsTabRef.current) {
-      warningsTabRef.current.focus();
-    }
+  const onPaneClose = () => {
     setPaneStatus('hidden');
-  }, [paneStatus]);
+  };
 
   const onAnnotationClick = ({ row = 0, column = 0 }: Ace.Annotation) => {
     if (!editor) {

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -99,7 +99,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     if (!ace || !elem) {
       return;
     }
-    const config = getDefaultConfig();
+    const config = getDefaultConfig(ace);
     setEditor(
       ace.edit(elem, {
         ...config,

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -32,6 +32,7 @@ import useForwardFocus from '../internal/hooks/forward-focus';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { useContainerQuery } from '../internal/hooks/container-queries/use-container-query';
 import { useCurrentMode } from '../internal/hooks/use-visual-mode';
+import { useInternalI18n } from '../internal/i18n/context';
 import { StatusBar } from './status-bar';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
@@ -39,7 +40,6 @@ import { useControllable } from '../internal/hooks/use-controllable';
 import LiveRegion from '../internal/components/live-region';
 
 import styles from './styles.css.js';
-import { useInternalI18n } from '../internal/i18n/context';
 
 export { CodeEditorProps };
 

--- a/src/code-editor/pane.tsx
+++ b/src/code-editor/pane.tsx
@@ -60,10 +60,6 @@ export const Pane = ({
     }
   }, [highlighted, annotations]);
 
-  const onItemFocus = () => {
-    onAnnotationClear();
-  };
-
   const onItemClick = (annotation: Ace.Annotation) => {
     onAnnotationClick(annotation);
   };
@@ -89,7 +85,7 @@ export const Pane = ({
   return (
     <div id={id} className={styles.pane} onKeyDown={onEscKeyDown} role="tabpanel">
       <ResizableBox height={paneHeight} minHeight={MIN_HEIGHT} onResize={newHeight => setPaneHeight(newHeight)}>
-        <FocusLock disabled={!visible} className={styles['focus-lock']} autoFocus={true} restoreFocus={true}>
+        <FocusLock className={styles['focus-lock']} autoFocus={true} restoreFocus={true}>
           <div className={styles.pane__list} tabIndex={-1}>
             <table className={styles.pane__table} role="presentation">
               <colgroup>
@@ -100,15 +96,12 @@ export const Pane = ({
                 {annotations.map((annotation, i) => (
                   <tr
                     key={i}
-                    className={clsx(styles.pane__item, {
-                      [styles['pane__item--highlighted']]: annotation === highlighted,
-                    })}
-                    onFocus={onItemFocus}
+                    role="link"
+                    className={styles.pane__item}
                     onMouseOver={onAnnotationClear}
                     onClick={onItemClick.bind(null, annotation)}
                     onKeyDown={onItemKeyDown.bind(null, annotation)}
                     tabIndex={0}
-                    role="link"
                   >
                     <td className={clsx(styles.pane__location, styles.pane__cell)} tabIndex={-1}>
                       {cursorPositionLabel?.((annotation.row || 0) + 1, (annotation.column || 0) + 1) ?? ''}

--- a/src/code-editor/pane.tsx
+++ b/src/code-editor/pane.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 import { Ace } from 'ace-builds';
 
 import { KeyCode } from '../internal/keycode';
-import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import FocusLock from '../internal/components/focus-lock';
 
 import { InternalButton } from '../button/internal';
@@ -45,7 +44,6 @@ export const Pane = ({
 }: PaneProps) => {
   const [paneHeight, setPaneHeight] = useState(MIN_HEIGHT);
   const listRef = useRef<HTMLTableSectionElement>(null);
-  const [isFocusTrapActive, setFocusTrapActive] = useState(false);
 
   useEffect(() => {
     if (!highlighted) {
@@ -58,30 +56,21 @@ export const Pane = ({
 
     if (highlightedAnnotationIndex > -1) {
       const errorItem = listRef.current?.children[highlightedAnnotationIndex] as HTMLElement | undefined;
-      scrollElementIntoView(errorItem);
+      errorItem?.focus();
     }
   }, [highlighted, annotations]);
 
-  useEffect(() => {
-    if (!visible) {
-      setFocusTrapActive(false);
-    }
-  }, [visible]);
-
   const onItemFocus = () => {
-    setFocusTrapActive(true);
     onAnnotationClear();
   };
 
   const onItemClick = (annotation: Ace.Annotation) => {
-    setFocusTrapActive(false);
     onAnnotationClick(annotation);
   };
 
   const onItemKeyDown = (annotation: Ace.Annotation, event: React.KeyboardEvent) => {
     if (event.keyCode === KeyCode.enter || event.keyCode === KeyCode.space) {
       event.preventDefault();
-      setFocusTrapActive(false);
       onAnnotationClick(annotation);
     }
   };
@@ -89,7 +78,6 @@ export const Pane = ({
   const onEscKeyDown = (event: React.KeyboardEvent) => {
     if (event.keyCode === KeyCode.escape) {
       event.preventDefault();
-      setFocusTrapActive(false);
       onClose();
     }
   };
@@ -101,7 +89,7 @@ export const Pane = ({
   return (
     <div id={id} className={styles.pane} onKeyDown={onEscKeyDown} role="tabpanel">
       <ResizableBox height={paneHeight} minHeight={MIN_HEIGHT} onResize={newHeight => setPaneHeight(newHeight)}>
-        <FocusLock disabled={!isFocusTrapActive} className={styles['focus-lock']} autoFocus={true}>
+        <FocusLock disabled={!visible} className={styles['focus-lock']} autoFocus={true} restoreFocus={true}>
           <div className={styles.pane__list} tabIndex={-1}>
             <table className={styles.pane__table} role="presentation">
               <colgroup>

--- a/src/code-editor/setup-editor.ts
+++ b/src/code-editor/setup-editor.ts
@@ -36,14 +36,6 @@ export function setupEditor(
     setAnnotations(newAnnotations);
   });
 
-  editor.commands.addCommand({
-    name: 'exitCodeEditor',
-    bindKey: 'Esc',
-    exec: () => {
-      editor.container.focus();
-    },
-  });
-
   editor.on('focus', () => {
     (editor as any).textInput.getElement().setAttribute('tabindex', 0);
   });
@@ -94,7 +86,7 @@ export function setupEditor(
 
   // open error/warning pane when user presses space/enter on gutter icon
   editor.on('gutterkeydown', e => {
-    if (e.getKey() === 'space' || e.getKey() === 'return') {
+    if (e.isInAnnotationLane() && (e.getKey() === 'space' || e.getKey() === 'return')) {
       const row: number = e.getRow();
       openAnnotation(row);
     }

--- a/src/code-editor/setup-editor.ts
+++ b/src/code-editor/setup-editor.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { Ace } from 'ace-builds';
-import { PaneStatus } from './util';
+import { PaneStatus, supportsKeyboardAccessibility } from './util';
 
 export function setupEditor(
   ace: any,
@@ -35,6 +35,16 @@ export function setupEditor(
     }
     setAnnotations(newAnnotations);
   });
+
+  if (!supportsKeyboardAccessibility(ace)) {
+    editor.commands.addCommand({
+      name: 'exitCodeEditor',
+      bindKey: 'Esc',
+      exec: () => {
+        editor.container.focus();
+      },
+    });
+  }
 
   editor.on('focus', () => {
     (editor as any).textInput.getElement().setAttribute('tabindex', 0);

--- a/src/code-editor/setup-editor.ts
+++ b/src/code-editor/setup-editor.ts
@@ -57,7 +57,11 @@ export function setupEditor(
 
   editor.commands.removeCommand('showSettingsMenu', false);
 
-  // Prevent default behavior on error/warning icon click
+  // Prevent default behavior on error/warning icon hover/click
+  editor.on('guttermousemove' as any, (e: any) => {
+    e.stop();
+  });
+
   editor.on('guttermousedown' as any, (e: any) => {
     e.stop();
   });

--- a/src/code-editor/setup-editor.ts
+++ b/src/code-editor/setup-editor.ts
@@ -57,11 +57,7 @@ export function setupEditor(
 
   editor.commands.removeCommand('showSettingsMenu', false);
 
-  // Prevent default behavior on error/warning icon hover/click
-  editor.on('guttermousemove' as any, (e: any) => {
-    e.stop();
-  });
-
+  // Prevent default behavior on error/warning icon click
   editor.on('guttermousedown' as any, (e: any) => {
     e.stop();
   });
@@ -72,9 +68,7 @@ export function setupEditor(
     }
   };
 
-  // open error/warning pane when user clicks on gutter icon
-  editor.on('gutterclick' as any, (e: any) => {
-    const { row }: Ace.Point = e.getDocumentPosition();
+  const openAnnotation = (row: number) => {
     const currentAnnotations = editor.session.getAnnotations().filter(a => a.row === row && a.type !== 'info');
     const errors = currentAnnotations.filter(a => a.type === 'error');
     if (errors.length > 0) {
@@ -89,6 +83,20 @@ export function setupEditor(
       setHighlightedAnnotation(undefined);
       setPaneStatus('hidden');
       editor.gotoLine(row + 1, 0, false);
+    }
+  };
+
+  // open error/warning pane when user clicks on gutter icon
+  editor.on('gutterclick' as any, (e: any) => {
+    const { row }: Ace.Point = e.getDocumentPosition();
+    openAnnotation(row);
+  });
+
+  // open error/warning pane when user presses space/enter on gutter icon
+  editor.on('gutterkeydown', e => {
+    if (e.getKey() === 'space' || e.getKey() === 'return') {
+      const row: number = e.getRow();
+      openAnnotation(row);
     }
   });
 

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -15,6 +15,7 @@ export const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_
 const KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION = [1, 23];
 
 export function supportsKeyboardAccessibility(ace: any): boolean {
+  // Split semantic version numbers. We don't need a full semver parser for this.
   const semanticVersion = ace?.version?.split('.').map((part: string) => {
     try {
       return parseInt(part);

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -17,15 +17,12 @@ const KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION = [1, 23];
 export function supportsKeyboardAccessibility(ace: any): boolean {
   // Split semantic version numbers. We don't need a full semver parser for this.
   const semanticVersion = ace?.version?.split('.').map((part: string) => {
-    try {
-      return parseInt(part);
-    } catch {
-      return part;
-    }
+    const parsed = parseInt(part);
+    return Number.isNaN(parsed) ? part : parsed;
   });
 
   return (
-    semanticVersion &&
+    !!semanticVersion &&
     typeof semanticVersion[0] === 'number' &&
     semanticVersion[0] >= KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION[0] &&
     typeof semanticVersion[1] === 'number' &&

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -15,6 +15,7 @@ export const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_
 export function getDefaultConfig(): Partial<Ace.EditorOptions> {
   return {
     behavioursEnabled: true,
+    enableKeyboardAccessibility: true,
   };
 }
 

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -12,10 +12,30 @@ export type PaneStatus = 'error' | 'warning' | 'hidden';
 export const DEFAULT_LIGHT_THEME: typeof LightThemes[number]['value'] = 'dawn';
 export const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_night_bright';
 
-export function getDefaultConfig(): Partial<Ace.EditorOptions> {
+const KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION = [1, 23];
+
+export function supportsKeyboardAccessibility(ace: any): boolean {
+  const semanticVersion = ace?.version?.split('.').map((part: string) => {
+    try {
+      return parseInt(part);
+    } catch {
+      return part;
+    }
+  });
+
+  return (
+    semanticVersion &&
+    typeof semanticVersion[0] === 'number' &&
+    semanticVersion[0] >= KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION[0] &&
+    typeof semanticVersion[1] === 'number' &&
+    semanticVersion[1] >= KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION[1]
+  );
+}
+
+export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
   return {
     behavioursEnabled: true,
-    enableKeyboardAccessibility: true,
+    ...(supportsKeyboardAccessibility(ace) ? { enableKeyboardAccessibility: true } : {}),
   };
 }
 


### PR DESCRIPTION
### Description

Ace recently released a flag to allow keyboard access to the gutter and code folding controls, and just improve keyboard accessibility in general (ajaxorg/ace#5146). This PR enables that option, and integrates it with the pane. Additionally, it simplifies the pane's focus management logic.

There are some changes around ace-builds 1.15.0 that breaks/changes how basePath is set, so I had to mess with the ace config in the dev pages, but following up on that shouldn't block this release. We use "ace-builds" in the component itself for the typings alone.

Related links, issue #, if available: AWSUI-19227

### How has this been tested?

Tests have been changed where they were failing due to behavioral changes. The rest is visual.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
