### PR TITLE
chore: Synchronize i18n messages

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10360,6 +10360,7 @@ The return type of the function should be a promise that resolves to a list of v
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "S3ResourceSelectorProps.I18nStrings",
         "properties": Array [
@@ -12622,6 +12623,7 @@ character validation. You should use this property only when absolutely necessar
     },
     Object {
       "description": "An object containing all the necessary localized strings required by the component.",
+      "i18nTag": true,
       "inlineType": Object {
         "name": "TagEditorProps.I18nStrings",
         "properties": Array [

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -203,7 +203,6 @@ export interface CloudscapeI18nFormatArgTypes {
     "i18nStrings.segmentAriaRoleDescription": never;
   }
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": never;
     "i18nStrings.inContextSelectPlaceholder": never;
     "i18nStrings.inContextBrowseButton": never;
     "i18nStrings.inContextViewButton": never;

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -1,0 +1,439 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable prettier/prettier */
+
+/** Auto-generated argument types based on "en" i18n strings. Do not edit manually. */
+export interface CloudscapeI18nFormatArgTypes {
+  "[charts]": {
+    "loadingText": never;
+    "errorText": never;
+    "recoveryText": never;
+    "i18nStrings.filterLabel": never;
+    "i18nStrings.filterPlaceholder": never;
+    "i18nStrings.legendAriaLabel": never;
+    "i18nStrings.chartAriaRoleDescription": never;
+    "i18nStrings.xAxisAriaRoleDescription": never;
+    "i18nStrings.yAxisAriaRoleDescription": never;
+  }
+  "alert": {
+    "dismissAriaLabel": never;
+  }
+  "annotation-context": {
+    "i18nStrings.nextButtonText": never;
+    "i18nStrings.previousButtonText": never;
+    "i18nStrings.finishButtonText": never;
+    "i18nStrings.labelDismissAnnotation": never;
+    "i18nStrings.stepCounterText": {
+      "stepNumber": string | number;
+      "totalStepCount": string | number;
+    }
+    "i18nStrings.taskTitle": {
+      "taskNumber": string | number;
+      "taskTitle": string | number;
+    }
+    "i18nStrings.labelHotspot": {
+      "openState": string;
+      "stepNumber": string | number;
+      "totalStepCount": string | number;
+    }
+  }
+  "app-layout": {
+    "ariaLabels.navigation": never;
+    "ariaLabels.navigationClose": never;
+    "ariaLabels.navigationToggle": never;
+    "ariaLabels.notifications": never;
+    "ariaLabels.tools": never;
+    "ariaLabels.toolsClose": never;
+    "ariaLabels.toolsToggle": never;
+  }
+  "area-chart": {
+    "i18nStrings.detailTotalLabel": never;
+  }
+  "attribute-editor": {
+    "removeButtonText": never;
+  }
+  "autosuggest": {
+    "errorIconAriaLabel": never;
+    "selectedAriaLabel": never;
+    "enteredTextLabel": {
+      "value": string | number;
+    }
+    "recoveryText": never;
+  }
+  "breadcrumb-group": {
+    "expandAriaLabel": never;
+  }
+  "calendar": {
+    "nextMonthAriaLabel": never;
+    "previousMonthAriaLabel": never;
+    "todayAriaLabel": never;
+  }
+  "cards": {
+    "ariaLabels.selectionGroupLabel": never;
+  }
+  "code-editor": {
+    "i18nStrings.loadingState": never;
+    "i18nStrings.errorState": never;
+    "i18nStrings.errorStateRecovery": never;
+    "i18nStrings.editorGroupAriaLabel": never;
+    "i18nStrings.statusBarGroupAriaLabel": never;
+    "i18nStrings.cursorPosition": {
+      "row": string | number;
+      "column": string | number;
+    }
+    "i18nStrings.errorsTab": never;
+    "i18nStrings.warningsTab": never;
+    "i18nStrings.preferencesButtonAriaLabel": never;
+    "i18nStrings.paneCloseButtonAriaLabel": never;
+    "i18nStrings.preferencesModalHeader": never;
+    "i18nStrings.preferencesModalCancel": never;
+    "i18nStrings.preferencesModalConfirm": never;
+    "i18nStrings.preferencesModalWrapLines": never;
+    "i18nStrings.preferencesModalTheme": never;
+    "i18nStrings.preferencesModalLightThemes": never;
+    "i18nStrings.preferencesModalDarkThemes": never;
+  }
+  "collection-preferences": {
+    "title": never;
+    "confirmLabel": never;
+    "cancelLabel": never;
+    "pageSizePreference.title": never;
+    "wrapLinesPreference.label": never;
+    "wrapLinesPreference.description": never;
+    "stripedRowsPreference.label": never;
+    "stripedRowsPreference.description": never;
+    "contentDensityPreference.label": never;
+    "contentDensityPreference.description": never;
+    "contentDisplayPreference.title": never;
+    "contentDisplayPreference.description": never;
+    "contentDisplayPreference.dragHandleAriaLabel": never;
+    "contentDisplayPreference.dragHandleAriaDescription": never;
+    "contentDisplayPreference.liveAnnouncementDndStarted": {
+      "position": string | number;
+      "total": string | number;
+    }
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": never;
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": {
+      "isInitialPosition": string;
+      "currentPosition": string | number;
+      "total": string | number;
+    }
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": {
+      "isInitialPosition": string;
+      "initialPosition": string | number;
+      "total": string | number;
+      "finalPosition": string | number;
+    }
+  }
+  "date-range-picker": {
+    "i18nStrings.relativeModeTitle": never;
+    "i18nStrings.absoluteModeTitle": never;
+    "i18nStrings.relativeRangeSelectionHeading": never;
+    "i18nStrings.cancelButtonLabel": never;
+    "i18nStrings.clearButtonLabel": never;
+    "i18nStrings.applyButtonLabel": never;
+    "i18nStrings.customRelativeRangeOptionLabel": never;
+    "i18nStrings.customRelativeRangeOptionDescription": never;
+    "i18nStrings.customRelativeRangeUnitLabel": never;
+    "i18nStrings.customRelativeRangeDurationLabel": never;
+    "i18nStrings.customRelativeRangeDurationPlaceholder": never;
+    "i18nStrings.startDateLabel": never;
+    "i18nStrings.startTimeLabel": never;
+    "i18nStrings.endDateLabel": never;
+    "i18nStrings.endTimeLabel": never;
+    "i18nStrings.dateTimeConstraintText": never;
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.renderSelectedAbsoluteRangeAriaLive": {
+      "startDate": string | number;
+      "endDate": string | number;
+    }
+    "i18nStrings.formatRelativeRange": {
+      "amount": number;
+      "unit": string | number;
+    }
+    "i18nStrings.formatUnit": {
+      "amount": number;
+      "unit": string | number;
+    }
+  }
+  "flashbar": {
+    "i18nStrings.ariaLabel": never;
+    "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.inProgressIconAriaLabel": never;
+    "i18nStrings.infoIconAriaLabel": never;
+    "i18nStrings.notificationBarAriaLabel": never;
+    "i18nStrings.notificationBarText": never;
+    "i18nStrings.successIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
+  }
+  "form": {
+    "errorIconAriaLabel": never;
+  }
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": never;
+  }
+  "input": {
+    "clearAriaLabel": never;
+  }
+  "help-panel": {
+    "loadingText": never;
+  }
+  "link": {
+    "externalIconAriaLabel": never;
+  }
+  "modal": {
+    "closeAriaLabel": never;
+  }
+  "multiselect": {
+    "deselectAriaLabel": {
+      "option__label": string | number;
+    }
+  }
+  "pagination": {
+    "ariaLabels.nextPageLabel": never;
+    "ariaLabels.pageLabel": {
+      "pageNumber": string | number;
+    }
+    "ariaLabels.previousPageLabel": never;
+  }
+  "pie-chart": {
+    "i18nStrings.detailsValue": never;
+    "i18nStrings.detailsPercentage": never;
+    "i18nStrings.chartAriaRoleDescription": never;
+    "i18nStrings.segmentAriaRoleDescription": never;
+  }
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": never;
+    "i18nStrings.inContextSelectPlaceholder": never;
+    "i18nStrings.inContextBrowseButton": never;
+    "i18nStrings.inContextViewButton": never;
+    "i18nStrings.inContextViewButtonAriaLabel": never;
+    "i18nStrings.inContextLoadingText": never;
+    "i18nStrings.inContextUriLabel": never;
+    "i18nStrings.inContextVersionSelectLabel": never;
+    "i18nStrings.modalTitle": never;
+    "i18nStrings.modalCancelButton": never;
+    "i18nStrings.modalSubmitButton": never;
+    "i18nStrings.modalBreadcrumbRootItem": never;
+    "i18nStrings.selectionBuckets": never;
+    "i18nStrings.selectionObjects": never;
+    "i18nStrings.selectionVersions": never;
+    "i18nStrings.selectionBucketsSearchPlaceholder": never;
+    "i18nStrings.selectionObjectsSearchPlaceholder": never;
+    "i18nStrings.selectionVersionsSearchPlaceholder": never;
+    "i18nStrings.selectionBucketsLoading": never;
+    "i18nStrings.selectionBucketsNoItems": never;
+    "i18nStrings.selectionObjectsLoading": never;
+    "i18nStrings.selectionObjectsNoItems": never;
+    "i18nStrings.selectionVersionsLoading": never;
+    "i18nStrings.selectionVersionsNoItems": never;
+    "i18nStrings.filteringNoMatches": never;
+    "i18nStrings.filteringCantFindMatch": never;
+    "i18nStrings.clearFilterButtonText": never;
+    "i18nStrings.columnBucketID": never;
+    "i18nStrings.columnBucketName": never;
+    "i18nStrings.columnBucketCreationDate": never;
+    "i18nStrings.columnBucketRegion": never;
+    "i18nStrings.columnObjectKey": never;
+    "i18nStrings.columnObjectLastModified": never;
+    "i18nStrings.columnObjectSize": never;
+    "i18nStrings.columnVersionID": never;
+    "i18nStrings.columnVersionLastModified": never;
+    "i18nStrings.columnVersionSize": never;
+    "i18nStrings.validationPathMustBegin": never;
+    "i18nStrings.validationBucketLowerCase": never;
+    "i18nStrings.validationBucketMustNotContain": never;
+    "i18nStrings.validationBucketLength": never;
+    "i18nStrings.validationBucketMustComplyDns": never;
+    "i18nStrings.labelSortedDescending": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelSortedAscending": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelNotSorted": {
+      "columnName": string | number;
+    }
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": {
+      "item__Name": string | number;
+    }
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": {
+      "item__Key": string | number;
+    }
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": never;
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": {
+      "item__VersionId": string | number;
+    }
+    "i18nStrings.labelFiltering": {
+      "itemsType": string | number;
+    }
+    "i18nStrings.labelRefresh": never;
+    "i18nStrings.labelBreadcrumbs": never;
+    "i18nStrings.filteringCounterText": {
+      "count": number;
+    }
+  }
+  "popover": {
+    "dismissAriaLabel": never;
+  }
+  "property-filter": {
+    "i18nStrings.allPropertiesLabel": never;
+    "i18nStrings.applyActionText": never;
+    "i18nStrings.cancelActionText": never;
+    "i18nStrings.clearFiltersText": never;
+    "i18nStrings.editTokenHeader": never;
+    "i18nStrings.groupPropertiesText": never;
+    "i18nStrings.groupValuesText": never;
+    "i18nStrings.operationAndText": never;
+    "i18nStrings.operationOrText": never;
+    "i18nStrings.operatorContainsText": never;
+    "i18nStrings.operatorDoesNotContainText": never;
+    "i18nStrings.operatorDoesNotEqualText": never;
+    "i18nStrings.operatorEqualsText": never;
+    "i18nStrings.operatorGreaterOrEqualText": never;
+    "i18nStrings.operatorGreaterText": never;
+    "i18nStrings.operatorLessOrEqualText": never;
+    "i18nStrings.operatorLessText": never;
+    "i18nStrings.operatorText": never;
+    "i18nStrings.operatorsText": never;
+    "i18nStrings.propertyText": never;
+    "i18nStrings.tokenLimitShowFewer": never;
+    "i18nStrings.tokenLimitShowMore": never;
+    "i18nStrings.valueText": never;
+    "i18nStrings.removeTokenButtonAriaLabel": {
+      "token__operator": string;
+      "token__propertyKey": string | number;
+      "token__value": string | number;
+    }
+  }
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": never;
+    "i18nStrings.openButtonAriaLabel": never;
+    "i18nStrings.preferencesTitle": never;
+    "i18nStrings.preferencesPositionLabel": never;
+    "i18nStrings.preferencesPositionDescription": never;
+    "i18nStrings.preferencesPositionSide": never;
+    "i18nStrings.preferencesPositionBottom": never;
+    "i18nStrings.preferencesConfirm": never;
+    "i18nStrings.preferencesCancel": never;
+    "i18nStrings.resizeHandleAriaLabel": never;
+  }
+  "select": {
+    "errorIconAriaLabel": never;
+    "selectedAriaLabel": never;
+    "recoveryText": never;
+  }
+  "table": {
+    "ariaLabels.submittingEditText": never;
+    "ariaLabels.successfulEditLabel": never;
+    "columnDefinitions.editConfig.errorIconAriaLabel": never;
+    "columnDefinitions.editConfig.editIconAriaLabel": never;
+  }
+  "tabs": {
+    "i18nStrings.scrollLeftAriaLabel": never;
+    "i18nStrings.scrollRightAriaLabel": never;
+  }
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": never;
+    "i18nStrings.valuePlaceholder": never;
+    "i18nStrings.addButton": never;
+    "i18nStrings.removeButton": never;
+    "i18nStrings.removeButtonAriaLabel": {
+      "tag__key": string | number;
+    }
+    "i18nStrings.undoButton": never;
+    "i18nStrings.undoPrompt": never;
+    "i18nStrings.loading": never;
+    "i18nStrings.keyHeader": never;
+    "i18nStrings.valueHeader": never;
+    "i18nStrings.optional": never;
+    "i18nStrings.keySuggestion": never;
+    "i18nStrings.valueSuggestion": never;
+    "i18nStrings.emptyTags": never;
+    "i18nStrings.tooManyKeysSuggestion": never;
+    "i18nStrings.tooManyValuesSuggestion": never;
+    "i18nStrings.keysSuggestionLoading": never;
+    "i18nStrings.keysSuggestionError": never;
+    "i18nStrings.valuesSuggestionLoading": never;
+    "i18nStrings.valuesSuggestionError": never;
+    "i18nStrings.emptyKeyError": never;
+    "i18nStrings.maxKeyCharLengthError": never;
+    "i18nStrings.maxValueCharLengthError": never;
+    "i18nStrings.duplicateKeyError": never;
+    "i18nStrings.invalidKeyError": never;
+    "i18nStrings.invalidValueError": never;
+    "i18nStrings.awsPrefixError": never;
+    "i18nStrings.tagLimitReached": {
+      "tagLimit": number;
+    }
+    "i18nStrings.tagLimitExceeded": {
+      "tagLimit": number;
+    }
+    "i18nStrings.tagLimit": {
+      "tagLimitAvailable": string;
+      "availableTags": number;
+      "tagLimit": string | number;
+    }
+  }
+  "token-group": {
+    "i18nStrings.limitShowFewer": never;
+    "i18nStrings.limitShowMore": never;
+  }
+  "top-navigation": {
+    "i18nStrings.searchIconAriaLabel": never;
+    "i18nStrings.searchDismissIconAriaLabel": never;
+    "i18nStrings.overflowMenuTriggerText": never;
+    "i18nStrings.overflowMenuDismissIconAriaLabel": never;
+    "i18nStrings.overflowMenuBackIconAriaLabel": never;
+    "i18nStrings.overflowMenuTitleText": never;
+  }
+  "tutorial-panel": {
+    "i18nStrings.loadingText": never;
+    "i18nStrings.tutorialListTitle": never;
+    "i18nStrings.tutorialListDownloadLinkText": never;
+    "i18nStrings.labelTutorialListDownloadLink": never;
+    "i18nStrings.tutorialCompletedText": never;
+    "i18nStrings.learnMoreLinkText": never;
+    "i18nStrings.startTutorialButtonText": never;
+    "i18nStrings.restartTutorialButtonText": never;
+    "i18nStrings.completionScreenTitle": never;
+    "i18nStrings.feedbackLinkText": never;
+    "i18nStrings.dismissTutorialButtonText": never;
+    "i18nStrings.taskTitle": {
+      "taskNumber": string | number;
+      "taskTitle": string | number;
+    }
+    "i18nStrings.stepTitle": {
+      "stepNumber": string | number;
+      "stepTitle": string | number;
+    }
+    "i18nStrings.labelExitTutorial": never;
+    "i18nStrings.labelTotalSteps": {
+      "totalStepCount": string | number;
+    }
+    "i18nStrings.labelsTaskStatus.pending": never;
+    "i18nStrings.labelsTaskStatus.in-progress": never;
+    "i18nStrings.labelsTaskStatus.success": never;
+  }
+  "wizard": {
+    "i18nStrings.stepNumberLabel": {
+      "stepNumber": string | number;
+    }
+    "i18nStrings.collapsedStepsLabel": {
+      "stepNumber": string | number;
+      "stepsCount": string | number;
+    }
+    "i18nStrings.skipToButtonLabel": {
+      "task__title": string | number;
+    }
+    "i18nStrings.navigationAriaLabel": never;
+    "i18nStrings.cancelButton": never;
+    "i18nStrings.previousButton": never;
+    "i18nStrings.nextButton": never;
+    "i18nStrings.optional": never;
+    "i18nStrings.nextButtonLoadingAnnouncement": never;
+    "i18nStrings.submitButtonLoadingAnnouncement": never;
+  }
+}

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Filter entfernen, {token__propertyKey} ist gleich {token__value}} not_equals {Filter entfernen, {token__propertyKey} ist nicht gleich {token__value}} greater_than {Filter entfernen, {token__propertyKey} ist größer als {token__value}} greater_than_equal {Filter entfernen, {token__propertyKey} ist größer oder gleich {token__value}} less_than {Filter entfernen, {token__propertyKey} ist kleiner als {token__value}} less_than_equal {Filter entfernen, {token__propertyKey} ist kleiner als oder gleich {token__value}} contains {Filter entfernen, {token__propertyKey} enthält {token__value}} not_contains {Filter entfernen, {token__propertyKey} enthält nicht {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Version auswählen",
     "i18nStrings.inContextBrowseButton": "S3 durchsuchen",
     "i18nStrings.inContextViewButton": "Anzeigen",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Warnung verwerfen"
-  },
   "[charts]": {
     "loadingText": "Diagramm wird geladen",
     "errorText": "Die Daten konnten nicht abgerufen werden. Versuchen Sie es später erneut.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Angezeigte Daten filtern",
     "i18nStrings.filterPlaceholder": "Daten filtern",
     "i18nStrings.legendAriaLabel": "Legende",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Verwerfen",
     "i18nStrings.xAxisAriaRoleDescription": "x-Achse",
     "i18nStrings.yAxisAriaRoleDescription": "y-Achse"
+  },
+  "alert": {
+    "dismissAriaLabel": "Warnung verwerfen"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Weiter",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Seitennavigation öffnen",
     "ariaLabels.notifications": "Benachrichtigungen",
     "ariaLabels.tools": "Hilfebereich",
-    "ariaLabels.toolsClose": "Hilfebereich öffnen",
-    "ariaLabels.toolsToggle": "Hilfebereich schließen"
+    "ariaLabels.toolsClose": "Hilfebereich schließen",
+    "ariaLabels.toolsToggle": "Hilfebereich öffnen"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Gesamtsumme"
   },
   "attribute-editor": {
-    "removeButtonText": "Entfernen",
-    "i18nStrings.errorIconAriaLabel": "Fehler"
+    "removeButtonText": "Entfernen"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Fehler",
     "selectedAriaLabel": "Ausgewählt",
-    "enteredTextLabel": "Verwenden Sie: {value}",
+    "enteredTextLabel": "„{value}“ verwenden",
     "recoveryText": "Wiederholen"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "Ziehpunkt",
     "contentDisplayPreference.dragHandleAriaDescription": "Verwenden Sie Space (Leertaste) oder Enter (Eingabetaste), um das Ziehen für ein Element zu aktivieren. Verwenden Sie dann die Pfeiltasten, um die Position abzuschließen. Verwenden Sie Space (Leertaste) oder Enter (Eingabetaste) oder, um den Zug zu verwerfen, verwenden Sie Escape (Escape).",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Aufgeholtes Element an Position {position} von {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Neuanordnung storniert"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Neuanordnung storniert",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Objekt zurück an die Position {currentPosition} von {total} verschieben} false {Objekt an Position {currentPosition} von {total} verschieben} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Das Objekt wurde zurück an seine ursprüngliche Position {initialPosition} von {total} verschoben} false {Das Objekt wurde von Position {initialPosition} zu Position {finalPosition} von {total} verschoben} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Relativer Modus",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "Erfolg",
     "i18nStrings.warningIconAriaLabel": "Warnung"
   },
-  "form": {
-    "errorIconAriaLabel": "Fehler"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Fehler"
+  },
+  "form": {
+    "errorIconAriaLabel": "Fehler"
   },
   "help-panel": {
     "loadingText": "Inhalte werden geladen"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Modal schließen"
   },
