### PR TITLE
chore: Remove dynamic overlap context

### DIFF
--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -25,12 +25,17 @@ div.background {
     z-index: 799;
 
     &:not(.has-sticky-notifications) {
-      height: calc(#{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight}));
+      height: calc(
+        #{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight}, 0px) + var(#{custom-props.$appLayoutOwnOverlapHeight})
+      );
     }
 
     &.has-sticky-notifications {
       height: calc(
-        var(#{custom-props.$notificationsGap}) + var(#{custom-props.$notificationsHeight}) + #{awsui.$space-s} + var(#{custom-props.$overlapHeight})
+        var(#{custom-props.$notificationsGap}) + var(#{custom-props.$notificationsHeight}) + #{awsui.$space-s} + var(
+            #{custom-props.$overlapHeight},
+            0px
+          ) + var(#{custom-props.$appLayoutOwnOverlapHeight})
       );
     }
   }

--- a/src/app-layout/visual-refresh/background.tsx
+++ b/src/app-layout/visual-refresh/background.tsx
@@ -6,17 +6,10 @@ import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 
 export default function Background() {
-  const {
-    breadcrumbs,
-    contentHeader,
-    dynamicOverlapHeight,
-    hasNotificationsContent,
-    hasStickyBackground,
-    isMobile,
-    stickyNotifications,
-  } = useAppLayoutInternals();
+  const { breadcrumbs, contentHeader, hasNotificationsContent, hasStickyBackground, isMobile, stickyNotifications } =
+    useAppLayoutInternals();
 
-  if (!hasNotificationsContent && (!breadcrumbs || isMobile) && !contentHeader && dynamicOverlapHeight <= 0) {
+  if (!hasNotificationsContent && (!breadcrumbs || isMobile) && !contentHeader) {
     return null;
   }
 

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -12,7 +12,7 @@ import React, {
 } from 'react';
 import { applyDefaults } from '../defaults';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
-import { DynamicOverlapContext } from '../../internal/context/dynamic-overlap-context';
+import { LayoutContext } from '../../internal/context/layout-context';
 import { AppLayoutProps } from '../interfaces';
 import { DrawersProps } from './drawers';
 import { fireNonCancelableEvent } from '../../internal/events';
@@ -35,7 +35,6 @@ interface AppLayoutInternals extends AppLayoutProps {
   drawers: DrawersProps;
   drawersRefs: FocusControlRefs;
   drawersTriggerCount: number;
-  dynamicOverlapHeight: number;
   handleDrawersClick: (activeDrawerId: string | null, skipFocusControl?: boolean) => void;
   handleSplitPanelClick: () => void;
   handleNavigationClick: (isOpen: boolean) => void;
@@ -125,12 +124,9 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     }
 
     /**
-     * The overlap height has a default set in CSS but can also be dynamically overridden
-     * for content types (such as Table and Wizard) that have variable size content in the overlap.
      * If a child component utilizes a sticky header the hasStickyBackground property will determine
      * if the background remains in the same vertical position.
      */
-    const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState(0);
     const [hasStickyBackground, setHasStickyBackground] = useState(false);
 
     /**
@@ -570,7 +566,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           drawers,
           drawersRefs,
           drawersTriggerCount,
-          dynamicOverlapHeight,
           headerHeight,
           footerHeight,
           hasDefaultToolsWidth,
@@ -629,7 +624,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
             setHasStickyBackground,
           }}
         >
-          <DynamicOverlapContext.Provider value={setDynamicOverlapHeight}>{children}</DynamicOverlapContext.Provider>
+          <LayoutContext.Provider value={{ layoutElement }}>{children}</LayoutContext.Provider>
         </AppLayoutContext.Provider>
       </AppLayoutInternalsContext.Provider>
     );

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -44,7 +44,7 @@ explicitly set in script.
   #{custom-props.$notificationsHeight}: 0px;
   #{custom-props.$offsetTop}: var(#{custom-props.$headerHeight});
   #{custom-props.$offsetTopWithNotifications}: 0px;
-  #{custom-props.$overlapHeight}: #{awsui.$space-dark-header-overlap-distance};
+  #{custom-props.$appLayoutOwnOverlapHeight}: #{awsui.$space-dark-header-overlap-distance};
   background-color: awsui.$color-background-layout-main;
   color: awsui.$color-text-body-default;
   display: grid;
@@ -74,7 +74,8 @@ explicitly set in script.
     var(#{custom-props.$headerGap})
     auto // contentHeader template area
     var(#{custom-props.$mainGap})
-    var(#{custom-props.$overlapHeight}) // main template area with overlap
+    calc(var(#{custom-props.$overlapHeight}, 0px) + var(#{custom-props.$appLayoutOwnOverlapHeight}))
+    // main template area with overlap
     var(#{custom-props.$mainTemplateRows}); // main template area
   min-height: var(#{custom-props.$contentHeight});
   position: relative;
@@ -111,7 +112,7 @@ explicitly set in script.
 
   // Override the dark header overlap height property if disableContentHeaderOverlap is true.
   &.is-overlap-disabled {
-    #{custom-props.$overlapHeight}: 0;
+    #{custom-props.$appLayoutOwnOverlapHeight}: 0px;
   }
 
   /*

--- a/src/app-layout/visual-refresh/layout.tsx
+++ b/src/app-layout/visual-refresh/layout.tsx
@@ -26,7 +26,6 @@ export default function Layout({ children }: LayoutProps) {
     disableContentHeaderOverlap,
     disableContentPaddings,
     drawersTriggerCount,
-    dynamicOverlapHeight,
     footerHeight,
     hasNotificationsContent,
     hasStickyBackground,
@@ -59,7 +58,7 @@ export default function Layout({ children }: LayoutProps) {
    * unless there is a dynamicOverlapHeight. The dynamicOverlapHeight property is set by a
    * component in the content slot that needs to manually control the overlap height.
    */
-  const isOverlapDisabled = disableContentHeaderOverlap || (!contentHeader && dynamicOverlapHeight <= 0);
+  const isOverlapDisabled = disableContentHeaderOverlap || !contentHeader;
 
   return (
     <main
@@ -93,8 +92,6 @@ export default function Layout({ children }: LayoutProps) {
         ...(maxContentWidth && { [customCssProps.maxContentWidth]: `${maxContentWidth}px` }),
         ...(minContentWidth && { [customCssProps.minContentWidth]: `${minContentWidth}px` }),
         [customCssProps.notificationsHeight]: `${notificationsHeight}px`,
-        ...(!isOverlapDisabled &&
-          dynamicOverlapHeight > 0 && { [customCssProps.overlapHeight]: `${dynamicOverlapHeight}px` }),
       }}
     >
       {children}

--- a/src/internal/context/dynamic-overlap-context.ts
+++ b/src/internal/context/dynamic-overlap-context.ts
@@ -1,5 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { createContext } from 'react';
-
-export const DynamicOverlapContext = createContext<(overlapHeight: number) => void>(() => {});

--- a/src/internal/context/layout-context.ts
+++ b/src/internal/context/layout-context.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext } from 'react';
+
+export interface LayoutContextProps {
+  layoutElement?: React.Ref<HTMLElement>;
+}
+
+export const LayoutContext = createContext<LayoutContextProps>({});

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -7,6 +7,7 @@
 const customCssPropertiesList = [
   // AppLayout Custom Properties
   'activeDrawerWidth',
+  'appLayoutOwnOverlapHeight',
   'breadcrumbsGap',
   'contentGapLeft',
   'contentGapRight',

--- a/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
+++ b/src/internal/hooks/use-dynamic-overlap/__tests__/use-dynamic-overlap.test.tsx
@@ -1,52 +1,47 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { useDynamicOverlap } from '../../../../../lib/components/internal/hooks/use-dynamic-overlap';
-import { DynamicOverlapContext } from '../../../../../lib/components/internal/context/dynamic-overlap-context';
+import { LayoutContext } from '../../../../../lib/components/internal/context/layout-context';
+import customCssProps from '../../../generated/custom-css-properties';
 
 jest.mock('../../../../../lib/components/internal/hooks/container-queries/use-container-query', () => ({
   useContainerQuery: () => [800, () => {}],
 }));
 
-function renderApp(children: React.ReactNode) {
-  const testId = 'resolver';
+const testId = 'resolver';
+const getDynamicOverlap = () => screen.getByTestId(testId).style.getPropertyValue(customCssProps.overlapHeight);
 
+function renderApp(children: React.ReactNode) {
   function App(props: { children: React.ReactNode }) {
-    const [dynamicOverlapHeight, setDynamicOverlapHeight] = useState<number | undefined>(0);
+    const ref = createRef<HTMLElement>();
     return (
-      <DynamicOverlapContext.Provider value={setDynamicOverlapHeight}>
-        <div data-testid={testId}>{dynamicOverlapHeight}</div>
-        {props.children}
-      </DynamicOverlapContext.Provider>
+      <>
+        <div data-testid={testId} ref={ref as React.Ref<HTMLDivElement>} />
+        <LayoutContext.Provider value={{ layoutElement: ref }}>{props.children}</LayoutContext.Provider>
+      </>
     );
   }
 
-  const { rerender } = render(<App>{children}</App>);
-  return {
-    getDynamicOverlap: () => Number.parseInt(screen.getByTestId(testId).textContent ?? ''),
-    rerender: (children: React.ReactNode) => rerender(<App>{children}</App>),
-  };
+  render(<App>{children}</App>);
 }
 
-test('is zero when disabled', () => {
+test('is not defined when disabled', () => {
   function Component() {
     const ref = useDynamicOverlap({ disabled: true });
     return <div ref={ref}></div>;
   }
-  const { getDynamicOverlap } = renderApp(<Component />);
-  expect(getDynamicOverlap()).toBe(0);
+  renderApp(<Component />);
+  expect(getDynamicOverlap()).toBe('');
 });
 
-test('sets and resets dynamic overlap', () => {
+test('sets dynamic overlap', () => {
   function Component() {
     const ref = useDynamicOverlap();
     return <div ref={ref}></div>;
   }
-  const { getDynamicOverlap, rerender } = renderApp(<Component />);
-  expect(getDynamicOverlap()).toBe(800);
-
-  rerender(<div />);
-  expect(getDynamicOverlap()).toBe(0);
+  renderApp(<Component />);
+  expect(getDynamicOverlap()).toBe('800px');
 });

--- a/src/internal/hooks/use-dynamic-overlap/index.ts
+++ b/src/internal/hooks/use-dynamic-overlap/index.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useContext, useLayoutEffect } from 'react';
-
-import { DynamicOverlapContext } from '../../context/dynamic-overlap-context';
+import { MutableRefObject, Ref, useContext, useLayoutEffect } from 'react';
+import { LayoutContext } from '../../context/layout-context';
 import { useContainerQuery } from '../container-queries';
+import customCssProps from '../../generated/custom-css-properties';
 
 export interface UseDynamicOverlapProps {
   /**
@@ -11,6 +11,15 @@ export interface UseDynamicOverlapProps {
    */
   disabled?: boolean;
 }
+
+const setDynamicOverlapHeight = (layoutElement: Ref<HTMLElement> | undefined, height: number) => {
+  if (layoutElement && (layoutElement as MutableRefObject<HTMLElement>).current) {
+    (layoutElement as MutableRefObject<HTMLElement>).current.style.setProperty(
+      customCssProps.overlapHeight,
+      `${height}px`
+    );
+  }
+};
 
 /**
  * Observes the height of an element referenced by the returning ref and sets the value as overlapping
@@ -20,22 +29,22 @@ export interface UseDynamicOverlapProps {
  */
 export function useDynamicOverlap(props?: UseDynamicOverlapProps) {
   const disabled = props?.disabled ?? false;
-  const setDynamicOverlapHeight = useContext(DynamicOverlapContext);
+  const { layoutElement } = useContext(LayoutContext);
   const [overlapHeight, overlapElementRef] = useContainerQuery(rect => rect.height);
 
   useLayoutEffect(
     function handleDynamicOverlapHeight() {
       if (!disabled) {
-        setDynamicOverlapHeight(overlapHeight ?? 0);
+        setDynamicOverlapHeight(layoutElement, overlapHeight ?? 0);
       }
 
       return () => {
         if (!disabled) {
-          setDynamicOverlapHeight(0);
+          setDynamicOverlapHeight(layoutElement, 0);
         }
       };
     },
-    [disabled, overlapHeight, setDynamicOverlapHeight]
+    [disabled, overlapHeight, layoutElement]
   );
 
   return overlapElementRef;


### PR DESCRIPTION
### Description

Rely on a css custom property for dynamic overlap, as opposed to a context variable that causes re-renders whenever the height of the overlap area changes.

### How has this been tested?

Locally and with unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._  Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
