### PR TITLE
chore: Fix padding of borderless table in VR

### DIFF
--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -73,7 +73,8 @@
       padding-right: awsui.$space-table-horizontal;
     }
   }
-  &.variant-embedded {
+  &.variant-embedded,
+  &.variant-borderless {
     padding-bottom: awsui.$space-table-embedded-content-bottom;
   }
   &.has-header {
@@ -201,7 +202,8 @@ the default white background of the container component.
     padding-left: calc(awsui.$space-table-horizontal + awsui.$space-table-header-horizontal);
     padding-right: calc(awsui.$space-table-horizontal + awsui.$space-table-header-horizontal);
   }
-  &.variant-embedded {
+  &.variant-embedded,
+  &.variant-borderless {
     padding-left: awsui.$space-table-header-horizontal;
     padding-right: awsui.$space-table-header-horizontal;
     padding-top: awsui.$space-table-embedded-header-top;


### PR DESCRIPTION
### Description

Fixes an unintentional regression in borderless tables in VR, introduced in https://github.com/cloudscape-design/components/pull/1095

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
