### PR TITLE
feat: Support descriptions in Expandable section headers for footer variant

### DIFF
--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -125,7 +125,7 @@ const permutations = createPermutations<ExpandableSectionProps>([
     headingTagOverride: [undefined, 'h2', 'h3'],
   },
   {
-    variant: ['default', 'container'],
+    variant: ['default', 'container', 'footer'],
     headerText: ['With description'],
     children: ['Sample content'],
     headerDescription: ['Sample description'],

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5856,7 +5856,7 @@ Behaves similar to the Header component counter.",
       "type": "string",
     },
     Object {
-      "description": "Supplementary text below the heading. Use with the container variant.",
+      "description": "Supplementary text below the heading. Use with the container, default or footer variants.",
       "name": "headerDescription",
       "optional": true,
       "type": "string",

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -25,8 +25,8 @@ function renderExpandableSection(props: ExpandableSectionProps = {}): Expandable
 }
 
 describe('Expandable Section', () => {
-  const variantsWithDescription: ExpandableSectionProps.Variant[] = ['container', 'default'];
-  const variantsWithoutDescription: ExpandableSectionProps.Variant[] = ['footer', 'navigation'];
+  const variantsWithDescription: ExpandableSectionProps.Variant[] = ['container', 'default', 'footer'];
+  const variantsWithoutDescription: ExpandableSectionProps.Variant[] = ['navigation'];
   const nonContainerVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'navigation'];
 
   describe('variant property', () => {

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -264,7 +264,7 @@ describe('Expandable Section', () => {
             expect(warnOnce).toHaveBeenCalledTimes(1);
             expect(warnOnce).toHaveBeenCalledWith(
               componentName,
-              'The `headerDescription` prop is only supported for the "default" and "container" variants.'
+              'The `headerDescription` prop is not supported for this variant.'
             );
           });
         }

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -264,7 +264,7 @@ describe('Expandable Section', () => {
             expect(warnOnce).toHaveBeenCalledTimes(1);
             expect(warnOnce).toHaveBeenCalledWith(
               componentName,
-              'The `headerDescription` prop is not supported for this variant.'
+              `The \`headerDescription\` prop is not supported for the ${variant} variant.`
             );
           });
         }

--- a/src/expandable-section/__tests__/interactions.test.tsx
+++ b/src/expandable-section/__tests__/interactions.test.tsx
@@ -14,46 +14,118 @@ function renderExpandableSection(props: ExpandableSectionProps = {}): Expandable
   return createWrapper(container).findExpandableSection()!;
 }
 describe('Expandable Section - Interactions', () => {
+  let onChangeSpy: jest.Mock;
+
   describe('click and keyup event handler', () => {
-    let wrapper: ExpandableSectionWrapper;
-    let onChangeSpy: jest.Mock;
-
-    beforeEach(() => {
-      onChangeSpy = jest.fn();
-      wrapper = renderExpandableSection({ onChange: onChangeSpy });
-    });
-    test('toggles from false to true when header is clicked, change event fires', () => {
-      wrapper.findExpandButton().click();
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
-    });
-    test('toggles from false to true when header receives "Enter" keyboard input, change event fires', () => {
-      wrapper.findExpandButton().keyup(KeyCode.enter);
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
-    });
-    test('toggles from false to true when header receives "Space" keyboard input, change event fires', () => {
-      wrapper.findExpandButton().keyup(KeyCode.space);
-      expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
-    });
-
-    describe('when already expanded', () => {
-      let wrapper: ExpandableSectionWrapper;
-      let onChangeSpy: jest.Mock;
-
+    describe('click on expand button', () => {
       beforeEach(() => {
         onChangeSpy = jest.fn();
-        wrapper = renderExpandableSection({ expanded: true, onChange: onChangeSpy });
       });
-      test('toggles from true to false when header is clicked, change event fires', () => {
-        wrapper.findExpandButton().click();
-        expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+
+      const testCases: ExpandableSectionProps[] = [
+        { variant: 'container' },
+        { variant: 'default' },
+        { variant: 'footer' },
+        { variant: 'navigation' },
+        { variant: 'container', headerDescription: 'Description' },
+        { variant: 'default', headerDescription: 'Description' },
+        { variant: 'footer', headerDescription: 'Description' },
+        { variant: 'container', headerActions: <Button>Action</Button> },
+        { variant: 'container', headerActions: <Button>Action</Button>, headerDescription: 'Description' },
+      ];
+      testCases.forEach(({ variant, headerDescription, headerActions }) => {
+        describe(`${variant} variant${headerDescription ? ', with description' : ''}${
+          headerActions ? ', with actions' : ''
+        }`, () => {
+          test('toggles from false to true when header is clicked, change event fires', () => {
+            const wrapper = renderExpandableSection({
+              onChange: onChangeSpy,
+              variant,
+              headerDescription,
+              headerActions,
+            });
+            wrapper.findExpandButton().click();
+            expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
+          });
+
+          describe('when already expanded', () => {
+            test('toggles from true to false when header is clicked, change event fires', () => {
+              const wrapper = renderExpandableSection({
+                expanded: true,
+                onChange: onChangeSpy,
+                variant,
+                headerDescription,
+                headerActions,
+              });
+              wrapper.findExpandButton().click();
+              expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+            });
+          });
+        });
       });
-      test('toggles from true to false when header receives "Enter" keyboard input, change event fires', () => {
-        wrapper.findExpandButton().keyup(KeyCode.enter);
-        expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+    });
+
+    describe('keyup on expand button', () => {
+      beforeEach(() => {
+        onChangeSpy = jest.fn();
       });
-      test('toggles from true to false when header receives "Space" keyboard input, change event fires', () => {
-        wrapper.findExpandButton().keyup(KeyCode.space);
-        expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+
+      const testCases: ExpandableSectionProps[] = [
+        { variant: 'container' },
+        { variant: 'default' },
+        { variant: 'footer' },
+        { variant: 'container', headerDescription: 'Description' },
+        { variant: 'default', headerDescription: 'Description' },
+        { variant: 'footer', headerDescription: 'Description' },
+        { variant: 'container', headerActions: <Button>Action</Button> },
+        { variant: 'container', headerActions: <Button>Action</Button>, headerDescription: 'Description' },
+      ];
+      testCases.forEach(({ variant, headerDescription, headerActions }) => {
+        describe(`${variant} variant${headerDescription ? ', with description' : ''}${
+          headerActions ? ', with actions' : ''
+        }`, () => {
+          test('toggles from false to true when header receives "Enter" keyboard input, change event fires', () => {
+            const wrapper = renderExpandableSection({
+              onChange: onChangeSpy,
+              variant,
+              headerDescription,
+              headerActions,
+            });
+            wrapper.findExpandButton().keyup(KeyCode.enter);
+            expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
+          });
+          test('toggles from false to true when header receives "Space" keyboard input, change event fires', () => {
+            const wrapper = renderExpandableSection({
+              onChange: onChangeSpy,
+              variant,
+              headerDescription,
+              headerActions,
+            });
+            wrapper.findExpandButton().keyup(KeyCode.space);
+            expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: true } }));
+          });
+
+          describe('when already expanded', () => {
+            let wrapper: ExpandableSectionWrapper;
+            beforeEach(() => {
+              wrapper = renderExpandableSection({
+                expanded: true,
+                onChange: onChangeSpy,
+                variant,
+                headerDescription,
+                headerActions,
+              });
+            });
+            test('toggles from true to false when header receives "Enter" keyboard input, change event fires', () => {
+              wrapper.findExpandButton().keyup(KeyCode.enter);
+              expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+            });
+            test('toggles from true to false when header receives "Space" keyboard input, change event fires', () => {
+              wrapper.findExpandButton().keyup(KeyCode.space);
+              expect(onChangeSpy).toBeCalledWith(expect.objectContaining({ detail: { expanded: false } }));
+            });
+          });
+        });
       });
     });
   });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -244,11 +244,8 @@ export const ExpandableSectionHeader = ({
     );
   }
 
-  if (headerDescription && variant !== 'container' && variant !== 'default' && isDevelopment) {
-    warnOnce(
-      componentName,
-      'The `headerDescription` prop is only supported for the "default" and "container" variants.'
-    );
+  if (headerDescription && !variantSupportsDescription(variant) && isDevelopment) {
+    warnOnce(componentName, 'The `headerDescription` prop is not supported for this variant.');
   }
 
   const wrapperClassName = clsx(styles.wrapper, styles[`wrapper-${variant}`], expanded && styles['wrapper-expanded']);

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -245,7 +245,7 @@ export const ExpandableSectionHeader = ({
   }
 
   if (headerDescription && !variantSupportsDescription(variant) && isDevelopment) {
-    warnOnce(componentName, 'The `headerDescription` prop is not supported for this variant.');
+    warnOnce(componentName, `The \`headerDescription\` prop is not supported for the ${variant} variant.`);
   }
 
   const wrapperClassName = clsx(styles.wrapper, styles[`wrapper-${variant}`], expanded && styles['wrapper-expanded']);

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -131,7 +131,6 @@ const ExpandableHeaderTextWrapper = ({
   onKeyDown,
 }: ExpandableHeaderTextWrapperProps) => {
   const isContainer = variant === 'container';
-  const isDefault = variant === 'default';
   const HeadingTag = headingTagOverride || 'div';
   const hasInteractiveElements = isContainer && (headerInfo || headerActions);
   const listeners = { onClick, onKeyDown, onKeyUp };
@@ -139,9 +138,9 @@ const ExpandableHeaderTextWrapper = ({
   // If interactive elements are present, constrain the clickable area to only the icon and the header text
   // to prevent nesting interactive elements.
   const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
-  // For the default variant, include also the immediate wrapper around it to include the entire row
+  // For the default and footer variants, include also the immediate wrapper around it to include the entire row
   // for backwards compatibility, but exclude the description below.
-  const headingTagListeners = !headerButtonListeners && isDefault ? listeners : undefined;
+  const headingTagListeners = !headerButtonListeners && !isContainer ? listeners : undefined;
   // For all other cases, make the entire header clickable for backwards compatibility.
   const wrapperListeners = !headerButtonListeners && !headingTagListeners ? listeners : undefined;
 
@@ -186,14 +185,16 @@ const ExpandableHeaderTextWrapper = ({
           {headerButton}
         </InternalHeader>
       ) : (
-        <HeadingTag
-          className={clsx(styles['header-wrapper'], headingTagListeners && styles['click-target'])}
-          {...headingTagListeners}
-        >
-          {headerButton}
-        </HeadingTag>
+        <>
+          <HeadingTag
+            className={clsx(styles['header-wrapper'], headingTagListeners && styles['click-target'])}
+            {...headingTagListeners}
+          >
+            {headerButton}
+          </HeadingTag>
+          {description && <HeaderDescription variantOverride="h3">{description}</HeaderDescription>}
+        </>
       )}
-      {isDefault && description && <HeaderDescription variantOverride="h3">{description}</HeaderDescription>}
     </div>
   );
 };

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -135,20 +135,21 @@ const ExpandableHeaderTextWrapper = ({
   const hasInteractiveElements = isContainer && (headerInfo || headerActions);
   const listeners = { onClick, onKeyDown, onKeyUp };
 
-  // If interactive elements are present, constrain the clickable area to only the icon and the header text
-  // to prevent nesting interactive elements.
-  const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
-  // For the default and footer variants, include also the immediate wrapper around it to include the entire row
-  // for backwards compatibility, but exclude the description below.
-  const headingTagListeners = !headerButtonListeners && !isContainer ? listeners : undefined;
-  // For all other cases, make the entire header clickable for backwards compatibility.
-  const wrapperListeners = !headerButtonListeners && !headingTagListeners ? listeners : undefined;
-
   const description = variantSupportsDescription(variant) && headerDescription && (
     <span id={descriptionId} className={styles[`description-${variant}`]}>
       {headerDescription}
     </span>
   );
+
+  // If interactive elements are present, constrain the clickable area to only the icon and the header text
+  // to prevent nesting interactive elements.
+  const headerButtonListeners = hasInteractiveElements ? listeners : undefined;
+  // For the default and footer variants with description,
+  // include also the immediate wrapper around it to include the entire row for backwards compatibility,
+  // but exclude the description.
+  const headingTagListeners = !headerButtonListeners && !isContainer && description ? listeners : undefined;
+  // For all other cases, make the entire header clickable for backwards compatibility.
+  const wrapperListeners = !headerButtonListeners && !headingTagListeners ? listeners : undefined;
 
   const headerButton = (
     <span

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -56,7 +56,7 @@ export interface ExpandableSectionProps extends BaseComponentProps {
   headerText?: React.ReactNode;
 
   /**
-   * Supplementary text below the heading. Use with the container variant.
+   * Supplementary text below the heading. Use with the container, default or footer variants.
    */
   headerDescription?: string;
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -191,7 +191,8 @@ $icon-margin-right-medium: awsui.$space-xs;
 }
 
 // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
-.description-default {
+.description-default,
+.description-footer {
   padding-left: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
 }
 .description-container {

--- a/src/expandable-section/utils.ts
+++ b/src/expandable-section/utils.ts
@@ -3,5 +3,5 @@
 import { ExpandableSectionProps } from './interfaces';
 
 export function variantSupportsDescription(variant: ExpandableSectionProps.Variant) {
-  return variant === 'container' || variant === 'default';
+  return variant === 'container' || variant === 'default' || variant === 'footer';
 }


### PR DESCRIPTION
### Description

After adding description for default variant (#1234), adding it to the footer variant too was a quite trivial change so we decided to follow up with it.

### How has this been tested?

- Adapted unit tests
- Added unit tests to make sure `findExpandButton` works in all variants and with or without descriptions
- Added permutations to existing permutations page
- Manually reviewed permutations page
- Verified that BackstopJS failures are due to the newly added permutations and look as expected

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
