### PR TITLE
feat: Add ariaLabel property to code editor

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3901,6 +3901,12 @@ and set the property to a string of each ID separated by spaces (for example, \`
       "type": "string",
     },
     Object {
+      "description": "Adds \`aria-label\` to the code editor's textarea element.",
+      "name": "ariaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
 don't set this property because the form field component automatically sets it.
 Use this property if the component isn't surrounded by a form field, or you want to override the value

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -209,6 +209,11 @@ describe('Code editor component', () => {
     editorMock.on.mockRestore();
   });
 
+  it('provides ariaLabel to the underlying textarea', () => {
+    renderCodeEditor({ ariaLabel: 'test aria label' });
+    expect(editorMock.renderer.textarea).toHaveAttribute('aria-label', 'test aria label');
+  });
+
   describe('onDelayedChange', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -54,6 +54,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     i18nStrings,
     editorContentHeight,
     onEditorContentResize,
+    ariaLabel,
     languageLabel: customLanguageLabel,
     ...rest
   } = props;
@@ -80,9 +81,10 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     const updateAttribute = (attribute: string, value: string | undefined) =>
       value ? textarea.setAttribute(attribute, value) : textarea.removeAttribute(attribute);
     updateAttribute('id', controlId);
+    updateAttribute('aria-label', ariaLabel);
     updateAttribute('aria-labelledby', ariaLabelledby);
     updateAttribute('aria-describedby', ariaDescribedby);
-  }, [ariaDescribedby, ariaLabelledby, controlId, editor]);
+  }, [ariaLabel, ariaDescribedby, ariaLabelledby, controlId, editor]);
 
   const [paneStatus, setPaneStatus] = useState<PaneStatus>('hidden');
   const [annotations, setAnnotations] = useState<Ace.Annotation[]>([]);

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -111,6 +111,11 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
    * The event `detail` contains the new height of the editor in pixels.
    */
   onEditorContentResize?: NonCancelableEventHandler<CodeEditorProps.ResizeDetail>;
+
+  /**
+   * Adds `aria-label` to the code editor's textarea element.
+   */
+  ariaLabel?: string;
 }
 
 // Prevents typescript from collapsing a string union type into a string type while still allowing any string.


### PR DESCRIPTION
### Description

A couple of people have asked about providing screen reader `ariaLabel` properties to the code editor. Just like other form elements, we accept `ariaLabelledby` and `ariaDescribedby` on the component, but the code editor doesn't currently allow an `ariaLabel`.

Related links, issue #, if available: AWSUI-21273

### How has this been tested?

Unit test (x1)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
