### PR TITLE
chore: Prepare design tokens template

### DIFF
--- a/build-tools/tasks/themeable-source.js
+++ b/build-tools/tasks/themeable-source.js
@@ -4,73 +4,68 @@ const { parallel } = require('gulp');
 const path = require('path');
 const { promises: fsp } = require('fs');
 const { join } = require('path');
-const { task, noop } = require('../utils/gulp-utils');
+const { task } = require('../utils/gulp-utils');
 const workspace = require('../utils/workspace');
 const themes = require('../utils/themes');
 const { generatePackageJson } = require('./package-json');
 const { copyThirdPartyLicenses } = require('./licenses');
 const execa = require('execa');
+const { compileTypescript } = require('./typescript');
 
-const templateDir = 'internal/template';
+const componentsTemplateDir = 'internal/template';
+const designTokensTemplateDir = 'internal/template-tokens';
 const stylesDir = 'internal/scss';
 
 const theme = themes.find(theme => theme.name === 'default');
-const themeables = [];
-
-if (theme) {
-  themeables.push({
-    name: 'components-themeable',
-    sourceDir: theme.outputPath,
-    targetDir: join(workspace.targetPath, 'components-themeable'),
-    packageJson: {
-      name: '@cloudscape-design/components-themed',
-    },
-  });
-}
-
-const createCopyStylesTask = themeable => {
-  return task(`themeable-source:copy-styles:${themeable.name}`, () => {
-    return execa('rsync', [
-      '--prune-empty-dirs',
-      '-a',
-      '--include',
-      '*/',
-      // Code Editor SVGs will be embedded into the styling
-      '--include',
-      'code-editor/assets/*.svg',
-      '--include',
-      '*.scss',
-      '--exclude',
-      '*',
-      `${workspace.sourcePath}/`,
-      `${path.join(themeable.targetDir, stylesDir)}/`,
-    ]);
-  });
+const themeable = {
+  name: 'components-themeable',
+  sourceDir: theme.outputPath,
+  targetDir: join(workspace.targetPath, 'components-themeable'),
+  packageJson: {
+    name: '@cloudscape-design/components-themed',
+  },
+  tokensPackageJson: {
+    name: '@cloudscape-design/design-tokens-themed',
+  },
 };
 
-const createCopyTemplateTask = themeable => {
-  return task(`themeable-source:copy-template:${themeable.name}`, async () => {
-    const dest = path.join(themeable.targetDir, templateDir);
-    await fsp.mkdir(dest, { recursive: true });
-    // The '.' tells cp to copy all files inside the source to the destination.
-    // Using it as part of path.join will simply resolve it. That's why, we use template strings.
-    return execa('cp', ['-R', `${path.join(themeable.sourceDir, '/')}.`, dest]);
-  });
-};
+const copyStylesTask = task(`themeable-source:copy-styles:${themeable.name}`, () => {
+  return execa('rsync', [
+    '--prune-empty-dirs',
+    '-a',
+    '--include',
+    '*/',
+    // Code Editor SVGs will be embedded into the styling
+    '--include',
+    'code-editor/assets/*.svg',
+    '--include',
+    '*.scss',
+    '--exclude',
+    '*',
+    `${workspace.sourcePath}/`,
+    `${path.join(themeable.targetDir, stylesDir)}/`,
+  ]);
+});
 
-const createGenerateExtrasTask = themeable => {
-  return parallel(
-    generatePackageJson(join(themeable.targetDir, templateDir), themeable.packageJson, {
-      injectDependencies: true,
-    }),
-    copyThirdPartyLicenses('themeable', join(themeable.targetDir, templateDir))
-  );
-};
+const copyTemplateTask = task(`themeable-source:copy-template:${themeable.name}`, async () => {
+  const dest = path.join(themeable.targetDir, componentsTemplateDir);
+  await fsp.mkdir(dest, { recursive: true });
+  // The '.' tells cp to copy all files inside the source to the destination.
+  // Using it as part of path.join will simply resolve it. That's why, we use template strings.
+  return execa('cp', ['-R', `${path.join(themeable.sourceDir, '/')}.`, dest]);
+});
 
-const parallelOrNOOP = tasks => (tasks.length ? parallel(...tasks) : noop);
-
-const copyStylesTask = parallelOrNOOP(themeables.map(themeable => createCopyStylesTask(themeable)));
-const copyTemplateTask = parallelOrNOOP(themeables.map(themeable => createCopyTemplateTask(themeable)));
-const generateExtraTask = parallelOrNOOP(themeables.map(themeable => createGenerateExtrasTask(themeable)));
-
-module.exports = parallel(copyStylesTask, copyTemplateTask, generateExtraTask);
+module.exports = parallel(
+  compileTypescript({
+    name: themeable.name,
+    tsConfigPath: 'tsconfig.src-themeable.json',
+    outputPath: themeable.targetDir,
+  }),
+  generatePackageJson(join(themeable.targetDir, componentsTemplateDir), themeable.packageJson, {
+    injectDependencies: true,
+  }),
+  generatePackageJson(join(themeable.targetDir, designTokensTemplateDir), themeable.tokensPackageJson),
+  copyThirdPartyLicenses('themeable', join(themeable.targetDir, componentsTemplateDir)),
+  copyStylesTask,
+  copyTemplateTask
+);

--- a/src-themeable/internal/template/internal/generated/theming/index.cjs.d.ts
+++ b/src-themeable/internal/template/internal/generated/theming/index.cjs.d.ts
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ThemePreset, GlobalValue, TypedModeValueOverride } from '@cloudscape-design/theming-build';
+
+export interface TypedOverride {
+  tokens: Partial<Record<string, GlobalValue | TypedModeValueOverride>>;
+}
+export const preset: ThemePreset;

