### PR TITLE
fix: Split panel takes space even when no split panel is closed

### DIFF
--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -689,7 +689,7 @@ const OldAppLayout = React.forwardRef(
                 topOffset={headerHeight}
                 bottomOffset={footerHeight}
                 displayed={splitPanelDisplayed}
-                width={splitPanelDisplayed ? splitPanelSize : undefined}
+                width={splitPanelOpen && splitPanel ? splitPanelSize : undefined}
               >
                 {splitPanelWrapped}
               </SideSplitPanelDrawer>


### PR DESCRIPTION
### Description

A follow up fix for regression caused by https://github.com/cloudscape-design/components/pull/1114.
Split Panel show not take space when it is closed or not set. 
Did not add more tests in this PR because it was caught be screenshot test.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
