### PR TITLE
fix: Fix visible focus being cut off in chart detail popover

### DIFF
--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -121,6 +121,7 @@ function ChartPopover(
             dismissAriaLabel={dismissAriaLabel}
             header={title}
             onDismiss={onDismiss}
+            overflowVisible="content"
             className={styles['popover-body']}
           >
             {children}


### PR DESCRIPTION
### Description
Currently the chart detail popover has `overflow: hidden` on its content, which means that focus outlines inside the popover are cut off. This change fixes it with the `overflowVisible` flag.

Requirement for https://github.com/cloudscape-design/components/pull/1124.

![Screenshot 2023-06-20 at 11 13 36](https://github.com/cloudscape-design/components/assets/2446349/ae9d2b27-a850-4b09-9ba1-28ebb41bfa1d)


Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
