### PR TITLE
chore: Log warnings for all variants when using deprecated header pro…

### DIFF
--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -169,15 +169,20 @@ describe('Expandable Section', () => {
 
   describe('dev warnings', () => {
     const componentName = 'ExpandableSection';
+    const allVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'container', 'navigation'];
     const nonContainerVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'navigation'];
 
-    test('logs warning for deprecated header prop', () => {
-      render(<ExpandableSection variant="container" header={<Header />} />);
-      expect(warnOnce).toHaveBeenCalledTimes(1);
-      expect(warnOnce).toHaveBeenCalledWith(
-        componentName,
-        'Use `headerText` instead of `header` to provide the button within the heading for a11y.'
-      );
+    describe('logs warning for deprecated header prop', () => {
+      for (const variant of allVariants) {
+        test(`${variant} variant`, () => {
+          render(<ExpandableSection variant={variant} header={<Header />} />);
+          expect(warnOnce).toHaveBeenCalledTimes(1);
+          expect(warnOnce).toHaveBeenCalledWith(
+            componentName,
+            'Use `headerText` instead of `header` to provide the button within the heading for a11y.'
+          );
+        });
+      }
     });
 
     describe('logs warning for non supported configurations', () => {

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -51,7 +51,7 @@ interface ExpandableSectionHeaderProps extends Omit<ExpandableDefaultHeaderProps
   ariaLabelledBy?: string;
 }
 
-const ExpandableDefaultHeader = ({
+const ExpandableDeprecatedHeader = ({
   id,
   className,
   onClick,
@@ -214,6 +214,10 @@ export const ExpandableSectionHeader = ({
     variant,
   };
 
+  if (header && isDevelopment) {
+    warnOnce(componentName, 'Use `headerText` instead of `header` to provide the button within the heading for a11y.');
+  }
+
   if ((headerDescription || headerCounter || headerInfo || headerActions) && variant !== 'container' && isDevelopment) {
     warnOnce(
       componentName,
@@ -258,18 +262,14 @@ export const ExpandableSectionHeader = ({
     );
   }
 
-  if (variant === 'container' && header && isDevelopment) {
-    warnOnce(componentName, 'Use `headerText` instead of `header` to provide the button within the heading for a11y.');
-  }
-
   return (
-    <ExpandableDefaultHeader
+    <ExpandableDeprecatedHeader
       className={clsx(className, wrapperClassName, styles.focusable, expanded && styles.expanded)}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
       {...defaultHeaderProps}
     >
       {header}
-    </ExpandableDefaultHeader>
+    </ExpandableDeprecatedHeader>
   );
 };


### PR DESCRIPTION
…p in Expandable section

### Description

The `header` prop is deprecated for all variants, so it makes no sense to log a dev warning only if using the container variant.

Also, renamed `ExpandableDefaultHeader` to `ExpandableDeprecatedHeader`, because it's not the header that is rendered when using the default variant —instead, it's the header that is rendered when the deprecated `header` prop is used with the default, container or footer variant.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Extended existing unit test for container variant to all other variants

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