+  "multiselect": {
+    "deselectAriaLabel": "{option__label} entfernen"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Nächste Seite",
     "ariaLabels.pageLabel": "Seite {pageNumber} aller Seiten",
     "ariaLabels.previousPageLabel": "Vorherige Seite"
   },
   "pie-chart": {
-    "loadingText": "Diagramm wird geladen",
-    "errorText": "Die Daten konnten nicht abgerufen werden. Versuchen Sie es später erneut.",
-    "recoveryText": "Wiederholen"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Entfernen {option__label}"
+    "i18nStrings.detailsValue": "Wert",
+    "i18nStrings.detailsPercentage": "Prozentsatz",
+    "i18nStrings.chartAriaRoleDescription": "Kreisdiagramm",
+    "i18nStrings.segmentAriaRoleDescription": "Segment"
   },
   "popover": {
     "dismissAriaLabel": "Popover schließen"
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "Wert",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Filter entfernen, {token__propertyKey} ist gleich {token__value}} not_equals {Filter entfernen, {token__propertyKey} ist nicht gleich {token__value}} greater_than {Filter entfernen, {token__propertyKey} ist größer als {token__value}} greater_than_equal {Filter entfernen, {token__propertyKey} ist größer oder gleich {token__value}} less_than {Filter entfernen, {token__propertyKey} ist kleiner als {token__value}} less_than_equal {Filter entfernen, {token__propertyKey} ist kleiner als oder gleich {token__value}} contains {Filter entfernen, {token__propertyKey} enthält {token__value}} not_contains {Filter entfernen, {token__propertyKey} enthält nicht {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Version auswählen",
+    "i18nStrings.inContextBrowseButton": "S3 durchsuchen",
+    "i18nStrings.inContextViewButton": "Anzeigen",
+    "i18nStrings.inContextViewButtonAriaLabel": "Anzeigen (wird in einem neuen Tab geöffnet)",
+    "i18nStrings.inContextLoadingText": "Ressourcen werden geladen",
+    "i18nStrings.inContextUriLabel": "S3-URI",
+    "i18nStrings.inContextVersionSelectLabel": "Objektversion auswählen",
+    "i18nStrings.modalTitle": "Ein Archiv in S3 auswählen",
+    "i18nStrings.modalCancelButton": "Abbrechen",
+    "i18nStrings.modalSubmitButton": "Auswählen",
+    "i18nStrings.modalBreadcrumbRootItem": "S3-Buckets",
+    "i18nStrings.selectionBuckets": "Buckets",
+    "i18nStrings.selectionObjects": "Objekte",
+    "i18nStrings.selectionVersions": "Versionen",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Bucket finden",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Objekt anhand des Präfix suchen",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Version finden",
+    "i18nStrings.selectionBucketsLoading": "Buckets laden",
+    "i18nStrings.selectionBucketsNoItems": "Keine Buckets",
+    "i18nStrings.selectionObjectsLoading": "Objekte werden geladen",
+    "i18nStrings.selectionObjectsNoItems": "Keine Objekte",
+    "i18nStrings.selectionVersionsLoading": "Versionen werden geladen",
+    "i18nStrings.selectionVersionsNoItems": "Keine Versionen",
+    "i18nStrings.filteringNoMatches": "Keine Übereinstimmungen",
+    "i18nStrings.filteringCantFindMatch": "Es konnte keine Übereinstimmung gefunden werden",
+    "i18nStrings.clearFilterButtonText": "Filter löschen",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Name",
+    "i18nStrings.columnBucketCreationDate": "Erstellungsdatum",
+    "i18nStrings.columnBucketRegion": "Region",
+    "i18nStrings.columnObjectKey": "Schlüssel",
+    "i18nStrings.columnObjectLastModified": "Zuletzt geändert",
+    "i18nStrings.columnObjectSize": "Größe",
+    "i18nStrings.columnVersionID": "ID-Version",
+    "i18nStrings.columnVersionLastModified": "Zuletzt geändert",
+    "i18nStrings.columnVersionSize": "Größe",
+    "i18nStrings.validationPathMustBegin": "Der Pfad muss mit s3:// beginnen",
+    "i18nStrings.validationBucketLowerCase": "Der Bucket-Name muss mit einem Kleinbuchstaben oder einer Zahl beginnen.",
+    "i18nStrings.validationBucketMustNotContain": "Der Bucket-Name darf keine Großbuchstaben enthalten.",
+    "i18nStrings.validationBucketLength": "Der Bucket-Name muss aus 3 bis 63 Zeichen bestehen.",
+    "i18nStrings.validationBucketMustComplyDns": "Der Bucket-Name muss den DNS-Namenskonventionen entsprechen.",
+    "i18nStrings.labelSortedDescending": "{columnName}, absteigend sortiert",
+    "i18nStrings.labelSortedAscending": "{columnName}, aufsteigend sortiert",
+    "i18nStrings.labelNotSorted": "{columnName}, nicht sortiert",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Buckets",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objekte",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versionen",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "{itemsType} finden",
+    "i18nStrings.labelRefresh": "Die Daten aktualisieren",
+    "i18nStrings.labelBreadcrumbs": "S3-Navigation",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 Übereinstimmung} other {{count} Übereinstimmungen}}"
+  },
   "select": {
     "errorIconAriaLabel": "Fehler",
-    "selectedAriaLabel": "Ausgewählt"
+    "selectedAriaLabel": "Ausgewählt",
+    "recoveryText": "Wiederholen"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Bereich schließen",
+    "i18nStrings.openButtonAriaLabel": "Bereich öffnen",
+    "i18nStrings.preferencesTitle": "Einstellungen für geteilten Bereich",
+    "i18nStrings.preferencesPositionLabel": "Position des geteilten Bereichs",
+    "i18nStrings.preferencesPositionDescription": "Wählen Sie die Standardposition für den geteilten Bereich für den Service.",
+    "i18nStrings.preferencesPositionSide": "Seite",
+    "i18nStrings.preferencesPositionBottom": "Unten",
+    "i18nStrings.preferencesConfirm": "Bestätigen",
+    "i18nStrings.preferencesCancel": "Abbrechen",
+    "i18nStrings.resizeHandleAriaLabel": "Größe des geteilten Bereichs ändern"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Bearbeitung wird gesendet",
     "ariaLabels.successfulEditLabel": "Bearbeitung erfolgreich",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Fehler",
-    "columnDefinitions.editConfig.editIconAriaLabel": "Editierbar"
+    "columnDefinitions.editConfig.editIconAriaLabel": "bearbeitbar"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Nach links scrollen",
     "i18nStrings.scrollRightAriaLabel": "Nach rechts scrollen"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Schlüssel eingeben",
+    "i18nStrings.valuePlaceholder": "Wert eingeben",
+    "i18nStrings.addButton": "Neues Tag hinzufügen",
+    "i18nStrings.removeButton": "Entfernen",
+    "i18nStrings.removeButtonAriaLabel": "{tag__key} entfernen",
+    "i18nStrings.undoButton": "Rückgängig machen",
+    "i18nStrings.undoPrompt": "Dieses Tag wird beim Speichern der Änderungen entfernt",
+    "i18nStrings.loading": "Laden von Tags, die dieser Ressource zugeordnet sind",
+    "i18nStrings.keyHeader": "Schlüssel",
+    "i18nStrings.valueHeader": "Wert",
+    "i18nStrings.optional": "optional",
+    "i18nStrings.keySuggestion": "Benutzerdefinierter Tag-Schlüssel",
+    "i18nStrings.valueSuggestion": "Benutzerdefinierter Tag-Wert",
+    "i18nStrings.emptyTags": "Der Ressource sind keine Tags zugeordnet.",
+    "i18nStrings.tooManyKeysSuggestion": "Sie haben mehr Schlüssel, als angezeigt werden können",
+    "i18nStrings.tooManyValuesSuggestion": "Sie haben mehr Werte, als angezeigt werden können",
+    "i18nStrings.keysSuggestionLoading": "Tag-Schlüssel werden geladen",
+    "i18nStrings.keysSuggestionError": "Tag-Schlüssel konnten nicht abgerufen werden",
+    "i18nStrings.valuesSuggestionLoading": "Tag-Werte werden geladen",
+    "i18nStrings.valuesSuggestionError": "Tag-Werte konnten nicht abgerufen werden",
+    "i18nStrings.emptyKeyError": "Sie müssen einen Tag-Schlüssel angeben",
+    "i18nStrings.maxKeyCharLengthError": "Die maximale Anzahl von Zeichen für einen Tag-Schlüssel beträgt 128.",
+    "i18nStrings.maxValueCharLengthError": "Die maximale Anzahl von Zeichen für einen Tag-Wert beträgt 256.",
+    "i18nStrings.duplicateKeyError": "Sie müssen einen eindeutigen Tag-Schlüssel angeben.",
+    "i18nStrings.invalidKeyError": "Ungültiger Schlüssel. Schlüssel können nur Unicode-Buchstaben, Ziffern, Leerzeichen und eines der folgenden Elemente enthalten: _.:/=+@–",
+    "i18nStrings.invalidValueError": "Ungültiger Wert. Werte dürfen nur Unicode-Buchstaben, -Ziffern, Leerzeichen und eines der folgenden Elemente enthalten: _.:/=+@–",
+    "i18nStrings.awsPrefixError": "Darf nicht mit aws beginnen:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Sie haben das Limit von 1 Tag erreicht.} other {Sie haben das Limit von {tagLimit} Tags erreicht.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Sie haben das Limit von 1 Tag überschritten.} other {Sie haben das Limit von {tagLimit} Tags überschritten.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {Sie können bis zu {tagLimit} Tags hinzufügen.}}} false {{availableTags, plural, one {Sie können bis zu 1 weiteres Tag hinzufügen.} other {Sie können bis zu {availableTags} weitere Tags hinzufügen.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Weniger anzeigen",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyKey} equals {token__value}} not_equals {Remove filter, {token__propertyKey} does not equal {token__value}} greater_than {Remove filter, {token__propertyKey} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyKey} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyKey} is less than {token__value}} less_than_equal {Remove filter, {token__propertyKey} is less than or equal to {token__value}} contains {Remove filter, {token__propertyKey} contains {token__value}} not_contains {Remove filter, {token__propertyKey} does not contain {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Choose a version",
     "i18nStrings.inContextBrowseButton": "Browse S3",
     "i18nStrings.inContextViewButton": "View",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Dismiss alert"
-  },
   "[charts]": {
     "loadingText": "Loading chart",
     "errorText": "The data couldn't be fetched. Try again later.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filter displayed data",
     "i18nStrings.filterPlaceholder": "Filter data",
     "i18nStrings.legendAriaLabel": "Legend",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Dismiss",
     "i18nStrings.xAxisAriaRoleDescription": "x-axis",
     "i18nStrings.yAxisAriaRoleDescription": "y-axis"
+  },
+  "alert": {
+    "dismissAriaLabel": "Dismiss alert"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Next",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Open side navigation",
     "ariaLabels.notifications": "Notifications",
     "ariaLabels.tools": "Help panel",
-    "ariaLabels.toolsClose": "Open help panel",
-    "ariaLabels.toolsToggle": "Close help panel"
+    "ariaLabels.toolsClose": "Close help panel",
+    "ariaLabels.toolsToggle": "Open help panel"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
   },
   "attribute-editor": {
-    "removeButtonText": "Remove",
-    "i18nStrings.errorIconAriaLabel": "Error"
+    "removeButtonText": "Remove"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Error",
     "selectedAriaLabel": "Selected",
-    "enteredTextLabel": "Use {value}",
+    "enteredTextLabel": "Use: ‘{value}’",
     "recoveryText": "Retry"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "Drag handle",
     "contentDisplayPreference.dragHandleAriaDescription": "Use Space or Enter to activate drag for an item, then use the arrow keys to move the item's position. To complete the position move, use Space or Enter, or to discard the move, use Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Picked up item at position {position} of {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordering cancelled"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordering cancelled",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Relative mode",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "Success",
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
-  "form": {
-    "errorIconAriaLabel": "Error"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
   },
   "help-panel": {
     "loadingText": "Loading content"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Close modal"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Remove {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Next page",
     "ariaLabels.pageLabel": "Page {pageNumber} of all pages",
     "ariaLabels.previousPageLabel": "Previous page"
   },
   "pie-chart": {
-    "loadingText": "Loading chart",
-    "errorText": "The data couldn't be fetched. Try again later.",
-    "recoveryText": "Retry"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Remove {option__label}"
+    "i18nStrings.detailsValue": "Value",
+    "i18nStrings.detailsPercentage": "Percentage",
+    "i18nStrings.chartAriaRoleDescription": "Pie chart",
+    "i18nStrings.segmentAriaRoleDescription": "Segment"
   },
   "popover": {
     "dismissAriaLabel": "Close pop-over"
@@ -184,12 +185,80 @@
     "i18nStrings.valueText": "Value",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyKey} equals {token__value}} not_equals {Remove filter, {token__propertyKey} does not equal {token__value}} greater_than {Remove filter, {token__propertyKey} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyKey} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyKey} is less than {token__value}} less_than_equal {Remove filter, {token__propertyKey} is less than or equal to {token__value}} contains {Remove filter, {token__propertyKey} contains {token__value}} not_contains {Remove filter, {token__propertyKey} does not contain {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Choose a version",
+    "i18nStrings.inContextBrowseButton": "Browse S3",
+    "i18nStrings.inContextViewButton": "View",
+    "i18nStrings.inContextViewButtonAriaLabel": "View (opens in a new tab)",
+    "i18nStrings.inContextLoadingText": "Loading resource",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "Object version",
+    "i18nStrings.modalTitle": "Choose an archive in S3",
+    "i18nStrings.modalCancelButton": "Cancel",
+    "i18nStrings.modalSubmitButton": "Choose",
+    "i18nStrings.modalBreadcrumbRootItem": "S3 buckets",
+    "i18nStrings.selectionBuckets": "Buckets",
+    "i18nStrings.selectionObjects": "Objects",
+    "i18nStrings.selectionVersions": "Versions",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Find bucket",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Find object by prefix",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Find version",
+    "i18nStrings.selectionBucketsLoading": "Loading buckets",
+    "i18nStrings.selectionBucketsNoItems": "No buckets",
+    "i18nStrings.selectionObjectsLoading": "Loading objects",
+    "i18nStrings.selectionObjectsNoItems": "No objects",
+    "i18nStrings.selectionVersionsLoading": "Loading versions",
+    "i18nStrings.selectionVersionsNoItems": "No versions",
+    "i18nStrings.filteringNoMatches": "No matches",
+    "i18nStrings.filteringCantFindMatch": "We can't find a match.",
+    "i18nStrings.clearFilterButtonText": "Clear filter",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Name",
+    "i18nStrings.columnBucketCreationDate": "Creation date",
+    "i18nStrings.columnBucketRegion": "Region",
+    "i18nStrings.columnObjectKey": "Key",
+    "i18nStrings.columnObjectLastModified": "Last modified",
+    "i18nStrings.columnObjectSize": "Size",
+    "i18nStrings.columnVersionID": "Version ID",
+    "i18nStrings.columnVersionLastModified": "Last modified",
+    "i18nStrings.columnVersionSize": "Size",
+    "i18nStrings.validationPathMustBegin": "The path must begin with s3://",
+    "i18nStrings.validationBucketLowerCase": "The bucket name must start with a lowercase character or number.",
+    "i18nStrings.validationBucketMustNotContain": "The bucket name must not contain uppercase characters.",
+    "i18nStrings.validationBucketLength": "The bucket name must be from 3 to 63 characters.",
+    "i18nStrings.validationBucketMustComplyDns": "The bucket name must comply with DNS naming conventions.",
+    "i18nStrings.labelSortedDescending": "{columnName}, sorted descending",
+    "i18nStrings.labelSortedAscending": "{columnName}, sorted ascending",
+    "i18nStrings.labelNotSorted": "{columnName}, not sorted",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Buckets",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objects",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versions",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Find {itemsType}",
+    "i18nStrings.labelRefresh": "Refresh the data",
+    "i18nStrings.labelBreadcrumbs": "S3 navigation",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 match} other {{count} matches}}"
+  },
   "select": {
     "errorIconAriaLabel": "Error",
-    "selectedAriaLabel": "Selected"
+    "selectedAriaLabel": "Selected",
+    "recoveryText": "Retry"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Close panel",
+    "i18nStrings.openButtonAriaLabel": "Open panel",
+    "i18nStrings.preferencesTitle": "Split panel preferences",
+    "i18nStrings.preferencesPositionLabel": "Split panel position",
+    "i18nStrings.preferencesPositionDescription": "Choose the default split panel position for the service.",
+    "i18nStrings.preferencesPositionSide": "Side",
+    "i18nStrings.preferencesPositionBottom": "Bottom",
+    "i18nStrings.preferencesConfirm": "Confirm",
+    "i18nStrings.preferencesCancel": "Cancel",
+    "i18nStrings.resizeHandleAriaLabel": "Resize split panel"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Submitting edit",
     "ariaLabels.successfulEditLabel": "Edit successful",
@@ -199,6 +268,38 @@
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Scroll left",
     "i18nStrings.scrollRightAriaLabel": "Scroll right"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Enter key",
+    "i18nStrings.valuePlaceholder": "Enter value",
+    "i18nStrings.addButton": "Add new tag",
+    "i18nStrings.removeButton": "Remove",
+    "i18nStrings.removeButtonAriaLabel": "Remove {tag__key}",
+    "i18nStrings.undoButton": "Undo",
+    "i18nStrings.undoPrompt": "This tag will be removed upon saving changes",
+    "i18nStrings.loading": "Loading tags that are associated with this resource",
+    "i18nStrings.keyHeader": "Key",
+    "i18nStrings.valueHeader": "Value",
+    "i18nStrings.optional": "optional",
+    "i18nStrings.keySuggestion": "Customised tag key",
+    "i18nStrings.valueSuggestion": "Customised tag value",
+    "i18nStrings.emptyTags": "No tags associated with the resource.",
+    "i18nStrings.tooManyKeysSuggestion": "You have more keys than can be displayed",
+    "i18nStrings.tooManyValuesSuggestion": "You have more values than can be displayed",
+    "i18nStrings.keysSuggestionLoading": "Loading tag keys",
+    "i18nStrings.keysSuggestionError": "Tag keys could not be retrieved",
+    "i18nStrings.valuesSuggestionLoading": "Loading tag values",
+    "i18nStrings.valuesSuggestionError": "Tag values could not be retrieved",
+    "i18nStrings.emptyKeyError": "You must specify a tag key",
+    "i18nStrings.maxKeyCharLengthError": "The maximum number of characters you can use in a tag key is 128.",
+    "i18nStrings.maxValueCharLengthError": "The maximum number of characters you can use in a tag value is 256.",
+    "i18nStrings.duplicateKeyError": "You must specify a unique tag key.",
+    "i18nStrings.invalidKeyError": "Invalid key. Keys can only contain Unicode letters, digits, white space and any of the following: _.:/=+@-",
+    "i18nStrings.invalidValueError": "Invalid value. Values can only contain Unicode letters, digits, white space and any of the following: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "Cannot start with aws:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {You have reached the limit of 1 tag.} other {You have reached the limit of {tagLimit} tags.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {You have exceeded the limit of 1 tag.} other {You have exceeded the limit of {tagLimit} tags.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {You can add up to {tagLimit} tags.}}} false {{availableTags, plural, one {You can add up to 1 more tag.} other {You can add up to {availableTags} more tags.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Show fewer",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Dismiss alert"
-  },
   "[charts]": {
     "loadingText": "Loading chart",
     "errorText": "The data couldn't be fetched. Try again later.",
@@ -9,8 +6,12 @@
     "i18nStrings.filterLabel": "Filter displayed data",
     "i18nStrings.filterPlaceholder": "Filter data",
     "i18nStrings.legendAriaLabel": "Legend",
+    "i18nStrings.chartAriaRoleDescription": "Chart",
     "i18nStrings.xAxisAriaRoleDescription": "x-axis",
     "i18nStrings.yAxisAriaRoleDescription": "y-axis"
+  },
+  "alert": {
+    "dismissAriaLabel": "Dismiss alert"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Next",
@@ -27,8 +28,8 @@
     "ariaLabels.navigationToggle": "Open side navigation",
     "ariaLabels.notifications": "Notifications",
     "ariaLabels.tools": "Help panel",
-    "ariaLabels.toolsClose": "Open help panel",
-    "ariaLabels.toolsToggle": "Close help panel"
+    "ariaLabels.toolsClose": "Close help panel",
+    "ariaLabels.toolsToggle": "Open help panel"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
@@ -124,11 +125,11 @@
     "i18nStrings.successIconAriaLabel": "Success",
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
-  "form": {
-    "errorIconAriaLabel": "Error"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
   },
   "help-panel": {
     "loadingText": "Loading content"
@@ -142,6 +143,9 @@
   "modal": {
     "closeAriaLabel": "Close modal"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Remove {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Next page",
     "ariaLabels.pageLabel": "Page {pageNumber} of all pages",
@@ -152,9 +156,6 @@
     "i18nStrings.detailsPercentage": "Percentage",
     "i18nStrings.chartAriaRoleDescription": "Pie chart",
     "i18nStrings.segmentAriaRoleDescription": "Segment"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Remove {option__label}"
   },
   "popover": {
     "dismissAriaLabel": "Close popover"

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -187,7 +187,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyKey} equals {token__value}} not_equals {Remove filter, {token__propertyKey} does not equal {token__value}} greater_than {Remove filter, {token__propertyKey} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyKey} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyKey} is less than {token__value}} less_than_equal {Remove filter, {token__propertyKey} is less than or equal to {token__value}} contains {Remove filter, {token__propertyKey} contains {token__value}} not_contains {Remove filter, {token__propertyKey} does not contain {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Choose a version",
     "i18nStrings.inContextBrowseButton": "Browse S3",
     "i18nStrings.inContextViewButton": "View",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Eliminar filtro, {token__propertyKey} igual a {token__value}} not_equals {Eliminar filtro, {token__propertyKey} no es igual a {token__value}} greater_than {Eliminar filtro, {token__propertyKey} es mayor que {token__value}} greater_than_equal {Eliminar filtro, {token__propertyKey} es mayor o igual que {token__value}} less_than {Eliminar filtro, {token__propertyKey} es menor que {token__value}} less_than_equal {Eliminar filtro, {token__propertyKey} es menor o igual que {token__value}} contains {Eliminar filtro, {token__propertyKey} contiene {token__value}} not_contains {Eliminar filtro, {token__propertyKey} no contiene {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Elija una versión",
     "i18nStrings.inContextBrowseButton": "Explorar S3",
     "i18nStrings.inContextViewButton": "Ver",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Descartar alerta"
-  },
   "[charts]": {
     "loadingText": "Cargando gráfico",
     "errorText": "No se pudieron recuperar los datos. Inténtelo de nuevo más tarde.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filtrar los datos mostrados",
     "i18nStrings.filterPlaceholder": "Filtrar datos",
     "i18nStrings.legendAriaLabel": "Leyenda",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Descartar",
     "i18nStrings.xAxisAriaRoleDescription": "eje x",
     "i18nStrings.yAxisAriaRoleDescription": "eje y"
+  },
+  "alert": {
+    "dismissAriaLabel": "Descartar alerta"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Siguiente",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Abrir navegación lateral",
     "ariaLabels.notifications": "Notificaciones",
     "ariaLabels.tools": "Panel de ayuda",
-    "ariaLabels.toolsClose": "Abrir panel de ayuda",
-    "ariaLabels.toolsToggle": "Cerrar panel de ayuda"
+    "ariaLabels.toolsClose": "Cerrar panel de ayuda",
+    "ariaLabels.toolsToggle": "Abrir panel de ayuda"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
   },
   "attribute-editor": {
-    "removeButtonText": "Eliminar",
-    "i18nStrings.errorIconAriaLabel": "Error"
+    "removeButtonText": "Eliminar"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Error",
     "selectedAriaLabel": "Seleccionado",
-    "enteredTextLabel": "Utilizar: {value}",
+    "enteredTextLabel": "Utilizar: “{value}”",
     "recoveryText": "Reintentar"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "Arrastrar controlador",
     "contentDisplayPreference.dragHandleAriaDescription": "Utilice la barra espaciadora o Enter para activar el arrastre de un elemento y, a continuación, utilice las teclas de flecha para mover la posición del elemento. Para completar el movimiento de la posición, utilice la barra espaciadora o Enter, o para descartar el movimiento, utilice Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Recogida del elemento en la posición {position} de {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordenación cancelada"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordenación cancelada",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Mover el elemento de nuevo a la posición {currentPosition} de {total}} false {Mover el elemento a la posición {currentPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {El artículo ha vuelto a su posición original {initialPosition} de {total}} false {El artículo se movió de la posición {initialPosition} a la posición {finalPosition} de {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modo relativo",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "Éxito",
     "i18nStrings.warningIconAriaLabel": "Advertencia"
   },
-  "form": {
-    "errorIconAriaLabel": "Error"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Error"
+  },
+  "form": {
+    "errorIconAriaLabel": "Error"
   },
   "help-panel": {
     "loadingText": "Cargando contenido"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Cerrar modal"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Eliminar {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Página siguiente",
     "ariaLabels.pageLabel": "Página {pageNumber} de todas las páginas",
     "ariaLabels.previousPageLabel": "Página anterior"
   },
   "pie-chart": {
-    "loadingText": "Cargando gráfico",
-    "errorText": "No se pudieron recuperar los datos. Inténtelo de nuevo más tarde.",
-    "recoveryText": "Reintentar"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Eliminar {option__label}"
+    "i18nStrings.detailsValue": "Valor",
+    "i18nStrings.detailsPercentage": "Porcentaje",
+    "i18nStrings.chartAriaRoleDescription": "Gráfico circular",
+    "i18nStrings.segmentAriaRoleDescription": "Segmento"
   },
   "popover": {
     "dismissAriaLabel": "Cerrar ventana emergente"
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "Valor",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Eliminar filtro, {token__propertyKey} igual a {token__value}} not_equals {Eliminar filtro, {token__propertyKey} no es igual a {token__value}} greater_than {Eliminar filtro, {token__propertyKey} es mayor que {token__value}} greater_than_equal {Eliminar filtro, {token__propertyKey} es mayor o igual que {token__value}} less_than {Eliminar filtro, {token__propertyKey} es menor que {token__value}} less_than_equal {Eliminar filtro, {token__propertyKey} es menor o igual que {token__value}} contains {Eliminar filtro, {token__propertyKey} contiene {token__value}} not_contains {Eliminar filtro, {token__propertyKey} no contiene {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Elija una versión",
+    "i18nStrings.inContextBrowseButton": "Explorar S3",
+    "i18nStrings.inContextViewButton": "Ver",
+    "i18nStrings.inContextViewButtonAriaLabel": "Ver (se abre en una pestaña nueva)",
+    "i18nStrings.inContextLoadingText": "Cargando recurso",
+    "i18nStrings.inContextUriLabel": "URI de S3",
+    "i18nStrings.inContextVersionSelectLabel": "Versión del objeto",
+    "i18nStrings.modalTitle": "Elija un archivo en S3",
+    "i18nStrings.modalCancelButton": "Cancelar",
+    "i18nStrings.modalSubmitButton": "Elija",
+    "i18nStrings.modalBreadcrumbRootItem": "Buckets de S3",
+    "i18nStrings.selectionBuckets": "Buckets",
+    "i18nStrings.selectionObjects": "Objetos",
+    "i18nStrings.selectionVersions": "Versiones",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Encuentra un bucket",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Buscar objeto por el prefijo",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Encuentre la versión",
+    "i18nStrings.selectionBucketsLoading": "Cargando buckets",
+    "i18nStrings.selectionBucketsNoItems": "No hay buckets",
+    "i18nStrings.selectionObjectsLoading": "Cargando objetos",
+    "i18nStrings.selectionObjectsNoItems": "No hay objetos",
+    "i18nStrings.selectionVersionsLoading": "Cargando versiones",
+    "i18nStrings.selectionVersionsNoItems": "No hay versiones",
+    "i18nStrings.filteringNoMatches": "No hay coincidencias",
+    "i18nStrings.filteringCantFindMatch": "No se encuentra ninguna coincidencia.",
+    "i18nStrings.clearFilterButtonText": "Borrar filtro",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Nombre",
+    "i18nStrings.columnBucketCreationDate": "Fecha de creación",
+    "i18nStrings.columnBucketRegion": "Región",
+    "i18nStrings.columnObjectKey": "Clave",
+    "i18nStrings.columnObjectLastModified": "Modificado por última vez",
+    "i18nStrings.columnObjectSize": "Tamaño",
+    "i18nStrings.columnVersionID": "ID de la versión",
+    "i18nStrings.columnVersionLastModified": "Modificado por última vez",
+    "i18nStrings.columnVersionSize": "Tamaño",
+    "i18nStrings.validationPathMustBegin": "La ruta debe empezar por s3://",
+    "i18nStrings.validationBucketLowerCase": "El nombre del bucket debe empezar por un carácter o número en minúscula.",
+    "i18nStrings.validationBucketMustNotContain": "El nombre del bucket no debe contener caracteres en mayúscula.",
+    "i18nStrings.validationBucketLength": "El nombre del bucket debe tener entre 3 y 63 caracteres.",
+    "i18nStrings.validationBucketMustComplyDns": "El nombre del bucket debe cumplir con las convenciones de nomenclatura de DNS.",
+    "i18nStrings.labelSortedDescending": "{columnName}, ordenados de forma descendente",
+    "i18nStrings.labelSortedAscending": "{columnName}, ordenados de forma ascendente",
+    "i18nStrings.labelNotSorted": "{columnName}, no ordenados",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Buckets",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objetos",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versiones",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Encuentre {itemsType}",
+    "i18nStrings.labelRefresh": "Actualizar los datos",
+    "i18nStrings.labelBreadcrumbs": "Navegación S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 coincidencia} other {{count} coincidencias}}"
+  },
   "select": {
     "errorIconAriaLabel": "Error",
-    "selectedAriaLabel": "Seleccionado"
+    "selectedAriaLabel": "Seleccionado",
+    "recoveryText": "Reintentar"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Cerrar panel",
+    "i18nStrings.openButtonAriaLabel": "Abrir panel",
+    "i18nStrings.preferencesTitle": "Preferencias de panel dividido",
+    "i18nStrings.preferencesPositionLabel": "Posición del panel dividido",
+    "i18nStrings.preferencesPositionDescription": "Elija la posición predeterminada del panel dividido para el servicio.",
+    "i18nStrings.preferencesPositionSide": "Lateral",
+    "i18nStrings.preferencesPositionBottom": "Parte inferior",
+    "i18nStrings.preferencesConfirm": "Confirmar",
+    "i18nStrings.preferencesCancel": "Cancelar",
+    "i18nStrings.resizeHandleAriaLabel": "Cambiar el tamaño del panel dividido"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Envío de edición",
     "ariaLabels.successfulEditLabel": "Se ha editado correctamente",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
-    "columnDefinitions.editConfig.editIconAriaLabel": "dditable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editable"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Desplácese hacia la izquierda",
     "i18nStrings.scrollRightAriaLabel": "Desplácese hacia la derecha"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Ingresar clave",
+    "i18nStrings.valuePlaceholder": "Ingresar valor",
+    "i18nStrings.addButton": "Agregar nueva etiqueta",
+    "i18nStrings.removeButton": "Eliminar",
+    "i18nStrings.removeButtonAriaLabel": "Eliminar {tag__key}",
+    "i18nStrings.undoButton": "Deshacer",
+    "i18nStrings.undoPrompt": "Esta etiqueta se eliminará una vez que se guarden los cambios.",
+    "i18nStrings.loading": "Cargando las etiquetas asociadas con este recurso",
+    "i18nStrings.keyHeader": "Clave",
+    "i18nStrings.valueHeader": "Valor",
+    "i18nStrings.optional": "opcional",
+    "i18nStrings.keySuggestion": "Clave de etiqueta personalizada",
+    "i18nStrings.valueSuggestion": "Valor de etiqueta personalizado",
+    "i18nStrings.emptyTags": "No hay etiquetas asociadas con el recurso.",
+    "i18nStrings.tooManyKeysSuggestion": "Tiene más claves de las que se pueden mostrar.",
+    "i18nStrings.tooManyValuesSuggestion": "Tiene más valores de los que se pueden mostrar.",
+    "i18nStrings.keysSuggestionLoading": "Cargando claves de etiqueta",
+    "i18nStrings.keysSuggestionError": "No se pudieron recuperar las claves de etiqueta.",
+    "i18nStrings.valuesSuggestionLoading": "Cargando valores de etiqueta",
+    "i18nStrings.valuesSuggestionError": "No se pudieron recuperar los valores de etiqueta.",
+    "i18nStrings.emptyKeyError": "Debe especificar una clave de etiqueta.",
+    "i18nStrings.maxKeyCharLengthError": "En una clave de etiqueta, puede utilizar 128 caracteres como máximo.",
+    "i18nStrings.maxValueCharLengthError": "En un valor de etiqueta, puede utilizar 256 caracteres como máximo.",
+    "i18nStrings.duplicateKeyError": "Debe especificar una clave de etiqueta que sea única.",
+    "i18nStrings.invalidKeyError": "La clave no es válida. Las claves solo pueden contener letras de un solo código, dígitos, espacios en blanco y uno de los siguientes símbolos: _.:/=+@-.",
+    "i18nStrings.invalidValueError": "El valor no es válido. Los valores solo pueden contener letras de un solo código, dígitos, espacios en blanco y uno de los siguientes símbolos: _.:/=+@-.",
+    "i18nStrings.awsPrefixError": "No se puede iniciar con “aws:”.",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Alcanzó el límite de 1 etiqueta.} other {Alcanzó el límite de {tagLimit} etiquetas.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Superó el límite de 1 etiqueta.} other {Superó el límite de {tagLimit} etiquetas.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {Puede agregar hasta {tagLimit} etiquetas.}}} false {{availableTags, plural, one {Puede agregar hasta 1 etiqueta más.} other {Puede agregar hasta {availableTags} etiquetas más.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Mostrar menos",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Ignorer l'alerte"
-  },
   "[charts]": {
     "loadingText": "Chargement du graphique",
     "errorText": "Impossible d'extraire les données. Réessayez plus tard.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filtrer les données affichées",
     "i18nStrings.filterPlaceholder": "Filtrer les données",
     "i18nStrings.legendAriaLabel": "Légende",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Ignorer",
     "i18nStrings.xAxisAriaRoleDescription": "axe X",
     "i18nStrings.yAxisAriaRoleDescription": "axe Y"
+  },
+  "alert": {
+    "dismissAriaLabel": "Ignorer l'alerte"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Suivant",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Ouvrir la navigation latérale",
     "ariaLabels.notifications": "Notifications",
     "ariaLabels.tools": "Volet d'aide",
-    "ariaLabels.toolsClose": "Ouvrir le volet d'aide",
-    "ariaLabels.toolsToggle": "Fermer le volet d'aide"
+    "ariaLabels.toolsClose": "Fermer le volet d'aide",
+    "ariaLabels.toolsToggle": "Ouvrir le volet d'aide"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
   },
   "attribute-editor": {
-    "removeButtonText": "Supprimer",
-    "i18nStrings.errorIconAriaLabel": "Erreur"
+    "removeButtonText": "Supprimer"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Erreur",
     "selectedAriaLabel": "Sélectionné",
-    "enteredTextLabel": "Utiliser {value}",
+    "enteredTextLabel": "Utiliser : «{value}»",
     "recoveryText": "Réessayer"
   },
   "breadcrumb-group": {
@@ -88,9 +86,11 @@
     "contentDisplayPreference.title": "Préférences de colonne",
     "contentDisplayPreference.description": "Personnalisez la visibilité et l'ordre des colonnes.",
     "contentDisplayPreference.dragHandleAriaLabel": "Faire glisser",
-    "contentDisplayPreference.dragHandleAriaDescription": "Utilisez Espace ou Entrée pour activer le glissement pour un élément, puis utilisez les touches fléchées pour déplacer la position de l'élément. Pour terminer le déplacement de la position, utilisez Espace ou Entrée. Pour ignorer le déplacement, utilisez Esc.",
+    "contentDisplayPreference.dragHandleAriaDescription": "Utilisez Espace ou Entrée pour activer le glissement pour un élément, puis utilisez les touches fléchées pour déplacer la position de l'élément. Pour terminer le déplacement de la position, utilisez Espace ou Entrée. Pour ignorer le déplacement, utilisez Échap.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Élément sélectionné à la position {position} de {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Réorganisation annulée"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Réorganisation annulée",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Remettre l'élément à la position {currentPosition} de {total}} false {Déplacer l'élément vers la position {currentPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'élément a été replacé dans sa position initiale {initialPosition} de {total}} false {L'élément a été déplacé de la position {initialPosition} à {finalPosition} de {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Mode relatif",
@@ -121,14 +121,14 @@
     "i18nStrings.infoIconAriaLabel": "Informations",
     "i18nStrings.notificationBarAriaLabel": "Toutes les notifications",
     "i18nStrings.notificationBarText": "Notifications",
-    "i18nStrings.successIconAriaLabel": "Réussite",
+    "i18nStrings.successIconAriaLabel": "Réussi",
     "i18nStrings.warningIconAriaLabel": "Avertissement"
-  },
-  "form": {
-    "errorIconAriaLabel": "Erreur"
   },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Erreur"
+  },
+  "form": {
+    "errorIconAriaLabel": "Erreur"
   },
   "help-panel": {
     "loadingText": "Chargement du contenu en cours"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Fermer le modal"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Supprimer {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Page suivante",
     "ariaLabels.pageLabel": "Page {pageNumber} de toutes les pages",
     "ariaLabels.previousPageLabel": "Page précédente"
   },
   "pie-chart": {
-    "loadingText": "Chargement du graphique",
-    "errorText": "Impossible d'extraire les données. Réessayez plus tard.",
-    "recoveryText": "Réessayer"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Supprimer {option__label}"
+    "i18nStrings.detailsValue": "Valeur",
+    "i18nStrings.detailsPercentage": "Pourcentage",
+    "i18nStrings.chartAriaRoleDescription": "Diagramme circulaire",
+    "i18nStrings.segmentAriaRoleDescription": "Segment"
   },
   "popover": {
     "dismissAriaLabel": "Fermer la fenêtre contextuelle"
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "Valeur",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Supprimer le filtre, {token__propertyKey} est égal à {token__value}} not_equals {Supprimer le filtre, {token__propertyKey} n'est pas égal à {token__value}} greater_than {Supprimer le filtre, {token__propertyKey} est supérieur à {token__value}} greater_than_equal {Supprimer le filtre, {token__propertyKey} est supérieur ou égal à {token__value}} less_than {Supprimer le filtre, {token__propertyKey} est inférieur à {token__value}} less_than_equal {Supprimer le filtre, {token__propertyKey} est inférieur ou égal à {token__value}} contains {Supprimer le filtre, {token__propertyKey} contient {token__value}} not_contains {Supprimer le filtre, {token__propertyKey} ne contient pas {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Choisir une version",
+    "i18nStrings.inContextBrowseButton": "Parcourir S3",
+    "i18nStrings.inContextViewButton": "Afficher",
+    "i18nStrings.inContextViewButtonAriaLabel": "Afficher (s'ouvre dans un nouvel onglet)",
+    "i18nStrings.inContextLoadingText": "Chargement de la ressource",
+    "i18nStrings.inContextUriLabel": "URI S3",
+    "i18nStrings.inContextVersionSelectLabel": "Version de l'objet",
+    "i18nStrings.modalTitle": "Choisir une archive dans S3",
+    "i18nStrings.modalCancelButton": "Annuler",
+    "i18nStrings.modalSubmitButton": "Choisir",
+    "i18nStrings.modalBreadcrumbRootItem": "Compartiments S3",
+    "i18nStrings.selectionBuckets": "Compartiments",
+    "i18nStrings.selectionObjects": "Objets",
+    "i18nStrings.selectionVersions": "Versions",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Trouver un compartiment",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Rechercher un objet par préfixe",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Trouver la version",
+    "i18nStrings.selectionBucketsLoading": "Chargement des compartiments",
+    "i18nStrings.selectionBucketsNoItems": "Aucun compartiment",
+    "i18nStrings.selectionObjectsLoading": "Chargement des objets",
+    "i18nStrings.selectionObjectsNoItems": "Aucun objet",
+    "i18nStrings.selectionVersionsLoading": "Chargement des versions",
+    "i18nStrings.selectionVersionsNoItems": "Aucune version",
+    "i18nStrings.filteringNoMatches": "Aucune correspondance",
+    "i18nStrings.filteringCantFindMatch": "Impossible de trouver une correspondance.",
+    "i18nStrings.clearFilterButtonText": "Effacer le filtre",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Nom",
+    "i18nStrings.columnBucketCreationDate": "Date de création",
+    "i18nStrings.columnBucketRegion": "Région",
+    "i18nStrings.columnObjectKey": "Clé",
+    "i18nStrings.columnObjectLastModified": "Dernière modification",
+    "i18nStrings.columnObjectSize": "Taille",
+    "i18nStrings.columnVersionID": "ID de version",
+    "i18nStrings.columnVersionLastModified": "Dernière modification",
+    "i18nStrings.columnVersionSize": "Taille",
+    "i18nStrings.validationPathMustBegin": "Le chemin doit commencer par s3 ://",
+    "i18nStrings.validationBucketLowerCase": "Le nom du compartiment doit commencer par une minuscule ou un chiffre.",
+    "i18nStrings.validationBucketMustNotContain": "Le nom du compartiment ne doit pas contenir de majuscules.",
+    "i18nStrings.validationBucketLength": "Le nom du compartiment doit comporter entre 3 et 63 caractères.",
+    "i18nStrings.validationBucketMustComplyDns": "Le nom du compartiment doit être conforme aux conventions de dénomination DNS.",
+    "i18nStrings.labelSortedDescending": "{columnName}, triés par ordre décroissant",
+    "i18nStrings.labelSortedAscending": "{columnName}, triés par ordre croissant",
+    "i18nStrings.labelNotSorted": "{columnName}, non triés",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Compartiments",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objets",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versions",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Trouver {itemsType}",
+    "i18nStrings.labelRefresh": "Actualiser les données",
+    "i18nStrings.labelBreadcrumbs": "Navigation S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 correspondance} other {{count} correspondances}}"
+  },
   "select": {
     "errorIconAriaLabel": "Erreur",
-    "selectedAriaLabel": "Sélectionné"
+    "selectedAriaLabel": "Sélectionné",
+    "recoveryText": "Réessayer"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Fermer le panneau",
+    "i18nStrings.openButtonAriaLabel": "Ouvrir le panneau",
+    "i18nStrings.preferencesTitle": "Préférences du panneau divisé",
+    "i18nStrings.preferencesPositionLabel": "Position du panneau divisé",
+    "i18nStrings.preferencesPositionDescription": "Choisir la position par défaut du panneau divisé pour le service.",
+    "i18nStrings.preferencesPositionSide": "Côté",
+    "i18nStrings.preferencesPositionBottom": "En bas",
+    "i18nStrings.preferencesConfirm": "Confirmer",
+    "i18nStrings.preferencesCancel": "Annuler",
+    "i18nStrings.resizeHandleAriaLabel": "Redimensionner le panneau divisé"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Soumission de modification",
     "ariaLabels.successfulEditLabel": "Modification réussie",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erreur",
-    "columnDefinitions.editConfig.editIconAriaLabel": "Modifiable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "modifiable"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Faire défiler vers la gauche",
     "i18nStrings.scrollRightAriaLabel": "Faire défiler vers la droite"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Saisir une clé",
+    "i18nStrings.valuePlaceholder": "Saisir une valeur",
+    "i18nStrings.addButton": "Ajouter une nouvelle identification",
+    "i18nStrings.removeButton": "Supprimer",
+    "i18nStrings.removeButtonAriaLabel": "Supprimer {tag__key}",
+    "i18nStrings.undoButton": "Annuler",
+    "i18nStrings.undoPrompt": "Cette identification sera supprimée lors de l'enregistrement des modifications.",
+    "i18nStrings.loading": "Chargement des identifications associées à cette ressource en cours",
+    "i18nStrings.keyHeader": "Clé",
+    "i18nStrings.valueHeader": "Valeur",
+    "i18nStrings.optional": "facultatif",
+    "i18nStrings.keySuggestion": "Clé d'identification personnalisée",
+    "i18nStrings.valueSuggestion": "Valeur d'identification personnalisée",
+    "i18nStrings.emptyTags": "Aucune identification n'est associée à la ressource.",
+    "i18nStrings.tooManyKeysSuggestion": "Vous avez plus de clés que ce qui peut être affiché.",
+    "i18nStrings.tooManyValuesSuggestion": "Vous avez plus de valeurs que ce qui peut être affiché.",
+    "i18nStrings.keysSuggestionLoading": "Chargement des clés d'identification en cours",
+    "i18nStrings.keysSuggestionError": "Les clés d'identification n'ont pas pu être récupérées.",
+    "i18nStrings.valuesSuggestionLoading": "Chargement des valeurs d'identification en cours",
+    "i18nStrings.valuesSuggestionError": "Les valeurs d'identification n'ont pas pu être récupérées.",
+    "i18nStrings.emptyKeyError": "Vous devez spécifier une clé d'identification.",
+    "i18nStrings.maxKeyCharLengthError": "Le nombre maximal de caractères que vous pouvez utiliser dans une clé d'identification est de 128.",
+    "i18nStrings.maxValueCharLengthError": "Le nombre maximal de caractères que vous pouvez utiliser dans une valeur d'identification est de 256.",
+    "i18nStrings.duplicateKeyError": "Vous devez spécifier une clé d'identification unique.",
+    "i18nStrings.invalidKeyError": "Clé non valide. Les clés peuvent contenir uniquement des caractères Unicode, des chiffres, des espaces blancs et l'un des éléments suivants : _.:/=+@-",
+    "i18nStrings.invalidValueError": "Valeur non valide. Les valeurs peuvent contenir uniquement des caractères Unicode, des chiffres, des espaces blancs et l'un des éléments suivants : _.:/=+@-",
+    "i18nStrings.awsPrefixError": "Impossible de commencer par aws :",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Vous avez atteint la limite de 1 identification.} other {Vous avez atteint la limite de {tagLimit} identifications.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Vous avez dépassé la limite de 1 identification.} other {Vous avez dépassé la limite de {tagLimit} identifications.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {Vous pouvez ajouter jusqu'à {tagLimit} identifications.}}} false {{availableTags, plural, one {Vous pouvez ajouter jusqu'à 1 identification supplémentaire.} other {Vous pouvez ajouter jusqu'à {availableTags} identifications supplémentaires.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Afficher moins",
@@ -220,12 +321,12 @@
     "i18nStrings.tutorialCompletedText": "Didacticiel terminé",
     "i18nStrings.learnMoreLinkText": "En savoir plus",
     "i18nStrings.startTutorialButtonText": "Commencer le didacticiel",
-    "i18nStrings.restartTutorialButtonText": "Didacticiel de redémarrage",
+    "i18nStrings.restartTutorialButtonText": "Redémarrer le didacticiel",
     "i18nStrings.completionScreenTitle": "Félicitations ! Vous avez terminé le didacticiel.",
     "i18nStrings.feedbackLinkText": "Commentaires",
     "i18nStrings.dismissTutorialButtonText": "Ignorer le didacticiel",
     "i18nStrings.taskTitle": "Tâche {taskNumber}: {taskTitle}",
-    "i18nStrings.stepTitle": "Étape {stepNumber} : {stepTitle}",
+    "i18nStrings.stepTitle": "Étape {stepNumber} : {stepTitle}",
     "i18nStrings.labelExitTutorial": "Ignorer le didacticiel",
     "i18nStrings.labelTotalSteps": "Nombre total d'étapes : {totalStepCount}",
     "i18nStrings.labelsTaskStatus.pending": "En attente",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Supprimer le filtre, {token__propertyKey} est égal à {token__value}} not_equals {Supprimer le filtre, {token__propertyKey} n'est pas égal à {token__value}} greater_than {Supprimer le filtre, {token__propertyKey} est supérieur à {token__value}} greater_than_equal {Supprimer le filtre, {token__propertyKey} est supérieur ou égal à {token__value}} less_than {Supprimer le filtre, {token__propertyKey} est inférieur à {token__value}} less_than_equal {Supprimer le filtre, {token__propertyKey} est inférieur ou égal à {token__value}} contains {Supprimer le filtre, {token__propertyKey} contient {token__value}} not_contains {Supprimer le filtre, {token__propertyKey} ne contient pas {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Choisir une version",
     "i18nStrings.inContextBrowseButton": "Parcourir S3",
     "i18nStrings.inContextViewButton": "Afficher",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Hapus filter, {token__propertyKey} sama dengan {token__value}} not_equals {Hapus filter, {token__propertyKey} tidak sama dengan {token__value}} greater_than {Hapus filter, {token__propertyKey} lebih besar dari {token__value}} greater_than_equal {Hapus filter, {token__propertyKey} lebih besar dari atau sama dengan {token__value}} less_than {Hapus filter, {token__propertyKey} kurang dari {token__value}} less_than_equal {Hapus filter, {token__propertyKey} kurang dari atau sama dengan {token__value}} contains {Hapus filter, {token__propertyKey} berisi {token__value}} not_contains {Hapus filter, {token__propertyKey} tidak berisi {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Pilih versi",
     "i18nStrings.inContextBrowseButton": "Jelajahi S3",
     "i18nStrings.inContextViewButton": "Lihat",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Abaikan pemberitahuan"
-  },
   "[charts]": {
     "loadingText": "Memuat bagan",
     "errorText": "Data tidak dapat diambil. Coba lagi nanti.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filter data yang ditampilkan",
     "i18nStrings.filterPlaceholder": "Filter data",
     "i18nStrings.legendAriaLabel": "Legenda",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Abaikan",
     "i18nStrings.xAxisAriaRoleDescription": "sumbu x",
     "i18nStrings.yAxisAriaRoleDescription": "sumbu y"
+  },
+  "alert": {
+    "dismissAriaLabel": "Abaikan pemberitahuan"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Berikutnya",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Buka navigasi samping",
     "ariaLabels.notifications": "Notifikasi",
     "ariaLabels.tools": "Panel bantuan",
-    "ariaLabels.toolsClose": "Buka panel bantuan",
-    "ariaLabels.toolsToggle": "Tutup panel bantuan"
+    "ariaLabels.toolsClose": "Tutup panel bantuan",
+    "ariaLabels.toolsToggle": "Buka panel bantuan"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
   },
   "attribute-editor": {
-    "removeButtonText": "Hapus",
-    "i18nStrings.errorIconAriaLabel": "Kesalahan"
+    "removeButtonText": "Hapus"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Kesalahan",
     "selectedAriaLabel": "Dipilih",
-    "enteredTextLabel": "Gunakan {value}",
+    "enteredTextLabel": "Gunakan: \"{value}\"",
     "recoveryText": "Coba lagi"
   },
   "breadcrumb-group": {
@@ -84,13 +82,15 @@
     "stripedRowsPreference.label": "Baris bergaris",
     "stripedRowsPreference.description": "Pilih untuk menambahkan baris berbayang bergantian",
     "contentDensityPreference.label": "Mode ringkas",
-    "contentDensityPreference.description": "Pilih untuk menampilkan konten dalam mode yang lebih padat dan lebih ringkas",
+    "contentDensityPreference.description": "Pilih untuk menampilkan konten dalam mode yang lebih padat dan ringkas",
     "contentDisplayPreference.title": "Preferensi kolom",
     "contentDisplayPreference.description": "Sesuaikan visibilitas dan urutan kolom.",
     "contentDisplayPreference.dragHandleAriaLabel": "Tuas seret",
-    "contentDisplayPreference.dragHandleAriaDescription": "Gunakan tombol Spasi atau Enter untuk mengaktifkan fitur seret item, lalu gunakan tombol panah untuk memindahkan posisi item. Untuk menyelesaikan perpindahan posisi, gunakan tombol Spasi atau Enter, atau untuk membatalkan perpindahan, gunakan tombol Escape.",
+    "contentDisplayPreference.dragHandleAriaDescription": "Gunakan Spasi atau Enter untuk mengaktifkan seret item, lalu gunakan tombol panah untuk memindahkan posisi item. Untuk menyelesaikan perpindahan posisi, gunakan Spasi atau Enter, atau untuk membatalkan perpindahan, gunakan Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Mengambil item pada posisi {position} dari {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Pengurutan ulang dibatalkan"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Pengurutan ulang dibatalkan",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Memindahkan item kembali ke posisi {currentPosition} dari {total}} false {Memindahkan item ke posisi {currentPosition} dari {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item dipindahkan kembali ke posisi aslinya {initialPosition} dari {total}} false {Item dipindahkan dari posisi {initialPosition} ke posisi {finalPosition} dari {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Mode relatif",
@@ -101,14 +101,14 @@
     "i18nStrings.applyButtonLabel": "Terapkan",
     "i18nStrings.customRelativeRangeOptionLabel": "Rentang kustom",
     "i18nStrings.customRelativeRangeOptionDescription": "Atur rentang kustom pada masa lalu",
-    "i18nStrings.customRelativeRangeUnitLabel": "Unit waktu",
+    "i18nStrings.customRelativeRangeUnitLabel": "Satuan waktu",
     "i18nStrings.customRelativeRangeDurationLabel": "Durasi",
     "i18nStrings.customRelativeRangeDurationPlaceholder": "Masukkan durasi",
     "i18nStrings.startDateLabel": "Tanggal mulai",
     "i18nStrings.startTimeLabel": "Waktu mulai",
     "i18nStrings.endDateLabel": "Tanggal berakhir",
     "i18nStrings.endTimeLabel": "Waktu berakhir",
-    "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan TTTT/BB/HH. Untuk waktu, gunakan format 24 jam.",
+    "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rentang dipilih dari {startDate} hingga {endDate}",
     "i18nStrings.formatRelativeRange": "{amount, plural, one {{amount} {unit} terakhir} other {{amount} {unit} terakhir}}",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "Berhasil",
     "i18nStrings.warningIconAriaLabel": "Peringatan"
   },
-  "form": {
-    "errorIconAriaLabel": "Kesalahan"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Kesalahan"
+  },
+  "form": {
+    "errorIconAriaLabel": "Kesalahan"
   },
   "help-panel": {
     "loadingText": "Memuat konten"
@@ -137,10 +137,13 @@
     "clearAriaLabel": "Hapus"
   },
   "link": {
-    "externalIconAriaLabel": "Terbuka di tab baru"
+    "externalIconAriaLabel": "Buka di tab baru"
   },
   "modal": {
     "closeAriaLabel": "Tutup modal"
+  },
+  "multiselect": {
+    "deselectAriaLabel": "Hapus {option__label}"
   },
   "pagination": {
     "ariaLabels.nextPageLabel": "Halaman berikutnya",
@@ -148,12 +151,10 @@
     "ariaLabels.previousPageLabel": "Halaman sebelumnya"
   },
   "pie-chart": {
-    "loadingText": "Memuat bagan",
-    "errorText": "Data tidak dapat diambil. Coba lagi nanti.",
-    "recoveryText": "Coba lagi"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Hapus {option__label}"
+    "i18nStrings.detailsValue": "Nilai",
+    "i18nStrings.detailsPercentage": "Persentase",
+    "i18nStrings.chartAriaRoleDescription": "Bagan pai",
+    "i18nStrings.segmentAriaRoleDescription": "Segmen"
   },
   "popover": {
     "dismissAriaLabel": "Tutup popover"
@@ -180,16 +181,84 @@
     "i18nStrings.operatorsText": "Operator",
     "i18nStrings.propertyText": "Properti",
     "i18nStrings.tokenLimitShowFewer": "Tampilkan lebih sedikit",
-    "i18nStrings.tokenLimitShowMore": "Tampilkan lebih banyak",
+    "i18nStrings.tokenLimitShowMore": "Tampilkan selengkapnya",
     "i18nStrings.valueText": "Nilai",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Hapus filter, {token__propertyKey} sama dengan {token__value}} not_equals {Hapus filter, {token__propertyKey} tidak sama dengan {token__value}} greater_than {Hapus filter, {token__propertyKey} lebih besar dari {token__value}} greater_than_equal {Hapus filter, {token__propertyKey} lebih besar dari atau sama dengan {token__value}} less_than {Hapus filter, {token__propertyKey} kurang dari {token__value}} less_than_equal {Hapus filter, {token__propertyKey} kurang dari atau sama dengan {token__value}} contains {Hapus filter, {token__propertyKey} berisi {token__value}} not_contains {Hapus filter, {token__propertyKey} tidak berisi {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Pilih versi",
+    "i18nStrings.inContextBrowseButton": "Jelajahi S3",
+    "i18nStrings.inContextViewButton": "Lihat",
+    "i18nStrings.inContextViewButtonAriaLabel": "Lihat (buka di tab baru)",
+    "i18nStrings.inContextLoadingText": "Memuat sumber daya",
+    "i18nStrings.inContextUriLabel": "URI S3",
+    "i18nStrings.inContextVersionSelectLabel": "Versi objek",
+    "i18nStrings.modalTitle": "Pilih arsip di S3",
+    "i18nStrings.modalCancelButton": "Batalkan",
+    "i18nStrings.modalSubmitButton": "Pilih",
+    "i18nStrings.modalBreadcrumbRootItem": "Bucket S3",
+    "i18nStrings.selectionBuckets": "Bucket",
+    "i18nStrings.selectionObjects": "Objek",
+    "i18nStrings.selectionVersions": "Versi",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Temukan bucket",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Temukan objek berdasarkan prefiks",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Temukan versi",
+    "i18nStrings.selectionBucketsLoading": "Memuat bucket",
+    "i18nStrings.selectionBucketsNoItems": "Tidak ada bucket",
+    "i18nStrings.selectionObjectsLoading": "Memuat objek",
+    "i18nStrings.selectionObjectsNoItems": "Tidak ada objek",
+    "i18nStrings.selectionVersionsLoading": "Memuat versi",
+    "i18nStrings.selectionVersionsNoItems": "Tidak ada versi",
+    "i18nStrings.filteringNoMatches": "Tidak ada kecocokan",
+    "i18nStrings.filteringCantFindMatch": "Kami tidak dapat menemukan kecocokan.",
+    "i18nStrings.clearFilterButtonText": "Hapus filter",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Nama",
+    "i18nStrings.columnBucketCreationDate": "Tanggal pembuatan",
+    "i18nStrings.columnBucketRegion": "Wilayah",
+    "i18nStrings.columnObjectKey": "Kunci",
+    "i18nStrings.columnObjectLastModified": "Terakhir diubah",
+    "i18nStrings.columnObjectSize": "Ukuran",
+    "i18nStrings.columnVersionID": "ID Versi",
+    "i18nStrings.columnVersionLastModified": "Terakhir diubah",
+    "i18nStrings.columnVersionSize": "Ukuran",
+    "i18nStrings.validationPathMustBegin": "Jalur harus dimulai dengan s3://",
+    "i18nStrings.validationBucketLowerCase": "Nama bucket harus diawali dengan karakter huruf kecil atau angka.",
+    "i18nStrings.validationBucketMustNotContain": "Nama bucket tidak boleh berisi karakter huruf besar.",
+    "i18nStrings.validationBucketLength": "Nama bucket harus terdiri dari 3 hingga 63 karakter.",
+    "i18nStrings.validationBucketMustComplyDns": "Nama bucket harus mematuhi konvensi penamaan DNS.",
+    "i18nStrings.labelSortedDescending": "{columnName}, diurutkan turun",
+    "i18nStrings.labelSortedAscending": "{columnName}, diurutkan naik",
+    "i18nStrings.labelNotSorted": "{columnName}, tidak diurutkan",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Bucket",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objek",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versi",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Temukan {itemsType}",
+    "i18nStrings.labelRefresh": "Segarkan data",
+    "i18nStrings.labelBreadcrumbs": "Navigasi S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 kecocokan} other {{count} kecocokan}}"
+  },
   "select": {
     "errorIconAriaLabel": "Kesalahan",
-    "selectedAriaLabel": "Dipilih"
+    "selectedAriaLabel": "Dipilih",
+    "recoveryText": "Coba lagi"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Tutup panel",
+    "i18nStrings.openButtonAriaLabel": "Buka panel",
+    "i18nStrings.preferencesTitle": "Preferensi panel terpisah",
+    "i18nStrings.preferencesPositionLabel": "Posisi panel terpisah",
+    "i18nStrings.preferencesPositionDescription": "Pilih posisi panel terpisah default untuk layanan.",
+    "i18nStrings.preferencesPositionSide": "Samping",
+    "i18nStrings.preferencesPositionBottom": "Bawah",
+    "i18nStrings.preferencesConfirm": "Konfirmasikan",
+    "i18nStrings.preferencesCancel": "Batalkan",
+    "i18nStrings.resizeHandleAriaLabel": "Ubah ukuran panel terpisah"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Mengirimkan pengeditan",
     "ariaLabels.successfulEditLabel": "Edit berhasil",
@@ -200,9 +269,41 @@
     "i18nStrings.scrollLeftAriaLabel": "Gulir ke kiri",
     "i18nStrings.scrollRightAriaLabel": "Gulir ke kanan"
   },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Masukkan kunci",
+    "i18nStrings.valuePlaceholder": "Masukkan nilai",
+    "i18nStrings.addButton": "Tambahkan tanda baru",
+    "i18nStrings.removeButton": "Hapus",
+    "i18nStrings.removeButtonAriaLabel": "Hapus {tag__key}",
+    "i18nStrings.undoButton": "Batalkan",
+    "i18nStrings.undoPrompt": "Tanda ini akan dihapus setelah perubahan disimpan",
+    "i18nStrings.loading": "Memuat tanda yang terkait dengan sumber daya ini",
+    "i18nStrings.keyHeader": "Kunci",
+    "i18nStrings.valueHeader": "Nilai",
+    "i18nStrings.optional": "opsional",
+    "i18nStrings.keySuggestion": "Kunci tanda kustom",
+    "i18nStrings.valueSuggestion": "Nilai tanda kustom",
+    "i18nStrings.emptyTags": "Tidak ada tanda yang terkait dengan sumber daya.",
+    "i18nStrings.tooManyKeysSuggestion": "Kunci yang Anda miliki lebih banyak dari yang dapat ditampilkan",
+    "i18nStrings.tooManyValuesSuggestion": "Nilai yang Anda miliki lebih banyak dari yang dapat ditampilkan",
+    "i18nStrings.keysSuggestionLoading": "Memuat kunci tanda",
+    "i18nStrings.keysSuggestionError": "Kunci tanda tidak dapat diambil",
+    "i18nStrings.valuesSuggestionLoading": "Memuat nilai tanda",
+    "i18nStrings.valuesSuggestionError": "Nilai tanda tidak dapat diambil",
+    "i18nStrings.emptyKeyError": "Anda harus menentukan kunci tanda",
+    "i18nStrings.maxKeyCharLengthError": "Jumlah maksimum karakter yang dapat Anda gunakan dalam kunci tanda adalah 128.",
+    "i18nStrings.maxValueCharLengthError": "Jumlah maksimum karakter yang dapat Anda gunakan dalam nilai tanda adalah 256.",
+    "i18nStrings.duplicateKeyError": "Anda harus menentukan kunci tanda unik.",
+    "i18nStrings.invalidKeyError": "Kunci tidak valid. Kunci hanya dapat berisi huruf Unicode, angka, spasi kosong, dan salah satu dari karakter berikut: _.:/=+@-",
+    "i18nStrings.invalidValueError": "Nilai tidak valid. Nilai hanya dapat berisi huruf Unicode, angka, spasi kosong, dan salah satu dari karakter berikut: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "Tidak boleh diawali dengan aws:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Anda telah mencapai batas 1 tanda.} other {Anda telah mencapai batas {tagLimit} tanda.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Anda telah melampaui batas 1 tanda.} other {Anda telah melampaui batas {tagLimit} tanda.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {Anda dapat menambahkan hingga {tagLimit} tanda.}}} false {{availableTags, plural, one {Anda dapat menambahkan hingga 1 tanda lagi.} other {Anda dapat menambahkan hingga {availableTags} tanda lagi.}}} other {}}"
+  },
   "token-group": {
     "i18nStrings.limitShowFewer": "Tampilkan lebih sedikit",
-    "i18nStrings.limitShowMore": "Tampilkan lebih banyak"
+    "i18nStrings.limitShowMore": "Tampilkan selengkapnya"
   },
   "top-navigation": {
     "i18nStrings.searchIconAriaLabel": "Cari",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Avviso di disattivazione"
-  },
   "[charts]": {
     "loadingText": "Caricamento del grafico in corso",
     "errorText": "Non è stato possibile recuperare i dati. Riprova più tardi.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filtra i dati visualizzati",
     "i18nStrings.filterPlaceholder": "Filtra i dati",
     "i18nStrings.legendAriaLabel": "Legenda",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Ignora",
     "i18nStrings.xAxisAriaRoleDescription": "asse x",
     "i18nStrings.yAxisAriaRoleDescription": "asse y"
+  },
+  "alert": {
+    "dismissAriaLabel": "Avviso di disattivazione"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Successivo",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Apri navigazione laterale",
     "ariaLabels.notifications": "Notifiche",
     "ariaLabels.tools": "Pannello di aiuto",
-    "ariaLabels.toolsClose": "Apri il pannello di aiuto",
-    "ariaLabels.toolsToggle": "Chiudere il pannello di aiuto"
+    "ariaLabels.toolsClose": "Chiudi il pannello di aiuto",
+    "ariaLabels.toolsToggle": "Apri il pannello di aiuto"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Totale"
   },
   "attribute-editor": {
-    "removeButtonText": "Rimuovi",
-    "i18nStrings.errorIconAriaLabel": "Errore"
+    "removeButtonText": "Rimuovi"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Errore",
     "selectedAriaLabel": "Selezionato",
-    "enteredTextLabel": "Utilizza {value}",
+    "enteredTextLabel": "Utilizza: «{value}»",
     "recoveryText": "Riprova"
   },
   "breadcrumb-group": {
@@ -72,7 +70,7 @@
     "i18nStrings.preferencesModalWrapLines": "Righe a capo",
     "i18nStrings.preferencesModalTheme": "Tema",
     "i18nStrings.preferencesModalLightThemes": "Temi chiari",
-    "i18nStrings.preferencesModalDarkThemes": "Tema scuro"
+    "i18nStrings.preferencesModalDarkThemes": "Temi scuri"
   },
   "collection-preferences": {
     "title": "Preferenze",
@@ -88,9 +86,11 @@
     "contentDisplayPreference.title": "Preferenze di colonna",
     "contentDisplayPreference.description": "Personalizza la visibilità e l'ordine delle colonne.",
     "contentDisplayPreference.dragHandleAriaLabel": "Punto di trascinamento",
-    "contentDisplayPreference.dragHandleAriaDescription": "Utilizza Space (Spazio) o Enter (Invio) per attivare il trascinamento di un elemento, quindi usa i tasti freccia per spostare la posizione dell'elemento. Per completare lo spostamento della posizione, utilizza Space (Spazio) o Enter (Invio) oppure per annullare lo spostamento, usare Escape (Esc).",
+    "contentDisplayPreference.dragHandleAriaDescription": "Utilizza Spazio o Invio per attivare il trascinamento di un elemento, quindi usa i tasti freccia per spostare la posizione dell'elemento. Per completare lo spostamento della posizione, utilizza Spazio o Invio oppure per annullare lo spostamento, usa Esc.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Elemento raccolto nella posizione {position} di {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Riordinamento annullato"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Riordinamento annullato",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Spostamento dell'elemento di nuovo nella posizione {currentPosition} di {total}} false {Spostamento dell'elemento nella posizione {currentPosition} di {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'elemento è stato spostato di nuovo nella posizione originale {initialPosition} di {total}} false {Elemento spostato da una posizione {initialPosition} alla posizione {finalPosition} di {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modalità relativa",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "Esito positivo",
     "i18nStrings.warningIconAriaLabel": "Avviso"
   },
-  "form": {
-    "errorIconAriaLabel": "Errore"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Errore"
+  },
+  "form": {
+    "errorIconAriaLabel": "Errore"
   },
   "help-panel": {
     "loadingText": "Caricamento dei contenuti"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Chiudi modale"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Rimuovi {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Pagina successiva",
     "ariaLabels.pageLabel": "Pagina {pageNumber} di tutte le pagine",
     "ariaLabels.previousPageLabel": "Pagina precedente"
   },
   "pie-chart": {
-    "loadingText": "Caricamento del grafico in corso",
-    "errorText": "Non è stato possibile recuperare i dati. Riprova più tardi.",
-    "recoveryText": "Riprova"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Rimuovi {option__label}"
+    "i18nStrings.detailsValue": "Valore",
+    "i18nStrings.detailsPercentage": "Percentuale",
+    "i18nStrings.chartAriaRoleDescription": "Grafico a torta",
+    "i18nStrings.segmentAriaRoleDescription": "Segmento"
   },
   "popover": {
     "dismissAriaLabel": "Chiudi popover"
@@ -182,23 +183,123 @@
     "i18nStrings.tokenLimitShowFewer": "Mostra meno",
     "i18nStrings.tokenLimitShowMore": "Mostra altro",
     "i18nStrings.valueText": "Valore",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Rimuovi filtro {token__propertyKey}, uguale a {token__value}} not_equals {Rimuovi filtro, {token__propertyKey} non è uguale a {token__value}} greater_than {Rimuovi filtro, {token__propertyKey} è maggiore di {token__value}} greater_than_equal {Rimuovi filtro, {token__propertyKey} è maggiore o uguale a {token__value}} less_than {Rimuovi filtro, {token__propertyKey} è inferiore a {token__value}} less_than_equal {Rimuovi filtro, {token__propertyKey} è minore o uguale a {token__value}} contains {Rimuovi filtro, {token__propertyKey} contiene {token__value}} not_contains {Rimuovi filtro, {token__propertyKey} non contiene {token__value}} other {}}"
+    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Rimuovi filtro, {token__propertyKey} uguale a {token__value}} not_equals {Rimuovi filtro, {token__propertyKey} non è uguale a {token__value}} greater_than {Rimuovi filtro, {token__propertyKey} è maggiore di {token__value}} greater_than_equal {Rimuovi filtro, {token__propertyKey} è maggiore o uguale a {token__value}} less_than {Rimuovi filtro, {token__propertyKey} è inferiore a {token__value}} less_than_equal {Rimuovi filtro, {token__propertyKey} è minore o uguale a {token__value}} contains {Rimuovi filtro, {token__propertyKey} contiene {token__value}} not_contains {Rimuovi filtro, {token__propertyKey} non contiene {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Scegli una versione",
+    "i18nStrings.inContextBrowseButton": "Sfoglia S3",
+    "i18nStrings.inContextViewButton": "Visualizza",
+    "i18nStrings.inContextViewButtonAriaLabel": "Visualizza (si apre in una nuova scheda)",
+    "i18nStrings.inContextLoadingText": "Caricamento delle risorse in corso",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "Versione dell’oggetto",
+    "i18nStrings.modalTitle": "Scegli un archivio in S3",
+    "i18nStrings.modalCancelButton": "Annulla",
+    "i18nStrings.modalSubmitButton": "Scegli",
+    "i18nStrings.modalBreadcrumbRootItem": "Bucket S3",
+    "i18nStrings.selectionBuckets": "Bucket",
+    "i18nStrings.selectionObjects": "Oggetti",
+    "i18nStrings.selectionVersions": "Versioni",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Trova bucket",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Trova oggetto per prefisso",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Trova versione",
+    "i18nStrings.selectionBucketsLoading": "Caricamento dei bucket in corso",
+    "i18nStrings.selectionBucketsNoItems": "Nessun bucket",
+    "i18nStrings.selectionObjectsLoading": "Caricamento di oggetti in corso",
+    "i18nStrings.selectionObjectsNoItems": "Nessun oggetto",
+    "i18nStrings.selectionVersionsLoading": "Caricamento delle versioni in corso",
+    "i18nStrings.selectionVersionsNoItems": "Nessuna versione",
+    "i18nStrings.filteringNoMatches": "Nessuna corrispondenza",
+    "i18nStrings.filteringCantFindMatch": "Impossibile trovare una corrispondenza.",
+    "i18nStrings.clearFilterButtonText": "Cancella filtro",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Nome",
+    "i18nStrings.columnBucketCreationDate": "Data di creazione",
+    "i18nStrings.columnBucketRegion": "Regione",
+    "i18nStrings.columnObjectKey": "Chiave",
+    "i18nStrings.columnObjectLastModified": "Ultima modifica",
+    "i18nStrings.columnObjectSize": "Dimensione",
+    "i18nStrings.columnVersionID": "ID Versione",
+    "i18nStrings.columnVersionLastModified": "Ultima modifica",
+    "i18nStrings.columnVersionSize": "Dimensione",
+    "i18nStrings.validationPathMustBegin": "Il percorso deve iniziare con s3://",
+    "i18nStrings.validationBucketLowerCase": "Il nome del bucket deve iniziare con un carattere minuscolo o un numero.",
+    "i18nStrings.validationBucketMustNotContain": "Il nome del bucket non deve contenere caratteri maiuscoli.",
+    "i18nStrings.validationBucketLength": "Il nome del bucket deve contenere da 3 a 63 caratteri.",
+    "i18nStrings.validationBucketMustComplyDns": "Il nome del bucket deve essere conforme alle convenzioni di denominazione DNS.",
+    "i18nStrings.labelSortedDescending": "{columnName}, ordinati in ordine decrescente",
+    "i18nStrings.labelSortedAscending": "{columnName}, ordinati in ordine ascendente",
+    "i18nStrings.labelNotSorted": "{columnName}, non ordinati",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Bucket",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Oggetti",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versioni",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Trova {itemsType}",
+    "i18nStrings.labelRefresh": "Aggiorna i dati",
+    "i18nStrings.labelBreadcrumbs": "Navigazione S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 corrispondenza} other {{count} corrispondenze}}"
+  },
   "select": {
     "errorIconAriaLabel": "Errore",
-    "selectedAriaLabel": "Selezionato"
+    "selectedAriaLabel": "Selezionato",
+    "recoveryText": "Riprova"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Chiudi pannello",
+    "i18nStrings.openButtonAriaLabel": "Apri pannello",
+    "i18nStrings.preferencesTitle": "Preferenze del pannello diviso",
+    "i18nStrings.preferencesPositionLabel": "Posizione del pannello diviso",
+    "i18nStrings.preferencesPositionDescription": "Scegli la posizione predefinita del pannello diviso per il servizio.",
+    "i18nStrings.preferencesPositionSide": "Lato",
+    "i18nStrings.preferencesPositionBottom": "Parte inferiore",
+    "i18nStrings.preferencesConfirm": "Conferma",
+    "i18nStrings.preferencesCancel": "Annulla",
+    "i18nStrings.resizeHandleAriaLabel": "Ridimensiona il pannello diviso"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Invio della modifica in corso",
-    "ariaLabels.successfulEditLabel": "Modifica riuscita",
+    "ariaLabels.successfulEditLabel": "Modifica eseguita correttamente",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Errore",
-    "columnDefinitions.editConfig.editIconAriaLabel": "Modificabile"
+    "columnDefinitions.editConfig.editIconAriaLabel": "modificabile"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Scorri a sinistra",
     "i18nStrings.scrollRightAriaLabel": "Scorri a destra"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Inserisci chiave",
+    "i18nStrings.valuePlaceholder": "Inserisci valore",
+    "i18nStrings.addButton": "Aggiungi nuovo tag",
+    "i18nStrings.removeButton": "Rimuovi",
+    "i18nStrings.removeButtonAriaLabel": "Rimuovi {tag__key}",
+    "i18nStrings.undoButton": "Annulla",
+    "i18nStrings.undoPrompt": "Questo tag verrà rimosso al momento del salvataggio delle modifiche",
+    "i18nStrings.loading": "Caricamento dei tag associati a questa risorsa",
+    "i18nStrings.keyHeader": "Chiave",
+    "i18nStrings.valueHeader": "Valore",
+    "i18nStrings.optional": "facoltativo",
+    "i18nStrings.keySuggestion": "Chiave di tag personalizzata",
+    "i18nStrings.valueSuggestion": "Valore di tag personalizzato",
+    "i18nStrings.emptyTags": "Nessun tag associato alla risorsa.",
+    "i18nStrings.tooManyKeysSuggestion": "Hai più chiavi di quelle che possono essere visualizzate",
+    "i18nStrings.tooManyValuesSuggestion": "Hai più valori di quelli che possono essere visualizzati",
+    "i18nStrings.keysSuggestionLoading": "Caricamento delle chiavi dei tag",
+    "i18nStrings.keysSuggestionError": "Impossibile recuperare le chiavi dei tag",
+    "i18nStrings.valuesSuggestionLoading": "Caricamento dei valori dei tag",
+    "i18nStrings.valuesSuggestionError": "Impossibile recuperare i valori dei tag",
+    "i18nStrings.emptyKeyError": "Devi specificare una chiave di tag",
+    "i18nStrings.maxKeyCharLengthError": "Il numero massimo di caratteri che è possibile utilizzare in una chiave di tag è 128.",
+    "i18nStrings.maxValueCharLengthError": "Il numero massimo di caratteri che è possibile utilizzare in un valore di tag è 256.",
+    "i18nStrings.duplicateKeyError": "Devi specificare una chiave di tag univoca.",
+    "i18nStrings.invalidKeyError": "Chiave non valida. Le chiavi possono contenere solo caratteri Unicode, lettere, spazi e uno dei seguenti: _.:/=+@-",
+    "i18nStrings.invalidValueError": "Valore non valido. I valori possono contenere solo caratteri Unicode, lettere, spazi e uno dei seguenti: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "Impossibile iniziare con aws:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Hai raggiunto il limite di 1 tag.} other {Hai raggiunto il limite di {tagLimit} tag.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Hai superato il limite di 1 tag.} other {Hai superato il limite di {tagLimit} tag.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {È possibile aggiungere fino a {tagLimit} tag.}}} false {{availableTags, plural, one {È possibile aggiungere al massimo 1 altro tag.} other {È possibile aggiungere fino a {availableTags} altri tag.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Mostra meno",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Rimuovi filtro, {token__propertyKey} uguale a {token__value}} not_equals {Rimuovi filtro, {token__propertyKey} non è uguale a {token__value}} greater_than {Rimuovi filtro, {token__propertyKey} è maggiore di {token__value}} greater_than_equal {Rimuovi filtro, {token__propertyKey} è maggiore o uguale a {token__value}} less_than {Rimuovi filtro, {token__propertyKey} è inferiore a {token__value}} less_than_equal {Rimuovi filtro, {token__propertyKey} è minore o uguale a {token__value}} contains {Rimuovi filtro, {token__propertyKey} contiene {token__value}} not_contains {Rimuovi filtro, {token__propertyKey} non contiene {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Scegli una versione",
     "i18nStrings.inContextBrowseButton": "Sfoglia S3",
     "i18nStrings.inContextViewButton": "Visualizza",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {フィルターを削除、{token__propertyKey} は {token__value} と等しい} not_equals {フィルターを削除、{token__propertyKey} は {token__value} と等しくない} greater_than {フィルターを削除、{token__propertyKey} は {token__value} より大きい} greater_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以上} less_than {フィルターを削除、{token__propertyKey} は {token__value} 未満} less_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以下} contains {フィルターを削除、{token__propertyKey} は {token__value} を含む} not_contains {フィルターを削除、{token__propertyKey} は {token__value} を含まない} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "バージョンを選択してください",
     "i18nStrings.inContextBrowseButton": "S3 を参照",
     "i18nStrings.inContextViewButton": "表示",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "アラートを閉じる"
-  },
   "[charts]": {
     "loadingText": "グラフのロード中",
     "errorText": "データを取得できませんでした。後でもう一度お試しください。",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "表示されたデータをフィルタリング",
     "i18nStrings.filterPlaceholder": "データをフィルタリング",
     "i18nStrings.legendAriaLabel": "凡例",
-    "i18nStrings.detailPopoverDismissAriaLabel": "閉じる",
-    "i18nStrings.xAxisAriaRoleDescription": "x 軸",
-    "i18nStrings.yAxisAriaRoleDescription": "y 軸"
+    "i18nStrings.xAxisAriaRoleDescription": "x-軸",
+    "i18nStrings.yAxisAriaRoleDescription": "y-軸"
+  },
+  "alert": {
+    "dismissAriaLabel": "アラートを閉じる"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "次へ",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "サイドナビゲーションを開く",
     "ariaLabels.notifications": "通知",
     "ariaLabels.tools": "ヘルプパネル",
-    "ariaLabels.toolsClose": "ヘルプパネルを開く",
-    "ariaLabels.toolsToggle": "ヘルプパネルを閉じる"
+    "ariaLabels.toolsClose": "ヘルプパネルを閉じる",
+    "ariaLabels.toolsToggle": "ヘルプパネルを開く"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "合計"
   },
   "attribute-editor": {
-    "removeButtonText": "削除",
-    "i18nStrings.errorIconAriaLabel": "エラー"
+    "removeButtonText": "削除"
   },
   "autosuggest": {
     "errorIconAriaLabel": "エラー",
     "selectedAriaLabel": "選択済み",
-    "enteredTextLabel": "使用: {value}",
+    "enteredTextLabel": "使用:「{value}」",
     "recoveryText": "再試行"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "ドラッグハンドル",
     "contentDisplayPreference.dragHandleAriaDescription": "Space または Enter を使用して項目のドラッグをアクティブ化し、矢印キーを使用して項目の位置を移動します。位置の移動を完了するには、Space または Enter を使用します。移動を取り消すには、Escape を使用します。",
     "contentDisplayPreference.liveAnnouncementDndStarted": "{position}/{total} の位置で項目をピックアップしました",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "順序変更をキャンセルしました"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "順序変更をキャンセルしました",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {項目を位置 {currentPosition}/{total} に戻しています} false {項目を位置 {currentPosition}/{total} に移動しています} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目は元の位置 {initialPosition}/{total} に戻りました} false {項目が位置 {initialPosition} から位置 {finalPosition}/{total} に移動しました} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相対モード",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": {
-    "errorIconAriaLabel": "エラー"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "エラー"
+  },
+  "form": {
+    "errorIconAriaLabel": "エラー"
   },
   "help-panel": {
     "loadingText": "コンテンツのロード中"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "モーダルを閉じる"
   },
+  "multiselect": {
+    "deselectAriaLabel": "{option__label} を削除"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "次のページ",
     "ariaLabels.pageLabel": "全ページ中 {pageNumber} ページ",
     "ariaLabels.previousPageLabel": "前のページ"
   },
   "pie-chart": {
-    "loadingText": "グラフのロード中",
-    "errorText": "データを取得できませんでした。後でもう一度お試しください。",
-    "recoveryText": "再試行"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "{option__label} を削除"
+    "i18nStrings.detailsValue": "値",
+    "i18nStrings.detailsPercentage": "パーセンテージ",
+    "i18nStrings.chartAriaRoleDescription": "円グラフ",
+    "i18nStrings.segmentAriaRoleDescription": "セグメント"
   },
   "popover": {
     "dismissAriaLabel": "ポップオーバーを閉じる"
@@ -172,10 +173,10 @@
     "i18nStrings.operatorDoesNotContainText": "次を含まない:",
     "i18nStrings.operatorDoesNotEqualText": "次と等しくない:",
     "i18nStrings.operatorEqualsText": "次と等しい:",
-    "i18nStrings.operatorGreaterOrEqualText": "次以上:",
-    "i18nStrings.operatorGreaterText": "次より大きい:",
-    "i18nStrings.operatorLessOrEqualText": "次以下:",
-    "i18nStrings.operatorLessText": "次未満:",
+    "i18nStrings.operatorGreaterOrEqualText": "次以上",
+    "i18nStrings.operatorGreaterText": "次より大きい",
+    "i18nStrings.operatorLessOrEqualText": "次以下",
+    "i18nStrings.operatorLessText": "次より少ない",
     "i18nStrings.operatorText": "演算子",
     "i18nStrings.operatorsText": "演算子",
     "i18nStrings.propertyText": "プロパティ",
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "値",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {フィルターを削除、{token__propertyKey} は {token__value} と等しい} not_equals {フィルターを削除、{token__propertyKey} は {token__value} と等しくない} greater_than {フィルターを削除、{token__propertyKey} は {token__value} より大きい} greater_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以上} less_than {フィルターを削除、{token__propertyKey} は {token__value} 未満} less_than_equal {フィルターを削除、{token__propertyKey} は {token__value} 以下} contains {フィルターを削除、{token__propertyKey} は {token__value} を含む} not_contains {フィルターを削除、{token__propertyKey} は {token__value} を含まない} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "バージョンを選択してください",
+    "i18nStrings.inContextBrowseButton": "S3 を参照",
+    "i18nStrings.inContextViewButton": "表示",
+    "i18nStrings.inContextViewButtonAriaLabel": "表示 (新しいタブで開きます)",
+    "i18nStrings.inContextLoadingText": "リソースのロード中",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "オブジェクトのバージョン",
+    "i18nStrings.modalTitle": "S3 のアーカイブを選択",
+    "i18nStrings.modalCancelButton": "キャンセル",
+    "i18nStrings.modalSubmitButton": "選択",
+    "i18nStrings.modalBreadcrumbRootItem": "S3 バケット",
+    "i18nStrings.selectionBuckets": "バケット",
+    "i18nStrings.selectionObjects": "オブジェクト",
+    "i18nStrings.selectionVersions": "バージョン",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "バケットを検索します",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "プレフィックスでオブジェクトを検索します",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "バージョンを検索します",
+    "i18nStrings.selectionBucketsLoading": "バケットのロード中",
+    "i18nStrings.selectionBucketsNoItems": "バケットなし",
+    "i18nStrings.selectionObjectsLoading": "オブジェクトのロード中",
+    "i18nStrings.selectionObjectsNoItems": "オブジェクトなし",
+    "i18nStrings.selectionVersionsLoading": "バージョンのロード中",
+    "i18nStrings.selectionVersionsNoItems": "バージョンなし",
+    "i18nStrings.filteringNoMatches": "一致なし",
+    "i18nStrings.filteringCantFindMatch": "一致が見つかりません。",
+    "i18nStrings.clearFilterButtonText": "フィルターをクリア",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "名前",
+    "i18nStrings.columnBucketCreationDate": "作成日",
+    "i18nStrings.columnBucketRegion": "リージョン",
+    "i18nStrings.columnObjectKey": "キー",
+    "i18nStrings.columnObjectLastModified": "最終更新日",
+    "i18nStrings.columnObjectSize": "サイズ",
+    "i18nStrings.columnVersionID": "バージョン ID",
+    "i18nStrings.columnVersionLastModified": "最終更新日",
+    "i18nStrings.columnVersionSize": "サイズ",
+    "i18nStrings.validationPathMustBegin": "パスの先頭は s3:// である必要があります",
+    "i18nStrings.validationBucketLowerCase": "バケット名の先頭は小文字または数字である必要があります。",
+    "i18nStrings.validationBucketMustNotContain": "バケット名には大文字を使用できません。",
+    "i18nStrings.validationBucketLength": "バケット名は 3～63 文字である必要があります。",
+    "i18nStrings.validationBucketMustComplyDns": "バケット名は DNS 命名規則に準拠している必要があります。",
+    "i18nStrings.labelSortedDescending": "{columnName} (降順でソート)",
+    "i18nStrings.labelSortedAscending": "{columnName} (昇順でソート)",
+    "i18nStrings.labelNotSorted": "{columnName} (ソートなし)",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "バケット",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "オブジェクト",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "バージョン",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "{itemsType} を検索",
+    "i18nStrings.labelRefresh": "データを更新",
+    "i18nStrings.labelBreadcrumbs": "S3 ナビゲーション",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 件の一致} other {{count} 件の一致}}"
+  },
   "select": {
     "errorIconAriaLabel": "エラー",
-    "selectedAriaLabel": "選択済み"
+    "selectedAriaLabel": "選択済み",
+    "recoveryText": "再試行"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "パネルを閉じる",
+    "i18nStrings.openButtonAriaLabel": "パネルを開く",
+    "i18nStrings.preferencesTitle": "分割パネルの詳細設定",
+    "i18nStrings.preferencesPositionLabel": "分割パネルの位置",
+    "i18nStrings.preferencesPositionDescription": "サービスの分割パネルのデフォルトの位置を選択します。",
+    "i18nStrings.preferencesPositionSide": "横",
+    "i18nStrings.preferencesPositionBottom": "下",
+    "i18nStrings.preferencesConfirm": "確認",
+    "i18nStrings.preferencesCancel": "キャンセル",
+    "i18nStrings.resizeHandleAriaLabel": "分割パネルのサイズを変更"
+  },
   "table": {
     "ariaLabels.submittingEditText": "編集を送信中",
     "ariaLabels.successfulEditLabel": "編集に成功しました",
     "columnDefinitions.editConfig.errorIconAriaLabel": "エラー",
-    "columnDefinitions.editConfig.editIconAriaLabel": "dditable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "編集可能"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "左にスクロール",
     "i18nStrings.scrollRightAriaLabel": "右にスクロール"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "キーを入力",
+    "i18nStrings.valuePlaceholder": "値を入力",
+    "i18nStrings.addButton": "新しいタグを追加",
+    "i18nStrings.removeButton": "削除",
+    "i18nStrings.removeButtonAriaLabel": "{tag__key} を削除",
+    "i18nStrings.undoButton": "元に戻す",
+    "i18nStrings.undoPrompt": "このタグは、変更を保存すると削除されます",
+    "i18nStrings.loading": "このリソースに関連付けられているタグをロードしています",
+    "i18nStrings.keyHeader": "キー",
+    "i18nStrings.valueHeader": "値",
+    "i18nStrings.optional": "オプション",
+    "i18nStrings.keySuggestion": "カスタムのタグキー",
+    "i18nStrings.valueSuggestion": "カスタムのタグ値",
+    "i18nStrings.emptyTags": "リソースに関連付けられたタグがありません。",
+    "i18nStrings.tooManyKeysSuggestion": "表示できる数を超えるキーがあります",
+    "i18nStrings.tooManyValuesSuggestion": "表示できる数を超える値があります",
+    "i18nStrings.keysSuggestionLoading": "タグキーをロードしています",
+    "i18nStrings.keysSuggestionError": "タグキーを取得できませんでした",
+    "i18nStrings.valuesSuggestionLoading": "タグ値をロードしています",
+    "i18nStrings.valuesSuggestionError": "タグ値を取得できませんでした",
+    "i18nStrings.emptyKeyError": "タグキーを指定してください",
+    "i18nStrings.maxKeyCharLengthError": "タグキーには最大 128 文字を使用できます。",
+    "i18nStrings.maxValueCharLengthError": "タグ値には最大 256 文字を使用できます。",
+    "i18nStrings.duplicateKeyError": "一意のタグキーを指定してください。",
+    "i18nStrings.invalidKeyError": "無効なキー。キーには、Unicode 文字、数字、空白、および次のいずれかのみを含めることができます: _.:/=+@-",
+    "i18nStrings.invalidValueError": "無効な値。値には、Unicode 文字、数字、空白、および次のいずれかのみを含めることができます: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "aws: で始めることはできません",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {タグの上限数である 1 個に達しました。} other {タグの上限数である {tagLimit} 個に達しました。}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {タグの上限数である 1 個を超えました。} other {タグの上限数である {tagLimit} 個を超えました。}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {最大 {tagLimit} 個のタグを追加できます。}}} false {{availableTags, plural, one {最大 1 個のタグをさらに追加できます。} other {最大 {availableTags} 個のタグをさらに追加できます。}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "少なく表示",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "알림 무시"
-  },
   "[charts]": {
     "loadingText": "차트 로드 중",
     "errorText": "데이터를 가져올 수 없습니다. 나중에 다시 시도하세요.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "표시된 데이터 필터링",
     "i18nStrings.filterPlaceholder": "데이터 필터링",
     "i18nStrings.legendAriaLabel": "범례",
-    "i18nStrings.detailPopoverDismissAriaLabel": "무시",
     "i18nStrings.xAxisAriaRoleDescription": "x축",
     "i18nStrings.yAxisAriaRoleDescription": "y축"
+  },
+  "alert": {
+    "dismissAriaLabel": "알림 무시"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "다음",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "측면 탐색 열기",
     "ariaLabels.notifications": "알림",
     "ariaLabels.tools": "도움말 창",
-    "ariaLabels.toolsClose": "도움말 창 열기",
-    "ariaLabels.toolsToggle": "도움말 창 닫기"
+    "ariaLabels.toolsClose": "도움말 창 닫기",
+    "ariaLabels.toolsToggle": "도움말 창 열기"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "합계"
   },
   "attribute-editor": {
-    "removeButtonText": "제거",
-    "i18nStrings.errorIconAriaLabel": "오류"
+    "removeButtonText": "제거"
   },
   "autosuggest": {
     "errorIconAriaLabel": "오류",
     "selectedAriaLabel": "선택됨",
-    "enteredTextLabel": "{value} 사용",
+    "enteredTextLabel": "사용: ‘{value}’",
     "recoveryText": "재시도"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "핸들 끌기",
     "contentDisplayPreference.dragHandleAriaDescription": "스페이스 또는 Enter를 사용하여 항목 끌기 기능을 활성화하고 화살표 키를 사용하여 항목의 위치를 이동합니다. 위치 이동을 완료하려면 스페이스 또는 Enter를 사용하거나 이동을 취소하려면 Escape를 사용합니다.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "{position}/{total}개 위치에서 선택한 항목",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "재정렬 취소됨"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "재정렬 취소됨",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {{currentPosition}/{total} 위치로 항목 다시 이동} false {{currentPosition}/{total} 위치로 항목 이동} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {항목이 원래 위치인 {initialPosition}/{total} 위치로 다시 이동됨} false {항목이 {initialPosition}/{total} 위치에서 인 {finalPosition}/{total} 위치로 이동됨} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "상대 모드",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "성공",
     "i18nStrings.warningIconAriaLabel": "경고"
   },