--- a/src-themeable/theming.ts
+++ b/src-themeable/theming.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { join } from 'path';
+import { buildThemedComponents as themingCoreBuild } from '@cloudscape-design/theming-build';
+import { preset, TypedOverride } from './internal/template/internal/generated/theming/index.cjs';
+
+const internalDir = join(__dirname, './internal');
+const scssDir = join(internalDir, './scss');
+const templateDir = join(internalDir, './template');
+const designTokensTemplateDir = join(internalDir, './template-tokens');
+
+export type Theme = TypedOverride;
+export interface BuildThemedComponentsParams {
+  theme: Theme;
+  outputDir: string;
+  baseThemeId?: string;
+}
+
+export function buildThemedComponents({ theme, outputDir, baseThemeId }: BuildThemedComponentsParams): Promise<void> {
+  return themingCoreBuild({
+    override: theme,
+    preset,
+    baseThemeId,
+    componentsOutputDir: join(outputDir, 'components'),
+    designTokensOutputDir: join(outputDir, 'design-tokens'),
+    templateDir,
+    designTokensTemplateDir,
+    scssDir,
+  });
+}

--- a/tsconfig.src-themeable.json
+++ b/tsconfig.src-themeable.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node16/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src-themeable",
+    "declaration": true,
+    "incremental": true
+  },
+  "include": ["src-themeable"]
+}


### PR DESCRIPTION
### Description

A step to support cloudscape-design/theming-core#35

This PR contains the same changes as already made in https://github.com/cloudscape-design/components/pull/1176 which got reverted because of a potential conflict about the `internalDir` path when generating the npm package artifacts. I verified successfully this wan't cause an issue by generating those artifacts and used them to generate a custom (build time) theme.

These changes:
- configures the `designTokensOutputDir` which holds the `package.json` which will be part of the generated build time theme artifacts.
- simplifies the way how we generate the themed components by generating the `buildThemedComponents` as part of the components build. It allows us to remove the ts build step in the theming package (which generates the build artifacts) - see CR-94529953 for details.

Related links, issue #, if available:
- CR-94529953
- https://github.com/cloudscape-design/components/pull/1176
- AWSUI-20466

### How has this been tested?

**1. Tested within the components package**
- build the related theming core change (https://github.com/cloudscape-design/theming-core/pull/40) and linked it in the components dependencies 
- create themed components by using this helper script: https://gist.github.com/johannes-weber/e11b937a6f9d31069d42fa068960343c
- validate the generated folders (components and design-tokens) contain the associated `package.json`

**2. Tested by generating the build artifacts using the release tools**
- build the package and follow the steps to generate the components-themeable package which would be published
- build a custom theme by using the generated components-themeable artifacts and generate a new theme
- verify the theme got generated and the output dir holds the correct `package.json`

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
