### PR TITLE
chore: Update generated interface name for i18n message types

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -3,7 +3,7 @@
 /* eslint-disable prettier/prettier */
 
 /** Auto-generated argument types based on "en" i18n strings. Do not edit manually. */
-export interface CloudscapeI18nFormatArgTypes {
+export interface I18nFormatArgTypes {
   "[charts]": {
     "loadingText": never;
     "errorText": never;


### PR DESCRIPTION
### Description

These types are used in #1189 so they're not needed yet, but they're meant to be merged in with every message update so they made it in early. That's not a problem, but still, the naming needs to be changed, so this PR does just that.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
