### PR TITLE
fix: Avoid cutting off half the stroke when line is at the edge of chart

### DIFF
--- a/pages/line-chart/permutations.page.tsx
+++ b/pages/line-chart/permutations.page.tsx
@@ -235,9 +235,82 @@ const stringPermutations = createPermutations<LineChartProps<string>>([
   },
 ]);
 
+const overflowPermutations = createPermutations<LineChartProps<Date>>([
+  // With some values at the edges and some values overflowing the graph
+  {
+    i18nStrings: [
+      {
+        ...commonProps.i18nStrings,
+        xTickFormatter: e =>
+          e
+            .toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: 'numeric',
+              hour12: !1,
+            })
+            .split(',')
+            .join('\n'),
+        yTickFormatter: function l(e) {
+          return Math.abs(e) >= 1e9
+            ? (e / 1e9).toFixed(1).replace(/\.0$/, '') + 'G'
+            : Math.abs(e) >= 1e6
+            ? (e / 1e6).toFixed(1).replace(/\.0$/, '') + 'M'
+            : Math.abs(e) >= 1e3
+            ? (e / 1e3).toFixed(1).replace(/\.0$/, '') + 'K'
+            : e.toFixed(2);
+        },
+      },
+    ],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [
+      [
+        {
+          title: 'Site 1',
+          type: 'line',
+          data: [
+            { x: new Date(1601017200000), y: 58020 },
+            { x: new Date(1601018100000), y: 102402 },
+            { x: new Date(1601019000000), y: 500000 },
+            { x: new Date(1601019900000), y: 500000 },
+            { x: new Date(1601020800000), y: 500000 },
+            { x: new Date(1601021700000), y: 264286 },
+            { x: new Date(1601022600000), y: 0 },
+            { x: new Date(1601023500000), y: 0 },
+            { x: new Date(1601024400000), y: 289210 },
+            { x: new Date(1601025300000), y: 600000 },
+            { x: new Date(1601026200000), y: 294020 },
+            { x: new Date(1601027100000), y: 385975 },
+            { x: new Date(1601028000000), y: -100000 },
+            { x: new Date(1601028900000), y: 490447 },
+          ],
+          valueFormatter: function l(e) {
+            return Math.abs(e) >= 1e9
+              ? (e / 1e9).toFixed(1).replace(/\.0$/, '') + 'G'
+              : Math.abs(e) >= 1e6
+              ? (e / 1e6).toFixed(1).replace(/\.0$/, '') + 'M'
+              : Math.abs(e) >= 1e3
+              ? (e / 1e3).toFixed(1).replace(/\.0$/, '') + 'K'
+              : e.toFixed(2);
+          },
+        },
+      ],
+    ],
+    xScaleType: ['time'],
+    xDomain: [[new Date(1601017200000), new Date(1601028900000)]],
+    yDomain: [[0, 500000]],
+    xTitle: ['Time (UTC)'],
+    yTitle: ['Bytes transferred'],
+    hideFilter: [true],
+    hideLegend: [true],
+  },
+]);
+
 /* eslint-enable react/jsx-key */
 
-const permutations = [...numericPermutations, ...timePermutations, ...stringPermutations];
+const permutations = [...numericPermutations, ...timePermutations, ...stringPermutations, ...overflowPermutations];
 
 export default function () {
   return (

--- a/src/mixed-line-bar-chart/data-series.tsx
+++ b/src/mixed-line-bar-chart/data-series.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import clsx from 'clsx';
 
 import { useUniqueId } from '../internal/hooks/use-unique-id';
@@ -11,6 +11,9 @@ import { ChartDataTypes, InternalChartSeries, MixedLineBarChartProps } from './i
 
 import styles from './styles.css.js';
 import { calculateOffsetMaps, StackedOffsets } from './utils';
+
+// Should have the same value as the `border-line-chart-width` token.
+const STROKE_WIDTH = 2;
 
 export interface DataSeriesProps<T> {
   axis: 'x' | 'y';
@@ -42,8 +45,6 @@ export default function DataSeries<T extends ChartDataTypes>({
   yScale,
 }: DataSeriesProps<T>) {
   const chartAreaClipPath = useUniqueId('awsui-mixed-line-bar-chart__chart-area-');
-  const seriesRef = useRef<SVGGElement | null>(null);
-  const strokeWidth = useRef(0);
 
   const stackedBarOffsetMaps: StackedOffsets[] = useMemo(() => {
     if (!stackedBars) {
@@ -59,17 +60,11 @@ export default function DataSeries<T extends ChartDataTypes>({
     return calculateOffsetMaps(barData);
   }, [visibleSeries, stackedBars]);
 
-  useLayoutEffect(() => {
-    if (!strokeWidth.current && seriesRef.current) {
-      strokeWidth.current = parseInt(getComputedStyle(seriesRef.current).strokeWidth);
-    }
-  });
-
   return (
     <>
       <defs aria-hidden="true">
         <clipPath id={chartAreaClipPath}>
-          <rect x={0} y={-strokeWidth.current / 2} width={plotWidth} height={plotHeight + strokeWidth.current} />
+          <rect x={0} y={-STROKE_WIDTH / 2} width={plotWidth} height={plotHeight + STROKE_WIDTH} />
         </clipPath>
       </defs>
       <g aria-hidden={isGroupNavigation ? true : undefined} role="group">
@@ -89,7 +84,6 @@ export default function DataSeries<T extends ChartDataTypes>({
                     [styles['series--highlighted']]: isHighlighted,
                     [styles['series--dimmed']]: isDimmed,
                   })}
-                  ref={index === 0 ? seriesRef : undefined}
                 >
                   <LineSeries
                     axis={axis}


### PR DESCRIPTION
### Description

Extend clipping rectangle vertically by half the stroke width in each direction vertically, to prevent the line stroke from being clipped in segments where it has the maximum or minimum value of the domain for several times in a row.

Issue: AWSUI-21329

### How has this been tested?

- Added permutation
- Manually tested with Chrome, Firefox and Safari

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
