### PR TITLE
feat: Stacked variant for Expandable Section

### DIFF
--- a/pages/container/stacked-components.page.tsx
+++ b/pages/container/stacked-components.page.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import Container from '~components/container';
+import Header from '~components/header';
+import ExpandableSection from '~components/expandable-section';
+import SpaceBetween from '~components/space-between';
+import Tabs from '~components/tabs';
+import ScreenshotArea from '../utils/screenshot-area';
+
+function StackedContainer() {
+  return (
+    <Container header={<Header>Container header</Header>} variant="stacked">
+      Container content
+    </Container>
+  );
+}
+
+function StackedExpandableSection({ defaultExpanded }: { defaultExpanded?: boolean }) {
+  return (
+    <ExpandableSection headerText="Expandable section" variant="stacked" defaultExpanded={defaultExpanded}>
+      Container content
+    </ExpandableSection>
+  );
+}
+
+function StackedTabs() {
+  return (
+    <Tabs
+      variant="stacked"
+      tabs={[
+        { label: 'First tab', id: 'first', content: 'First tab content', href: '#first' },
+        { label: 'Second tab', id: 'second', href: '#second' },
+        { label: 'Third tab', id: 'third', href: '#third' },
+      ]}
+    />
+  );
+}
+
+function StackedComponent({ component }: { component: number }) {
+  switch (component) {
+    case 1:
+      return <StackedContainer />;
+    case 2:
+      return <StackedExpandableSection />;
+    case 3:
+      return <StackedExpandableSection defaultExpanded={true} />;
+    default:
+      return <StackedTabs />;
+  }
+}
+
+function StackedPermutation({ order }: { order: Array<number> }) {
+  return (
+    <div>
+      <StackedComponent component={order[0]} />
+      <StackedComponent component={order[1]} />
+      <StackedComponent component={order[2]} />
+      <StackedComponent component={order[3]} />
+    </div>
+  );
+}
+
+export default function StackedComponents() {
+  return (
+    <article>
+      <h1>Stacked container-like components</h1>
+      <ScreenshotArea>
+        <SpaceBetween size="l">
+          <StackedPermutation order={[1, 2, 3, 4]} />
+          <StackedPermutation order={[2, 3, 4, 1]} />
+          <StackedPermutation order={[3, 4, 1, 2]} />
+          <StackedPermutation order={[4, 1, 2, 3]} />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -26,7 +26,11 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
   },
 ]);
