### PR TITLE
chore: Refactor expandable section test pages

### DIFF
--- a/pages/expandable-section/common.tsx
+++ b/pages/expandable-section/common.tsx
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import Link from '~components/link';
+import React from 'react';
+import Button from '~components/button';
+import SpaceBetween from '~components/space-between';
+
+export const headerInfo = <Link variant="info">info</Link>;
+
+export const headerActions = (
+  <SpaceBetween direction="horizontal" size="xs">
+    <Button>Action</Button>
+    <Button>Another action</Button>
+  </SpaceBetween>
+);

--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -2,28 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import ExpandableSection, { ExpandableSectionProps } from '~components/expandable-section';
-import SpaceBetween from '~components/space-between';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import Link from '~components/link';
-import Button from '~components/button';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
+import { headerActions, headerInfo } from './common';
 
 const permutations = createPermutations<ExpandableSectionProps>([
   {
     headerCounter: [undefined, '(5)'],
     headerDescription: [undefined, 'Expandable section header description'],
-    // eslint-disable-next-line react/jsx-key
-    headerInfo: [undefined, <Link variant="info">info</Link>],
-    headerActions: [
-      undefined,
-      // eslint-disable-next-line react/jsx-key
-      <SpaceBetween direction="horizontal" size="xs">
-        <Button>Action</Button>
-        <Button>Another action</Button>
-      </SpaceBetween>,
-    ],
+    headerInfo: [undefined, headerInfo],
+    headerActions: [undefined, headerActions],
   },
 ]);
 export default function ExpandableSectionContainerVariantPermutations({
@@ -34,8 +24,6 @@ export default function ExpandableSectionContainerVariantPermutations({
   return (
     <article>
       <h1>Expandable Section - container variant</h1>
-
-      <button id="focus-target">Focus target</button>
 
       <ScreenshotArea>
         <PermutationsView

--- a/pages/expandable-section/focus.page.tsx
+++ b/pages/expandable-section/focus.page.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+import AppContext, { AppContextType } from '../app/app-context';
+
+import ExpandableSection, { ExpandableSectionProps } from '~components/expandable-section';
+
+import ScreenshotArea from '../utils/screenshot-area';
+import { headerActions, headerInfo } from './common';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    hasHeaderActions?: boolean;
+    hasHeaderInfo?: boolean;
+    headerCounter?: string;
+    headerDescription?: string;
+    headerText: string;
+    variant?: string;
+  }>
+>;
+
+export default function () {
+  const { urlParams } = useContext(AppContext as DemoContext);
+  const { hasHeaderActions, hasHeaderInfo, headerCounter, headerDescription, headerText, variant } = urlParams;
+
+  const isVariantValid = variant && ['container', 'default', 'footer', 'navigation'].indexOf(variant) !== -1;
+
+  return (
+    <article>
+      <h1>Expandable Section - focus tests</h1>
+
+      <button id="focus-target">Focus target</button>
+
+      <ScreenshotArea>
+        <ExpandableSection
+          defaultExpanded={true}
+          headerActions={hasHeaderActions ? headerActions : undefined}
+          headerCounter={headerCounter}
+          headerDescription={headerDescription}
+          headerInfo={hasHeaderInfo ? headerInfo : undefined}
+          headerText={headerText || 'Header text'}
+          variant={isVariantValid ? (variant as ExpandableSectionProps.Variant) : undefined}
+        >
+          Expandable section content
+        </ExpandableSection>
+      </ScreenshotArea>
+    </article>
+  );
+}


### PR DESCRIPTION
### Description

Add a separate page for Expandable section focus ring visual tests.

Until now, the container variant permutations page was being used for this and adding or removing permutations would make the focus ring tests fail unnecessarily.

This also allows us to test the focus rings much more thoroughly, across variants and features.

### Testing

- Tested locally against new visual regression tests
- Verified BackstopJS failures

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
