### PR TITLE
fix: Remove implicit unlabeled group around contents when focus is moved to modal

### DIFF
--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -135,7 +135,6 @@ function InnerModal({
               isRefresh && styles.refresh
             )}
             onKeyDown={escKeyHandler}
-            tabIndex={-1}
           >
             <div className={styles.container}>
               <div className={styles.header}>


### PR DESCRIPTION
### Description

Fun little fact I learned today: a tabindex on a generic element will often be interpreted by screen readers as having role="group". And if there is no accessible name associated with that element, it'll just read out the entire contents of the element (in this case, the modal).

In this case, when the modal is opened, the focus gets set into the close button, and since there's a "context switch", the screen reader reads the group "name", which ends up being the contents of the entire group.

Spelunking through commit history for this component, this tabIndex={-1} goes all the way back to the initial implementation of the modal where this div also had a ref (back when we set the focus to the whole modal instead of the close button), but after this ref was removed, this tabIndex stuck around. Removing this _shouldn't_ break _anything_.

Related links, issue #, if available: AWSUI-21277

### How has this been tested?

As mentioned before, deleting that one line should be it!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
