### PR TITLE
revert: Revert "fix: Ensure that modal content can't overlap footer"

### DIFF
--- a/pages/modal/vertical-scroll.page.tsx
+++ b/pages/modal/vertical-scroll.page.tsx
@@ -11,7 +11,7 @@ export default function () {
 
   for (let i = 0; i < 10; i++) {
     content.push(
-      <p key={i} style={{ position: 'relative', zIndex: 999 }}>
+      <p key={i}>
         Bacon ipsum dolor amet jowl short ribs shankle prosciutto flank tenderloin tri-tip tongue. Meatloaf salami
         turducken bresaola ribeye flank shankle boudin sirloin. Picanha meatloaf short ribs chicken jowl andouille filet
         mignon spare ribs kevin rump corned beef. Cow pastrami beef ribs turkey kielbasa alcatra.
@@ -22,9 +22,7 @@ export default function () {
   return (
     <article>
       <h1>Vertical scroll modal</h1>
-      <Button data-testid="modal-trigger" onClick={() => setVisible(true)}>
-        Show modal
-      </Button>
+      <Button onClick={() => setVisible(true)}>Show modal</Button>
       <ScreenshotArea>
         <Modal
           header="Modal title"

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -78,19 +78,3 @@ test(
     }
   })
 );
-
-test(
-  'should not let content with z-index overlap footer',
-  useBrowser(async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/modal/vertical-scroll');
-
-    // Open modal
-    await page.click('[data-testid="modal-trigger"]');
-    const modal = createWrapper().findModal();
-    const footerSelector = modal.findFooter().toSelector();
-
-    // this will throw an error if the footer is overlapped by the content
-    await page.click(footerSelector);
-  })
-);

--- a/src/modal/styles.scss
+++ b/src/modal/styles.scss
@@ -87,8 +87,6 @@ $modal-z-index: 5000;
 
 .content {
   padding: awsui.$space-container-content-top awsui.$space-modal-horizontal awsui.$space-modal-content-bottom;
-  z-index: 0;
-  position: relative;
   &.no-paddings {
     padding: 0;
   }


### PR DESCRIPTION
Reverts cloudscape-design/components#1139. We have an internal test that fails because of this, so this is a temporary rollback.