### PR TITLE
chore: Remove dependency on react-focus-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "date-fns": "^2.25.0",
         "intl-messageformat": "^10.3.1",
         "mnth": "^2.0.0",
-        "react-focus-lock": "~2.8.1",
         "react-keyed-flatten-children": "^1.3.0",
         "react-transition-group": "^4.4.2",
         "react-virtual": "^2.8.2",
@@ -2023,7 +2022,7 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -2038,7 +2037,7 @@
     },
     "node_modules/@types/react": {
       "version": "16.14.34",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2109,7 +2108,7 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -5720,10 +5719,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/devtools": {
       "version": "7.27.0",
       "dev": true,
@@ -7768,16 +7763,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/focus-lock": {
-      "version": "0.10.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/follow-redirects": {
@@ -14568,16 +14553,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-clientside-effect": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "16.14.0",
       "license": "MIT",
@@ -14589,21 +14564,6 @@
       },
       "peerDependencies": {
         "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-focus-lock": {
-      "version": "2.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.10.2",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {
@@ -17696,45 +17656,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/util": {
       "version": "0.12.5",
       "dev": true,
@@ -20118,7 +20039,7 @@
     },
     "@types/prop-types": {
       "version": "15.7.5",
-      "devOptional": true
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -20130,7 +20051,7 @@
     },
     "@types/react": {
       "version": "16.14.34",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -20192,7 +20113,7 @@
     },
     "@types/scheduler": {
       "version": "0.16.2",
-      "devOptional": true
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -22557,9 +22478,6 @@
       "version": "2.1.0",
       "dev": true
     },
-    "detect-node-es": {
-      "version": "1.1.0"
-    },
     "devtools": {
       "version": "7.27.0",
       "dev": true,
@@ -23969,12 +23887,6 @@
             "util-deprecate": "~1.0.1"
           }
         }
-      }
-    },
-    "focus-lock": {
-      "version": "0.10.2",
-      "requires": {
-        "tslib": "^2.0.3"
       }
     },
     "follow-redirects": {
@@ -28364,12 +28276,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-clientside-effect": {
-      "version": "1.2.6",
-      "requires": {
-        "@babel/runtime": "^7.12.13"
-      }
-    },
     "react-dom": {
       "version": "16.14.0",
       "requires": {
@@ -28377,17 +28283,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
-      }
-    },
-    "react-focus-lock": {
-      "version": "2.8.1",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.10.2",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
       }
     },
     "react-is": {
@@ -30441,19 +30336,6 @@
     "use": {
       "version": "3.1.1",
       "dev": true
-    },
-    "use-callback-ref": {
-      "version": "1.3.0",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "use-sidecar": {
-      "version": "1.1.2",
-      "requires": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      }
     },
     "util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "date-fns": "^2.25.0",
     "intl-messageformat": "^10.3.1",
     "mnth": "^2.0.0",
-    "react-focus-lock": "~2.8.1",
     "react-keyed-flatten-children": "^1.3.0",
     "react-transition-group": "^4.4.2",
     "react-virtual": "^2.8.2",

--- a/src/top-navigation/parts/overflow-menu/views/submenu.tsx
+++ b/src/top-navigation/parts/overflow-menu/views/submenu.tsx
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import FocusLock from 'react-focus-lock';
 
 import { useNavigate } from '../router';
 import Header from '../header';
 import { SubmenuItem } from '../menu-item';
 import { useUniqueId } from '../../../../internal/hooks/use-unique-id';
+import FocusLock from '../../../../internal/components/focus-lock';
 
 import { TopNavigationProps } from '../../../interfaces';
 
@@ -33,7 +33,7 @@ const SubmenuView = ({
   const headerId = useUniqueId('overflow-menu-header');
 
   return (
-    <FocusLock returnFocus={true}>
+    <FocusLock autoFocus={true}>
       <Header
         secondaryText={headerSecondaryText}
         dismissIconAriaLabel={dismissIconAriaLabel}

--- a/src/top-navigation/parts/overflow-menu/views/utilities.tsx
+++ b/src/top-navigation/parts/overflow-menu/views/utilities.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef } from 'react';
-import FocusLock from 'react-focus-lock';
+import FocusLock from '../../../../internal/components/focus-lock';
 
 import Header from '../header';
 import { UtilityMenuItem } from '../menu-item';
@@ -30,7 +30,7 @@ const UtilitiesView = ({ headerText, dismissIconAriaLabel, onClose, items = [], 
   }, [focusIndex]);
 
   return (
-    <FocusLock returnFocus={true}>
+    <FocusLock autoFocus={true}>
       <Header dismissIconAriaLabel={dismissIconAriaLabel} onClose={onClose}>
         <span id={headerId}>{headerText}</span>
       </Header>


### PR DESCRIPTION
### Description

"Mom, can we use react-focus-lock?" "We have react-focus-lock at home"

Over the past year or so, we've mostly switched from react-focus-lock to using our own internal tab trap that's simpler to coordinate, and far less aggressive when it comes to focus management. This PR removes the final two components that still rely on the original focus lock and removes the dependency altogether. But I also couldn't resist a little refactor - moving things around so they read easier, mostly.

Related links, issue #, if available: AWSUI-18931

### How has this been tested?

Added a new focus lock test for the return backoff logic thing, but other than that, existing tests should pass.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
