### PR TITLE
fix: Indent descriptions in headers of container variant Expandable sections

### DIFF
--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -177,7 +177,7 @@ const ExpandableHeaderTextWrapper = ({
       {isContainer ? (
         <InternalHeader
           variant="h2"
-          description={description}
+          description={<span className={styles['description-container']}>{description}</span>}
           counter={headerCounter}
           info={headerInfo}
           actions={headerActions}

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -177,7 +177,7 @@ const ExpandableHeaderTextWrapper = ({
       {isContainer ? (
         <InternalHeader
           variant="h2"
-          description={<span className={styles['description-container']}>{description}</span>}
+          description={description}
           counter={headerCounter}
           info={headerInfo}
           actions={headerActions}

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -2,7 +2,6 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
-@use 'sass:map';
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -12,7 +12,8 @@
 $icon-width-normal: awsui.$size-icon-normal;
 $icon-width-medium: awsui.$size-icon-medium;
 $icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width-normal}) / -2';
-$icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
+$icon-margin-right-normal: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
+$icon-margin-right-medium: awsui.$space-xs;
 
 .root {
   @include styles.styles-reset;
@@ -36,9 +37,9 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
   position: relative;
   margin-left: calc(#{$icon-margin-left});
   // For vertical alignment of text in side navigation items
-  margin-right: calc(#{$icon-margin-right});
+  margin-right: calc(#{$icon-margin-right-normal});
   &-container {
-    margin-right: awsui.$space-xs;
+    margin-right: $icon-margin-right-medium;
   }
 }
 
@@ -188,8 +189,8 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 
 // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
 .description-default {
-  padding-left: calc(#{$icon-width-normal} + #{$icon-margin-right} + #{$icon-margin-left});
+  padding-left: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
 }
 .description-container {
-  padding-left: calc(#{$icon-width-medium} + #{$icon-margin-right} + #{$icon-margin-left});
+  padding-left: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
 }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -2,7 +2,7 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
-
+@use 'sass:map';
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/hooks/focus-visible' as focus-visible;
@@ -10,8 +10,9 @@
 
 @use './motion';
 
-$icon-width: awsui.$size-icon-normal;
-$icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width}) / -2';
+$icon-width-normal: awsui.$size-icon-normal;
+$icon-width-medium: awsui.$size-icon-medium;
+$icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width-normal}) / -2';
 $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 
 .root {
@@ -186,7 +187,10 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
   }
 }
 
+// Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
 .description-default {
-  // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
-  padding-left: calc(#{$icon-width} + #{$icon-margin-right} + #{$icon-margin-left});
+  padding-left: calc(#{$icon-width-normal} + #{$icon-margin-right} + #{$icon-margin-left});
+}
+.description-container {
+  padding-left: calc(#{$icon-width-medium} + #{$icon-margin-right} + #{$icon-margin-left});
 }


### PR DESCRIPTION
### Description

Visual design review for #1206 surfaced that descriptions in expandable section headers should always be indented to match the header, for al variants, including container.

Related issue: AWSUI-21297

### How has this been tested?

- Manually tested in Chrome, Firefox and Safari
- Reviewed that BackstopJS failures are as expected
- Visual regression tests are in place

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
