### PR TITLE
chore: Add recovery text back to chart permutation pages

### DIFF
--- a/pages/area-chart/example.tsx
+++ b/pages/area-chart/example.tsx
@@ -38,6 +38,7 @@ export default function Example<T extends AreaChartProps.DataTypes>({
         loadingText="Loading chart data..."
         errorText="Error loading chart data."
         recoveryText="Retry"
+        onRecoveryClick={() => {}}
         empty={
           <Box textAlign="center" color="inherit">
             <b>No data</b>

--- a/pages/line-chart/permutations.page.tsx
+++ b/pages/line-chart/permutations.page.tsx
@@ -244,7 +244,10 @@ export default function () {
     <>
       <h1>Line chart permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView permutations={permutations} render={permutation => <LineChart<any> {...permutation} />} />
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => <LineChart<any> onRecoveryClick={() => {}} {...permutation} />}
+        />
       </ScreenshotArea>
     </>
   );

--- a/pages/mixed-line-bar-chart/permutations.page.tsx
+++ b/pages/mixed-line-bar-chart/permutations.page.tsx
@@ -234,7 +234,7 @@ export default function () {
       <ScreenshotArea disableAnimations={true}>
         <PermutationsView
           permutations={permutations}
-          render={permutation => <MixedLineBarChart<any> {...permutation} />}
+          render={permutation => <MixedLineBarChart<any> onRecoveryClick={() => {}} {...permutation} />}
         />
       </ScreenshotArea>
     </>

--- a/pages/pie-chart/permutations.page.tsx
+++ b/pages/pie-chart/permutations.page.tsx
@@ -126,6 +126,7 @@ export default function PieChartPermutations() {
               legendTitle="Legend"
               segmentDescription={segmentDescription1}
               ariaLabel="Permutation chart"
+              onRecoveryClick={() => {}}
               {...permutation}
             />
           )}


### PR DESCRIPTION
### Description

#1135 made it so that recovery text is no longer displayed if the recovery click handler isn't provided. We don't that for permutation pages, so we had some visual test failures. This PR restores that link for visual testing.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
