### PR TITLE
chore: Increase sticky scrollbar z-index

### DIFF
--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -11,6 +11,7 @@
   overflow-y: hidden;
   bottom: 0;
   width: 100%;
+  z-index: 800; // Higher than sticky-columns
 
   &-content {
     height: 15px;


### PR DESCRIPTION
### Description

Increased the sticky scrollbar z-index to have it appear above the table sticky columns.

You can check it out here: https://d21d5uik3ws71m.cloudfront.net/components/120fe4afc191975697c3c9c4473d0ec3a19e108b/index.html#/light/table/sticky-columns/?stickyColumnsFirst=1&stickyColumnsLast=1

### How has this been tested?

Existing tests.
<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
