### PR TITLE
fix: Fix stickyColumnsFirst calculation in useStickyColumns hook argu…

### DIFF
--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -151,8 +151,6 @@ const InternalTable = React.forwardRef(
     const hasSelection = !!selectionType;
     const hasFooter = !!footer;
 
-    const noStickyColumns = !stickyColumns?.first && !stickyColumns?.last;
-
     const visibleColumnsWithSelection = useMemo(() => {
       const columnIds = visibleColumnDefinitions.map((it, index) => it.id ?? index.toString());
       return hasSelection ? [selectionColumnId.toString(), ...columnIds] : columnIds ?? [];
@@ -160,7 +158,7 @@ const InternalTable = React.forwardRef(
 
     const stickyState = useStickyColumns({
       visibleColumns: visibleColumnsWithSelection,
-      stickyColumnsFirst: noStickyColumns ? 0 : (stickyColumns?.first || 0) + (hasSelection ? 1 : 0),
+      stickyColumnsFirst: (stickyColumns?.first ?? 0) + (stickyColumns?.first && hasSelection ? 1 : 0),
       stickyColumnsLast: stickyColumns?.last || 0,
     });
 


### PR DESCRIPTION
### Description

Fixed calculation so that the selection cell doesn't get sticky if there are `stickyColumns.last` but no `stickyColumns.first`.

Before: https://d1shx1xnz9gwue.cloudfront.net/polaris/index.html#/light/table/sticky-columns/?visualRefresh=true&selectionType=single&stickyColumnsLast=1

After: https://d21d5uik3ws71m.cloudfront.net/components/a8b0d340b02ca9de8020d92302ba70a09696ca2d/index.html#/light/table/sticky-columns/?stickyColumnsFirst=0&selectionType=single&stickyColumnsLast=1

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
