### PR TITLE
fix: Prevent bars from covering baselines in graphs

### DIFF
--- a/src/mixed-line-bar-chart/data-series.tsx
+++ b/src/mixed-line-bar-chart/data-series.tsx
@@ -46,6 +46,9 @@ export default function DataSeries<T extends ChartDataTypes>({
 }: DataSeriesProps<T>) {
   const chartAreaClipPath = useUniqueId('awsui-mixed-line-bar-chart__chart-area-');
 
+  // Lines get a small extra space at the top and bottom to account for the strokes when they are at the edge of the graph.
+  const lineAreaClipPath = useUniqueId('awsui-line-chart__chart-area-');
+
   const stackedBarOffsetMaps: StackedOffsets[] = useMemo(() => {
     if (!stackedBars) {
       return [];
@@ -64,6 +67,9 @@ export default function DataSeries<T extends ChartDataTypes>({
     <>
       <defs aria-hidden="true">
         <clipPath id={chartAreaClipPath}>
+          <rect x={0} y={0} width={plotWidth} height={plotHeight} />
+        </clipPath>
+        <clipPath id={lineAreaClipPath}>
           <rect x={0} y={-STROKE_WIDTH / 2} width={plotWidth} height={plotHeight + STROKE_WIDTH} />
         </clipPath>
       </defs>
@@ -91,7 +97,7 @@ export default function DataSeries<T extends ChartDataTypes>({
                     color={color}
                     xScale={xScale}
                     yScale={yScale}
-                    chartAreaClipPath={chartAreaClipPath}
+                    chartAreaClipPath={lineAreaClipPath}
                   />
                 </g>
               );


### PR DESCRIPTION
### Description

Because of existing borders in bars, #1224 had some unexpected changes in graphs which include bars. This addresses this issue by letting lines and bars have different clip paths.

### How has this been tested?

Visual regression tests are in place.

Manually tested.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
