### PR TITLE
fix: Ensure that modal content can't overlap footer

### DIFF
--- a/pages/modal/vertical-scroll.page.tsx
+++ b/pages/modal/vertical-scroll.page.tsx
@@ -11,7 +11,7 @@ export default function () {
 
   for (let i = 0; i < 10; i++) {
     content.push(
-      <p key={i}>
+      <p key={i} style={{ position: 'relative', zIndex: 10 }}>
         Bacon ipsum dolor amet jowl short ribs shankle prosciutto flank tenderloin tri-tip tongue. Meatloaf salami
         turducken bresaola ribeye flank shankle boudin sirloin. Picanha meatloaf short ribs chicken jowl andouille filet
         mignon spare ribs kevin rump corned beef. Cow pastrami beef ribs turkey kielbasa alcatra.
@@ -22,7 +22,9 @@ export default function () {
   return (
     <article>
       <h1>Vertical scroll modal</h1>
-      <Button onClick={() => setVisible(true)}>Show modal</Button>
+      <Button data-testid="modal-trigger" onClick={() => setVisible(true)}>
+        Show modal
+      </Button>
       <ScreenshotArea>
         <Modal
           header="Modal title"

--- a/pages/popover/in-modal-test.page.tsx
+++ b/pages/popover/in-modal-test.page.tsx
@@ -44,6 +44,7 @@ export default function () {
             visible={isModalOpened}
             onDismiss={() => setModalOpened(false)}
             closeAriaLabel="Close modal"
+            footer="Modal footer"
           >
             <Popover
               id="popover"

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -78,3 +78,19 @@ test(
     }
   })
 );
+
+test(
+  'should not let content with z-index overlap footer',
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/modal/vertical-scroll');
+
+    // Open modal
+    await page.click('[data-testid="modal-trigger"]');
+    const modal = createWrapper().findModal();
+    const footerSelector = modal.findFooter().toSelector();
+
+    // this will throw an error if the footer is overlapped by the content
+    await page.click(footerSelector);
+  })
+);

--- a/src/modal/styles.scss
+++ b/src/modal/styles.scss
@@ -111,6 +111,7 @@ $modal-z-index: 5000;
   // Make sure that the footer is always visible
   position: sticky;
   bottom: 0;
+  z-index: 800;
 
   &--stuck {
     border-radius: 0 0 awsui.$border-radius-container awsui.$border-radius-container;


### PR DESCRIPTION
### Description

Ensure that modal content can't overlap footer, even if it e.g. has a z-index set.

Related links, issue #, if available: AWSUI-21216

Follow-up from https://github.com/cloudscape-design/components/pull/1139 which was reverted after unexpected visual changes in some scenarios.

TODO: also update website article https://cloudscape.design/get-started/dev-guides/z-index/

### How has this been tested?

Updated integ and screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
