### PR TITLE
revert: Revert "feat: Support descriptions in Expandable section header for  …

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -13,7 +13,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<ExpandableSectionProps>([
   {
-    defaultExpanded: [true, false],
+    expanded: [true, false],
     variant: ['default'],
     headerText: [
       'Default Example Header',
@@ -28,7 +28,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    defaultExpanded: [true],
+    expanded: [true],
     variant: ['footer'],
     headerText: [
       'Footer Example Header',
@@ -40,7 +40,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    defaultExpanded: [true, false],
+    expanded: [true, false],
     variant: ['container'],
     headerText: [
       'Container example header',
@@ -53,7 +53,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    defaultExpanded: [true],
+    expanded: [true],
     variant: ['container'],
     headerText: [
       'Container example header',
@@ -66,7 +66,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     headerCounter: [undefined, '(0)'],
   },
   {
-    defaultExpanded: [true],
+    expanded: [true],
     variant: ['container'],
     headerText: ['Container example header'],
     children: [
@@ -82,7 +82,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     disableContentPaddings: [false],
   },
   {
-    defaultExpanded: [true],
+    expanded: [true],
     variant: ['container'],
     // keep on variant='container' with header for screenshot test to check no style breaks
     header: [<Header variant="h2">Container example header</Header>],
@@ -99,7 +99,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     disableContentPaddings: [true],
   },
   {
-    defaultExpanded: [true, false],
+    expanded: [true, false],
     variant: ['navigation'],
     headerText: [
       'Navigation Example Header',
@@ -111,25 +111,18 @@ const permutations = createPermutations<ExpandableSectionProps>([
     children: ['Navigation content'],
   },
   {
-    defaultExpanded: [true],
+    expanded: [true],
     headerAriaLabel: ['Header with ARIA label (ARIA)'],
     variant: ['default', 'footer', 'navigation'],
     headerText: ['Header with ARIA label'],
     children: ['Sample content'],
   },
   {
-    defaultExpanded: [false],
+    expanded: [false],
     variant: ['default', 'footer', 'navigation'],
     headerText: ['Custom heading tag override'],
     children: ['Sample content'],
     headingTagOverride: [undefined, 'h2', 'h3'],
-  },
-  {
-    variant: ['default', 'container'],
-    headerText: ['With description'],
-    children: ['Sample content'],
-    headerDescription: ['Sample description'],
-    defaultExpanded: [false, true],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -25,10 +25,6 @@ function renderExpandableSection(props: ExpandableSectionProps = {}): Expandable
 }
 
 describe('Expandable Section', () => {
-  const variantsWithDescription: ExpandableSectionProps.Variant[] = ['container', 'default'];
-  const variantsWithoutDescription: ExpandableSectionProps.Variant[] = ['footer', 'navigation'];
-  const nonContainerVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'navigation'];
-
   describe('variant property', () => {
     test('has one trigger button and no div=[role=button] for variant navigation', () => {
       const wrapper = renderExpandableSection({ variant: 'navigation' });
@@ -54,18 +50,6 @@ describe('Expandable Section', () => {
       });
       const header = wrapper.findHeader().getElement();
       expect(header).toHaveTextContent('Test Header');
-    });
-    describe('populates description slot correctly', () => {
-      for (const variant of variantsWithDescription) {
-        test(`${variant} variant`, () => {
-          const wrapper = renderExpandableSection({
-            headerText: 'Test Header',
-            headerDescription: 'Description',
-          });
-          const header = wrapper.findHeader().getElement();
-          expect(header).toHaveTextContent('Description');
-        });
-      }
     });
     test('populates info links slot correctly for "container" variant', () => {
       const wrapper = renderExpandableSection({
@@ -106,52 +90,6 @@ describe('Expandable Section', () => {
       });
       const expandedContent = wrapper.findExpandedContent()?.getElement();
       expect(expandedContent).toHaveTextContent('Example content');
-    });
-  });
-
-  describe('does not populate non-supported slots', () => {
-    describe('Description', () => {
-      for (const variant of variantsWithoutDescription) {
-        test(`${variant} variant`, () => {
-          const wrapper = renderExpandableSection({
-            headerText: 'Test Header',
-            headerDescription: 'Description',
-            variant,
-          });
-          const header = wrapper.findHeader().getElement();
-          expect(header).not.toHaveTextContent('Description');
-        });
-      }
-    });
-    describe('Other props', () => {
-      for (const variant of nonContainerVariants) {
-        describe(`${variant} variant`, () => {
-          test('Counter', () => {
-            const wrapper = renderExpandableSection({
-              headerText: 'Test Header',
-              headerCounter: '(3)',
-            });
-            const header = wrapper.findHeader().getElement();
-            expect(header).not.toHaveTextContent('(3)');
-          });
-          test('Info links', () => {
-            const wrapper = renderExpandableSection({
-              headerText: 'Test Header',
-              headerInfo: <Link variant="info">Info</Link>,
-            });
-            const header = wrapper.findHeader().getElement();
-            expect(header).not.toHaveTextContent('Info');
-          });
-          test('Action buttons', () => {
-            const wrapper = renderExpandableSection({
-              headerText: 'Test Header',
-              headerInfo: <Button>Action</Button>,
-            });
-            const header = wrapper.findHeader().getElement();
-            expect(header).not.toHaveTextContent('Action');
-          });
-        });
-      }
     });
   });
 
@@ -199,22 +137,18 @@ describe('Expandable Section', () => {
   });
 
   describe('a11y', () => {
-    describe('content region is labelled by header', () => {
-      for (const variant of variantsWithDescription) {
-        test(`${variant} variant`, () => {
-          const wrapper = renderExpandableSection({
-            variant,
-            headerText: 'Header',
-            headerDescription: 'Description',
-          });
-          const header = wrapper.findExpandButton().getElement();
-          const expandedContent = wrapper.findContent().getElement();
-          const contentId = expandedContent?.getAttribute('id');
-          expect(header).toHaveAttribute('aria-controls', contentId);
-          expect(expandedContent).toHaveAccessibleName('Header');
-          expect(expandedContent).toHaveAccessibleDescription('Description');
-        });
-      }
+    test('content region is labelled by header', () => {
+      const wrapper = renderExpandableSection({
+        variant: 'container',
+        headerText: 'Container header',
+        headerDescription: 'Container description',
+      });
+      const header = wrapper.findExpandButton().getElement();
+      const expandedContent = wrapper.findContent().getElement();
+      const contentId = expandedContent?.getAttribute('id');
+      expect(header).toHaveAttribute('aria-controls', contentId);
+      expect(expandedContent).toHaveAccessibleName('Container header');
+      expect(expandedContent).toHaveAccessibleDescription('Container description');
     });
     test('aria-expanded=false when collapsed', () => {
       const wrapper = renderExpandableSection();
@@ -242,6 +176,7 @@ describe('Expandable Section', () => {
 
   describe('dev warnings', () => {
     const componentName = 'ExpandableSection';
+    const nonContainerVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'navigation'];
 
     test('logs warning for deprecated header prop', () => {
       render(<ExpandableSection variant="container" header={<Header />} />);
@@ -253,63 +188,31 @@ describe('Expandable Section', () => {
     });
 
     describe('logs warning for non supported configurations', () => {
-      describe('headerDescription', () => {
-        for (const variant of variantsWithoutDescription) {
-          test(`${variant} variant`, () => {
-            render(<ExpandableSection variant={variant} headerDescription={'Description'} />);
-            expect(warnOnce).toHaveBeenCalledTimes(1);
-            expect(warnOnce).toHaveBeenCalledWith(
-              componentName,
-              'The `headerDescription` prop is only supported for the "default" and "container" variants.'
-            );
-          });
-        }
-      });
+      const testWarnings = (props: ExpandableSectionProps) => {
+        render(<ExpandableSection {...props} />);
+        expect(warnOnce).toHaveBeenCalledTimes(1);
+        expect(warnOnce).toHaveBeenCalledWith(
+          componentName,
+          'The `headerCounter`, `headerDescription`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
+        );
+      };
 
-      describe('other properties', () => {
-        const testWarnings = (props: ExpandableSectionProps) => {
-          render(<ExpandableSection {...props} />);
-          expect(warnOnce).toHaveBeenCalledTimes(1);
-          expect(warnOnce).toHaveBeenCalledWith(
-            componentName,
-            'The `headerCounter`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
-          );
-        };
-
-        for (const variant of nonContainerVariants) {
-          describe(`${variant} variant`, () => {
-            test('headerCounter', () => {
-              testWarnings({ variant, headerCounter: '(2)' });
-            });
-            test('headerInfo', () => {
-              testWarnings({ variant, headerInfo: <Link>Info</Link> });
-            });
-            test('headerActions', () => {
-              testWarnings({ variant, headerActions: <Button>Action</Button> });
-            });
+      for (const variant of nonContainerVariants) {
+        describe(`${variant} variant`, () => {
+          test('headerCounter', () => {
+            testWarnings({ variant, headerCounter: '(2)' });
           });
-        }
-      });
-
-      describe('headerDescription and other properties combined', () => {
-        const testWarnings = (props: ExpandableSectionProps) => {
-          render(<ExpandableSection {...props} headerDescription="Description" />);
-          expect(warnOnce).toHaveBeenCalledTimes(2);
-        };
-        for (const variant of variantsWithoutDescription) {
-          describe(`${variant} variant`, () => {
-            test('headerCounter', () => {
-              testWarnings({ variant, headerCounter: '(2)' });
-            });
-            test('headerInfo', () => {
-              testWarnings({ variant, headerInfo: <Link>Info</Link> });
-            });
-            test('headerActions', () => {
-              testWarnings({ variant, headerActions: <Button>Action</Button> });
-            });
+          test('headerCounter', () => {
+            testWarnings({ variant, headerDescription: 'Description' });
           });
-        }
-      });
+          test('headerInfo', () => {
+            testWarnings({ variant, headerInfo: <Link>Info</Link> });
+          });
+          test('headerActions', () => {
+            testWarnings({ variant, headerActions: <Button>Action</Button> });
+          });
+        });
+      }
     });
 
     describe('does not log warning for supported configurations', () => {
@@ -331,13 +234,6 @@ describe('Expandable Section', () => {
           headerDescription: 'Description',
           headerInfo: <Link>Info</Link>,
           headerActions: <Button>Action</Button>,
-        });
-      });
-
-      test('default variant', () => {
-        testWarnings({
-          variant: 'default',
-          headerDescription: 'Description',
         });
       });
     });
@@ -450,6 +346,14 @@ describe('Variant container with headerText', () => {
     });
     const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
     expect(headerButton).toHaveAccessibleDescription('Expand to see more content');
+  });
+  test('does not set aria-labelledby for default variant', () => {
+    const wrapper = renderExpandableSection({
+      variant: 'default',
+      headerText: 'Header component',
+    });
+    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+    expect(headerButton).not.toHaveAttribute('aria-labelledby');
   });
   test('button should be under heading', () => {
     const wrapper = renderExpandableSection({

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -5,10 +5,9 @@ import React, { KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react
 import InternalIcon from '../icon/internal';
 import clsx from 'clsx';
 import styles from './styles.css.js';
-import InternalHeader, { Description as HeaderDescription } from '../header/internal';
+import InternalHeader from '../header/internal';
 import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { variantSupportsDescription } from './utils';
 
 export const componentName = 'ExpandableSection';
 
@@ -68,7 +67,7 @@ const ExpandableDefaultHeader = ({
     <div
       id={id}
       role="button"
-      className={clsx(className, styles['expand-button'], styles['click-target'])}
+      className={clsx(className, styles['expand-button'])}
       tabIndex={0}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
@@ -95,7 +94,7 @@ const ExpandableNavigationHeader = ({
   icon,
 }: ExpandableNavigationHeaderProps) => {
   return (
-    <div id={id} className={clsx(className, styles['click-target'])} onClick={onClick}>
+    <div id={id} className={className} onClick={onClick}>
       <button
         className={clsx(styles['icon-container'], styles['expand-button'])}
         aria-labelledby={ariaLabelledBy}
@@ -131,38 +130,22 @@ const ExpandableHeaderTextWrapper = ({
   onKeyDown,
 }: ExpandableHeaderTextWrapperProps) => {
   const isContainer = variant === 'container';
-  const isDefault = variant === 'default';
   const HeadingTag = headingTagOverride || 'div';
   const hasInteractiveElements = isContainer && (headerInfo || headerActions);
   const listeners = { onClick, onKeyDown, onKeyUp };
-
-  // If interactive elements are present, constrain the clickable area to only the icon and the header text
-  // to prevent nesting interactive elements.
+  const wrapperListeners = hasInteractiveElements ? undefined : listeners;
   const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
-  // For the default variant, include also the immediate wrapper around it to include the entire row
-  // for backwards compatibility, but exclude the description below.
-  const headingTagListeners = !headerButtonListeners && isDefault ? listeners : undefined;
-  // For all other cases, make the entire header clickable for backwards compatibility.
-  const wrapperListeners = !headerButtonListeners && !headingTagListeners ? listeners : undefined;
-
-  const description = variantSupportsDescription(variant) && headerDescription && (
-    <span id={descriptionId} className={styles[`description-${variant}`]}>
-      {headerDescription}
-    </span>
-  );
-
   const headerButton = (
     <span
       className={clsx(
         styles['expand-button'],
-        isContainer ? styles['header-container-button'] : styles['header-button'],
-        headerButtonListeners && styles['click-target']
+        isContainer ? styles['header-container-button'] : styles['header-button']
       )}
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}
-      aria-labelledby={!ariaLabel && description ? id : undefined}
-      aria-describedby={description ? descriptionId : undefined}
+      aria-labelledby={!ariaLabel && isContainer ? id : undefined}
+      aria-describedby={isContainer && headerDescription ? descriptionId : undefined}
       aria-controls={ariaControls}
       aria-expanded={expanded}
       {...headerButtonListeners}
@@ -173,11 +156,14 @@ const ExpandableHeaderTextWrapper = ({
   );
 
   return (
-    <div className={clsx(className, wrapperListeners && styles['click-target'])} {...wrapperListeners}>
+    <div
+      className={clsx(className, hasInteractiveElements && styles['with-interactive-elements'])}
+      {...wrapperListeners}
+    >
       {isContainer ? (
         <InternalHeader
           variant="h2"
-          description={description}
+          description={headerDescription && <span id={descriptionId}>{headerDescription}</span>}
           counter={headerCounter}
           info={headerInfo}
           actions={headerActions}
@@ -186,14 +172,8 @@ const ExpandableHeaderTextWrapper = ({
           {headerButton}
         </InternalHeader>
       ) : (
-        <HeadingTag
-          className={clsx(styles['header-wrapper'], headingTagListeners && styles['click-target'])}
-          {...headingTagListeners}
-        >
-          {headerButton}
-        </HeadingTag>
+        <HeadingTag className={styles['header-wrapper']}>{headerButton}</HeadingTag>
       )}
-      {isDefault && description && <HeaderDescription variantOverride="h3">{description}</HeaderDescription>}
     </div>
   );
 };
@@ -235,17 +215,10 @@ export const ExpandableSectionHeader = ({
     variant,
   };
 
-  if ((headerCounter || headerInfo || headerActions) && variant !== 'container' && isDevelopment) {
+  if ((headerDescription || headerCounter || headerInfo || headerActions) && variant !== 'container' && isDevelopment) {
     warnOnce(
       componentName,
-      'The `headerCounter`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
-    );
-  }
-
-  if (headerDescription && variant !== 'container' && variant !== 'default' && isDevelopment) {
-    warnOnce(
-      componentName,
-      'The `headerDescription` prop is only supported for the "default" and "container" variants.'
+      'The `headerCounter`, `headerDescription`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
     );
   }
 

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -16,7 +16,6 @@ import styles from './styles.css.js';
 import { ExpandableSectionContainer } from './expandable-section-container';
 import { ExpandableSectionHeader } from './expandable-section-header';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { variantSupportsDescription } from './utils';
 
 type InternalExpandableSectionProps = ExpandableSectionProps & InternalBaseComponentProps;
 
@@ -123,7 +122,7 @@ export default function InternalExpandableSection({
           role="group"
           aria-label={triggerProps.ariaLabel}
           aria-labelledby={triggerProps.ariaLabelledBy}
-          aria-describedby={variantSupportsDescription(variant) && headerDescription ? descriptionId : undefined}
+          aria-describedby={variant === 'container' && headerDescription ? descriptionId : undefined}
         >
           {children}
         </div>

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -10,10 +10,6 @@
 
 @use './motion';
 
-$icon-width: awsui.$size-icon-normal;
-$icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width}) / -2';
-$icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
-
 .root {
   @include styles.styles-reset;
   @include styles.text-wrapping;
@@ -34,9 +30,9 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 
 .icon-container {
   position: relative;
-  margin-left: calc(#{$icon-margin-left});
+  margin-left: calc((#{awsui.$font-body-m-line-height} - #{awsui.$size-icon-normal}) / -2);
   // For vertical alignment of text in side navigation items
-  margin-right: calc(#{$icon-margin-right});
+  margin-right: calc(#{awsui.$space-xxs} + #{awsui.$border-divider-list-width});
   &-container {
     margin-right: awsui.$space-xs;
   }
@@ -44,6 +40,7 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 
 .wrapper {
   box-sizing: border-box;
+  display: flex;
   border: none;
   width: 100%;
   line-height: awsui.$font-body-m-line-height;
@@ -67,20 +64,17 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
     border-left: awsui.$border-divider-section-width solid transparent;
   }
 
-  &-navigation,
-  &-footer,
-  &-container {
-    display: flex;
-    font-weight: awsui.$font-heading-s-weight;
-  }
-
   &-default,
   &-navigation,
   &-footer {
     color: awsui.$color-text-expandable-section-default;
+    font-weight: awsui.$font-heading-s-weight;
     @include styles.font-smoothing;
     font-size: awsui.$font-expandable-heading-size;
     letter-spacing: awsui.$font-heading-s-letter-spacing;
+    &:hover {
+      color: awsui.$color-text-expandable-section-hover;
+    }
   }
 
   &-container {
@@ -98,15 +92,14 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 }
 
 .header {
-  /* used in test-utils */
+  display: flex;
 
   &-wrapper {
+    font-weight: inherit;
     font-size: inherit;
     letter-spacing: inherit;
     margin: 0;
     padding: 0;
-    font-weight: awsui.$font-heading-s-weight;
-    display: flex;
   }
 
   &-button {
@@ -121,11 +114,20 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
     }
   }
 
+  &:not(.with-interactive-elements) {
+    cursor: pointer;
+  }
+
   &-container {
     width: 100%;
     // The icon-container style is kept for variant='container' and header
     > .icon-container {
       margin-top: awsui.$space-expandable-section-icon-offset-top;
+    }
+
+    // stylelint-disable-next-line selector-combinator-disallowed-list
+    &.with-interactive-elements &-button {
+      cursor: pointer;
     }
   }
 
@@ -177,16 +179,4 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
   @include focus-visible.when-visible {
     @include styles.form-focus-element(awsui.$border-radius-control-default-focus-ring);
   }
-}
-
-.click-target {
-  cursor: pointer;
-  &:not(.wrapper-container):not(.header-container-button):hover {
-    color: awsui.$color-text-expandable-section-hover;
-  }
-}
-
-.description-default {
-  // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
-  padding-left: calc(#{$icon-width} + #{$icon-margin-right} + #{$icon-margin-left});
 }

--- a/src/expandable-section/utils.ts
+++ b/src/expandable-section/utils.ts
@@ -1,7 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-import { ExpandableSectionProps } from './interfaces';
-
-export function variantSupportsDescription(variant: ExpandableSectionProps.Variant) {
-  return variant === 'container' || variant === 'default';
-}

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -82,7 +82,17 @@ export default function InternalHeader({
             {info && <span className={styles.info}>{info}</span>}
           </InfoLinkLabelContext.Provider>
         </div>
-        <Description variantOverride={variantOverride}>{description}</Description>
+        {description && (
+          <p
+            className={clsx(
+              styles.description,
+              styles[`description-variant-${variantOverride}`],
+              isRefresh && styles[`description-variant-${variantOverride}-refresh`]
+            )}
+          >
+            {description}
+          </p>
+        )}
       </div>
       {actions && (
         <div
@@ -96,23 +106,5 @@ export default function InternalHeader({
         </div>
       )}
     </div>
-  );
-}
-
-export function Description({ children, variantOverride }: { children: React.ReactNode; variantOverride: string }) {
-  const isRefresh = useVisualRefresh();
-  return (
-    (children && (
-      <p
-        className={clsx(
-          styles.description,
-          styles[`description-variant-${variantOverride}`],
-          isRefresh && styles[`description-variant-${variantOverride}-refresh`]
-        )}
-      >
-        {children}
-      </p>
-    )) ||
-    null
   );
 }


### PR DESCRIPTION
…default variant (#1206)"

This reverts commit 2375723f0ce93d2ca66c98c73b5cd1ffacb7cfd7.

### Description

Because it breaks the default variant when using the deprecated `header` prop. We need to keep supporting that case for backwards compatibility.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
