### PR TITLE
chore: Add analytics components and hooks

### DIFF
--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -1,0 +1,394 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { FunnelMetrics, setFunnelMetrics } from '../../../../../lib/components/internal/analytics';
+import {
+  AnalyticsFunnel,
+  AnalyticsFunnelStep,
+  AnalyticsFunnelSubStep,
+} from '../../../../../lib/components/internal/analytics/components/analytics-funnel';
+import { useFunnel, useFunnelSubStep } from '../../../../../lib/components/internal/analytics/hooks/use-funnel';
+
+const mockedFunnelInteractionId = 'mocked-funnel-id';
+function mockFunnelMetrics() {
+  setFunnelMetrics({
+    funnelStart: jest.fn(() => mockedFunnelInteractionId),
+    funnelError: jest.fn(),
+    funnelComplete: jest.fn(),
+    funnelSuccessful: jest.fn(),
+    funnelCancelled: jest.fn(),
+    funnelStepStart: jest.fn(),
+    funnelStepComplete: jest.fn(),
+    funnelStepNavigation: jest.fn(),
+    funnelSubStepStart: jest.fn(),
+    funnelSubStepComplete: jest.fn(),
+    funnelSubStepError: jest.fn(),
+    helpPanelInteracted: jest.fn(),
+    externalLinkInteracted: jest.fn(),
+  });
+}
+
+describe('AnalyticsFunnel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFunnelMetrics();
+  });
+
+  test('renders children', () => {
+    const { getByText } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={3}>
+        <div>Child Content</div>
+      </AnalyticsFunnel>
+    );
+
+    const childElement = getByText('Child Content');
+    expect(childElement).toBeInTheDocument();
+  });
+
+  test('adds analytics data attributes to root node', () => {
+    const ChildComponent = () => {
+      const { funnelProps } = useFunnel();
+
+      return <div data-testid="root" {...funnelProps} />;
+    };
+
+    const optionalStepNumbers = [1, 3];
+    const totalFunnelSteps = 5;
+
+    const { getByTestId } = render(
+      <AnalyticsFunnel
+        funnelType="single-page"
+        optionalStepNumbers={optionalStepNumbers}
+        totalFunnelSteps={totalFunnelSteps}
+      >
+        <ChildComponent />
+      </AnalyticsFunnel>
+    );
+
+    // Check if the root element has a specific data attribute
+    expect(getByTestId('root')).toHaveAttribute('data-analytics-funnel-interaction-id', expect.any(String));
+  });
+
+  test('calls funnelStart when the component renders', () => {
+    render(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
+
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelNameSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('calls funnelComplete when the component unmounts after submitting', () => {
+    // ChildComponent is a sample component that renders a button to call funnelSubmit
+    const ChildComponent = () => {
+      const { funnelSubmit } = useFunnel();
+
+      return <button onClick={funnelSubmit}>Submit</button>;
+    };
+
+    const { unmount, getByText } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={3}>
+        <ChildComponent />
+      </AnalyticsFunnel>
+    );
+    expect(FunnelMetrics.funnelComplete).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Submit')); // Trigger the button click event
+    unmount();
+    expect(FunnelMetrics.funnelComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls funnelCancelled when the component unmounts after cancelling', () => {
+    // ChildComponent is a sample component that renders a button to call funnelCancel
+    const ChildComponent = () => {
+      const { funnelCancel } = useFunnel();
+
+      return <button onClick={funnelCancel}>Cancel</button>;
+    };
+
+    const { unmount, getByText } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <ChildComponent />
+      </AnalyticsFunnel>
+    );
+    expect(FunnelMetrics.funnelCancelled).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Cancel')); // Trigger the button click event
+    unmount();
+
+    expect(FunnelMetrics.funnelCancelled).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls funnelCancelled when the component unmounts after submitting then cancelling', () => {
+    const ChildComponent = () => {
+      const { funnelSubmit, funnelCancel } = useFunnel();
+
+      return (
+        <>
+          <button onClick={funnelSubmit}>Submit</button>
+          <button onClick={funnelCancel}>Cancel</button>
+        </>
+      );
+    };
+
+    const { unmount, getByText } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <ChildComponent />
+      </AnalyticsFunnel>
+    );
+    expect(FunnelMetrics.funnelCancelled).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Submit'));
+    fireEvent.click(getByText('Cancel'));
+    unmount();
+
+    expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelCancelled).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AnalyticsFunnelStep', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFunnelMetrics();
+  });
+
+  test('renders children components', () => {
+    const { getByText } = render(
+      <AnalyticsFunnelStep stepNumber={1} stepNameSelector=".step-name-selector">
+        <div>Child Content</div>
+      </AnalyticsFunnelStep>
+    );
+
+    const childElement = getByText('Child Content');
+    expect(childElement).toBeInTheDocument();
+  });
+
+  test('calls funnelStepStart with the correct arguments when the step mounts', () => {
+    const stepNumber = 2; // Must be different to mocked focussed element
+    const stepNameSelector = '.step-name-selector';
+
+    render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          Step Content
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith({
+      funnelInteractionId: mockedFunnelInteractionId,
+      stepNumber,
+      stepNameSelector,
+      subStepAllSelector: expect.any(String),
+    });
+  });
+
+  test('calls funnelStepComplete with the correct arguments when the step unmounts', () => {
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    const { rerender } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          Step Content
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
+
+    rerender(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
+
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith({
+      funnelInteractionId: mockedFunnelInteractionId,
+      stepNumber,
+      stepNameSelector,
+      subStepAllSelector: expect.any(String),
+    });
+  });
+
+  test('calls funnelStepComplete with the correct arguments when the everything unmounts', () => {
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    const { unmount } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          Step Content
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith({
+      funnelInteractionId: mockedFunnelInteractionId,
+      stepNumber,
+      stepNameSelector,
+      subStepAllSelector: expect.any(String),
+    });
+  });
+
+  test('calls funnelStepStart and funnelStepComplete when stepNumber changes', () => {
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    const { rerender } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          Step Content
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
+
+    rerender(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber + 1} stepNameSelector={stepNameSelector}>
+          Step Content
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(2);
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call funnelStepStart when not in a AnalyticsFunnel Context', () => {
+    render(
+      <AnalyticsFunnelStep stepNumber={1} stepNameSelector=".step-name-selector">
+        Step Content
+      </AnalyticsFunnelStep>
+    );
+
+    expect(FunnelMetrics.funnelStepStart).not.toHaveBeenCalled();
+  });
+
+  test('does not call funnetStepComplete when not in a AnalyticsFunnel Context', () => {
+    const { unmount } = render(
+      <AnalyticsFunnelStep stepNumber={1} stepNameSelector=".step-name-selector">
+        Step Content
+      </AnalyticsFunnelStep>
+    );
+
+    unmount();
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
+  });
+});
+
+describe('AnalyticsFunnelSubStep', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFunnelMetrics();
+  });
+
+  test('renders children components', () => {
+    const { getByText } = render(
+      <AnalyticsFunnelSubStep>
+        <div>Substep Content</div>
+      </AnalyticsFunnelSubStep>
+    );
+
+    const childElement = getByText('Substep Content');
+    expect(childElement).toBeInTheDocument();
+  });
+
+  test('does not call funnelSubStepStart or funnelSubStepComplete when funnelInteractionId is not present', () => {
+    const { getByTestId } = render(
+      <AnalyticsFunnelSubStep>
+        <div data-testid="substep-content">Substep Content</div>
+      </AnalyticsFunnelSubStep>
+    );
+
+    fireEvent.focus(getByTestId('substep-content'));
+
+    expect(FunnelMetrics.funnelSubStepStart).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelSubStepComplete).not.toHaveBeenCalled();
+  });
+
+  test('calls funnelSubStepStart with the correct arguments when the substep is focused', () => {
+    // ChildComponent is a sample component that renders a button to call funnelSubmit
+    const ChildComponent = () => {
+      const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+
+      return (
+        <div ref={subStepRef} {...funnelSubStepProps}>
+          <input data-testid="input" />
+        </div>
+      );
+    };
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    const { getByTestId } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          <AnalyticsFunnelSubStep>
+            <ChildComponent />
+          </AnalyticsFunnelSubStep>
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    fireEvent.focus(getByTestId('input'));
+
+    expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledWith({
+      funnelInteractionId: mockedFunnelInteractionId,
+      stepNumber,
+      stepNameSelector,
+      subStepAllSelector: expect.any(String),
+      subStepSelector: expect.any(String),
+      subStepNameSelector: expect.any(String),
+    });
+  });
+
+  test('calls funnelSubStepComplete with the correct arguments when the substep loses focus', () => {
+    const ChildComponent = () => {
+      const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+
+      return (
+        <div ref={subStepRef} {...funnelSubStepProps}>
+          <input data-testid="input" />
+        </div>
+      );
+    };
+
+    const stepNumber = 1;
+    const stepNameSelector = '.step-name-selector';
+
+    const { getByTestId } = render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+          <AnalyticsFunnelSubStep>
+            <ChildComponent />
+          </AnalyticsFunnelSubStep>
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+
+    fireEvent.blur(getByTestId('input'));
+
+    expect(FunnelMetrics.funnelSubStepComplete).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelSubStepComplete).toHaveBeenCalledWith({
+      funnelInteractionId: mockedFunnelInteractionId,
+      stepNumber,
+      stepNameSelector,
+      subStepAllSelector: expect.any(String),
+      subStepSelector: expect.any(String),
+      subStepNameSelector: expect.any(String),
+    });
+  });
+});

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { FunnelStepContext } from '../../../../../lib/components/internal/analytics/context/analytics-context';
+import { useFunnelStep } from '../../../../../lib/components/internal/analytics/hooks/use-funnel';
+
+describe('useFunnelStep hook', () => {
+  test('returns the correct initial context value', () => {
+    const ChildComponent = () => {
+      const { stepNumber, stepNameSelector } = useFunnelStep();
+      return (
+        <>
+          <div data-testid="stepNumber">{stepNumber}</div>
+          <div data-testid="stepNameSelector">{stepNameSelector}</div>
+        </>
+      );
+    };
+
+    const { getByTestId } = render(
+      <FunnelStepContext.Provider
+        value={{
+          funnelInteractionId: undefined,
+          stepNameSelector: 'step_name_selector',
+          stepNumber: 0,
+        }}
+      >
+        <ChildComponent />
+      </FunnelStepContext.Provider>
+    );
+
+    expect(getByTestId('stepNumber')).toHaveTextContent('0');
+    expect(getByTestId('stepNameSelector')).toHaveTextContent('step_name_selector');
+  });
+});

