### PR TITLE
refactor: Table resizable columns remove dependency on indices

### DIFF
--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -57,6 +57,7 @@ it('renders a fake focus outline on the sort control', () => {
         onResizeFinish={() => {}}
         stickyState={result.current}
         columnId="id"
+        cellRef={() => {}}
       />
     </TableWrapper>
   );
@@ -80,6 +81,7 @@ it('renders a fake focus outline on the resize control', () => {
         onResizeFinish={() => {}}
         stickyState={result.current}
         columnId="id"
+        cellRef={() => {}}
       />
     </TableWrapper>
   );
@@ -105,6 +107,7 @@ describe('i18n', () => {
             stickyState={result.current}
             columnId="id"
             isEditable={true}
+            cellRef={() => {}}
           />
         </TableWrapper>
       </TestI18nProvider>

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -13,6 +13,7 @@ import { InteractiveComponent } from '../thead';
 import { getStickyClassNames } from '../utils';
 import { useInternalI18n } from '../../internal/i18n/context';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
+import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 
 interface TableHeaderCellProps<ItemType> {
   className?: string;
@@ -34,7 +35,7 @@ interface TableHeaderCellProps<ItemType> {
   isEditable?: boolean;
   columnId: PropertyKey;
   stickyState: StickyColumnsModel;
-
+  cellRef: React.RefCallback<HTMLElement>;
   focusedComponent?: InteractiveComponent | null;
   onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
 }
@@ -59,6 +60,7 @@ export function TableHeaderCell<ItemType>({
   isEditable,
   columnId,
   stickyState,
+  cellRef,
 }: TableHeaderCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
@@ -89,6 +91,8 @@ export function TableHeaderCell<ItemType>({
     getClassName: props => getStickyClassNames(styles, props),
   });
 
+  const mergedRef = useMergeRefs(stickyStyles.ref, cellRef);
+
   return (
     <th
       className={clsx(
@@ -107,7 +111,7 @@ export function TableHeaderCell<ItemType>({
       aria-sort={sortingStatus && getAriaSort(sortingStatus)}
       style={{ ...style, ...stickyStyles.style }}
       scope="col"
-      ref={stickyStyles.ref}
+      ref={mergedRef}
     >
       <div
         className={clsx(styles['header-cell-content'], {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -235,11 +235,7 @@ const InternalTable = React.forwardRef(
       (toolsHeaderWrapper?.current as HTMLDivElement | null)?.getBoundingClientRect().height ?? 0;
 
     return (
-      <ColumnWidthsProvider
-        tableRef={tableRefObject}
-        visibleColumns={visibleColumnWidthsWithSelection}
-        resizableColumns={resizableColumns}
-      >
+      <ColumnWidthsProvider visibleColumns={visibleColumnWidthsWithSelection} resizableColumns={resizableColumns}>
         <InternalContainer
           {...baseProps}
           __internalRootRef={__internalRootRef}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -91,7 +91,7 @@ const Thead = React.forwardRef(
       isVisualRefresh && styles['is-visual-refresh']
     );
 
-    const { columnWidths, totalWidth, updateColumn } = useColumnWidths();
+    const { columnWidths, totalWidth, updateColumn, setCell } = useColumnWidths();
 
     const stickyStyles = useStickyCellStyles({
       stickyColumns: stickyState,
@@ -130,11 +130,13 @@ const Thead = React.forwardRef(
           ) : null}
 
           {columnDefinitions.map((column, colIndex) => {
+            const columnId = getColumnKey(column, colIndex);
+
             let widthOverride;
             if (resizableColumns) {
               if (columnWidths) {
                 // use stateful value if available
-                widthOverride = columnWidths[getColumnKey(column, colIndex)];
+                widthOverride = columnWidths[columnId];
               }
               if (colIndex === columnDefinitions.length - 1 && containerWidth && containerWidth > totalWidth) {
                 // let the last column grow and fill the container width
@@ -143,7 +145,7 @@ const Thead = React.forwardRef(
             }
             return (
               <TableHeaderCell
-                key={getColumnKey(column, colIndex)}
+                key={columnId}
                 className={headerCellClass}
                 style={{
                   width: widthOverride || column.width,
@@ -160,13 +162,14 @@ const Thead = React.forwardRef(
                 wrapLines={wrapLines}
                 hidden={hidden}
                 colIndex={colIndex}
-                columnId={column.id ?? colIndex}
+                columnId={columnId}
                 updateColumn={updateColumn}
                 onResizeFinish={() => onResizeFinish(columnWidths)}
                 resizableColumns={resizableColumns}
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 isEditable={!!column.editConfig}
                 stickyState={stickyState}
+                cellRef={node => setCell(columnId, node)}
               />
             );
           })}

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -74,16 +74,17 @@ export function ColumnWidthsProvider({ tableRef, visibleColumns, resizableColumn
     if (!resizableColumns) {
       return;
     }
+    const updates: Record<PropertyKey, number> = {};
     const lastVisible = visibleColumnsRef.current;
     if (lastVisible) {
       for (let index = 0; index < visibleColumns.length; index++) {
         const column = visibleColumns[index];
         if (!columnWidths[column.id] && lastVisible.indexOf(column.id) === -1) {
-          setColumnWidths(columnWidths => ({
-            ...columnWidths,
-            [column.id]: (column.width as number) || DEFAULT_COLUMN_WIDTH,
-          }));
+          updates[column.id] = (column.width as number) || DEFAULT_COLUMN_WIDTH;
         }
+      }
+      if (Object.keys(updates).length > 0) {
+        setColumnWidths(columnWidths => ({ ...columnWidths, ...updates }));
       }
     }
     visibleColumnsRef.current = visibleColumns.map(column => column.id);

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -5,7 +5,13 @@ import headerCellStyles from './header-cell/styles.css.js';
 
 export const DEFAULT_COLUMN_WIDTH = 120;
 
-function readWidths(headerEl: HTMLElement, visibleColumns: readonly Column[]) {
+export interface ColumnWidthDefinition {
+  id: PropertyKey;
+  minWidth?: string | number;
+  width?: string | number;
+}
+
+function readWidths(headerEl: HTMLElement, visibleColumns: readonly ColumnWidthDefinition[]) {
   const result: Record<PropertyKey, number> = {};
   for (let index = 0; index < visibleColumns.length; index++) {
     const column = visibleColumns[index];
@@ -25,7 +31,7 @@ function readWidths(headerEl: HTMLElement, visibleColumns: readonly Column[]) {
 }
 
 function updateWidths(
-  visibleColumns: readonly Column[],
+  visibleColumns: readonly ColumnWidthDefinition[],
   oldWidths: Record<PropertyKey, number>,
   newWidth: number,
   columnId: PropertyKey
@@ -53,15 +59,9 @@ const WidthsContext = createContext<WidthsContext>({
 
 interface WidthProviderProps {
   tableRef: React.MutableRefObject<HTMLElement | null>;
-  visibleColumns: readonly Column[];
+  visibleColumns: readonly ColumnWidthDefinition[];
   resizableColumns: boolean | undefined;
   children: React.ReactNode;
-}
-
-interface Column {
-  id: PropertyKey;
-  minWidth?: string | number;
-  width?: string | number;
 }
 
 export function ColumnWidthsProvider({ tableRef, visibleColumns, resizableColumns, children }: WidthProviderProps) {


### PR DESCRIPTION
### Description

A set of refactorings for resizable columns to remove the dependency on column indices and improve performance of the first rendering.

### How has this been tested?

Existing tests, manual testing, lighthouse testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
