### PR TITLE
fix: Correctly indent all header elements in expandable sections

### DIFF
--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -11,7 +11,11 @@ import { headerActions, headerInfo } from './common';
 const permutations = createPermutations<ExpandableSectionProps>([
   {
     headerCounter: [undefined, '(5)'],
-    headerDescription: [undefined, 'Expandable section header description'],
+    headerDescription: [
+      undefined,
+      'Expandable section header description',
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
     headerInfo: [undefined, headerInfo],
     headerActions: [undefined, headerActions],
   },

--- a/pages/expandable-section/permutations.page.tsx
+++ b/pages/expandable-section/permutations.page.tsx
@@ -128,7 +128,10 @@ const permutations = createPermutations<ExpandableSectionProps>([
     variant: ['default', 'container', 'footer'],
     headerText: ['With description'],
     children: ['Sample content'],
-    headerDescription: ['Sample description'],
+    headerDescription: [
+      'Sample description',
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
     defaultExpanded: [false, true],
   },
   {

--- a/src/container/shared.scss
+++ b/src/container/shared.scss
@@ -6,7 +6,9 @@
 @use '../internal/styles' as styles;
 @use '../internal/styles/tokens' as awsui;
 
-$header-padding: awsui.$space-container-header-vertical awsui.$space-container-horizontal;
+$header-padding-horizontal: awsui.$space-container-horizontal;
+$header-padding-vertical: awsui.$space-container-header-vertical;
+$header-padding: $header-padding-vertical $header-padding-horizontal;
 $footer-padding: awsui.$space-scaled-s awsui.$space-container-horizontal;
 
 // HACK: Remediate focus border for expandable section

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -15,6 +15,11 @@ $icon-margin-left: '(#{awsui.$font-body-m-line-height} - #{$icon-width-normal}) 
 $icon-margin-right-normal: '#{awsui.$space-xxs} + #{awsui.$border-divider-list-width}';
 $icon-margin-right-medium: awsui.$space-xs;
 
+// Total space occupied by the expand icon on the left and its margins.
+// Useful to keep elements correctly aligned.
+$icon-total-space-normal: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
+$icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
+
 .root {
   @include styles.styles-reset;
   @include styles.text-wrapping;
@@ -50,15 +55,6 @@ $icon-margin-right-medium: awsui.$space-xs;
   line-height: awsui.$font-body-m-line-height;
   text-align: left;
 
-  &-default {
-    padding: awsui.$space-scaled-xxs awsui.$space-xxs;
-  }
-
-  &-footer {
-    // We remove left and right padding here to better align the carat icon
-    padding: awsui.$space-scaled-xxs 0;
-  }
-
   &-default,
   &-footer {
     border: awsui.$border-divider-section-width solid transparent;
@@ -83,8 +79,42 @@ $icon-margin-right-medium: awsui.$space-xs;
     letter-spacing: awsui.$font-heading-s-letter-spacing;
   }
 
+  &-default {
+    padding-top: awsui.$space-scaled-xxs;
+    padding-bottom: awsui.$space-scaled-xxs;
+    padding-right: awsui.$space-xxs;
+    &.header-deprecated {
+      padding-left: awsui.$space-xxs;
+    }
+    &:not(.header-deprecated) {
+      padding-left: calc(#{awsui.$space-xxs} + #{$icon-total-space-normal});
+    }
+  }
+
+  &-footer {
+    // We remove left and right padding here to better align the carat icon
+    padding-top: awsui.$space-scaled-xxs;
+    padding-bottom: awsui.$space-scaled-xxs;
+    padding-right: 0;
+    &.header-deprecated {
+      padding-left: 0;
+    }
+    &:not(.header-deprecated) {
+      padding-left: $icon-total-space-normal;
+    }
+  }
+
   &-container {
-    padding: container.$header-padding;
+    padding-top: container.$header-padding-vertical;
+    padding-bottom: container.$header-padding-vertical;
+    padding-right: container.$header-padding-horizontal;
+
+    &.header-deprecated {
+      padding-left: container.$header-padding-horizontal;
+    }
+    &:not(.header-deprecated) {
+      padding-left: calc(#{container.$header-padding-horizontal} + #{$icon-total-space-medium});
+    }
 
     @include focus-visible.when-visible {
       // HACK: Remediate focus border
@@ -113,16 +143,21 @@ $icon-margin-right-medium: awsui.$space-xs;
     padding: 0;
   }
 
-  &-button {
-    box-sizing: border-box;
-    display: flex;
-  }
-
   &-button,
   &-container-button {
     @include focus-visible.when-visible {
       @include styles.focus-highlight(0px);
     }
+  }
+
+  &-button {
+    box-sizing: border-box;
+    display: flex;
+    margin-left: calc(-1 * #{$icon-total-space-normal});
+  }
+
+  &-container-button {
+    margin-left: calc(-1 * #{$icon-total-space-medium});
   }
 
   &-container {
@@ -188,13 +223,4 @@ $icon-margin-right-medium: awsui.$space-xs;
   &:not(.wrapper-container):not(.header-container-button):hover {
     color: awsui.$color-text-expandable-section-hover;
   }
-}
-
-// Indent the description by exactly the same amount as the header, which is pushed to the right by the icon.
-.description-default,
-.description-footer {
-  padding-left: calc(#{$icon-width-normal} + #{$icon-margin-left} + #{$icon-margin-right-normal});
-}
-.description-container {
-  padding-left: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{$icon-margin-right-medium});
 }


### PR DESCRIPTION
### Description

Currently the elements inside the header of Expandable sections don't behave as they should when wrapping. Heading and description are indented on the first line, but they don't align correctly when they wrap, and the action buttons are also not indented when wrapping below the description:

![Screenshot 2023-06-30 at 06 43 46](https://github.com/cloudscape-design/components/assets/1257272/24f27317-ca2a-4680-a025-4f7caf7e4b3a)

This is fixed here by indenting the entire header content, and then applying a negative margin to the element that contains the icon and the heading (which needs to be kept together in order to receive focus):

![Screenshot 2023-06-30 at 06 38 01](https://github.com/cloudscape-design/components/assets/1257272/05d024d2-9e3a-487f-b027-8f917bcf3293)


### How has this been tested?

- Added permutations with long descriptions for all variants that support descriptions
- Ran in my pipeline
- Reviewed BackstopJS failures
- Reviewed by visual design

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
