### PR TITLE
chore: Add i18n support to chart components and popover

### DIFF
--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -7,6 +7,7 @@ import AreaChart, { AreaChartProps } from '../../../lib/components/area-chart';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 import popoverStyles from '../../../lib/components/popover/styles.css.js';
 import { warnOnce } from '../../../lib/components/internal/logging';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 import { cloneDeep } from 'lodash';
 import '../../__a11y__/to-validate-a11y';
 
@@ -433,4 +434,30 @@ test('warns when data series have different x values', () => {
   renderAreaChart(<AreaChart series={[s1, s2]} statusType="finished" />);
 
   expect(warnOnce).toHaveBeenCalledTimes(1);
+});
+
+describe('i18n', () => {
+  test('detailTotalLabel can be provided through provider', () => {
+    const { wrapper } = renderAreaChart(
+      <TestI18nProvider
+        messages={{
+          'area-chart': { 'i18nStrings.detailTotalLabel': 'Custom total label' },
+          popover: { dismissAriaLabel: 'Custom dismiss' },
+        }}
+      >
+        <AreaChart series={[areaSeries1]} statusType="finished" />
+      </TestI18nProvider>
+    );
+
+    // Show popover for the first data point.
+    wrapper.findApplication()!.focus();
+    // Pin popover.
+    wrapper.findApplication()!.keydown(KeyCode.enter);
+
+    expect(wrapper.findDetailPopover()!.findDismissButton()!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom dismiss'
+    );
+    expect(wrapper.findDetailPopover()!.findContent()!.getElement()).toHaveTextContent('Custom total label');
+  });
 });

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -77,6 +77,7 @@ test('error and recovery texts are assigned', () => {
       loadingText="Loading..."
       errorText="Ooops!"
       recoveryText="Try again"
+      onRecoveryClick={() => {}}
     />
   );
   expect(wrapper.findStatusContainer()!.getElement()).toHaveTextContent('Ooops! Try again');

--- a/src/area-chart/elements/use-highlight-details.ts
+++ b/src/area-chart/elements/use-highlight-details.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { CartesianChartProps } from '../../internal/components/cartesian-chart/interfaces';
 import { ChartSeriesDetailItem } from '../../internal/components/chart-series-details';
+import { useInternalI18n } from '../../internal/i18n/context';
 import { AreaChartProps } from '../interfaces';
 import { ChartModel } from '../model';
 import { useSelector } from '../model/async-store';
@@ -31,6 +32,7 @@ export default function useHighlightDetails<T extends AreaChartProps.DataTypes>(
   detailTotalFormatter?: CartesianChartProps.TickFormatter<number>;
   detailTotalLabel?: string;
 }): null | HighlightDetails {
+  const i18n = useInternalI18n('area-chart');
   const hX = useSelector(model.interactions, state => state.highlightedX);
   const hPoint = useSelector(model.interactions, state => state.highlightedPoint);
   const isPopoverPinned = useSelector(model.interactions, state => state.isPopoverPinned);
@@ -53,7 +55,7 @@ export default function useHighlightDetails<T extends AreaChartProps.DataTypes>(
   });
   const totalDetails = [
     {
-      key: detailTotalLabel || '',
+      key: i18n('i18nStrings.detailTotalLabel', detailTotalLabel) || '',
       value: detailTotalFormatter
         ? detailTotalFormatter(detailsTotal)
         : yTickFormatter

--- a/src/area-chart/interfaces.ts
+++ b/src/area-chart/interfaces.ts
@@ -18,6 +18,7 @@ export interface AreaChartProps<T extends AreaChartProps.DataTypes>
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: AreaChartProps.I18nStrings<T>;
 }

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -9,6 +9,7 @@ import { TICK_LENGTH, TICK_LINE_HEIGHT, TICK_MARGIN } from './constants';
 
 import styles from './styles.css.js';
 import { formatTicks, getVisibleTicks } from './label-utils';
+import { useInternalI18n } from '../../i18n/context';
 
 interface BottomLabelsProps {
   axis?: 'x' | 'y';
@@ -40,6 +41,7 @@ function BottomLabels({
   offsetLeft = 0,
   offsetRight = 0,
 }: BottomLabelsProps) {
+  const i18n = useInternalI18n('[charts]');
   const virtualTextRef = useRef<SVGTextElement>(null);
 
   const xOffset = scale.isCategorical() && axis === 'x' ? Math.max(0, scale.d3Scale.bandwidth() - 1) / 2 : 0;
@@ -84,7 +86,7 @@ function BottomLabels({
       className={styles['labels-bottom']}
       aria-label={title}
       role="list"
-      aria-roledescription={ariaRoleDescription}
+      aria-roledescription={i18n('i18nStrings.ariaRoleDescription', ariaRoleDescription)}
       aria-hidden={true}
     >
       {visibleTicks.map(

--- a/src/internal/components/cartesian-chart/interfaces.ts
+++ b/src/internal/components/cartesian-chart/interfaces.ts
@@ -69,6 +69,7 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: CartesianChartProps.I18nStrings<T>;
 
@@ -137,16 +138,19 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * Text that is displayed when the chart is loading, i.e. when `statusType` is set to `"loading"`.
+   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that is displayed when the chart is in error state, i.e. when `statusType` is set to `"error"`.
+   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that is displayed next to the error text.
+   * @i18n
    **/
   recoveryText?: string;
 

--- a/src/internal/components/cartesian-chart/left-labels.tsx
+++ b/src/internal/components/cartesian-chart/left-labels.tsx
@@ -9,6 +9,7 @@ import { TICK_LENGTH, TICK_MARGIN } from './constants';
 import styles from './styles.css.js';
 import { formatTicks, getVisibleTicks } from './label-utils';
 import { ChartDataTypes } from '../../../mixed-line-bar-chart/interfaces';
+import { useInternalI18n } from '../../i18n/context';
 
 const OFFSET_PX = 12;
 
@@ -36,6 +37,7 @@ function LeftLabels({
   title,
   ariaRoleDescription,
 }: LeftLabelsProps) {
+  const i18n = useInternalI18n('[charts]');
   const virtualTextRef = useRef<SVGTextElement>(null);
 
   const yOffset = axis === 'x' && scale.isCategorical() ? Math.max(0, scale.d3Scale.bandwidth() - 1) / 2 : 0;
@@ -68,7 +70,7 @@ function LeftLabels({
       className={clsx(styles['labels-left'])}
       aria-label={title}
       role="list"
-      aria-roledescription={ariaRoleDescription}
+      aria-roledescription={i18n('i18nStrings.ariaRoleDescription', ariaRoleDescription)}
       aria-hidden={true}
     >
       {visibleTicks.map(

--- a/src/internal/components/chart-filter/__tests__/i18n.test.tsx
+++ b/src/internal/components/chart-filter/__tests__/i18n.test.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import ChartFilter from '../../../../../lib/components/internal/components/chart-filter';
+import createWrapper from '../../../../../lib/components/test-utils/dom';
+import TestI18nProvider from '../../../../../lib/components/internal/i18n/testing';
+
+const datum0 = {};
+const datum1 = {};
+
+const series = [
+  { label: 'Chocolate', color: 'chocolate', type: 'line', datum: datum0 },
+  { label: 'Apples', color: 'red', type: 'rectangle', datum: datum1 },
+] as const;
+
+const defaultProps = {
+  series,
+  selectedSeries: [datum0],
+  onChange: jest.fn(),
+};
+
+function renderChartFilter(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return createWrapper(container);
+}
+
+it('uses filterLabel and filterPlaceholder from i18n provider', () => {
+  const wrapper = renderChartFilter(
+    <TestI18nProvider
+      messages={{
+        '[charts]': {
+          'i18nStrings.filterLabel': 'Custom filter label',
+          'i18nStrings.filterPlaceholder': 'Custom filter placeholder',
+        },
+      }}
+    >
+      <ChartFilter {...defaultProps} />
+    </TestI18nProvider>
+  );
+  expect(wrapper.findFormField()!.findLabel()!.getElement()).toHaveTextContent('Custom filter label');
+  expect(wrapper.findFormField()!.findControl()!.findMultiselect()!.findTrigger()!.getElement()).toHaveTextContent(
+    'Custom filter placeholder'
+  );
+});

--- a/src/internal/components/chart-filter/index.tsx
+++ b/src/internal/components/chart-filter/index.tsx
@@ -9,6 +9,7 @@ import InternalMultiselect from '../../../multiselect/internal';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { MultiselectProps } from '../../../multiselect/interfaces';
 import SeriesMarker, { ChartSeriesMarkerType } from '../chart-series-marker';
+import { useInternalI18n } from '../../i18n/context';
 
 import styles from './styles.css.js';
 
@@ -37,6 +38,7 @@ export default memo(ChartFilter) as typeof ChartFilter;
 function ChartFilter<T>({ series, i18nStrings, selectedSeries, onChange, ...restProps }: ChartFilterProps<T>) {
   const baseProps = getBaseProps(restProps);
   const className = clsx(baseProps.className, styles.root);
+  const i18n = useInternalI18n('[charts]');
 
   const defaultOptions = series.map((d, i) => ({
     label: d.label,
@@ -62,9 +64,13 @@ function ChartFilter<T>({ series, i18nStrings, selectedSeries, onChange, ...rest
   );
 
   return (
-    <InternalFormField {...baseProps} label={i18nStrings?.filterLabel} className={className}>
+    <InternalFormField
+      {...baseProps}
+      label={i18n('i18nStrings.filterLabel', i18nStrings?.filterLabel)}
+      className={className}
+    >
       <InternalMultiselect
-        placeholder={i18nStrings?.filterPlaceholder}
+        placeholder={i18n('i18nStrings.filterPlaceholder', i18nStrings?.filterPlaceholder)}
         options={defaultOptions}
         selectedOptions={selectedOptions}
         onChange={updateSelection}

--- a/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
+++ b/src/internal/components/chart-legend/__tests__/chart-legend.test.tsx
@@ -126,3 +126,14 @@ describe('Chart legend', () => {
     expect(legend.wrapper.find('[role="button"]')!.getElement().getAttribute('aria-pressed')).toBe('false');
   });
 });
+
+describe('i18n', () => {
+  test('ariaRole', () => {
+    const legend = renderChartLegend();
+
+    expect(legend.findAllLabels()).toEqual(series.map(s => s.label));
+    expect(legend.findHighlightedLabels()).toEqual([series[1].label]);
+    expect(legend.findDimmedLabels()).toEqual([series[0].label, series[2].label]);
+    expect(legend.findFocusedLabel()).toEqual(undefined);
+  });
+});

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -7,6 +7,7 @@ import InternalBox from '../../../box/internal';
 import { KeyCode } from '../../keycode';
 import SeriesMarker, { ChartSeriesMarkerType } from '../chart-series-marker';
 import styles from './styles.css.js';
+import { useInternalI18n } from '../../i18n/context';
 
 export interface ChartLegendItem<T> {
   label: string;
@@ -34,6 +35,7 @@ function ChartLegend<T>({
   ariaLabel,
   plotContainerRef,
 }: ChartLegendProps<T>) {
+  const i18n = useInternalI18n('[charts]');
   const containerRef = useRef<HTMLDivElement>(null);
   const segmentsRef = useRef<Record<number, HTMLElement>>([]);
 
@@ -104,7 +106,7 @@ function ChartLegend<T>({
       <div
         ref={containerRef}
         role="toolbar"
-        aria-label={legendTitle || ariaLabel}
+        aria-label={legendTitle || i18n('i18nStrings.legendAriaLabel', ariaLabel)}
         className={styles.root}
         onKeyDown={handleKeyPress}
         onBlur={handleBlur}

--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -11,6 +11,7 @@ import LiveRegion from '../live-region/index';
 import ApplicationController, { ApplicationRef } from './application-controller';
 import FocusOutline from './focus-outline';
 import { Offset } from '../interfaces';
+import { useInternalI18n } from '../../i18n/context.js';
 
 const DEFAULT_PLOT_FOCUS_OFFSET = 3;
 const DEFAULT_ELEMENT_FOCUS_OFFSET = 3;
@@ -92,6 +93,7 @@ function ChartPlot(
   }: ChartPlotProps,
   ref: React.Ref<ChartPlotRef>
 ) {
+  const i18n = useInternalI18n('[charts]');
   const svgRef = useRef<SVGSVGElement>(null);
   const applicationRef = useRef<ApplicationRef>(null);
   const plotClickedRef = useRef(false);
@@ -156,7 +158,7 @@ function ChartPlot(
         'aria-label': ariaLabel,
         'aria-labelledby': ariaLabelledby,
         'aria-describedby': ariaDescriptionId,
-        'aria-roledescription': ariaRoleDescription,
+        'aria-roledescription': i18n('i18nStrings.chartAriaRoleDescription', ariaRoleDescription),
       }
     : {};
 

--- a/src/internal/components/chart-status-container/__tests__/chart-status-container.test.tsx
+++ b/src/internal/components/chart-status-container/__tests__/chart-status-container.test.tsx
@@ -57,7 +57,7 @@ describe('Chart status container', () => {
 
   it('renders error state', () => {
     const { wrapper } = renderStatusContainer(
-      <ChartStatusContainer {...commonProps} isEmpty={true} statusType="error" />
+      <ChartStatusContainer {...commonProps} isEmpty={true} statusType="error" onRecoveryClick={() => {}} />
     );
     expect(wrapper.getElement()).toHaveTextContent('Error');
     expect(wrapper.getElement()).toHaveTextContent('Retry');

--- a/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
+++ b/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../../../lib/components/test-utils/dom';
+import TestI18nProvider from '../../../../../lib/components/internal/i18n/testing';
+import ChartStatusContainer from '../../../../../lib/components/internal/components/chart-status-container';
+import styles from '../../../../../lib/components/internal/components/chart-status-container/styles.css.js';
+
+function renderStatusContainer(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return createWrapper(container).findByClassName(styles.root)!;
+}
+
+it('uses loadingText from i18n provider', () => {
+  const wrapper = renderStatusContainer(
+    <TestI18nProvider messages={{ '[charts]': { loadingText: 'Custom loading' } }}>
+      <ChartStatusContainer statusType="loading" />
+    </TestI18nProvider>
+  );
+  expect(wrapper.getElement()).toHaveTextContent('Custom loading');
+});
+
+it('uses errorText and recoveryText from i18n provider', () => {
+  const wrapper = renderStatusContainer(
+    <TestI18nProvider messages={{ '[charts]': { errorText: 'Custom error', recoveryText: 'Custom recovery' } }}>
+      <ChartStatusContainer statusType="error" onRecoveryClick={() => {}} />
+    </TestI18nProvider>
+  );
+  expect(wrapper.getElement()).toHaveTextContent('Custom error Custom recovery');
+  expect(wrapper.find('a')!.getElement()).toHaveTextContent('Custom recovery');
+});
+
+it('does not use recoveryText from i18n provider if onRecoveryClick is not provided', () => {
+  const wrapper = renderStatusContainer(
+    <TestI18nProvider messages={{ '[charts]': { errorText: 'Custom error', recoveryText: 'Custom recovery' } }}>
+      <ChartStatusContainer statusType="error" />
+    </TestI18nProvider>
+  );
+  expect(wrapper.getElement()).toHaveTextContent('Custom error Custom recovery');
+  expect(wrapper.find('a')!.getElement()).toHaveTextContent('Custom recovery');
+});

--- a/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
+++ b/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
@@ -37,6 +37,5 @@ it('does not use recoveryText from i18n provider if onRecoveryClick is not provi
       <ChartStatusContainer statusType="error" />
     </TestI18nProvider>
   );
-  expect(wrapper.getElement()).toHaveTextContent('Custom error Custom recovery');
-  expect(wrapper.find('a')!.getElement()).toHaveTextContent('Custom recovery');
+  expect(wrapper.getElement()).toHaveTextContent('Custom error');
 });

--- a/src/internal/components/chart-status-container/index.tsx
+++ b/src/internal/components/chart-status-container/index.tsx
@@ -8,6 +8,7 @@ import InternalStatusIndicator from '../../../status-indicator/internal';
 import InternalLink from '../../../link/internal';
 
 import styles from './styles.css.js';
+import { useInternalI18n } from '../../i18n/context';
 
 interface ChartStatusContainerProps extends BaseComponentProps {
   statusType: 'loading' | 'finished' | 'error';
@@ -54,18 +55,21 @@ export default function ChartStatusContainer({
   isEmpty,
   showChart,
 }: ChartStatusContainerProps) {
+  const i18n = useInternalI18n('[charts]');
+
   const statusContainer = useMemo(() => {
     const handleRecoveryClick = (event: CustomEvent) => {
       event.preventDefault();
       fireNonCancelableEvent(onRecoveryClick);
     };
     if (statusType === 'error') {
+      const renderedRecoveryText = i18n('recoveryText', recoveryText);
       return (
         <span>
-          <InternalStatusIndicator type="error">{errorText}</InternalStatusIndicator>{' '}
-          {recoveryText && (
+          <InternalStatusIndicator type="error">{i18n('errorText', errorText)}</InternalStatusIndicator>{' '}
+          {!!renderedRecoveryText && !!onRecoveryClick && (
             <InternalLink onFollow={handleRecoveryClick} variant="recovery">
-              {recoveryText}
+              {renderedRecoveryText}
             </InternalLink>
           )}
         </span>
@@ -73,7 +77,7 @@ export default function ChartStatusContainer({
     }
 
     if (statusType === 'loading') {
-      return <InternalStatusIndicator type="loading">{loadingText}</InternalStatusIndicator>;
+      return <InternalStatusIndicator type="loading">{i18n('loadingText', loadingText)}</InternalStatusIndicator>;
     }
 
     if (isNoMatch) {
@@ -83,7 +87,7 @@ export default function ChartStatusContainer({
     if (isEmpty) {
       return <div className={styles.empty}>{empty}</div>;
     }
-  }, [statusType, onRecoveryClick, isEmpty, isNoMatch, recoveryText, loadingText, errorText, empty, noMatch]);
+  }, [i18n, statusType, onRecoveryClick, isEmpty, isNoMatch, recoveryText, loadingText, errorText, empty, noMatch]);
 
   return (
     <div className={styles.root} aria-live="polite" aria-atomic="true">

--- a/src/internal/i18n/testing.tsx
+++ b/src/internal/i18n/testing.tsx
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { I18nProvider } from './provider';
+
+export interface TestI18nProviderProps {
+  messages: Record<string, Record<string, string>>;
+  locale?: string;
+  children: React.ReactNode;
+}
+
+export default function TestI18nProvider({ messages = {}, locale = 'en', children }: TestI18nProviderProps) {
+  return (
+    <I18nProvider locale={locale} messages={[{ '@cloudscape-design/components': { [locale]: messages } }]}>
+      {children}
+    </I18nProvider>
+  );
+}

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -333,7 +333,9 @@ describe('States', () => {
   });
 
   test('error state is shown when error occurred', () => {
-    const { wrapper } = renderPieChart(<PieChart {...stateProps} data={[]} statusType="error" />);
+    const { wrapper } = renderPieChart(
+      <PieChart {...stateProps} data={[]} statusType="error" onRecoveryClick={() => {}} />
+    );
     expect(wrapper.findStatusContainer()?.getElement()).toHaveTextContent('Error');
     expect(wrapper.findStatusContainer()?.getElement()).toHaveTextContent('Recover');
   });

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -9,6 +9,7 @@ import PieChart, { PieChartProps } from '../../../lib/components/pie-chart';
 import styles from '../../../lib/components/pie-chart/styles.css.js';
 import * as colors from '../../../lib/design-tokens';
 import { act } from 'react-dom/test-utils';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const variants: Array<PieChartProps<PieChartProps.Datum>['variant']> = ['pie', 'donut'];
 const sizes: Array<PieChartProps<PieChartProps.Datum>['size']> = ['small', 'medium', 'large'];
@@ -79,7 +80,7 @@ describe('Chart container', () => {
 });
 
 describe('i18nStrings', () => {
-  test('are applied', () => {
+  test('are applied directly', () => {
     const i18nStrings: PieChartProps.I18nStrings = {
       detailsValue: 'Value',
       detailsPercentage: 'Percentage',
@@ -122,6 +123,48 @@ describe('i18nStrings', () => {
     );
     expect(detailPopover?.getElement()).toHaveTextContent(i18nStrings.detailsValue!);
     expect(detailPopover?.getElement()).toHaveTextContent(i18nStrings.detailsPercentage!);
+  });
+
+  test('are applied from i18n provider', () => {
+    const { wrapper } = renderPieChart(
+      <TestI18nProvider
+        messages={{
+          '[charts]': {
+            'i18nStrings.filterLabel': 'Custom filter label',
+            'i18nStrings.filterPlaceholder': 'Custom filter placeholder',
+            'i18nStrings.legendAriaLabel': 'Custom legend',
+            'i18nStrings.chartAriaRoleDescription': 'Custom chart',
+          },
+          'pie-chart': {
+            'i18nStrings.detailsValue': 'Custom value',
+            'i18nStrings.detailsPercentage': 'Custom percentage',
+            'i18nStrings.segmentAriaRoleDescription': 'Custom segment',
+          },
+        }}
+      >
+        <PieChart data={defaultData} />
+      </TestI18nProvider>
+    );
+
+    expect(wrapper.findChart()?.getElement()).toHaveAttribute('aria-roledescription', 'Custom chart');
+    expect(wrapper.findSegments()[0].getElement()).toHaveAttribute('aria-roledescription', 'Custom segment');
+
+    expect(wrapper.findFilterContainer()!.findFormField()?.findLabel()?.getElement()).toHaveTextContent(
+      'Custom filter label'
+    );
+    expect(wrapper.findFilterContainer()!.findMultiselect()?.findTrigger()?.getElement()).toHaveTextContent(
+      'Custom filter placeholder'
+    );
+
+    expect(wrapper.findLegend()!.getElement()).toHaveAttribute('aria-label', 'Custom legend');
+
+    // Open and pin one popover
+    wrapper.findApplication()!.focus();
+    wrapper.findApplication()!.keydown(KeyCode.enter);
+
+    const detailPopover = wrapper.findDetailPopover();
+    expect(detailPopover!.getElement()).toHaveTextContent('Custom value');
+    expect(detailPopover!.getElement()).toHaveTextContent('Custom percentage');
   });
 });
 

--- a/src/pie-chart/interfaces.ts
+++ b/src/pie-chart/interfaces.ts
@@ -151,16 +151,19 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * Text that's displayed when the chart is loading (that is, when `statusType` is set to `loading`).
+   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that's displayed when the chart is in error state (that is, when `statusType` is set to `error`).
+   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that's displayed next to the error text.
+   * @i18n
    **/
   recoveryText?: string;
 
@@ -203,6 +206,7 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * An object that contains all of the localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: PieChartProps.I18nStrings;
 }

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -21,6 +21,7 @@ import Segments from './segments';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import ChartPlot, { ChartPlotRef } from '../internal/components/chart-plot';
 import { SomeRequired } from '../internal/types';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export interface InternalChartDatum<T> {
   index: number;
@@ -128,7 +129,8 @@ export default <T extends PieChartProps.Datum>({
     return null;
   }, [pieData, highlightedSegment]);
 
-  const detailFunction = detailPopoverContent || defaultDetails(i18nStrings);
+  const i18n = useInternalI18n('pie-chart');
+  const detailFunction = detailPopoverContent || defaultDetails(i18n, i18nStrings);
   const details = tooltipData ? detailFunction(tooltipData.datum, dataSum) : [];
   const tooltipContent = tooltipData && <SeriesDetails details={details} />;
 

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -9,6 +9,7 @@ import { InternalChartDatum } from './pie-chart';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
 import clsx from 'clsx';
+import { useInternalI18n } from '../internal/i18n/context';
 
 interface SegmentsProps<T> {
   pieData: Array<PieArcDatum<InternalChartDatum<T>>>;
@@ -36,6 +37,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   onMouseOver,
   onMouseOut,
 }: SegmentsProps<T>) {
+  const i18n = useInternalI18n('pie-chart');
   const isRefresh = useVisualRefresh();
 
   const { arcFactory, highlightedArcFactory } = useMemo(() => {
@@ -91,7 +93,7 @@ export default function Segments<T extends PieChartProps.Datum>({
             ref={isHighlighted ? focusedSegmentRef : undefined}
             aria-label={`${datum.data.datum.title} (${datum.data.datum.value})`}
             role="button"
-            aria-roledescription={segmentAriaRoleDescription}
+            aria-roledescription={i18n('i18nStrings.segmentAriaRoleDescription', segmentAriaRoleDescription)}
           >
             <path d={arcPath} fill={datum.data.color} className={styles.segment__path} aria-hidden="true" />
             <path

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ComponentFormatFunction } from '../internal/i18n/context';
 import { PieChartProps } from './interfaces';
 import styles from './styles.css.js';
 
@@ -55,11 +56,12 @@ export const refreshDimensionsBySize: Record<NonNullable<PieChartProps['size']>,
 };
 
 export const defaultDetails =
-  (i18nStrings: PieChartProps.I18nStrings) => (datum: PieChartProps.Datum, dataSum: number) =>
+  (i18n: ComponentFormatFunction, i18nStrings: PieChartProps.I18nStrings) =>
+  (datum: PieChartProps.Datum, dataSum: number) =>
     [
-      { key: i18nStrings.detailsValue || '', value: datum.value },
+      { key: i18n('i18nStrings.detailsValue', i18nStrings.detailsValue) || '', value: datum.value },
       {
-        key: i18nStrings.detailsPercentage || '',
+        key: i18n('i18nStrings.detailsPercentage', i18nStrings.detailsPercentage) || '',
         value: `${((datum.value * 100) / dataSum).toFixed(0)}%`,
       },
     ];

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -8,6 +8,7 @@ import '../../__a11y__/to-validate-a11y';
 
 import styles from '../../../lib/components/popover/styles.selectors.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 class PopoverInternalWrapper extends PopoverWrapper {
   findBody({ renderWithPortal } = { renderWithPortal: false }): ElementWrapper | null {
@@ -188,6 +189,19 @@ describe('Keyboard interaction', () => {
     wrapper.findTrigger().click();
     wrapper.findTrigger().keydown(KeyCode.escape);
     expect(wrapper.findBody()).toBeNull();
+  });
+});
+
+describe('i18n', () => {
+  it('uses dismissAriaLabel from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider messages={{ popover: { dismissAriaLabel: 'Custom dismiss' } }}>
+        <Popover content="Content">Trigger</Popover>
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findPopover()!;
+    wrapper.findTrigger().click();
+    expect(wrapper.findDismissButton()!.getElement()).toHaveAttribute('aria-label', 'Custom dismiss');
   });
 });
 

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -10,6 +10,7 @@ import { InternalButton } from '../button/internal';
 import FocusLock from '../internal/components/focus-lock';
 
 import styles from './styles.css.js';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export interface PopoverBodyProps {
   dismissButton: boolean;
@@ -36,6 +37,7 @@ export default function PopoverBody({
   className,
   ariaLabelledby,
 }: PopoverBodyProps) {
+  const i18n = useInternalI18n('popover');
   const labelledById = useUniqueId('awsui-popover-');
   const dismissButtonFocused = useRef(false);
   const dismissButtonRef = useRef<ButtonProps.Ref>(null);
@@ -66,7 +68,7 @@ export default function PopoverBody({
         formAction="none"
         iconName="close"
         className={styles['dismiss-control']}
-        ariaLabel={dismissAriaLabel}
+        ariaLabel={i18n('dismissAriaLabel', dismissAriaLabel)}
         onClick={() => onDismiss()}
         ref={dismissButtonRef}
       />

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -51,6 +51,7 @@ export interface PopoverProps extends BaseComponentProps {
 
   /**
    * Adds an `aria-label` to the dismiss button for accessibility.
+   * @i18n
    */
   dismissAriaLabel?: string;
 


### PR DESCRIPTION
### Description

First batch of post-beta components for internationalization! The actual support addition is rather small; a lot of this PR is just tests. As before, we're continuing to add the integration as close to its use as possible, so a lot of chart subcomponents were updated. There are some additional things to consider:

- Simpler unit tests using an internal-only "TestI18nProvider"
- The addition of a new `@i18n` tag provided to interfaces

Related links, issue #, if available: n/a

### How has this been tested?

Unit testing. Generally each string is tested in unit tests. Also added a little test support provider so that we don't need to fake a locale and provide a full namespaced structure for each test case.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
