### PR TITLE
fix: Use primary link visuals for anchors in HelpPanel and TextContent

### DIFF
--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -103,7 +103,7 @@
     font-weight: styles.$font-weight-bold;
   }
   a {
-    @include styles.link-default;
+    @include styles.link-inline;
     &:focus {
       @include styles.link-focus;
     }

--- a/src/text-content/styles.scss
+++ b/src/text-content/styles.scss
@@ -72,7 +72,7 @@
   }
   /* stylelint-disable no-descending-specificity */
   a {
-    @include styles.link-default;
+    @include styles.link-inline;
 
     &:focus {
       @include styles.link-focus;


### PR DESCRIPTION
### Description

> Use primary links to help differentiate link text from surrounding text when interactivity is not implied by its context.

Text heavy components like the help panel and text content currently use secondary links, so we just rely on color to determine interactivity in those. This adds an additional bold link affordance.

~~Needs a design check before it's ready to merge.~~ All good to review!

Related links, issue #, if available: AWSUI-21173

### How has this been tested?

Purely visual change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