--- a/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { FunnelSubStepContext } from '../../../../../lib/components/internal/analytics/context/analytics-context';
+import { useFunnelSubStep } from '../../../../../lib/components/internal/analytics/hooks/use-funnel';
+import { FunnelMetrics, setFunnelMetrics } from '../../../../../lib/components/internal/analytics';
+
+const mockedFunnelInteractionId = 'mocked-funnel-id';
+function mockFunnelMetrics() {
+  setFunnelMetrics({
+    funnelStart: jest.fn(() => mockedFunnelInteractionId),
+    funnelError: jest.fn(),
+    funnelComplete: jest.fn(),
+    funnelSuccessful: jest.fn(),
+    funnelCancelled: jest.fn(),
+    funnelStepStart: jest.fn(),
+    funnelStepComplete: jest.fn(),
+    funnelStepNavigation: jest.fn(),
+    funnelSubStepStart: jest.fn(),
+    funnelSubStepComplete: jest.fn(),
+    funnelSubStepError: jest.fn(),
+    helpPanelInteracted: jest.fn(),
+    externalLinkInteracted: jest.fn(),
+  });
+}
+
+describe('useFunnelSubStep hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFunnelMetrics();
+  });
+
+  test('assigns correct attributes to given ref container', () => {
+    const ChildComponent = () => {
+      const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+      return <div data-testid="container" ref={subStepRef} {...funnelSubStepProps} />;
+    };
+
+    const funnelInteractionId = '123';
+    const subStepId = '456';
+    const stepNumber = 1;
+    const stepNameSelector = 'step1';
+    const subStepSelector = 'subStep1';
+    const subStepNameSelector = 'subStepName1';
+
+    const { getByTestId } = render(
+      <FunnelSubStepContext.Provider
+        value={{
+          subStepId,
+          funnelInteractionId,
+          stepNumber,
+          stepNameSelector,
+          subStepSelector,
+          subStepNameSelector,
+        }}
+      >
+        <ChildComponent />
+      </FunnelSubStepContext.Provider>
+    );
+
+    const container = getByTestId('container');
+    expect(container).toHaveAttribute('data-analytics-funnel-substep');
+  });
+
+  test('calls funnelSubStepStart when the substep is focused', () => {
+    const ChildComponent = () => {
+      const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+      return (
+        <div ref={subStepRef} {...funnelSubStepProps}>
+          <input data-testid="input" />
+        </div>
+      );
+    };
+
+    const funnelInteractionId = '123';
+    const subStepId = '456';
+    const stepNumber = 1;
+    const stepNameSelector = 'step1';
+    const subStepSelector = 'subStep1';
+    const subStepNameSelector = 'subStepName1';
+
+    const { getByTestId } = render(
+      <FunnelSubStepContext.Provider
+        value={{
+          subStepId,
+          funnelInteractionId,
+          stepNumber,
+          stepNameSelector,
+          subStepSelector,
+          subStepNameSelector,
+        }}
+      >
+        <ChildComponent />
+      </FunnelSubStepContext.Provider>
+    );
+
+    getByTestId('input').focus();
+
+    expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId,
+        subStepSelector,
+        subStepNameSelector,
+        stepNumber,
+        stepNameSelector,
+        subStepAllSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('calls funnelSubStepComplete when the substep is blurred', () => {
+    const ChildComponent = () => {
+      const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+      return (
+        <div ref={subStepRef} {...funnelSubStepProps}>
+          <input data-testid="input" />
+        </div>
+      );
+    };
+
+    const funnelInteractionId = '123';
+    const subStepId = '456';
+    const stepNumber = 1;
+    const stepNameSelector = 'step1';
+    const subStepSelector = 'subStep1';
+    const subStepNameSelector = 'subStepName1';
+
+    const { getByTestId } = render(
+      <FunnelSubStepContext.Provider
+        value={{
+          subStepId,
+          funnelInteractionId,
+          stepNumber,
+          stepNameSelector,
+          subStepSelector,
+          subStepNameSelector,
+        }}
+      >
+        <ChildComponent />
+      </FunnelSubStepContext.Provider>
+    );
+
+    const input = getByTestId('input');
+    input.focus();
+    input.blur();
+
+    expect(FunnelMetrics.funnelSubStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelInteractionId,
+        subStepSelector,
+        subStepNameSelector,
+        stepNumber,
+        stepNameSelector,
+        subStepAllSelector: expect.any(String),
+      })
+    );
+  });
+});

