### PR TITLE
chore: Add SpaceBetween in the media page

### DIFF
--- a/pages/container/media.page.tsx
+++ b/pages/container/media.page.tsx
@@ -113,47 +113,49 @@ export default function MediaContainers() {
       <SpaceBetween size="l">
         <SettingsForm />
         <ScreenshotArea>
-          <ContainerPlayground
-            header={
-              <Header
-                variant="h2"
-                headingTagOverride="h1"
-                description={
-                  <>
-                    Some additional text{' '}
-                    <Link fontSize="inherit" variant="primary">
-                      with a link
-                    </Link>
-                    .
-                  </>
-                }
-                info={<Link variant="info">Info</Link>}
-              >
-                <Link fontSize="heading-m" href="" variant="primary">
-                  Secondary link
-                </Link>
-              </Header>
-            }
-            footer={<Link>Learn more</Link>}
-          >
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
-            tortor, mollis vitae molestie sed, malesuada.Lorem ipsum dolor sit amet, consectetur adipiscing. Nullam dui
-            tortor, mollis vitae molestie sed. Phasellus tincidunt suscipit varius.
-          </ContainerPlayground>
-          <ContainerPlayground header="ContainerPlayground plain text in header">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
-            tortor, mollis vitae molestie sed, malesuada.Lorem ipsum dolor sit amet, consectetur adipiscing. Nullam dui
-            tortor, mollis vitae molestie sed. Phasellus tincidunt suscipit varius.
-          </ContainerPlayground>
-          <div className={styles.grid}>
+          <SpaceBetween size="l">
             <ContainerPlayground
-              fitHeight={true}
-              header={<Header variant="h2">Fixed Height Container</Header>}
-              footer="Footer"
+              header={
+                <Header
+                  variant="h2"
+                  headingTagOverride="h1"
+                  description={
+                    <>
+                      Some additional text{' '}
+                      <Link fontSize="inherit" variant="primary">
+                        with a link
+                      </Link>
+                      .
+                    </>
+                  }
+                  info={<Link variant="info">Info</Link>}
+                >
+                  <Link fontSize="heading-m" href="" variant="primary">
+                    Secondary link
+                  </Link>
+                </Header>
+              }
+              footer={<Link>Learn more</Link>}
             >
-              Content area takes the available vertical space, fixed height of 400px
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
+              tortor, mollis vitae molestie sed, malesuada.Lorem ipsum dolor sit amet, consectetur adipiscing. Nullam
+              dui tortor, mollis vitae molestie sed. Phasellus tincidunt suscipit varius.
             </ContainerPlayground>
-          </div>
+            <ContainerPlayground header="ContainerPlayground plain text in header">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit. Phasellus tincidunt suscipit varius. Nullam dui
+              tortor, mollis vitae molestie sed, malesuada.Lorem ipsum dolor sit amet, consectetur adipiscing. Nullam
+              dui tortor, mollis vitae molestie sed. Phasellus tincidunt suscipit varius.
+            </ContainerPlayground>
+            <div className={styles.grid}>
+              <ContainerPlayground
+                fitHeight={true}
+                header={<Header variant="h2">Fixed Height Container</Header>}
+                footer="Footer"
+              >
+                Content area takes the available vertical space, fixed height of 400px
+              </ContainerPlayground>
+            </div>
+          </SpaceBetween>
         </ScreenshotArea>
       </SpaceBetween>
     </article>


### PR DESCRIPTION
### Description

Added a `SpaceBetween` to have the containers spaced out in the screenshots testing page.

Before: https://d1dnby8l05mrxs.cloudfront.net/polaris/index.html#/light/container/media/?density=compact&visualRefresh=true&motionDisabled=true&position=top&height=150px&content=4-3

After: https://d21d5uik3ws71m.cloudfront.net/components/9ed3141fcea1348d11b51a33865847a1717a7ce1/index.html#/light/container/media/?density=compact&visualRefresh=true&motionDisabled=true&position=top&height=150px&content=4-3

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
