### PR TITLE
fix: Prevent VoiceOver from announcing "empty" when focusing line/bar charts

### DIFF
--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -191,7 +191,7 @@ function ChartPlot(
       >
         <FocusOutline elementRef={svgRef} elementKey={isPlotFocused} offset={focusOffset} />
 
-        <g transform={transform} role="group">
+        <g transform={transform}>
           <ApplicationController
             activeElementKey={activeElementKey || null}
             activeElementRef={activeElementRef}


### PR DESCRIPTION
### Description

When focusing a bar chart, VoiceOver would announce "Chart of things, bar chart, empty". The focusable element is marked with role="application", but we still have inner elements marked up with "aria-*" properties. The empty announcement comes from a role="group" element directly below the chart plot. If marked as presentational (or not specially marked at all), the parent is not announced as empty.

We used to need the role="group" because we used to announce the vertical and horizontal axis labels under it, but we don't do that anymore, so there's really nothing outside of aria-hidden inside the bar chart anymore. So this is safe to do; for bar charts anyway, which are designed to fully rely on application-specific keyboard navigation.

Related links, issue #, if available: AWSUI-18682

### How has this been tested?

Manually tested with VoiceOver.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
