### PR TITLE
chore: Return i18n tags to components (see #1165)

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -28,6 +28,7 @@ when the \`dismissible\` property is set to \`true\`.",
     },
     Object {
       "description": "Adds an aria-label to the dismiss button.",
+      "i18nTag": true,
       "name": "dismissAriaLabel",
       "optional": true,
       "type": "string",
@@ -389,8 +390,8 @@ Example:
   toolsClose: \\"Close help panel\\",
   toolsToggle: \\"Open help panel\\"
 }
-\`\`\`
-",
+\`\`\`",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "AppLayoutProps.Labels",
         "properties": Array [
@@ -739,6 +740,7 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     },
     Object {
       "description": "Text that is displayed when the chart is in error state, i.e. when \`statusType\` is set to \`\\"error\\"\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -777,6 +779,7 @@ A value of \`null\` means no series is highlighted.
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "AreaChartProps.I18nStrings",
         "properties": Array [
@@ -862,12 +865,14 @@ A value of \`null\` means no series is highlighted.
     },
     Object {
       "description": "Text that is displayed when the chart is loading, i.e. when \`statusType\` is set to \`\\"loading\\"\`.",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Text for the recovery button that is displayed next to the error text.",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -1083,6 +1088,7 @@ A maximum of four fields are supported.
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "AttributeEditorProps.I18nStrings",
         "properties": Array [
@@ -1423,6 +1429,7 @@ scrolled out of the viewport.",
     },
     Object {
       "description": "Adds an \`aria-label\` to the clear button inside the search input.",
+      "i18nTag": true,
       "name": "clearAriaLabel",
       "optional": true,
       "type": "string",
@@ -1459,6 +1466,7 @@ receive focus.",
     },
     Object {
       "description": "Specifies a function that generates the custom value indicator (for example, \`Use \\"\${value}\\"\`).",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "AutosuggestProps.EnteredTextLabel",
         "parameters": Array [
@@ -1476,12 +1484,14 @@ receive focus.",
     },
     Object {
       "description": "Provides a text alternative for the error icon in the error message.",
+      "i18nTag": true,
       "name": "errorIconAriaLabel",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -1625,6 +1635,7 @@ Don't use read-only inputs outside a form.
     Object {
       "description": "Specifies the text for the recovery button. The text is displayed next to the error text.
 Use the \`onLoadItems\` event to perform a recovery action (for example, retrying the request).",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -1662,6 +1673,7 @@ For more information, see the
       "description": "Specifies the localized string that describes an option as being selected.
 This is required to provide a good screen reader experience. For more information, see the
 [accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).",
+      "i18nTag": true,
       "name": "selectedAriaLabel",
       "optional": true,
       "type": "string",
@@ -1873,6 +1885,7 @@ See the usage guidelines for more details.",
     },
     Object {
       "description": "Text that is displayed when the chart is in error state, i.e. when \`statusType\` is set to \`\\"error\\"\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -1919,6 +1932,7 @@ This can only be used when the chart consists exclusively of bar series.",
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CartesianChartProps.I18nStrings",
         "properties": Array [
@@ -1994,12 +2008,14 @@ This can only be used when the chart consists exclusively of bar series.",
     },
     Object {
       "description": "Text that is displayed when the chart is loading, i.e. when \`statusType\` is set to \`\\"loading\\"\`.",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Text for the recovery button that is displayed next to the error text.",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -2480,6 +2496,7 @@ without pressing modifier keys (that is, CTRL, ALT, SHIFT, META).",
     },
     Object {
       "description": "Provides an \`aria-label\` to the ellipsis button that screen readers can read (for accessibility).",
+      "i18nTag": true,
       "name": "expandAriaLabel",
       "optional": true,
       "type": "string",
@@ -3208,12 +3225,14 @@ Supported values and formats are listed in the
     },
     Object {
       "description": "Specifies an \`aria-label\` for the 'next month' button.",
+      "i18nTag": true,
       "name": "nextMonthAriaLabel",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Specifies an \`aria-label\` for the 'previous month' button.",
+      "i18nTag": true,
       "name": "previousMonthAriaLabel",
       "optional": true,
       "type": "string",
@@ -3227,6 +3246,7 @@ By default the starting day of the week is defined by the locale, but you can us
     },
     Object {
       "description": "Used as part of the \`aria-label\` for today's date in the calendar.",
+      "i18nTag": true,
       "name": "todayAriaLabel",
       "optional": true,
       "type": "string",
@@ -3285,8 +3305,8 @@ scroll parent up to reveal the first card or row of cards.",
 You can use the first arguments of type \`SelectionState\` to access the current selection
 state of the component (for example, the \`selectedItems\` list). The label function for individual
 items also receives the corresponding  \`Item\` object. You can use the group label to
-add a meaningful description to the whole selection.
-",
+add a meaningful description to the whole selection.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CardsProps.AriaLabels",
         "properties": Array [
@@ -3921,8 +3941,8 @@ The object should contain, among others:
 * \`loadingState\` - Specifies the text to display while the component is loading.
 * \`errorState\` - Specifies the text to display if there is an error loading Ace.
 * \`errorStateRecovery\`: Specifies the text for the recovery button that's displayed next to the error text.
-   Use the \`recoveryClick\` event to do a recovery action (for example, retrying the request).
-",
+   Use the \`recoveryClick\` event to do a recovery action (for example, retrying the request).",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CodeEditorProps.I18nStrings",
         "properties": Array [
@@ -4195,6 +4215,7 @@ The values for all configured preferences are present even if the user didn't ch
   "properties": Array [
     Object {
       "description": "Label of the cancel button in the modal footer.",
+      "i18nTag": true,
       "name": "cancelLabel",
       "optional": true,
       "type": "string",
@@ -4208,6 +4229,7 @@ The values for all configured preferences are present even if the user didn't ch
     },
     Object {
       "description": "Label of the confirm button in the modal footer.",
+      "i18nTag": true,
       "name": "confirmLabel",
       "optional": true,
       "type": "string",
@@ -4220,8 +4242,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.contentDensity\` property.
-",
+You must set the current value in the \`preferences.contentDensity\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.ContentDensityPreference",
         "properties": Array [
@@ -4262,8 +4284,8 @@ Each option contains the following:
 - \`label\` (string) - Specifies a short description of the content.
 - \`alwaysVisible\` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to \`false\` by default.
 
-You must provide an ordered list of the items to display in the \`preferences.contentDisplay\` property.
-",
+You must provide an ordered list of the items to display in the \`preferences.contentDisplay\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.ContentDisplayPreference",
         "properties": Array [
@@ -4367,8 +4389,8 @@ It contains the following:
   - \`value\` (number) - The value for the radio button (that is, the number of items per page).
   - \`label\` (string) - A label for the radio button (for example, \\"10 resources\\").
 
-You must set the current value in the \`preferences.pageSize\` property.
-",
+You must set the current value in the \`preferences.pageSize\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.PageSizePreference",
         "properties": Array [
@@ -4456,8 +4478,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
 - \`description\` (string) - Specifies the text displayed below each radio group label.
 
-You must set the current value in the \`preferences.stickyColumns\` property.
-",
+You must set the current value in the \`preferences.stickyColumns\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.StickyColumnsPreference",
         "properties": Array [
@@ -4486,8 +4508,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.stripedRows\` property.
-",
+You must set the current value in the \`preferences.stripedRows\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.StripedRowsPreference",
         "properties": Array [
@@ -4510,6 +4532,7 @@ You must set the current value in the \`preferences.stripedRows\` property.
     },
     Object {
       "description": "Specifies the title of the preferences modal dialog. It is also used as an \`aria-label\` for the trigger button.",
+      "i18nTag": true,
       "name": "title",
       "optional": true,
       "type": "string",
@@ -4559,8 +4582,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for the option checkbox.
 - \`description\` (string) - Specifies the text displayed below the checkbox label.
 
-You must set the current value in the \`preferences.wrapLines\` property.
-",
+You must set the current value in the \`preferences.wrapLines\` property.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CollectionPreferencesProps.WrapLinesPreference",
         "properties": Array [
@@ -5147,6 +5170,7 @@ Supported values and formats are listed in the
     },
     Object {
       "description": "Specifies an \`aria-label\` for the 'next month' button.",
+      "i18nTag": true,
       "name": "nextMonthAriaLabel",
       "optional": true,
       "type": "string",
@@ -5179,6 +5203,7 @@ a human-readable localised string representing the current value of the input.
     },
     Object {
       "description": "Specifies an \`aria-label\` for the 'previous month' button.",
+      "i18nTag": true,
       "name": "previousMonthAriaLabel",
       "optional": true,
       "type": "string",
@@ -5203,6 +5228,7 @@ By default the starting day of the week is defined by the locale, but you can us
     },
     Object {
       "description": "Used as part of the \`aria-label\` for today's date in the calendar.",
+      "i18nTag": true,
       "name": "todayAriaLabel",
       "optional": true,
       "type": "string",
@@ -5386,6 +5412,7 @@ Default: the user's current time offset as provided by the browser.
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "DateRangePickerProps.I18nStrings",
         "properties": Array [
@@ -6089,8 +6116,8 @@ If \`stackItems\` is set to \`true\`, it should also contain:
 * \`warningIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`warning\`.
 * \`infoIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`info\`.
 * \`successIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type \`success\`.
-* \`inProgressIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where \`loading\` is set to \`true\`).
-",
+* \`inProgressIconAriaLabel\` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where \`loading\` is set to \`true\`).",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "FlashbarProps.I18nStrings",
         "properties": Array [
@@ -6205,6 +6232,7 @@ Object {
     },
     Object {
       "description": "Provides a text alternative for the error icon in the error alert.",
+      "i18nTag": true,
       "name": "errorIconAriaLabel",
       "optional": true,
       "type": "string",
@@ -6292,6 +6320,7 @@ This only works well if you're using a single control in the form field.
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "FormFieldProps.I18nStrings",
         "properties": Array [
@@ -6562,6 +6591,7 @@ Object {
     },
     Object {
       "description": "Specifies the text that's displayed when the panel is in a loading state.",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
@@ -7098,6 +7128,7 @@ scrolled out of the viewport.",
     },
     Object {
       "description": "Adds an \`aria-label\` to the clear button inside the search input.",
+      "i18nTag": true,
       "name": "clearAriaLabel",
       "optional": true,
       "type": "string",
@@ -7358,6 +7389,7 @@ See the usage guidelines for more details.",
     },
     Object {
       "description": "Text that is displayed when the chart is in error state, i.e. when \`statusType\` is set to \`\\"error\\"\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -7396,6 +7428,7 @@ A value of \`null\` means no series is highlighted.
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CartesianChartProps.I18nStrings",
         "properties": Array [
@@ -7471,12 +7504,14 @@ A value of \`null\` means no series is highlighted.
     },
     Object {
       "description": "Text that is displayed when the chart is loading, i.e. when \`statusType\` is set to \`\\"loading\\"\`.",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Text for the recovery button that is displayed next to the error text.",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -7697,6 +7732,7 @@ is provided, opens the link in a new tab when clicked.",
     },
     Object {
       "description": "Adds an aria-label to the external icon.",
+      "i18nTag": true,
       "name": "externalIconAriaLabel",
       "optional": true,
       "type": "string",
@@ -7898,6 +7934,7 @@ See the usage guidelines for more details.",
     },
     Object {
       "description": "Text that is displayed when the chart is in error state, i.e. when \`statusType\` is set to \`\\"error\\"\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -7944,6 +7981,7 @@ This can only be used when the chart consists exclusively of bar series.",
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "CartesianChartProps.I18nStrings",
         "properties": Array [
@@ -8019,12 +8057,14 @@ This can only be used when the chart consists exclusively of bar series.",
     },
     Object {
       "description": "Text that is displayed when the chart is loading, i.e. when \`statusType\` is set to \`\\"loading\\"\`.",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Text for the recovery button that is displayed next to the error text.",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -8203,6 +8243,7 @@ The event detail contains the \`reason\`, which can be any of the following:
     },
     Object {
       "description": "Adds an \`aria-label\` to the close button, for accessibility.",
+      "i18nTag": true,
       "name": "closeAriaLabel",
       "optional": true,
       "type": "string",
@@ -8413,6 +8454,7 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     Object {
       "description": "Specifies an \`aria-label\` for the token deselection button.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "MultiselectProps.DeselectAriaLabelFunction",
         "parameters": Array [
@@ -8436,12 +8478,14 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     Object {
       "description": "Provides a text alternative for the error icon in the error message.",
+      "i18nTag": true,
       "name": "errorIconAriaLabel",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -8465,6 +8509,7 @@ in a slight, visible lag when scrolling complex pages.",
     },
     Object {
       "description": "Adds an \`aria-label\` to the clear button inside the search input.",
+      "i18nTag": true,
       "name": "filteringClearAriaLabel",
       "optional": true,
       "type": "string",
@@ -8634,6 +8679,7 @@ on your own.
     Object {
       "description": "Specifies the text for the recovery button. The text is displayed next to the error text.
 Use the \`onLoadItems\` event to perform a recovery action (for example, retrying the request).",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -8671,6 +8717,7 @@ For more information, see the
       "description": "Specifies the localized string that describes an option as being selected.
 This is required to provide a good screen reader experience. For more information, see the
 [accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
+      "i18nTag": true,
       "name": "selectedAriaLabel",
       "optional": true,
       "type": "string",
@@ -8830,8 +8877,8 @@ Example:
   previousPageLabel: 'Previous page',
   pageLabel: pageNumber => \`Page \${pageNumber}\`
 }
-\`\`\`
-",
+\`\`\`",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "PaginationProps.Labels",
         "properties": Array [
@@ -9037,6 +9084,7 @@ Each pair has the following properties:
     },
     Object {
       "description": "Text that's displayed when the chart is in error state (that is, when \`statusType\` is set to \`error\`).",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -9085,6 +9133,7 @@ A value of \`null\` means no segment is being highlighted.
     },
     Object {
       "description": "An object that contains all of the localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "PieChartProps.I18nStrings",
         "properties": Array [
@@ -9168,12 +9217,14 @@ This is usually the unit of the \`innerMetricValue\`.",
     },
     Object {
       "description": "Text that's displayed when the chart is loading (that is, when \`statusType\` is set to \`loading\`).",
+      "i18nTag": true,
       "name": "loadingText",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Text for the recovery button that's displayed next to the error text.",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -9300,6 +9351,7 @@ Object {
     },
     Object {
       "description": "Adds an \`aria-label\` to the dismiss button for accessibility.",
+      "i18nTag": true,
       "name": "dismissAriaLabel",
       "optional": true,
       "type": "string",
@@ -9802,6 +9854,7 @@ operations are communicated to the user in another way.",
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "PropertyFilterProps.I18nStrings",
         "properties": Array [
@@ -10899,12 +10952,14 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     Object {
       "description": "Provides a text alternative for the error icon in the error message.",
+      "i18nTag": true,
       "name": "errorIconAriaLabel",
       "optional": true,
       "type": "string",
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
+      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -10928,6 +10983,7 @@ in a slight, visible lag when scrolling complex pages.",
     },
     Object {
       "description": "Adds an \`aria-label\` to the clear button inside the search input.",
+      "i18nTag": true,
       "name": "filteringClearAriaLabel",
       "optional": true,
       "type": "string",
@@ -11058,6 +11114,7 @@ on your own.
     Object {
       "description": "Specifies the text for the recovery button. The text is displayed next to the error text.
 Use the \`onLoadItems\` event to perform a recovery action (for example, retrying the request).",
+      "i18nTag": true,
       "name": "recoveryText",
       "optional": true,
       "type": "string",
@@ -11095,6 +11152,7 @@ For more information, see the
       "description": "Specifies the localized string that describes an option as being selected.
 This is required to provide a good screen reader experience. For more information, see the
 [accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).",
+      "i18nTag": true,
       "name": "selectedAriaLabel",
       "optional": true,
       "type": "string",
@@ -11577,6 +11635,7 @@ Object {
 - \`preferencesConfirm\` - The text of the preference modal confirm button.
 - \`preferencesCancel\` - The text of the preference modal cancel button.
 - \`resizeHandleAriaLabel\` - The label of the resize handle aria label.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "SplitPanelProps.I18nStrings",
         "properties": Array [
@@ -11909,8 +11968,8 @@ add a meaningful description to the whole selection.
 * \`successfulEditLabel\` (EditableColumnDefinition) => string -
                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
 * \`submittingEditText\` (EditableColumnDefinition) => string -
-                     Specifies a text that is announced to screen readers when a cell edit operation is submitted.
-",
+                     Specifies a text that is announced to screen readers when a cell edit operation is submitted.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "TableProps.AriaLabels",
         "properties": Array [
@@ -12417,6 +12476,7 @@ Don't use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "TabsProps.I18nStrings",
         "properties": Array [
@@ -13782,6 +13842,7 @@ Object {
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "TokenGroupProps.I18nStrings",
         "properties": Array [
@@ -13854,6 +13915,7 @@ Object {
     },
     Object {
       "description": "An object containing all the localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "TopNavigationProps.I18nStrings",
         "properties": Array [
@@ -14299,8 +14361,8 @@ Defaults to \`false\`.
 - \`submitButton\` (string) - The text of the button that enables the user to submit the form.
 - \`optional\` (string) - The text displayed next to the step title and form header title when a step is declared optional.
 - \`nextButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *next* button is in a loading state.
-- \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.
-",
+- \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "WizardProps.I18nStrings",
         "properties": Array [

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -31,6 +31,7 @@ export interface AlertProps extends BaseComponentProps {
   dismissible?: boolean;
   /**
    * Adds an aria-label to the dismiss button.
+   * @i18n
    */
   dismissAriaLabel?: string;
   /**

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -105,6 +105,7 @@ export interface AppLayoutProps extends BaseComponentProps {
    *   toolsToggle: "Open help panel"
    * }
    * ```
+   * @i18n
    */
   ariaLabels?: AppLayoutProps.Labels;
 

--- a/src/area-chart/interfaces.ts
+++ b/src/area-chart/interfaces.ts
@@ -18,6 +18,7 @@ export interface AreaChartProps<T extends AreaChartProps.DataTypes>
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: AreaChartProps.I18nStrings<T>;
 }

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -119,6 +119,7 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: AttributeEditorProps.I18nStrings<T>;
 }

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -74,6 +74,7 @@ export interface AutosuggestProps
 
   /**
    * Specifies a function that generates the custom value indicator (for example, `Use "${value}"`).
+   * @i18n
    */
   enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
 
