### PR TITLE
feat: Add `renderAriaLive` to cards component

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3392,6 +3392,14 @@ Default value:
       "type": "string",
     },
     Object {
+      "description": " Use this property to inform screen readers which range of cards is currently displayed.
+ It specifies the index (1-based) of the first card.
+ If the cards list has no pagination, leave this property undefined.",
+      "name": "firstIndex",
+      "optional": true,
+      "type": "number",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
@@ -3437,6 +3445,13 @@ The \`cardDefinition\` property handles the display of this data.
       "type": "string",
     },
     Object {
+      "description": "Use this function to announce page changes to screen reader users.
+Requires the properties firstIndex and totalItemsCount to be set correctly.",
+      "name": "renderAriaLive",
+      "optional": true,
+      "type": "(data: CardsProps.LiveAnnouncement) => string",
+    },
+    Object {
       "description": "Specifies the list of selected items.",
       "name": "selectedItems",
       "optional": true,
@@ -3466,6 +3481,14 @@ The \`cardDefinition\` property handles the display of this data.
       "description": "Optionally provide a vertical offset (in pixels) for the sticky header, for example if you
 need to position the sticky header below other fixed position elements on the page.",
       "name": "stickyHeaderVerticalOffset",
+      "optional": true,
+      "type": "number",
+    },
+    Object {
+      "description": "Use this property to inform screen readers how many cards there are.
+It specifies the total number of cards.
+If there is an unknown total number of cards, leave this property undefined.",
+      "name": "totalItemsCount",
       "optional": true,
       "type": "number",
     },

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import Cards, { CardsProps } from '../../../lib/components/cards';
 import { CardsWrapper } from '../../../lib/components/test-utils/dom';
+import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 
 interface Item {
   id: number;
@@ -219,6 +220,29 @@ describe('Cards', () => {
       ).wrapper;
       expect(wrapper.findItems()).toHaveLength(0);
       expect(wrapper?.findLoadingText()?.getElement()).toHaveTextContent('Resources loading');
+    });
+  });
+  describe('live region', () => {
+    test('Should render a live region with table total count and indices when renderAriaLive and firstIndex are available', () => {
+      const firstIndex = 1;
+      const totalItemsCount = defaultItems.length;
+      const lastIndex = firstIndex + defaultItems.length - 1;
+
+      const wrapper = renderCards(
+        <Cards<Item>
+          cardDefinition={cardDefinition}
+          items={defaultItems}
+          firstIndex={firstIndex}
+          totalItemsCount={totalItemsCount}
+          renderAriaLive={({ firstIndex, lastIndex, totalItemsCount }) =>
+            `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
+          }
+        />
+      ).wrapper;
+
+      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
+        `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
+      );
     });
   });
 });

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -48,6 +48,9 @@ const Cards = React.forwardRef(function <T = any>(
     stickyHeader,
     stickyHeaderVerticalOffset,
     variant = 'container',
+    renderAriaLive,
+    firstIndex,
+    totalItemsCount,
     ...rest
   }: CardsProps<T>,
   ref: React.Ref<CardsProps.Ref>
@@ -141,6 +144,11 @@ const Cards = React.forwardRef(function <T = any>(
         __darkHeader={computedVariant === 'full-page'}
       >
         <div className={clsx(hasToolsHeader && styles['has-header'])}>
+          {!!renderAriaLive && !!firstIndex && (
+            <LiveRegion>
+              <span>{renderAriaLive({ totalItemsCount, firstIndex, lastIndex: firstIndex + items.length - 1 })}</span>
+            </LiveRegion>
+          )}
           {status ?? (
             <CardsList
               items={items}

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -183,6 +183,22 @@ export interface CardsProps<T = any> extends BaseComponentProps {
   stickyHeaderVerticalOffset?: number;
 
   /**
+   * Use this property to inform screen readers how many cards there are.
+   * It specifies the total number of cards.
+   * If there is an unknown total number of cards, leave this property undefined.   */
+  totalItemsCount?: number;
+  /**
+   *  Use this property to inform screen readers which range of cards is currently displayed.
+   *  It specifies the index (1-based) of the first card.
+   *  If the cards list has no pagination, leave this property undefined.   */
+  firstIndex?: number;
+  /**
+   * Use this function to announce page changes to screen reader users.
+   * Requires the properties firstIndex and totalItemsCount to be set correctly.
+   */
+  renderAriaLive?: (data: CardsProps.LiveAnnouncement) => string;
+
+  /**
    * Specify a cards variant with one of the following:
    * * `container` - Use this variant to have the cards displayed as a container.
    * * `full-page` – Use this variant when cards are the entire content of a page. Full page variants
@@ -229,6 +245,13 @@ export namespace CardsProps {
     selectionGroupLabel: string;
     cardsLabel?: string;
   }
+
+  export interface LiveAnnouncement {
+    totalItemsCount?: number;
+    firstIndex: number;
+    lastIndex: number;
+  }
+
   export interface Ref {
     /**
      * When the sticky header is enabled, calling this function scrolls cards's


### PR DESCRIPTION
### Description

We added this to table but not cards, however the same functionality is useful there too.

Related links, issue #, if available: n/a

### How has this been tested?

New unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
