### PR TITLE
fix: Fix elements with expandToViewport inside chart detail popover

### DIFF
--- a/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
+++ b/src/internal/hooks/use-portal-mode-classes/__tests__/use-portal-mode-classes.test.tsx
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
-import { usePortalModeClasses } from '../../../../../lib/components/internal/hooks/use-portal-mode-classes';
+import {
+  isInsidePortal,
+  usePortalModeClasses,
+} from '../../../../../lib/components/internal/hooks/use-portal-mode-classes';
 import VisualContext from '../../../../../lib/components/internal/components/visual-context';
 import { useVisualRefresh } from '../../../../../lib/components/internal/hooks/use-visual-mode';
+import styles from '../../../../../lib/components/internal/hooks/use-portal-mode-classes/styles.css.js';
 
 jest.mock('../../../../../lib/components/internal/hooks/use-visual-mode', () => {
   const original = jest.requireActual('../../../../../lib/components/internal/hooks/use-visual-mode');
@@ -31,21 +35,26 @@ describe('usePortalModeClasses', () => {
     jest.clearAllMocks();
   });
 
-  test('should not add any classes by default', () => {
+  test('should only add portal class by default', () => {
     render(<RenderTest refClasses="" />);
-    expect(screen.getByTestId('subject')).toHaveClass('', {
+    expect(screen.getByTestId('subject')).toHaveClass(styles.portal, {
       exact: true,
     });
   });
 
   test('should detect dark mode', () => {
     render(<RenderTest refClasses="awsui-polaris-dark-mode" />);
-    expect(screen.getByTestId('subject')).toHaveClass('awsui-polaris-dark-mode awsui-dark-mode', { exact: true });
+    expect(screen.getByTestId('subject')).toHaveClass(`${styles.portal} awsui-polaris-dark-mode awsui-dark-mode`, {
+      exact: true,
+    });
   });
 
   test('should detect compact mode', () => {
     render(<RenderTest refClasses="awsui-polaris-compact-mode" />);
-    expect(screen.getByTestId('subject')).toHaveClass('awsui-polaris-compact-mode awsui-compact-mode', { exact: true });
+    expect(screen.getByTestId('subject')).toHaveClass(
+      `${styles.portal} awsui-polaris-compact-mode awsui-compact-mode`,
+      { exact: true }
+    );
   });
 
   test('should detect visual refresh mode', () => {
@@ -56,7 +65,7 @@ describe('usePortalModeClasses', () => {
     (useVisualRefresh as jest.Mock).mockImplementation(() => true);
 
     render(<RenderTest refClasses="" />);
-    expect(screen.getByTestId('subject')).toHaveClass('awsui-visual-refresh', { exact: true });
+    expect(screen.getByTestId('subject')).toHaveClass(`${styles.portal} awsui-visual-refresh`, { exact: true });
   });
 
   test('should detect contexts', () => {
@@ -65,7 +74,7 @@ describe('usePortalModeClasses', () => {
         <RenderTest refClasses="" />
       </VisualContext>
     );
-    expect(screen.getByTestId('subject')).toHaveClass('awsui-context-content-header', { exact: true });
+    expect(screen.getByTestId('subject')).toHaveClass(`${styles.portal} awsui-context-content-header`, { exact: true });
   });
 
   test('should detect multiple modes and contexts', () => {
@@ -75,10 +84,37 @@ describe('usePortalModeClasses', () => {
       </VisualContext>
     );
     expect(screen.getByTestId('subject')).toHaveClass(
-      'awsui-polaris-dark-mode awsui-polaris-compact-mode awsui-dark-mode awsui-compact-mode awsui-context-content-header',
+      `${styles.portal} awsui-polaris-dark-mode awsui-polaris-compact-mode awsui-dark-mode awsui-compact-mode awsui-context-content-header`,
       {
         exact: true,
       }
     );
+  });
+});
+
+describe('isInsidePortal', () => {
+  function RenderTest() {
+    const ref = useRef(null);
+    const classes = usePortalModeClasses(ref);
+    return (
+      <div>
+        <div data-testid="outside" />
+        <div data-testid="portal" ref={ref}>
+          <div data-testid="inside" className={classes}>
+            Inside the portal
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  it('identifies elements inside and outside of portals', () => {
+    const { getByTestId } = render(<RenderTest />);
+
+    const outside = getByTestId('outside');
+    const inside = getByTestId('inside');
+
+    expect(isInsidePortal(outside)).toBe(false);
+    expect(isInsidePortal(inside)).toBe(true);
   });
 });

--- a/src/internal/hooks/use-portal-mode-classes/index.ts
+++ b/src/internal/hooks/use-portal-mode-classes/index.ts
@@ -17,3 +17,7 @@ export function usePortalModeClasses(ref: React.RefObject<HTMLElement>) {
     [`awsui-context-${context}`]: context,
   });
 }
+
+export function isInsidePortal(node: Element | null): boolean {
+  return !!node?.closest(`.${styles.portal}`);
+}

--- a/src/mixed-line-bar-chart/internal.tsx
+++ b/src/mixed-line-bar-chart/internal.tsx
@@ -22,6 +22,7 @@ import { isDevelopment } from '../internal/is-development';
 import createCategoryColorScale from '../internal/utils/create-category-color-scale';
 import { ScaledPoint } from './make-scaled-series';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
+import { isInsidePortal } from '../internal/hooks/use-portal-mode-classes';
 import { nodeContains } from '../internal/utils/dom';
 import { SomeRequired } from '../internal/types';
 import { isXThreshold, isYThreshold } from './utils';
@@ -184,7 +185,8 @@ export default function InternalMixedLineBarChart<T extends number | string | Da
   };
 
   const onBlur = (event: React.FocusEvent) => {
-    if (event.relatedTarget && !nodeContains(containerRef.current, event.relatedTarget)) {
+    const { relatedTarget } = event;
+    if (relatedTarget && !isInsidePortal(relatedTarget) && !nodeContains(containerRef.current, relatedTarget)) {
       highlightedSeries && onHighlightChange(highlightedSeries);
       setHighlightedPoint(null);
       setHighlightedGroupIndex(null);


### PR DESCRIPTION
### Description
For an upcoming chart feature (https://github.com/cloudscape-design/components/pull/1124), we will allow buttons and button dropdowns inside chart detail popovers for in-context actions and drill-down. However, there is currently a bug that prevents button dropdown (with `expandToViewport={true}`) from working inside those popovers.

This is because the button dropdown is rendered inside a portal and therefore fails this `nodeContains` check, which causes then resets the popover state: https://github.com/cloudscape-design/components/blob/6f71624769d9164b35902c0dfbea81b0dd358aa2/src/mixed-line-bar-chart/internal.tsx#L187.

This change introduces a new helper `isInsidePortal` that prevents this from happening.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
