### PR TITLE
fix: Add some missing aria label properties to S3 Selector

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10479,6 +10479,16 @@ The return type of the function should be a promise that resolves to a list of v
             "type": "string",
           },
           Object {
+            "name": "labelClearFilter",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "labelExpandBreadcrumbs",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "labelFiltering",
             "optional": true,
             "type": "(itemsType: string) => string",

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -253,6 +253,8 @@ export namespace S3ResourceSelectorProps {
     labelRefresh?: string;
     labelModalDismiss?: string;
     labelBreadcrumbs?: string;
+    labelExpandBreadcrumbs?: string;
+    labelClearFilter?: string;
   }
 
   export interface ChangeDetail {

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -23,6 +23,7 @@ interface BasicS3TableStrings<T> {
   loadingText?: string;
   filteringPlaceholder?: string;
   filteringAriaLabel?: string;
+  filteringClearAriaLabel?: string;
   filteringCounterText?: S3ResourceSelectorProps.I18nStrings['filteringCounterText'];
   emptyText?: string;
   noMatchTitle?: string;
@@ -60,6 +61,7 @@ export function getSharedI18Strings(
     noMatchTitle: i18n('i18nStrings.filteringNoMatches', i18nStrings?.filteringNoMatches),
     noMatchSubtitle: i18n('i18nStrings.filteringCantFindMatch', i18nStrings?.filteringCantFindMatch),
     clearFilterButtonText: i18n('i18nStrings.clearFilterButtonText', i18nStrings?.clearFilterButtonText),
+    filteringClearAriaLabel: i18nStrings?.labelClearFilter,
   };
 }
 
@@ -150,6 +152,7 @@ export function BasicS3Table<T>({
           {...filterProps}
           ref={textFilterRef}
           filteringAriaLabel={i18nStrings.filteringAriaLabel}
+          filteringClearAriaLabel={i18nStrings.filteringClearAriaLabel}
           filteringPlaceholder={i18nStrings.filteringPlaceholder}
           countText={i18nStrings.filteringCounterText ? i18nStrings.filteringCounterText(filteredItemsCount!) : ''}
         />

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -144,7 +144,7 @@ export function S3Modal({
         <InternalSpaceBetween size={isVisualRefresh ? 'xxs' : 'xs'}>
           <InternalBreadcrumbGroup
             ariaLabel={i18n('i18nStrings.labelBreadcrumbs', i18nStrings?.labelBreadcrumbs)}
-            expandAriaLabel="Show path"
+            expandAriaLabel={i18nStrings?.labelExpandBreadcrumbs}
             onFollow={event => {
               event.preventDefault();
               event.detail.item.meta.onClick();


### PR DESCRIPTION
### Description

Ensure that customers can set aria labels on components used
inside s3 resource selector.

(NB, we don't need to add internationalized versions, as they
will already be handled by the child components)

Related links, issue #, if available: AWSUI-21154

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
