### PR TITLE
fix: Document and mitigate infinite loop caused by react-virtual

### DIFF
--- a/src/autosuggest/__integ__/async-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/async-autosuggest.test.ts
@@ -142,7 +142,7 @@ describe.each([true, false])('Async autosuggest scrolling (with virtualScrolling
       const { bottom: optionBottom } = await page.getHighlightedPosition();
       const { bottom: dropdownBottom } = await page.getDropdownPosition();
       // a small give for borders and negative margins
-      expect(Math.abs(optionBottom - dropdownBottom)).toBeLessThan(3);
+      expect(Math.abs(optionBottom - dropdownBottom)).toBeLessThanOrEqual(3);
     })
   );
   test(

--- a/src/autosuggest/__integ__/async-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/async-autosuggest.test.ts
@@ -142,7 +142,7 @@ describe.each([true, false])('Async autosuggest scrolling (with virtualScrolling
       const { bottom: optionBottom } = await page.getHighlightedPosition();
       const { bottom: dropdownBottom } = await page.getDropdownPosition();
       // a small give for borders and negative margins
-      expect(Math.abs(optionBottom - dropdownBottom)).toBeLessThanOrEqual(3);
+      expect(Math.abs(optionBottom - dropdownBottom)).toBeLessThan(3);
     })
   );
   test(

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -56,7 +56,7 @@ const VirtualList = ({
         aria-hidden="true"
         key="total-size"
         className={styles['layout-strut']}
-        style={{ height: rowVirtualizer.totalSize }}
+        style={{ height: rowVirtualizer.totalSize + (autosuggestItemsState.items.length === 1 ? 1 : 0) }}
       />
       {rowVirtualizer.virtualItems.map(virtualRow => {
         const { index, start, measureRef } = virtualRow;

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -25,13 +25,22 @@ const VirtualList = ({
   // update component, when it gets wider or narrower to reposition items
   const [width, strutRef] = useContainerQuery(rect => rect.width, []);
   useImperativeHandle(strutRef, () => scrollRef.current);
+
+  // The useVirtual from react-virtual@2 might produce an infinite update loop caused by setting
+  // measured item sizes in the render cycle (as part of the measureRef assignment).
+  // The sum of all measured item sizes is returned as totalSize which is then set on the list container.
+  // Enforcing new container height might result in an items size change e.g. when the content wraps.
+  // The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed
+  // by logging the totalSize which should then bounce between two values.
+  // Empirically it has been found out that increasing the container size slightly decreases the risk of items content
+  // wrapping in one size and not wrapping in the other that prevents the infinite loop.
   const rowVirtualizer = useVirtual({
     size: autosuggestItemsState.items.length,
     parentRef: scrollRef,
     // estimateSize is a dependency of measurements memo. We update it to force full recalculation
     // when the height of any option could have changed:
     // 1: because the component got resized (width property got updated)
-    // 2: becasue the option changed its content (highlightText property controls the highlight and the visibility of hidden tags)
+    // 2: because the option changed its content (highlightText property controls the highlight and the visibility of hidden tags)
     // eslint-disable-next-line react-hooks/exhaustive-deps
     estimateSize: useCallback(() => 31, [width, highlightText]),
     overscan: 5,
@@ -56,7 +65,7 @@ const VirtualList = ({
         aria-hidden="true"
         key="total-size"
         className={styles['layout-strut']}
-        style={{ height: rowVirtualizer.totalSize + (autosuggestItemsState.items.length === 1 ? 1 : 0) }}
+        style={{ height: rowVirtualizer.totalSize + 1 }}
       />
       {rowVirtualizer.virtualItems.map(virtualRow => {
         const { index, start, measureRef } = virtualRow;

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -75,8 +75,7 @@ const VirtualList = ({
             key={index}
             ref={measureRef}
             highlightText={highlightText}
-            // option={item}
-            option={rowVirtualizer.totalSize < 110 ? { ...item, label: item.label + 'xxxxxxxxxxx' } : item}
+            option={item}
             highlighted={item === autosuggestItemsState.highlightedOption}
             current={item.value === highlightText}
             data-mouse-target={index}

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
-import { useVirtual } from 'react-virtual';
 
 import OptionsList from '../internal/components/options-list';
 import { useContainerQuery } from '../internal/hooks/container-queries';
@@ -9,6 +8,7 @@ import { useContainerQuery } from '../internal/hooks/container-queries';
 import AutosuggestOption from './autosuggest-option';
 import { getOptionProps, ListProps } from './plain-list';
 import styles from './styles.css.js';
+import { useVirtual } from '../internal/hooks/use-virtual';
 
 const VirtualList = ({
   autosuggestItemsState,
@@ -26,16 +26,8 @@ const VirtualList = ({
   const [width, strutRef] = useContainerQuery(rect => rect.width, []);
   useImperativeHandle(strutRef, () => scrollRef.current);
 
-  // The useVirtual from react-virtual@2 might produce an infinite update loop caused by setting
-  // measured item sizes in the render cycle (as part of the measureRef assignment).
-  // The sum of all measured item sizes is returned as totalSize which is then set on the list container.
-  // Enforcing new container height might result in an items size change e.g. when the content wraps.
-  // The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed
-  // by logging the totalSize which should then bounce between two values.
-  // Empirically it has been found out that increasing the container size slightly decreases the risk of items content
-  // wrapping in one size and not wrapping in the other that prevents the infinite loop.
   const rowVirtualizer = useVirtual({
-    size: autosuggestItemsState.items.length,
+    items: autosuggestItemsState.items,
     parentRef: scrollRef,
     // estimateSize is a dependency of measurements memo. We update it to force full recalculation
     // when the height of any option could have changed:
@@ -43,7 +35,6 @@ const VirtualList = ({
     // 2: because the option changed its content (highlightText property controls the highlight and the visibility of hidden tags)
     // eslint-disable-next-line react-hooks/exhaustive-deps
     estimateSize: useCallback(() => 31, [width, highlightText]),
-    overscan: 5,
   });
 
   useEffect(() => {
@@ -65,7 +56,7 @@ const VirtualList = ({
         aria-hidden="true"
         key="total-size"
         className={styles['layout-strut']}
-        style={{ height: rowVirtualizer.totalSize + 1 }}
+        style={{ height: rowVirtualizer.totalSize }}
       />
       {rowVirtualizer.virtualItems.map(virtualRow => {
         const { index, start, measureRef } = virtualRow;
@@ -84,7 +75,8 @@ const VirtualList = ({
             key={index}
             ref={measureRef}
             highlightText={highlightText}
-            option={item}
+            // option={item}
+            option={rowVirtualizer.totalSize < 110 ? { ...item, label: item.label + 'xxxxxxxxxxx' } : item}
             highlighted={item === autosuggestItemsState.highlightedOption}
             current={item.value === highlightText}
             data-mouse-target={index}

--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -59,5 +59,9 @@ export function useVirtual<Item extends object>({
     },
   }));
 
-  return { virtualItems, totalSize: rowVirtualizer.totalSize + 3, scrollToIndex: rowVirtualizer.scrollToIndex };
+  return {
+    virtualItems,
+    totalSize: rowVirtualizer.totalSize + 3,
+    scrollToIndex: rowVirtualizer.scrollToIndex,
+  };
 }

--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -22,6 +22,7 @@ interface RowVirtualizer {
  * measured item sizes in the render cycle (as part of the measureRef assignment):
  *      The sum of all measured item sizes is returned as totalSize which is then set on the list container.
  *      Enforcing new container height might result in an items size change e.g. when the content wraps.
+ *
  * The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed
  * by logging the totalSize which should then bounce between two values.
  *
@@ -41,11 +42,11 @@ export function useVirtual<Item extends object>({
   // Cache virtual item mounts to limit the amount of mounts per item.
   const measuresCache = useRef(new WeakMap<Item, number>());
 
-  // Clear mounts cache every time indices or items change.
+  // Clear mounts cache every time indices, items, or size estimate change.
   const indicesKey = rowVirtualizer.virtualItems.map(item => `${item.index}`).join(':');
   useEffect(() => {
     measuresCache.current = new WeakMap();
-  }, [indicesKey, items]);
+  }, [indicesKey, items, estimateSize]);
 
   const virtualItems = rowVirtualizer.virtualItems.map(virtualRow => ({
     ...virtualRow,

--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef } from 'react';
+import { useVirtual as useVirtualDefault, VirtualItem } from 'react-virtual';
+
+const MAX_ITEM_MOUNTS = 100;
+
+interface UseVirtualProps<Item> {
+  items: readonly Item[];
+  parentRef: React.RefObject<HTMLElement>;
+  estimateSize: () => number;
+}
+
+interface RowVirtualizer {
+  virtualItems: VirtualItem[];
+  totalSize: number;
+  scrollToIndex: (index: number) => void;
+}
+
+/**
+ * The useVirtual from react-virtual@2 might produce an infinite update loop caused by setting
+ * measured item sizes in the render cycle (as part of the measureRef assignment):
+ *      The sum of all measured item sizes is returned as totalSize which is then set on the list container.
+ *      Enforcing new container height might result in an items size change e.g. when the content wraps.
+ * The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed
+ * by logging the totalSize which should then bounce between two values.
+ *
+ * Empirically it has been found out that increasing the container size slightly decreases the risk of items content
+ * wrapping in one size and not wrapping in the other that prevents the infinite loop.
+ *
+ * The number of item refs assignments is limited to MAX_ITEM_MOUNTS unless items or indices change.
+ * That is based on the assumption the item height stays constant after its first render.
+ */
+export function useVirtual<Item extends object>({
+  items,
+  parentRef,
+  estimateSize,
+}: UseVirtualProps<Item>): RowVirtualizer {
+  const rowVirtualizer = useVirtualDefault({ size: items.length, parentRef, estimateSize, overscan: 5 });
+
+  // Cache virtual item mounts to limit the amount of mounts per item.
+  const measuresCache = useRef(new WeakMap<Item, number>());
+
+  // Clear mounts cache every time indices or items change.
+  const indicesKey = rowVirtualizer.virtualItems.map(item => `${item.index}`).join(':');
+  useEffect(() => {
+    measuresCache.current = new WeakMap();
+  }, [indicesKey, items]);
+
+  const virtualItems = rowVirtualizer.virtualItems.map(virtualRow => ({
+    ...virtualRow,
+    measureRef: (node: null | HTMLElement) => {
+      const mountedCount = measuresCache.current.get(items[virtualRow.index]) ?? 0;
+      if (mountedCount < MAX_ITEM_MOUNTS) {
+        virtualRow.measureRef(node);
+        measuresCache.current.set(items[virtualRow.index], mountedCount + 1);
+      }
+    },
+  }));
+
+  return { virtualItems, totalSize: rowVirtualizer.totalSize + 3, scrollToIndex: rowVirtualizer.scrollToIndex };
+}

--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useVirtual as useVirtualDefault, VirtualItem } from 'react-virtual';
 
 const MAX_ITEM_MOUNTS = 100;
@@ -45,16 +45,20 @@ export function useVirtual<Item extends object>({
     measuresCache.current = new WeakMap();
   }, [indicesKey, items, estimateSize]);
 
-  const virtualItems = rowVirtualizer.virtualItems.map(virtualRow => ({
-    ...virtualRow,
-    measureRef: (node: null | HTMLElement) => {
-      const mountedCount = measuresCache.current.get(items[virtualRow.index]) ?? 0;
-      if (mountedCount < MAX_ITEM_MOUNTS) {
-        virtualRow.measureRef(node);
-        measuresCache.current.set(items[virtualRow.index], mountedCount + 1);
-      }
-    },
-  }));
+  const virtualItems = useMemo(
+    () =>
+      rowVirtualizer.virtualItems.map(virtualItem => ({
+        ...virtualItem,
+        measureRef: (node: null | HTMLElement) => {
+          const mountedCount = measuresCache.current.get(items[virtualItem.index]) ?? 0;
+          if (mountedCount < MAX_ITEM_MOUNTS) {
+            virtualItem.measureRef(node);
+            measuresCache.current.set(items[virtualItem.index], mountedCount + 1);
+          }
+        },
+      })),
+    [items, rowVirtualizer.virtualItems]
+  );
 
   return {
     virtualItems,

--- a/src/internal/hooks/use-virtual/index.ts
+++ b/src/internal/hooks/use-virtual/index.ts
@@ -26,9 +26,6 @@ interface RowVirtualizer {
  * The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed
  * by logging the totalSize which should then bounce between two values.
  *
- * Empirically it has been found out that increasing the container size slightly decreases the risk of items content
- * wrapping in one size and not wrapping in the other that prevents the infinite loop.
- *
  * The number of item refs assignments is limited to MAX_ITEM_MOUNTS unless items or indices change.
  * That is based on the assumption the item height stays constant after its first render.
  */
@@ -61,7 +58,7 @@ export function useVirtual<Item extends object>({
 
   return {
     virtualItems,
-    totalSize: rowVirtualizer.totalSize + 3,
+    totalSize: rowVirtualizer.totalSize,
     scrollToIndex: rowVirtualizer.scrollToIndex,
   };
 }


### PR DESCRIPTION
### Description

The useVirtual from react-virtual@2 might produce an infinite update loop caused by setting measured item sizes in the render cycle (as part of the `measureRef` assignment). The sum of all measured item sizes is returned as `totalSize` which is then set on the list container. Enforcing new container height might result in an items size change e.g. when the content wraps. 

The infinite update cycle causes React "Maximum update depth exceeded" error and can be additionally confirmed by logging the totalSize which should then bounce between two values. Empirically it has been found out that increasing the container size slightly (e.g. by 1px) - decreases the risk of items content wrapping in one size and not wrapping in the other that prevents the infinite loop.

Increasing the size does not eliminate the issue completely. E.g. the issue can be reproduced with a trick when the item content is set dependent of the totalSize: `option={rowVirtualizer.totalSize < 110 ? { ...item, label: item.label + 'xxxxxxxxxxx' } : item}` (now the issue can be reproduced when the list height with normal items content is below 110px).

Using `@tanstack/react-virtual@beta` has a better outcome. Instead of an error the option content is wrapped incorrectly:

<img width="513" alt="Screenshot 2023-06-12 at 10 52 25" src="https://github.com/cloudscape-design/components/assets/20790937/2209bda1-b1ae-4547-bb95-507859d451dd">

To prevent the infinite loops completely the measureRef assignments were cached so that no more than 100 assignments per item is possible. That allows measuring the initial item height (after first bunch of renders) but then we assume the height stays the same, unless item object or indices are updated.

See: AWSUI-20997

### How has this been tested?

Manual testing on the only reproducible example that has been found.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
