### PR TITLE
fix: Use secondary links in help panel footers

### DIFF
--- a/src/help-panel/styles.scss
+++ b/src/help-panel/styles.scss
@@ -102,12 +102,6 @@
   strong {
     font-weight: styles.$font-weight-bold;
   }
-  a {
-    @include styles.link-inline;
-    &:focus {
-      @include styles.link-focus;
-    }
-  }
 
   .header {
     @include styles.font-panel-header;
@@ -144,6 +138,10 @@
   h6:first-child {
     margin-top: 0;
   }
+
+  a {
+    @include styles.link-inline;
+  }
 }
 
 .footer {
@@ -157,5 +155,15 @@
   ul {
     list-style: none;
     padding-left: 0;
+  }
+  a {
+    @include styles.link-default;
+  }
+}
+
+.content,
+.footer {
+  a:focus {
+    @include styles.link-focus;
   }
 }


### PR DESCRIPTION
### Description

Updated the help panel links to be primary links, but the footer that contains a list of links are not part of text content and should remain secondary.

Related links, issue #, if available: n/a

### How has this been tested?

Spotted during visual tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
