### PR TITLE
fix: Accept i18nStrings.navigationAriaLabel in wizard through i18n provider

### DIFF
--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -538,6 +538,7 @@ describe('i18n', () => {
     expect(wrapper.findCancelButton().getElement()).toHaveTextContent('Custom cancel');
     expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent('Custom next');
     expect(wrapper.findSkipToButton()!.getElement()).toHaveTextContent('Custom skip to Step 3');
+    expect(wrapper.find('nav')!.getElement()).toHaveAccessibleName('Custom steps');
     wrapper.findPrimaryButton().click();
     expect(wrapper.findPreviousButton()!.getElement()).toHaveTextContent('Custom previous');
   });

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -112,6 +112,7 @@ export default function InternalWizard({
       rest.i18nStrings?.collapsedStepsLabel,
       format => (stepNumber, stepsCount) => format({ stepNumber, stepsCount })
     ),
+    navigationAriaLabel: i18n('i18nStrings.navigationAriaLabel', rest.i18nStrings.navigationAriaLabel),
     cancelButton: i18n('i18nStrings.cancelButton', rest.i18nStrings.cancelButton),
     previousButton: i18n('i18nStrings.previousButton', rest.i18nStrings.previousButton),
     nextButton: i18n('i18nStrings.nextButton', rest.i18nStrings.nextButton),


### PR DESCRIPTION
### Description

Caused accessibility tests to fail in our pipeline; turns out a necessary string was missing and it came out after we adopted i18n strings in our own demos. Updated the component, updated the tests.

Related links, issue #, if available: n/a

### How has this been tested?

Updated i18n unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