-  "form": {
-    "errorIconAriaLabel": "오류"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "오류"
+  },
+  "form": {
+    "errorIconAriaLabel": "오류"
   },
   "help-panel": {
     "loadingText": "콘텐츠 로드 중"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "모달 닫기"
   },
+  "multiselect": {
+    "deselectAriaLabel": "{option__label} 제거"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "다음 페이지",
     "ariaLabels.pageLabel": "전체 페이지 중 {pageNumber}페이지",
     "ariaLabels.previousPageLabel": "이전 페이지"
   },
   "pie-chart": {
-    "loadingText": "차트 로드 중",
-    "errorText": "데이터를 가져올 수 없습니다. 나중에 다시 시도하세요.",
-    "recoveryText": "재시도"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "{option__label} 제거"
+    "i18nStrings.detailsValue": "값",
+    "i18nStrings.detailsPercentage": "백분율",
+    "i18nStrings.chartAriaRoleDescription": "원형 차트",
+    "i18nStrings.segmentAriaRoleDescription": "세그먼트"
   },
   "popover": {
     "dismissAriaLabel": "팝오버 닫기"
@@ -179,17 +180,85 @@
     "i18nStrings.operatorText": "연산자",
     "i18nStrings.operatorsText": "연산자",
     "i18nStrings.propertyText": "속성",
-    "i18nStrings.tokenLimitShowFewer": "더 적게 보기",
-    "i18nStrings.tokenLimitShowMore": "더 많이 보기",
+    "i18nStrings.tokenLimitShowFewer": "간단히 표시",
+    "i18nStrings.tokenLimitShowMore": "자세히 표시",
     "i18nStrings.valueText": "값",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {{token__propertyKey}이(가) {token__value}과(와) 같음 필터 제거} not_equals {{token__propertyKey}이(가) {token__value}과(와) 같지 않음 필터 제거} greater_than {{token__propertyKey}이(가) {token__value}보다 큼 필터 제거} greater_than_equal {{token__propertyKey}이(가) {token__value}보다 크거나 같음 필터 제거} less_than {{token__propertyKey}이(가) {token__value}보다 작음 필터 제거} less_than_equal {{token__propertyKey}이(가) {token__value}보다 작거나 같음 필터 제거} contains {{token__propertyKey}이(가) {token__value}을(를) 포함함 필터 제거} not_contains {{token__propertyKey}이(가) {token__value}을(를) 포함하지 않음 필터 제거} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "버전 선택",
+    "i18nStrings.inContextBrowseButton": "S3 둘러보기",
+    "i18nStrings.inContextViewButton": "보기",
+    "i18nStrings.inContextViewButtonAriaLabel": "보기(새 탭에서 열림)",
+    "i18nStrings.inContextLoadingText": "리소스 로드 중",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "객체 버전",
+    "i18nStrings.modalTitle": "S3에서 아카이브 선택",
+    "i18nStrings.modalCancelButton": "취소",
+    "i18nStrings.modalSubmitButton": "선택",
+    "i18nStrings.modalBreadcrumbRootItem": "S3 버킷",
+    "i18nStrings.selectionBuckets": "버킷",
+    "i18nStrings.selectionObjects": "객체",
+    "i18nStrings.selectionVersions": "버전",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "버킷 찾기",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "접두사로 객체 찾기",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "버전 찾기",
+    "i18nStrings.selectionBucketsLoading": "버킷 로드 중",
+    "i18nStrings.selectionBucketsNoItems": "버킷 없음",
+    "i18nStrings.selectionObjectsLoading": "객체 로드 중",
+    "i18nStrings.selectionObjectsNoItems": "객체 없음",
+    "i18nStrings.selectionVersionsLoading": "버전 로드 중",
+    "i18nStrings.selectionVersionsNoItems": "버전 없음",
+    "i18nStrings.filteringNoMatches": "일치 항목 없음",
+    "i18nStrings.filteringCantFindMatch": "일치 항목을 찾을 수 없습니다.",
+    "i18nStrings.clearFilterButtonText": "필터 지우기",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "이름",
+    "i18nStrings.columnBucketCreationDate": "생성 날짜",
+    "i18nStrings.columnBucketRegion": "리전",
+    "i18nStrings.columnObjectKey": "키",
+    "i18nStrings.columnObjectLastModified": "최종 수정 날짜",
+    "i18nStrings.columnObjectSize": "크기",
+    "i18nStrings.columnVersionID": "버전 ID",
+    "i18nStrings.columnVersionLastModified": "최종 수정 날짜",
+    "i18nStrings.columnVersionSize": "크기",
+    "i18nStrings.validationPathMustBegin": "경로는 s3://로 시작해야 합니다.",
+    "i18nStrings.validationBucketLowerCase": "버킷 이름은 소문자나 숫자로 시작해야 합니다.",
+    "i18nStrings.validationBucketMustNotContain": "버킷 이름에 대문자를 포함할 수 없습니다.",
+    "i18nStrings.validationBucketLength": "버킷 이름은 3~63자여야 합니다.",
+    "i18nStrings.validationBucketMustComplyDns": "버킷 이름은 DNS 명명 규칙을 준수해야 합니다.",
+    "i18nStrings.labelSortedDescending": "{columnName}, 내림차순 정렬",
+    "i18nStrings.labelSortedAscending": "{columnName}, 오름차순 정렬",
+    "i18nStrings.labelNotSorted": "{columnName}, 정렬되지 않음",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "버킷",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "객체",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "버전",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "{itemsType} 찾기",
+    "i18nStrings.labelRefresh": "데이터 새로고침",
+    "i18nStrings.labelBreadcrumbs": "S3 탐색",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1개 일치} other {{count}개 일치}}"
+  },
   "select": {
     "errorIconAriaLabel": "오류",
-    "selectedAriaLabel": "선택됨"
+    "selectedAriaLabel": "선택됨",
+    "recoveryText": "재시도"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "패널 닫기",
+    "i18nStrings.openButtonAriaLabel": "패널 열기",
+    "i18nStrings.preferencesTitle": "분할 패널 환경 설정",
+    "i18nStrings.preferencesPositionLabel": "분할 패널 위치",
+    "i18nStrings.preferencesPositionDescription": "서비스의 기본 분할 패널 위치를 선택합니다.",
+    "i18nStrings.preferencesPositionSide": "측면",
+    "i18nStrings.preferencesPositionBottom": "하단",
+    "i18nStrings.preferencesConfirm": "확인",
+    "i18nStrings.preferencesCancel": "취소",
+    "i18nStrings.resizeHandleAriaLabel": "분할 패널 크기 조정"
+  },
   "table": {
     "ariaLabels.submittingEditText": "편집 제출 중",
     "ariaLabels.successfulEditLabel": "편집 성공",
@@ -199,6 +268,38 @@
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "왼쪽으로 스크롤",
     "i18nStrings.scrollRightAriaLabel": "오른쪽으로 스크롤"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "키 입력",
+    "i18nStrings.valuePlaceholder": "값 입력",
+    "i18nStrings.addButton": "새 태그 추가",
+    "i18nStrings.removeButton": "제거",
+    "i18nStrings.removeButtonAriaLabel": "{tag__key} 제거",
+    "i18nStrings.undoButton": "실행 취소",
+    "i18nStrings.undoPrompt": "이 태그는 변경 사항을 저장할 때 제거됩니다.",
+    "i18nStrings.loading": "이 리소스와 연결된 태그를 로드하는 중",
+    "i18nStrings.keyHeader": "키",
+    "i18nStrings.valueHeader": "값",
+    "i18nStrings.optional": "선택 사항",
+    "i18nStrings.keySuggestion": "사용자 지정 태그 키",
+    "i18nStrings.valueSuggestion": "사용자 지정 태그 값",
+    "i18nStrings.emptyTags": "리소스와 연결된 태그가 없습니다.",
+    "i18nStrings.tooManyKeysSuggestion": "표시할 수 있는 것보다 많은 키가 있습니다.",
+    "i18nStrings.tooManyValuesSuggestion": "표시할 수 있는 것보다 많은 값이 있습니다.",
+    "i18nStrings.keysSuggestionLoading": "태그 키 로드 중",
+    "i18nStrings.keysSuggestionError": "태그 키를 검색할 수 없음",
+    "i18nStrings.valuesSuggestionLoading": "태그 값 로드 중",
+    "i18nStrings.valuesSuggestionError": "태그 값을 검색할 수 없음",
+    "i18nStrings.emptyKeyError": "태그 키를 지정해야 합니다.",
+    "i18nStrings.maxKeyCharLengthError": "태그 키에 사용할 수 있는 최대 문자 수는 128자입니다.",
+    "i18nStrings.maxValueCharLengthError": "태그 값에 사용할 수 있는 최대 문자 수는 256자입니다.",
+    "i18nStrings.duplicateKeyError": "고유한 태그 키를 지정해야 합니다.",
+    "i18nStrings.invalidKeyError": "잘못된 키입니다. 키는 유니코드 문자, 숫자, 공백 및 다음의 기호만 가능합니다. _.:/=+@-",
+    "i18nStrings.invalidValueError": "잘못된 값입니다. 값은 유니코드 문자, 숫자, 공백 및 다음의 기호만 가능합니다. _.:/=+@-",
+    "i18nStrings.awsPrefixError": "aws로 시작할 수 없음:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {태그 1개의 한도에 도달했습니다.} other {태그 {tagLimit}개의 한도에 도달했습니다.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {태그 1개의 한도를 초과했습니다.} other {태그 {tagLimit}개의 한도를 초과했습니다.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {최대 {tagLimit}개의 태그를 더 추가할 수 있습니다.}}} false {{availableTags, plural, one {태그를 최대 1개 더 추가할 수 있습니다.} other {최대 {availableTags}개의 태그를 더 추가할 수 있습니다.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "간단히 표시",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {{token__propertyKey}이(가) {token__value}과(와) 같음 필터 제거} not_equals {{token__propertyKey}이(가) {token__value}과(와) 같지 않음 필터 제거} greater_than {{token__propertyKey}이(가) {token__value}보다 큼 필터 제거} greater_than_equal {{token__propertyKey}이(가) {token__value}보다 크거나 같음 필터 제거} less_than {{token__propertyKey}이(가) {token__value}보다 작음 필터 제거} less_than_equal {{token__propertyKey}이(가) {token__value}보다 작거나 같음 필터 제거} contains {{token__propertyKey}이(가) {token__value}을(를) 포함함 필터 제거} not_contains {{token__propertyKey}이(가) {token__value}을(를) 포함하지 않음 필터 제거} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "버전 선택",
     "i18nStrings.inContextBrowseButton": "S3 둘러보기",
     "i18nStrings.inContextViewButton": "보기",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "Descartar alerta"
-  },
   "[charts]": {
     "loadingText": "Carregando gráfico",
     "errorText": "Não foi possível obter dados. Tente novamente mais tarde.",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "Filtrar dados exibidos",
     "i18nStrings.filterPlaceholder": "Filtrar dados",
     "i18nStrings.legendAriaLabel": "Legenda",
-    "i18nStrings.detailPopoverDismissAriaLabel": "Descartar",
     "i18nStrings.xAxisAriaRoleDescription": "Eixo x",
     "i18nStrings.yAxisAriaRoleDescription": "Eixo Y"
+  },
+  "alert": {
+    "dismissAriaLabel": "Descartar alerta"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "Próxima",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "Abrir navegação lateral",
     "ariaLabels.notifications": "Notificações",
     "ariaLabels.tools": "Painel de ajuda",
-    "ariaLabels.toolsClose": "Abrir o painel de ajuda",
-    "ariaLabels.toolsToggle": "Fechar o painel de ajuda"
+    "ariaLabels.toolsClose": "Fechar o painel de ajuda",
+    "ariaLabels.toolsToggle": "Abrir o painel de ajuda"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "Total"
   },
   "attribute-editor": {
-    "removeButtonText": "Remover",
-    "i18nStrings.errorIconAriaLabel": "Erro"
+    "removeButtonText": "Remover"
   },
   "autosuggest": {
     "errorIconAriaLabel": "Erro",
     "selectedAriaLabel": "Selecionado",
-    "enteredTextLabel": "Usar {value}",
+    "enteredTextLabel": "Usar: “{value}”",
     "recoveryText": "Tentar novamente"
   },
   "breadcrumb-group": {
@@ -80,7 +78,7 @@
     "cancelLabel": "Cancelar",
     "pageSizePreference.title": "Tamanho da página",
     "wrapLinesPreference.label": "Quebrar linhas",
-    "wrapLinesPreference.description": "Selecione para visualizar todo o texto e quebrar automaticamente as linhas.",
+    "wrapLinesPreference.description": "Selecione para visualizar todo o texto e quebrar as linhas.",
     "stripedRowsPreference.label": "Linhas distribuídas",
     "stripedRowsPreference.description": "Selecione para adicionar linhas esmaecidas alternadas.",
     "contentDensityPreference.label": "Modo compacto",
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "Ícone de arrastar",
     "contentDisplayPreference.dragHandleAriaDescription": "Use Space ou Enter para ativar a função de arrastar para um item e, em seguida, use as teclas de setas para movimentar o posicionamento do item. Para completar o movimento de posicionamento, use Space ou Enter, ou para descartar o movimento, use Escape.",
     "contentDisplayPreference.liveAnnouncementDndStarted": "Item selecionado na posição {position} de {total}",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordenação cancelada"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "Reordenação cancelada",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Movendo o item de volta para a posição {currentPosition} de {total}} false {Movendo o item para a posição {currentPosition} de {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item movido de volta à sua posição original {initialPosition} de {total}} false {Item movido da posição {initialPosition} para a posição {finalPosition} de {total}} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modo relativo",
@@ -121,14 +121,14 @@
     "i18nStrings.infoIconAriaLabel": "Informações",
     "i18nStrings.notificationBarAriaLabel": "Todas as notificações",
     "i18nStrings.notificationBarText": "Notificações",
-    "i18nStrings.successIconAriaLabel": "Com êxito",
+    "i18nStrings.successIconAriaLabel": "Êxito",
     "i18nStrings.warningIconAriaLabel": "Aviso"
-  },
-  "form": {
-    "errorIconAriaLabel": "Erro"
   },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "Erro"
