### PR TITLE
feat: Add ariaLabel as `title` to buttons as a visual hint

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2628,7 +2628,7 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
     },
     Object {
       "description": "Adds \`aria-label\` to the button element. It should be used in buttons that don't have text in order to make
-them accessible.",
+them accessible. The text will also be added to the \`title\` attribute of the button.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -353,13 +353,28 @@ describe('Button Component', () => {
   describe('aria-label attribute and children content', () => {
     test('renders from ariaLabel property', () => {
       const wrapper = renderButton({ ariaLabel: 'Benjamin', children: 'Button' });
-      expect(wrapper.getElement()).toHaveAttribute('aria-label', 'Benjamin');
+      expect(wrapper.getElement()).toHaveAccessibleName('Benjamin');
       expect(wrapper.findTextRegion()!.getElement()).toHaveTextContent('Button');
     });
 
     test('does not render if there is no label property', () => {
       const wrapper = renderButton({ children: 'Button' });
-      expect(wrapper.getElement()).not.toHaveAttribute('aria-label');
+      expect(wrapper.getElement()).toHaveAccessibleName('Button');
+    });
+
+    test('adds ariaLabel as title attribute - icon-only', () => {
+      const wrapper = renderButton({ ariaLabel: 'Benjamin', variant: 'icon', iconName: 'add-plus' });
+      expect(wrapper.getElement()).toHaveAttribute('title', 'Benjamin');
+    });
+
+    test('adds ariaLabel as title attribute - standard', () => {
+      const wrapper = renderButton({ ariaLabel: 'Remove item 1', children: 'Remove' });
+      expect(wrapper.getElement()).toHaveAttribute('title', 'Remove item 1');
+    });
+
+    test('does not add title to buttons without ariaLabel', () => {
+      const wrapper = renderButton({ variant: 'icon', iconName: 'add-plus' });
+      expect(wrapper.getElement()).not.toHaveAttribute('title');
     });
   });
 

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -67,7 +67,7 @@ export interface ButtonProps extends BaseComponentProps {
 
   /**
    * Adds `aria-label` to the button element. It should be used in buttons that don't have text in order to make
-   * them accessible.
+   * them accessible. The text will also be added to the `title` attribute of the button.
    */
   ariaLabel?: string;
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -94,6 +94,8 @@ export const InternalButton = React.forwardRef(
       'aria-label': ariaLabel,
       'aria-describedby': ariaDescribedby,
       'aria-expanded': ariaExpanded,
+      // add ariaLabel as `title` as visible hint text
+      title: ariaLabel,
       className: buttonClass,
       onClick: handleClick,
     } as const;


### PR DESCRIPTION
### Description

Add ariaLabel as `title` to buttons as a visual hint.

This can help, for example, to give extra information about
icon-only buttons whose meaning may not be immediately clear to all users.

Related links, issue #, if available: AWSUI-21235

### How has this been tested?

Unit tests & local testing in various browsers.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
