### PR TITLE
feat: The `embedded` table variant is now deprecated in favor of `container` and `borderless`

### DIFF
--- a/pages/table/compact-mode.page.tsx
+++ b/pages/table/compact-mode.page.tsx
@@ -66,7 +66,7 @@ export default function App() {
   );
 
   const [variant, setVariant] = useState<TableProps.Variant>('container');
-  const variants: TableProps.Variant[] = ['container', 'embedded', 'full-page', 'stacked'];
+  const variants: TableProps.Variant[] = ['container', 'embedded', 'full-page', 'stacked', 'borderless'];
 
   const variantButtons = (
     <div style={{ paddingBottom: '10px', display: 'inline-flex', gap: '10px' }}>

--- a/pages/table/simple-permutations.page.tsx
+++ b/pages/table/simple-permutations.page.tsx
@@ -81,7 +81,7 @@ const permutations = createPermutations<TableProps>([
     header: [null, <Box>header</Box>],
     footer: [null, <Box>footer</Box>],
     items: [createSimpleItems(3)],
-    variant: ['embedded', 'stacked', 'full-page'],
+    variant: ['embedded', 'stacked', 'full-page', 'borderless'],
   },
   {
     columnDefinitions: [SIMPLE_COLUMNS],

--- a/pages/table/sticky-header.page.tsx
+++ b/pages/table/sticky-header.page.tsx
@@ -11,7 +11,7 @@ const items = generateItems(20);
 
 export default function () {
   const [variant, setVariant] = useState<TableProps.Variant>('container');
-  const variants: TableProps.Variant[] = ['container', 'embedded', 'full-page', 'stacked'];
+  const variants: TableProps.Variant[] = ['container', 'embedded', 'full-page', 'stacked', 'borderless'];
 
   const variantButtons = (
     <div style={{ paddingBottom: '10px', display: 'inline-flex', gap: '10px' }}>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12274,6 +12274,7 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
                  (such as in a dashboard item container).
 * \`embedded\` - Use this variant within a parent container (such as a modal, expandable
                section, container or split panel).
+               **Deprecated**, replaced by \`borderless\` and \`container\`.
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,
               table).
 * \`full-page\` – Use this variant when the table is the entire content of a page. Full page variants

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -124,7 +124,7 @@ export function BasicS3Table<T>({
 
   return (
     <InternalTable<T>
-      variant="embedded"
+      variant={isVisualRefresh ? 'borderless' : 'container'}
       {...collectionProps}
       header={
         <InternalHeader

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -280,6 +280,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *                  (such as in a dashboard item container).
    * * `embedded` - Use this variant within a parent container (such as a modal, expandable
    *                section, container or split panel).
+   *                **Deprecated**, replaced by `borderless` and `container`.
    * * `stacked` - Use this variant adjacent to other stacked containers (such as a container,
    *               table).
    * * `full-page` – Use this variant when the table is the entire content of a page. Full page variants


### PR DESCRIPTION
### Description

Following the addition of the new `borderless` variant in Table, we are now deprecating the old `embedded` variant. `borderless` and `embedded` currently have the exact same behavior in VR.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