--- a/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { FunnelContext } from '../../../../../lib/components/internal/analytics/context/analytics-context';
+import { useFunnel } from '../../../../../lib/components/internal/analytics/hooks/use-funnel';
+
+describe('useFunnel hook', () => {
+  test('adds the correct data attributes', () => {
+    const ChildComponent = () => {
+      const { funnelProps } = useFunnel();
+      return (
+        <div data-testid="content" {...funnelProps}>
+          Content
+        </div>
+      );
+    };
+
+    const { getByTestId } = render(
+      <FunnelContext.Provider
+        value={{
+          funnelInteractionId: 'funnel-id',
+          setFunnelInteractionId: () => {},
+          funnelType: 'single-page',
+          optionalStepNumbers: [],
+          totalFunnelSteps: 0,
+          funnelSubmit: () => {},
+          funnelCancel: () => {},
+        }}
+      >
+        <ChildComponent />
+      </FunnelContext.Provider>
+    );
+
+    const content = getByTestId('content');
+    expect(content).toHaveAttribute('data-analytics-funnel-interaction-id');
+  });
+
+  test('calls funnelSubmit, funnelCancel and setFunnelInteractionId methods', () => {
+    const funnelSubmit = jest.fn();
+    const funnelCancel = jest.fn();
+    const setFunnelInteractionId = jest.fn();
+
+    const ChildComponent = () => {
+      const { funnelProps, funnelSubmit, funnelCancel, setFunnelInteractionId } = useFunnel();
+      return (
+        <div {...funnelProps}>
+          <button onClick={funnelSubmit}>Submit</button>
+          <button onClick={funnelCancel}>Cancel</button>
+          <button onClick={() => setFunnelInteractionId('funnel-id-test')}>Set Funnel Id</button>
+        </div>
+      );
+    };
+
+    const { getByText } = render(
+      <FunnelContext.Provider
+        value={{
+          funnelInteractionId: 'funnel-id',
+          funnelType: 'single-page',
+          optionalStepNumbers: [],
+          totalFunnelSteps: 0,
+          setFunnelInteractionId,
+          funnelSubmit,
+          funnelCancel,
+        }}
+      >
+        <ChildComponent />
+      </FunnelContext.Provider>
+    );
+
+    getByText('Submit').click();
+    expect(funnelSubmit).toHaveBeenCalledTimes(1);
+
+    getByText('Cancel').click();
+    expect(funnelCancel).toHaveBeenCalledTimes(1);
+
+    getByText('Set Funnel Id').click();
+    expect(setFunnelInteractionId).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -1,0 +1,156 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef, useState } from 'react';
+
+import {
+  FunnelStepContext,
+  FunnelSubStepContext,
+  FunnelContext,
+  FunnelContextValue,
+} from '../context/analytics-context';
+import { useFunnel, useFunnelStep } from '../hooks/use-funnel';
+import { useUniqueId } from '../../hooks/use-unique-id';
+import { useVisualRefresh } from '../../hooks/use-visual-mode';
+
+import { PACKAGE_VERSION } from '../../environment';
+
+import { FunnelMetrics } from '../';
+import { FunnelProps, FunnelStepProps } from '../interfaces';
+
+import { getFunnelNameSelector, getSubStepAllSelector, getSubStepNameSelector, getSubStepSelector } from '../selectors';
+
+export const FUNNEL_VERSION = '1.0';
+
+type AnalyticsFunnelProps = { children?: React.ReactNode } & Pick<
+  FunnelProps,
+  'funnelType' | 'optionalStepNumbers' | 'totalFunnelSteps'
+>;
+
+export const AnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) => {
+  const [funnelInteractionId, setFunnelInteractionId] = useState<string>();
+  const funnelResultRef = useRef<boolean>(false);
+  const isVisualRefresh = useVisualRefresh();
+
+  // This useEffect hook is run once on component mount to initiate the funnel analytics.
+  // It first calls the 'funnelStart' method from FunnelMetrics, providing all necessary details
+  // about the funnel, and receives a unique interaction id.
+  // This unique interaction id is then stored in the state for further use.
+  //
+  // On component unmount, it checks whether the funnel was successfully completed.
+  // Based on this, it either calls 'funnelComplete' or 'funnelCancelled' method from FunnelMetrics.
+  //
+  // The eslint-disable is required as we deliberately want this effect to run only once on mount and unmount,
+  // hence we do not provide any dependencies.
+  useEffect(() => {
+    const funnelInteractionId = FunnelMetrics.funnelStart({
+      funnelNameSelector: getFunnelNameSelector(),
+      optionalStepNumbers: props.optionalStepNumbers,
+      funnelType: props.funnelType,
+      totalFunnelSteps: props.totalFunnelSteps,
+      componentVersion: PACKAGE_VERSION,
+      componentTheme: isVisualRefresh ? 'vr' : 'classic',
+      funnelVersion: FUNNEL_VERSION,
+    });
+
+    setFunnelInteractionId(funnelInteractionId);
+
+    return () => {
+      if (funnelResultRef.current === true) {
+        FunnelMetrics.funnelComplete({ funnelInteractionId });
+      } else {
+        FunnelMetrics.funnelCancelled({ funnelInteractionId });
+      }
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const funnelSubmit = () => {
+    funnelResultRef.current = true;
+  };
+
+  const funnelCancel = () => {
+    funnelResultRef.current = false;
+  };
+
+  const funnelContextValue: FunnelContextValue = {
+    funnelInteractionId,
+    setFunnelInteractionId,
+    funnelType: props.funnelType,
+    optionalStepNumbers: props.optionalStepNumbers,
+    totalFunnelSteps: props.totalFunnelSteps,
+    funnelSubmit,
+    funnelCancel,
+  };
+
+  return <FunnelContext.Provider value={funnelContextValue}>{children}</FunnelContext.Provider>;
+};
+
+type AnalyticsFunnelStepProps = { children?: React.ReactNode } & Pick<
+  FunnelStepProps,
+  'stepNumber' | 'stepNameSelector'
+>;
+
+export const AnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: AnalyticsFunnelStepProps) => {
+  const { funnelInteractionId } = useFunnel();
+
+  // This useEffect hook is used to track the start and completion of interaction with the step.
+  // On mount, if there is a valid funnel interaction id, it calls the 'funnelStepStart' method from FunnelMetrics
+  // to record the beginning of the interaction with the current step.
+  // On unmount, it does a similar thing but this time calling 'funnelStepComplete' to record the completion of the interaction.
+  useEffect(() => {
+    if (funnelInteractionId) {
+      FunnelMetrics.funnelStepStart({
+        funnelInteractionId,
+        stepNumber,
+        stepNameSelector,
+        subStepAllSelector: getSubStepAllSelector(),
+      });
+    }
+
+    return () => {
+      if (funnelInteractionId) {
+        FunnelMetrics.funnelStepComplete({
+          funnelInteractionId,
+          stepNumber,
+          stepNameSelector,
+          subStepAllSelector: getSubStepAllSelector(),
+        });
+      }
+    };
+  }, [funnelInteractionId, stepNumber, stepNameSelector]);
+
+  return (
+    <FunnelStepContext.Provider value={{ funnelInteractionId, stepNumber, stepNameSelector }}>
+      {children}
+    </FunnelStepContext.Provider>
+  );
+};
+
+interface AnalyticsFunnelSubStepProps {
+  children?: React.ReactNode;
+}
+
+export const AnalyticsFunnelSubStep = ({ children }: AnalyticsFunnelSubStepProps) => {
+  const { funnelInteractionId } = useFunnel();
+  const { stepNumber, stepNameSelector } = useFunnelStep();
+
+  const subStepId = useUniqueId('substep');
+  const subStepSelector = getSubStepSelector(subStepId);
+  const subStepNameSelector = getSubStepNameSelector(subStepId);
+
+  return (
+    <FunnelSubStepContext.Provider
+      value={{
+        funnelInteractionId,
+        stepNumber,
+        stepNameSelector,
+        subStepSelector,
+        subStepNameSelector,
+        subStepId,
+      }}
+    >
+      {children}
+    </FunnelSubStepContext.Provider>
+  );
+};

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext } from 'react';
+import { FunnelType } from '../interfaces';
+
+export interface BaseContextProps {
+  funnelInteractionId: string | undefined;
+}
+
+export interface FunnelContextValue extends BaseContextProps {
+  funnelType: FunnelType;
+  optionalStepNumbers: number[];
+  totalFunnelSteps: number;
+  funnelSubmit: () => void;
+  funnelCancel: () => void;
+  setFunnelInteractionId: (funnelInteractionId: string) => void;
+}
+
+export interface FunnelStepContextValue extends BaseContextProps {
+  stepNameSelector: string;
+  stepNumber: number;
+}
+
+export interface FunnelSubStepContextValue extends FunnelStepContextValue {
+  subStepId: string;
+  subStepSelector: string;
+  subStepNameSelector: string;
+  stepNumber: number;
+}
+
+export const FunnelContext = createContext<FunnelContextValue>({
+  funnelInteractionId: undefined,
+  setFunnelInteractionId: () => {},
+  funnelType: 'single-page',
+  optionalStepNumbers: [],
+  totalFunnelSteps: 0,
+  funnelSubmit: () => {},
+  funnelCancel: () => {},
+});
+
+export const FunnelStepContext = createContext<FunnelStepContextValue>({
+  funnelInteractionId: undefined,
+  stepNameSelector: '',
+  stepNumber: 0,
+});
+
+export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({
+  funnelInteractionId: undefined,
+  subStepId: '',
+  stepNumber: 0,
+  stepNameSelector: '',
+  subStepSelector: '',
+  subStepNameSelector: '',
+});

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext, useRef } from 'react';
+import { FunnelContext, FunnelStepContext, FunnelSubStepContext } from '../context/analytics-context';
+import { getSubStepAllSelector } from '../selectors';
+import { FunnelMetrics } from '../';
+
+/**
+ * Custom React Hook to manage and interact with FunnelSubStep.
+ * This hook will provide necessary properties and methods required
+ * to track and manage interactions with a FunnelSubStep component.
+ *
+ * The `onFocus` method is used to track the beginning of interaction with the FunnelSubStep.
+ * The `onBlur` method is used to track the completion of interaction with the FunnelSubStep.
+ * The subStepId is a unique identifier for the funnel sub-step.
+ * The subStepRef is a reference to the DOM element of the funnel sub-step.
+ */
+export const useFunnelSubStep = () => {
+  const subStepRef = useRef<HTMLDivElement | null>(null);
+  const context = useContext(FunnelSubStepContext);
+  const { funnelInteractionId, subStepId, subStepSelector, subStepNameSelector, stepNumber, stepNameSelector } =
+    context;
+
+  const onFocus = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (
+      funnelInteractionId &&
+      subStepRef.current &&
+      (!event.relatedTarget || !subStepRef.current.contains(event.relatedTarget as Node))
+    ) {
+      FunnelMetrics.funnelSubStepStart({
+        funnelInteractionId,
+        subStepSelector,
+        subStepNameSelector,
+        stepNumber,
+        stepNameSelector,
+        subStepAllSelector: getSubStepAllSelector(),
+      });
+    }
+  };
+
+  const onBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (funnelInteractionId && subStepRef.current && !subStepRef.current.contains(event.relatedTarget)) {
+      FunnelMetrics.funnelSubStepComplete({
+        funnelInteractionId,
+        subStepSelector,
+        subStepNameSelector,
+        stepNumber,
+        stepNameSelector,
+        subStepAllSelector: getSubStepAllSelector(),
+      });
+    }
+  };
+
+  const funnelSubStepProps: Record<string, any> = {
+    'data-analytics-funnel-substep': subStepId,
+    onFocus,
+    onBlur,
+  };
+
+  return { funnelSubStepProps, subStepRef, ...context };
+};
+
+/**
+ * Custom React Hook to manage and interact with FunnelStep.
+ * This hook will provide necessary properties required to track
+ * and manage interactions with a FunnelStep component.
+ *
+ * The 'data-analytics-funnel-step-index' property of funnelStepProps is used to track the index of the current step in the funnel.
+ * The context contains additional properties of the FunnelStep.
+ */
+export const useFunnelStep = () => {
+  const context = useContext(FunnelStepContext);
+  const funnelStepProps: Record<string, string | number | boolean | undefined> = {
+    'data-analytics-funnel-step-index': context.stepNumber,
+  };
+
+  return { funnelStepProps, ...context };
+};
+
+/**
+ * Custom React Hook to manage and interact with Funnel.
+ * This hook will provide necessary properties required to track
+ * and manage interactions with a Funnel component.
+ *
+ * The 'data-analytics-funnel-interaction-id' property of funnelProps is used to track the unique identifier of the current interaction with the funnel.
+ */
+export const useFunnel = () => {
+  const context = useContext(FunnelContext);
+  const funnelProps: Record<string, string | number | boolean | undefined> = {
+    'data-analytics-funnel-interaction-id': context.funnelInteractionId,
+  };
+
+  return { funnelProps, ...context };
+};

