### PR TITLE
feat: Add i18n support to date range picker, s3 resource selector, top navigation

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5391,12 +5391,12 @@ Default: the user's current time offset as provided by the browser.
         "properties": Array [
           Object {
             "name": "absoluteModeTitle",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "applyButtonLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -5416,37 +5416,37 @@ Default: the user's current time offset as provided by the browser.
           },
           Object {
             "name": "cancelButtonLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "clearButtonLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "customRelativeRangeDurationLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "customRelativeRangeDurationPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "customRelativeRangeOptionDescription",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "customRelativeRangeOptionLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "customRelativeRangeUnitLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -5456,12 +5456,12 @@ Default: the user's current time offset as provided by the browser.
           },
           Object {
             "name": "endDateLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "endTimeLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -5471,32 +5471,32 @@ Default: the user's current time offset as provided by the browser.
           },
           Object {
             "name": "formatRelativeRange",
-            "optional": false,
+            "optional": true,
             "type": "(value: DateRangePickerProps.RelativeValue) => string",
           },
           Object {
             "name": "formatUnit",
-            "optional": false,
+            "optional": true,
             "type": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
           },
           Object {
             "name": "nextMonthAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "previousMonthAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "relativeModeTitle",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "relativeRangeSelectionHeading",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -5506,24 +5506,24 @@ Default: the user's current time offset as provided by the browser.
           },
           Object {
             "name": "startDateLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "startTimeLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "todayAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "DateRangePickerProps.I18nStrings",
     },
     Object {
@@ -10291,7 +10291,7 @@ The return type of the function should be a promise that resolves to a list of v
         "properties": Array [
           Object {
             "name": "clearFilterButtonText",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10301,7 +10301,7 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "columnBucketName",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10311,7 +10311,7 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "columnObjectKey",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10326,12 +10326,12 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "columnVersionID",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "columnVersionLastModified",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10341,22 +10341,22 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "filteringCantFindMatch",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "filteringCounterText",
-            "optional": false,
+            "optional": true,
             "type": "(count: number) => string",
           },
           Object {
             "name": "filteringNoMatches",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextBrowseButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10366,32 +10366,32 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "inContextInputPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextLoadingText",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextSelectPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextUriLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextVersionSelectLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "inContextViewButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10401,162 +10401,162 @@ The return type of the function should be a promise that resolves to a list of v
           },
           Object {
             "name": "labelBreadcrumbs",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "labelFiltering",
-            "optional": false,
+            "optional": true,
             "type": "(itemsType: string) => string",
           },
           Object {
             "name": "labelModalDismiss",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "labelNotSorted",
-            "optional": false,
+            "optional": true,
             "type": "SortingColumnContainingString",
           },
           Object {
             "name": "labelRefresh",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "labelSortedAscending",
-            "optional": false,
+            "optional": true,
             "type": "SortingColumnContainingString",
           },
           Object {
             "name": "labelSortedDescending",
-            "optional": false,
+            "optional": true,
             "type": "SortingColumnContainingString",
           },
           Object {
             "name": "labelsBucketsSelection",
-            "optional": false,
+            "optional": true,
             "type": "SelectionLabels<S3ResourceSelectorProps.Bucket>",
           },
           Object {
             "name": "labelsObjectsSelection",
-            "optional": false,
+            "optional": true,
             "type": "SelectionLabels<S3ResourceSelectorProps.Object>",
           },
           Object {
             "name": "labelsPagination",
-            "optional": false,
+            "optional": true,
             "type": "PaginationProps.Labels",
           },
           Object {
             "name": "labelsVersionsSelection",
-            "optional": false,
+            "optional": true,
             "type": "SelectionLabels<S3ResourceSelectorProps.Version>",
           },
           Object {
             "name": "modalBreadcrumbRootItem",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "modalCancelButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "modalSubmitButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "modalTitle",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionBuckets",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionBucketsLoading",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionBucketsNoItems",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionBucketsSearchPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionObjects",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionObjectsLoading",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionObjectsNoItems",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionObjectsSearchPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionVersions",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionVersionsLoading",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionVersionsNoItems",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "selectionVersionsSearchPlaceholder",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "validationBucketLength",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "validationBucketLowerCase",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "validationBucketMustComplyDns",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "validationBucketMustNotContain",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "validationPathMustBegin",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],
@@ -13868,12 +13868,12 @@ Object {
           },
           Object {
             "name": "overflowMenuTitleText",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "overflowMenuTriggerText",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -13890,7 +13890,7 @@ Object {
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "TopNavigationProps.I18nStrings",
     },
     Object {

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -7,6 +7,7 @@ import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/d
 import { i18nStrings } from './i18n-strings';
 import { isValidRange } from './is-valid-range';
 import '../../__a11y__/to-validate-a11y';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const defaultProps: DateRangePickerProps = {
   locale: 'en-US',
@@ -534,6 +535,44 @@ describe('Date range picker', () => {
         expect(wrapper.findDropdown()!.findSelectedEndDate()).toBeNull();
         expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('');
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('');
+      });
+    });
+
+    describe('i18n', () => {
+      test('supports using relative range props from i18n provider', () => {
+        const { container } = render(
+          <TestI18nProvider
+            messages={{
+              'date-range-picker': {
+                'i18nStrings.startDateLabel': 'Custom start date',
+                'i18nStrings.startTimeLabel': 'Custom start time',
+                'i18nStrings.endDateLabel': 'Custom end date',
+                'i18nStrings.endTimeLabel': 'Custom end time',
+                'i18nStrings.dateTimeConstraintText': 'Custom constraint text',
+              },
+            }}
+          >
+            <DateRangePicker {...defaultProps} rangeSelectorMode="absolute-only" i18nStrings={undefined} />
+          </TestI18nProvider>
+        );
+        const wrapper = createWrapper(container).findDateRangePicker()!;
+        wrapper.openDropdown();
+
+        expect(wrapper.findDropdown()?.findStartDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+          'Custom start date'
+        );
+        expect(wrapper.findDropdown()?.findStartTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+          'Custom start time'
+        );
+        expect(wrapper.findDropdown()?.findEndDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+          'Custom end date'
+        );
+        expect(wrapper.findDropdown()?.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+          'Custom end time'
+        );
+        expect(wrapper.findDropdown()?.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleDescription(
+          'Custom constraint text'
+        );
       });
     });
   });

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -558,19 +558,19 @@ describe('Date range picker', () => {
         const wrapper = createWrapper(container).findDateRangePicker()!;
         wrapper.openDropdown();
 
-        expect(wrapper.findDropdown()?.findStartDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+        expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
           'Custom start date'
         );
-        expect(wrapper.findDropdown()?.findStartTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+        expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
           'Custom start time'
         );
-        expect(wrapper.findDropdown()?.findEndDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+        expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveAccessibleName(
           'Custom end date'
         );
-        expect(wrapper.findDropdown()?.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleName(
           'Custom end time'
         );
-        expect(wrapper.findDropdown()?.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleDescription(
+        expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveAccessibleDescription(
           'Custom constraint text'
         );
       });

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -261,7 +261,7 @@ describe('Date range picker', () => {
           createWrapper(wrapper.findDropdown()!.getElement()).findFormField()!.findLabel()!.getElement()
         ).toHaveTextContent('Custom choose range');
         expect(
-          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[0].findLabel()!.getElement()
+          wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[0].findLabel()!.getElement()
         ).toHaveTextContent('Custom last 5 minute');
         expect(
           wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[4]!.findLabel()!.getElement()

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -264,10 +264,10 @@ describe('Date range picker', () => {
           wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[0].findLabel()!.getElement()
         ).toHaveTextContent('Custom last 5 minute');
         expect(
-          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[4]!.findLabel()!.getElement()
+          wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4]!.findLabel()!.getElement()
         ).toHaveTextContent('Custom custom range');
         expect(
-          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[4]!.findDescription()!.getElement()
+          wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4]!.findDescription()!.getElement()
         ).toHaveTextContent('Custom custom range description');
       });
     });

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -10,6 +10,7 @@ import { i18nStrings } from './i18n-strings';
 import { changeMode } from './change-mode';
 import { isValidRange } from './is-valid-range';
 import '../../__a11y__/to-validate-a11y';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const defaultProps: DateRangePickerProps = {
   locale: 'en-US',
@@ -133,7 +134,7 @@ describe('Date range picker', () => {
         .getAttribute('aria-labelledby')!
         .split(' ')[0];
       expect(wrapper.find(`#${durationAriaLabelId}`)!.getElement()).toHaveTextContent(
-        i18nStrings.customRelativeRangeDurationLabel
+        i18nStrings.customRelativeRangeDurationLabel!
       );
 
       const unitAriaLabelId = wrapper
@@ -144,7 +145,7 @@ describe('Date range picker', () => {
         .getAttribute('aria-labelledby')!
         .split(' ')[0];
       expect(wrapper.find(`#${unitAriaLabelId}`)!.getElement()).toHaveTextContent(
-        i18nStrings.customRelativeRangeUnitLabel
+        i18nStrings.customRelativeRangeUnitLabel!
       );
     });
 
@@ -234,6 +235,41 @@ describe('Date range picker', () => {
 
       wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual(['days', 'weeks', 'months', 'years']);
+    });
+
+    describe('i18n', () => {
+      test('supports using relative range props from i18n provider', () => {
+        const { container } = render(
+          <TestI18nProvider
+            messages={{
+              'date-range-picker': {
+                'i18nStrings.relativeRangeSelectionHeading': 'Custom choose range',
+                'i18nStrings.formatRelativeRange': 'Custom last {amount} {unit}',
+                'i18nStrings.customRelativeRangeOptionLabel': 'Custom custom range',
+                'i18nStrings.customRelativeRangeOptionDescription': 'Custom custom range description',
+              },
+            }}
+          >
+            <DateRangePicker {...defaultProps} rangeSelectorMode="relative-only" i18nStrings={undefined} />
+          </TestI18nProvider>
+        );
+
+        const wrapper = createWrapper(container).findDateRangePicker()!;
+
+        wrapper.openDropdown();
+        expect(
+          createWrapper(wrapper.findDropdown()!.getElement()).findFormField()!.findLabel()!.getElement()
+        ).toHaveTextContent('Custom choose range');
+        expect(
+          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[0].findLabel()!.getElement()
+        ).toHaveTextContent('Custom last 5 minute');
+        expect(
+          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[4]!.findLabel()!.getElement()
+        ).toHaveTextContent('Custom custom range');
+        expect(
+          wrapper.findDropdown()?.findRelativeRangeRadioGroup()!.findButtons()[4]!.findDescription()!.getElement()
+        ).toHaveTextContent('Custom custom range description');
+      });
     });
   });
 });

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -12,6 +12,7 @@ import { isValidRange } from './is-valid-range';
 import { changeMode } from './change-mode';
 import { warnOnce } from '../../../lib/components/internal/logging';
 import styles from '../../../lib/components/date-range-picker/styles.css.js';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 jest.mock('../../../lib/components/internal/logging', () => ({
   warnOnce: jest.fn(),
@@ -310,6 +311,35 @@ describe('Date range picker', () => {
         'DateRangePicker',
         'The provided value does not correspond to the current range selector mode. Reverting back to default.'
       );
+    });
+  });
+
+  describe('i18n', () => {
+    test('supports using mode selector and modal footer props from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider
+          messages={{
+            'date-range-picker': {
+              'i18nStrings.relativeModeTitle': 'Custom relative',
+              'i18nStrings.absoluteModeTitle': 'Custom absolute',
+              'i18nStrings.clearButtonLabel': 'Custom clear',
+              'i18nStrings.cancelButtonLabel': 'Custom cancel',
+              'i18nStrings.applyButtonLabel': 'Custom apply',
+            },
+          }}
+        >
+          <DateRangePicker {...defaultProps} i18nStrings={undefined} />
+        </TestI18nProvider>
+      );
+      const wrapper = createWrapper(container).findDateRangePicker()!;
+      wrapper.openDropdown();
+      const modeSwitch = wrapper.findDropdown()!.findSelectionModeSwitch()!.findModesAsSelect()!;
+      modeSwitch.openDropdown();
+      expect(modeSwitch.findDropdown().findOption(1)!.getElement()).toHaveTextContent('Custom relative');
+      expect(modeSwitch.findDropdown().findOption(2)!.getElement()).toHaveTextContent('Custom absolute');
+      expect(wrapper.findDropdown()!.findClearButton()!.getElement()).toHaveTextContent('Custom clear');
+      expect(wrapper.findDropdown()!.findCancelButton()!.getElement()).toHaveTextContent('Custom cancel');
+      expect(wrapper.findDropdown()!.findApplyButton()!.getElement()).toHaveTextContent('Custom apply');
     });
   });
 });

