### PR TITLE
fix: Bug fixes in iconSvg feature in drawers

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -39,3 +39,26 @@ awsuiPlugins.appLayout.registerDrawer({
   },
   unmountContent: container => unmountComponentAtNode(container),
 });
+
+awsuiPlugins.appLayout.registerDrawer({
+  id: 'circle',
+
+  ariaLabels: {
+    closeButton: 'Close button',
+    content: 'Content',
+    triggerButton: 'Trigger button',
+    resizeHandle: 'Resize handle',
+  },
+
+  trigger: {
+    iconSvg: `<svg viewBox="0 0 16 16" focusable="false">
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="7" />
+      <circle stroke-width="2" stroke="currentColor" fill="none" cx="8" cy="8" r="3" />
+    </svg>`,
+  },
+
+  mountContent: container => {
+    ReactDOM.render(<>Nothing to see here</>, container);
+  },
+  unmountContent: container => unmountComponentAtNode(container),
+});

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -64,6 +64,15 @@ describe('Runtime drawers', () => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
+  test('propagates iconSvg as html content', async () => {
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      trigger: { iconSvg: `<rect data-testid="custom-icon" />` },
+    });
+    const { wrapper } = await renderComponent(<AppLayout />);
+    expect(wrapper.find('[data-testid="custom-icon"]')).toBeTruthy();
+  });
+
   test('persists drawer config between mounts/unmounts', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout key="first" />);

--- a/src/app-layout/runtime-api.tsx
+++ b/src/app-layout/runtime-api.tsx
@@ -28,8 +28,17 @@ export interface DrawersLayout {
 }
 
 export function convertRuntimeDrawers(drawers: Array<RuntimeDrawerConfig>): DrawersLayout {
-  const converted = drawers.map(({ mountContent, unmountContent, ...runtimeDrawer }) => ({
+  const converted = drawers.map(({ mountContent, unmountContent, trigger, ...runtimeDrawer }) => ({
     ...runtimeDrawer,
+    trigger: trigger.iconSvg
+      ? {
+          ...trigger,
+          iconSvg: (
+            // eslint-disable-next-line react/no-danger
+            <span dangerouslySetInnerHTML={{ __html: trigger.iconSvg }} />
+          ),
+        }
+      : trigger,
     content: (
       <RuntimeContentWrapper key={runtimeDrawer.id} mountContent={mountContent} unmountContent={unmountContent} />
     ),

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -36,8 +36,7 @@ function TriggerButton(
       ref={ref as React.Ref<HTMLButtonElement>}
       type="button"
     >
-      {iconName && !iconSvg && <Icon name={iconName} />}
-      {iconSvg}
+      <Icon name={iconName} svg={iconSvg} />
     </button>
   );
 }

--- a/src/internal/plugins/drawers-controller.ts
+++ b/src/internal/plugins/drawers-controller.ts
@@ -1,9 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { DrawerItem } from '../../app-layout/drawer/interfaces';
+import { IconProps } from '../../icon/interfaces';
 
 export type DrawerConfig = Omit<DrawerItem, 'content'> & {
   orderPriority?: number;
+  trigger: {
+    iconName?: IconProps.Name;
+    iconSvg?: string;
+  };
   mountContent: (container: HTMLElement) => void;
   unmountContent: (container: HTMLElement) => void;
 };


### PR DESCRIPTION
### Description

1. Accept svg content as a string in runtime API (because it has no access to JSX)
2. Fix `iconSvg` use in visual refresh mode

Related links, issue #, if available: n/a

### How has this been tested?

Updated dev page, checked that custom SVG renders correctly

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
