### PR TITLE
fix: Makes drawers toggles and updates line

### DIFF
--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -162,4 +162,12 @@ describeEachThemeAppLayout(false, () => {
     expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-label', 'Security trigger button');
     expect(wrapper.findDrawersDesktopTriggersContainer()!.getElement()).toHaveAttribute('aria-label', 'Drawers');
   });
+
+  test(`should toggle drawer on click`, () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersConfigurations.singleDrawer} />);
+    act(() => wrapper.findDrawersTriggers()![0].click());
+    expect(wrapper.findActiveDrawer()).toBeTruthy();
+    act(() => wrapper.findDrawersTriggers()![0].click());
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+  });
 });

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -163,7 +163,9 @@ export function DrawerTriggersBar({
                 iconName={item.trigger.iconName}
                 iconSvg={item.trigger.iconSvg}
                 ariaLabel={item.ariaLabels?.triggerButton}
-                onClick={() => drawers.onChange({ activeDrawerId: item.id })}
+                onClick={() =>
+                  drawers.onChange({ activeDrawerId: item.id !== drawers.activeDrawerId ? item.id : undefined })
+                }
                 ariaExpanded={drawers.activeDrawerId !== undefined}
               />
             ))}

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -65,8 +65,8 @@ $drawer-z-index-mobile: 1001;
 
 .trigger {
   .drawer-content > .drawer-triggers > & {
-    padding: constants.$drawers-padding;
-    margin: 1px constants.$drawers-padding-horizontal;
+    padding: constants.$drawers-padding-vertical awsui.$space-s;
+    margin-top: 1px;
     border-radius: 0;
     border: 0;
 
@@ -84,17 +84,12 @@ $drawer-z-index-mobile: 1001;
 
     &.selected,
     &.selected:hover {
-      padding: constants.$drawers-padding-vertical awsui.$space-s;
       margin: 0;
       border-top: 1px solid awsui.$color-background-layout-panel-trigger-active;
-      border-bottom: 1px solid awsui.$color-background-layout-panel-trigger-active;
 
       background-color: awsui.$color-background-layout-panel-trigger-active;
       color: awsui.$color-text-layout-panel-trigger-active;
       box-shadow: none;
-      &:hover {
-        cursor: default;
-      }
     }
   }
 }

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -701,9 +701,7 @@ const OldAppLayout = React.forwardRef(
                   contentClassName={
                     selectedDrawer?.id === 'tools' ? testutilStyles.tools : testutilStyles['active-drawer']
                   }
-                  toggleClassName={
-                    selectedDrawer?.id === 'tools' ? testutilStyles['tools-toggle'] : testutilStyles['drawers-trigger']
-                  }
+                  toggleClassName={testutilStyles['tools-toggle']}
                   closeClassName={
                     selectedDrawer?.id === 'tools'
                       ? testutilStyles['tools-close']


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

This PR fixes 3 issues:

1. Makes drawer items work like toggles (which they already do in VR), so that you can click to open and click again to close.
2. Expands the divider line to go across the entire trigger bar. This makes it consistent with mobile and also is from feedback from the stakeholder team.
3. Makes the focus state on selected items the same as non-selected items.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