-export default function ExpandableSectionContainerVariantPermutations() {
+export default function ExpandableSectionContainerVariantPermutations({
+  variant = 'container',
+}: {
+  variant: ExpandableSectionProps.Variant;
+}) {
   return (
     <article>
       <h1>Expandable Section - container variant</h1>
@@ -41,7 +45,7 @@ export default function ExpandableSectionContainerVariantPermutations() {
               {...permutation}
               headerText={'Expandable section heading'}
               defaultExpanded={true}
-              variant="container"
+              variant={variant}
             >
               Expandable section content
             </ExpandableSection>

--- a/pages/expandable-section/stacked-variant.permutations.page.tsx
+++ b/pages/expandable-section/stacked-variant.permutations.page.tsx
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import ExpandableSectionContainerVariantPermutations from './container-variant.permutations.page';
+
+export default function ExpandableSectionStackedVariantPermutations() {
+  return <ExpandableSectionContainerVariantPermutations variant="stacked" />;
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5894,7 +5894,8 @@ works with the \`headerText\` slot (not with the deprecated \`header\`), and not
  * \`footer\` - Use this variant in container footers.
  * \`container\` - Use this variant in a detail page alongside other containers.
  * \`navigation\` - Use this variant in the navigation panel with anchors and custom styled content.
-   It doesn't have any default styles.",
+   It doesn't have any default styles.
+* \`stacked\` - Use this variant directly adjacent to other stacked containers (such as a container, table).",
       "inlineType": Object {
         "name": "ExpandableSectionProps.Variant",
         "type": "union",
@@ -5903,11 +5904,13 @@ works with the \`headerText\` slot (not with the deprecated \`header\`), and not
           "footer",
           "container",
           "navigation",
+          "stacked",
         ],
       },
       "name": "variant",
       "optional": true,
       "type": "string",
+      "visualRefreshTag": "\`stacked\` variant",
     },
   ],
   "regions": Array [

--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -24,8 +24,10 @@ function renderExpandableSection(props: ExpandableSectionProps = {}): Expandable
   return createWrapper(container).findExpandableSection()!;
 }
 
+const containerizedVariants: ExpandableSectionProps.Variant[] = ['container', 'stacked'];
+
 describe('Expandable Section', () => {
-  const variantsWithDescription: ExpandableSectionProps.Variant[] = ['container', 'default', 'footer'];
+  const variantsWithDescription: ExpandableSectionProps.Variant[] = [...containerizedVariants, 'default', 'footer'];
   const variantsWithoutDescription: ExpandableSectionProps.Variant[] = ['navigation'];
   const nonContainerVariants: ExpandableSectionProps.Variant[] = ['default', 'footer', 'navigation'];
 
@@ -35,10 +37,14 @@ describe('Expandable Section', () => {
       expect(wrapper.findAll('button').length).toBe(1);
       expect(wrapper.findAll('div[role=button]').length).toBe(0);
     });
-    test('has no trigger button and div=[role=button] for variant container', () => {
-      const wrapper = renderExpandableSection({ variant: 'container' });
-      expect(wrapper.findAll('div[role=button]').length).toBe(1);
-      expect(wrapper.findAll('button').length).toBe(0);
+    describe('has no trigger button and div=[role=button]', () => {
+      for (const variant of containerizedVariants) {
+        test(`${variant} variant`, () => {
+          const wrapper = renderExpandableSection({ variant });
+          expect(wrapper.findAll('div[role=button]').length).toBe(1);
+          expect(wrapper.findAll('button').length).toBe(0);
+        });
+      }
     });
     test('has no trigger button and div=[role=button] for variant footer', () => {
       const wrapper = renderExpandableSection({ variant: 'footer' });
@@ -68,27 +74,35 @@ describe('Expandable Section', () => {
         });
       }
     });
-    test('populates info links slot correctly for "container" variant', () => {
-      const wrapper = renderExpandableSection({
-        headerText: 'Test Header',
-        variant: 'container',
-        headerInfo: <Link>Info</Link>,
-      });
-      const infoLink = wrapper.findHeader().findLink();
-      expect(infoLink).toBeTruthy();
-      expect(infoLink!.getElement()).toHaveTextContent('Info');
+    describe('populates info links slot correctly', () => {
+      for (const variant of containerizedVariants) {
+        test(`${variant} variant`, () => {
+          const wrapper = renderExpandableSection({
+            headerText: 'Test Header',
+            variant,
+            headerInfo: <Link>Info</Link>,
+          });
+          const infoLink = wrapper.findHeader().findLink();
+          expect(infoLink).toBeTruthy();
+          expect(infoLink!.getElement()).toHaveTextContent('Info');
+        });
+      }
     });
-    test('populates action buttons slot correctly for "container" variant', () => {
-      const wrapper = renderExpandableSection({
-        headerText: 'Test Header',
-        variant: 'container',
-        headerActions: <Button>Action</Button>,
-      });
-      const button = wrapper.findHeader().findButton();
-      expect(button).toBeTruthy();
-      expect(button!.getElement()).toHaveTextContent('Action');
+    describe('populates action buttons slot correctly', () => {
+      for (const variant of containerizedVariants) {
+        test(`${variant} variant`, () => {
+          const wrapper = renderExpandableSection({
+            headerText: 'Test Header',
+            variant,
+            headerActions: <Button>Action</Button>,
+          });
+          const button = wrapper.findHeader().findButton();
+          expect(button).toBeTruthy();
+          expect(button!.getElement()).toHaveTextContent('Action');
+        });
+      }
     });
-    test.each<ExpandableSectionProps.Variant>(['default', 'footer', 'container', 'navigation'])(
+    test.each<ExpandableSectionProps.Variant>(['default', 'footer', 'container', 'navigation', 'stacked'])(
       'populates content slot correctly for "%s" variant',
       variant => {
         const wrapper = renderExpandableSection({
@@ -327,16 +341,17 @@ describe('Expandable Section', () => {
           testWarnings({ variant });
         });
       }
-
-      test('container variant', () => {
-        testWarnings({
-          variant: 'container',
-          headerCounter: '(2)',
-          headerDescription: 'Description',
-          headerInfo: <Link>Info</Link>,
-          headerActions: <Button>Action</Button>,
+      for (const variant of containerizedVariants) {
+        test(`${variant} variant`, () => {
+          testWarnings({
+            variant,
+            headerCounter: '(2)',
+            headerDescription: 'Description',
+            headerInfo: <Link>Info</Link>,
+            headerActions: <Button>Action</Button>,
+          });
         });
-      });
+      }
 
       test('default variant', () => {
         testWarnings({
@@ -349,22 +364,24 @@ describe('Expandable Section', () => {
 });
 
 describe('headingTagOverride', () => {
-  test('container variant tag defaults to h2', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
+  for (const variant of containerizedVariants) {
+    test(`${variant} variant tag defaults to h2`, () => {
+      const wrapper = renderExpandableSection({
+        variant,
+        headerText: 'Header component',
+      });
+      expect(wrapper.findHeader().findAll('h2').length).toBe(1);
     });
-    expect(wrapper.findHeader().findAll('h2').length).toBe(1);
-  });
-  test('container variant tag can be overwritten', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-      headingTagOverride: 'h3',
+    test(`${variant} variant tag can be overwritten`, () => {
+      const wrapper = renderExpandableSection({
+        variant,
+        headerText: 'Header component',
+        headingTagOverride: 'h3',
+      });
+      expect(wrapper.findHeader().findAll('h2').length).toBe(0);
+      expect(wrapper.findHeader().findAll('h3').length).toBe(1);
     });
-    expect(wrapper.findHeader().findAll('h2').length).toBe(0);
-    expect(wrapper.findHeader().findAll('h3').length).toBe(1);
-  });
+  }
   for (const variant of ['default', 'footer']) {
     describe.each<ExpandableSectionProps.Variant>(['default', 'footer'])(`variant: ${variant}`, variant => {
       test('tag defaults to div', () => {
@@ -386,81 +403,85 @@ describe('headingTagOverride', () => {
   }
 });
 
-describe('Variant container with headerText', () => {
-  test('validate a11y for container with headerText', async () => {
-    const { container } = render(
-      <ExpandableSection
-        variant="container"
-        headerText="Header component"
-        headerCounter="5"
-        headerDescription="Testing"
-      />
-    );
-    await expect(container).toValidateA11y();
-  });
+describe('headerText', () => {
+  for (const variant of containerizedVariants) {
+    describe(`with ${variant} variant`, () => {
+      test('validate a11y for container with headerText', async () => {
+        const { container } = render(
+          <ExpandableSection
+            variant={variant}
+            headerText="Header component"
+            headerCounter="5"
+            headerDescription="Testing"
+          />
+        );
+        await expect(container).toValidateA11y();
+      });
 
-  test('header button have aria-controls associated to expanded content', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
+      test('header button have aria-controls associated to expanded content', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        const expandedContent = wrapper.findContent().getElement();
+        const contentId = expandedContent?.getAttribute('id');
+        expect(headerButton).toHaveAttribute('aria-controls', contentId);
+      });
+      test('aria-expanded=false when collapsed', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        expect(headerButton).toHaveAttribute('aria-expanded', 'false');
+      });
+      test('aria-expanded=true when expanded', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+          defaultExpanded: true,
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        expect(headerButton).toHaveAttribute('aria-expanded', 'true');
+      });
+      test('set headerAriaLabel assigns an aria-label to the header, and no aria-labelledby will be set', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+          headerAriaLabel: 'ARIA Label',
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        const content = wrapper.findContent().getElement();
+        expect(headerButton).toHaveAttribute('aria-label', 'ARIA Label');
+        expect(content).toHaveAttribute('aria-label', 'ARIA Label');
+        expect(headerButton).not.toHaveAttribute('aria-labelledby');
+      });
+      test('set aria labels when no headerAriaLabel is set', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        expect(headerButton).toHaveAccessibleName('Header component');
+      });
+      test('set aria description if description present', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+          headerDescription: 'Expand to see more content',
+        });
+        const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
+        expect(headerButton).toHaveAccessibleDescription('Expand to see more content');
+      });
+      test('button should be under heading', () => {
+        const wrapper = renderExpandableSection({
+          variant,
+          headerText: 'Header component',
+        });
+        expect(wrapper.findHeader().find('[role="button"]')!.findAll('h2')!.length).toBe(0);
+        expect(wrapper.find('h2')!.find('[role="button"]')!.getElement()).toHaveTextContent('Header component');
+      });
     });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    const expandedContent = wrapper.findContent().getElement();
-    const contentId = expandedContent?.getAttribute('id');
-    expect(headerButton).toHaveAttribute('aria-controls', contentId);
-  });
-  test('aria-expanded=false when collapsed', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-    });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    expect(headerButton).toHaveAttribute('aria-expanded', 'false');
-  });
-  test('aria-expanded=true when expanded', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-      defaultExpanded: true,
-    });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    expect(headerButton).toHaveAttribute('aria-expanded', 'true');
-  });
-  test('set headerAriaLabel assigns an aria-label to the header, and no aria-labelledby will be set', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-      headerAriaLabel: 'ARIA Label',
-    });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    const content = wrapper.findContent().getElement();
-    expect(headerButton).toHaveAttribute('aria-label', 'ARIA Label');
-    expect(content).toHaveAttribute('aria-label', 'ARIA Label');
-    expect(headerButton).not.toHaveAttribute('aria-labelledby');
-  });
-  test('set aria labels when no headerAriaLabel is set', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-    });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    expect(headerButton).toHaveAccessibleName('Header component');
-  });
-  test('set aria description if description present', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-      headerDescription: 'Expand to see more content',
-    });
-    const headerButton = wrapper.findHeader().find('[role="button"]')!.getElement();
-    expect(headerButton).toHaveAccessibleDescription('Expand to see more content');
-  });
-  test('button should be under heading', () => {
-    const wrapper = renderExpandableSection({
-      variant: 'container',
-      headerText: 'Header component',
-    });
-    expect(wrapper.findHeader().find('[role="button"]')!.findAll('h2')!.length).toBe(0);
-    expect(wrapper.find('h2')!.find('[role="button"]')!.getElement()).toHaveTextContent('Header component');
-  });
+  }
 });

--- a/src/expandable-section/expandable-section-container.tsx
+++ b/src/expandable-section/expandable-section-container.tsx
@@ -24,13 +24,13 @@ export const ExpandableSectionContainer = ({
   __internalRootRef,
   ...rest
 }: ExpandableSectionContainerProps) => {
-  if (variant === 'container') {
+  if (variant === 'container' || variant === 'stacked') {
     return (
       <InternalContainer
         {...rest}
         className={className}
         header={header}
-        variant="default"
+        variant={variant === 'stacked' ? 'stacked' : 'default'}
         disableContentPaddings={disableContentPaddings || !expanded}
         disableHeaderPaddings={true}
         __hiddenContent={!expanded}

--- a/src/expandable-section/interfaces.ts
+++ b/src/expandable-section/interfaces.ts
@@ -5,7 +5,7 @@ import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
 export namespace ExpandableSectionProps {
-  export type Variant = 'default' | 'footer' | 'container' | 'navigation';
+  export type Variant = 'default' | 'footer' | 'container' | 'navigation' | 'stacked';
   export interface ChangeDetail {
     expanded: boolean;
   }
@@ -32,6 +32,8 @@ export interface ExpandableSectionProps extends BaseComponentProps {
    *  * `container` - Use this variant in a detail page alongside other containers.
    *  * `navigation` - Use this variant in the navigation panel with anchors and custom styled content.
    *    It doesn't have any default styles.
+   * * `stacked` - Use this variant directly adjacent to other stacked containers (such as a container, table).
+   * @visualrefresh `stacked` variant
    * */
   variant?: ExpandableSectionProps.Variant;
 

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -89,6 +89,9 @@ export default function InternalExpandableSection({
     onClick,
   };
 
+  // Map stacked variant to container to avoid code duplication
+  const baseVariant: ExpandableSectionProps.Variant = variant === 'stacked' ? 'container' : variant;
+
   return (
     <ExpandableSectionContainer
       {...baseProps}
@@ -100,8 +103,8 @@ export default function InternalExpandableSection({
         <ExpandableSectionHeader
           id={triggerControlId}
           descriptionId={descriptionId}
-          className={clsx(styles.header, styles[`header-${variant}`])}
-          variant={variant}
+          className={clsx(styles.header, styles[`header-${baseVariant}`])}
+          variant={baseVariant}
           expanded={!!expanded}
           header={header}
           headerText={headerText}
@@ -119,11 +122,11 @@ export default function InternalExpandableSection({
         <div
           id={controlId}
           ref={ref}
-          className={clsx(styles.content, styles[`content-${variant}`], expanded && styles['content-expanded'])}
+          className={clsx(styles.content, styles[`content-${baseVariant}`], expanded && styles['content-expanded'])}
           role="group"
           aria-label={triggerProps.ariaLabel}
           aria-labelledby={triggerProps.ariaLabelledBy}
-          aria-describedby={variantSupportsDescription(variant) && headerDescription ? descriptionId : undefined}
+          aria-describedby={variantSupportsDescription(baseVariant) && headerDescription ? descriptionId : undefined}
         >
           {children}
         </div>


### PR DESCRIPTION
### Description

The variant is useful to group expandable sections with other stacked containers.


### How has this been tested?

Additional unit and visual regression tests


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ Yes
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ 
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ Confirmed

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
