### PR TITLE
fix: Make inline editing focus triggers only once in case a re-render…

### DIFF
--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
 import styles from './styles.css.js';
-import React, { useRef, useState } from 'react';
-import { useEffectOnUpdate } from '../../internal/hooks/use-effect-on-update';
+import React, { useEffect, useRef, useState } from 'react';
 import Icon from '../../icon/internal';
 import { TableProps } from '../interfaces';
 import { TableTdElement, TableTdElementProps } from './td-element';
@@ -44,13 +43,14 @@ function TableCellEditable<ItemType>({
   const tdNativeAttributes = {
     'data-inline-editing-active': isEditing.toString(),
   };
+  const isFocusMoveNeededRef = useRef(false);
 
-  useEffectOnUpdate(() => {
-    if (!isEditing && editActivateRef.current) {
+  useEffect(() => {
+    if (!isEditing && editActivateRef.current && isFocusMoveNeededRef.current) {
+      isFocusMoveNeededRef.current = false;
       editActivateRef.current.focus();
     }
   }, [isEditing]);
-
   // To improve the initial page render performance we only show the edit icon when necessary.
   const [hasHover, setHasHover] = useState(false);
   const [hasFocus, setHasFocus] = useState(false);
@@ -76,7 +76,10 @@ function TableCellEditable<ItemType>({
           ariaLabels={ariaLabels}
           column={column}
           item={item}
-          onEditEnd={onEditEnd}
+          onEditEnd={e => {
+            isFocusMoveNeededRef.current = true;
+            onEditEnd(e);
+          }}
           submitEdit={submitEdit ?? submitHandlerFallback}
         />
       ) : (


### PR DESCRIPTION
… happens

### Description

In React Strict Mode the inline-editing cell re-renders twice and the `useEffectOnUpdate` is triggered with the second re-render making the inline-editing cell get focused because of the double rendering.

This should not happen in production but it is still a bug.


<!-- Include a summary of the changes and the related issue. -->
AWSUI-21262

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
