### PR TITLE
feat: Add i18n support to table, split panel, collection preferences

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4196,7 +4196,7 @@ The values for all configured preferences are present even if the user didn't ch
     Object {
       "description": "Label of the cancel button in the modal footer.",
       "name": "cancelLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4209,7 +4209,7 @@ The values for all configured preferences are present even if the user didn't ch
     Object {
       "description": "Label of the confirm button in the modal footer.",
       "name": "confirmLabel",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4227,12 +4227,12 @@ You must set the current value in the \`preferences.contentDensity\` property.
         "properties": Array [
           Object {
             "name": "description",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "label",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -4309,7 +4309,7 @@ You must provide an ordered list of the items to display in the \`preferences.co
           },
           Object {
             "name": "title",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -4379,7 +4379,7 @@ You must set the current value in the \`preferences.pageSize\` property.
           },
           Object {
             "name": "title",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -4493,12 +4493,12 @@ You must set the current value in the \`preferences.stripedRows\` property.
         "properties": Array [
           Object {
             "name": "description",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "label",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -4511,7 +4511,7 @@ You must set the current value in the \`preferences.stripedRows\` property.
     Object {
       "description": "Specifies the title of the preferences modal dialog. It is also used as an \`aria-label\` for the trigger button.",
       "name": "title",
-      "optional": false,
+      "optional": true,
       "type": "string",
     },
     Object {
@@ -4566,12 +4566,12 @@ You must set the current value in the \`preferences.wrapLines\` property.
         "properties": Array [
           Object {
             "name": "description",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "label",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -11582,7 +11582,7 @@ Object {
         "properties": Array [
           Object {
             "name": "closeButtonAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -11627,14 +11627,14 @@ Object {
           },
           Object {
             "name": "resizeHandleAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "SplitPanelProps.I18nStrings",
     },
     Object {

--- a/src/collection-preferences/__tests__/collection-preferences.test.tsx
+++ b/src/collection-preferences/__tests__/collection-preferences.test.tsx
@@ -1,5 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import CollectionPreferences from '../../../lib/components/collection-preferences';
+import createWrapper from '../../../lib/components/test-utils/dom';
 import { CollectionPreferencesWrapper } from '../../../lib/components/test-utils/dom';
 import {
   renderCollectionPreferences,
@@ -9,6 +13,7 @@ import {
   stripedRowsPreference,
   contentDisplayPreference,
 } from './shared';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const expectVisibleModal = (wrapper: CollectionPreferencesWrapper, visible = true) => {
   if (visible) {
@@ -179,5 +184,100 @@ describe('Collection preferences - Preferences display', () => {
     wrapper.findTriggerButton().click();
     expect(wrapper.findModal()!.findVisibleContentPreference()).toBeNull();
     expect(wrapper.findModal()!.findContentDisplayPreference()).not.toBeNull();
+  });
+});
+
+describe('i18n', () => {
+  test('supports using title from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider messages={{ 'collection-preferences': { title: 'Custom title' } }}>
+        <CollectionPreferences />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCollectionPreferences()!;
+    expect(wrapper.findTriggerButton().getElement()).toHaveAttribute('aria-label', 'Custom title');
+    wrapper.findTriggerButton().click();
+    expect(wrapper.findModal()!.findHeader()!.getElement()).toHaveTextContent('Custom title');
+  });
+
+  test('supports using confirmLabel and cancelLabel from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider
+        messages={{ 'collection-preferences': { confirmLabel: 'Custom confirm', cancelLabel: 'Custom cancel' } }}
+      >
+        <CollectionPreferences />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCollectionPreferences()!;
+    wrapper.findTriggerButton().click();
+    const footerItems = wrapper.findModal()!.findFooter()!.findSpaceBetween()!;
+    expect(footerItems.find(':nth-child(1)')!.findButton()!.getElement()).toHaveTextContent('Custom cancel');
+    expect(footerItems.find(':nth-child(2)')!.findButton()!.getElement()).toHaveTextContent('Custom confirm');
+  });
+
+  test('supports using preference labels and descriptions from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider
+        messages={{
+          'collection-preferences': {
+            'pageSizePreference.title': 'Custom page size',
+            'wrapLinesPreference.label': 'Custom wrap lines',
+            'wrapLinesPreference.description': 'Custom wrap lines description',
+            'stripedRowsPreference.label': 'Custom striped rows',
+            'stripedRowsPreference.description': 'Custom striped rows description',
+            'contentDensityPreference.label': 'Custom density',
+            'contentDensityPreference.description': 'Custom density description',
+            'contentDisplayPreference.title': 'Custom content display',
+            'contentDisplayPreference.description': 'Custom content display description',
+            'contentDisplayPreference.dragHandleAriaLabel': 'Custom drag handle',
+            'contentDisplayPreference.liveAnnouncementDndStarted': 'Picked up item at position {position} of {total}',
+            'contentDisplayPreference.liveAnnouncementDndItemReordered':
+              '{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}',
+            'contentDisplayPreference.liveAnnouncementDndItemCommitted':
+              '{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}',
+          },
+        }}
+      >
+        <CollectionPreferences
+          preferences={{
+            contentDisplay: [
+              { id: '1', visible: true },
+              { id: '2', visible: true },
+            ],
+          }}
+          pageSizePreference={{ options: [] }}
+          wrapLinesPreference={{}}
+          stripedRowsPreference={{}}
+          contentDensityPreference={{}}
+          contentDisplayPreference={{
+            options: [
+              { id: '1', label: 'One' },
+              { id: '2', label: 'Two' },
+            ],
+          }}
+        />
+      </TestI18nProvider>
+    );
+    const wrapper = createWrapper(container).findCollectionPreferences()!;
+    wrapper.findTriggerButton().click();
+    const modal = wrapper.findModal()!;
+    expect(modal.findPageSizePreference()!.findTitle().getElement()).toHaveTextContent('Custom page size');
+    expect(modal.findWrapLinesPreference()!.findLabel().getElement()).toHaveTextContent('Custom wrap lines');
+    expect(modal.findWrapLinesPreference()!.findDescription()!.getElement()).toHaveTextContent(
+      'Custom wrap lines description'
+    );
+    expect(modal.findStripedRowsPreference()!.findLabel().getElement()).toHaveTextContent('Custom striped rows');
+    expect(modal.findStripedRowsPreference()!.findDescription()!.getElement()).toHaveTextContent(
+      'Custom striped rows description'
+    );
+    expect(modal.findContentDensityPreference()!.findLabel().getElement()).toHaveTextContent('Custom density');
+    expect(modal.findContentDensityPreference()!.findDescription()!.getElement()).toHaveTextContent(
+      'Custom density description'
+    );
+    expect(modal.findContentDisplayPreference()!.findTitle().getElement()).toHaveTextContent('Custom content display');
+    expect(modal.findContentDisplayPreference()!.findDescription()!.getElement()).toHaveTextContent(
+      'Custom content display description'
+    );
+    expect(modal.findContentDisplayPreference()!.find('[aria-label*="Custom drag handle"')).toBeTruthy();
   });
 });

--- a/src/collection-preferences/content-display/index.tsx
+++ b/src/collection-preferences/content-display/index.tsx
@@ -13,6 +13,7 @@ import useDragAndDropReorder from './use-drag-and-drop-reorder';
 import useLiveAnnouncements from './use-live-announcements';
 import Portal from '../../internal/components/portal';
 import ContentDisplayOption from './content-display-option';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 const componentPrefix = 'content-display';
 
@@ -40,6 +41,7 @@ export default function ContentDisplayPreference({
   dragHandleAriaLabel,
 }: ContentDisplayPreferenceProps) {
   const idPrefix = useUniqueId(componentPrefix);
+  const i18n = useInternalI18n('collection-preferences');
 
   const onToggle = (option: OptionWithVisibility) => {
     onChange(value.map(item => (item.id === option.id ? { ...item, visible: !option.visible } : item)));
@@ -58,20 +60,42 @@ export default function ContentDisplayPreference({
 
   const announcements = useLiveAnnouncements({
     isDragging: activeItem !== null,
-    liveAnnouncementDndStarted,
-    liveAnnouncementDndItemReordered,
-    liveAnnouncementDndItemCommitted,
-    liveAnnouncementDndDiscarded,
+    liveAnnouncementDndStarted: i18n(
+      'contentDisplayPreference.liveAnnouncementDndStarted',
+      liveAnnouncementDndStarted,
+      format => (position, total) => format({ position, total })
+    ),
+    liveAnnouncementDndItemReordered: i18n(
+      'contentDisplayPreference.liveAnnouncementDndItemReordered',
+      liveAnnouncementDndItemReordered,
+      format => (initialPosition, currentPosition, total) =>
+        format({ initialPosition, currentPosition, total, isInitialPosition: `${initialPosition === currentPosition}` })
+    ),
+    liveAnnouncementDndItemCommitted: i18n(
+      'contentDisplayPreference.liveAnnouncementDndItemCommitted',
+      liveAnnouncementDndItemCommitted,
+      format => (initialPosition, finalPosition, total) =>
+        format({ initialPosition, finalPosition, total, isInitialPosition: `${initialPosition === finalPosition}` })
+    ),
+    liveAnnouncementDndDiscarded: i18n(
+      'contentDisplayPreference.liveAnnouncementDndDiscarded',
+      liveAnnouncementDndDiscarded
+    ),
     sortedOptions: value,
   });
+
+  const renderedDragHandleAriaDescription = i18n(
+    'contentDisplayPreference.dragHandleAriaDescription',
+    dragHandleAriaDescription
+  );
 
   return (
     <div className={styles[componentPrefix]}>
       <h3 className={getClassName('title')} id={titleId}>
-        {title}
+        {i18n('contentDisplayPreference.title', title)}
       </h3>
       <p className={getClassName('description')} id={descriptionId}>
-        {description}
+        {i18n('contentDisplayPreference.description', description)}
       </p>
       <DndContext
         sensors={sensors}
@@ -79,7 +103,9 @@ export default function ContentDisplayPreference({
         accessibility={{
           announcements,
           restoreFocus: false,
-          screenReaderInstructions: dragHandleAriaDescription ? { draggable: dragHandleAriaDescription } : undefined,
+          screenReaderInstructions: renderedDragHandleAriaDescription
+            ? { draggable: renderedDragHandleAriaDescription }
+            : undefined,
         }}
         onDragStart={({ active }) => setActiveItem(active.id)}
         onDragEnd={event => {
@@ -106,7 +132,7 @@ export default function ContentDisplayPreference({
             {sortedOptions.map(option => {
               return (
                 <DraggableOption
-                  dragHandleAriaLabel={dragHandleAriaLabel}
+                  dragHandleAriaLabel={i18n('contentDisplayPreference.dragHandleAriaLabel', dragHandleAriaLabel)}
                   key={option.id}
                   onKeyDown={handleKeyDown}
                   onToggle={onToggle}
@@ -127,7 +153,7 @@ export default function ContentDisplayPreference({
             {activeOption && (
               <ContentDisplayOption
                 listeners={{ onKeyDown: handleKeyDown }}
-                dragHandleAriaLabel={dragHandleAriaLabel}
+                dragHandleAriaLabel={i18n('contentDisplayPreference.dragHandleAriaLabel', dragHandleAriaLabel)}
                 onToggle={onToggle}
                 option={activeOption}
               />

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -28,6 +28,7 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import ContentDisplayPreference from './content-display';
 import { warnOnce } from '../internal/logging';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export { CollectionPreferencesProps };
 
@@ -54,11 +55,14 @@ export default function CollectionPreferences({
 }: CollectionPreferencesProps) {
   const { __internalRootRef } = useBaseComponent('CollectionPreferences');
   checkControlled('CollectionPreferences', 'preferences', preferences, 'onConfirm', onConfirm);
+
+  const i18n = useInternalI18n('collection-preferences');
   const baseProps = getBaseProps(rest);
   const [modalVisible, setModalVisible] = useState(false);
   const [temporaryPreferences, setTemporaryPreferences] = useState(copyPreferences(preferences || {}));
   const triggerRef = useRef<ButtonProps.Ref>(null);
   const dialogPreviouslyOpen = useRef(false);
+
   useEffect(() => {
     if (!modalVisible) {
       dialogPreviouslyOpen.current && triggerRef.current && triggerRef.current.focus();
@@ -104,7 +108,7 @@ export default function CollectionPreferences({
         ref={triggerRef}
         className={styles['trigger-button']}
         disabled={disabled}
-        ariaLabel={title}
+        ariaLabel={i18n('title', title)}
         onClick={() => {
           setTemporaryPreferences(copyPreferences(preferences || {}));
           setModalVisible(true);
@@ -117,7 +121,7 @@ export default function CollectionPreferences({
         <InternalModal
           className={styles['modal-root']}
           visible={true}
-          header={title}
+          header={i18n('title', title)}
           footer={
             <InternalBox float="right">
               <InternalSpaceBetween direction="horizontal" size="xs">
@@ -127,7 +131,7 @@ export default function CollectionPreferences({
                   formAction="none"
                   onClick={onCancelListener}
                 >
-                  {cancelLabel}
+                  {i18n('cancelLabel', cancelLabel)}
                 </InternalButton>
                 <InternalButton
                   className={styles['confirm-button']}
@@ -135,7 +139,7 @@ export default function CollectionPreferences({
                   formAction="none"
                   onClick={onConfirmListener}
                 >
-                  {confirmLabel}
+                  {i18n('confirmLabel', confirmLabel)}
                 </InternalButton>
               </InternalSpaceBetween>
             </InternalBox>

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -7,15 +7,15 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
   /**
    * Specifies the title of the preferences modal dialog. It is also used as an `aria-label` for the trigger button.
    */
-  title: string;
+  title?: string;
   /**
    * Label of the confirm button in the modal footer.
    */
-  confirmLabel: string;
+  confirmLabel?: string;
   /**
    * Label of the cancel button in the modal footer.
    */
-  cancelLabel: string;
+  cancelLabel?: string;
   /**
    * Determines whether the preferences trigger button is disabled.
    */
@@ -196,7 +196,7 @@ export namespace CollectionPreferencesProps {
   }
 
   export interface ContentDisplayPreference {
-    title: string;
+    title?: string;
     description?: string;
     options: ReadonlyArray<CollectionPreferencesProps.ContentDisplayOption>;
     liveAnnouncementDndStarted?: (position: number, total: number) => string;
@@ -235,28 +235,28 @@ export namespace CollectionPreferencesProps {
   }
 
   export interface PageSizePreference {
-    title: string;
+    title?: string;
     options: ReadonlyArray<PageSizeOption>;
   }
 
   export interface PageSizeOption {
     value: number;
-    label: string;
+    label?: string;
   }
 
   export interface WrapLinesPreference {
-    label: string;
-    description: string;
+    label?: string;
+    description?: string;
   }
 
   export interface StripedRowsPreference {
-    label: string;
-    description: string;
+    label?: string;
+    description?: string;
   }
 
   export interface ContentDensityPreference {
-    label: string;
-    description: string;
+    label?: string;
+    description?: string;
   }
 
   interface StickyColumns {

--- a/src/collection-preferences/utils.tsx
+++ b/src/collection-preferences/utils.tsx
@@ -10,6 +10,7 @@ import InternalSpaceBetween from '../space-between/internal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { CollectionPreferencesProps } from './interfaces';
 import styles from './styles.css.js';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export const copyPreferences = ({
   pageSize,
@@ -90,66 +91,82 @@ interface PageSizePreferenceProps extends CollectionPreferencesProps.PageSizePre
   value?: number;
 }
 
-export const PageSizePreference = ({ title, options, value, onChange }: PageSizePreferenceProps) => (
-  <div className={styles['page-size']}>
-    <InternalFormField label={title} stretch={true} className={styles['page-size-form-field']}>
-      <InternalRadioGroup
-        className={styles['page-size-radio-group']}
-        value={`${value}`}
-        items={options.map(({ label, value }) => ({ label, value: `${value}` }))}
-        onChange={({ detail }) => onChange(parseInt(detail.value, 10))}
-      />
-    </InternalFormField>
-  </div>
-);
+export const PageSizePreference = ({ title, options, value, onChange }: PageSizePreferenceProps) => {
+  const i18n = useInternalI18n('collection-preferences');
+  return (
+    <div className={styles['page-size']}>
+      <InternalFormField
+        label={i18n('pageSizePreference.title', title)}
+        stretch={true}
+        className={styles['page-size-form-field']}
+      >
+        <InternalRadioGroup
+          className={styles['page-size-radio-group']}
+          value={`${value}`}
+          items={options.map(({ label, value }) => ({ label, value: `${value}` }))}
+          onChange={({ detail }) => onChange(parseInt(detail.value, 10))}
+        />
+      </InternalFormField>
+    </div>
+  );
+};
 
 interface WrapLinesPreferenceProps extends CollectionPreferencesProps.WrapLinesPreference {
   onChange: (value: boolean) => void;
   value?: boolean;
 }
 
-export const WrapLinesPreference = ({ label, description, value, onChange }: WrapLinesPreferenceProps) => (
-  <InternalCheckbox
-    checked={!!value}
-    description={description}
-    onChange={({ detail }) => onChange(detail.checked)}
-    className={styles['wrap-lines']}
-  >
-    {label}
-  </InternalCheckbox>
-);
+export const WrapLinesPreference = ({ label, description, value, onChange }: WrapLinesPreferenceProps) => {
+  const i18n = useInternalI18n('collection-preferences');
+  return (
+    <InternalCheckbox
+      checked={!!value}
+      description={i18n('wrapLinesPreference.description', description)}
+      onChange={({ detail }) => onChange(detail.checked)}
+      className={styles['wrap-lines']}
+    >
+      {i18n('wrapLinesPreference.label', label)}
+    </InternalCheckbox>
+  );
+};
 
 interface StripedRowsPreferenceProps extends CollectionPreferencesProps.StripedRowsPreference {
   onChange: (value: boolean) => void;
   value?: boolean;
 }
 
-export const StripedRowsPreference = ({ label, description, value, onChange }: StripedRowsPreferenceProps) => (
-  <InternalCheckbox
-    checked={!!value}
-    description={description}
-    onChange={({ detail }) => onChange(detail.checked)}
-    className={styles['striped-rows']}
-  >
-    {label}
-  </InternalCheckbox>
-);
+export function StripedRowsPreference({ label, description, value, onChange }: StripedRowsPreferenceProps) {
+  const i18n = useInternalI18n('collection-preferences');
+  return (
+    <InternalCheckbox
+      checked={!!value}
+      description={i18n('stripedRowsPreference.description', description)}
+      onChange={({ detail }) => onChange(detail.checked)}
+      className={styles['striped-rows']}
+    >
+      {i18n('stripedRowsPreference.label', label)}
+    </InternalCheckbox>
+  );
+}
 
 interface ContentDensityPreferenceProps extends CollectionPreferencesProps.ContentDensityPreference {
   onChange: (value: 'comfortable' | 'compact') => void;
   value?: 'comfortable' | 'compact';
 }
 
-export const ContentDensityPreference = ({ label, description, value, onChange }: ContentDensityPreferenceProps) => (
-  <InternalCheckbox
-    checked={value === 'compact'}
-    description={description}
-    onChange={({ detail }) => onChange(detail.checked ? 'compact' : 'comfortable')}
-    className={styles['content-density']}
-  >
-    {label}
-  </InternalCheckbox>
-);
+export const ContentDensityPreference = ({ label, description, value, onChange }: ContentDensityPreferenceProps) => {
+  const i18n = useInternalI18n('collection-preferences');
+  return (
+    <InternalCheckbox
+      checked={value === 'compact'}
+      description={i18n('contentDensityPreference.description', description)}
+      onChange={({ detail }) => onChange(detail.checked ? 'compact' : 'comfortable')}
+      className={styles['content-density']}
+    >
+      {i18n('contentDensityPreference.label', label)}
+    </InternalCheckbox>
+  );
+};
 
 interface StickyColumnsPreferenceProps extends CollectionPreferencesProps.StickyColumnsPreference {
   onChange: (value?: { first?: number; last?: number }) => void;

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -11,6 +11,7 @@ import {
 import createWrapper, { SplitPanelWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/split-panel/styles.css.js';
 import { defaultSplitPanelContextProps } from './helpers';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const onKeyDown = jest.fn();
 jest.mock('../../../lib/components/split-panel/utils/use-keyboard-events', () => ({
@@ -45,14 +46,18 @@ const defaultProps: SplitPanelProps = {
 function renderSplitPanel({
   props,
   contextProps,
+  messages = {},
 }: {
   props?: Partial<SplitPanelProps>;
   contextProps?: Partial<SplitPanelContextProps>;
+  messages?: Record<string, string>;
 } = {}) {
   const { container } = render(
-    <SplitPanelContextProvider value={{ ...defaultSplitPanelContextProps, ...contextProps }}>
-      <SplitPanel {...defaultProps} {...props} />
-    </SplitPanelContextProvider>
+    <TestI18nProvider messages={{ 'split-panel': messages }}>
+      <SplitPanelContextProvider value={{ ...defaultSplitPanelContextProps, ...contextProps }}>
+        <SplitPanel {...defaultProps} {...props} />
+      </SplitPanelContextProvider>
+    </TestI18nProvider>
   );
   const wrapper = createWrapper(container).findSplitPanel()!;
   return { wrapper };
@@ -278,6 +283,61 @@ describe('Split panel', () => {
       const labelId = sidePanelElem?.getAttribute('aria-labelledby');
 
       expect(sidePanelElem?.querySelector(`#${labelId}`)!.textContent).toBe('Split panel header');
+    });
+  });
+
+  describe('i18n', () => {
+    test('supports using i18nStrings.openButtonAriaLabel from i18n provider', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { i18nStrings: undefined },
+        contextProps: { position: 'bottom', isOpen: false },
+        messages: { 'i18nStrings.openButtonAriaLabel': 'Custom open button' },
+      });
+      expect(wrapper.findOpenButton()!.getElement()).toHaveAttribute('aria-label', 'Custom open button');
+    });
+
+    test('supports using i18nStrings.closeButtonAriaLabel and i18nStrings.resizeHandleAriaLabel from i18n provider', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { i18nStrings: undefined },
+        contextProps: { position: 'bottom', isOpen: true },
+        messages: {
+          'i18nStrings.closeButtonAriaLabel': 'Custom close button',
+          'i18nStrings.resizeHandleAriaLabel': 'Custom resize',
+        },
+      });
+      expect(wrapper.findCloseButton()!.getElement()).toHaveAttribute('aria-label', 'Custom close button');
+      expect(wrapper.findSlider()!.getElement()).toHaveAttribute('aria-label', 'Custom resize');
+    });
+
+    test('supports using preferences props from i18n provider', () => {
+      const { wrapper } = renderSplitPanel({
+        props: { i18nStrings: undefined },
+        contextProps: { position: 'bottom', isOpen: true },
+        messages: {
+          'i18nStrings.preferencesTitle': 'Custom title',
+          'i18nStrings.preferencesPositionLabel': 'Custom position',
+          'i18nStrings.preferencesPositionDescription': 'Custom position description',
+          'i18nStrings.preferencesPositionSide': 'Custom side',
+          'i18nStrings.preferencesPositionBottom': 'Custom bottom',
+          'i18nStrings.preferencesConfirm': 'Custom confirm',
+          'i18nStrings.preferencesCancel': 'Custom cancel',
+        },
+      });
+      wrapper.findPreferencesButton()!.click();
+      const modalWrapper = createWrapper().findModal()!;
+      expect(modalWrapper.findHeader().getElement()).toHaveTextContent('Custom title');
+      expect(modalWrapper.findContent().findFormField()!.findLabel()!.getElement()).toHaveTextContent(
+        'Custom position'
+      );
+      expect(modalWrapper.findContent().findFormField()!.findDescription()!.getElement()).toHaveTextContent(
+        'Custom position description'
+      );
+      const tileItems = modalWrapper.findContent().findTiles()!.findItems();
+      expect(tileItems[0].findLabel().getElement()).toHaveTextContent('Custom bottom');
+      expect(tileItems[1].findLabel().getElement()).toHaveTextContent('Custom side');
+      const footerItems = modalWrapper.findFooter()!.findSpaceBetween()!;
+      expect(footerItems.find(':nth-child(1)')!.findButton()!.getElement()).toHaveTextContent('Custom cancel');
+      expect(footerItems.find(':nth-child(2)')!.findButton()!.getElement()).toHaveTextContent('Custom confirm');
     });
   });
 });

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -24,6 +24,7 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { SplitPanelContentSide } from './side';
 import { SplitPanelContentBottom } from './bottom';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export { SplitPanelProps };
 
