### PR TITLE
feat: Auto-label info links where possible

### DIFF
--- a/pages/form-field/permutations.page.tsx
+++ b/pages/form-field/permutations.page.tsx
@@ -41,11 +41,7 @@ const permutations = createPermutations<FormFieldProps>([
     errorText: [null, 'An application with that name already exists'],
     constraintText: [null, 'Only normal characters are allowed'],
     description: [null, 'Enter your name'],
-    info: [
-      <Link variant="info" ariaLabel="Info label">
-        info
-      </Link>,
-    ],
+    info: [<Link variant="info">info</Link>],
     children: [
       <div>Some plain text</div>,
       <Input value="" onChange={() => {}} placeholder="Main Instance" />,

--- a/pages/form-field/permutations.page.tsx
+++ b/pages/form-field/permutations.page.tsx
@@ -41,7 +41,11 @@ const permutations = createPermutations<FormFieldProps>([
     errorText: [null, 'An application with that name already exists'],
     constraintText: [null, 'Only normal characters are allowed'],
     description: [null, 'Enter your name'],
-    info: [<Link variant="info">info</Link>],
+    info: [
+      <Link variant="info" ariaLabel="Info label">
+        info
+      </Link>,
+    ],
     children: [
       <div>Some plain text</div>,
       <Input value="" onChange={() => {}} placeholder="Main Instance" />,

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -16,6 +16,7 @@ import styles from './styles.css.js';
 import { InternalFormFieldProps } from './interfaces';
 import { joinStrings } from '../internal/utils/strings';
 import { useInternalI18n } from '../internal/i18n/context';
+import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
@@ -146,7 +147,9 @@ export default function InternalFormField({
             {label}
           </label>
         )}
-        {!__hideLabel && info && <span className={styles.info}>{info}</span>}
+        <InfoLinkLabelContext.Provider value={slotIds.label}>
+          {!__hideLabel && info && <span className={styles.info}>{info}</span>}
+        </InfoLinkLabelContext.Provider>
       </div>
 
       {description && (

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -10,6 +10,8 @@ import { HeaderProps } from './interfaces';
 import styles from './styles.css.js';
 import { SomeRequired } from '../internal/types';
 import { useMobile } from '../internal/hooks/use-mobile';
+import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_SUBSTEP_NAME } from '../internal/analytics/selectors';
 
 interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, InternalBaseComponentProps {
@@ -33,6 +35,7 @@ export default function InternalHeader({
   const { isStuck } = useContext(StickyHeaderContext);
   const baseProps = getBaseProps(restProps);
   const isRefresh = useVisualRefresh();
+  const headingId = useUniqueId('heading');
   // If is mobile there is no need to have the dynamic variant because it's scrolled out of view
   const dynamicVariant = !isMobile && isStuck ? 'h2' : 'h1';
   const variantOverride = variant === 'awsui-h1-sticky' ? (isRefresh ? dynamicVariant : 'h2') : variant;
@@ -69,12 +72,15 @@ export default function InternalHeader({
             <span
               {...{ [DATA_ATTR_FUNNEL_KEY]: FUNNEL_KEY_SUBSTEP_NAME }}
               className={clsx(styles['heading-text'], styles[`heading-text-variant-${variantOverride}`])}
+              id={headingId}
             >
               {children}
             </span>
             {counter !== undefined && <span className={styles.counter}> {counter}</span>}
           </HeadingTag>
-          {info && <span className={styles.info}>{info}</span>}
+          <InfoLinkLabelContext.Provider value={headingId}>
+            {info && <span className={styles.info}>{info}</span>}
+          </InfoLinkLabelContext.Provider>
         </div>
         {description && (
           <p

--- a/src/internal/context/info-link-label-context.ts
+++ b/src/internal/context/info-link-label-context.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext } from 'react';
+
+export const InfoLinkLabelContext = createContext<string | undefined>(undefined);

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -7,6 +7,8 @@ import styles from '../../../lib/components/link/styles.css.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { linkRelExpectations, linkTargetExpectations } from '../../__tests__/target-rel-test-helper';
 import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import FormField from '../../../lib/components/form-field';
+import Header from '../../../lib/components/header';
 
 import { AnalyticsFunnel } from '../../../lib/components/internal/analytics/components/analytics-funnel';
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
@@ -53,6 +55,31 @@ describe('Link component', () => {
       const wrapper = renderLink({ variant: 'info', fontSize: 'heading-xl', color: 'inverted' });
       expect(wrapper.getElement()).not.toHaveClass(styles['font-size-heading-xl']);
       expect(wrapper.getElement()).not.toHaveClass(styles['color-inverted']);
+    });
+    test('can get additional label from form field', () => {
+      const { container } = render(<FormField label="Testing label" info={<Link variant="info">Info</Link>} />);
+      const wrapper = createWrapper(container);
+      expect(wrapper.findFormField()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info Testing label');
+    });
+    test('can get additional label from header', () => {
+      const { container } = render(<Header info={<Link variant="info">Info</Link>}>Testing header</Header>);
+      const wrapper = createWrapper(container);
+      expect(wrapper.findHeader()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info Testing header');
+    });
+    test('can override the automatic label', () => {
+      const { container } = render(
+        <Header
+          info={
+            <Link variant="info" ariaLabel="Info about something">
+              Info
+            </Link>
+          }
+        >
+          Testing header
+        </Header>
+      );
+      const wrapper = createWrapper(container);
+      expect(wrapper.findHeader()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info about something');
     });
   });
 

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -59,12 +59,14 @@ describe('Link component', () => {
     test('can get additional label from form field', () => {
       const { container } = render(<FormField label="Testing label" info={<Link variant="info">Info</Link>} />);
       const wrapper = createWrapper(container);
-      expect(wrapper.findFormField()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info Testing label');
+      expect(wrapper.findFormField()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName(
+        'Info : Testing label'
+      );
     });
     test('can get additional label from header', () => {
       const { container } = render(<Header info={<Link variant="info">Info</Link>}>Testing header</Header>);
       const wrapper = createWrapper(container);
-      expect(wrapper.findHeader()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info Testing header');
+      expect(wrapper.findHeader()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info : Testing header');
     });
     test('can override the automatic label', () => {
       const { container } = render(

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -59,14 +59,24 @@ describe('Link component', () => {
     test('can get additional label from form field', () => {
       const { container } = render(<FormField label="Testing label" info={<Link variant="info">Info</Link>} />);
       const wrapper = createWrapper(container);
-      expect(wrapper.findFormField()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName(
-        'Info : Testing label'
-      );
+      const infoLinkElement = wrapper.findFormField()!.findInfo()!.findLink()?.getElement();
+
+      // @testing-library/dom doesn't respect aria-labelledby referencing hidden child elements, so the ":" is missing
+      // https://github.com/eps1lon/dom-accessibility-api/issues/939
+      // expect(infoLinkElement).toHaveAccessibleName('Info : Testing label');
+      expect(infoLinkElement).toHaveAccessibleName('Info Testing label');
+      // therefore, we also check the length to ensure 3 elements are references
+      expect(infoLinkElement?.getAttribute('aria-labelledby')?.split(' ').length).toBe(3);
     });
     test('can get additional label from header', () => {
       const { container } = render(<Header info={<Link variant="info">Info</Link>}>Testing header</Header>);
       const wrapper = createWrapper(container);
-      expect(wrapper.findHeader()?.findInfo()?.findLink()?.getElement()).toHaveAccessibleName('Info : Testing header');
+      const infoLinkElement = wrapper.findHeader()!.findInfo()!.findLink()?.getElement();
+
+      // (see above)
+      // expect(infoLinkElement).toHaveAccessibleName('Info : Testing header');
+      expect(infoLinkElement).toHaveAccessibleName('Info Testing header');
+      expect(infoLinkElement?.getAttribute('aria-labelledby')?.split(' ').length).toBe(3);
     });
     test('can override the automatic label', () => {
       const { container } = render(

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import clsx from 'clsx';
 import InternalIcon from '../icon/internal';
 import styles from './styles.css.js';
@@ -14,6 +14,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../internal/i18n/context';
+import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 
 import { FunnelMetrics } from '../internal/analytics';
@@ -54,6 +55,8 @@ const InternalLink = React.forwardRef(
     const anchorTarget = target ?? (external ? '_blank' : undefined);
     const anchorRel = rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
     const uniqueId = useUniqueId('link');
+
+    const infoLinkLabelFromContext = useContext(InfoLinkLabelContext);
 
     const { funnelInteractionId } = useFunnel();
     const { stepNumber, stepNameSelector, subStepSelector, subStepNameSelector } = useFunnelSubStep();
@@ -115,6 +118,7 @@ const InternalLink = React.forwardRef(
     const applyButtonStyles = isButton && isVisualRefresh && !hasSpecialStyle;
 
     const sharedProps = {
+      id: uniqueId,
       ...baseProps,
       // https://github.com/microsoft/TypeScript/issues/36659
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,8 +132,13 @@ const InternalLink = React.forwardRef(
         styles[getColorStyle(variant, color)]
       ),
       'aria-label': ariaLabel,
+      'aria-labelledby': '',
       [DATA_ATTR_FUNNEL_VALUE]: uniqueId,
     };
+
+    if (variant === 'info' && infoLinkLabelFromContext && !ariaLabel) {
+      sharedProps['aria-labelledby'] = `${sharedProps.id} ${infoLinkLabelFromContext}`;
+    }
 
     const renderedExternalIconAriaLabel = i18n('externalIconAriaLabel', externalIconAriaLabel);
     const content = (

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -15,6 +15,7 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../internal/i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 
 import { FunnelMetrics } from '../internal/analytics';
@@ -156,6 +157,7 @@ const InternalLink = React.forwardRef(
             </span>
           </span>
         )}
+        {variant === 'info' && <ScreenreaderOnly>:</ScreenreaderOnly>}
       </>
     );
 

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -15,7 +15,6 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../internal/i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
-import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 
 import { FunnelMetrics } from '../internal/analytics';
@@ -56,6 +55,8 @@ const InternalLink = React.forwardRef(
     const anchorTarget = target ?? (external ? '_blank' : undefined);
     const anchorRel = rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
     const uniqueId = useUniqueId('link');
+    const linkId = useUniqueId('link-self');
+    const infoId = useUniqueId('link-info');
 
     const infoLinkLabelFromContext = useContext(InfoLinkLabelContext);
 
@@ -119,7 +120,7 @@ const InternalLink = React.forwardRef(
     const applyButtonStyles = isButton && isVisualRefresh && !hasSpecialStyle;
 
     const sharedProps = {
-      id: uniqueId,
+      id: linkId,
       ...baseProps,
       // https://github.com/microsoft/TypeScript/issues/36659
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,7 +139,7 @@ const InternalLink = React.forwardRef(
     };
 
     if (variant === 'info' && infoLinkLabelFromContext && !ariaLabel) {
-      sharedProps['aria-labelledby'] = `${sharedProps.id} ${infoLinkLabelFromContext}`;
+      sharedProps['aria-labelledby'] = `${sharedProps.id} ${infoId} ${infoLinkLabelFromContext}`;
     }
 
     const renderedExternalIconAriaLabel = i18n('externalIconAriaLabel', externalIconAriaLabel);
@@ -157,7 +158,11 @@ const InternalLink = React.forwardRef(
             </span>
           </span>
         )}
-        {variant === 'info' && <ScreenreaderOnly>:</ScreenreaderOnly>}
+        {variant === 'info' && (
+          <span hidden={true} id={infoId}>
+            :
+          </span>
+        )}
       </>
     );
 


### PR DESCRIPTION
### Description

Add additional labelling to "Info" links where it can be derived from the context.

Related links, issue #, if available: AWSUI-21219

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
