### PR TITLE
feat: Add dark background to ContentLayout without header

### DIFF
--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -26,6 +26,8 @@ explicitly set in script.
   #{custom-props.$contentGapLeft}: 0px;
   #{custom-props.$contentGapRight}: 0px;
   #{custom-props.$contentHeight}: calc(100vh - var(#{custom-props.$headerHeight}) - var(#{custom-props.$footerHeight}));
+  #{custom-props.$containerFirstGap}: 0px;
+  #{custom-props.$containerFirstOverlapExtension}: 0px;
   #{custom-props.$defaultMaxContentWidth}: 1280px;
   #{custom-props.$defaultMinContentWidth}: 0px;
   #{custom-props.$footerHeight}: 0px;
@@ -217,6 +219,11 @@ explicitly set in script.
     #{custom-props.$mainGap}: #{awsui.$space-xs};
   }
 
+  // Set gap to be used by content that has a container on top (e.g. content-layout without header) when breadcrumbs are present
+  &.has-breadcrumbs:not(.has-header) {
+    #{custom-props.$containerFirstGap}: calc(var(#{custom-props.$breadcrumbsGap}) - var(#{custom-props.$mainGap}));
+  }
+
   // Set the Main gap when it follows the Breadcrumbs without an overlap
   &.has-breadcrumbs:not(.has-header).is-overlap-disabled {
     #{custom-props.$mainGap}: #{awsui.$space-scaled-m};
@@ -236,6 +243,14 @@ explicitly set in script.
   &.content-first-child-main:not(.is-overlap-disabled),
   &.content-first-child-main.is-overlap-disabled:not(.disable-content-paddings) {
     #{custom-props.$mainGap}: #{awsui.$space-scaled-xs};
+  }
+
+  // Set an extension of the overlap and an additional gap on top to be used by content-layout without header
+  @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
+    &.content-first-child-main:not(.has-header) {
+      #{custom-props.$containerFirstOverlapExtension}: #{awsui.$space-m};
+      #{custom-props.$containerFirstGap}: #{awsui.$space-xxs};
+    }
   }
 
   /*

--- a/src/content-layout/__tests__/content-layout.test.tsx
+++ b/src/content-layout/__tests__/content-layout.test.tsx
@@ -73,14 +73,14 @@ describe('ContentLayout component', () => {
       expect(isOverlapEnabled()).toBe(false);
     });
 
-    test('does not render the overlap if the header is empty', () => {
+    test('renders the overlap if the header is empty', () => {
       const { isOverlapEnabled } = renderContentLayout({
         children: <>Content text</>,
       });
-      expect(isOverlapEnabled()).toBe(false);
+      expect(isOverlapEnabled()).toBe(true);
     });
 
-    test('does not render the overlap if the header is toggled', () => {
+    test('does not render the overlap if the content is toggled', () => {
       const { isOverlapEnabled, rerender } = renderContentLayout({
         children: <>Content text</>,
         header: <>Header text</>,
@@ -88,7 +88,7 @@ describe('ContentLayout component', () => {
       expect(isOverlapEnabled()).toBe(true);
 
       rerender({
-        children: <>Content text</>,
+        header: <>Header text</>,
       });
       expect(isOverlapEnabled()).toBe(false);
 

--- a/src/content-layout/internal.tsx
+++ b/src/content-layout/internal.tsx
@@ -26,12 +26,7 @@ export default function InternalContentLayout({
   const isVisualRefresh = useVisualRefresh();
   const overlapElement = useDynamicOverlap();
 
-  /**
-   * Disable the overlap if the component is missing either a header or child
-   * content. If the component is not using visual refresh then the overlap
-   * will not be displayed at all. This is handled in the CSS not the JavaScript.
-   */
-  const isOverlapDisabled = !children || !header || disableOverlap;
+  const isOverlapDisabled = !children || disableOverlap;
 
   return (
     <div
@@ -39,6 +34,7 @@ export default function InternalContentLayout({
       className={clsx(baseProps.className, styles.layout, {
         [styles['is-overlap-disabled']]: isOverlapDisabled,
         [styles['is-visual-refresh']]: isVisualRefresh,
+        [styles['has-header']]: !!header,
       })}
       ref={mergedRef}
     >

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -4,6 +4,7 @@
 */
 @use '../internal/styles/' as styles;
 @use '../internal/styles/tokens' as awsui;
+@use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 /*
 Pass through the header and child content if not rendering in 
@@ -29,10 +30,6 @@ nodes will directly touch with no gap between them.
   grid-template-rows: auto #{awsui.$space-dark-header-overlap-distance} 1fr;
   min-height: 100%;
 
-  &.is-overlap-disabled {
-    grid-template-rows: auto 0 1fr;
-  }
-
   > .background {
     background-color: awsui.$color-background-layout-main;
     grid-column: 1;
@@ -53,5 +50,21 @@ nodes will directly touch with no gap between them.
   > .content {
     grid-column: 1;
     grid-row: 2 / 4;
+  }
+
+  &:not(.has-header) {
+    grid-template-rows:
+      auto calc(
+        #{awsui.$space-dark-header-overlap-distance} + var(#{custom-props.$containerFirstOverlapExtension}, 0px) + var(#{custom-props.$containerFirstGap}, 0px)
+      )
+      1fr;
+
+    > .content {
+      padding-top: var(#{custom-props.$containerFirstGap}, 0px);
+    }
+  }
+
+  &.is-overlap-disabled {
+    grid-template-rows: auto 0 1fr;
   }
 }

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -11,6 +11,8 @@ const customCssPropertiesList = [
   'contentGapLeft',
   'contentGapRight',
   'contentHeight',
+  'containerFirstGap',
+  'containerFirstOverlapExtension',
   'defaultMaxContentWidth',
   'defaultMinContentWidth',
   'footerHeight',

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -7,6 +7,7 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
+@use '../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .root {
   @include styles.styles-reset;
@@ -32,7 +33,7 @@
 .navigation.refresh {
   grid-column: 1;
   grid-row: 1 / span 2;
-  padding-top: awsui.$space-scaled-xxs;
+  padding-top: var(#{custom-props.$containerFirstGap}, 0px);
 
   > ul {
     background: awsui.$color-background-container-content;


### PR DESCRIPTION
### Description

- Add dark background to ContentLayout when header is not defined
- Align spacing below breadcrumbs across ContentLayout and Wizard

### How has this been tested?

<!-- How did you test to verify your changes? --> Locally, plus existing screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ Confirmed
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
