### PR TITLE
fix: Preserve indendation of Expandable section description when wrapping

### DIFF
--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -13,7 +13,11 @@ import PermutationsView from '../utils/permutations-view';
 const permutations = createPermutations<ExpandableSectionProps>([
   {
     headerCounter: [undefined, '(5)'],
-    headerDescription: [undefined, 'Expandable section header description'],
+    headerDescription: [
+      undefined,
+      'Expandable section header description',
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
     // eslint-disable-next-line react/jsx-key
     headerInfo: [undefined, <Link variant="info">info</Link>],
     headerActions: [

--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -128,7 +128,10 @@ const permutations = createPermutations<ExpandableSectionProps>([
     variant: ['default', 'container', 'footer'],
     headerText: ['With description'],
     children: ['Sample content'],
-    headerDescription: ['Sample description'],
+    headerDescription: [
+      'Sample description',
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
     defaultExpanded: [false, true],
   },
   {

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -136,7 +136,7 @@ const ExpandableHeaderTextWrapper = ({
   const listeners = { onClick, onKeyDown, onKeyUp };
 
   const description = variantSupportsDescription(variant) && headerDescription && (
-    <span id={descriptionId} className={styles[`description-${variant}`]}>
+    <span id={descriptionId} className={clsx(styles.description, styles[`description-${variant}`])}>
       {headerDescription}
     </span>
   );

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -190,11 +190,14 @@ $icon-margin-right-medium: awsui.$space-xs;
   }
 }
 
-// Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
-.description-default,
-.description-footer {
-  padding-left: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
-}
-.description-container {
-  padding-left: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
+.description {
+  display: block;
+  // Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
+  &-default,
+  &-footer {
+    padding-left: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
+  }
+  &-container {
+    padding-left: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
+  }
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Added permutations
- Manually verified

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