--- a/src/date-range-picker/__tests__/i18n-strings.ts
+++ b/src/date-range-picker/__tests__/i18n-strings.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DateRangePickerProps } from '../interfaces';
 
-export const i18nStrings: DateRangePickerProps['i18nStrings'] = {
+export const i18nStrings: DateRangePickerProps.I18nStrings = {
   ariaLabel: 'date range picker',
   todayAriaLabel: 'TEST TODAY',
   nextMonthAriaLabel: 'TEST NEXT MONTH',

--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -21,7 +21,7 @@ afterEach(() => Mockdate.reset());
 
 describe('Date range picker calendar', () => {
   const outsideId = 'outside';
-  const defaultProps: DateRangePickerProps = {
+  const defaultProps: DateRangePickerProps & Pick<Required<DateRangePickerProps>, 'i18nStrings'> = {
     i18nStrings,
     relativeOptions: [
       { key: 'previous-5-minutes', amount: 5, unit: 'minute', type: 'relative' },
@@ -461,22 +461,22 @@ describe('Date range picker calendar', () => {
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
       });
-      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
       });
-      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings!.renderSelectedAbsoluteRangeAriaLive!('', ''))
       );
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 3, 2).click();
       });
-      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 3, 1).click();
       });
-      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings.renderSelectedAbsoluteRangeAriaLive!('', ''))
       );
@@ -497,7 +497,7 @@ describe('Date range picker calendar', () => {
       act(() => {
         wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
       });
-      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel));
+      expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent('Sunday, September 6, 2020 – Monday, September 7, 2020');
     });
 

