### PR TITLE
fix: Fix generation of declaration files for i18n messages

### DIFF
--- a/build-tools/tasks/generate-i18n-messages.js
+++ b/build-tools/tasks/generate-i18n-messages.js
@@ -13,7 +13,7 @@ const namespace = '@cloudscape-design/components';
 const destinationDir = path.join(targetPath, 'components/i18n/messages');
 const internalDestinationDir = path.join(targetPath, 'components/internal/i18n/messages');
 const declarationFile = `import { I18nProviderProps } from "../provider";
-const messages: I18nProviderProps.Messages;
+declare const messages: I18nProviderProps.Messages;
 export default messages;
 `;
 


### PR DESCRIPTION
### Description

```error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.```

News to me! Don't know how people used it just fine so far with this, but I assume it's a TypeScript version thing.

### How has this been tested?

Changed it manually in the failing build and it worked. Also VS Code stopped yelling at me.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
