### PR TITLE
fix: Don't use dark mode for print media

### DIFF
--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -8,6 +8,9 @@ import { useMutationObserver } from '../use-mutation-observer';
 import { isDevelopment } from '../../is-development';
 import { warnOnce } from '../../logging';
 
+// Note that this hook doesn't take into consideration @media print (unlike the dark mode CSS),
+// due to challenges with cross-browser implementations of media/print state change listeners.
+// This means that components using this hook will render in dark mode even when printing.
 export function useCurrentMode(elementRef: React.RefObject<HTMLElement>) {
   const [value, setValue] = useState<'light' | 'dark'>('light');
   useMutationObserver(elementRef, node => {

--- a/src/internal/styles/utils/theming.scss
+++ b/src/internal/styles/utils/theming.scss
@@ -3,9 +3,11 @@
  SPDX-License-Identifier: Apache-2.0
 */
 @mixin dark-mode-only($selector: '') {
-  /* stylelint-disable selector-combinator-disallowed-list, selector-class-pattern */
-  :global(#{$selector}.awsui-polaris-dark-mode) &,
-  :global(#{$selector}.awsui-dark-mode) & {
-    @content;
+  @media not print {
+    /* stylelint-disable selector-combinator-disallowed-list, selector-class-pattern */
+    :global(#{$selector}.awsui-polaris-dark-mode) &,
+    :global(#{$selector}.awsui-dark-mode) & {
+      @content;
+    }
   }
 }

--- a/style-dictionary/utils/modes.ts
+++ b/style-dictionary/utils/modes.ts
@@ -4,7 +4,7 @@ export const createColorMode = (darkSelector: string) => ({
   id: 'color',
   states: {
     light: { default: true },
-    dark: { selector: darkSelector },
+    dark: { selector: darkSelector, media: 'not print' },
   },
 });
 


### PR DESCRIPTION
### Description

"Print" typically prints on a white background (and removes dark backgrounds),
so in general it's better to use light mode for this media.

Related links, issue #, if available: https://github.com/cloudscape-design/theming-core/pull/47

### How has this been tested?

Tested in dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
