### PR TITLE
fix: Table sticky scrollbar dangling when draging the table

### DIFF
--- a/src/table/__integ__/sticky-scrollbar.test.ts
+++ b/src/table/__integ__/sticky-scrollbar.test.ts
@@ -5,7 +5,6 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 const tableWrapper = createWrapper().findTable();
 import styles from '../../../lib/components/table/styles.selectors.js';
-import splitPanelStyles from '../../../lib/components/split-panel/styles.selectors.js';
 
 const scrollbarSelector = `.${styles['sticky-scrollbar-visible']}`;
 
@@ -61,14 +60,6 @@ describe('Sticky scrollbar', () => {
     })
   );
   test(
-    `is hidden, when table bottom is in view`,
-    setupTest(async page => {
-      await page.windowScrollTo({ top: 1000 });
-      await page.waitForVisible(tableWrapper.findRows().toSelector());
-      await expect(page.isExisting(await page.findVisibleScrollbar())).resolves.toEqual(false);
-    })
-  );
-  test(
     `scrollbar position updates when window resizes`,
     setupTest(async page => {
       await page.setWindowSize({ width: 600, height: 400 });
@@ -80,34 +71,3 @@ describe('Sticky scrollbar', () => {
     })
   );
 });
-
-[false, true].forEach(visualRefresh =>
-  describe(`visualRefresh=${visualRefresh}`, () => {
-    test(
-      'Table sticky scrollbar should not be shown when bottom is visible in split panel in page with footer',
-      useBrowser(async browser => {
-        const page = new BasePageObject(browser);
-        await page.setWindowSize({ width: 1600, height: 400 });
-        await browser.url(`#/light/app-layout/with-table-and-split-panel?visualRefresh=${visualRefresh}`);
-
-        const wrapper = createWrapper();
-        await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-        await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-        await page.click(wrapper.findModal().findContent().findTiles().findItemByValue('side').toSelector());
-        await page.click('button=Confirm');
-        const { bottom } = await page.getBoundingBox(
-          wrapper.find(`.${splitPanelStyles['content-side']}`).findTable().toSelector()
-        );
-        const { bottom: parentBottom } = await page.getBoundingBox(
-          wrapper.find(`.${splitPanelStyles['content-side']}`).toSelector()
-        );
-        await page.elementScrollTo(wrapper.find(`.${splitPanelStyles['content-side']}`).toSelector(), {
-          top: bottom - parentBottom + 15,
-        });
-        await expect(
-          page.isExisting(await wrapper.find(`.${splitPanelStyles['content-side']} ${scrollbarSelector}`).toSelector())
-        ).resolves.toEqual(false);
-      })
-    );
-  })
-);

--- a/src/table/__tests__/sticky-scrollbar.test.ts
+++ b/src/table/__tests__/sticky-scrollbar.test.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { updatePosition } from '../../../lib/components/table/use-sticky-scrollbar';
+
+describe('updatePosition', () => {
+  it('satisfies istanbul coverage', () => {
+    const scrollbarRef = {
+      current: document.createElement('div'),
+    };
+    const scrollbarContentRef = {
+      current: document.createElement('div'),
+    };
+    const tableRef = {
+      current: document.createElement('table'),
+    };
+    tableRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ width: 800 });
+    const wrapperRef = {
+      current: document.createElement('div'),
+    };
+    wrapperRef.current.getBoundingClientRect = jest.fn().mockReturnValue({ width: 600 });
+
+    updatePosition(tableRef.current, wrapperRef.current, scrollbarRef.current, scrollbarContentRef.current, false, 30);
+    expect(scrollbarRef.current.style.bottom).toBe('30px');
+    expect(scrollbarRef.current.style.width).toBe('600px');
+    expect(scrollbarContentRef.current.style.width).toBe('800px');
+  });
+});

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -154,7 +154,6 @@ filter search icon.
   display: none;
   overflow-x: auto;
   overflow-y: hidden;
-  margin-top: -15px;
   bottom: 0;
   width: 100%;
 
@@ -163,6 +162,11 @@ filter search icon.
   }
   &-visible {
     display: block;
+  }
+  &-native-invisible {
+    // Native scrollbar does not take space when it is not always invisible
+    // For example it is set as "show when scrolling"
+    margin-top: -15px;
   }
 }
 

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -66,6 +66,8 @@
   padding-top: awsui.$space-table-content-top;
   padding-bottom: awsui.$space-table-content-bottom;
   overflow-x: auto;
+
+  scrollbar-width: none; /* Hide scrollbar in Firefox */
   &.variant-stacked,
   &.variant-container {
     & > .table {
@@ -85,6 +87,9 @@
   &:not(.has-header) {
     border-top-right-radius: awsui.$border-radius-container;
     border-top-left-radius: awsui.$border-radius-container;
+  }
+  &::-webkit-scrollbar {
+    display: none; /* Hide scrollbar in Safari and Chrome */
   }
 
   @include focus-visible.when-visible {
@@ -145,7 +150,7 @@ filter search icon.
 
 .sticky-scrollbar {
   height: 15px;
-  position: fixed;
+  position: sticky;
   display: none;
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/table/use-sticky-scrollbar.ts
+++ b/src/table/use-sticky-scrollbar.ts
@@ -39,6 +39,10 @@ const updatePosition = (
     }
 
     scrollbarEl.classList.add(styles['sticky-scrollbar-visible']);
+    if (!scrollbarHeight) {
+      /* istanbul ignore next: covered by screenshot tests */
+      scrollbarEl.classList.add(styles['sticky-scrollbar-native-invisible']);
+    }
   }
 
   if (scrollbarHeight && scrollbarEl && scrollbarContentEl) {

--- a/src/table/use-sticky-scrollbar.ts
+++ b/src/table/use-sticky-scrollbar.ts
@@ -8,7 +8,7 @@ import { getOverflowParents } from '../internal/utils/scrollable-containers';
 import { browserScrollbarSize } from '../internal/utils/browser-scrollbar-size';
 import { supportsStickyPosition, getContainingBlock } from '../internal/utils/dom';
 
-const updatePosition = (
+export const updatePosition = (
   tableEl: HTMLElement | null,
   wrapperEl: HTMLElement | null,
   scrollbarEl: HTMLElement | null,


### PR DESCRIPTION
### Description

- Use `position: sticky` for sticky scrollbar of table. So that the scrollbar position moves together with the table. 
- Hide the real scrollbar but always use the fake one. Avoid the edge case that table start vibrating when scroll to the bottom, due to the cycle of fake scrollbar disappearing and reappearing.  

Related links, issue #AWSUI-21067

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
