### PR TITLE
chore: Temporarily remove i18n tags from components

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -389,7 +389,8 @@ Example:
   toolsClose: \\"Close help panel\\",
   toolsToggle: \\"Open help panel\\"
 }
-\`\`\`",
+\`\`\`
+",
       "inlineType": Object {
         "name": "AppLayoutProps.Labels",
         "properties": Array [
@@ -3284,7 +3285,8 @@ scroll parent up to reveal the first card or row of cards.",
 You can use the first arguments of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The label function for individual
 items also receives the corresponding  \`Item\` object. You can use the group label to
-add a meaningful description to the whole selection.",
+add a meaningful description to the whole selection.
+",
       "inlineType": Object {
         "name": "CardsProps.AriaLabels",
         "properties": Array [
@@ -3919,7 +3921,8 @@ The object should contain, among others:
 * \`loadingState\` - Specifies the text to display while the component is loading.
 * \`errorState\` - Specifies the text to display if there is an error loading Ace.
 * \`errorStateRecovery\`: Specifies the text for the recovery button that's displayed next to the error text.
-   Use the \`recoveryClick\` event to do a recovery action (for example, retrying the request).",
+   Use the \`recoveryClick\` event to do a recovery action (for example, retrying the request).
+",
       "inlineType": Object {
         "name": "CodeEditorProps.I18nStrings",
         "properties": Array [
@@ -4217,7 +4220,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.contentDensity\` property.",
+You must set the current value in the \`preferences.contentDensity\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.ContentDensityPreference",
         "properties": Array [
@@ -4258,7 +4262,8 @@ Each option contains the following:
 - \`label\` (string) - Specifies a short description of the content.
 - \`alwaysVisible\` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to \`false\` by default.
 
-You must provide an ordered list of the items to display in the \`preferences.contentDisplay\` property.",
+You must provide an ordered list of the items to display in the \`preferences.contentDisplay\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.ContentDisplayPreference",
         "properties": Array [
@@ -4362,7 +4367,8 @@ It contains the following:
   - \`value\` (number) - The value for the radio button (that is, the number of items per page).
   - \`label\` (string) - A label for the radio button (for example, \\"10 resources\\").
 
-You must set the current value in the \`preferences.pageSize\` property.",
+You must set the current value in the \`preferences.pageSize\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.PageSizePreference",
         "properties": Array [
@@ -4450,7 +4456,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
 - \`description\` (string) - Specifies the text displayed below each radio group label.
 
-You must set the current value in the \`preferences.stickyColumns\` property.",
+You must set the current value in the \`preferences.stickyColumns\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.StickyColumnsPreference",
         "properties": Array [
@@ -4479,7 +4486,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.stripedRows\` property.",
+You must set the current value in the \`preferences.stripedRows\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.StripedRowsPreference",
         "properties": Array [
@@ -4551,7 +4559,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.wrapLines\` property.",
+You must set the current value in the \`preferences.wrapLines\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.WrapLinesPreference",
         "properties": Array [
@@ -6080,7 +6089,8 @@ If \`stackItems\` is set to \`true\`, it should also contain:
 * \`warningIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`warning\`.
 * \`infoIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`info\`.
 * \`successIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`success\`.
-* \`inProgressIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where \`loading\` is set to \`true\`).",
+* \`inProgressIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where \`loading\` is set to \`true\`).
+",
       "inlineType": Object {
         "name": "FlashbarProps.I18nStrings",
         "properties": Array [
@@ -8820,7 +8830,8 @@ Example:
   previousPageLabel: 'Previous page',
   pageLabel: pageNumber => \`Page \${pageNumber}\`
 }
-\`\`\`",
+\`\`\`
+",
       "inlineType": Object {
         "name": "PaginationProps.Labels",
         "properties": Array [
@@ -11898,7 +11909,8 @@ add a meaningful description to the whole selection.
 * \`successfulEditLabel\` (EditableColumnDefinition) => string -
                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
 * \`submittingEditText\` (EditableColumnDefinition) => string -
-                     Specifies a text that is announced to screen readers when a cell edit operation is submitted.",
+                     Specifies a text that is announced to screen readers when a cell edit operation is submitted.
+",
       "inlineType": Object {
         "name": "TableProps.AriaLabels",
         "properties": Array [
@@ -14287,7 +14299,8 @@ Defaults to \`false\`.
 - \`submitButton\` (string) - The text of the button that enables the user to submit the form.
 - \`optional\` (string) - The text displayed next to the step title and form header title when a step is declared optional.
 - \`nextButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *next* button is in a loading state.
-- \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.",
+- \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.
+",
       "inlineType": Object {
         "name": "WizardProps.I18nStrings",
         "properties": Array [

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -31,7 +31,6 @@ export interface AlertProps extends BaseComponentProps {
   dismissible?: boolean;
   /**
    * Adds an aria-label to the dismiss button.
-   * @i18n
    */
   dismissAriaLabel?: string;
   /**

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -105,7 +105,6 @@ export interface AppLayoutProps extends BaseComponentProps {
    *   toolsToggle: "Open help panel"
    * }
    * ```
