### PR TITLE
feat: Support descriptions in Expandable section header for default variant

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -13,7 +13,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<ExpandableSectionProps>([
   {
-    expanded: [true, false],
+    defaultExpanded: [true, false],
     variant: ['default'],
     headerText: [
       'Default Example Header',
@@ -28,7 +28,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    expanded: [true],
+    defaultExpanded: [true],
     variant: ['footer'],
     headerText: [
       'Footer Example Header',
@@ -40,7 +40,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    expanded: [true, false],
+    defaultExpanded: [true, false],
     variant: ['container'],
     headerText: [
       'Container example header',
@@ -53,7 +53,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
   {
-    expanded: [true],
+    defaultExpanded: [true],
     variant: ['container'],
     headerText: [
       'Container example header',
@@ -66,7 +66,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     headerCounter: [undefined, '(0)'],
   },
   {
-    expanded: [true],
+    defaultExpanded: [true],
     variant: ['container'],
     headerText: ['Container example header'],
     children: [
@@ -82,7 +82,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     disableContentPaddings: [false],
   },
   {
-    expanded: [true],
+    defaultExpanded: [true],
     variant: ['container'],
     // keep on variant='container' with header for screenshot test to check no style breaks
     header: [<Header variant="h2">Container example header</Header>],
@@ -99,7 +99,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     disableContentPaddings: [true],
   },
   {
-    expanded: [true, false],
+    defaultExpanded: [true, false],
     variant: ['navigation'],
     headerText: [
       'Navigation Example Header',
@@ -111,18 +111,25 @@ const permutations = createPermutations<ExpandableSectionProps>([
     children: ['Navigation content'],
   },
   {
-    expanded: [true],
+    defaultExpanded: [true],
     headerAriaLabel: ['Header with ARIA label (ARIA)'],
     variant: ['default', 'footer', 'navigation'],
     headerText: ['Header with ARIA label'],
     children: ['Sample content'],
   },
   {
-    expanded: [false],
+    defaultExpanded: [false],
     variant: ['default', 'footer', 'navigation'],
     headerText: ['Custom heading tag override'],
     children: ['Sample content'],
     headingTagOverride: [undefined, 'h2', 'h3'],
+  },
+  {
+    variant: ['default', 'container'],
+    headerText: ['With description'],
+    children: ['Sample content'],
+    headerDescription: ['Sample description'],
+    defaultExpanded: [false, true],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -131,6 +131,12 @@ const permutations = createPermutations<ExpandableSectionProps>([
     headerDescription: ['Sample description'],
     defaultExpanded: [false, true],
   },
+  {
+    defaultExpanded: [false],
+    variant: ['default', 'footer'],
+    header: ['Deprecated header prop'],
+    children: ['Sample content'],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -59,6 +59,7 @@ describe('Expandable Section', () => {
       for (const variant of variantsWithDescription) {
         test(`${variant} variant`, () => {
           const wrapper = renderExpandableSection({
+            variant,
             headerText: 'Test Header',
             headerDescription: 'Description',
           });
@@ -128,6 +129,7 @@ describe('Expandable Section', () => {
         describe(`${variant} variant`, () => {
           test('Counter', () => {
             const wrapper = renderExpandableSection({
+              variant,
               headerText: 'Test Header',
               headerCounter: '(3)',
             });
@@ -136,6 +138,7 @@ describe('Expandable Section', () => {
           });
           test('Info links', () => {
             const wrapper = renderExpandableSection({
+              variant,
               headerText: 'Test Header',
               headerInfo: <Link variant="info">Info</Link>,
             });
@@ -144,6 +147,7 @@ describe('Expandable Section', () => {
           });
           test('Action buttons', () => {
             const wrapper = renderExpandableSection({
+              variant,
               headerText: 'Test Header',
               headerInfo: <Button>Action</Button>,
             });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -51,7 +51,7 @@ interface ExpandableSectionHeaderProps extends Omit<ExpandableDefaultHeaderProps
   ariaLabelledBy?: string;
 }
 
-const ExpandableDefaultHeader = ({
+const ExpandableDeprecatedHeader = ({
   id,
   className,
   onClick,
@@ -68,7 +68,7 @@ const ExpandableDefaultHeader = ({
     <div
       id={id}
       role="button"
-      className={clsx(className, styles['expand-button'], styles['click-target'])}
+      className={clsx(className, styles['expand-button'], styles['click-target'], styles['header-deprecated'])}
       tabIndex={0}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
@@ -286,13 +286,13 @@ export const ExpandableSectionHeader = ({
   }
 
   return (
-    <ExpandableDefaultHeader
+    <ExpandableDeprecatedHeader
       className={clsx(className, wrapperClassName, styles.focusable, expanded && styles.expanded)}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
       {...defaultHeaderProps}
     >
       {header}
-    </ExpandableDefaultHeader>
+    </ExpandableDeprecatedHeader>
   );
 };

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -5,9 +5,10 @@ import React, { KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react
 import InternalIcon from '../icon/internal';
 import clsx from 'clsx';
 import styles from './styles.css.js';
-import InternalHeader from '../header/internal';
+import InternalHeader, { Description as HeaderDescription } from '../header/internal';
 import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { variantSupportsDescription } from './utils';
 
 export const componentName = 'ExpandableSection';
 
@@ -67,7 +68,7 @@ const ExpandableDefaultHeader = ({
     <div
       id={id}
       role="button"
-      className={clsx(className, styles['expand-button'])}
+      className={clsx(className, styles['expand-button'], styles['click-target'])}
       tabIndex={0}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
@@ -94,7 +95,7 @@ const ExpandableNavigationHeader = ({
   icon,
 }: ExpandableNavigationHeaderProps) => {
   return (
-    <div id={id} className={className} onClick={onClick}>
+    <div id={id} className={clsx(className, styles['click-target'])} onClick={onClick}>
       <button
         className={clsx(styles['icon-container'], styles['expand-button'])}
         aria-labelledby={ariaLabelledBy}
@@ -130,22 +131,38 @@ const ExpandableHeaderTextWrapper = ({
   onKeyDown,
 }: ExpandableHeaderTextWrapperProps) => {
   const isContainer = variant === 'container';
+  const isDefault = variant === 'default';
   const HeadingTag = headingTagOverride || 'div';
   const hasInteractiveElements = isContainer && (headerInfo || headerActions);
   const listeners = { onClick, onKeyDown, onKeyUp };
-  const wrapperListeners = hasInteractiveElements ? undefined : listeners;
+
+  // If interactive elements are present, constrain the clickable area to only the icon and the header text
+  // to prevent nesting interactive elements.
   const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
+  // For the default variant, include also the immediate wrapper around it to include the entire row
+  // for backwards compatibility, but exclude the description below.
+  const headingTagListeners = !headerButtonListeners && isDefault ? listeners : undefined;
+  // For all other cases, make the entire header clickable for backwards compatibility.
+  const wrapperListeners = !headerButtonListeners && !headingTagListeners ? listeners : undefined;
+
+  const description = variantSupportsDescription(variant) && headerDescription && (
+    <span id={descriptionId} className={styles[`description-${variant}`]}>
+      {headerDescription}
+    </span>
+  );
+
   const headerButton = (
     <span
       className={clsx(
         styles['expand-button'],
-        isContainer ? styles['header-container-button'] : styles['header-button']
+        isContainer ? styles['header-container-button'] : styles['header-button'],
+        headerButtonListeners && styles['click-target']
       )}
       role="button"
       tabIndex={0}
       aria-label={ariaLabel}
-      aria-labelledby={!ariaLabel && isContainer ? id : undefined}
-      aria-describedby={isContainer && headerDescription ? descriptionId : undefined}
+      aria-labelledby={!ariaLabel && description ? id : undefined}
+      aria-describedby={description ? descriptionId : undefined}
       aria-controls={ariaControls}
       aria-expanded={expanded}
       {...headerButtonListeners}
@@ -156,14 +173,11 @@ const ExpandableHeaderTextWrapper = ({
   );
 
   return (
-    <div
-      className={clsx(className, hasInteractiveElements && styles['with-interactive-elements'])}
-      {...wrapperListeners}
-    >
+    <div className={clsx(className, wrapperListeners && styles['click-target'])} {...wrapperListeners}>
       {isContainer ? (
         <InternalHeader
           variant="h2"
-          description={headerDescription && <span id={descriptionId}>{headerDescription}</span>}
+          description={description}
           counter={headerCounter}
           info={headerInfo}
           actions={headerActions}
@@ -172,8 +186,14 @@ const ExpandableHeaderTextWrapper = ({
           {headerButton}
         </InternalHeader>
       ) : (
-        <HeadingTag className={styles['header-wrapper']}>{headerButton}</HeadingTag>
+        <HeadingTag
+          className={clsx(styles['header-wrapper'], headingTagListeners && styles['click-target'])}
+          {...headingTagListeners}
+        >
+          {headerButton}
+        </HeadingTag>
       )}
+      {isDefault && description && <HeaderDescription variantOverride="h3">{description}</HeaderDescription>}
     </div>
   );
 };
@@ -215,10 +235,17 @@ export const ExpandableSectionHeader = ({
     variant,
   };
 
-  if ((headerDescription || headerCounter || headerInfo || headerActions) && variant !== 'container' && isDevelopment) {
+  if ((headerCounter || headerInfo || headerActions) && variant !== 'container' && isDevelopment) {
     warnOnce(
       componentName,
-      'The `headerCounter`, `headerDescription`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
+      'The `headerCounter`, `headerInfo` and `headerActions` props are only supported for the "container" variant.'
+    );
+  }
+
+  if (headerDescription && variant !== 'container' && variant !== 'default' && isDevelopment) {
+    warnOnce(
+      componentName,
+      'The `headerDescription` prop is only supported for the "default" and "container" variants.'
     );
   }
 

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -16,6 +16,7 @@ import styles from './styles.css.js';
 import { ExpandableSectionContainer } from './expandable-section-container';
 import { ExpandableSectionHeader } from './expandable-section-header';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { variantSupportsDescription } from './utils';
 
 type InternalExpandableSectionProps = ExpandableSectionProps & InternalBaseComponentProps;
 
@@ -122,7 +123,7 @@ export default function InternalExpandableSection({
           role="group"
           aria-label={triggerProps.ariaLabel}
           aria-labelledby={triggerProps.ariaLabelledBy}
-          aria-describedby={variant === 'container' && headerDescription ? descriptionId : undefined}
+          aria-describedby={variantSupportsDescription(variant) && headerDescription ? descriptionId : undefined}
         >
           {children}
         </div>

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -10,6 +10,10 @@
 
 @use './motion';
 
+$icon-width: awsui.$size-icon-normal;
+$icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width}) / -2';
+$icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
+
 .root {
   @include styles.styles-reset;
   @include styles.text-wrapping;
@@ -30,9 +34,9 @@
 
 .icon-container {
   position: relative;
-  margin-left: calc((#{awsui.$font-body-m-line-height} - #{awsui.$size-icon-normal}) / -2);
+  margin-left: calc(#{$icon-margin-left});
   // For vertical alignment of text in side navigation items
-  margin-right: calc(#{awsui.$space-xxs} + #{awsui.$border-divider-list-width});
+  margin-right: calc(#{$icon-margin-right});
   &-container {
     margin-right: awsui.$space-xs;
   }
@@ -40,7 +44,6 @@
 
 .wrapper {
   box-sizing: border-box;
-  display: flex;
   border: none;
   width: 100%;
   line-height: awsui.$font-body-m-line-height;
@@ -64,17 +67,20 @@
     border-left: awsui.$border-divider-section-width solid transparent;
   }
 
+  &-navigation,
+  &-footer,
+  &-container {
+    display: flex;
+    font-weight: awsui.$font-heading-s-weight;
+  }
+
   &-default,
   &-navigation,
   &-footer {
     color: awsui.$color-text-expandable-section-default;
-    font-weight: awsui.$font-heading-s-weight;
     @include styles.font-smoothing;
     font-size: awsui.$font-expandable-heading-size;
     letter-spacing: awsui.$font-heading-s-letter-spacing;
-    &:hover {
-      color: awsui.$color-text-expandable-section-hover;
-    }
   }
 
   &-container {
@@ -92,14 +98,15 @@
 }
 
 .header {
-  display: flex;
+  /* used in test-utils */
 
   &-wrapper {
-    font-weight: inherit;
     font-size: inherit;
     letter-spacing: inherit;
     margin: 0;
     padding: 0;
+    font-weight: awsui.$font-heading-s-weight;
+    display: flex;
   }
 
   &-button {
@@ -114,20 +121,11 @@
     }
   }
 
-  &:not(.with-interactive-elements) {
-    cursor: pointer;
-  }
-
   &-container {
     width: 100%;
     // The icon-container style is kept for variant='container' and header
     > .icon-container {
       margin-top: awsui.$space-expandable-section-icon-offset-top;
-    }
-
-    // stylelint-disable-next-line selector-combinator-disallowed-list
-    &.with-interactive-elements &-button {
-      cursor: pointer;
     }
   }
 
@@ -179,4 +177,16 @@
   @include focus-visible.when-visible {
     @include styles.form-focus-element(awsui.$border-radius-control-default-focus-ring);
   }
+}
+
+.click-target {
+  cursor: pointer;
+  &:not(.wrapper-container):not(.header-container-button):hover {
+    color: awsui.$color-text-expandable-section-hover;
+  }
+}
+
+.description-default {
+  // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
+  padding-left: calc(#{$icon-width} + #{$icon-margin-right} + #{$icon-margin-left});
 }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -68,7 +68,6 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
   }
 
   &-navigation,
-  &-footer,
   &-container {
     display: flex;
     font-weight: awsui.$font-heading-s-weight;
@@ -100,6 +99,7 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 .header {
   /* used in test-utils */
 
+  &-wrapper,
   &-deprecated {
     display: flex;
     font-weight: awsui.$font-heading-s-weight;
@@ -110,8 +110,6 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
     letter-spacing: inherit;
     margin: 0;
     padding: 0;
-    font-weight: awsui.$font-heading-s-weight;
-    display: flex;
   }
 
   &-button {

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -100,6 +100,11 @@ $icon-margin-right: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 .header {
   /* used in test-utils */
 
+  &-deprecated {
+    display: flex;
+    font-weight: awsui.$font-heading-s-weight;
+  }
+
   &-wrapper {
     font-size: inherit;
     letter-spacing: inherit;

--- a/src/expandable-section/utils.ts
+++ b/src/expandable-section/utils.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ExpandableSectionProps } from './interfaces';
+
+export function variantSupportsDescription(variant: ExpandableSectionProps.Variant) {
+  return variant === 'container' || variant === 'default';
+}

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -82,17 +82,7 @@ export default function InternalHeader({
             {info && <span className={styles.info}>{info}</span>}
           </InfoLinkLabelContext.Provider>
         </div>
-        {description && (
-          <p
-            className={clsx(
-              styles.description,
-              styles[`description-variant-${variantOverride}`],
-              isRefresh && styles[`description-variant-${variantOverride}-refresh`]
-            )}
-          >
-            {description}
-          </p>
-        )}
+        <Description variantOverride={variantOverride}>{description}</Description>
       </div>
       {actions && (
         <div
@@ -106,5 +96,23 @@ export default function InternalHeader({
         </div>
       )}
     </div>
+  );
+}
+
+export function Description({ children, variantOverride }: { children: React.ReactNode; variantOverride: string }) {
+  const isRefresh = useVisualRefresh();
+  return (
+    (children && (
+      <p
+        className={clsx(
+          styles.description,
+          styles[`description-variant-${variantOverride}`],
+          isRefresh && styles[`description-variant-${variantOverride}-refresh`]
+        )}
+      >
+        {children}
+      </p>
+    )) ||
+    null
   );
 }


### PR DESCRIPTION
### Description

Reverts #1232 which reverted #1206, and adds fixes to default and footer variants when using the deprecated `header` prop.

### How has this been tested?

- Same as in #1206 
- Added two new permutations
- Verified that BackstopJS fails only because of the newly added permutations
- Ran in my pipeline including visual regression tests against Examples, which originally surfaced the issue that motivated the revert, because the Tutorial panel component uses Expandable section internally with the deprecated `header` prop

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
