### PR TITLE
feat: Add support for aligning to start and end in SpaceBetween

### DIFF
--- a/pages/space-between/alignment.permutations.page.tsx
+++ b/pages/space-between/alignment.permutations.page.tsx
@@ -8,14 +8,21 @@ import ScreenshotArea from '../utils/screenshot-area';
 import Container from '~components/container';
 import Button from '~components/button';
 import Header from '~components/header';
+import styles from './styles.scss';
 
 const size = 'm';
 
 const ExampleChildren = (
   <>
-    <h2>Heading</h2>
-    <p>Paragraph</p>
-    <Button>Button</Button>
+    <div className={styles['border-box-inner']}>
+      <h2>Heading</h2>
+    </div>
+    <div className={styles['border-box-inner']}>
+      <p>Paragraph</p>
+    </div>
+    <div className={styles['border-box-inner']}>
+      <Button>Button</Button>
+    </div>
   </>
 );
 
@@ -25,18 +32,14 @@ const NestedExample = createPermutations([
     alignItems: [undefined, 'center'] as SpaceBetweenProps.AlignItems[],
   },
 ]).map(({ direction, alignItems }) => (
-  <Container
-    key={`direction-${direction}-alignment-${alignItems || 'default'}`}
-    header={
-      <Header headingTagOverride="h3">
-        Direction: {direction}, alignment: {alignItems || 'default'}
-      </Header>
-    }
-  >
+  <div className={styles['border-box-outer']} key={`direction-${direction}-alignment-${alignItems || 'default'}`}>
+    <h3>
+      Direction: {direction}, alignment: {alignItems || 'default'}
+    </h3>
     <SpaceBetween size={size} direction={direction} alignItems={alignItems}>
       {ExampleChildren}
     </SpaceBetween>
-  </Container>
+  </div>
 ));
 
 /* eslint-disable react/jsx-key */
@@ -44,7 +47,7 @@ const permutations = createPermutations<Pick<SpaceBetweenProps, 'direction' | 'a
   {
     children: [ExampleChildren, NestedExample],
     direction: ['vertical', 'horizontal'],
-    alignItems: [undefined, 'center'],
+    alignItems: [undefined, 'center', 'start', 'end'],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/pages/space-between/styles.scss
+++ b/pages/space-between/styles.scss
@@ -5,9 +5,17 @@
 
 @use '~design-tokens' as tokens;
 
+.border-box-outer,
+.box {
+  border: 1px solid tokens.$color-border-status-info;
+}
+
+.border-box-inner {
+  border: 1px solid tokens.$color-border-status-error;
+}
+
 .box {
   background-color: tokens.$color-background-status-info;
-  border: 1px solid tokens.$color-border-status-info;
   display: inline-block;
   padding: 1rem;
 }

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11550,12 +11550,16 @@ Object {
       "description": "Determines how the child elements will be aligned based on the [align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items) property of the CSS Flexbox.",
       "inlineType": Object {
         "name": "SpaceBetweenProps.AlignItems",
-        "properties": Array [],
-        "type": "object",
+        "type": "union",
+        "values": Array [
+          "center",
+          "start",
+          "end",
+        ],
       },
       "name": "alignItems",
       "optional": true,
-      "type": "SpaceBetweenProps.AlignItems",
+      "type": "string",
     },
     Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",

--- a/src/space-between/interfaces.ts
+++ b/src/space-between/interfaces.ts
@@ -29,5 +29,5 @@ export namespace SpaceBetweenProps {
 
   export type Size = 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl';
 
-  export type AlignItems = 'center';
+  export type AlignItems = 'center' | 'start' | 'end';
 }

--- a/src/space-between/styles.scss
+++ b/src/space-between/styles.scss
@@ -72,3 +72,11 @@ $sizes-vertical: (
 .align-center {
   align-items: center;
 }
+
+.align-start {
+  align-items: start;
+}
+
+.align-end {
+  align-items: end;
+}


### PR DESCRIPTION
### Description

As discussed, add more options to `alignItems` prop added in #1195: `start` and `end`.

### Questions and answers

**Why not include `stretch` as well?**

`stretch` is already the default behavior. According to [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#values), the initial value for `align-items` is `normal`, and this value:
> For flex items, the keyword behaves as `stretch`.

**Why not `flex-start` and `flex-end` instead of `start` and `end`?**

- Technically, the result would be the same. Whereas `flex-start` and `flex-end` are specific to the Flexbox, `start` and `end` are generic for all box models. [W3C docs](https://d21d5uik3ws71m.cloudfront.net/components/3489063170a9df7f7021c168aa0db3f2bf0e56ae/index.html#/light/space-between/alignment.permutations)
- As [this article](https://csslayout.news/whats-the-difference-between-the-alignment-values-of-start-flex-start-and-self-start/) explains, the only difference in practice is that `flex-start` and `flex-end` revert the order of items when `flex-direction` is set to `row-reverse` or `column-reverse`, but we don't use these properties. Both `flex-start` / `flex-end` and `start` / `end` respect the write direction (LTR / RTL).
- `start` and `end` are more user-friendly terms and are not specific to the fact that we use Flexbox internally.
- Browser support: https://caniuse.com/mdn-css_properties_align-items_flex_context_start_end

### How has this been tested?

- Added permutations to existing visual regressions test page (`pages/space-between/alignment.permutations.page.tsx`), and added some borders for easier visual debugging.
- Manually tested in Chrome, Firefox and Safari
- Ran dry run build successfully

The visual regression tests for the page mentioned above are expected to fail because of these intentional changes.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