--- a/src/internal/analytics/index.ts
+++ b/src/internal/analytics/index.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+/* istanbul ignore file */
+
+import { IFunnelMetrics } from './interfaces';
+
+export function setFunnelMetrics(funnelMetrics: IFunnelMetrics) {
+  FunnelMetrics = funnelMetrics;
+}
+
+/**
+ * This is a stub implementation of the FunnelMetrics interface and will be replaced during
+ * build time with the actual implementation.
+ */
+export let FunnelMetrics: IFunnelMetrics = {
+  funnelStart(): string {
+    return '';
+  },
+
+  funnelError(): void {},
+  funnelComplete(): void {},
+  funnelSuccessful(): void {},
+  funnelCancelled(): void {},
+  funnelStepStart(): void {},
+  funnelStepComplete(): void {},
+  funnelStepNavigation(): void {},
+  funnelSubStepStart(): void {},
+  funnelSubStepComplete(): void {},
+  funnelSubStepError(): void {},
+  helpPanelInteracted(): void {},
+  externalLinkInteracted(): void {},
+};

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type FunnelType = 'single-page' | 'multi-page';
+
+// Common properties for all funnels
+export interface BaseFunnelProps {
+  funnelInteractionId: string;
+}
+
+export interface FunnelProps extends BaseFunnelProps {
+  totalFunnelSteps: number;
+  optionalStepNumbers: number[];
+  funnelType: FunnelType;
+}
+
+export interface FunnelStartProps {
+  funnelNameSelector: string;
+  totalFunnelSteps: number;
+  optionalStepNumbers: number[];
+  funnelType: FunnelType;
+  funnelVersion: string;
+  componentVersion: string;
+  componentTheme: string;
+}
+
+// A function type for a generic funnel method
+export type FunnelMethod<T extends BaseFunnelProps> = (props: T) => void;
+
+// A function type specifically for funnelStart
+export type FunnelStartMethod = (props: FunnelStartProps) => string;
+
+// Define individual method props by extending the base
+export interface FunnelStepProps extends BaseFunnelProps {
+  stepNumber: number;
+  stepNameSelector: string;
+  subStepAllSelector: string;
+}
+
+export interface FunnelStepNavigationProps extends FunnelStepProps {
+  destinationStepNumber: number;
+  navigationType: string;
+}
+
+export interface FunnelSubStepProps extends FunnelStepProps {
+  subStepSelector: string;
+  subStepNameSelector?: string;
+}
+
+export interface FunnelSubStepErrorProps extends FunnelSubStepProps {
+  fieldLabelSelector: string;
+  fieldErrorSelector: string;
+}
+
+export interface OptionalFunnelSubStepErrorProps extends FunnelSubStepProps {
+  fieldLabelSelector?: string;
+  fieldErrorSelector?: string;
+}
+
+export interface FunnelLinkInteractionProps extends FunnelSubStepProps {
+  elementSelector: string;
+}
+
+// Define the interface using the method type
+export interface IFunnelMetrics {
+  funnelStart: FunnelStartMethod;
+  funnelError: FunnelMethod<BaseFunnelProps>;
+  funnelComplete: FunnelMethod<BaseFunnelProps>;
+  funnelSuccessful: FunnelMethod<BaseFunnelProps>;
+  funnelCancelled: FunnelMethod<BaseFunnelProps>;
+  funnelStepStart: FunnelMethod<FunnelStepProps>;
+  funnelStepComplete: FunnelMethod<FunnelStepProps>;
+  funnelStepNavigation: FunnelMethod<FunnelStepNavigationProps>;
+  funnelSubStepStart: FunnelMethod<FunnelSubStepProps>;
+  funnelSubStepComplete: FunnelMethod<FunnelSubStepProps>;
+  funnelSubStepError: FunnelMethod<OptionalFunnelSubStepErrorProps>;
+  helpPanelInteracted: FunnelMethod<FunnelLinkInteractionProps>;
+  externalLinkInteracted: FunnelMethod<FunnelLinkInteractionProps>;
+}

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export const getFunnelNameSelector = () => '[data-analytics-context="breadcrumb"]';
+export const getSubStepAllSelector = () => `[data-analytics-substep]`;
+export const getSubStepSelector = (subStepId: string) => `[data-analytics-substep="${subStepId}"]`;
+export const getSubStepNameSelector = (subStepId: string) =>
+  `[data-analytics-substep="${subStepId}"] [data-analytics="heading-text"]`;
+export const getElementSelector = (uniqueId: string) => `[data-analytics-element-id="${uniqueId}"]`;

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh-static.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-refresh-static.test.tsx
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { useVisualRefresh } from '../index';
 import { render, screen } from '@testing-library/react';
+import { useVisualRefresh } from '../../../../../lib/components/internal/hooks/use-visual-mode';
 
-jest.mock('../../../environment', () => ({ ALWAYS_VISUAL_REFRESH: true }), { virtual: true });
+jest.mock('../../../../../lib/components/internal/environment', () => ({ ALWAYS_VISUAL_REFRESH: true }));
 
 describe('useVisualRefresh with locked visual refresh mode', () => {
   function App() {


### PR DESCRIPTION
### Description

This change includes all the context providers, hooks and a stubbed implementation to orchestrate funnel based metrics within the components.

Design documentation: https://tiny.amazon.com/1190or99x/quipBBl9Tech
This Draft PR holds a all of the proposed changes to show how these will be used across the various components: https://github.com/cloudscape-design/components/pull/1115/files#diff-dbf7be64bedaf235736054490dfada45331ea33b255c3a27d8b1f5a9aeb0c83c

#### Additional
- A follow up PRs will replace the existing implementation in Wizard and introduce the context and hooks to the Form, Container, FormField, Alert, Flashbar and Button components.
- An additional follow up CR will be created to inject the relevant Analytics library to replace the stubbed implementation at build time.

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests for the various components.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
