### PR TITLE
chore: Add visual regression coverage for deprecated header prop in E…

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -124,6 +124,12 @@ const permutations = createPermutations<ExpandableSectionProps>([
     children: ['Sample content'],
     headingTagOverride: [undefined, 'h2', 'h3'],
   },
+  {
+    defaultExpanded: [false],
+    variant: ['default', 'footer'],
+    header: ['Deprecated header prop'],
+    children: ['Sample content'],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 


### PR DESCRIPTION
…xpandable section

### Description

This will be useful to revert #1232 safely, and in general to prevent breakage of this prop even if it's deprecated. If it shouldn't break, it should be covered.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
