### PR TITLE
chore: Add page for ContentLayout without header

### DIFF
--- a/pages/content-layout/without-header.page.tsx
+++ b/pages/content-layout/without-header.page.tsx
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import AppLayout from '~components/app-layout';
+import ContentLayout from '~components/content-layout';
+import Container from '~components/container';
+import Toggle from '~components/toggle';
+import Flashbar from '~components/flashbar';
+import Header from '~components/header';
+import { Breadcrumbs } from '../app-layout/utils/content-blocks';
+import ScreenshotArea from '../utils/screenshot-area';
+import appLayoutLabels from '../app-layout/utils/labels';
+
+export default function () {
+  const [hasBreadcrumbs, setHasBreadcrumbs] = useState(false);
+  const [hasNotifications, setHasNotifications] = useState(false);
+  const [stickyNotifications, setStickyNotifications] = useState(true);
+  const [disableOverlap, setDisableOverlap] = useState(false);
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        contentType="form"
+        ariaLabels={appLayoutLabels}
+        stickyNotifications={stickyNotifications}
+        notifications={
+          hasNotifications && (
+            <Flashbar
+              items={[
+                {
+                  type: 'success',
+                  header: 'Success message',
+                  statusIconAriaLabel: 'success',
+                },
+              ]}
+            />
+          )
+        }
+        breadcrumbs={hasBreadcrumbs && <Breadcrumbs />}
+        content={
+          <ContentLayout disableOverlap={disableOverlap}>
+            <Container
+              header={
+                <Header variant="h2" headingTagOverride="h1">
+                  Container header
+                </Header>
+              }
+            >
+              <Toggle
+                checked={hasBreadcrumbs}
+                onChange={() => setHasBreadcrumbs(!hasBreadcrumbs)}
+                data-id="toggle-breadcrumbs"
+              >
+                Has breadcrumbs
+              </Toggle>
+              <Toggle
+                checked={hasNotifications}
+                onChange={() => setHasNotifications(!hasNotifications)}
+                data-id="toggle-notifications"
+              >
+                Has notifications
+              </Toggle>
+              <Toggle checked={stickyNotifications} onChange={() => setStickyNotifications(!stickyNotifications)}>
+                Sticky notifications
+              </Toggle>
+              <Toggle
+                checked={disableOverlap}
+                onChange={() => setDisableOverlap(!disableOverlap)}
+                data-id="toggle-overlap"
+              >
+                Disable overlap
+              </Toggle>
+              <div style={{ height: 2000 }}></div>
+            </Container>
+          </ContentLayout>
+        }
+      />
+    </ScreenshotArea>
+  );
+}


### PR DESCRIPTION
### Description

Adding a new page to be able to take screenshots of the current status, before making changes to the visuals in upcoming PRs.


### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ N/A
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