+  },
+  "form": {
+    "errorIconAriaLabel": "Erro"
   },
   "help-panel": {
     "loadingText": "Carregando conteúdo"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "Fechar modal"
   },
+  "multiselect": {
+    "deselectAriaLabel": "Remover {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "Próxima página",
     "ariaLabels.pageLabel": "Página {pageNumber} de todas as páginas",
     "ariaLabels.previousPageLabel": "Página anterior"
   },
   "pie-chart": {
-    "loadingText": "Carregando gráfico",
-    "errorText": "Não foi possível obter dados. Tente novamente mais tarde.",
-    "recoveryText": "Tentar novamente"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "Remover {option__label}"
+    "i18nStrings.detailsValue": "Valor",
+    "i18nStrings.detailsPercentage": "Porcentagem",
+    "i18nStrings.chartAriaRoleDescription": "Gráfico de pizza",
+    "i18nStrings.segmentAriaRoleDescription": "Segmento"
   },
   "popover": {
     "dismissAriaLabel": "Fechar pop-over"
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "Valor",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remover filtro, {token__propertyKey} é igual a {token__value}} not_equals {Remover filtro, {token__propertyKey} diferente de {token__value}} greater_than {Remover filtro, {token__propertyKey} é maior que {token__value}} greater_than_equal {Remover filtro, {token__propertyKey} é maior que ou igual a {token__value}} less_than {Remover filtro, {token__propertyKey} é menor que {token__value}} less_than_equal {Remover filtro, {token__propertyKey} é menor que ou igual a {token__value}} contains {Remove filtro, {token__propertyKey} contém {token__value}} not_contains {Remover filtro, {token__propertyKey} não contém {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "Escolher uma versão",
+    "i18nStrings.inContextBrowseButton": "Navegar pelo S3",
+    "i18nStrings.inContextViewButton": "Visualizar",
+    "i18nStrings.inContextViewButtonAriaLabel": "Visualizar (abre em uma nova guia)",
+    "i18nStrings.inContextLoadingText": "Carregando recurso",
+    "i18nStrings.inContextUriLabel": "URI do S3",
+    "i18nStrings.inContextVersionSelectLabel": "Versão do objeto",
+    "i18nStrings.modalTitle": "Escolher um arquivo no S3",
+    "i18nStrings.modalCancelButton": "Cancelar",
+    "i18nStrings.modalSubmitButton": "Escolher",
+    "i18nStrings.modalBreadcrumbRootItem": "Buckets do S3",
+    "i18nStrings.selectionBuckets": "Buckets",
+    "i18nStrings.selectionObjects": "Objetos",
+    "i18nStrings.selectionVersions": "Versões",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "Encontrar bucket",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "Encontrar objeto por prefixo",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "Encontrar versão",
+    "i18nStrings.selectionBucketsLoading": "Carregando buckets",
+    "i18nStrings.selectionBucketsNoItems": "Não há buckets",
+    "i18nStrings.selectionObjectsLoading": "Carregando objetos",
+    "i18nStrings.selectionObjectsNoItems": "Não há objetos",
+    "i18nStrings.selectionVersionsLoading": "Carregando versões",
+    "i18nStrings.selectionVersionsNoItems": "Não há versões",
+    "i18nStrings.filteringNoMatches": "Não há correspondências",
+    "i18nStrings.filteringCantFindMatch": "Não conseguimos encontrar uma correspondência.",
+    "i18nStrings.clearFilterButtonText": "Limpar filtro",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "Nome",
+    "i18nStrings.columnBucketCreationDate": "Data de criação",
+    "i18nStrings.columnBucketRegion": "Região",
+    "i18nStrings.columnObjectKey": "Chave",
+    "i18nStrings.columnObjectLastModified": "Última modificação",
+    "i18nStrings.columnObjectSize": "Tamanho",
+    "i18nStrings.columnVersionID": "ID da versão",
+    "i18nStrings.columnVersionLastModified": "Última modificação",
+    "i18nStrings.columnVersionSize": "Tamanho",
+    "i18nStrings.validationPathMustBegin": "O caminho precisa começar com s3://",
+    "i18nStrings.validationBucketLowerCase": "O nome do bucket deve começar com um caractere minúsculo ou com um número.",
+    "i18nStrings.validationBucketMustNotContain": "O nome do bucket não deve conter caracteres maiúsculos.",
+    "i18nStrings.validationBucketLength": "O nome do bucket deve ter de 3 a 63 caracteres.",
+    "i18nStrings.validationBucketMustComplyDns": "O nome do bucket deve estar em conformidade com as convenções de nomenclatura de DNS.",
+    "i18nStrings.labelSortedDescending": "{columnName}, classificada em ordem decrescente",
+    "i18nStrings.labelSortedAscending": "{columnName}, classificada em ordem crescente",
+    "i18nStrings.labelNotSorted": "{columnName}, não classificada",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "Buckets",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "Objetos",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "Versões",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "Encontrar {itemsType}",
+    "i18nStrings.labelRefresh": "Atualizar os dados",
+    "i18nStrings.labelBreadcrumbs": "Navegação no S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {Uma correspondência} other {{count} correspondências}}"
+  },
   "select": {
     "errorIconAriaLabel": "Erro",
-    "selectedAriaLabel": "Selecionado"
+    "selectedAriaLabel": "Selecionado",
+    "recoveryText": "Tentar novamente"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "Fechar painel",
+    "i18nStrings.openButtonAriaLabel": "Abrir painel",
+    "i18nStrings.preferencesTitle": "Preferências de divisão de painel",
+    "i18nStrings.preferencesPositionLabel": "Posição de divisão de painel",
+    "i18nStrings.preferencesPositionDescription": "Escolha a posição padrão de divisão de painel para o serviço.",
+    "i18nStrings.preferencesPositionSide": "Lateral",
+    "i18nStrings.preferencesPositionBottom": "Inferior",
+    "i18nStrings.preferencesConfirm": "Confirmar",
+    "i18nStrings.preferencesCancel": "Cancelar",
+    "i18nStrings.resizeHandleAriaLabel": "Redimensionar painel dividido"
+  },
   "table": {
     "ariaLabels.submittingEditText": "Envio de edição",
-    "ariaLabels.successfulEditLabel": "Edição foi bem sucedida",
+    "ariaLabels.successfulEditLabel": "A edição foi bem sucedida",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erro",
-    "columnDefinitions.editConfig.editIconAriaLabel": "Editable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "editável"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "Rolar para a esquerda",
     "i18nStrings.scrollRightAriaLabel": "Rolar para a direita"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "Inserir chave",
+    "i18nStrings.valuePlaceholder": "Inserir valor",
+    "i18nStrings.addButton": "Adicionar nova tag",
+    "i18nStrings.removeButton": "Remover",
+    "i18nStrings.removeButtonAriaLabel": "Remover {tag__key}",
+    "i18nStrings.undoButton": "Desfazer",
+    "i18nStrings.undoPrompt": "Essa tag será removida depois que as alterações forem salvas",
+    "i18nStrings.loading": "Carregando tags associadas a este recurso",
+    "i18nStrings.keyHeader": "Chave",
+    "i18nStrings.valueHeader": "Valor",
+    "i18nStrings.optional": "opcional",
+    "i18nStrings.keySuggestion": "Chave de tag personalizada",
+    "i18nStrings.valueSuggestion": "Valor de tag personalizado",
+    "i18nStrings.emptyTags": "Nenhuma tag associada ao recurso.",
+    "i18nStrings.tooManyKeysSuggestion": "Você tem mais chaves do que é possível exibir",
+    "i18nStrings.tooManyValuesSuggestion": "Você tem mais valores do que é possível exibir",
+    "i18nStrings.keysSuggestionLoading": "Carregando chaves de tag",
+    "i18nStrings.keysSuggestionError": "Não foi possível recuperar chaves de tag",
+    "i18nStrings.valuesSuggestionLoading": "Carregando valores de tag",
+    "i18nStrings.valuesSuggestionError": "Não foi possível recuperar valores de tag",
+    "i18nStrings.emptyKeyError": "Você deve especificar uma chave de tag",
+    "i18nStrings.maxKeyCharLengthError": "O número máximo de caracteres que você pode usar em uma chave de tag é 128.",
+    "i18nStrings.maxValueCharLengthError": "O número máximo de caracteres que você pode usar em um valor de tag é 256.",
+    "i18nStrings.duplicateKeyError": "Você deve especificar uma chave de tag exclusiva.",
+    "i18nStrings.invalidKeyError": "Chave inválida. As chaves só podem conter letras Unicode, dígitos, espaço em branco e os seguintes caracteres: _.:/=+@-",
+    "i18nStrings.invalidValueError": "Valor inválido. Os valores só podem conter letras Unicode, dígitos, espaço em branco e os seguintes caracteres: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "Não foi possível começar com a AWS:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {Você atingiu o limite de 1 tag.} other {Você atingiu o limite de {tagLimit} tags.}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {Você excedeu o limite de 1 tag.} other {Você excedeu o limite de {tagLimit} tags.}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {Você pode adicionar até {tagLimit} tags.}}} false {{availableTags, plural, one {Você pode adicionar mais 1 tag.} other {Você pode adicionar mais {availableTags} tags.}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "Mostrar menos",
@@ -208,15 +309,15 @@
     "i18nStrings.searchIconAriaLabel": "Pesquisar",
     "i18nStrings.searchDismissIconAriaLabel": "Fechar pesquisa",
     "i18nStrings.overflowMenuTriggerText": "Mais",
-    "i18nStrings.overflowMenuDismissIconAriaLabel": "Fecha menu",
+    "i18nStrings.overflowMenuDismissIconAriaLabel": "Fechar menu",
     "i18nStrings.overflowMenuBackIconAriaLabel": "Voltar",
     "i18nStrings.overflowMenuTitleText": "Todos"
   },
   "tutorial-panel": {
     "i18nStrings.loadingText": "Carregando",
     "i18nStrings.tutorialListTitle": "Escolha um tutorial",
-    "i18nStrings.tutorialListDownloadLinkText": "Baixe a versão em PDF",
-    "i18nStrings.labelTutorialListDownloadLink": "Baixe a versão em PDF deste tutorial",
+    "i18nStrings.tutorialListDownloadLinkText": "Baixar a versão em PDF",
+    "i18nStrings.labelTutorialListDownloadLink": "Baixar a versão em PDF deste tutorial",
     "i18nStrings.tutorialCompletedText": "Tutorial concluído",
     "i18nStrings.learnMoreLinkText": "Saiba mais",
     "i18nStrings.startTutorialButtonText": "Iniciar o tutorial",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remover filtro, {token__propertyKey} é igual a {token__value}} not_equals {Remover filtro, {token__propertyKey} diferente de {token__value}} greater_than {Remover filtro, {token__propertyKey} é maior que {token__value}} greater_than_equal {Remover filtro, {token__propertyKey} é maior que ou igual a {token__value}} less_than {Remover filtro, {token__propertyKey} é menor que {token__value}} less_than_equal {Remover filtro, {token__propertyKey} é menor que ou igual a {token__value}} contains {Remove filtro, {token__propertyKey} contém {token__value}} not_contains {Remover filtro, {token__propertyKey} não contém {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "Escolher uma versão",
     "i18nStrings.inContextBrowseButton": "Navegar pelo S3",
     "i18nStrings.inContextViewButton": "Visualizar",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "退出提示"
-  },
   "[charts]": {
     "loadingText": "正在加载图表",
     "errorText": "无法获取数据。请稍后重试。",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "筛选显示的数据",
     "i18nStrings.filterPlaceholder": "筛选数据",
     "i18nStrings.legendAriaLabel": "图例",
-    "i18nStrings.detailPopoverDismissAriaLabel": "关闭",
     "i18nStrings.xAxisAriaRoleDescription": "x 轴",
     "i18nStrings.yAxisAriaRoleDescription": "y 轴"
+  },
+  "alert": {
+    "dismissAriaLabel": "关闭提示"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "下一步",
@@ -19,7 +18,7 @@
     "i18nStrings.finishButtonText": "完成",
     "i18nStrings.labelDismissAnnotation": "关闭注释",
     "i18nStrings.stepCounterText": "第 {stepNumber} 步，共 {totalStepCount} 步",
-    "i18nStrings.taskTitle": "任务{taskNumber}：{taskTitle}",
+    "i18nStrings.taskTitle": "任务 {taskNumber}：{taskTitle}",
     "i18nStrings.labelHotspot": "{openState, select, true {关闭第 {stepNumber} 步（共 {totalStepCount} 步）的注释} false {打开第 {stepNumber} 步（共 {totalStepCount} 步）的注释} other {}}"
   },
   "app-layout": {
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "打开侧导航",
     "ariaLabels.notifications": "通知",
     "ariaLabels.tools": "帮助面板",
-    "ariaLabels.toolsClose": "打开帮助面板",
-    "ariaLabels.toolsToggle": "关闭帮助面板"
+    "ariaLabels.toolsClose": "关闭帮助面板",
+    "ariaLabels.toolsToggle": "打开帮助面板"
   },
   "area-chart": {
-    "i18nStrings.detailTotalLabel": "合计"
+    "i18nStrings.detailTotalLabel": "总计"
   },
   "attribute-editor": {
-    "removeButtonText": "删除",
-    "i18nStrings.errorIconAriaLabel": "错误"
+    "removeButtonText": "删除"
   },
   "autosuggest": {
     "errorIconAriaLabel": "错误",
     "selectedAriaLabel": "已选定",
-    "enteredTextLabel": "使用 {value}",
+    "enteredTextLabel": "使用：“{value}”",
     "recoveryText": "重试"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "拖动手柄",
     "contentDisplayPreference.dragHandleAriaDescription": "使用空格键或 Enter 键激活项目拖动功能，然后使用箭头键移动项目的位置。要完成位置移动，请使用空格键或 Enter 键，要放弃移动，请使用 Esc 键。",
     "contentDisplayPreference.liveAnnouncementDndStarted": "已选择位于位置 {position}（共 {total} 个位置）的项目",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "重新排序已取消"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "重新排序已取消",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {正在将项目移回位置 {currentPosition}（共 {total} 个位置）} false {正在将项目移动到位置 {currentPosition}（共 {total} 个位置）} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {已将项目移回其原始位置 {initialPosition}（共 {total} 个位置）} false {已将项目从位置 {initialPosition} 移动到位置 {finalPosition}（共 {total} 个位置）} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相对模式",
@@ -102,8 +102,8 @@
     "i18nStrings.customRelativeRangeOptionLabel": "自定义范围",
     "i18nStrings.customRelativeRangeOptionDescription": "设置过去的自定义范围",
     "i18nStrings.customRelativeRangeUnitLabel": "时间单位",
-    "i18nStrings.customRelativeRangeDurationLabel": "时长",
-    "i18nStrings.customRelativeRangeDurationPlaceholder": "输入时长",
+    "i18nStrings.customRelativeRangeDurationLabel": "持续时间",
+    "i18nStrings.customRelativeRangeDurationPlaceholder": "输入持续时间",
     "i18nStrings.startDateLabel": "开始日期",
     "i18nStrings.startTimeLabel": "开始时间",
     "i18nStrings.endDateLabel": "结束日期",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": {
-    "errorIconAriaLabel": "错误"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "错误"
+  },
+  "form": {
+    "errorIconAriaLabel": "错误"
   },
   "help-panel": {
     "loadingText": "正在加载内容"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "关闭模态"
   },
+  "multiselect": {
+    "deselectAriaLabel": "删除 {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "下一页",
-    "ariaLabels.pageLabel": "第 {pageNumber} 页",
+    "ariaLabels.pageLabel": "所有页面中的第 {pageNumber} 页",
     "ariaLabels.previousPageLabel": "上一页"
   },
   "pie-chart": {
-    "loadingText": "正在加载图表",
-    "errorText": "无法获取数据。请稍后重试。",
-    "recoveryText": "重试"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "删除 {option__label}"
+    "i18nStrings.detailsValue": "值",
+    "i18nStrings.detailsPercentage": "百分比",
+    "i18nStrings.chartAriaRoleDescription": "饼状图",
+    "i18nStrings.segmentAriaRoleDescription": "部分"
   },
   "popover": {
     "dismissAriaLabel": "关闭弹出框"
@@ -166,7 +167,7 @@
     "i18nStrings.editTokenHeader": "编辑筛选条件",
     "i18nStrings.groupPropertiesText": "属性",
     "i18nStrings.groupValuesText": "值",
-    "i18nStrings.operationAndText": "和",
+    "i18nStrings.operationAndText": "与",
     "i18nStrings.operationOrText": "或",
     "i18nStrings.operatorContainsText": "包含",
     "i18nStrings.operatorDoesNotContainText": "不包含",
@@ -184,12 +185,80 @@
     "i18nStrings.valueText": "值",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {删除筛选条件，{token__propertyKey} 等于 {token__value}} not_equals {删除筛选条件，{token__propertyKey} 不等于 {token__value}} greater_than {删除筛选条件，{token__propertyKey} 大于 {token__value}} greater_than_equal {删除筛选条件，{token__propertyKey} 大于或等于 {token__value}} less_than {删除筛选条件，{token__propertyKey} 小于 {token__value}} less_than_equal {删除筛选条件，{token__propertyKey} 小于或等于 {token__value}} contains {删除筛选条件，{token__propertyKey} 包含 {token__value}} not_contains {删除筛选条件，{token__propertyKey} 不包含 {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "选择版本",
+    "i18nStrings.inContextBrowseButton": "浏览 S3",
+    "i18nStrings.inContextViewButton": "查看",
+    "i18nStrings.inContextViewButtonAriaLabel": "查看（在新选项卡中打开）",
+    "i18nStrings.inContextLoadingText": "正在加载资源",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "对象版本",
+    "i18nStrings.modalTitle": "在 S3 中选择档案",
+    "i18nStrings.modalCancelButton": "取消",
+    "i18nStrings.modalSubmitButton": "选择",
+    "i18nStrings.modalBreadcrumbRootItem": "S3 存储桶",
+    "i18nStrings.selectionBuckets": "存储桶",
+    "i18nStrings.selectionObjects": "对象",
+    "i18nStrings.selectionVersions": "版本",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "查找存储桶",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "按前缀查找对象",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "查找版本",
+    "i18nStrings.selectionBucketsLoading": "正在加载存储桶",
+    "i18nStrings.selectionBucketsNoItems": "没有存储桶",
+    "i18nStrings.selectionObjectsLoading": "正在加载对象",
+    "i18nStrings.selectionObjectsNoItems": "没有对象",
+    "i18nStrings.selectionVersionsLoading": "正在加载版本",
+    "i18nStrings.selectionVersionsNoItems": "没有版本",
+    "i18nStrings.filteringNoMatches": "没有匹配项",
+    "i18nStrings.filteringCantFindMatch": "找不到匹配项",
+    "i18nStrings.clearFilterButtonText": "清除筛选条件",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "名称",
+    "i18nStrings.columnBucketCreationDate": "创建日期",
+    "i18nStrings.columnBucketRegion": "区域",
+    "i18nStrings.columnObjectKey": "键",
+    "i18nStrings.columnObjectLastModified": "上次修改时间",
+    "i18nStrings.columnObjectSize": "大小",
+    "i18nStrings.columnVersionID": "版本 ID",
+    "i18nStrings.columnVersionLastModified": "上次修改时间",
+    "i18nStrings.columnVersionSize": "大小",
+    "i18nStrings.validationPathMustBegin": "路径必须以 s3:// 开头",
+    "i18nStrings.validationBucketLowerCase": "存储桶名称必须以小写字符或数字开头。",
+    "i18nStrings.validationBucketMustNotContain": "存储桶名称不得包含大写字符。",
+    "i18nStrings.validationBucketLength": "存储桶名称必须介于 3 到 63 个字符之间。",
+    "i18nStrings.validationBucketMustComplyDns": "存储桶名称必须符合 DNS 命名惯例。",
+    "i18nStrings.labelSortedDescending": "{columnName}，按降序排序",
+    "i18nStrings.labelSortedAscending": "{columnName}，按升序排序",
+    "i18nStrings.labelNotSorted": "{columnName}，未排序",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "存储桶",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "对象",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "版本",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "查找 {itemsType}",
+    "i18nStrings.labelRefresh": "刷新数据",
+    "i18nStrings.labelBreadcrumbs": "S3 导航",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 个匹配项} other {{count} 个匹配项}}"
+  },
   "select": {
     "errorIconAriaLabel": "错误",
-    "selectedAriaLabel": "已选定"
+    "selectedAriaLabel": "已选定",
+    "recoveryText": "重试"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "关闭面板",
+    "i18nStrings.openButtonAriaLabel": "打开面板",
+    "i18nStrings.preferencesTitle": "拆分面板首选项",
+    "i18nStrings.preferencesPositionLabel": "拆分面板位置",
+    "i18nStrings.preferencesPositionDescription": "为服务选择默认的拆分面板位置。",
+    "i18nStrings.preferencesPositionSide": "侧面",
+    "i18nStrings.preferencesPositionBottom": "底部",
+    "i18nStrings.preferencesConfirm": "确认",
+    "i18nStrings.preferencesCancel": "取消",
+    "i18nStrings.resizeHandleAriaLabel": "调整拆分面板的大小"
+  },
   "table": {
     "ariaLabels.submittingEditText": "正在提交编辑",
     "ariaLabels.successfulEditLabel": "编辑成功",
@@ -199,6 +268,38 @@
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "向左滚动",
     "i18nStrings.scrollRightAriaLabel": "向右滚动"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "输入键",
+    "i18nStrings.valuePlaceholder": "输入值",
+    "i18nStrings.addButton": "添加新标签",
+    "i18nStrings.removeButton": "删除",
+    "i18nStrings.removeButtonAriaLabel": "删除 {tag__key}",
+    "i18nStrings.undoButton": "撤销",
+    "i18nStrings.undoPrompt": "保存更改后将删除此标签",
+    "i18nStrings.loading": "正在加载与此资源关联的标签",
+    "i18nStrings.keyHeader": "键",
+    "i18nStrings.valueHeader": "值",
+    "i18nStrings.optional": "可选",
+    "i18nStrings.keySuggestion": "自定义标签键",
+    "i18nStrings.valueSuggestion": "自定义标签值",
+    "i18nStrings.emptyTags": "没有与资源关联的标签。",
+    "i18nStrings.tooManyKeysSuggestion": "您的键超过了可以显示的数量",
+    "i18nStrings.tooManyValuesSuggestion": "您的值超过了可以显示的数量",
+    "i18nStrings.keysSuggestionLoading": "正在加载标签键",
+    "i18nStrings.keysSuggestionError": "无法检索标签键",
+    "i18nStrings.valuesSuggestionLoading": "正在加载标签值",
+    "i18nStrings.valuesSuggestionError": "无法检索标签值",
+    "i18nStrings.emptyKeyError": "您必须指定标签键",
+    "i18nStrings.maxKeyCharLengthError": "标签键中最多可使用 128 个字符。",
+    "i18nStrings.maxValueCharLengthError": "标签值中最多可使用 256 个字符。",
+    "i18nStrings.duplicateKeyError": "您必须指定唯一的标签键。",
+    "i18nStrings.invalidKeyError": "键无效。键只能包含 Unicode 字母、数字、空格和以下任意字符：_.:/=+@-",
+    "i18nStrings.invalidValueError": "值无效。值只能包含 Unicode 字母、数字、空格和以下任意字符：_.:/=+@-",
+    "i18nStrings.awsPrefixError": "不能以 aws: 开头",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {您已达到 1 个标签的限制。} other {您已达到 {tagLimit} 个标签的限制。}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {您已超过 1 个标签的限制。} other {您已超过 {tagLimit} 个标签的限制。}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {您最多可以添加 {tagLimit} 个标签。}}} false {{availableTags, plural, one {您最多可以再添加 1 个标签。} other {您最多可以再添加 {availableTags} 个标签。}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "显示更少",
@@ -224,7 +325,7 @@
     "i18nStrings.completionScreenTitle": "恭喜！您完成了本教程。",
     "i18nStrings.feedbackLinkText": "反馈",
     "i18nStrings.dismissTutorialButtonText": "关闭教程",
-    "i18nStrings.taskTitle": "任务{taskNumber}：{taskTitle}",
+    "i18nStrings.taskTitle": "任务 {taskNumber}：{taskTitle}",
     "i18nStrings.stepTitle": "步骤 {stepNumber}：{stepTitle}",
     "i18nStrings.labelExitTutorial": "关闭教程",
     "i18nStrings.labelTotalSteps": "总步骤数：{totalStepCount}",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {删除筛选条件，{token__propertyKey} 等于 {token__value}} not_equals {删除筛选条件，{token__propertyKey} 不等于 {token__value}} greater_than {删除筛选条件，{token__propertyKey} 大于 {token__value}} greater_than_equal {删除筛选条件，{token__propertyKey} 大于或等于 {token__value}} less_than {删除筛选条件，{token__propertyKey} 小于 {token__value}} less_than_equal {删除筛选条件，{token__propertyKey} 小于或等于 {token__value}} contains {删除筛选条件，{token__propertyKey} 包含 {token__value}} not_contains {删除筛选条件，{token__propertyKey} 不包含 {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "选择版本",
     "i18nStrings.inContextBrowseButton": "浏览 S3",
     "i18nStrings.inContextViewButton": "查看",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -186,7 +186,6 @@
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {移除篩選條件，{token__propertyKey} 等於 {token__value}} not_equals {移除篩選條件，{token__propertyKey} 不等於 {token__value}} greater_than {移除篩選條件，{token__propertyKey} 大於 {token__value}} greater_than_equal {移除篩選條件，{token__propertyKey} 大於或等於 {token__value}} less_than {移除篩選條件，{token__propertyKey} 小於 {token__value}} less_than_equal {移除篩選條件，{token__propertyKey} 小於或等於 {token__value}} contains {移除篩選條件，{token__propertyKey} 包含 {token__value}} not_contains {移除篩選條件，{token__propertyKey} 不包含 {token__value}} other {}}"
   },
   "s3-resource-selector": {
-    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
     "i18nStrings.inContextSelectPlaceholder": "選擇一個版本",
     "i18nStrings.inContextBrowseButton": "瀏覽 S3",
     "i18nStrings.inContextViewButton": "檢視",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -1,7 +1,4 @@
 {
-  "alert": {
-    "dismissAriaLabel": "關閉提醒"
-  },
   "[charts]": {
     "loadingText": "正在載入圖表",
     "errorText": "無法擷取資料。請稍後再試一次。",
@@ -9,9 +6,11 @@
     "i18nStrings.filterLabel": "篩選顯示的資料",
     "i18nStrings.filterPlaceholder": "篩選資料",
     "i18nStrings.legendAriaLabel": "圖例",
-    "i18nStrings.detailPopoverDismissAriaLabel": "關閉",
     "i18nStrings.xAxisAriaRoleDescription": "X 軸",
     "i18nStrings.yAxisAriaRoleDescription": "Y 軸"
+  },
+  "alert": {
+    "dismissAriaLabel": "關閉提醒"
   },
   "annotation-context": {
     "i18nStrings.nextButtonText": "下一步",
@@ -28,20 +27,19 @@
     "ariaLabels.navigationToggle": "開啟側邊導覽",
     "ariaLabels.notifications": "通知",
     "ariaLabels.tools": "說明面板",
-    "ariaLabels.toolsClose": "開啟說明面板",
-    "ariaLabels.toolsToggle": "關閉說明面板"
+    "ariaLabels.toolsClose": "關閉說明面板",
+    "ariaLabels.toolsToggle": "開啟說明面板"
   },
   "area-chart": {
     "i18nStrings.detailTotalLabel": "合計"
   },
   "attribute-editor": {
-    "removeButtonText": "移除",
-    "i18nStrings.errorIconAriaLabel": "錯誤"
+    "removeButtonText": "移除"
   },
   "autosuggest": {
     "errorIconAriaLabel": "錯誤",
     "selectedAriaLabel": "已選取",
-    "enteredTextLabel": "使用 {value}",
+    "enteredTextLabel": "使用：“{value}”",
     "recoveryText": "重試"
   },
   "breadcrumb-group": {
@@ -90,7 +88,9 @@
     "contentDisplayPreference.dragHandleAriaLabel": "拖曳控點",
     "contentDisplayPreference.dragHandleAriaDescription": "使用空白鍵或 ENTER 鍵啟用項目拖曳功能，然後使用方向鍵移動項目的位置。若要完成位置移動，請使用空白鍵或 ENTER 鍵，或者若要捨棄移動，請使用 ESC 鍵。",
     "contentDisplayPreference.liveAnnouncementDndStarted": "在第 {position} 位置 (共 {total} 個位置) 拾取了項目",
-    "contentDisplayPreference.liveAnnouncementDndDiscarded": "重新排序已取消"
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "重新排序已取消",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {將項目移回 {currentPosition} 位置 (共 {total} 個位置)} false {將項目移到 {currentPosition} 位置 (共 {total} 個位置)} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目移回原來的 {initialPosition} 位置 (共 {total} 個位置)} false {項目已從 {initialPosition} 位置移到 {finalPosition} 位置 (共 {total} 個位置)} other {}}"
   },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相對模式",
@@ -124,11 +124,11 @@
     "i18nStrings.successIconAriaLabel": "成功",
     "i18nStrings.warningIconAriaLabel": "警告"
   },
-  "form": {
-    "errorIconAriaLabel": "錯誤"
-  },
   "form-field": {
     "i18nStrings.errorIconAriaLabel": "錯誤"
+  },
+  "form": {
+    "errorIconAriaLabel": "錯誤"
   },
   "help-panel": {
     "loadingText": "載入內容"
@@ -142,18 +142,19 @@
   "modal": {
     "closeAriaLabel": "關閉強制回應"
   },
+  "multiselect": {
+    "deselectAriaLabel": "移除 {option__label}"
+  },
   "pagination": {
     "ariaLabels.nextPageLabel": "下一頁",
     "ariaLabels.pageLabel": "所有頁面中的第 {pageNumber} 頁",
     "ariaLabels.previousPageLabel": "上一頁"
   },
   "pie-chart": {
-    "loadingText": "正在載入圖表",
-    "errorText": "無法擷取資料。請稍後再試一次。",
-    "recoveryText": "重試"
-  },
-  "multiselect": {
-    "deselectAriaLabel": "移除 {option__label}"
+    "i18nStrings.detailsValue": "值",
+    "i18nStrings.detailsPercentage": "百分比",
+    "i18nStrings.chartAriaRoleDescription": "圓餅圖",
+    "i18nStrings.segmentAriaRoleDescription": "區段"
   },
   "popover": {
     "dismissAriaLabel": "關閉彈出視窗"
@@ -184,21 +185,121 @@
     "i18nStrings.valueText": "值",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {移除篩選條件，{token__propertyKey} 等於 {token__value}} not_equals {移除篩選條件，{token__propertyKey} 不等於 {token__value}} greater_than {移除篩選條件，{token__propertyKey} 大於 {token__value}} greater_than_equal {移除篩選條件，{token__propertyKey} 大於或等於 {token__value}} less_than {移除篩選條件，{token__propertyKey} 小於 {token__value}} less_than_equal {移除篩選條件，{token__propertyKey} 小於或等於 {token__value}} contains {移除篩選條件，{token__propertyKey} 包含 {token__value}} not_contains {移除篩選條件，{token__propertyKey} 不包含 {token__value}} other {}}"
   },
-  "s3-resource-selector": {},
+  "s3-resource-selector": {
+    "i18nStrings.inContextInputPlaceholder": "s3://bucket/prefix/object",
+    "i18nStrings.inContextSelectPlaceholder": "選擇一個版本",
+    "i18nStrings.inContextBrowseButton": "瀏覽 S3",
+    "i18nStrings.inContextViewButton": "檢視",
+    "i18nStrings.inContextViewButtonAriaLabel": "檢視 (在新索引標籤中開啟)",
+    "i18nStrings.inContextLoadingText": "正在載入資源",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "選取版本",
+    "i18nStrings.modalTitle": "選擇 S3 中的存檔",
+    "i18nStrings.modalCancelButton": "取消",
+    "i18nStrings.modalSubmitButton": "選擇",
+    "i18nStrings.modalBreadcrumbRootItem": "S3 儲存貯體",
+    "i18nStrings.selectionBuckets": "儲存貯體",
+    "i18nStrings.selectionObjects": "物件",
+    "i18nStrings.selectionVersions": "版本",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "尋找儲存貯體",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "按前綴查找物件",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "尋找版本",
+    "i18nStrings.selectionBucketsLoading": "裝載儲存貯體",
+    "i18nStrings.selectionBucketsNoItems": "沒有儲存貯體",
+    "i18nStrings.selectionObjectsLoading": "載入物件",
+    "i18nStrings.selectionObjectsNoItems": "沒有物件",
+    "i18nStrings.selectionVersionsLoading": "載入版本",
+    "i18nStrings.selectionVersionsNoItems": "沒有版本",
+    "i18nStrings.filteringNoMatches": "無相符項目",
+    "i18nStrings.filteringCantFindMatch": "找不到相符項目",
+    "i18nStrings.clearFilterButtonText": "清除篩選條件",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "名稱",
+    "i18nStrings.columnBucketCreationDate": "建立日期",
+    "i18nStrings.columnBucketRegion": "區域",
+    "i18nStrings.columnObjectKey": "索引鍵",
+    "i18nStrings.columnObjectLastModified": "上次修改",
+    "i18nStrings.columnObjectSize": "尺寸",
+    "i18nStrings.columnVersionID": "版本 ID",
+    "i18nStrings.columnVersionLastModified": "上次修改",
+    "i18nStrings.columnVersionSize": "尺寸",
+    "i18nStrings.validationPathMustBegin": "路徑必須以 s3:// 開頭",
+    "i18nStrings.validationBucketLowerCase": "儲存貯體名稱必須以小寫字元或數字開頭。",
+    "i18nStrings.validationBucketMustNotContain": "儲存貯體名稱不得包含大寫字元。",
+    "i18nStrings.validationBucketLength": "儲存貯體名稱必須介於 3 到 63 個字元之間。",
+    "i18nStrings.validationBucketMustComplyDns": "儲存貯體名稱必須符合 DNS 命名慣例。",
+    "i18nStrings.labelSortedDescending": "{columnName}，遞減排序",
+    "i18nStrings.labelSortedAscending": "{columnName}，升序排序",
+    "i18nStrings.labelNotSorted": "{columnName}，未排序",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "儲存貯體",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "物件",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "版本",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "尋找 {itemsType}",
+    "i18nStrings.labelRefresh": "重新整理資料",
+    "i18nStrings.labelBreadcrumbs": "S3 導覽",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 個符合} other {{count} 個符合}}"
+  },
   "select": {
     "errorIconAriaLabel": "錯誤",
-    "selectedAriaLabel": "已選取"
+    "selectedAriaLabel": "已選取",
+    "recoveryText": "重試"
   },
