### PR TITLE
feat: Add dark background to ContentLayout without header

### DIFF
--- a/pages/app-layout/with-wizard-and-table.page.tsx
+++ b/pages/app-layout/with-wizard-and-table.page.tsx
@@ -1,16 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { AppLayout, Box, Button, ColumnLayout, Container, Header, SpaceBetween, Table, Wizard } from '~components';
 import { columnsConfig } from '../table/shared-configs';
 import { generateItems, Instance } from '../table/generate-data';
 import labels from './utils/labels';
+import { Breadcrumbs } from './utils/content-blocks';
+import AppContext, { AppContextType } from '../app/app-context';
 
 import ScreenshotArea from '../utils/screenshot-area';
+
+type DemoContext = React.Context<
+  AppContextType<{ hasBreadcrumbs: boolean; hasNotifications: boolean; disableOverlap: boolean }>
+>;
 
 const items = generateItems(20);
 
 export default function () {
+  const { urlParams } = useContext(AppContext as DemoContext);
   const [activeStepIndex, setActiveStepIndex] = useState(0);
 
   return (
@@ -18,6 +25,7 @@ export default function () {
       <AppLayout
         ariaLabels={labels}
         navigationHide={false}
+        breadcrumbs={urlParams.hasBreadcrumbs && <Breadcrumbs />}
         content={
           <Wizard
             i18nStrings={{

--- a/pages/content-layout/with-absolute-components.page.tsx
+++ b/pages/content-layout/with-absolute-components.page.tsx
@@ -65,7 +65,7 @@ export default function () {
         }
         breadcrumbs={<Breadcrumbs />}
         content={
-          <ContentLayout>
+          <ContentLayout disableOverlap={true}>
             <SpaceBetween size="s">
               <h1>With absolutely positioned elements</h1>
               <ButtonDropdown items={dropdownItems} expandableGroups={true}>

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -26,6 +26,8 @@ explicitly set in script.
   #{custom-props.$contentGapLeft}: 0px;
   #{custom-props.$contentGapRight}: 0px;
   #{custom-props.$contentHeight}: calc(100vh - var(#{custom-props.$headerHeight}) - var(#{custom-props.$footerHeight}));
+  #{custom-props.$containerFirstGap}: 0px;
+  #{custom-props.$containerFirstOverlapExtension}: 0px;
   #{custom-props.$defaultMaxContentWidth}: 1280px;
   #{custom-props.$defaultMinContentWidth}: 0px;
   #{custom-props.$footerHeight}: 0px;
@@ -217,6 +219,11 @@ explicitly set in script.
     #{custom-props.$mainGap}: #{awsui.$space-xs};
   }
 
+  // Set gap to be used by content that has a container on top (e.g. content-layout without header) when breadcrumbs are present
+  &.has-breadcrumbs:not(.has-header) {
+    #{custom-props.$containerFirstGap}: calc(var(#{custom-props.$breadcrumbsGap}) - var(#{custom-props.$mainGap}));
+  }
+
   // Set the Main gap when it follows the Breadcrumbs without an overlap
   &.has-breadcrumbs:not(.has-header).is-overlap-disabled {
     #{custom-props.$mainGap}: #{awsui.$space-scaled-m};
@@ -235,7 +242,14 @@ explicitly set in script.
   // Set the Main gap when it is the first page content
   &.content-first-child-main:not(.is-overlap-disabled),
   &.content-first-child-main.is-overlap-disabled:not(.disable-content-paddings) {
-    #{custom-props.$mainGap}: #{awsui.$space-scaled-xs};
+    #{custom-props.$mainGap}: #{awsui.$space-scaled-s};
+  }
+
+  // Set an extension of the overlap to be used by header-less content-layout without header
+  @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
+    &.content-first-child-main:not(.has-header) {
+      #{custom-props.$containerFirstOverlapExtension}: #{awsui.$space-m};
+    }
   }
 
   /*
@@ -243,10 +257,6 @@ explicitly set in script.
   components for mobile viewports.
   */
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
-    &.content-first-child-notifications {
-      #{custom-props.$notificationsGap}: #{awsui.$space-scaled-s};
-    }
-
     &.content-first-child-header {
       #{custom-props.$headerGap}: #{awsui.$space-scaled-s};
     }
@@ -255,7 +265,6 @@ explicitly set in script.
       #{custom-props.$headerGap}: #{awsui.$space-scaled-s};
     }
 
-    &.content-first-child-notifications:not(.has-breadcrumbs):not(.has-header),
     &.content-first-child-main:not(.is-overlap-disabled) {
       #{custom-props.$mainGap}: #{awsui.$space-scaled-s};
     }

--- a/src/content-layout/__tests__/content-layout.test.tsx
+++ b/src/content-layout/__tests__/content-layout.test.tsx
@@ -51,6 +51,14 @@ describe('ContentLayout component', () => {
     });
   });
 
+  test('renders empty header', () => {
+    const { wrapper } = renderContentLayout({
+      children: <>Content text</>,
+    });
+
+    expect(wrapper.findByClassName(styles['empty-header'])).toBeDefined();
+  });
+
   describe('overlap', () => {
     test('renders the overlap by default', () => {
       const { isOverlapEnabled } = renderContentLayout({ children: <>Content text</>, header: <>Header text</> });
@@ -73,14 +81,14 @@ describe('ContentLayout component', () => {
       expect(isOverlapEnabled()).toBe(false);
     });
 
-    test('does not render the overlap if the header is empty', () => {
+    test('renders the overlap if the header is empty', () => {
       const { isOverlapEnabled } = renderContentLayout({
         children: <>Content text</>,
       });
-      expect(isOverlapEnabled()).toBe(false);
+      expect(isOverlapEnabled()).toBe(true);
     });
 
-    test('does not render the overlap if the header is toggled', () => {
+    test('does not render the overlap if the content is toggled', () => {
       const { isOverlapEnabled, rerender } = renderContentLayout({
         children: <>Content text</>,
         header: <>Header text</>,
@@ -88,7 +96,7 @@ describe('ContentLayout component', () => {
       expect(isOverlapEnabled()).toBe(true);
 
       rerender({
-        children: <>Content text</>,
+        header: <>Header text</>,
       });
       expect(isOverlapEnabled()).toBe(false);
 

--- a/src/content-layout/internal.tsx
+++ b/src/content-layout/internal.tsx
@@ -26,12 +26,7 @@ export default function InternalContentLayout({
   const isVisualRefresh = useVisualRefresh();
   const overlapElement = useDynamicOverlap();
 
-  /**
-   * Disable the overlap if the component is missing either a header or child
-   * content. If the component is not using visual refresh then the overlap
-   * will not be displayed at all. This is handled in the CSS not the JavaScript.
-   */
-  const isOverlapDisabled = !children || !header || disableOverlap;
+  const isOverlapDisabled = !children || disableOverlap;
 
   return (
     <div
@@ -39,6 +34,7 @@ export default function InternalContentLayout({
       className={clsx(baseProps.className, styles.layout, {
         [styles['is-overlap-disabled']]: isOverlapDisabled,
         [styles['is-visual-refresh']]: isVisualRefresh,
+        [styles['increased-overlap']]: isVisualRefresh && !header,
       })}
       ref={mergedRef}
     >
@@ -51,7 +47,9 @@ export default function InternalContentLayout({
         ref={overlapElement}
       />
 
-      {header && <div className={clsx(styles.header, 'awsui-context-content-header')}>{header}</div>}
+      <div className={clsx(header ? styles.header : styles['empty-header'], 'awsui-context-content-header')}>
+        {header}
+      </div>
 
       <div className={styles.content}>{children}</div>
     </div>

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -4,6 +4,7 @@
 */
 @use '../internal/styles/' as styles;
 @use '../internal/styles/tokens' as awsui;
+@use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 /*
 Pass through the header and child content if not rendering in 
@@ -29,6 +30,14 @@ nodes will directly touch with no gap between them.
   grid-template-rows: auto #{awsui.$space-dark-header-overlap-distance} 1fr;
   min-height: 100%;
 
+  &.increased-overlap {
+    grid-template-rows:
+      auto calc(
+        #{awsui.$space-dark-header-overlap-distance} + var(#{custom-props.$containerFirstOverlapExtension}, 0px)
+      )
+      1fr;
+  }
+
   &.is-overlap-disabled {
     grid-template-rows: auto 0 1fr;
   }
@@ -48,6 +57,12 @@ nodes will directly touch with no gap between them.
     grid-column: 1;
     grid-row: 1;
     padding-bottom: awsui.$space-content-header-padding-bottom;
+  }
+
+  > .empty-header {
+    grid-column: 1;
+    grid-row: 1;
+    height: var(#{custom-props.$containerFirstGap}, 0px);
   }
 
   > .content {

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -11,6 +11,8 @@ const customCssPropertiesList = [
   'contentGapLeft',
   'contentGapRight',
   'contentHeight',
+  'containerFirstGap',
+  'containerFirstOverlapExtension',
   'defaultMaxContentWidth',
   'defaultMinContentWidth',
   'footerHeight',

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -7,6 +7,7 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
+@use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .root {
   @include styles.styles-reset;
@@ -32,7 +33,7 @@
 .navigation.refresh {
   grid-column: 1;
   grid-row: 1 / span 2;
-  padding-top: awsui.$space-scaled-xxs;
+  padding-top: var(#{custom-props.$containerFirstGap}, 0px);
 
   > ul {
     background: awsui.$color-background-container-content;


### PR DESCRIPTION
### Description

- Add dark background to ContentLayout when header is not defined
- Fix spacing in mobile views for notifications
- Align spacing below breadcrumbs across ContentLayout and Wizard

### How has this been tested?

<!-- How did you test to verify your changes? --> Locally, plus existing screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ Confirmed
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