@@ -98,6 +99,7 @@ export interface AutosuggestProps
    * Specifies the localized string that describes an option as being selected.
    * This is required to provide a good screen reader experience. For more information, see the
    * [accessibility guidelines](/components/autosuggest/?tabId=usage#accessibility-guidelines).
+   * @i18n
    */
   selectedAriaLabel?: string;
   /**

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -26,6 +26,7 @@ export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = Brea
 
   /**
    * Provides an `aria-label` to the ellipsis button that screen readers can read (for accessibility).
+   * @i18n
    */
   expandAriaLabel?: string;
   /**

--- a/src/calendar/interfaces.ts
+++ b/src/calendar/interfaces.ts
@@ -50,16 +50,19 @@ export interface CalendarProps extends BaseComponentProps {
 
   /**
    * Used as part of the `aria-label` for today's date in the calendar.
+   * @i18n
    */
   todayAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'next month' button.
+   * @i18n
    */
   nextMonthAriaLabel?: string;
 
   /**
    * Specifies an `aria-label` for the 'previous month' button.
+   * @i18n
    */
   previousMonthAriaLabel?: string;
 

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -157,6 +157,7 @@ export interface CardsProps<T = any> extends BaseComponentProps {
    * state of the component (for example, the `selectedItems` list). The label function for individual
    * items also receives the corresponding  `Item` object. You can use the group label to
    * add a meaningful description to the whole selection.
+   * @i18n
    */
   ariaLabels?: CardsProps.AriaLabels<T>;
   /**

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -97,6 +97,7 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
    * * `errorState` - Specifies the text to display if there is an error loading Ace.
    * * `errorStateRecovery`: Specifies the text for the recovery button that's displayed next to the error text.
    *    Use the `recoveryClick` event to do a recovery action (for example, retrying the request).
+   * @i18n
    */
   i18nStrings?: CodeEditorProps.I18nStrings;
 

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -6,14 +6,17 @@ import { NonCancelableEventHandler } from '../internal/events';
 export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
   /**
    * Specifies the title of the preferences modal dialog. It is also used as an `aria-label` for the trigger button.
+   * @i18n
    */
   title?: string;
   /**
    * Label of the confirm button in the modal footer.
+   * @i18n
    */
   confirmLabel?: string;
   /**
    * Label of the cancel button in the modal footer.
+   * @i18n
    */
   cancelLabel?: string;
   /**
@@ -32,6 +35,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    *   - `label` (string) - A label for the radio button (for example, "10 resources").
    *
    * You must set the current value in the `preferences.pageSize` property.
+   * @i18n
    */
   pageSizePreference?: CollectionPreferencesProps.PageSizePreference;
   /**
@@ -44,6 +48,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.wrapLines` property.
+   * @i18n
    */
   wrapLinesPreference?: CollectionPreferencesProps.WrapLinesPreference;
   /**
@@ -56,6 +61,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.stripedRows` property.
+   * @i18n
    */
   stripedRowsPreference?: CollectionPreferencesProps.StripedRowsPreference;
   /**
@@ -68,6 +74,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below the checkbox label.
    *
    * You must set the current value in the `preferences.contentDensity` property.
+   * @i18n
    */
   contentDensityPreference?: CollectionPreferencesProps.ContentDensityPreference;
   /**
@@ -80,6 +87,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below each radio group label.
    *
    * You must set the current value in the `preferences.stickyColumns` property.
+   * @i18n
    */
   stickyColumnsPreference?: CollectionPreferencesProps.StickyColumnsPreference;
   /**
@@ -104,6 +112,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `alwaysVisible` (boolean) - (Optional) Determines whether the visibility is always on and therefore cannot be toggled. This is set to `false` by default.
    *
    * You must provide an ordered list of the items to display in the `preferences.contentDisplay` property.
+   * @i18n
    */
   contentDisplayPreference?: CollectionPreferencesProps.ContentDisplayPreference;
   /**

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -45,6 +45,7 @@ export interface DateRangePickerBaseProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: DateRangePickerProps.I18nStrings;
 

--- a/src/flashbar/interfaces.ts
+++ b/src/flashbar/interfaces.ts
@@ -85,6 +85,7 @@ export interface FlashbarProps extends BaseComponentProps {
    * * `infoIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `info`.
    * * `successIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of items of type `success`.
    * * `inProgressIconAriaLabel` - (optional) Specifies the ARIA label for the icon displayed next to the number of in-progress items (where `loading` is set to `true`).
+   * @i18n
    */
   i18nStrings?: FlashbarProps.I18nStrings;
 }

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -35,6 +35,7 @@ export interface FormFieldProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: FormFieldProps.I18nStrings;
 

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -21,6 +21,7 @@ export interface FormProps extends BaseComponentProps {
 
   /**
    * Provides a text alternative for the error icon in the error alert.
+   * @i18n
    */
   errorIconAriaLabel?: string;
 

--- a/src/help-panel/interfaces.ts
+++ b/src/help-panel/interfaces.ts
@@ -31,6 +31,7 @@ export interface HelpPanelProps extends BaseComponentProps {
 
   /**
    * Specifies the text that's displayed when the panel is in a loading state.
+   * @i18n
    */
   loadingText?: string;
 }

--- a/src/input/interfaces.ts
+++ b/src/input/interfaces.ts
@@ -131,6 +131,7 @@ export interface InputKeyEvents {
 export interface InputClearLabel {
   /**
    * Adds an `aria-label` to the clear button inside the search input.
+   * @i18n
    */
   clearAriaLabel?: string;
 }

--- a/src/internal/components/cartesian-chart/interfaces.ts
+++ b/src/internal/components/cartesian-chart/interfaces.ts
@@ -69,6 +69,7 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: CartesianChartProps.I18nStrings<T>;
 
@@ -137,16 +138,19 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
 
   /**
    * Text that is displayed when the chart is loading, i.e. when `statusType` is set to `"loading"`.
+   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that is displayed when the chart is in error state, i.e. when `statusType` is set to `"error"`.
+   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that is displayed next to the error text.
+   * @i18n
    **/
   recoveryText?: string;
 

--- a/src/internal/components/dropdown-status/interfaces.ts
+++ b/src/internal/components/dropdown-status/interfaces.ts
@@ -18,16 +18,19 @@ export interface DropdownStatusProps {
   finishedText?: string;
   /**
    * Specifies the text to display when a data fetching error occurs. Make sure that you provide `recoveryText`.
+   * @i18n
    **/
   errorText?: string;
   /**
    * Specifies the text for the recovery button. The text is displayed next to the error text.
    * Use the `onLoadItems` event to perform a recovery action (for example, retrying the request).
+   * @i18n
    **/
   recoveryText?: string;
 
   /**
    * Provides a text alternative for the error icon in the error message.
+   * @i18n
    */
   errorIconAriaLabel?: string;
   /**

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -68,6 +68,7 @@ export interface LinkProps extends BaseComponentProps {
 
   /**
    * Adds an aria-label to the external icon.
+   * @i18n
    */
   externalIconAriaLabel?: string;
 

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -18,6 +18,7 @@ export interface ModalProps extends BaseComponentProps {
   visible: boolean;
   /**
    * Adds an `aria-label` to the close button, for accessibility.
+   * @i18n
    */
   closeAriaLabel?: string;
   /**

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -26,6 +26,7 @@ export interface MultiselectProps extends BaseSelectProps {
   hideTokens?: boolean;
   /**
    * Specifies an `aria-label` for the token deselection button.
+   * @i18n
    */
   deselectAriaLabel?: MultiselectProps.DeselectAriaLabelFunction;
   /**

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -45,6 +45,7 @@ export interface PaginationProps {
    *   pageLabel: pageNumber => `Page ${pageNumber}`
    * }
    * ```
+   * @i18n
    */
   ariaLabels?: PaginationProps.Labels;
 

--- a/src/pie-chart/interfaces.ts
+++ b/src/pie-chart/interfaces.ts
@@ -151,16 +151,19 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * Text that's displayed when the chart is loading (that is, when `statusType` is set to `loading`).
+   * @i18n
    */
   loadingText?: string;
 
   /**
    * Text that's displayed when the chart is in error state (that is, when `statusType` is set to `error`).
+   * @i18n
    */
   errorText?: string;
 
   /**
    * Text for the recovery button that's displayed next to the error text.
+   * @i18n
    **/
   recoveryText?: string;
 
@@ -203,6 +206,7 @@ export interface PieChartProps<T extends PieChartProps.Datum = PieChartProps.Dat
 
   /**
    * An object that contains all of the localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: PieChartProps.I18nStrings;
 }

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -51,6 +51,7 @@ export interface PopoverProps extends BaseComponentProps {
 
   /**
    * Adds an `aria-label` to the dismiss button for accessibility.
+   * @i18n
    */
   dismissAriaLabel?: string;
 

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -29,6 +29,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   disabled?: boolean;
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings: PropertyFilterProps.I18nStrings;
   /**

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -86,6 +86,7 @@ export interface BaseSelectProps
   filteringAriaLabel?: string;
   /**
    * Adds an `aria-label` to the clear button inside the search input.
+   * @i18n
    */
   filteringClearAriaLabel?: string;
   /**
@@ -112,6 +113,7 @@ export interface BaseSelectProps
    * Specifies the localized string that describes an option as being selected.
    * This is required to provide a good screen reader experience. For more information, see the
    * [accessibility guidelines](/components/select/?tabId=usage#accessibility-guidelines).
+   * @i18n
    */
   selectedAriaLabel?: string;
   /**

--- a/src/split-panel/interfaces.ts
+++ b/src/split-panel/interfaces.ts
@@ -29,6 +29,7 @@ export interface SplitPanelProps extends BaseComponentProps {
    * - `preferencesConfirm` - The text of the preference modal confirm button.
    * - `preferencesCancel` - The text of the preference modal cancel button.
    * - `resizeHandleAriaLabel` - The label of the resize handle aria label.
+   * @i18n
    */
   i18nStrings?: SplitPanelProps.I18nStrings;
 }

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -178,6 +178,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
    * * `submittingEditText` (EditableColumnDefinition) => string -
    *                      Specifies a text that is announced to screen readers when a cell edit operation is submitted.
+   * @i18n
    */
   ariaLabels?: TableProps.AriaLabels<T>;
 

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -61,6 +61,7 @@ export interface TabsProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: TabsProps.I18nStrings;
 }

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -8,6 +8,7 @@ import { IconProps } from '../icon/interfaces';
 export interface TokenGroupProps extends BaseComponentProps {
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: TokenGroupProps.I18nStrings;
 

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -62,6 +62,7 @@ export interface TopNavigationProps extends BaseComponentProps {
 
   /**
    * An object containing all the localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: TopNavigationProps.I18nStrings;
 }

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -52,6 +52,7 @@ export interface WizardProps extends BaseComponentProps {
    * - `optional` (string) - The text displayed next to the step title and form header title when a step is declared optional.
    * - `nextButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *next* button is in a loading state.
    * - `submitButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *submit* button is in a loading state.
+   * @i18n
    */
   i18nStrings: WizardProps.I18nStrings;
 


### PR DESCRIPTION
Mostly, this reverts commit 0ea772bfc3f3dc7e102e07be46e16ac351f92e0c. The documenter had to be rebuilt after the merge to add those tags back in after merging cloudscape-design/documenter#21, so this isn't a straight revert. The tags also weren't brought back to s3 resource selector and tag editor, which are waiting on translations.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
