### PR TITLE
fix: Split panel takes space even when no split panel is set

### DIFF
--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -8,6 +8,7 @@ import { KeyCode } from '../../../lib/components/internal/keycode';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import { renderComponent, splitPanelI18nStrings } from './utils';
 import splitPanelStyles from '../../../lib/components/split-panel/styles.selectors.js';
+import applayoutTools from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
 
 const defaultSplitPanel = (
   <SplitPanel i18nStrings={splitPanelI18nStrings} header="test header">
@@ -214,6 +215,25 @@ describe('Visual refresh only features', () => {
     const { wrapper } = renderComponent(<AppLayout />);
     expect(wrapper.find(`.${splitPanelStyles['open-button']}`)).toBeFalsy();
   });
+
+  test('should not show background color of split panel drawer when there is no splitPanel', () => {
+    isMocked = true;
+    const { wrapper } = renderComponent(
+      <AppLayout
+        splitPanel={null}
+        splitPanelOpen={true}
+        splitPanelSize={400}
+        splitPanelPreferences={{ position: 'side' }}
+        onSplitPanelPreferencesChange={noop}
+        onSplitPanelToggle={noop}
+        onSplitPanelResize={noop}
+      />
+    );
+    expect(wrapper.find('[data-testid="side-split-panel-drawer"]')?.getElement()).not.toHaveClass(
+      applayoutTools['has-tools-form-persistence']
+    );
+    isMocked = false;
+  });
 });
 
 test('should fire split panel toggle event', () => {
@@ -264,4 +284,17 @@ test('should fire split panel resize event', () => {
   );
   wrapper.findSplitPanel()!.findSlider()!.keydown(KeyCode.pageUp);
   expect(onSplitPanelResize).toHaveBeenCalledWith({ size: 460 });
+});
+
+test('should not set width on split panel drawer when there is no splitPanel', () => {
+  const { wrapper } = renderComponent(
+    <AppLayout
+      splitPanel={null}
+      splitPanelOpen={true}
+      splitPanelSize={400}
+      onSplitPanelToggle={noop}
+      splitPanelPreferences={{ position: 'side' }}
+    />
+  );
+  expect(wrapper.find('[data-testid="side-split-panel-drawer"]')?.getElement().style.width).toBeFalsy();
 });

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -689,7 +689,7 @@ const OldAppLayout = React.forwardRef(
                 topOffset={headerHeight}
                 bottomOffset={footerHeight}
                 displayed={splitPanelDisplayed}
-                width={splitPanelOpen ? splitPanelSize : undefined}
+                width={splitPanelDisplayed ? splitPanelSize : undefined}
               >
                 {splitPanelWrapped}
               </SideSplitPanelDrawer>

--- a/src/app-layout/split-panel-drawer/index.tsx
+++ b/src/app-layout/split-panel-drawer/index.tsx
@@ -14,7 +14,11 @@ interface SideSplitPanelDrawer {
 
 export function SideSplitPanelDrawer({ topOffset, bottomOffset, width, displayed, children }: SideSplitPanelDrawer) {
   return (
-    <div className={clsx(displayed && styles['drawer-displayed'])} style={{ width }}>
+    <div
+      className={clsx(displayed && styles['drawer-displayed'])}
+      style={{ width }}
+      data-testid="side-split-panel-drawer"
+    >
       <div className={styles['drawer-content']} style={{ width: width, top: topOffset, bottom: bottomOffset }}>
         {children}
       </div>

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -36,6 +36,7 @@ export default function Tools({ children }: ToolsProps) {
     isSplitPanelOpen,
     isToolsOpen,
     loseToolsFocus,
+    splitPanel,
     splitPanelDisplayed,
     splitPanelPosition,
     splitPanelRefs,
@@ -46,7 +47,7 @@ export default function Tools({ children }: ToolsProps) {
     toolsWidth,
   } = useAppLayoutInternals();
 
-  const hasSplitPanel = getSplitPanelStatus(splitPanelDisplayed, splitPanelPosition);
+  const hasSplitPanel = !!splitPanel && getSplitPanelStatus(splitPanelDisplayed, splitPanelPosition);
   const hasToolsForm = getToolsFormStatus(hasSplitPanel, isMobile, isSplitPanelOpen, isToolsOpen, toolsHide);
   const hasToolsFormPersistence = getToolsFormPersistence(hasSplitPanel, isSplitPanelOpen, isToolsOpen, toolsHide);
   const isUnfocusable = hasDrawerViewportOverlay && !isToolsOpen;
@@ -124,6 +125,7 @@ export default function Tools({ children }: ToolsProps) {
                 [styles['has-tools-form-persistence']]: hasToolsFormPersistence,
               })}
               ref={state === 'exiting' ? transitionEventsRef : undefined}
+              data-testid="side-split-panel-drawer"
             >
               {!toolsHide && (
                 <TriggerButton


### PR DESCRIPTION
### Description

Split Panel always takes width when `splitPanelOpen` and `splitPanelSize` are set even when no `splitPanel` is set.

Related links, issue #AWSUI-21104

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit tests. 

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
