### PR TITLE
fix: Content inside bottom split panel should not above the header

### DIFF
--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -221,6 +221,8 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
 .content-bottom {
   padding: 0 awsui.$space-scaled-2x-xxxl;
   margin-top: awsui.$space-panel-split-top;
+  position: relative;
+  z-index: 0; // the content inside .content-bottom should not be above pane-header-wrapper-bottom
   .drawer-mobile > .drawer-content-bottom > & {
     padding: 0 awsui.$space-l;
   }


### PR DESCRIPTION
### Description

Although the SplitPanel sticky header has the z-index as 1. But its sibling, the content of the SplitPanel does not any z-index set. The items inside of the content of the SplitPanel can still overlap the header.

Related links, issue #AWSUI-20971

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
