### PR TITLE
fix: Use more standard aria-labels/descriptions in expandable section

### DIFF
--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -137,11 +137,17 @@ describe('Expandable Section', () => {
 
   describe('a11y', () => {
     test('content region is labelled by header', () => {
-      const wrapper = renderExpandableSection();
-      const header = wrapper.findHeader().getElement();
+      const wrapper = renderExpandableSection({
+        variant: 'container',
+        headerText: 'Container header',
+        headerDescription: 'Container description',
+      });
+      const header = wrapper.findExpandButton().getElement();
       const expandedContent = wrapper.findContent().getElement();
       const contentId = expandedContent?.getAttribute('id');
       expect(header).toHaveAttribute('aria-controls', contentId);
+      expect(expandedContent).toHaveAccessibleName('Container header');
+      expect(expandedContent).toHaveAccessibleDescription('Container description');
     });
     test('aria-expanded=false when collapsed', () => {
       const wrapper = renderExpandableSection();
@@ -323,16 +329,22 @@ describe('Variant container with headerText', () => {
     expect(content).toHaveAttribute('aria-label', 'ARIA Label');
     expect(headerButton).not.toHaveAttribute('aria-labelledby');
   });
-  test('set aria-labelledby when no headerAriaLabel is set', () => {
+  test('set aria labels when no headerAriaLabel is set', () => {
     const wrapper = renderExpandableSection({
       variant: 'container',
       headerText: 'Header component',
-      headerCounter: '(5)',
+    });
+    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+    expect(headerButton).toHaveAccessibleName('Header component');
+  });
+  test('set aria description if description present', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'container',
+      headerText: 'Header component',
       headerDescription: 'Expand to see more content',
     });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement()!.getAttribute('aria-labelledby');
-    const screenreaderElement = wrapper.findHeader().find(`#${headerButton}`)!.getElement();
-    expect(screenreaderElement.textContent).toBe('Header component (5) Expand to see more content');
+    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+    expect(headerButton).toHaveAccessibleDescription('Expand to see more content');
   });
   test('does not set aria-labelledby for default variant', () => {
     const wrapper = renderExpandableSection({

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -6,8 +6,6 @@ import InternalIcon from '../icon/internal';
 import clsx from 'clsx';
 import styles from './styles.css.js';
 import InternalHeader from '../header/internal';
-import ScreenreaderOnly from '../internal/components/screenreader-only';
-import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '../internal/logging';
 
@@ -15,6 +13,7 @@ export const componentName = 'ExpandableSection';
 
 interface ExpandableDefaultHeaderProps {
   id: string;
+  descriptionId?: string;
   className?: string;
   children?: ReactNode;
   expanded: boolean;
@@ -113,6 +112,7 @@ const ExpandableNavigationHeader = ({
 
 const ExpandableHeaderTextWrapper = ({
   id,
+  descriptionId,
   className,
   onClick,
   ariaLabel,
@@ -129,7 +129,6 @@ const ExpandableHeaderTextWrapper = ({
   onKeyUp,
   onKeyDown,
 }: ExpandableHeaderTextWrapperProps) => {
-  const screenreaderContentId = useUniqueId('expandable-section-header-content-');
   const isContainer = variant === 'container';
   const HeadingTag = headingTagOverride || 'div';
   const hasInteractiveElements = isContainer && (headerInfo || headerActions);
@@ -145,27 +144,26 @@ const ExpandableHeaderTextWrapper = ({
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}
-      // Do not use aria-labelledby={id} but ScreenreaderOnly because safari+VO does not read headerText in this case.
-      aria-labelledby={ariaLabel || !isContainer ? undefined : screenreaderContentId}
+      aria-labelledby={!ariaLabel && isContainer ? id : undefined}
+      aria-describedby={isContainer && headerDescription ? descriptionId : undefined}
       aria-controls={ariaControls}
       aria-expanded={expanded}
       {...headerButtonListeners}
     >
       <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
-      <span>{children}</span>
+      <span id={id}>{children}</span>
     </span>
   );
 
   return (
     <div
-      id={id}
       className={clsx(className, hasInteractiveElements && styles['with-interactive-elements'])}
       {...wrapperListeners}
     >
       {isContainer ? (
         <InternalHeader
           variant="h2"
-          description={headerDescription}
+          description={headerDescription && <span id={descriptionId}>{headerDescription}</span>}
           counter={headerCounter}
           info={headerInfo}
           actions={headerActions}
@@ -176,17 +174,13 @@ const ExpandableHeaderTextWrapper = ({
       ) : (
         <HeadingTag className={styles['header-wrapper']}>{headerButton}</HeadingTag>
       )}
-      {isContainer && (
-        <ScreenreaderOnly id={screenreaderContentId}>
-          {children} {headerCounter} {headerDescription}
-        </ScreenreaderOnly>
-      )}
     </div>
   );
 };
 
 export const ExpandableSectionHeader = ({
   id,
+  descriptionId,
   className,
   variant,
   header,
@@ -245,6 +239,7 @@ export const ExpandableSectionHeader = ({
     return (
       <ExpandableHeaderTextWrapper
         className={clsx(className, wrapperClassName, expanded && styles.expanded)}
+        descriptionId={descriptionId}
         headerDescription={headerDescription}
         headerCounter={headerCounter}
         headerInfo={headerInfo}

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -40,6 +40,7 @@ export default function InternalExpandableSection({
   const ref = useRef<HTMLDivElement>(null);
   const controlId = useUniqueId();
   const triggerControlId = `${controlId}-trigger`;
+  const descriptionId = `${controlId}-description`;
 
   const baseProps = getBaseProps(props);
   const [expanded, setExpanded] = useControllable(controlledExpanded, onChange, defaultExpanded, {
@@ -97,6 +98,7 @@ export default function InternalExpandableSection({
       header={
         <ExpandableSectionHeader
           id={triggerControlId}
+          descriptionId={descriptionId}
           className={clsx(styles.header, styles[`header-${variant}`])}
           variant={variant}
           expanded={!!expanded}
@@ -120,6 +122,7 @@ export default function InternalExpandableSection({
           role="group"
           aria-label={triggerProps.ariaLabel}
           aria-labelledby={triggerProps.ariaLabelledBy}
+          aria-describedby={variant === 'container' && headerDescription ? descriptionId : undefined}
         >
           {children}
         </div>


### PR DESCRIPTION
### Description

Previously we had a workaround for VO+Safari that was causing problems
for other users (as the label & description were combined into one). This 
PR uses a more standard label/description approach.

Related links, issue #, if available: AWSUI-21215

### How has this been tested?

New unit tests, local testing in VO+Chrome, NVDA+FF

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