-   * @i18n
    */
   ariaLabels?: AppLayoutProps.Labels;
 

--- a/src/area-chart/interfaces.ts
+++ b/src/area-chart/interfaces.ts
@@ -18,7 +18,6 @@ export interface AreaChartProps<T extends AreaChartProps.DataTypes>
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: AreaChartProps.I18nStrings<T>;
 }

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -119,7 +119,6 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: AttributeEditorProps.I18nStrings<T>;
 }

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -74,7 +74,6 @@ export interface AutosuggestProps
 
   /**
    * Specifies a function that generates the custom value indicator (for example, `Use "${value}"`).
-   * @i18n
    */
   enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
 
@@ -99,7 +98,6 @@ export interface AutosuggestProps
    * Specifies the localized string that describes an option as being selected.
    * This is required to provide a good screen reader experience. For more information, see the
    * [accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).
-   * @i18n
    */
   selectedAriaLabel?: string;
   /**

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -26,7 +26,6 @@ export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = Brea
 
   /**
    * Provides an `aria-label` to the ellipsis button that screen readers can read (for accessibility).
-   * @i18n
    */
   expandAriaLabel?: string;
   /**

--- a/src/calendar/interfaces.ts
+++ b/src/calendar/interfaces.ts
@@ -50,19 +50,16 @@ export interface CalendarProps extends BaseComponentProps {
 
   /**
    * Used as part of the `aria-label` for today's date in the calendar.
-   * @i18n
    */
   todayAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'next month' button.
-   * @i18n
    */
   nextMonthAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'previous month' button.
