### PR TITLE
chore: Add check to ensure token value is string and add test

### DIFF
--- a/src/property-filter/__tests__/utils.test.ts
+++ b/src/property-filter/__tests__/utils.test.ts
@@ -146,4 +146,9 @@ describe('matchTokenValue', () => {
     );
     expect(result.value).toBe('one');
   });
+  test('should return token as-is for a token value of type string[]', () => {
+    const token: Token = { propertyKey: 'key', operator: '=', value: ['one', 'two', 'three'] };
+    const result = matchTokenValue(token, toInternalOptions([{ propertyKey: 'key', value: 'one,two,three' }]));
+    expect(result.value).toEqual(['one', 'two', 'three']);
+  });
 });

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -69,7 +69,10 @@ export function matchTokenValue(token: Token, filteringOptions: readonly Interna
       // exact match found: return it
       return { ...token, value: option.value };
     }
-    if (token.value.toLowerCase() === (option.label ?? option.value ?? '').toLowerCase()) {
+    if (
+      typeof token.value === 'string' &&
+      token.value.toLowerCase() === (option.label ?? option.value ?? '').toLowerCase()
+    ) {
       // non-exact match: save and keep running in case exact match found later
       bestMatch.value = option.value;
     }

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -69,6 +69,9 @@ export function matchTokenValue(token: Token, filteringOptions: readonly Interna
       // exact match found: return it
       return { ...token, value: option.value };
     }
+
+    // By default, the token value is a string, but when a custom property is used,
+    // the token value can be any, therefore we need to check for its type before calling toLowerCase()
     if (
       typeof token.value === 'string' &&
       token.value.toLowerCase() === (option.label ?? option.value ?? '').toLowerCase()


### PR DESCRIPTION
### Description

In trying to construct a `PropertyFilterOperatorExtended<string[]>` in a PropertyFilter, a token value type of `string[]` doesn’t actually work, but not until you try to edit. At token edit time, there’s a util that tries to manipulate the value as a string that fails (trying to call `toLowerCase()` on it). This wasn't caught by TypeScript because we don't have an ESLint rule for checking unsafe calls of `any` typed values.

This PR makes the handling logic in the util more robust by checking the type first. 

Related links, issue #, if available: AWSUI-21107

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