@@ -59,6 +60,7 @@ export default function SplitPanel({
     refs,
   } = useSplitPanelContext();
   const baseProps = getBaseProps(restProps);
+  const i18n = useInternalI18n('split-panel');
   const [isPreferencesOpen, setPreferencesOpen] = useState<boolean>(false);
   const [relativeSize, setRelativeSize] = useState(0);
   const [maxSize, setMaxSize] = useState(size);
@@ -66,9 +68,10 @@ export default function SplitPanel({
   const cappedSize = getLimitedValue(minSize, size, maxSize);
   const appLayoutMaxWidth = isRefresh && position === 'bottom' ? contentWidthStyles : undefined;
 
+  const openButtonAriaLabel = i18n('i18nStrings.openButtonAriaLabel', i18nStrings?.openButtonAriaLabel);
   useEffect(() => {
-    setSplitPanelToggle({ displayed: closeBehavior === 'collapse', ariaLabel: i18nStrings.openButtonAriaLabel });
-  }, [setSplitPanelToggle, i18nStrings.openButtonAriaLabel, closeBehavior]);
+    setSplitPanelToggle({ displayed: closeBehavior === 'collapse', ariaLabel: openButtonAriaLabel });
+  }, [setSplitPanelToggle, openButtonAriaLabel, closeBehavior]);
 
   useEffect(() => {
     // effects are called inside out in the components tree
@@ -149,7 +152,7 @@ export default function SplitPanel({
               variant="icon"
               onClick={() => setPreferencesOpen(true)}
               formAction="none"
-              ariaLabel={i18nStrings.preferencesTitle}
+              ariaLabel={i18n('i18nStrings.preferencesTitle', i18nStrings?.preferencesTitle)}
               ref={refs.preferences}
             />
             <span className={styles.divider} />
@@ -165,7 +168,7 @@ export default function SplitPanel({
             variant="icon"
             onClick={onToggle}
             formAction="none"
-            ariaLabel={i18nStrings.closeButtonAriaLabel}
+            ariaLabel={i18n('i18nStrings.closeButtonAriaLabel', i18nStrings?.closeButtonAriaLabel)}
             ariaExpanded={isOpen}
           />
         ) : position === 'side' ? null : (
@@ -174,7 +177,7 @@ export default function SplitPanel({
             iconName="angle-up"
             variant="icon"
             formAction="none"
-            ariaLabel={i18nStrings.openButtonAriaLabel}
+            ariaLabel={i18n('i18nStrings.openButtonAriaLabel', i18nStrings?.openButtonAriaLabel)}
             ref={refs.toggle}
             ariaExpanded={isOpen}
           />
@@ -188,7 +191,7 @@ export default function SplitPanel({
       ref={refs.slider}
       role="slider"
       tabIndex={0}
-      aria-label={i18nStrings.resizeHandleAriaLabel}
+      aria-label={i18n('i18nStrings.resizeHandleAriaLabel', i18nStrings?.resizeHandleAriaLabel)}
       aria-valuemax={100}
       aria-valuemin={0}
       // Allows us to use the logical left/right keys to move the slider left/right,
@@ -256,7 +259,7 @@ export default function SplitPanel({
               splitPanelRef={mergedRef}
               cappedSize={cappedSize}
               onToggle={onToggle}
-              i18nStrings={i18nStrings}
+              openButtonAriaLabel={i18n('i18nStrings.openButtonAriaLabel', i18nStrings?.openButtonAriaLabel)}
               toggleRef={refs.toggle}
               header={wrappedHeader}
               panelHeaderId={panelHeaderId}
@@ -289,13 +292,16 @@ export default function SplitPanel({
               disabledSidePosition={position === 'bottom' && isForcedPosition}
               isRefresh={isRefresh}
               i18nStrings={{
-                header: i18nStrings.preferencesTitle,
-                confirm: i18nStrings.preferencesConfirm,
-                cancel: i18nStrings.preferencesCancel,
-                positionLabel: i18nStrings.preferencesPositionLabel,
-                positionDescription: i18nStrings.preferencesPositionDescription,
-                positionBottom: i18nStrings.preferencesPositionBottom,
-                positionSide: i18nStrings.preferencesPositionSide,
+                header: i18n('i18nStrings.preferencesTitle', i18nStrings?.preferencesTitle),
+                confirm: i18n('i18nStrings.preferencesConfirm', i18nStrings?.preferencesConfirm),
+                cancel: i18n('i18nStrings.preferencesCancel', i18nStrings?.preferencesCancel),
+                positionLabel: i18n('i18nStrings.preferencesPositionLabel', i18nStrings?.preferencesPositionLabel),
+                positionDescription: i18n(
+                  'i18nStrings.preferencesPositionDescription',
+                  i18nStrings?.preferencesPositionDescription
+                ),
+                positionBottom: i18n('i18nStrings.preferencesPositionBottom', i18nStrings?.preferencesPositionBottom),
+                positionSide: i18n('i18nStrings.preferencesPositionSide', i18nStrings?.preferencesPositionSide),
               }}
               onConfirm={preferences => {
                 onPreferencesChange({ ...preferences });

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -30,12 +30,12 @@ export interface SplitPanelProps extends BaseComponentProps {
    * - `preferencesCancel` - The text of the preference modal cancel button.
    * - `resizeHandleAriaLabel` - The label of the resize handle aria label.
    */
-  i18nStrings: SplitPanelProps.I18nStrings;
+  i18nStrings?: SplitPanelProps.I18nStrings;
 }
 
 export namespace SplitPanelProps {
   export interface I18nStrings {
-    closeButtonAriaLabel: string;
+    closeButtonAriaLabel?: string;
     openButtonAriaLabel?: string;
     preferencesTitle?: string;
     preferencesPositionLabel?: string;
@@ -44,7 +44,7 @@ export namespace SplitPanelProps {
     preferencesPositionBottom?: string;
     preferencesConfirm?: string;
     preferencesCancel?: string;
-    resizeHandleAriaLabel: string;
+    resizeHandleAriaLabel?: string;
   }
 }
 

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -5,12 +5,12 @@ import clsx from 'clsx';
 import { ButtonProps } from '../button/interfaces';
 import InternalButton from '../button/internal';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { SplitPanelProps, SplitPanelContentProps } from './interfaces';
+import { SplitPanelContentProps } from './interfaces';
 import styles from './styles.css.js';
 import { useSplitPanelContext } from '../internal/context/split-panel-context';
 
 interface SplitPanelContentSideProps extends SplitPanelContentProps {
-  i18nStrings: SplitPanelProps.I18nStrings;
+  openButtonAriaLabel?: string;
   toggleRef: React.RefObject<ButtonProps.Ref>;
 }
 
@@ -23,7 +23,7 @@ export function SplitPanelContentSide({
   resizeHandle,
   isOpen,
   cappedSize,
-  i18nStrings,
+  openButtonAriaLabel,
   panelHeaderId,
   onToggle,
 }: SplitPanelContentSideProps) {
@@ -61,7 +61,7 @@ export function SplitPanelContentSide({
             iconName="angle-left"
             variant="icon"
             formAction="none"
-            ariaLabel={i18nStrings.openButtonAriaLabel}
+            ariaLabel={openButtonAriaLabel}
             ariaExpanded={isOpen}
             ref={isRefresh ? null : toggleRef}
           />

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -9,6 +9,7 @@ import { renderHook } from '../../__tests__/render-hook';
 import styles from '../../../lib/components/table/header-cell/styles.css.js';
 import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
 import { useStickyColumns } from '../../../lib/components/table/use-sticky-columns';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const testItem = {
   test: 'test',
@@ -85,4 +86,29 @@ it('renders a fake focus outline on the resize control', () => {
   // Activate focus-visible
   fireEvent.keyDown(document.body, { key: 'Tab', keyCode: 65 });
   expect(container.querySelector(`.${resizerStyles['has-focus']}`)).toBeInTheDocument();
+});
+
+describe('i18n', () => {
+  it('supports using editIconAriaLabel from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider messages={{ table: { 'columnDefinitions.editConfig.editIconAriaLabel': 'Custom editable' } }}>
+        <TableWrapper>
+          <TableHeaderCell<typeof testItem>
+            column={{ ...column, editConfig: undefined }}
+            colIndex={0}
+            tabIndex={0}
+            resizableColumns={true}
+            onFocusedComponentChange={() => {}}
+            updateColumn={() => {}}
+            onClick={() => {}}
+            onResizeFinish={() => {}}
+            stickyState={result.current}
+            columnId="id"
+            isEditable={true}
+          />
+        </TableWrapper>
+      </TestI18nProvider>
+    );
+    expect(container.querySelector(`.${styles['edit-icon']}`)).toHaveAttribute('aria-label', 'Custom editable');
+  });
 });

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -9,6 +9,7 @@ import { TableProps } from '../interfaces';
 import { TableTdElement, TableTdElementProps } from './td-element';
 import { InlineEditor } from './inline-editor';
 import LiveRegion from '../../internal/components/live-region/index.js';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 const submitHandlerFallback = () => {
   throw new Error('The function `handleSubmit` is required for editable columns');
@@ -38,6 +39,7 @@ function TableCellEditable<ItemType>({
   successfulEdit = false,
   ...rest
 }: TableBodyCellProps<ItemType>) {
+  const i18n = useInternalI18n('table');
   const editActivateRef = useRef<HTMLButtonElement>(null);
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
@@ -89,7 +91,9 @@ function TableCellEditable<ItemType>({
               >
                 <Icon name="status-positive" variant="success" />
               </span>
-              <LiveRegion>{ariaLabels?.successfulEditLabel?.(column)}</LiveRegion>
+              <LiveRegion>
+                {i18n('ariaLabels.successfulEditLabel', ariaLabels?.successfulEditLabel?.(column))}
+              </LiveRegion>
             </>
           )}
           <button

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -10,6 +10,7 @@ import styles from './styles.css.js';
 import { Optional } from '../../internal/types';
 import FocusLock, { FocusLockRef } from '../../internal/components/focus-lock';
 import LiveRegion from '../../internal/components/live-region';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 // A function that does nothing
 const noop = () => undefined;
@@ -33,6 +34,7 @@ export function InlineEditor<ItemType>({
 }: InlineEditorProps<ItemType>) {
   const [currentEditLoading, setCurrentEditLoading] = useState(false);
   const [currentEditValue, setCurrentEditValue] = useState<Optional<any>>();
+  const i18n = useInternalI18n('table');
 
   const focusLockRef = useRef<FocusLockRef>(null);
 
@@ -136,7 +138,11 @@ export function InlineEditor<ItemType>({
                     loading={currentEditLoading}
                   />
                 </SpaceBetween>
-                <LiveRegion>{currentEditLoading ? ariaLabels?.submittingEditText?.(column) : ''}</LiveRegion>
+                <LiveRegion>
+                  {currentEditLoading
+                    ? i18n('ariaLabels.submittingEditText', ariaLabels?.submittingEditText?.(column))
+                    : ''}
+                </LiveRegion>
               </span>
             </div>
           </FormField>

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -12,6 +12,7 @@ import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { InteractiveComponent } from '../thead';
 import { StickyColumnsModel, useStickyCellStyles } from '../use-sticky-columns';
 import { getStickyClassNames } from '../utils';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 interface TableHeaderCellProps<ItemType> {
   className?: string;
@@ -59,6 +60,7 @@ export function TableHeaderCell<ItemType>({
   columnId,
   stickyState,
 }: TableHeaderCellProps<ItemType>) {
+  const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
   const sorted = !!activeSortingColumn && isSorted(column, activeSortingColumn);
   const sortingStatus = getSortingStatus(sortable, sorted, !!sortingDescending, !!sortingDisabled);
@@ -134,7 +136,11 @@ export function TableHeaderCell<ItemType>({
         <div className={clsx(styles['header-cell-text'], wrapLines && styles['header-cell-text-wrap'])} id={headerId}>
           {column.header}
           {isEditable ? (
-            <span className={styles['edit-icon']} role="img" aria-label={column.editConfig?.editIconAriaLabel}>
+            <span
+              className={styles['edit-icon']}
+              role="img"
+              aria-label={i18n('columnDefinitions.editConfig.editIconAriaLabel', column.editConfig?.editIconAriaLabel)}
+            >
               <InternalIcon name="edit" />
             </span>
           ) : null}


### PR DESCRIPTION
### Description

It's a lot of files, but it reads quick! Adds i18n string support to a batch of related components. The strings themselves will come in a later PR, so this PR itself will not change anything for users.

Codecov is yelling at me so I'll add a couple of tests before merging, but you can still take a look in the meantime :)

Related links, issue #, if available: n/a

### How has this been tested?

All i18n string additions are being tested with unit tests. As I'm sure you've noticed, there's a little internal test helper to make building test-specific i18n providers easy. Also, tests are most of the actual code in this PR.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
