### PR TITLE
fix: Top navigation overflow menu does not close when clicking menu item

### DIFF
--- a/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
@@ -3,6 +3,7 @@
 import { TopNavigationProps } from '../../../lib/components/top-navigation/interfaces';
 import { transformUtility } from '../../../lib/components/top-navigation/1.0-beta/parts/overflow-menu';
 import { UtilityMenuItem } from '../../../lib/components/top-navigation/parts/overflow-menu/menu-item';
+import UtilitiesView from '../../../lib/components/top-navigation/parts/overflow-menu/views/utilities';
 import SubmenuView from '../../../lib/components/top-navigation/parts/overflow-menu/views/submenu';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { act, render } from '@testing-library/react';
@@ -166,6 +167,25 @@ describe('Submenu', () => {
     act(() => wrapper.click({ ctrlKey: true }));
     expect(onClick).toBeCalledTimes(2);
   });
+
+  test('onClose is fired when clicking on submenuItem', () => {
+    const onClose = jest.fn();
+
+    const wrapper = createWrapper(
+      render(
+        <SubmenuView
+          definition={{
+            type: 'menu-dropdown',
+            items: [{ id: 'one', text: 'One', href: '#' }],
+          }}
+          onClose={onClose}
+        />
+      ).container
+    ).find('a')!;
+
+    act(() => wrapper.click());
+    expect(onClose).toBeCalledTimes(1);
+  });
 });
 
 describe('UtilityMenuItem', () => {
@@ -200,4 +220,33 @@ describe('UtilityMenuItem', () => {
       expect(onClick).toBeCalledWith(expect.objectContaining({ detail: {} }));
     }
   );
+
+  test('onClose is fired when clicking on utilityMenuItem', () => {
+    const onClose = jest.fn();
+
+    const wrapper = createWrapper(
+      render(
+        <UtilitiesView
+          items={[
+            {
+              type: 'button',
+              variant: 'primary-button',
+              text: 'New Thing',
+            },
+            {
+              type: 'button',
+              href: '#',
+            },
+          ]}
+          onClose={onClose}
+        />
+      ).container
+    );
+
+    act(() => wrapper.find('button')!.click());
+    expect(onClose).toBeCalledTimes(1);
+
+    act(() => wrapper.find('a')!.click());
+    expect(onClose).toBeCalledTimes(2);
+  });
 });

--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -169,7 +169,7 @@ const ExpandableItem: React.FC<
 };
 
 function utilityComponentFactory(
-  utility: TopNavigationProps.Utility,
+  utility: TopNavigationProps.Utility & { onClose?: () => void },
   index: number,
   ref?: React.Ref<HTMLAnchorElement & HTMLButtonElement>
 ) {
@@ -187,6 +187,7 @@ function utilityComponentFactory(
         }
 
         fireCancelableEvent(utility.onClick, {}, event);
+        utility.onClose?.();
       };
 
       const content = (
@@ -283,7 +284,7 @@ function dropdownComponentFactory(
   );
 }
 
-type UtilityMenuItemProps = TopNavigationProps.Utility & { index: number };
+type UtilityMenuItemProps = TopNavigationProps.Utility & { index: number; onClose?: () => void };
 
 export const UtilityMenuItem = forwardRef(
   ({ index, ...props }: UtilityMenuItemProps, ref: React.Ref<HTMLAnchorElement & HTMLButtonElement>) => {

--- a/src/top-navigation/parts/overflow-menu/views/submenu.tsx
+++ b/src/top-navigation/parts/overflow-menu/views/submenu.tsx
@@ -65,6 +65,7 @@ const SubmenuView = ({
                 { id: item.id, href: item.href, external: item.external },
                 event
               );
+              onClose?.();
             }}
           />
         ))}

--- a/src/top-navigation/parts/overflow-menu/views/utilities.tsx
+++ b/src/top-navigation/parts/overflow-menu/views/utilities.tsx
@@ -36,7 +36,13 @@ const UtilitiesView = ({ headerText, dismissIconAriaLabel, onClose, items = [], 
       </Header>
       <ul className={styles['overflow-menu-list']} aria-labelledby={headerId}>
         {items.map((utility, index) => (
-          <UtilityMenuItem key={index} index={index} ref={index === focusIndex ? ref : undefined} {...utility} />
+          <UtilityMenuItem
+            key={index}
+            index={index}
+            ref={index === focusIndex ? ref : undefined}
+            onClose={onClose}
+            {...utility}
+          />
         ))}
       </ul>
     </FocusLock>


### PR DESCRIPTION
### Description

Clicking on item in overflow menu should close the dropdown menu. It is how other dropdowns work(like ButtonDropdown). Moreover, we don't provide exposed functionality to close the menu dropdown to implement it from customer side. 

Related links, issue #AWSUI-21026

### How has this been tested?

<!-- How did you test to verify your changes? --> Add unit tests.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
