### PR TITLE
chore: Improve API doc for headerText prop in Expandable section

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5832,7 +5832,7 @@ works with the \`headerText\` slot (not with the deprecated \`header\`), and not
       "name": "header",
     },
     Object {
-      "description": "Heading displayed above the content text. When using the container variant, use it with additional header props. Otherwise, use plain text.",
+      "description": "The heading text. Use plain text. When using the container variant, you can use additional header props like \`headerDescription\` and \`headerCounter\` to display other elements in the header.",
       "isDefault": false,
       "name": "headerText",
     },

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -51,7 +51,7 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   header?: React.ReactNode;
 
   /**
-   * Heading displayed above the content text. When using the container variant, use it with additional header props. Otherwise, use plain text.
+   * The heading text. Use plain text. When using the container variant, you can use additional header props like `headerDescription` and `headerCounter` to display other elements in the header.
    */
   headerText?: React.ReactNode;
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

The main motivation for this change is the word "otherwise" in the last sentence. This is a leftover from the now deprecated `header` prop, from the API doc text was copied over. Now that we use `headerText` instead since https://github.com/cloudscape-design/components/pull/473, plain text should be used in all cases, not just in non-container variants.

Also applied the following changes in the wording:

- Replaced "Heading displayed above the content text" with just "The heading text", because I find "content text" confusing (I assume it refers to the content in the default slot, but it can be any React node, not just text), and because I see no need to specify that it's above the content, that is already obvious if it refers the heading which is part of the header. I based this part, and the overall structure, on the title [slot](https://cloudscape.design/components/header/?tabId=api#slots) of the Header component.
- Extend the "When using the container variant (...)" sentence to make it more clear that using the other header props is not something mandatory and what they are for.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
