### PR TITLE
chore: Add findExpandButton to Expandable section test utils

### DIFF
--- a/src/expandable-section/__tests__/interactions.test.tsx
+++ b/src/expandable-section/__tests__/interactions.test.tsx
@@ -23,15 +23,15 @@ describe('Expandable Section - Interactions', () => {
       wrapper = renderExpandableSection({ onChange: onChangeSpy });
     });
     test('toggles from false to true when header is clicked, change event fires', () => {
-      wrapper.findHeader().click();
+      wrapper.findExpandButton().click();
       expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
     });
     test('toggles from false to true when header receives "Enter" keyboard input, change event fires', () => {
-      wrapper.findHeader().keyup(KeyCode.enter);
+      wrapper.findExpandButton().keyup(KeyCode.enter);
       expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
     });
     test('toggles from false to true when header receives "Space" keyboard input, change event fires', () => {
-      wrapper.findHeader().keyup(KeyCode.space);
+      wrapper.findExpandButton().keyup(KeyCode.space);
       expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
     });
 
@@ -44,15 +44,15 @@ describe('Expandable Section - Interactions', () => {
         wrapper = renderExpandableSection({ expanded: true, onChange: onChangeSpy });
       });
       test('toggles from true to false when header is clicked, change event fires', () => {
-        wrapper.findHeader().click();
+        wrapper.findExpandButton().click();
         expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
       });
       test('toggles from true to false when header receives "Enter" keyboard input, change event fires', () => {
-        wrapper.findHeader().keyup(KeyCode.enter);
+        wrapper.findExpandButton().keyup(KeyCode.enter);
         expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
       });
       test('toggles from true to false when header receives "Space" keyboard input, change event fires', () => {
-        wrapper.findHeader().keyup(KeyCode.space);
+        wrapper.findExpandButton().keyup(KeyCode.space);
         expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
       });
     });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -68,7 +68,7 @@ const ExpandableDefaultHeader = ({
     <div
       id={id}
       role="button"
-      className={className}
+      className={clsx(className, styles['expand-button'])}
       tabIndex={0}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
@@ -97,7 +97,7 @@ const ExpandableNavigationHeader = ({
   return (
     <div id={id} className={className} onClick={onClick}>
       <button
-        className={styles['icon-container']}
+        className={clsx(styles['icon-container'], styles['expand-button'])}
         aria-labelledby={ariaLabelledBy}
         aria-label={ariaLabel}
         aria-controls={ariaControls}
@@ -132,13 +132,16 @@ const ExpandableHeaderTextWrapper = ({
   const screenreaderContentId = useUniqueId('expandable-section-header-content-');
   const isContainer = variant === 'container';
   const HeadingTag = headingTagOverride || 'div';
-  const hasInteractiveElements = headerInfo || headerActions;
+  const hasInteractiveElements = isContainer && (headerInfo || headerActions);
   const listeners = { onClick, onKeyDown, onKeyUp };
   const wrapperListeners = hasInteractiveElements ? undefined : listeners;
   const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
   const headerButton = (
     <span
-      className={isContainer ? styles['header-container-button'] : styles['header-button']}
+      className={clsx(
+        styles['expand-button'],
+        isContainer ? styles['header-container-button'] : styles['header-button']
+      )}
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}
@@ -154,7 +157,11 @@ const ExpandableHeaderTextWrapper = ({
   );
 
   return (
-    <div id={id} className={className} {...wrapperListeners}>
+    <div
+      id={id}
+      className={clsx(className, hasInteractiveElements && styles['with-interactive-elements'])}
+      {...wrapperListeners}
+    >
       {isContainer ? (
         <InternalHeader
           variant="h2"
@@ -235,15 +242,9 @@ export const ExpandableSectionHeader = ({
   }
 
   if (headerText) {
-    const hasInteractiveElements = headerInfo || headerActions;
     return (
       <ExpandableHeaderTextWrapper
-        className={clsx(
-          className,
-          wrapperClassName,
-          hasInteractiveElements && styles['with-interactive-elements'],
-          expanded && styles.expanded
-        )}
+        className={clsx(className, wrapperClassName, expanded && styles.expanded)}
         headerDescription={headerDescription}
         headerCounter={headerCounter}
         headerInfo={headerInfo}

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -16,6 +16,10 @@
   display: block;
 }
 
+.expand-button {
+  /* used in test-utils */
+}
+
 .icon {
   transform: rotate(-90deg);
 

--- a/src/test-utils/dom/expandable-section/index.ts
+++ b/src/test-utils/dom/expandable-section/index.ts
@@ -15,6 +15,13 @@ export default class ExpandableSectionWrapper extends ComponentWrapper {
     return this.findByClassName(styles.content)!;
   }
 
+  /*
+   * Returns the area that can be clicked in order to expand or collapse the section.
+   */
+  findExpandButton(): ElementWrapper {
+    return this.findByClassName(styles['expand-button'])!;
+  }
+
   findExpandedContent(): ElementWrapper | null {
     return this.find(
       `:scope > .${styles['content-expanded']}, :scope > .${containerStyles.content} > .${styles['content-expanded']}`


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

After #1143, the clickable area to expand and collapse expandable sections is restricted to a subset of the header elements when interactive elements are present in the header. Therefore, clicking on the entire header with `ExpandableSection.findHeader().click()` is not reliable anymore to expand an expandable section in tests, and a new function `findExpandButton` is provided in test utils for this purpose, which returns only the clickable area.

<!-- Also include relevant motivation and context. -->

Related documents:
- API proposal: kSXNASqTs3Sk
- More information about changes in the clickable area: 7SZJAvbhbznX

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
