### PR TITLE
fix: Provide tagLimit value to tag editor's tagLimit i18n formatter

### DIFF
--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -674,7 +674,7 @@ describe('Tag Editor component', () => {
               'i18nStrings.optional': 'Custom optional',
               'i18nStrings.keySuggestion': 'Custom key suggestion',
               'i18nStrings.valuePlaceholder': 'Custom value placeholder',
-              'i18nStrings.tagLimit': 'Custom limit {availableTags}',
+              'i18nStrings.tagLimit': 'Custom limit {availableTags} out of {tagLimit}',
               'i18nStrings.tagLimitReached': 'Custom limit reached {tagLimit}',
             },
           }}
@@ -685,7 +685,7 @@ describe('Tag Editor component', () => {
       const wrapper = createWrapper(container).findTagEditor()!;
       expect(wrapper.findEmptySlot()!.getElement()).toHaveTextContent('Custom empty tags');
       expect(wrapper.findAddButton().getElement()).toHaveTextContent('Custom add');
-      expect(wrapper.findAdditionalInfo()!.getElement()).toHaveTextContent('Custom limit 1');
+      expect(wrapper.findAdditionalInfo()!.getElement()).toHaveTextContent('Custom limit 1 out of 1');
 
       wrapper.findAddButton().click();
       expect(wrapper.findAdditionalInfo()!.getElement()).toHaveTextContent('Custom limit reached 1');

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -316,7 +316,7 @@ const TagEditor = React.forwardRef(
             ) ?? ''
           ) : (
             i18n('i18nStrings.tagLimit', i18nStrings?.tagLimit?.(remainingTags, tagLimit), format =>
-              format({ tagLimitAvailable: `${remainingTags === tagLimit}`, availableTags: remainingTags })
+              format({ tagLimitAvailable: `${remainingTags === tagLimit}`, availableTags: remainingTags, tagLimit })
             )
           )
         }


### PR DESCRIPTION
### Description

What it says on the tin. I didn't provide it because the string didn't use it, and my test string didn't either, but it's needed for pluralization inside the string still.

Related links, issue #, if available: n/a

### How has this been tested?

Modified the unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
