### PR TITLE
feat: Support interactive elements in Expandable section headers

### DIFF
--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -24,7 +24,6 @@ const permutations = createPermutations<ExpandableSectionProps>([
         <Button>Another action</Button>
       </SpaceBetween>,
     ],
-    variant: ['default', 'container'],
   },
 ]);
 export default function ExpandableSectionContainerVariantPermutations() {
@@ -38,7 +37,12 @@ export default function ExpandableSectionContainerVariantPermutations() {
         <PermutationsView
           permutations={permutations}
           render={permutation => (
-            <ExpandableSection {...permutation} headerText={'Expandable section heading'} defaultExpanded={true}>
+            <ExpandableSection
+              {...permutation}
+              headerText={'Expandable section heading'}
+              defaultExpanded={true}
+              variant="container"
+            >
               Expandable section content
             </ExpandableSection>
           )}

--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import ExpandableSection, { ExpandableSectionProps } from '~components/expandable-section';
+import SpaceBetween from '~components/space-between';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import Link from '~components/link';
+import Button from '~components/button';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+
+const permutations = createPermutations<ExpandableSectionProps>([
+  {
+    headerCounter: [undefined, '(5)'],
+    headerDescription: [undefined, 'Expandable section header description'],
+    // eslint-disable-next-line react/jsx-key
+    headerInfo: [undefined, <Link variant="info">info</Link>],
+    headerActions: [
+      undefined,
+      // eslint-disable-next-line react/jsx-key
+      <SpaceBetween direction="horizontal" size="xs">
+        <Button>Action</Button>
+        <Button>Another action</Button>
+      </SpaceBetween>,
+    ],
+    variant: ['default', 'container'],
+  },
+]);
+export default function ExpandableSectionContainerVariantPermutations() {
+  return (
+    <article>
+      <h1>Expandable Section - container variant</h1>
+
+      <button id="focus-target">Focus target</button>
+
+      <ScreenshotArea>
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => (
+            <ExpandableSection {...permutation} headerText={'Expandable section heading'} defaultExpanded={true}>
+              Expandable section content
+            </ExpandableSection>
+          )}
+        />
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5859,6 +5859,16 @@ works with the \`headerText\` slot (not with the deprecated \`header\`), and not
       "name": "header",
     },
     Object {
+      "description": "Actions for the header. Use with container variant.",
+      "isDefault": false,
+      "name": "headerActions",
+    },
+    Object {
+      "description": "Area next to the heading to display an Info link. Use with container variant.",
+      "isDefault": false,
+      "name": "headerInfo",
+    },
+    Object {
       "description": "The heading text. Use plain text. When using the container variant, you can use additional header props like \`headerDescription\` and \`headerCounter\` to display other elements in the header.",
       "isDefault": false,
       "name": "headerText",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5785,21 +5785,21 @@ Use to assign unique labels when there are multiple expandable sections with the
       "type": "string",
     },
     Object {
-      "description": "Specifies secondary text that's displayed to the right of the heading title. Use with container variant.
+      "description": "Specifies secondary text that's displayed to the right of the heading title. Use with the container variant.
 Behaves similar to the Header component counter.",
       "name": "headerCounter",
       "optional": true,
       "type": "string",
     },
     Object {
-      "description": "Supplementary text below the heading. Use with container variant.",
+      "description": "Supplementary text below the heading. Use with the container variant.",
       "name": "headerDescription",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
-Use with container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
+Use with the container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
 works with the \`headerText\` slot (not with the deprecated \`header\`), and not with the navigation variant.",
       "inlineType": Object {
         "name": "ExpandableSectionProps.HeadingTag",
@@ -5859,12 +5859,12 @@ works with the \`headerText\` slot (not with the deprecated \`header\`), and not
       "name": "header",
     },
     Object {
-      "description": "Actions for the header. Use with container variant.",
+      "description": "Actions for the header. Use with the container variant.",
       "isDefault": false,
       "name": "headerActions",
     },
     Object {
-      "description": "Area next to the heading to display an Info link. Use with container variant.",
+      "description": "The area next to the heading, used to display an Info link. Use with the container variant.",
       "isDefault": false,
       "name": "headerInfo",
     },

--- a/src/expandable-section/__tests__/interactions.test.tsx
+++ b/src/expandable-section/__tests__/interactions.test.tsx
@@ -6,6 +6,8 @@ import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 
 import createWrapper, { ExpandableSectionWrapper } from '../../../lib/components/test-utils/dom';
 import ExpandableSection, { ExpandableSectionProps } from '../../../lib/components/expandable-section';
+import Button from '../../../lib/components/button';
+import Link from '../../../lib/components/link';
 
 function renderExpandableSection(props: ExpandableSectionProps = {}): ExpandableSectionWrapper {
   const { container } = render(<ExpandableSection {...props} />);
@@ -53,6 +55,64 @@ describe('Expandable Section - Interactions', () => {
         wrapper.findHeader().keyup(KeyCode.space);
         expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
       });
+    });
+  });
+
+  describe('Custom interactive elements in the header do not interfere with the expand/collapse functionality', () => {
+    let wrapper: ExpandableSectionWrapper;
+    let onChangeSpy: jest.Mock;
+    let onLinkClickSpy: jest.Mock;
+    let onButtonClickSpy: jest.Mock;
+
+    beforeEach(() => {
+      onChangeSpy = jest.fn();
+      onLinkClickSpy = jest.fn();
+      onButtonClickSpy = jest.fn();
+      wrapper = renderExpandableSection({
+        expanded: true,
+        onChange: onChangeSpy,
+        headerText: 'Header text',
+        headerInfo: <Link onFollow={onLinkClickSpy}>Info</Link>,
+        headerActions: <Button onClick={onButtonClickSpy}>Action</Button>,
+        variant: 'container',
+      });
+    });
+
+    test('when clicking on an info link', () => {
+      wrapper.findHeader().findLink()!.click();
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onLinkClickSpy).toHaveBeenCalledTimes(1);
+      expect(onButtonClickSpy).not.toHaveBeenCalled();
+    });
+    test('when clicking on an action button', () => {
+      wrapper.findHeader().findButton()!.click();
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onLinkClickSpy).not.toHaveBeenCalled();
+      expect(onButtonClickSpy).toHaveBeenCalledTimes(1);
+    });
+    test('when typing "Enter" on an interactive element', () => {
+      wrapper = renderExpandableSection({
+        expanded: true,
+        onChange: onChangeSpy,
+        headerText: 'Header text',
+        headerActions: <button onKeyUp={onButtonClickSpy}>Action</button>,
+        variant: 'container',
+      });
+      wrapper.findHeader().find('button')!.keyup(KeyCode.enter);
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onButtonClickSpy).toHaveBeenCalledTimes(1);
+    });
+    test('when typing "Space" on an interactive element', () => {
+      wrapper = renderExpandableSection({
+        expanded: true,
+        onChange: onChangeSpy,
+        headerText: 'Header text',
+        headerActions: <button onKeyUp={onButtonClickSpy}>Action</button>,
+        variant: 'container',
+      });
+      wrapper.findHeader().find('button')!.keyup(KeyCode.enter);
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect(onButtonClickSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -56,19 +56,19 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   headerText?: React.ReactNode;
 
   /**
-   * Supplementary text below the heading. Use with container variant.
+   * Supplementary text below the heading. Use with the container variant.
    */
   headerDescription?: string;
 
   /**
-   * Specifies secondary text that's displayed to the right of the heading title. Use with container variant.
+   * Specifies secondary text that's displayed to the right of the heading title. Use with the container variant.
    * Behaves similar to the Header component counter.
    */
   headerCounter?: string;
 
   /**
    * Overrides the default [HTML heading tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
-   * Use with container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
+   * Use with the container variant (which defaults to H2) or default/footer variants (which default to DIV). Note that this only
    * works with the `headerText` slot (not with the deprecated `header`), and not with the navigation variant.
    */
   headingTagOverride?: ExpandableSectionProps.HeadingTag;
@@ -86,12 +86,12 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   onChange?: NonCancelableEventHandler<ExpandableSectionProps.ChangeDetail>;
 
   /**
-   * Area next to the heading to display an Info link. Use with container variant.
+   * The area next to the heading, used to display an Info link. Use with the container variant.
    */
   headerInfo?: React.ReactNode;
 
   /**
-   * Actions for the header. Use with container variant.
+   * Actions for the header. Use with the container variant.
    */
   headerActions?: React.ReactNode;
 }

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -84,4 +84,14 @@ export interface ExpandableSectionProps extends BaseComponentProps {
    * The event `detail` contains the current value of the `expanded` property.
    */
   onChange?: NonCancelableEventHandler<ExpandableSectionProps.ChangeDetail>;
+
+  /**
+   * Area next to the heading to display an Info link. Use with container variant.
+   */
+  headerInfo?: React.ReactNode;
+
+  /**
+   * Actions for the header. Use with container variant.
+   */
+  headerActions?: React.ReactNode;
 }

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -29,6 +29,8 @@ export default function InternalExpandableSection({
   headerText,
   headerCounter,
   headerDescription,
+  headerInfo,
+  headerActions,
   headingTagOverride,
   disableContentPaddings,
   headerAriaLabel,
@@ -102,6 +104,8 @@ export default function InternalExpandableSection({
           headerText={headerText}
           headerDescription={headerDescription}
           headerCounter={headerCounter}
+          headerInfo={headerInfo}
+          headerActions={headerActions}
           headingTagOverride={headingTagOverride}
           {...triggerProps}
         />

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -82,7 +82,7 @@
     }
   }
 
-  &-default.trigger-expanded {
+  &-default.wrapper-expanded {
     border-bottom-color: awsui.$color-border-divider-default;
   }
 }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -34,8 +34,7 @@
   }
 }
 
-.trigger {
-  cursor: pointer;
+.wrapper {
   box-sizing: border-box;
   display: flex;
   border: none;
@@ -102,11 +101,17 @@
   &-button {
     box-sizing: border-box;
     display: flex;
+  }
 
-    // Header buttons for non-container variants show the focus ring directly
+  &-button,
+  &-container-button {
     @include focus-visible.when-visible {
       @include styles.focus-highlight(0px);
     }
+  }
+
+  &:not(.with-interactive-elements) {
+    cursor: pointer;
   }
 
   &-container {
@@ -117,20 +122,8 @@
     }
 
     // stylelint-disable-next-line selector-combinator-disallowed-list
-    body[data-awsui-focus-visible='true'] &:focus-within {
-      outline: none;
-      text-decoration: none;
-      padding: container.$header-focus-visible-padding;
-
-      @include styles.form-focus-element(awsui.$border-radius-control-default-focus-ring);
-    }
-
-    // Header buttons that sit in a container should not show focus because the parent container has a focus ring already
-    &-button {
-      @include focus-visible.when-visible {
-        outline: none;
-        text-decoration: none;
-      }
+    &.with-interactive-elements &-button {
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-20024

### How has this been tested?

<!-- How did you test to verify your changes? -->

- Added unit tests
- Added integration tests
- New permutations page for visual regression tests. Visual regression test will be added including focus states

BackstopJS tests are failing because a new page was added (`expandable-section/container-variant.permutations`) for which there is no reference.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