--- a/src/date-range-picker/calendar/grids/grid.tsx
+++ b/src/date-range-picker/calendar/grids/grid.tsx
@@ -54,7 +54,7 @@ export interface GridProps {
 
   locale: string;
   startOfWeek: DayIndex;
-  todayAriaLabel: string;
+  todayAriaLabel?: string;
   ariaLabelledby: string;
 
   className?: string;

--- a/src/date-range-picker/calendar/grids/index.tsx
+++ b/src/date-range-picker/calendar/grids/index.tsx
@@ -40,7 +40,7 @@ export interface GridProps {
 
   locale: string;
   startOfWeek: DayIndex;
-  todayAriaLabel: string;
+  todayAriaLabel?: string;
   headingIdPrefix: string;
 }
 

--- a/src/date-range-picker/calendar/header/header-button.tsx
+++ b/src/date-range-picker/calendar/header/header-button.tsx
@@ -6,7 +6,7 @@ import { InternalButton } from '../../../button/internal';
 import styles from '../../styles.css.js';
 
 interface HeaderButtonProps {
-  ariaLabel: string;
+  ariaLabel?: string;
   baseDate: Date;
   onChangeMonth: (date: Date) => void;
 }

--- a/src/date-range-picker/calendar/header/index.tsx
+++ b/src/date-range-picker/calendar/header/index.tsx
@@ -11,8 +11,8 @@ interface CalendarHeaderProps {
   baseDate: Date;
   locale: string;
   onChangeMonth: (date: Date) => void;
-  previousMonthLabel: string;
-  nextMonthLabel: string;
+  previousMonthLabel?: string;
+  nextMonthLabel?: string;
   isSingleGrid: boolean;
   headingIdPrefix: string;
 }

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -20,6 +20,7 @@ import { getBaseDate } from '../../calendar/utils/navigation';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
 import RangeInputs from './range-inputs.js';
 import { findDateToFocus, findMonthToDisplay } from './utils';
+import { useInternalI18n } from '../../internal/i18n/context.js';
 
 export interface DateRangePickerCalendarProps extends BaseComponentProps {
   value: DateRangePickerProps.PendingAbsoluteValue;
@@ -27,7 +28,7 @@ export interface DateRangePickerCalendarProps extends BaseComponentProps {
   locale?: string;
   startOfWeek?: number;
   isDateEnabled?: (date: Date) => boolean;
-  i18nStrings: RangeCalendarI18nStrings;
+  i18nStrings?: RangeCalendarI18nStrings;
   dateOnly?: boolean;
   timeInputFormat?: TimeInputProps.Format;
   customAbsoluteRangeControl: DateRangePickerProps.AbsoluteRangeControl | undefined;
@@ -47,6 +48,7 @@ export default function DateRangePickerCalendar({
   const isSingleGrid = useMobile();
   const normalizedLocale = normalizeLocale('DateRangePicker', locale);
   const normalizedStartOfWeek = normalizeStartOfWeek(startOfWeek, normalizedLocale);
+  const i18n = useInternalI18n('date-range-picker');
 
   const [announcement, setAnnouncement] = useState('');
   const [currentMonth, setCurrentMonth] = useState(() => findMonthToDisplay(value, isSingleGrid));
@@ -74,11 +76,11 @@ export default function DateRangePickerCalendar({
   // because the user is not aware of the fact that a start/end time is also set as soon as they select a date
   const announceStart = (startDate: Date) => {
     return (
-      i18nStrings.startDateLabel +
+      i18n('i18nStrings.startDateLabel', i18nStrings?.startDateLabel) +
       ', ' +
       getDateLabel(normalizedLocale, startDate) +
       ', ' +
-      i18nStrings.startTimeLabel +
+      i18n('i18nStrings.startTimeLabel', i18nStrings?.startTimeLabel) +
       ', ' +
       renderTimeLabel(normalizedLocale, startDate, timeInputFormat) +
       '. '
@@ -87,22 +89,28 @@ export default function DateRangePickerCalendar({
 
   const announceEnd = (endDate: Date) => {
     return (
-      i18nStrings.endDateLabel +
+      i18n('i18nStrings.endDateLabel', i18nStrings?.endDateLabel) +
       ', ' +
       getDateLabel(normalizedLocale, endDate) +
       ', ' +
-      i18nStrings.endTimeLabel +
+      i18n('i18nStrings.endTimeLabel', i18nStrings?.endTimeLabel) +
       ', ' +
       renderTimeLabel(normalizedLocale, endDate, timeInputFormat) +
       '. '
     );
   };
 
+  const renderSelectedAbsoluteRangeAriaLive = i18n(
+    'i18nStrings.renderSelectedAbsoluteRangeAriaLive',
+    i18nStrings?.renderSelectedAbsoluteRangeAriaLive,
+    format => (startDate, endDate) => format({ startDate, endDate })
+  );
+
   const announceRange = (startDate: Date, endDate: Date) => {
-    if (!i18nStrings.renderSelectedAbsoluteRangeAriaLive) {
+    if (!renderSelectedAbsoluteRangeAriaLive) {
       return `${getDateLabel(normalizedLocale, startDate)} – ${getDateLabel(normalizedLocale, endDate)}`;
     }
-    return i18nStrings.renderSelectedAbsoluteRangeAriaLive(
+    return renderSelectedAbsoluteRangeAriaLive(
       getDateLabel(normalizedLocale, startDate),
       getDateLabel(normalizedLocale, endDate)
     );
@@ -217,8 +225,8 @@ export default function DateRangePickerCalendar({
               baseDate={currentMonth}
               locale={normalizedLocale}
               onChangeMonth={onHeaderChangeMonthHandler}
-              previousMonthLabel={i18nStrings.previousMonthAriaLabel}
-              nextMonthLabel={i18nStrings.nextMonthAriaLabel}
+              previousMonthLabel={i18n('i18nStrings.previousMonthAriaLabel', i18nStrings?.previousMonthAriaLabel)}
+              nextMonthLabel={i18n('i18nStrings.nextMonthAriaLabel', i18nStrings?.nextMonthAriaLabel)}
               isSingleGrid={isSingleGrid}
               headingIdPrefix={headingIdPrefix}
             />
@@ -233,7 +241,7 @@ export default function DateRangePickerCalendar({
               onSelectDate={onSelectDateHandler}
               onChangeMonth={setCurrentMonth}
               startOfWeek={normalizedStartOfWeek}
-              todayAriaLabel={i18nStrings.todayAriaLabel}
+              todayAriaLabel={i18nStrings?.todayAriaLabel}
               selectedStartDate={parseDate(value.start.date, true)}
               selectedEndDate={parseDate(value.end.date, true)}
               headingIdPrefix={headingIdPrefix}

--- a/src/date-range-picker/calendar/range-inputs.tsx
+++ b/src/date-range-picker/calendar/range-inputs.tsx
@@ -9,6 +9,7 @@ import InternalFormField from '../../form-field/internal';
 import InternalDateInput from '../../date-input/internal';
 import { TimeInputProps } from '../../time-input/interfaces';
 import InternalTimeInput from '../../time-input/internal';
+import { useInternalI18n } from '../../internal/i18n/context.js';
 
 type I18nStrings = Pick<
   RangeCalendarI18nStrings,
@@ -24,7 +25,7 @@ export interface RangeInputsProps extends BaseComponentProps {
   onChangeEndDate: (value: string) => void;
   endTime: string;
   onChangeEndTime: (value: string) => void;
-  i18nStrings: I18nStrings;
+  i18nStrings?: I18nStrings;
   dateOnly: boolean;
   timeInputFormat: TimeInputProps.Format;
 }
@@ -42,11 +43,13 @@ export default function RangeInputs({
   dateOnly,
   timeInputFormat,
 }: RangeInputsProps) {
+  const i18n = useInternalI18n('date-range-picker');
+
   return (
-    <InternalFormField constraintText={i18nStrings.dateTimeConstraintText}>
+    <InternalFormField constraintText={i18n('i18nStrings.dateTimeConstraintText', i18nStrings?.dateTimeConstraintText)}>
       <div className={styles['date-and-time-container']}>
         <div className={styles['date-and-time-wrapper']}>
-          <InternalFormField label={i18nStrings.startDateLabel} stretch={true}>
+          <InternalFormField label={i18n('i18nStrings.startDateLabel', i18nStrings?.startDateLabel)} stretch={true}>
             <InternalDateInput
               value={startDate}
               className={styles['start-date-input']}
@@ -55,7 +58,7 @@ export default function RangeInputs({
             />
           </InternalFormField>
           {!dateOnly && (
-            <InternalFormField label={i18nStrings.startTimeLabel} stretch={true}>
+            <InternalFormField label={i18n('i18nStrings.startTimeLabel', i18nStrings?.startTimeLabel)} stretch={true}>
               <InternalTimeInput
                 value={startTime}
                 onChange={event => onChangeStartTime(event.detail.value)}
@@ -68,7 +71,7 @@ export default function RangeInputs({
         </div>
 
         <div className={styles['date-and-time-wrapper']}>
-          <InternalFormField label={i18nStrings.endDateLabel} stretch={true}>
+          <InternalFormField label={i18n('i18nStrings.endDateLabel', i18nStrings?.endDateLabel)} stretch={true}>
             <InternalDateInput
               value={endDate}
               className={styles['end-date-input']}
@@ -77,7 +80,7 @@ export default function RangeInputs({
             />
           </InternalFormField>
           {!dateOnly && (
-            <InternalFormField label={i18nStrings.endTimeLabel} stretch={true}>
+            <InternalFormField label={i18n('i18nStrings.endTimeLabel', i18nStrings?.endTimeLabel)} stretch={true}>
               <InternalTimeInput
                 value={endTime}
                 onChange={event => onChangeEndTime(event.detail.value)}

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -17,6 +17,7 @@ import clsx from 'clsx';
 import InternalAlert from '../alert/internal';
 import LiveRegion from '../internal/components/live-region';
 import { getDefaultMode, joinAbsoluteValue, splitAbsoluteValue } from './utils';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export const VALID_RANGE: DateRangePickerProps.ValidRangeResult = { valid: true };
 
@@ -29,7 +30,6 @@ export interface DateRangePickerDropdownProps
     | 'value'
     | 'relativeOptions'
     | 'showClearButton'
-    | 'i18nStrings'
     | 'dateOnly'
     | 'timeInputFormat'
     | 'rangeSelectorMode'
@@ -39,6 +39,7 @@ export interface DateRangePickerDropdownProps
   startOfWeek: number | undefined;
   onDropdownClose: () => void;
   isSingleGrid: boolean;
+  i18nStrings?: DateRangePickerProps.I18nStrings;
 
   ariaLabelledby?: string;
   ariaDescribedby?: string;
@@ -65,6 +66,8 @@ export function DateRangePickerDropdown({
   ariaDescribedby,
   customAbsoluteRangeControl,
 }: DateRangePickerDropdownProps) {
+  const i18n = useInternalI18n('date-range-picker');
+
   const [rangeSelectionMode, setRangeSelectionMode] = useState<'absolute' | 'relative'>(
     getDefaultMode(value, relativeOptions, rangeSelectorMode)
   );
@@ -137,9 +140,9 @@ export function DateRangePickerDropdown({
           tabIndex={0}
           role="dialog"
           aria-modal="true"
-          aria-label={i18nStrings.ariaLabel}
-          aria-labelledby={ariaLabelledby ?? i18nStrings.ariaLabelledby}
-          aria-describedby={ariaDescribedby ?? i18nStrings.ariaDescribedby}
+          aria-label={i18nStrings?.ariaLabel}
+          aria-labelledby={ariaLabelledby ?? i18nStrings?.ariaLabelledby}
+          aria-describedby={ariaDescribedby ?? i18nStrings?.ariaDescribedby}
         >
           <div
             className={clsx(styles['dropdown-content'], {
@@ -193,7 +196,10 @@ export function DateRangePickerDropdown({
                 >
                   {!validationResult.valid && (
                     <>
-                      <InternalAlert type="error" statusIconAriaLabel={i18nStrings.errorIconAriaLabel}>
+                      <InternalAlert
+                        type="error"
+                        statusIconAriaLabel={i18n('i18nStrings.errorIconAriaLabel', i18nStrings?.errorIconAriaLabel)}
+                      >
                         <span className={styles['validation-error']}>{validationResult.errorMessage}</span>
                       </InternalAlert>
                       <LiveRegion>{validationResult.errorMessage}</LiveRegion>
@@ -216,7 +222,7 @@ export function DateRangePickerDropdown({
                       variant="link"
                       formAction="none"
                     >
-                      {i18nStrings.clearButtonLabel}
+                      {i18n('i18nStrings.clearButtonLabel', i18nStrings?.clearButtonLabel)}
                     </InternalButton>
                   </div>
                 )}
@@ -228,7 +234,7 @@ export function DateRangePickerDropdown({
                       variant="link"
                       formAction="none"
                     >
-                      {i18nStrings.cancelButtonLabel}
+                      {i18n('i18nStrings.cancelButtonLabel', i18nStrings?.cancelButtonLabel)}
                     </InternalButton>
 
                     <InternalButton
@@ -237,7 +243,7 @@ export function DateRangePickerDropdown({
                       ref={applyButtonRef}
                       formAction="none"
                     >
-                      {i18nStrings.applyButtonLabel}
+                      {i18n('i18nStrings.applyButtonLabel', i18nStrings?.applyButtonLabel)}
                     </InternalButton>
                   </InternalSpaceBetween>
                 </div>

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -214,11 +214,13 @@ const DateRangePicker = React.forwardRef(
           format({ amount, unit })
     );
 
-    if (!formatRelativeRange) {
-      warnOnce(
-        'DateRangePicker',
-        'A function for i18nStrings.formatRelativeRange was not provided. Relative ranges will not be correctly rendered.'
-      );
+    if (isDevelopment) {
+      if (!formatRelativeRange) {
+        warnOnce(
+          'DateRangePicker',
+          'A function for i18nStrings.formatRelativeRange was not provided. Relative ranges will not be correctly rendered.'
+        );
+      }
     }
 
     const trigger = (

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -28,6 +28,7 @@ import { usePrevious } from '../internal/hooks/use-previous/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { formatDateRange, isIsoDateOnly } from '../internal/utils/date-time';
 import { formatValue } from './utils.js';
+import { useInternalI18n } from '../internal/i18n/context.js';
 
 export { DateRangePickerProps };
 
@@ -47,7 +48,7 @@ function renderDateRange(
 
   const formatted =
     range.type === 'relative' ? (
-      formatRelativeRange(range)
+      formatRelativeRange?.(range) ?? ''
     ) : (
       <BreakSpaces text={formatDateRange(range.startDate, range.endDate, timeOffset)} />
     );
@@ -116,8 +117,8 @@ const DateRangePicker = React.forwardRef(
 
     const baseProps = getBaseProps(rest);
     const { invalid, controlId, ariaDescribedby, ariaLabelledby } = useFormFieldContext({
-      ariaLabelledby: rest.ariaLabelledby ?? i18nStrings.ariaLabelledby,
-      ariaDescribedby: rest.ariaDescribedby ?? i18nStrings.ariaDescribedby,
+      ariaLabelledby: rest.ariaLabelledby ?? i18nStrings?.ariaLabelledby,
+      ariaDescribedby: rest.ariaDescribedby ?? i18nStrings?.ariaDescribedby,
       ...rest,
     });
     const isSingleGrid = useMobile();
@@ -204,13 +205,22 @@ const DateRangePicker = React.forwardRef(
       value = null;
     }
 
+    const i18n = useInternalI18n('date-range-picker');
+    const formatRelativeRange = i18n(
+      'i18nStrings.formatRelativeRange',
+      i18nStrings?.formatRelativeRange,
+      format =>
+        ({ amount, unit }) =>
+          format({ amount, unit })
+    );
+
     const trigger = (
       <div className={styles['trigger-wrapper']}>
         <ButtonTrigger
           ref={triggerRef}
           id={controlId}
           invalid={invalid}
-          ariaLabel={i18nStrings.ariaLabel}
+          ariaLabel={i18nStrings?.ariaLabel}
           ariaDescribedby={ariaDescribedby}
           ariaLabelledby={ariaLabelledby}
           className={clsx(styles.label, {
@@ -230,7 +240,7 @@ const DateRangePicker = React.forwardRef(
             <span className={styles['icon-wrapper']}>
               <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
             </span>
-            {renderDateRange(value, placeholder ?? '', i18nStrings.formatRelativeRange, normalizedTimeOffset)}
+            {renderDateRange(value, placeholder ?? '', formatRelativeRange, normalizedTimeOffset)}
           </span>
         </ButtonTrigger>
       </div>

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -214,6 +214,13 @@ const DateRangePicker = React.forwardRef(
           format({ amount, unit })
     );
 
+    if (!formatRelativeRange) {
+      warnOnce(
+        'DateRangePicker',
+        'A function for i18nStrings.formatRelativeRange was not provided. Relative ranges will not be correctly rendered.'
+      );
+    }
+
     const trigger = (
       <div className={styles['trigger-wrapper']}>
         <ButtonTrigger

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -46,7 +46,7 @@ export interface DateRangePickerBaseProps {
   /**
    * An object containing all the necessary localized strings required by the component.
    */
-  i18nStrings: DateRangePickerProps.I18nStrings;
+  i18nStrings?: DateRangePickerProps.I18nStrings;
 
   /**
    * Hides time inputs and changes the input format to date-only, e.g. 2021-04-06.
@@ -266,107 +266,107 @@ export namespace DateRangePickerProps {
     /**
      * Segment title of the relative range selection mode
      */
-    relativeModeTitle: string;
+    relativeModeTitle?: string;
 
     /**
      * Segment title of the absolute range selection mode
      */
-    absoluteModeTitle: string;
+    absoluteModeTitle?: string;
 
     /**
      * Heading for the relative range selection area
      */
-    relativeRangeSelectionHeading: string;
+    relativeRangeSelectionHeading?: string;
 
     /**
      * Visible label of the Cancel button
      */
-    cancelButtonLabel: string;
+    cancelButtonLabel?: string;
     /**
      * Visible label of the Clear and dismiss button
      */
-    clearButtonLabel: string;
+    clearButtonLabel?: string;
     /**
      * Visible label of the Apply button
      */
-    applyButtonLabel: string;
+    applyButtonLabel?: string;
 
     /**
      * Formatting function for relative ranges.
      * This function must convert a relative range to a human-readable string.
      */
-    formatRelativeRange: (value: RelativeValue) => string;
+    formatRelativeRange?: (value: RelativeValue) => string;
 
     /**
      * Formatting function for time units.
      *
      * This function must return a localized form of the unit that fits the provided time value.
      */
-    formatUnit: (unit: TimeUnit, value: number) => string;
+    formatUnit?: (unit: TimeUnit, value: number) => string;
 
     /**
      * Visible label for the option for selecting
      * a custom relative range.
      */
-    customRelativeRangeOptionLabel: string;
+    customRelativeRangeOptionLabel?: string;
 
     /**
      * Visible description for the option for selecting
      * a custom relative range.
      */
-    customRelativeRangeOptionDescription: string;
+    customRelativeRangeOptionDescription?: string;
 
     /**
      * Visible label for the duration selector for
      * the custom relative range.
      */
-    customRelativeRangeDurationLabel: string;
+    customRelativeRangeDurationLabel?: string;
     /**
      * Placeholder for the duration selector for
      * the custom relative range.
      */
-    customRelativeRangeDurationPlaceholder: string;
+    customRelativeRangeDurationPlaceholder?: string;
     /**
      * Visible label for the unit selector for the
      * custom relative range.
      */
-    customRelativeRangeUnitLabel: string;
+    customRelativeRangeUnitLabel?: string;
 
     /**
      * Used as part of the aria label for today's date in the calendar.
      */
-    todayAriaLabel: string;
+    todayAriaLabel?: string;
 
     /**
      * An aria label for the 'next month' button.
      */
-    nextMonthAriaLabel: string;
+    nextMonthAriaLabel?: string;
 
     /**
      * An aria label for the 'previous month' button.
      */
-    previousMonthAriaLabel: string;
+    previousMonthAriaLabel?: string;
 
     /**
      * Visible label for the Start Date input for the
      * absolute range.
      */
-    startDateLabel: string;
+    startDateLabel?: string;
     /**
      * Visible label for the Start Time input for the
      * absolute range.
      */
-    startTimeLabel: string;
+    startTimeLabel?: string;
     /**
      * Visible label for the End Date input for the
      * absolute range.
      */
-    endDateLabel: string;
+    endDateLabel?: string;
     /**
      * Visible label for the End Time input for the
      * absolute range.
      */
-    endTimeLabel: string;
+    endTimeLabel?: string;
 
     /**
      * Constraint text for the input fields for the

--- a/src/date-range-picker/mode-switcher.tsx
+++ b/src/date-range-picker/mode-switcher.tsx
@@ -5,20 +5,23 @@ import { DateRangePickerProps } from './interfaces';
 import InternalSegmentedControl from '../segmented-control/internal';
 
 import styles from './styles.css.js';
+import { useInternalI18n } from '../internal/i18n/context';
 
-interface ModeSwitcherProps extends Pick<Required<DateRangePickerProps>, 'i18nStrings'> {
+interface ModeSwitcherProps extends Pick<DateRangePickerProps, 'i18nStrings'> {
   mode: 'absolute' | 'relative';
   onChange: (mode: 'absolute' | 'relative') => void;
 }
 
 export default function ModeSwitcher({ i18nStrings, mode, onChange }: ModeSwitcherProps) {
+  const i18n = useInternalI18n('date-range-picker');
+
   return (
     <InternalSegmentedControl
       className={styles['mode-switch']}
       selectedId={mode}
       options={[
-        { id: 'relative', text: i18nStrings.relativeModeTitle },
-        { id: 'absolute', text: i18nStrings.absoluteModeTitle },
+        { id: 'relative', text: i18n('i18nStrings.relativeModeTitle', i18nStrings?.relativeModeTitle) },
+        { id: 'absolute', text: i18n('i18nStrings.absoluteModeTitle', i18nStrings?.absoluteModeTitle) },
       ]}
       onChange={e => onChange(e.detail.selectedId as 'absolute' | 'relative')}
     />

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -11,13 +11,14 @@ import InternalRadioGroup from '../../radio-group/internal';
 import InternalSelect from '../../select/internal';
 import InternalSpaceBetween from '../../space-between/internal';
 import styles from './styles.css.js';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 export interface RelativeRangePickerProps {
   dateOnly: boolean;
   options: ReadonlyArray<DateRangePickerProps.RelativeOption>;
   initialSelection: DateRangePickerProps.RelativeValue | null;
   onChange: (range: DateRangePickerProps.RelativeValue) => void;
-  i18nStrings: DateRangePickerProps.I18nStrings;
+  i18nStrings?: DateRangePickerProps.I18nStrings;
   isSingleGrid: boolean;
 }
 
@@ -39,14 +40,31 @@ export default function RelativeRangePicker({
   i18nStrings,
   isSingleGrid,
 }: RelativeRangePickerProps) {
+  const i18n = useInternalI18n('date-range-picker');
+  const formatRelativeRange = i18n(
+    'i18nStrings.formatRelativeRange',
+    i18nStrings?.formatRelativeRange,
+    format =>
+      ({ amount, unit }) =>
+        format({ amount, unit })
+  );
+  const formatUnit = i18n(
+    'i18nStrings.formatUnit',
+    i18nStrings?.formatUnit,
+    format => (unit, amount) => format({ amount, unit })
+  );
+
   const radioOptions: RadioGroupProps.RadioButtonDefinition[] = clientOptions.map(option => ({
     value: option.key,
-    label: i18nStrings.formatRelativeRange(option),
+    label: formatRelativeRange?.(option),
   }));
   radioOptions.push({
     value: CUSTOM_OPTION_SELECT_KEY,
-    label: i18nStrings.customRelativeRangeOptionLabel,
-    description: i18nStrings.customRelativeRangeOptionDescription,
+    label: i18n('i18nStrings.customRelativeRangeOptionLabel', i18nStrings?.customRelativeRangeOptionLabel),
+    description: i18n(
+      'i18nStrings.customRelativeRangeOptionDescription',
+      i18nStrings?.customRelativeRangeOptionDescription
+    ),
   });
 
   const [selectedRadio, setSelectedRadio] = useState(() => {
@@ -76,7 +94,9 @@ export default function RelativeRangePicker({
     <div>
       <InternalSpaceBetween size="xs" direction="vertical">
         {showRadioControl && (
-          <InternalFormField label={i18nStrings.relativeRangeSelectionHeading}>
+          <InternalFormField
+            label={i18n('i18nStrings.relativeRangeSelectionHeading', i18nStrings?.relativeRangeSelectionHeading)}
+          >
             <InternalRadioGroup
               className={styles['relative-range-radio-group']}
               onChange={({ detail }) => {
@@ -105,7 +125,10 @@ export default function RelativeRangePicker({
           <InternalSpaceBetween direction="vertical" size="xs">
             {!showRadioControl && (
               <InternalBox fontSize="body-m" color="text-body-secondary">
-                {i18nStrings.customRelativeRangeOptionDescription}
+                {i18n(
+                  'i18nStrings.customRelativeRangeOptionDescription',
+                  i18nStrings?.customRelativeRangeOptionDescription
+                )}
               </InternalBox>
             )}
 
@@ -120,7 +143,12 @@ export default function RelativeRangePicker({
                 })}
               >
                 <div className={styles['custom-range-duration']}>
-                  <InternalFormField label={i18nStrings.customRelativeRangeDurationLabel}>
+                  <InternalFormField
+                    label={i18n(
+                      'i18nStrings.customRelativeRangeDurationLabel',
+                      i18nStrings?.customRelativeRangeDurationLabel
+                    )}
+                  >
                     <InternalInput
                       type="number"
                       className={styles['custom-range-duration-input']}
@@ -131,20 +159,25 @@ export default function RelativeRangePicker({
                         setCustomDuration(amount);
                         onChangeRangeSize({ amount, unit: customUnitOfTime, type: 'relative' });
                       }}
-                      placeholder={i18nStrings.customRelativeRangeDurationPlaceholder}
+                      placeholder={i18n(
+                        'i18nStrings.customRelativeRangeDurationPlaceholder',
+                        i18nStrings?.customRelativeRangeDurationPlaceholder
+                      )}
                       __inheritFormFieldProps={true}
                     />
                   </InternalFormField>
                 </div>
 
                 <div className={styles['custom-range-unit']}>
-                  <InternalFormField label={i18nStrings.customRelativeRangeUnitLabel}>
+                  <InternalFormField
+                    label={i18n('i18nStrings.customRelativeRangeUnitLabel', i18nStrings?.customRelativeRangeUnitLabel)}
+                  >
                     <InternalSelect
                       className={styles['custom-range-unit-select']}
                       selectedOption={
                         {
                           value: customUnitOfTime,
-                          label: i18nStrings.formatUnit(customUnitOfTime, customDuration),
+                          label: formatUnit?.(customUnitOfTime, customDuration),
                         } as UnitSelectOption
                       }
                       onChange={e => {
@@ -155,7 +188,7 @@ export default function RelativeRangePicker({
                       }}
                       options={(dateOnly ? dayUnits : units).map(unit => ({
                         value: unit,
-                        label: i18nStrings.formatUnit(unit, customDuration),
+                        label: formatUnit?.(unit, customDuration),
                       }))}
                       renderHighlightedAriaLive={option => option.label || option.value || ''}
                     />

--- a/src/s3-resource-selector/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/__tests__/main.test.tsx
@@ -6,6 +6,7 @@ import S3ResourceSelector, { S3ResourceSelectorProps } from '../../../lib/compon
 import createWrapper, { S3ResourceSelectorWrapper } from '../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from './fixtures';
 import FormField from '../../../lib/components/form-field';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 jest.setTimeout(10_000);
 
@@ -195,4 +196,69 @@ test('Should overwrites aria-labelledby aria-describedby from surrounding FormFi
   );
   expect(wrapper.getElement()).toHaveAttribute('aria-labelledby', 'label-id');
   expect(wrapper.getElement()).toHaveAttribute('aria-describedby', 'description-id');
+});
+
+describe('i18n', () => {
+  test('supports using (bucket) modal strings from i18n provider', async () => {
+    const wrapper = renderComponent(
+      <TestI18nProvider
+        messages={{
+          's3-resource-selector': {
+            'i18nStrings.modalTitle': 'Custom modal title',
+            'i18nStrings.modalCancelButton': 'Custom cancel',
+            'i18nStrings.modalSubmitButton': 'Custom submit',
+            'i18nStrings.modalBreadcrumbRootItem': 'Custom root',
+            'i18nStrings.selectionBuckets': 'Custom buckets',
+            'i18nStrings.labelRefresh': 'Custom refresh',
+            'i18nStrings.selectionBucketsSearchPlaceholder': 'Custom find buckets',
+            'i18nStrings.columnBucketName': 'Custom name',
+            'i18nStrings.columnBucketCreationDate': 'Custom creation date',
+            'i18nStrings.labelNotSorted': 'Custom {columnName} not sorted',
+            'i18nStrings.labelSortedAscending': 'Custom {columnName} sorted ascending',
+            'i18nStrings.labelSortedDescending': 'Custom {columnName} sorted descending',
+          },
+        }}
+      >
+        <S3ResourceSelector {...defaultProps} i18nStrings={undefined} />
+      </TestI18nProvider>
+    );
+    await openBrowseDialog(wrapper);
+    expect(wrapper.findModal()!.findHeader().getElement()).toHaveTextContent('Custom modal title');
+    expect(
+      wrapper.findModal()!.findFooter()!.findSpaceBetween()!.find(':nth-child(1)')!.findButton()!.getElement()
+    ).toHaveTextContent('Custom cancel');
+    expect(
+      wrapper.findModal()!.findFooter()!.findSpaceBetween()!.find(':nth-child(2)')!.findButton()!.getElement()
+    ).toHaveTextContent('Custom submit');
+    const modalContent = wrapper.findModal()!.findContent();
+    expect(modalContent.findBreadcrumbGroup()!.getElement()).toHaveTextContent('Custom root');
+    const table = modalContent.findTable()!;
+    expect(table.findHeaderSlot()!.findHeader()!.findHeadingText().getElement()).toHaveTextContent('Custom buckets');
+    expect(table.findHeaderSlot()!.findHeader()!.findActions()!.findButton()!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom refresh'
+    );
+    expect(table.findHeaderSlot()!.findTextFilter()!.findInput()!.findNativeInput()!.getElement()).toHaveAttribute(
+      'placeholder',
+      'Custom find buckets'
+    );
+    expect(table.findColumnHeaders()[1].getElement()).toHaveTextContent('Custom name');
+    expect(table.findColumnSortingArea(2)!.getElement()).toHaveAttribute('aria-label', 'Custom Custom name not sorted');
+    expect(table.findColumnHeaders()[2].getElement()).toHaveTextContent('Custom creation date');
+    expect(table.findColumnSortingArea(3)!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom Custom creation date not sorted'
+    );
+
+    table.findColumnSortingArea(2)!.click();
+    expect(table.findColumnSortingArea(2)!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom Custom name sorted ascending'
+    );
+    table.findColumnSortingArea(2)!.click();
+    expect(table.findColumnSortingArea(2)!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom Custom name sorted descending'
+    );
+  });
 });

--- a/src/s3-resource-selector/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/__tests__/main.test.tsx
@@ -213,6 +213,7 @@ describe('i18n', () => {
             'i18nStrings.selectionBucketsSearchPlaceholder': 'Custom find buckets',
             'i18nStrings.columnBucketName': 'Custom name',
             'i18nStrings.columnBucketCreationDate': 'Custom creation date',
+            'i18nStrings.labelFiltering': 'Custom find {itemsType}',
             'i18nStrings.labelNotSorted': 'Custom {columnName} not sorted',
             'i18nStrings.labelSortedAscending': 'Custom {columnName} sorted ascending',
             'i18nStrings.labelSortedDescending': 'Custom {columnName} sorted descending',
@@ -241,6 +242,10 @@ describe('i18n', () => {
     expect(table.findHeaderSlot()!.findTextFilter()!.findInput()!.findNativeInput()!.getElement()).toHaveAttribute(
       'placeholder',
       'Custom find buckets'
+    );
+    expect(table.findHeaderSlot()!.findTextFilter()!.findInput()!.findNativeInput()!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Custom find Custom buckets'
     );
     expect(table.findColumnHeaders()[1].getElement()).toHaveTextContent('Custom name');
     expect(table.findColumnSortingArea(2)!.getElement()).toHaveAttribute('aria-label', 'Custom Custom name not sorted');

--- a/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
+++ b/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
@@ -7,6 +7,7 @@ import FormField from '../../../lib/components/form-field';
 import S3ResourceSelector from '../../../lib/components/s3-resource-selector';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from './fixtures';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 const defaultProps = {
   resource: { uri: '' },
@@ -47,10 +48,10 @@ test('renders element labels', () => {
     i18nStrings.inContextInputPlaceholder
   );
   expect(wrapper.findVersionsSelect()!.findTrigger().getElement()).toHaveTextContent(
-    i18nStrings.inContextSelectPlaceholder
+    i18nStrings.inContextSelectPlaceholder!
   );
-  expect(wrapper.findViewButton().getElement()).toHaveTextContent(i18nStrings.inContextViewButton);
-  expect(wrapper.findBrowseButton().getElement()).toHaveTextContent(i18nStrings.inContextBrowseButton);
+  expect(wrapper.findViewButton().getElement()).toHaveTextContent(i18nStrings.inContextViewButton!);
+  expect(wrapper.findBrowseButton().getElement()).toHaveTextContent(i18nStrings.inContextBrowseButton!);
 });
 
 test('inherits aria-describedby from the surrounding FormField', () => {
@@ -84,7 +85,7 @@ test('renders loading state', async () => {
   expect(wrapper.findUriInput().findNativeInput().getElement()).toBeEnabled();
   expect(wrapper.findVersionsSelect()!.isDisabled()).toEqual(true);
   expect(wrapper.findBrowseButton().getElement()).toBeDisabled();
-  expect(findLoadingIndicator(wrapper)!.getElement()).toHaveTextContent(i18nStrings.inContextLoadingText);
+  expect(findLoadingIndicator(wrapper)!.getElement()).toHaveTextContent(i18nStrings.inContextLoadingText!);
   await waitForFetch();
   expect(wrapper.findVersionsSelect()!.isDisabled()).toEqual(false);
   expect(wrapper.findBrowseButton().getElement()).toBeEnabled();
@@ -342,5 +343,34 @@ describe('onChange', () => {
       errorText: undefined,
       resource: { uri: 's3://my-bucket/folder-1/my-song.mp3', versionId: versions[1].VersionId },
     });
+  });
+});
+
+describe('i18n', () => {
+  test('supports using in-context strings from i18n provider', () => {
+    const wrapper = renderComponent(
+      <TestI18nProvider
+        messages={{
+          's3-resource-selector': {
+            'i18nStrings.inContextUriLabel': 'Custom URI label',
+            'i18nStrings.inContextInputPlaceholder': 'Custom placeholder',
+            'i18nStrings.inContextSelectPlaceholder': 'Custom version select',
+            'i18nStrings.inContextViewButton': 'Custom view',
+            'i18nStrings.inContextViewButtonAriaLabel': 'Custom view aria label',
+            'i18nStrings.inContextBrowseButton': 'Custom browse',
+          },
+        }}
+      >
+        <S3ResourceSelector {...defaultProps} i18nStrings={undefined} />
+      </TestI18nProvider>
+    );
+    expect(createWrapper(wrapper.getElement()).findFormField()!.findLabel()!.getElement()).toHaveTextContent(
+      'Custom URI label'
+    );
+    expect(wrapper.findUriInput().findNativeInput().getElement()).toHaveAttribute('placeholder', 'Custom placeholder');
+    expect(wrapper.findVersionsSelect()!.findTrigger().getElement()).toHaveTextContent('Custom version select');
+    expect(wrapper.findViewButton()!.getElement()).toHaveTextContent('Custom view');
+    expect(wrapper.findViewButton()!.getElement()).toHaveAttribute('aria-label', 'Custom view aria label');
+    expect(wrapper.findBrowseButton().getElement()).toHaveTextContent('Custom browse');
   });
 });

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -193,66 +193,66 @@ export namespace S3ResourceSelectorProps {
   export type SelectableItems = 'buckets' | 'objects' | 'versions';
 
   export interface I18nStrings {
-    inContextInputPlaceholder: string;
+    inContextInputPlaceholder?: string;
     inContextInputClearAriaLabel?: string;
-    inContextSelectPlaceholder: string;
-    inContextBrowseButton: string;
-    inContextViewButton: string;
+    inContextSelectPlaceholder?: string;
+    inContextBrowseButton?: string;
+    inContextViewButton?: string;
     inContextViewButtonAriaLabel?: string;
-    inContextLoadingText: string;
-    inContextUriLabel: string;
-    inContextVersionSelectLabel: string;
+    inContextLoadingText?: string;
+    inContextUriLabel?: string;
+    inContextVersionSelectLabel?: string;
 
-    modalTitle: string;
-    modalCancelButton: string;
-    modalSubmitButton: string;
-    modalBreadcrumbRootItem: string;
+    modalTitle?: string;
+    modalCancelButton?: string;
+    modalSubmitButton?: string;
+    modalBreadcrumbRootItem?: string;
 
-    selectionBuckets: string;
-    selectionObjects: string;
-    selectionVersions: string;
-    selectionBucketsSearchPlaceholder: string;
-    selectionObjectsSearchPlaceholder: string;
-    selectionVersionsSearchPlaceholder: string;
-    selectionBucketsLoading: string;
-    selectionBucketsNoItems: string;
-    selectionObjectsLoading: string;
-    selectionObjectsNoItems: string;
-    selectionVersionsLoading: string;
-    selectionVersionsNoItems: string;
+    selectionBuckets?: string;
+    selectionObjects?: string;
+    selectionVersions?: string;
+    selectionBucketsSearchPlaceholder?: string;
+    selectionObjectsSearchPlaceholder?: string;
+    selectionVersionsSearchPlaceholder?: string;
+    selectionBucketsLoading?: string;
+    selectionBucketsNoItems?: string;
+    selectionObjectsLoading?: string;
+    selectionObjectsNoItems?: string;
+    selectionVersionsLoading?: string;
+    selectionVersionsNoItems?: string;
 
-    filteringCounterText: (count: number) => string;
-    filteringNoMatches: string;
-    filteringCantFindMatch: string;
-    clearFilterButtonText: string;
+    filteringCounterText?: (count: number) => string;
+    filteringNoMatches?: string;
+    filteringCantFindMatch?: string;
+    clearFilterButtonText?: string;
 
-    columnBucketName: string;
+    columnBucketName?: string;
     columnBucketCreationDate?: string;
     columnBucketRegion?: string;
-    columnObjectKey: string;
+    columnObjectKey?: string;
     columnObjectLastModified?: string;
     columnObjectSize?: string;
-    columnVersionID: string;
-    columnVersionLastModified: string;
+    columnVersionID?: string;
+    columnVersionLastModified?: string;
     columnVersionSize?: string;
 
-    validationPathMustBegin: string;
-    validationBucketLowerCase: string;
-    validationBucketMustNotContain: string;
-    validationBucketLength: string;
-    validationBucketMustComplyDns: string;
+    validationPathMustBegin?: string;
+    validationBucketLowerCase?: string;
+    validationBucketMustNotContain?: string;
+    validationBucketLength?: string;
+    validationBucketMustComplyDns?: string;
 
-    labelSortedDescending: SortingColumnContainingString;
-    labelSortedAscending: SortingColumnContainingString;
-    labelNotSorted: SortingColumnContainingString;
-    labelsPagination: PaginationProps.Labels;
-    labelsBucketsSelection: SelectionLabels<Bucket>;
-    labelsObjectsSelection: SelectionLabels<S3ResourceSelectorProps.Object>;
-    labelsVersionsSelection: SelectionLabels<Version>;
-    labelFiltering: (itemsType: string) => string;
-    labelRefresh: string;
-    labelModalDismiss: string;
-    labelBreadcrumbs: string;
+    labelSortedDescending?: SortingColumnContainingString;
+    labelSortedAscending?: SortingColumnContainingString;
+    labelNotSorted?: SortingColumnContainingString;
+    labelsPagination?: PaginationProps.Labels;
+    labelsBucketsSelection?: SelectionLabels<Bucket>;
+    labelsObjectsSelection?: SelectionLabels<S3ResourceSelectorProps.Object>;
+    labelsVersionsSelection?: SelectionLabels<Version>;
+    labelFiltering?: (itemsType: string) => string;
+    labelRefresh?: string;
+    labelModalDismiss?: string;
+    labelBreadcrumbs?: string;
   }
 
   export interface ChangeDetail {

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -15,6 +15,7 @@ import { validate, getErrorText } from './validation';
 import styles from './styles.css.js';
 import { SearchInput } from './search-input';
 import LiveRegion from '../../internal/components/live-region';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 interface S3InContextProps {
   i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined;
@@ -47,6 +48,7 @@ export const S3InContext = React.forwardRef(
     }: S3InContextProps,
     ref: React.Ref<S3InContextRef>
   ) => {
+    const i18n = useInternalI18n('s3-resource-selector');
     const isInputBlurredRef = useRef(true);
     const [isInputTouched, setInputTouched] = useState(false);
     const { versions, loading, loadVersions, resetVersions } = useVersionsFetch(fetchVersions);
@@ -62,14 +64,14 @@ export const S3InContext = React.forwardRef(
       const uri = event.detail.value;
       const errorCode = isInputTouched ? validate(uri) : undefined;
       resetVersions();
-      onChange({ uri }, getErrorText(i18nStrings, errorCode));
+      onChange({ uri }, getErrorText(i18n, i18nStrings, errorCode));
     }
 
     function handleUriBlur() {
       isInputBlurredRef.current = true;
       setInputTouched(true);
       const errorCode = validate(resource.uri);
-      onChange(resource, getErrorText(i18nStrings, errorCode));
+      onChange(resource, getErrorText(i18n, i18nStrings, errorCode));
       if (supportsVersions) {
         loadVersions(resource.uri);
       }
@@ -86,13 +88,17 @@ export const S3InContext = React.forwardRef(
     return (
       <div className={styles.root}>
         <div className={styles.layout}>
-          <InternalFormField className={styles['layout-uri']} label={i18nStrings?.inContextUriLabel} stretch={true}>
+          <InternalFormField
+            className={styles['layout-uri']}
+            label={i18n('i18nStrings.inContextUriLabel', i18nStrings?.inContextUriLabel)}
+            stretch={true}
+          >
             <SearchInput
               ref={inputRef}
               value={uri}
               ariaDescribedby={inputAriaDescribedby}
               clearAriaLabel={i18nStrings?.inContextInputClearAriaLabel}
-              placeholder={i18nStrings?.inContextInputPlaceholder}
+              placeholder={i18n('i18nStrings.inContextInputPlaceholder', i18nStrings?.inContextInputPlaceholder)}
               onChange={handleUriChange}
               invalid={invalid}
               onFocus={() => (isInputBlurredRef.current = false)}
@@ -102,12 +108,12 @@ export const S3InContext = React.forwardRef(
           {supportsVersions && (
             <InternalFormField
               className={styles['layout-version']}
-              label={i18nStrings?.inContextVersionSelectLabel}
+              label={i18n('i18nStrings.inContextVersionSelectLabel', i18nStrings?.inContextVersionSelectLabel)}
               stretch={true}
             >
               <InternalSelect
                 selectedOption={selectedVersion}
-                placeholder={i18nStrings?.inContextSelectPlaceholder}
+                placeholder={i18n('i18nStrings.inContextSelectPlaceholder', i18nStrings?.inContextSelectPlaceholder)}
                 disabled={versions.length === 0}
                 options={versions}
                 onChange={event => onChange({ ...resource, versionId: event.detail.selectedOption.value }, undefined)}
@@ -124,15 +130,15 @@ export const S3InContext = React.forwardRef(
               iconName="external"
               iconAlign="right"
               formAction="none"
-              ariaLabel={i18nStrings?.inContextViewButtonAriaLabel}
+              ariaLabel={i18n('i18nStrings.inContextViewButtonAriaLabel', i18nStrings?.inContextViewButtonAriaLabel)}
             >
-              {i18nStrings?.inContextViewButton}
+              {i18n('i18nStrings.inContextViewButton', i18nStrings?.inContextViewButton)}
             </InternalButton>
           </div>
           <div className={styles['layout-divider']} />
           <div>
             <InternalButton className={styles['browse-button']} disabled={loading} formAction="none" onClick={onBrowse}>
-              {i18nStrings?.inContextBrowseButton}
+              {i18n('i18nStrings.inContextBrowseButton', i18nStrings?.inContextBrowseButton)}
             </InternalButton>
           </div>
         </div>
@@ -141,7 +147,9 @@ export const S3InContext = React.forwardRef(
           {loading && (
             <InternalBox margin={{ top: 's' }}>
               <InternalStatusIndicator type="loading">
-                <LiveRegion visible={true}>{i18nStrings?.inContextLoadingText}</LiveRegion>
+                <LiveRegion visible={true}>
+                  {i18n('i18nStrings.inContextLoadingText', i18nStrings?.inContextLoadingText)}
+                </LiveRegion>
               </InternalStatusIndicator>
             </InternalBox>
           )}

--- a/src/s3-resource-selector/s3-in-context/validation.ts
+++ b/src/s3-resource-selector/s3-in-context/validation.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ComponentFormatFunction } from '../../internal/i18n/context';
 import { S3ResourceSelectorProps } from '../interfaces';
 
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
@@ -41,8 +42,9 @@ export function validate(uri: string) {
 }
 
 export function getErrorText(
+  i18n: ComponentFormatFunction,
   i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined,
   errorCode: ReturnType<typeof validate>
 ) {
-  return errorCode ? i18nStrings?.[errorCode] : undefined;
+  return errorCode ? i18n(`i18nStrings.${errorCode}`, i18nStrings?.[errorCode]) : undefined;
 }

--- a/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/main.test.tsx
@@ -19,7 +19,7 @@ async function renderModal(jsx: React.ReactElement) {
 test('renders correct strings and aria labels', async () => {
   const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
   const modal = wrapper.findModal()!;
-  expect(modal.findHeader().getElement()).toHaveTextContent(i18nStrings.modalTitle);
+  expect(modal.findHeader().getElement()).toHaveTextContent(i18nStrings.modalTitle!);
   expect(screen.getByRole('button', { name: i18nStrings.modalSubmitButton })).toBeTruthy();
   expect(screen.getByRole('button', { name: i18nStrings.modalCancelButton })).toBeTruthy();
   expect(modal.findContent().findBreadcrumbGroup()!.getElement()).toHaveAttribute(

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -14,6 +14,7 @@ import useForwardFocus, { ForwardFocusRef } from '../../internal/hooks/forward-f
 import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
 import { S3ResourceSelectorProps } from '../interfaces';
 import { EmptyState } from './empty-state';
+import { ComponentFormatFunction } from '../../internal/i18n/context';
 
 interface BasicS3TableStrings<T> {
   labelRefresh?: string;
@@ -44,14 +45,21 @@ interface BasicS3TableProps<T> {
   onSelect: (item: T | undefined) => void;
 }
 
-export function getSharedI18Strings(i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined) {
+export function getSharedI18Strings(
+  i18n: ComponentFormatFunction,
+  i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined
+) {
   return {
-    filteringCounterText: i18nStrings?.filteringCounterText,
-    labelRefresh: i18nStrings?.labelRefresh,
+    filteringCounterText: i18n(
+      'i18nStrings.filteringCounterText',
+      i18nStrings?.filteringCounterText,
+      format => count => format({ count })
+    ),
+    labelRefresh: i18n('i18nStrings.labelRefresh', i18nStrings?.labelRefresh),
     labelsPagination: i18nStrings?.labelsPagination,
-    noMatchTitle: i18nStrings?.filteringNoMatches,
-    noMatchSubtitle: i18nStrings?.filteringCantFindMatch,
-    clearFilterButtonText: i18nStrings?.clearFilterButtonText,
+    noMatchTitle: i18n('i18nStrings.filteringNoMatches', i18nStrings?.filteringNoMatches),
+    noMatchSubtitle: i18n('i18nStrings.filteringCantFindMatch', i18nStrings?.filteringCantFindMatch),
+    clearFilterButtonText: i18n('i18nStrings.clearFilterButtonText', i18nStrings?.clearFilterButtonText),
   };
 }
 

--- a/src/s3-resource-selector/s3-modal/buckets-table.tsx
+++ b/src/s3-resource-selector/s3-modal/buckets-table.tsx
@@ -8,6 +8,7 @@ import { S3ResourceSelectorProps } from '../interfaces';
 import { compareDates, getColumnAriaLabel, includes } from './table-utils';
 import { formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 interface BucketsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;
@@ -32,6 +33,8 @@ export function BucketsTable({
   onDrilldown,
   onSelect,
 }: BucketsTableProps) {
+  const i18n = useInternalI18n('s3-resource-selector');
+
   return (
     <BasicS3Table<S3ResourceSelectorProps.Bucket>
       forwardFocusRef={forwardFocusRef}
@@ -40,20 +43,38 @@ export function BucketsTable({
       visibleColumns={visibleColumns}
       isItemDisabled={isItemDisabled || (() => !includes(selectableItemsTypes, 'buckets'))}
       i18nStrings={{
-        ...getSharedI18Strings(i18nStrings),
-        header: i18nStrings?.selectionBuckets,
-        loadingText: i18nStrings?.selectionBucketsLoading,
-        filteringAriaLabel: i18nStrings?.labelFiltering(i18nStrings?.selectionBuckets),
-        filteringPlaceholder: i18nStrings?.selectionBucketsSearchPlaceholder,
-        emptyText: i18nStrings?.selectionBucketsNoItems,
-        selectionLabels: i18nStrings?.labelsBucketsSelection,
+        ...getSharedI18Strings(i18n, i18nStrings),
+        header: i18n('i18nStrings.selectionBuckets', i18nStrings?.selectionBuckets),
+        loadingText: i18n('i18nStrings.selectionBucketsLoading', i18nStrings?.selectionBucketsLoading),
+        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionBuckets ?? ''),
+        filteringPlaceholder: i18n(
+          'i18nStrings.selectionBucketsSearchPlaceholder',
+          i18nStrings?.selectionBucketsSearchPlaceholder
+        ),
+        emptyText: i18n('i18nStrings.selectionBucketsNoItems', i18nStrings?.selectionBucketsNoItems),
+        selectionLabels: {
+          ...i18nStrings?.labelsBucketsSelection,
+          selectionGroupLabel: i18n(
+            'i18nStrings.labelsBucketsSelection.selectionGroupLabel',
+            i18nStrings?.labelsBucketsSelection?.selectionGroupLabel
+          ),
+          itemSelectionLabel: i18n(
+            'i18nStrings.labelsBucketsSelection.itemSelectionLabel',
+            i18nStrings?.labelsBucketsSelection?.itemSelectionLabel,
+            format => (data, item) => format({ item__Name: item.Name ?? '' })
+          ),
+        },
       }}
       isVisualRefresh={isVisualRefresh}
       columnDefinitions={[
         {
           id: 'Name',
-          header: i18nStrings?.columnBucketName,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnBucketName),
+          header: i18n('i18nStrings.columnBucketName', i18nStrings?.columnBucketName),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnBucketName', i18nStrings?.columnBucketName)
+          ),
           sortingField: 'Name',
           cell: item => {
             const isClickable = includes(selectableItemsTypes, 'objects') || includes(selectableItemsTypes, 'versions');
@@ -69,15 +90,23 @@ export function BucketsTable({
         },
         {
           id: 'CreationDate',
-          header: i18nStrings?.columnBucketCreationDate,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnBucketCreationDate),
+          header: i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnBucketCreationDate', i18nStrings?.columnBucketCreationDate)
+          ),
           sortingComparator: (a, b) => compareDates(a.CreationDate, b.CreationDate),
           cell: item => formatDefault(item.CreationDate),
         },
         {
           id: 'Region',
-          header: i18nStrings?.columnBucketRegion,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnBucketRegion),
+          header: i18n('i18nStrings.columnBucketRegion', i18nStrings?.columnBucketRegion),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnBucketRegion', i18nStrings?.columnBucketRegion)
+          ),
           sortingField: 'Region',
           cell: item => formatDefault(item.Region),
           minWidth: '150px',

--- a/src/s3-resource-selector/s3-modal/buckets-table.tsx
+++ b/src/s3-resource-selector/s3-modal/buckets-table.tsx
@@ -46,7 +46,11 @@ export function BucketsTable({
         ...getSharedI18Strings(i18n, i18nStrings),
         header: i18n('i18nStrings.selectionBuckets', i18nStrings?.selectionBuckets),
         loadingText: i18n('i18nStrings.selectionBucketsLoading', i18nStrings?.selectionBucketsLoading),
-        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionBuckets ?? ''),
+        filteringAriaLabel: i18n(
+          'i18nStrings.labelFiltering',
+          i18nStrings?.labelFiltering,
+          format => itemsType => format({ itemsType })
+        )?.(i18n('i18nStrings.selectionBuckets', i18nStrings?.selectionBuckets) ?? ''),
         filteringPlaceholder: i18n(
           'i18nStrings.selectionBucketsSearchPlaceholder',
           i18nStrings?.selectionBucketsSearchPlaceholder

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -14,6 +14,7 @@ import { ObjectsTable } from './objects-table';
 import { VersionsTable } from './versions-table';
 import styles from './styles.css.js';
 import { joinObjectPath } from '../utils';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 export interface S3ModalProps {
   alert: React.ReactNode;
@@ -107,6 +108,7 @@ export function S3Modal({
 }: S3ModalProps) {
   const [{ currentView, breadcrumbs, selectedItem }, dispatch] = useReducer(s3BrowseReducer, initialBrowseState);
   const forwardFocusRef = useRef<ForwardFocusRef>(null);
+  const i18n = useInternalI18n('s3-resource-selector');
 
   const isVisualRefresh = useVisualRefresh();
 
@@ -119,13 +121,13 @@ export function S3Modal({
       <InternalModal
         visible={true}
         size="max"
-        closeAriaLabel={i18nStrings?.labelModalDismiss ?? ''}
+        closeAriaLabel={i18nStrings?.labelModalDismiss}
         onDismiss={onDismiss}
-        header={i18nStrings?.modalTitle}
+        header={i18n('i18nStrings.modalTitle', i18nStrings?.modalTitle)}
         footer={
           <InternalSpaceBetween className={styles['modal-actions']} size="xs" direction="horizontal">
             <InternalButton variant="link" formAction="none" onClick={onDismiss}>
-              {i18nStrings?.modalCancelButton}
+              {i18n('i18nStrings.modalCancelButton', i18nStrings?.modalCancelButton)}
             </InternalButton>
             <InternalButton
               variant="primary"
@@ -134,14 +136,14 @@ export function S3Modal({
               formAction="none"
               onClick={() => onSubmit(createResourceInfo({ currentView, breadcrumbs, selectedItem }))}
             >
-              {i18nStrings?.modalSubmitButton}
+              {i18n('i18nStrings.modalSubmitButton', i18nStrings?.modalSubmitButton)}
             </InternalButton>
           </InternalSpaceBetween>
         }
       >
         <InternalSpaceBetween size={isVisualRefresh ? 'xxs' : 'xs'}>
           <InternalBreadcrumbGroup
-            ariaLabel={i18nStrings?.labelBreadcrumbs}
+            ariaLabel={i18n('i18nStrings.labelBreadcrumbs', i18nStrings?.labelBreadcrumbs)}
             expandAriaLabel="Show path"
             onFollow={event => {
               event.preventDefault();
@@ -149,7 +151,7 @@ export function S3Modal({
             }}
             items={[
               {
-                text: i18nStrings?.modalBreadcrumbRootItem ?? '',
+                text: i18n('i18nStrings.modalBreadcrumbRootItem', i18nStrings?.modalBreadcrumbRootItem) ?? '',
                 href: '',
                 meta: { onClick: () => dispatch({ type: 'browse-buckets' }) },
               },

--- a/src/s3-resource-selector/s3-modal/objects-table.tsx
+++ b/src/s3-resource-selector/s3-modal/objects-table.tsx
@@ -53,7 +53,11 @@ export function ObjectsTable({
         ...getSharedI18Strings(i18n, i18nStrings),
         header: i18n('i18nStrings.selectionObjects', i18nStrings?.selectionObjects),
         loadingText: i18n('i18nStrings.selectionObjectsLoading', i18nStrings?.selectionObjectsLoading),
-        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionObjects ?? ''),
+        filteringAriaLabel: i18n(
+          'i18nStrings.labelFiltering',
+          i18nStrings?.labelFiltering,
+          format => itemsType => format({ itemsType })
+        )?.(i18n('i18nStrings.selectionObjects', i18nStrings?.selectionObjects) ?? ''),
         filteringPlaceholder: i18n(
           'i18nStrings.selectionObjectsSearchPlaceholder',
           i18nStrings?.selectionObjectsSearchPlaceholder

--- a/src/s3-resource-selector/s3-modal/objects-table.tsx
+++ b/src/s3-resource-selector/s3-modal/objects-table.tsx
@@ -10,6 +10,7 @@ import { ForwardFocusRef } from '../../internal/hooks/forward-focus';
 import { formatSize, formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
 import { joinObjectPath } from '../utils';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 interface ObjectsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;
@@ -36,6 +37,8 @@ export function ObjectsTable({
   onDrilldown,
   onSelect,
 }: ObjectsTableProps) {
+  const i18n = useInternalI18n('s3-resource-selector');
+
   return (
     <BasicS3Table<S3ResourceSelectorProps.Object>
       // remount fresh component every we change the path to reset the inner state (e.g. selection/filtering)
@@ -47,13 +50,27 @@ export function ObjectsTable({
         return fetchData(bucketName, joinObjectPath(rest));
       }}
       i18nStrings={{
-        ...getSharedI18Strings(i18nStrings),
-        header: i18nStrings?.selectionObjects,
-        filteringAriaLabel: i18nStrings?.labelFiltering(i18nStrings?.selectionObjects),
-        filteringPlaceholder: i18nStrings?.selectionObjectsSearchPlaceholder,
-        loadingText: i18nStrings?.selectionObjectsLoading,
-        emptyText: i18nStrings?.selectionObjectsNoItems,
-        selectionLabels: i18nStrings?.labelsObjectsSelection,
+        ...getSharedI18Strings(i18n, i18nStrings),
+        header: i18n('i18nStrings.selectionObjects', i18nStrings?.selectionObjects),
+        loadingText: i18n('i18nStrings.selectionObjectsLoading', i18nStrings?.selectionObjectsLoading),
+        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionObjects ?? ''),
+        filteringPlaceholder: i18n(
+          'i18nStrings.selectionObjectsSearchPlaceholder',
+          i18nStrings?.selectionObjectsSearchPlaceholder
+        ),
+        emptyText: i18n('i18nStrings.selectionObjectsNoItems', i18nStrings?.selectionObjectsNoItems),
+        selectionLabels: {
+          ...i18nStrings?.labelsObjectsSelection,
+          selectionGroupLabel: i18n(
+            'i18nStrings.labelsObjectsSelection.selectionGroupLabel',
+            i18nStrings?.labelsObjectsSelection?.selectionGroupLabel
+          ),
+          itemSelectionLabel: i18n(
+            'i18nStrings.labelsObjectsSelection.itemSelectionLabel',
+            i18nStrings?.labelsObjectsSelection?.itemSelectionLabel,
+            format => (data, item) => format({ item__Key: item.Key ?? '' })
+          ),
+        },
       }}
       isVisualRefresh={isVisualRefresh}
       visibleColumns={visibleColumns}
@@ -61,8 +78,12 @@ export function ObjectsTable({
       columnDefinitions={[
         {
           id: 'Key',
-          header: i18nStrings?.columnObjectKey,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnObjectKey),
+          header: i18n('i18nStrings.columnObjectKey', i18nStrings?.columnObjectKey),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnObjectKey', i18nStrings?.columnObjectKey)
+          ),
           sortingField: 'Key',
           cell: item => {
             const isClickable = item.IsFolder || includes(selectableItemsTypes, 'versions');
@@ -83,15 +104,23 @@ export function ObjectsTable({
         },
         {
           id: 'LastModified',
-          header: i18nStrings?.columnObjectLastModified,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnObjectLastModified),
+          header: i18n('i18nStrings.columnObjectLastModified', i18nStrings?.columnObjectLastModified),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnObjectLastModified', i18nStrings?.columnObjectLastModified)
+          ),
           sortingComparator: (a, b) => compareDates(a.LastModified, b.LastModified),
           cell: item => formatDefault(item.LastModified),
         },
         {
           id: 'Size',
-          header: i18nStrings?.columnObjectSize,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnObjectSize),
+          header: i18n('i18nStrings.columnObjectSize', i18nStrings?.columnObjectSize),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnObjectSize', i18nStrings?.columnObjectSize)
+          ),
           sortingField: 'Size',
           cell: item => formatSize(item.Size),
         },

--- a/src/s3-resource-selector/s3-modal/table-utils.ts
+++ b/src/s3-resource-selector/s3-modal/table-utils.ts
@@ -2,12 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { S3ResourceSelectorProps } from '../interfaces';
 import { TableProps } from '../../table/interfaces';
-
-const defaultLabels = {
-  labelNotSorted: () => '',
-  labelSortedDescending: () => '',
-  labelSortedAscending: () => '',
-};
+import { ComponentFormatFunction } from '../../internal/i18n/context';
 
 export function includes<T>(array: ReadonlyArray<T> | undefined, item: T) {
   return !!array && array.indexOf(item) > -1;
@@ -20,19 +15,32 @@ export const compareDates = (itemA: string | undefined, itemB: string | undefine
 };
 
 export function getColumnAriaLabel(
-  i18nStrings: Pick<
+  i18n: ComponentFormatFunction,
+  i18nStrings?: Pick<
     S3ResourceSelectorProps.I18nStrings,
     'labelNotSorted' | 'labelSortedDescending' | 'labelSortedAscending'
-  > = defaultLabels,
+  >,
   columnName = ''
 ) {
   return ({ sorted, descending }: TableProps.LabelData) => {
     if (!sorted) {
-      return i18nStrings?.labelNotSorted(columnName);
+      return (
+        i18n('i18nStrings.labelNotSorted', i18nStrings?.labelNotSorted?.(columnName), format =>
+          format({ columnName })
+        ) ?? ''
+      );
     }
     if (descending) {
-      return i18nStrings?.labelSortedDescending(columnName);
+      return (
+        i18n('i18nStrings.labelSortedDescending', i18nStrings?.labelSortedDescending?.(columnName), format =>
+          format({ columnName })
+        ) ?? ''
+      );
     }
-    return i18nStrings?.labelSortedAscending(columnName);
+    return (
+      i18n('i18nStrings.labelSortedAscending', i18nStrings?.labelSortedAscending?.(columnName), format =>
+        format({ columnName })
+      ) ?? ''
+    );
   };
 }

--- a/src/s3-resource-selector/s3-modal/versions-table.tsx
+++ b/src/s3-resource-selector/s3-modal/versions-table.tsx
@@ -8,6 +8,7 @@ import { ForwardFocusRef } from '../../internal/hooks/forward-focus';
 import { formatSize, formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
 import { joinObjectPath } from '../utils';
+import { useInternalI18n } from '../../internal/i18n/context';
 
 interface VersionsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;
@@ -30,6 +31,8 @@ export function VersionsTable({
   visibleColumns,
   onSelect,
 }: VersionsTableProps) {
+  const i18n = useInternalI18n('s3-resource-selector');
+
   return (
     <BasicS3Table<S3ResourceSelectorProps.Version>
       forwardFocusRef={forwardFocusRef}
@@ -39,13 +42,27 @@ export function VersionsTable({
         return fetchData(bucketName, joinObjectPath(rest));
       }}
       i18nStrings={{
-        ...getSharedI18Strings(i18nStrings),
-        header: i18nStrings?.selectionVersions,
-        filteringAriaLabel: i18nStrings?.labelFiltering(i18nStrings?.selectionVersions),
-        filteringPlaceholder: i18nStrings?.selectionVersionsSearchPlaceholder,
-        loadingText: i18nStrings?.selectionVersionsLoading,
-        emptyText: i18nStrings?.selectionVersionsNoItems,
-        selectionLabels: i18nStrings?.labelsVersionsSelection,
+        ...getSharedI18Strings(i18n, i18nStrings),
+        header: i18n('i18nStrings.selectionVersions', i18nStrings?.selectionVersions),
+        loadingText: i18n('i18nStrings.selectionVersionsLoading', i18nStrings?.selectionVersionsLoading),
+        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionVersions ?? ''),
+        filteringPlaceholder: i18n(
+          'i18nStrings.selectionVersionsSearchPlaceholder',
+          i18nStrings?.selectionVersionsSearchPlaceholder
+        ),
+        emptyText: i18n('i18nStrings.selectionVersionsNoItems', i18nStrings?.selectionVersionsNoItems),
+        selectionLabels: {
+          ...i18nStrings?.labelsVersionsSelection,
+          selectionGroupLabel: i18n(
+            'i18nStrings.labelsVersionsSelection.selectionGroupLabel',
+            i18nStrings?.labelsVersionsSelection?.selectionGroupLabel
+          ),
+          itemSelectionLabel: i18n(
+            'i18nStrings.labelsVersionsSelection.itemSelectionLabel',
+            i18nStrings?.labelsVersionsSelection?.itemSelectionLabel,
+            format => (data, item) => format({ item__VersionId: item.VersionId ?? '' })
+          ),
+        },
       }}
       isVisualRefresh={isVisualRefresh}
       visibleColumns={visibleColumns}
@@ -53,23 +70,35 @@ export function VersionsTable({
       columnDefinitions={[
         {
           id: 'ID',
-          header: i18nStrings?.columnVersionID,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnVersionID),
+          header: i18n('i18nStrings.columnVersionID', i18nStrings?.columnVersionID),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnVersionID', i18nStrings?.columnVersionID)
+          ),
           sortingField: 'VersionId',
           cell: item => item.VersionId,
           minWidth: '250px',
         },
         {
           id: 'LastModified',
-          header: i18nStrings?.columnVersionLastModified,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnVersionLastModified),
+          header: i18n('i18nStrings.columnVersionLastModified', i18nStrings?.columnVersionLastModified),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnVersionLastModified', i18nStrings?.columnVersionLastModified)
+          ),
           sortingComparator: (a, b) => compareDates(a.LastModified, b.LastModified),
           cell: item => formatDefault(item.LastModified),
         },
         {
           id: 'Size',
-          header: i18nStrings?.columnVersionSize,
-          ariaLabel: getColumnAriaLabel(i18nStrings, i18nStrings?.columnVersionSize),
+          header: i18n('i18nStrings.columnVersionSize', i18nStrings?.columnVersionSize),
+          ariaLabel: getColumnAriaLabel(
+            i18n,
+            i18nStrings,
+            i18n('i18nStrings.columnVersionSize', i18nStrings?.columnVersionSize)
+          ),
           sortingField: 'Size',
           cell: item => formatSize(item.Size),
         },

--- a/src/s3-resource-selector/s3-modal/versions-table.tsx
+++ b/src/s3-resource-selector/s3-modal/versions-table.tsx
@@ -45,7 +45,11 @@ export function VersionsTable({
         ...getSharedI18Strings(i18n, i18nStrings),
         header: i18n('i18nStrings.selectionVersions', i18nStrings?.selectionVersions),
         loadingText: i18n('i18nStrings.selectionVersionsLoading', i18nStrings?.selectionVersionsLoading),
-        filteringAriaLabel: i18nStrings?.labelFiltering?.(i18nStrings?.selectionVersions ?? ''),
+        filteringAriaLabel: i18n(
+          'i18nStrings.labelFiltering',
+          i18nStrings?.labelFiltering,
+          format => itemsType => format({ itemsType })
+        )?.(i18n('i18nStrings.selectionVersions', i18nStrings?.selectionVersions) ?? ''),
         filteringPlaceholder: i18n(
           'i18nStrings.selectionVersionsSearchPlaceholder',
           i18nStrings?.selectionVersionsSearchPlaceholder

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -5,7 +5,12 @@ import { act, render } from '@testing-library/react';
 import Input from '../../../lib/components/input';
 
 import TopNavigation, { TopNavigationProps } from '../../../lib/components/top-navigation';
-import TopNavigationWrapper from '../../../lib/components/test-utils/dom/top-navigation';
+import OverflowMenu from '../../../lib/components/top-navigation/parts/overflow-menu';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import TopNavigationWrapper, {
+  OverflowMenu as OverflowMenuWrapper,
+} from '../../../lib/components/test-utils/dom/top-navigation';
+import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
 
 export const I18N_STRINGS: TopNavigationProps.I18nStrings = {
   searchIconAriaLabel: 'Search',
@@ -20,7 +25,7 @@ type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 const renderTopNavigation = (props: PickPartial<TopNavigationProps, 'i18nStrings'>) => {
   const { container } = render(<TopNavigation i18nStrings={I18N_STRINGS} {...props} />);
-  return new TopNavigationWrapper(container.querySelector<HTMLElement>(`.${TopNavigationWrapper.rootSelector}`)!);
+  return createWrapper(container).findTopNavigation()!;
 };
 
 describe('TopNavigation Component', () => {
@@ -343,6 +348,25 @@ describe('URL sanitization', () => {
       expect(console.warn).toHaveBeenCalledWith(
         `[AwsUi] [TopNavigation] A javascript: URL was blocked as a security precaution. The URL was "javascript:alert('Hello from a nested utility menu item!')".`
       );
+    });
+  });
+
+  describe('i18n', () => {
+    test('supports using overflow menu strings from i18n provider', () => {
+      const { container } = render(
+        <TestI18nProvider
+          messages={{
+            'top-navigation': {
+              'i18nStrings.overflowMenuDismissIconAriaLabel': 'Custom dismiss',
+              'i18nStrings.overflowMenuTitleText': 'Custom all',
+            },
+          }}
+        >
+          <OverflowMenu />
+        </TestI18nProvider>
+      );
+      const wrapper = new OverflowMenuWrapper(container);
+      expect(wrapper.findTitle()!.getElement()).toHaveTextContent('Custom all');
     });
   });
 });

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -367,6 +367,7 @@ describe('URL sanitization', () => {
       );
       const wrapper = new OverflowMenuWrapper(container);
       expect(wrapper.findTitle()!.getElement()).toHaveTextContent('Custom all');
+      expect(wrapper.findDismissButton()!.getElement()).toHaveAccessibleName('Custom dismiss');
     });
   });
 });

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -63,7 +63,7 @@ export interface TopNavigationProps extends BaseComponentProps {
   /**
    * An object containing all the localized strings required by the component.
    */
-  i18nStrings: TopNavigationProps.I18nStrings;
+  i18nStrings?: TopNavigationProps.I18nStrings;
 }
 
 export namespace TopNavigationProps {
@@ -120,7 +120,7 @@ export namespace TopNavigationProps {
     searchDismissIconAriaLabel?: string;
     overflowMenuDismissIconAriaLabel?: string;
     overflowMenuBackIconAriaLabel?: string;
-    overflowMenuTriggerText: string;
-    overflowMenuTitleText: string;
+    overflowMenuTriggerText?: string;
+    overflowMenuTitleText?: string;
   }
 }

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -19,6 +19,7 @@ import { ButtonTrigger } from '../internal/components/menu-dropdown';
 import styles from './styles.css.js';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { SomeRequired } from '../internal/types';
+import { useInternalI18n } from '../internal/i18n/context';
 
 export type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
 
@@ -40,6 +41,7 @@ export default function InternalTopNavigation({
   const isNarrowViewport = breakpoint === 'default';
   const isMediumViewport = breakpoint === 'xxs';
   const isLargeViewport = breakpoint === 's';
+  const i18n = useInternalI18n('top-navigation');
 
   const onIdentityClick = (event: React.MouseEvent) => {
     if (isPlainLeftClick(event)) {
@@ -135,8 +137,8 @@ export default function InternalTopNavigation({
                     type: 'button',
                     iconName: isSearchExpanded ? 'close' : 'search',
                     ariaLabel: isSearchExpanded
-                      ? i18nStrings.searchDismissIconAriaLabel
-                      : i18nStrings.searchIconAriaLabel,
+                      ? i18n('i18nStrings.searchDismissIconAriaLabel', i18nStrings?.searchDismissIconAriaLabel)
+                      : i18n('i18nStrings.searchIconAriaLabel', i18nStrings?.searchIconAriaLabel),
                     onClick: onSearchUtilityClick,
                   }}
                 />
@@ -214,7 +216,7 @@ export default function InternalTopNavigation({
                   offsetRight="l"
                   ref={!isVirtual ? overflowMenuTriggerRef : undefined}
                 >
-                  {i18nStrings.overflowMenuTriggerText}
+                  {i18n('i18nStrings.overflowMenuTriggerText', i18nStrings?.overflowMenuTriggerText)}
                 </ButtonTrigger>
               </div>
             )}
@@ -232,9 +234,9 @@ export default function InternalTopNavigation({
         {menuTriggerVisible && overflowMenuOpen && (
           <div className={styles['overflow-menu-drawer']}>
             <OverflowMenu
-              headerText={i18nStrings.overflowMenuTitleText}
-              dismissIconAriaLabel={i18nStrings.overflowMenuDismissIconAriaLabel}
-              backIconAriaLabel={i18nStrings.overflowMenuBackIconAriaLabel}
+              headerText={i18nStrings?.overflowMenuTitleText}
+              dismissIconAriaLabel={i18nStrings?.overflowMenuDismissIconAriaLabel}
+              backIconAriaLabel={i18nStrings?.overflowMenuBackIconAriaLabel}
               items={utilities.filter(
                 (utility, i) =>
                   (!responsiveState.hideUtilities || responsiveState.hideUtilities.indexOf(i) !== -1) &&

--- a/src/top-navigation/parts/overflow-menu/index.tsx
+++ b/src/top-navigation/parts/overflow-menu/index.tsx
@@ -10,6 +10,7 @@ import { HeaderProps } from './header';
 
 import styles from '../../styles.css.js';
 import { TopNavigationProps } from '../../interfaces';
+import { useInternalI18n } from '../../../internal/i18n/context';
 interface OverflowMenuProps {
   headerText?: string;
   items?: TopNavigationProps['utilities'];
@@ -29,6 +30,10 @@ const OverflowMenu = ({
   items = [],
   onClose,
 }: OverflowMenuProps) => {
+  const i18n = useInternalI18n('top-navigation');
+  const renderedDismissIconAriaLabel = i18n('i18nStrings.overflowMenuDismissIconAriaLabel', dismissIconAriaLabel);
+  const renderedBackIconAriaLabel = i18n('i18nStrings.overflowMenuBackIconAriaLabel', backIconAriaLabel);
+
   return (
     <div
       className={styles['overflow-menu']}
@@ -43,11 +48,11 @@ const OverflowMenu = ({
           view="utilities"
           element={data => (
             <UtilitiesView
-              headerText={headerText}
+              headerText={i18n('i18nStrings.overflowMenuTitleText', headerText)}
               items={items}
               focusIndex={data?.utilityIndex}
-              dismissIconAriaLabel={dismissIconAriaLabel}
-              backIconAriaLabel={backIconAriaLabel}
+              dismissIconAriaLabel={renderedDismissIconAriaLabel}
+              backIconAriaLabel={renderedBackIconAriaLabel}
               onClose={onClose}
             />
           )}
@@ -58,8 +63,8 @@ const OverflowMenu = ({
             <SubmenuView
               headerText={data?.headerText}
               headerSecondaryText={data?.headerSecondaryText}
-              dismissIconAriaLabel={dismissIconAriaLabel}
-              backIconAriaLabel={backIconAriaLabel}
+              dismissIconAriaLabel={renderedDismissIconAriaLabel}
+              backIconAriaLabel={renderedBackIconAriaLabel}
               definition={data?.definition}
               utilityIndex={data?.utilityIndex}
               onClose={onClose}


### PR DESCRIPTION
### Description

It's a lot of files, but it reads quick! Adds i18n string support to a batch of related components. The strings themselves will come in a later PR, so this PR itself will not change anything for users.

Codecov is yelling at me so I'll add a couple of tests before merging, but you can still take a look in the meantime :)

Related links, issue #, if available: n/a

### How has this been tested?

All i18n string additions are being tested with unit tests. As I'm sure you've noticed, there's a little internal test helper to make building test-specific i18n providers easy. Also, tests are most of the actual code in this PR.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