-   * @i18n
    */
   previousMonthAriaLabel?: string;
 

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -157,7 +157,6 @@ export interface CardsProps<T = any> extends BaseComponentProps {
    * state of the component (for example, the `selectedItems` list). The label function for individual
    * items also receives the corresponding  `Item` object. You can use the group label to
    * add a meaningful description to the whole selection.
-   * @i18n
    */
   ariaLabels?: CardsProps.AriaLabels<T>;
   /**

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -97,7 +97,6 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
    * * `errorState` - Specifies the text to display if there is an error loading Ace.
    * * `errorStateRecovery`: Specifies the text for the recovery button that's displayed next to the error text.
    *    Use the `recoveryClick` event to do a recovery action (for example, retrying the request).
-   * @i18n
    */
   i18nStrings?: CodeEditorProps.I18nStrings;
 

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -6,17 +6,14 @@ import { NonCancelableEventHandler } from '../internal/events';
 export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
   /**
    * Specifies the title of the preferences modal dialog. It is also used as an `aria-label` for the trigger button.
-   * @i18n
    */
   title?: string;
   /**
    * Label of the confirm button in the modal footer.
-   * @i18n
    */
   confirmLabel?: string;
   /**
    * Label of the cancel button in the modal footer.
-   * @i18n
    */
   cancelLabel?: string;
   /**
@@ -35,7 +32,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    *   - `label` (string) - A label for the radio button (for example, "10 resources").
    *
    * You must set the current value in the `preferences.pageSize` property.
-   * @i18n
    */
   pageSizePreference?: CollectionPreferencesProps.PageSizePreference;
   /**
@@ -48,7 +44,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.wrapLines` property.
-   * @i18n
    */
   wrapLinesPreference?: CollectionPreferencesProps.WrapLinesPreference;
   /**
@@ -61,7 +56,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.stripedRows` property.
-   * @i18n
    */
   stripedRowsPreference?: CollectionPreferencesProps.StripedRowsPreference;
   /**
@@ -74,7 +68,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.contentDensity` property.
-   * @i18n
    */
   contentDensityPreference?: CollectionPreferencesProps.ContentDensityPreference;
   /**
@@ -87,7 +80,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below each radio group label.
    *
    * You must set the current value in the `preferences.stickyColumns` property.
-   * @i18n
    */
   stickyColumnsPreference?: CollectionPreferencesProps.StickyColumnsPreference;
   /**
@@ -112,7 +104,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `alwaysVisible` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to `false` by default.
    *
    * You must provide an ordered list of the items to display in the `preferences.contentDisplay` property.
-   * @i18n
    */
   contentDisplayPreference?: CollectionPreferencesProps.ContentDisplayPreference;
   /**

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -45,7 +45,6 @@ export interface DateRangePickerBaseProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: DateRangePickerProps.I18nStrings;
 

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -85,7 +85,6 @@ export interface FlashbarProps extends BaseComponentProps {
    * * `infoIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `info`.
    * * `successIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `success`.
    * * `inProgressIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where `loading` is set to `true`).
-   * @i18n
    */
   i18nStrings?: FlashbarProps.I18nStrings;
 }

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -35,7 +35,6 @@ export interface FormFieldProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: FormFieldProps.I18nStrings;
 

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -21,7 +21,6 @@ export interface FormProps extends BaseComponentProps {
 
   /**
    * Provides a text alternative for the error icon in the error alert.
-   * @i18n
    */
   errorIconAriaLabel?: string;
 

--- a/src/help-panel/interfaces.ts
+++ b/src/help-panel/interfaces.ts
@@ -31,7 +31,6 @@ export interface HelpPanelProps extends BaseComponentProps {
 
   /**
    * Specifies the text that's displayed when the panel is in a loading state.
-   * @i18n
    */
   loadingText?: string;
 }

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -131,7 +131,6 @@ export interface InputKeyEvents {
 export interface InputClearLabel {
   /**
    * Adds an `aria-label` to the clear button inside the search input.
-   * @i18n
    */
   clearAriaLabel?: string;
 }

--- a/src/internal/components/cartesian-chart/interfaces.ts
+++ b/src/internal/components/cartesian-chart/interfaces.ts
@@ -69,7 +69,6 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: CartesianChartProps.I18nStrings<T>;
 
@@ -138,19 +137,16 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * Text that is displayed when the chart is loading, i.e. when `statusType` is set to `"loading"`.
-   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that is displayed when the chart is in error state, i.e. when `statusType` is set to `"error"`.
-   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that is displayed next to the error text.
-   * @i18n
    **/
   recoveryText?: string;
 

--- a/src/internal/components/dropdown-status/interfaces.ts
+++ b/src/internal/components/dropdown-status/interfaces.ts
@@ -18,19 +18,16 @@ export interface DropdownStatusProps {
   finishedText?: string;
   /**
    * Specifies the text to display when a data fetching error occurs. Make sure that you provide `recoveryText`.
-   * @i18n
    **/
   errorText?: string;
   /**
    * Specifies the text for the recovery button. The text is displayed next to the error text.
    * Use the `onLoadItems` event to perform a recovery action (for example, retrying the request).
-   * @i18n
    **/
   recoveryText?: string;
 
   /**
    * Provides a text alternative for the error icon in the error message.
-   * @i18n
    */
   errorIconAriaLabel?: string;
   /**

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -68,7 +68,6 @@ export interface LinkProps extends BaseComponentProps {
 
   /**
    * Adds an aria-label to the external icon.
-   * @i18n
    */
   externalIconAriaLabel?: string;
 

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -18,7 +18,6 @@ export interface ModalProps extends BaseComponentProps {
   visible: boolean;
   /**
    * Adds an `aria-label` to the close button, for accessibility.
-   * @i18n
    */
   closeAriaLabel?: string;
   /**

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -26,7 +26,6 @@ export interface MultiselectProps extends BaseSelectProps {
   hideTokens?: boolean;
   /**
    * Specifies an `aria-label` for the token deselection button.
-   * @i18n
    */
   deselectAriaLabel?: MultiselectProps.DeselectAriaLabelFunction;
   /**

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -45,7 +45,6 @@ export interface PaginationProps {
    *   pageLabel: pageNumber => `Page ${pageNumber}`
    * }
    * ```
-   * @i18n
    */
   ariaLabels?: PaginationProps.Labels;
 

--- a/src/pie-chart/interfaces.ts
+++ b/src/pie-chart/interfaces.ts
@@ -151,19 +151,16 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * Text that's displayed when the chart is loading (that is, when `statusType` is set to `loading`).
-   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that's displayed when the chart is in error state (that is, when `statusType` is set to `error`).
-   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that's displayed next to the error text.
-   * @i18n
    **/
   recoveryText?: string;
 
@@ -206,7 +203,6 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * An object that contains all of the localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: PieChartProps.I18nStrings;
 }

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -51,7 +51,6 @@ export interface PopoverProps extends BaseComponentProps {
 
   /**
    * Adds an `aria-label` to the dismiss button for accessibility.
-   * @i18n
    */
   dismissAriaLabel?: string;
 

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -29,7 +29,6 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   disabled?: boolean;
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings: PropertyFilterProps.I18nStrings;
   /**

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -118,7 +118,6 @@ export interface S3ResourceSelectorProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: S3ResourceSelectorProps.I18nStrings;
 

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -86,7 +86,6 @@ export interface BaseSelectProps
   filteringAriaLabel?: string;
   /**
    * Adds an `aria-label` to the clear button inside the search input.
-   * @i18n
    */
   filteringClearAriaLabel?: string;
   /**
@@ -113,7 +112,6 @@ export interface BaseSelectProps
    * Specifies the localized string that describes an option as being selected.
    * This is required to provide a good screen reader experience. For more information, see the
    * [accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
-   * @i18n
    */
   selectedAriaLabel?: string;
   /**

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -29,7 +29,6 @@ export interface SplitPanelProps extends BaseComponentProps {
    * - `preferencesConfirm` - The text of the preference modal confirm button.
    * - `preferencesCancel` - The text of the preference modal cancel button.
    * - `resizeHandleAriaLabel` - The label of the resize handle aria label.
-   * @i18n
    */
   i18nStrings?: SplitPanelProps.I18nStrings;
 }

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -178,7 +178,6 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
    * * `submittingEditText` (EditableColumnDefinition) => string -
    *                      Specifies a text that is announced to screen readers when a cell edit operation is submitted.
-   * @i18n
    */
   ariaLabels?: TableProps.AriaLabels<T>;
 

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -61,7 +61,6 @@ export interface TabsProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: TabsProps.I18nStrings;
 }

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -21,7 +21,6 @@ export interface TagEditorProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: TagEditorProps.I18nStrings;
 

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -8,7 +8,6 @@ import { IconProps } from '../icon/interfaces';
 export interface TokenGroupProps extends BaseComponentProps {
   /**
    * An object containing all the necessary localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: TokenGroupProps.I18nStrings;
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -62,7 +62,6 @@ export interface TopNavigationProps extends BaseComponentProps {
 
   /**
    * An object containing all the localized strings required by the component.
-   * @i18n
    */
   i18nStrings?: TopNavigationProps.I18nStrings;
 }

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -52,7 +52,6 @@ export interface WizardProps extends BaseComponentProps {
    * - `optional` (string) - The text displayed next to the step title and form header title when a step is declared optional.
    * - `nextButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *next* button is in a loading state.
    * - `submitButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *submit* button is in a loading state.
-   * @i18n
    */
   i18nStrings: WizardProps.I18nStrings;
 


### PR DESCRIPTION
### Description

To allow cloudscape-design/documenter#21 to be safely merged. After it's merged, I'll revert this.

### How has this been tested?

Documenter tests should pass.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
