### PR TITLE
fix: Prevent headings from being cut off in Header component

### DIFF
--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -45,7 +45,10 @@
 }
 
 .main {
-  @include styles.text-flex-wrapping;
+  // Like styles.text-flex-wrapping, but without overflow: hidden, to prevent headings from being partially cut off.
+  word-wrap: break-word;
+  max-width: 100%;
+
   :not(.root-no-actions) > & {
     margin-right: awsui.$space-xs;
   }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

A wrapping area around the heading in the Header component has `overflow: hidden` which causes any bit of overflowing content to be cut off.

This is most obvious with italics text:
<img width="267" alt="Screenshot 2023-06-01 at 22 19 48 copy" src="https://github.com/cloudscape-design/components/assets/1257272/dd5eac86-a3d1-46e4-8e23-e79c24dda9c5">

<img width="267" alt="Screenshot 2023-06-01 at 22 19 48 copy" src="https://github.com/cloudscape-design/components/assets/1257272/4ec8e4c1-fb3e-4f86-9ba1-f418de34c016">

But even without italics, the very tip of certain characters is also sometimes cut off (screenshot diffs below):
<img width="270" alt="Screenshot 2023-06-01 at 22 35 18" src="https://github.com/cloudscape-design/components/assets/1257272/6b4bee06-f1b7-40fd-8576-bcd761769444">
<img width="114" alt="Screenshot 2023-06-01 at 22 38 31" src="https://github.com/cloudscape-design/components/assets/1257272/77356eb2-fedf-4c2d-9f87-3198c54e5983">

This overflow rule comes from a mixin (`text-flex-wrapping`) which is also used by components such as popover or alert, where it is applied at the outermost level of the component tree, so that eventually cutting off content seems justified (the content is really at the border of the component), but this is not the case here.

This is also relevant for #1143, since without this fix the focus ring around the new clickable area is cut off:
<img width="390" alt="Screenshot 2023-06-01 at 22 25 14" src="https://github.com/cloudscape-design/components/assets/1257272/a4ab6ae0-ae92-4e41-bc71-61d3b0ea0cc6">

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

Ran against my pipeline and verified the visual regression failures, which come from headings not being cut off anymore and are therefore desired changes.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
