### PR TITLE
feat: Add i18n support to cards, code editor

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4031,7 +4031,7 @@ The object should contain, among others:
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "CodeEditorProps.I18nStrings",
     },
     Object {

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import Cards, { CardsProps } from '../../../lib/components/cards';
 import { CardsWrapper } from '../../../lib/components/test-utils/dom';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 interface Item {
   id: number;
@@ -242,6 +243,20 @@ describe('Cards', () => {
 
       expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
         `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
+      );
+    });
+  });
+
+  describe('i18n', () => {
+    test('supports using selectionGroupLabel from i18n provider', () => {
+      ({ wrapper } = renderCards(
+        <TestI18nProvider messages={{ cards: { 'ariaLabels.selectionGroupLabel': 'Custom label' } }}>
+          <Cards<Item> cardDefinition={cardDefinition} selectionType="multi" items={defaultItems} />
+        </TestI18nProvider>
+      ));
+      expect(getCard(0).findSelectionArea()!.getElement()).toHaveAttribute(
+        'aria-label',
+        expect.stringContaining('Custom label')
       );
     });
   });

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -23,6 +23,7 @@ import LiveRegion from '../internal/components/live-region';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { supportsStickyPosition } from '../internal/utils/dom';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export { CardsProps };
 
@@ -72,6 +73,7 @@ const Cards = React.forwardRef(function <T = any>(
   const mergedRef = useMergeRefs(measureRef, refObject, __internalRootRef);
   const getMouseDownTarget = useMouseDownTarget();
 
+  const i18n = useInternalI18n('cards');
   const { isItemSelected, getItemSelectionProps, updateShiftToggle } = useSelection({
     items,
     trackBy,
@@ -79,7 +81,10 @@ const Cards = React.forwardRef(function <T = any>(
     selectionType,
     isItemDisabled,
     onSelectionChange,
-    ariaLabels,
+    ariaLabels: {
+      itemSelectionLabel: ariaLabels?.itemSelectionLabel,
+      selectionGroupLabel: i18n('ariaLabels.selectionGroupLabel', ariaLabels?.selectionGroupLabel),
+    },
   });
   const hasToolsHeader = header || filter || pagination || preferences;
   const headerRef = useRef<HTMLDivElement>(null);

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -18,6 +18,7 @@ import { warnOnce } from '../../../lib/components/internal/logging';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 import { createWrapper } from '@cloudscape-design/test-utils-core/dom';
 import '../../__a11y__/to-validate-a11y';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 jest.mock('../../../lib/components/internal/logging', () => ({
   warnOnce: jest.fn(),
@@ -327,8 +328,8 @@ describe('Code editor component', () => {
 
     const liveRegion = wrapper.findStatusBar()?.find(`.${liveRegionStyles.root}`)?.getElement().innerHTML;
 
-    expect(liveRegion).toContain(defaultProps.i18nStrings.errorsTab);
-    expect(liveRegion).toContain(defaultProps.i18nStrings.warningsTab);
+    expect(liveRegion).toContain(defaultProps.i18nStrings!.errorsTab);
+    expect(liveRegion).toContain(defaultProps.i18nStrings!.warningsTab);
   });
 
   it('moves cursor to annotation when clicked', () => {
@@ -472,5 +473,120 @@ describe('Code editor component', () => {
   test('a11y', async () => {
     const { wrapper } = renderCodeEditor();
     await expect(wrapper.getElement()).toValidateA11y();
+  });
+
+  describe('i18n', () => {
+    test('supports using i18nStrings.loadingState from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider messages={{ 'code-editor': { 'i18nStrings.loadingState': 'Custom loading' } }}>
+          <CodeEditor {...defaultProps} ace={undefined} loading={true} i18nStrings={undefined} />
+        </TestI18nProvider>
+      );
+      const wrapper = createWrapper(container).findCodeEditor()!;
+      expect(wrapper.findLoadingScreen()!.getElement()).toHaveTextContent('Custom loading');
+    });
+
+    test('supports using i18nStrings.errorState and i18nStrings.errorStateRecovery from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider
+          messages={{
+            'code-editor': {
+              'i18nStrings.errorState': 'Custom error',
+              'i18nStrings.errorStateRecovery': 'Custom recovery',
+            },
+          }}
+        >
+          <CodeEditor {...defaultProps} ace={undefined} i18nStrings={undefined} />
+        </TestI18nProvider>
+      );
+      const wrapper = createWrapper(container).findCodeEditor()!;
+      expect(wrapper.findErrorScreen()!.getElement()).toHaveTextContent('Custom error Custom recovery');
+      expect(wrapper.findErrorScreen()!.find('a')!.getElement()).toHaveTextContent('Custom recovery');
+    });
+
+    test('supports using group aria label and status bar strings from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider
+          messages={{
+            'code-editor': {
+              'i18nStrings.editorGroupAriaLabel': 'Custom editor',
+              'i18nStrings.statusBarGroupAriaLabel': 'Custom status bar',
+              'i18nStrings.errorsTab': 'Custom errors',
+              'i18nStrings.warningsTab': 'Custom warnings',
+              'i18nStrings.preferencesButtonAriaLabel': 'Custom settings',
+              'i18nStrings.cursorPosition': 'Custom row {row}, Custom col {column}',
+            },
+          }}
+        >
+          <CodeEditor {...defaultProps} i18nStrings={undefined} />
+        </TestI18nProvider>
+      );
+      const wrapper = createWrapper(container).findCodeEditor()!;
+      expect(wrapper.findEditor()!.getElement()).toHaveAttribute('aria-label', 'Custom editor');
+      expect(wrapper.find('[aria-label="Custom status bar"]')).toBeTruthy();
+      expect(wrapper.findStatusBar()!.getElement().textContent).toEqual(
+        expect.stringContaining('Custom row 1, Custom col 1')
+      );
+      expect(wrapper.findErrorsTab()!.getElement()).toHaveTextContent('Custom errors: 0');
+      expect(wrapper.findWarningsTab()!.getElement()).toHaveTextContent('Custom warnings: 0');
+      expect(wrapper.findSettingsButton()!.getElement()).toHaveAttribute('aria-label', 'Custom settings');
+    });
+  });
+
+  test('supports using pane props from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider
+        messages={{
+          'code-editor': {
+            'i18nStrings.paneCloseButtonAriaLabel': 'Custom close',
+          },
+        }}
+      >
+        <CodeEditor {...defaultProps} i18nStrings={undefined} />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCodeEditor()!;
+    act(() => emulateAceAnnotationEvent!());
+    wrapper.findErrorsTab()!.click();
+    expect(wrapper.findPane()!.findButton()!.getElement()).toHaveAttribute('aria-label', 'Custom close');
+  });
+
+  test('supports using preferences modal strings from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider
+        messages={{
+          'code-editor': {
+            'i18nStrings.preferencesModalHeader': 'Custom modal header',
+            'i18nStrings.preferencesModalCancel': 'Custom cancel',
+            'i18nStrings.preferencesModalConfirm': 'Custom confirm',
+            'i18nStrings.preferencesModalWrapLines': 'Custom wrap lines',
+            'i18nStrings.preferencesModalTheme': 'Custom theme',
+            'i18nStrings.preferencesModalLightThemes': 'Custom light themes',
+            'i18nStrings.preferencesModalDarkThemes': 'Custom dark themes',
+          },
+        }}
+      >
+        <CodeEditor {...defaultProps} themes={{ light: ['One'], dark: ['Two'] }} i18nStrings={undefined} />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCodeEditor()!;
+    wrapper.findSettingsButton()!.click();
+    const modal = createWrapper().findModal()!;
+    expect(modal.findHeader().getElement()).toHaveTextContent('Custom modal header');
+    expect(modal.findFooter()!.findSpaceBetween()!.find(':nth-child(1)')!.findButton()!.getElement()).toHaveTextContent(
+      'Custom cancel'
+    );
+    expect(modal.findFooter()!.findSpaceBetween()!.find(':nth-child(2)')!.findButton()!.getElement()).toHaveTextContent(
+      'Custom confirm'
+    );
+    expect(modal.findContent()!.findCheckbox()!.findLabel().getElement()).toHaveTextContent('Custom wrap lines');
+    expect(modal.findContent()!.findFormField()!.findLabel()!.getElement()).toHaveTextContent('Custom theme');
+    modal.findContent()!.findSelect()!.openDropdown();
+    expect(modal.findContent()!.findSelect()!.findDropdown().find('li:nth-child(1)')!.getElement()).toHaveTextContent(
+      'Custom light themes'
+    );
+    expect(modal.findContent()!.findSelect()!.findDropdown().find('li:nth-child(2)')!.getElement()).toHaveTextContent(
+      'Custom dark themes'
+    );
   });
 });

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -39,6 +39,7 @@ import { useControllable } from '../internal/hooks/use-controllable';
 import LiveRegion from '../internal/components/live-region';
 
 import styles from './styles.css.js';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export { CodeEditorProps };
 
@@ -62,6 +63,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     controlledProp: 'editorContentHeight',
   });
   const baseProps = getBaseProps(rest);
+  const i18n = useInternalI18n('code-editor');
 
   const [editor, setEditor] = useState<Ace.Editor>();
   const mode = useCurrentMode(__internalRootRef);
@@ -245,13 +247,16 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     >
       {props.loading && (
         <LoadingScreen>
-          <LiveRegion visible={true}>{i18nStrings.loadingState}</LiveRegion>
+          <LiveRegion visible={true}>{i18n('i18nStrings.loadingState', i18nStrings?.loadingState)}</LiveRegion>
         </LoadingScreen>
       )}
 
       {!ace && !props.loading && (
-        <ErrorScreen recoveryText={i18nStrings.errorStateRecovery} onRecoveryClick={props.onRecoveryClick}>
-          {i18nStrings.errorState}
+        <ErrorScreen
+          recoveryText={i18n('i18nStrings.errorStateRecovery', i18nStrings?.errorStateRecovery)}
+          onRecoveryClick={props.onRecoveryClick}
+        >
+          {i18n('i18nStrings.errorState', i18nStrings?.errorState)}
         </ErrorScreen>
       )}
 
@@ -272,13 +277,20 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
               onKeyDown={onEditorKeydown}
               tabIndex={0}
               role="group"
-              aria-label={i18nStrings.editorGroupAriaLabel}
+              aria-label={i18n('i18nStrings.editorGroupAriaLabel', i18nStrings?.editorGroupAriaLabel)}
             />
           </ResizableBox>
-          <div role="group" aria-label={i18nStrings.statusBarGroupAriaLabel}>
+          <div
+            role="group"
+            aria-label={i18n('i18nStrings.statusBarGroupAriaLabel', i18nStrings?.statusBarGroupAriaLabel)}
+          >
             <StatusBar
               languageLabel={languageLabel}
-              cursorPosition={i18nStrings.cursorPosition(cursorPosition.row + 1, cursorPosition.column + 1)}
+              cursorPosition={i18n(
+                'i18nStrings.cursorPosition',
+                i18nStrings?.cursorPosition(cursorPosition.row + 1, cursorPosition.column + 1),
+                format => format({ row: cursorPosition.row + 1, column: cursorPosition.column + 1 })
+              )}
               errorCount={errorCount}
               warningCount={warningCount}
               paneStatus={paneStatus}
@@ -302,8 +314,12 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
               onAnnotationClick={onAnnotationClick}
               onAnnotationClear={onAnnotationClear}
               onClose={onPaneClose}
-              cursorPositionLabel={i18nStrings.cursorPosition}
-              closeButtonAriaLabel={i18nStrings.paneCloseButtonAriaLabel}
+              cursorPositionLabel={i18n(
+                'i18nStrings.cursorPosition',
+                i18nStrings?.cursorPosition,
+                format => (row, column) => format({ row, column })
+              )}
+              closeButtonAriaLabel={i18n('i18nStrings.paneCloseButtonAriaLabel', i18nStrings?.paneCloseButtonAriaLabel)}
             />
           </div>
           {isPreferencesModalVisible && (
@@ -314,16 +330,16 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
               preferences={props.preferences}
               defaultTheme={defaultTheme}
               i18nStrings={{
-                header: i18nStrings.preferencesModalHeader,
-                cancel: i18nStrings.preferencesModalCancel,
-                confirm: i18nStrings.preferencesModalConfirm,
-                wrapLines: i18nStrings.preferencesModalWrapLines,
-                theme: i18nStrings.preferencesModalTheme,
-                lightThemes: i18nStrings.preferencesModalLightThemes,
-                darkThemes: i18nStrings.preferencesModalDarkThemes,
-                themeFilteringAriaLabel: i18nStrings.preferencesModalThemeFilteringAriaLabel,
-                themeFilteringClearAriaLabel: i18nStrings.preferencesModalThemeFilteringClearAriaLabel,
-                themeFilteringPlaceholder: i18nStrings.preferencesModalThemeFilteringPlaceholder,
+                header: i18n('i18nStrings.preferencesModalHeader', i18nStrings?.preferencesModalHeader),
+                cancel: i18n('i18nStrings.preferencesModalCancel', i18nStrings?.preferencesModalCancel),
+                confirm: i18n('i18nStrings.preferencesModalConfirm', i18nStrings?.preferencesModalConfirm),
+                wrapLines: i18n('i18nStrings.preferencesModalWrapLines', i18nStrings?.preferencesModalWrapLines),
+                theme: i18n('i18nStrings.preferencesModalTheme', i18nStrings?.preferencesModalTheme),
+                lightThemes: i18n('i18nStrings.preferencesModalLightThemes', i18nStrings?.preferencesModalLightThemes),
+                darkThemes: i18n('i18nStrings.preferencesModalDarkThemes', i18nStrings?.preferencesModalDarkThemes),
+                themeFilteringAriaLabel: i18nStrings?.preferencesModalThemeFilteringAriaLabel,
+                themeFilteringClearAriaLabel: i18nStrings?.preferencesModalThemeFilteringClearAriaLabel,
+                themeFilteringPlaceholder: i18nStrings?.preferencesModalThemeFilteringPlaceholder,
               }}
             />
           )}

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -98,7 +98,7 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
    * * `errorStateRecovery`: Specifies the text for the recovery button that's displayed next to the error text.
    *    Use the `recoveryClick` event to do a recovery action (for example, retrying the request).
    */
-  i18nStrings: CodeEditorProps.I18nStrings;
+  i18nStrings?: CodeEditorProps.I18nStrings;
 
   /**
    * Specifies the height of the code editor document.

--- a/src/code-editor/pane.tsx
+++ b/src/code-editor/pane.tsx
@@ -24,8 +24,8 @@ export interface PaneProps {
   annotations: Ace.Annotation[];
   highlighted?: Ace.Annotation;
 
-  cursorPositionLabel: (row: number, column: number) => string;
-  closeButtonAriaLabel: string;
+  cursorPositionLabel?: (row: number, column: number) => string;
+  closeButtonAriaLabel?: string;
 
   onClose: () => void;
   onAnnotationClick: (annotation: Ace.Annotation) => void;
@@ -123,7 +123,7 @@ export const Pane = ({
                     role="link"
                   >
                     <td className={clsx(styles.pane__location, styles.pane__cell)} tabIndex={-1}>
-                      {cursorPositionLabel((annotation.row || 0) + 1, (annotation.column || 0) + 1)}
+                      {cursorPositionLabel?.((annotation.row || 0) + 1, (annotation.column || 0) + 1) ?? ''}
                     </td>
                     <td className={clsx(styles.pane__description, styles.pane__cell)} tabIndex={-1}>
                       {annotation.text}

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -16,13 +16,13 @@ import { LightThemes, DarkThemes } from './ace-themes';
 import { CodeEditorProps } from './interfaces';
 
 interface PreferencesModali18nStrings {
-  header: string;
-  cancel: string;
-  confirm: string;
-  wrapLines: string;
-  theme: string;
-  lightThemes: string;
-  darkThemes: string;
+  header?: string;
+  cancel?: string;
+  confirm?: string;
+  wrapLines?: string;
+  theme?: string;
+  lightThemes?: string;
+  darkThemes?: string;
   themeFilteringPlaceholder?: string;
   themeFilteringAriaLabel?: string;
   themeFilteringClearAriaLabel?: string;

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -8,14 +8,15 @@ import { TabButton } from './tab-button';
 import { InternalButton } from '../button/internal';
 import { useContainerQuery } from '../internal/hooks/container-queries/use-container-query';
 import { CodeEditorProps } from './interfaces';
+import { useInternalI18n } from '../internal/i18n/context.js';
 
 interface StatusBarProps {
   languageLabel: string;
-  cursorPosition: string;
+  cursorPosition?: string;
   paneStatus: string;
   isTabFocused: boolean;
   paneId?: string;
-  i18nStrings: CodeEditorProps.I18nStrings;
+  i18nStrings?: CodeEditorProps.I18nStrings;
   errorCount: number;
   warningCount: number;
   isRefresh: boolean;
@@ -58,8 +59,9 @@ function InternalStatusBar({
   minifyCounters,
   isRefresh,
 }: InternalStatusBarProps) {
-  const errorText = `${i18nStrings.errorsTab}: ${errorCount}`;
-  const warningText = `${i18nStrings.warningsTab}: ${warningCount}`;
+  const i18n = useInternalI18n('code-editor');
+  const errorText = `${i18n('i18nStrings.errorsTab', i18nStrings?.errorsTab)}: ${errorCount}`;
+  const warningText = `${i18n('i18nStrings.warningsTab', i18nStrings?.warningsTab)}: ${warningCount}`;
 
   // Virtual status bar is inaccessible for screen readers and keyboard interactions.
 
@@ -127,7 +129,7 @@ function InternalStatusBar({
             variant="icon"
             iconName="settings"
             iconAlt="Settings"
-            ariaLabel={i18nStrings.preferencesButtonAriaLabel}
+            ariaLabel={i18n('i18nStrings.preferencesButtonAriaLabel', i18nStrings?.preferencesButtonAriaLabel)}
             onClick={onPreferencesOpen}
             __nativeAttributes={{
               tabIndex: paneStatus !== 'hidden' && isTabFocused ? -1 : undefined,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
