### PR TITLE
fix: Use content header context for alerts

### DIFF
--- a/pages/content-layout/dark-header-main.page.tsx
+++ b/pages/content-layout/dark-header-main.page.tsx
@@ -39,6 +39,7 @@ export default function () {
                     dismissible={true}
                     dismissAriaLabel="Close alert"
                     onDismiss={() => setVisible(false)}
+                    action={<Button>Do something</Button>}
                   >
                     Demo alert
                   </Alert>

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -6,7 +6,7 @@ import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
-import VisualContext, { useVisualContext } from '../internal/components/visual-context';
+import VisualContext from '../internal/components/visual-context';
 import styles from './styles.css.js';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
@@ -23,8 +23,6 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
   success: 'status-positive',
   info: 'status-info',
 };
-
-const HEADER_CONTEXT_NAME = 'content-header';
 
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps;
 
@@ -53,9 +51,6 @@ export default function InternalAlert({
   const isRefresh = useVisualRefresh();
   const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
 
-  const context = useVisualContext(contextRef);
-  const hasHeaderContext = isRefresh && context === HEADER_CONTEXT_NAME;
-
   const actionButton = action || (
     <InternalButton
       className={styles['action-button']}
@@ -81,7 +76,7 @@ export default function InternalAlert({
       )}
       ref={mergedRef}
     >
-      <VisualContext contextName={hasHeaderContext ? 'alert-header' : 'alert'}>
+      <VisualContext contextName={'alert'}>
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
           <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
             <InternalIcon name={typeToIcon[type]} size={size} />

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
@@ -45,8 +45,7 @@ export default function InternalAlert({
   const i18n = useInternalI18n('alert');
 
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const contextRef = useRef<HTMLElement>(null);
-  const mergedRef = useMergeRefs(contextRef, breakpointRef, __internalRootRef);
+  const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
   const isRefresh = useVisualRefresh();
   const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
 import InternalIcon from '../icon/internal';
 import { getBaseProps } from '../internal/base-component';
-import VisualContext from '../internal/components/visual-context';
+import VisualContext, { useVisualContext } from '../internal/components/visual-context';
 import styles from './styles.css.js';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
@@ -23,6 +23,8 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
   success: 'status-positive',
   info: 'status-info',
 };
+
+const HEADER_CONTEXT_NAME = 'content-header';
 
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps;
 
@@ -45,10 +47,14 @@ export default function InternalAlert({
   const i18n = useInternalI18n('alert');
 
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
+  const contextRef = useRef<HTMLElement>(null);
+  const mergedRef = useMergeRefs(contextRef, breakpointRef, __internalRootRef);
 
   const isRefresh = useVisualRefresh();
   const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
+
+  const context = useVisualContext(contextRef);
+  const hasHeaderContext = isRefresh && context === HEADER_CONTEXT_NAME;
 
   const actionButton = action || (
     <InternalButton
@@ -75,7 +81,7 @@ export default function InternalAlert({
       )}
       ref={mergedRef}
     >
-      <VisualContext contextName="alert">
+      <VisualContext contextName={hasHeaderContext ? 'alert-header' : 'alert'}>
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
           <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
             <InternalIcon name={typeToIcon[type]} size={size} />

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -75,7 +75,7 @@ export default function InternalAlert({
       )}
       ref={mergedRef}
     >
-      <VisualContext contextName={'alert'}>
+      <VisualContext contextName="alert">
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
           <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
             <InternalIcon name={typeToIcon[type]} size={size} />

--- a/style-dictionary/visual-refresh/contexts/header-alert.ts
+++ b/style-dictionary/visual-refresh/contexts/header-alert.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { StyleDictionary } from '../../utils/interfaces';
+import alertTokens from './alert';
+import merge from 'lodash/merge';
+import { expandColorDictionary, pickState } from '../../utils';
+
+const darkModeColorValues = pickState(alertTokens, 'dark');
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(
+  merge({}, alertTokens, darkModeColorValues)
+);
+
+export default expandedTokens;

--- a/style-dictionary/visual-refresh/index.ts
+++ b/style-dictionary/visual-refresh/index.ts
@@ -9,6 +9,7 @@ import {
   createFlashbarContext,
 } from '../utils/contexts';
 import alertContextTokens from './contexts/alert';
+import alertHeaderContextTokens from './contexts/header-alert';
 
 const modes = [
   createColorMode('.awsui-dark-mode'),
@@ -46,6 +47,11 @@ export function buildVisualRefresh(builder: ThemeBuilder) {
     id: 'alert',
     selector: '.awsui-context-alert',
     tokens: alertContextTokens,
+  });
+  builder.addContext({
+    id: 'alert-header',
+    selector: '.awsui-context-alert-header',
+    tokens: alertHeaderContextTokens,
   });
 
   return builder.build();

--- a/style-dictionary/visual-refresh/index.ts
+++ b/style-dictionary/visual-refresh/index.ts
@@ -50,7 +50,7 @@ export function buildVisualRefresh(builder: ThemeBuilder) {
   });
   builder.addContext({
     id: 'alert-header',
-    selector: '.awsui-context-alert-header',
+    selector: '.awsui-context-content-header .awsui-context-alert',
     tokens: alertHeaderContextTokens,
   });
 


### PR DESCRIPTION
### Description

Alert context overrides button styles. It results in using incorrect color palette in light mode when alert is inside content layout header.
![image](https://github.com/cloudscape-design/components/assets/29692746/98250d98-9ebf-4f33-84b7-01ffea17557d)

This PR creates `alert-header` context, which uses dark mode state for color tokens. Context is applied to alerts inside `content-header` context.


Related links, issue #, if available: AWSUI-21158

### How has this been tested?


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