-  "split-panel": {},
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "關閉面板",
+    "i18nStrings.openButtonAriaLabel": "打開面板",
+    "i18nStrings.preferencesTitle": "分割面板偏好",
+    "i18nStrings.preferencesPositionLabel": "分割面板位置",
+    "i18nStrings.preferencesPositionDescription": "選擇服務的預設分割面板位置。",
+    "i18nStrings.preferencesPositionSide": "側邊",
+    "i18nStrings.preferencesPositionBottom": "底部",
+    "i18nStrings.preferencesConfirm": "確認",
+    "i18nStrings.preferencesCancel": "取消",
+    "i18nStrings.resizeHandleAriaLabel": "調整分割面板大小"
+  },
   "table": {
     "ariaLabels.submittingEditText": "提交編輯",
     "ariaLabels.successfulEditLabel": "編輯成功",
     "columnDefinitions.editConfig.errorIconAriaLabel": "錯誤",
-    "columnDefinitions.editConfig.editIconAriaLabel": "dditable"
+    "columnDefinitions.editConfig.editIconAriaLabel": "可編輯"
   },
   "tabs": {
     "i18nStrings.scrollLeftAriaLabel": "向左捲動",
     "i18nStrings.scrollRightAriaLabel": "向右捲動"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "輸入索引鍵",
+    "i18nStrings.valuePlaceholder": "輸入值",
+    "i18nStrings.addButton": "新增標籤",
+    "i18nStrings.removeButton": "移除",
+    "i18nStrings.removeButtonAriaLabel": "移除 {tag__key}",
+    "i18nStrings.undoButton": "復原",
+    "i18nStrings.undoPrompt": "此標籤會在儲存變更時移除",
+    "i18nStrings.loading": "正在載入與此資源相關聯的標籤",
+    "i18nStrings.keyHeader": "索引鍵",
+    "i18nStrings.valueHeader": "值",
+    "i18nStrings.optional": "選用",
+    "i18nStrings.keySuggestion": "自訂標籤索引鍵",
+    "i18nStrings.valueSuggestion": "自訂標籤值",
+    "i18nStrings.emptyTags": "沒有與資源相關聯的標籤。",
+    "i18nStrings.tooManyKeysSuggestion": "您的索引鍵數目超過可顯示的數目",
+    "i18nStrings.tooManyValuesSuggestion": "您的值數目超過可顯示的數目",
+    "i18nStrings.keysSuggestionLoading": "正在載入標籤索引鍵",
+    "i18nStrings.keysSuggestionError": "無法擷取標籤索引鍵",
+    "i18nStrings.valuesSuggestionLoading": "正在載入標籤值",
+    "i18nStrings.valuesSuggestionError": "無法擷取標籤值",
+    "i18nStrings.emptyKeyError": "您必須指定標籤索引鍵",
+    "i18nStrings.maxKeyCharLengthError": "標籤索引鍵中可使用的字元數上限為 128 個字元。",
+    "i18nStrings.maxValueCharLengthError": "標籤值中可使用的字元數上限為 256 個字元。",
+    "i18nStrings.duplicateKeyError": "您必須指定唯一的標籤索引鍵。",
+    "i18nStrings.invalidKeyError": "無效的金鑰。金鑰只能包含 Unicode 字母、數字、空格和下列符號︰ _.:/=+@–",
+    "i18nStrings.invalidValueError": "無效的值。值只能包含 Unicode 字母、數字、空格和下列符號︰_.:/=+@ –",
+    "i18nStrings.awsPrefixError": "開頭不能為 aws:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {您已達到 1 個標籤的上限。} other {您已達到 {tagLimit} 個標籤的上限。}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {您已超過 1 個標籤的上限。} other {您已超過 {tagLimit} 個標籤的上限。}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {您最多可以新增 {tagLimit} 個標籤。}}} false {{availableTags, plural, one {您最多可以再新增 1 個標籤。} other {您最多可以再新增 {availableTags} 個標籤。}}} other {}}"
   },
   "token-group": {
     "i18nStrings.limitShowFewer": "顯示較少",

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -118,6 +118,7 @@ export interface S3ResourceSelectorProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: S3ResourceSelectorProps.I18nStrings;
 

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -21,6 +21,7 @@ export interface TagEditorProps extends BaseComponentProps {
 
   /**
    * An object containing all the necessary localized strings required by the component.
+   * @i18n
    */
   i18nStrings?: TagEditorProps.I18nStrings;
 


### PR DESCRIPTION
### Description

Synchronizes messages from the internal repo, picking up the translations since the last update (when we release i18n support). See #1189 for why we have a `messages-types.ts` file. This will be merged in on top of that PR.

Additionally, since we have strings for s3 resource selector and tag editor, this adds the `@i18n` marker to those components docs as well.

Related links, issue #, if available: n/a

Fixes #1193.

### How has this been tested?

Strings are strings. Docs have a documenter update.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
