### PR TITLE
feat: Pass form field context to text filter

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13116,9 +13116,44 @@ period of time. If you want a delayed handler to invoke a filtering API call, yo
   "name": "TextFilter",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-describedby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for each element that you want to use as a description
+and set the property to a string of each ID separated by spaces (for example, \`\\"id1 id2 id3\\"\`).
+",
+      "name": "ariaDescribedby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds \`aria-labelledby\` to the component. If you're using this component within a form field,
+don't set this property because the form field component automatically sets it.
+Use this property if the component isn't surrounded by a form field, or you want to override the value
+automatically set by the form field (for example, if you have two components within a single form field).
+
+To use it correctly, define an ID for the element you want to use as label and set the property to that ID.
+",
+      "name": "ariaLabelledby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Specifies the ID of the native form element. You can use it to relate
+a label element's \`for\` attribute to this control.
+It defaults to an automatically generated ID that
+is provided by its parent form field component.
+",
+      "name": "controlId",
       "optional": true,
       "type": "string",
     },

--- a/src/text-filter/__tests__/text-filter.test.tsx
+++ b/src/text-filter/__tests__/text-filter.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DEBOUNCE_DEFAULT_DELAY } from '../../../lib/components/internal/debounce';
+import FormField from '../../../lib/components/form-field';
 import TextFilter, { TextFilterProps } from '../../../lib/components/text-filter';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import '../../__a11y__/to-validate-a11y';
@@ -93,6 +94,18 @@ test('has autocomplete turned off', () => {
   expect(wrapper.findInput().findNativeInput().getElement()).toHaveAttribute('autocomplete', 'off');
 });
 
+test('should pass through properties using form field context', () => {
+  const { wrapper } = renderTextFilter(
+    <FormField label="Test label" description="Test description" controlId="control-id">
+      <TextFilter filteringText="" />
+    </FormField>
+  );
+  const nativeInput = wrapper.findInput().findNativeInput().getElement();
+  expect(document.getElementById(nativeInput.getAttribute('aria-labelledby')!)).toHaveTextContent('Test label');
+  expect(document.getElementById(nativeInput.getAttribute('aria-describedby')!)).toHaveTextContent('Test description');
+  expect(nativeInput.id).toBe('control-id');
+});
+
 describe('countText', () => {
   test('not displayed if no value was given', () => {
     const { wrapper } = renderTextFilter(<TextFilter filteringText="" />);
@@ -107,6 +120,21 @@ describe('countText', () => {
   test('displays the text when all conditions met', () => {
     const { wrapper } = renderTextFilter(<TextFilter filteringText="test" countText="10 matches" />);
     expect(wrapper.findResultsCount().getElement().textContent).toEqual('10 matches');
+  });
+
+  test('placed first in the aria-describedby list', () => {
+    const { wrapper } = renderTextFilter(
+      <TextFilter filteringText="test" ariaDescribedby="test-description" countText="10 matches" />
+    );
+    const ariaDescribedby = wrapper
+      .findInput()
+      .findNativeInput()
+      .getElement()
+      .getAttribute('aria-describedby')!
+      .split(' ');
+
+    expect(document.getElementById(ariaDescribedby[0])).toHaveTextContent('10 matches');
+    expect(ariaDescribedby[1]).toBe('test-description');
   });
 });
 

--- a/src/text-filter/interfaces.ts
+++ b/src/text-filter/interfaces.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { FormFieldControlProps } from '../internal/context/form-field-context';
 
-export interface TextFilterProps extends BaseComponentProps {
+export interface TextFilterProps extends BaseComponentProps, FormFieldControlProps {
   /**
    * The current value of the filtering input.
    */

--- a/src/text-filter/internal.tsx
+++ b/src/text-filter/internal.tsx
@@ -6,11 +6,13 @@ import InternalInput from '../input/internal';
 import { getBaseProps } from '../internal/base-component';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { fireNonCancelableEvent } from '../internal/events';
-import styles from './styles.css.js';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { TextFilterProps } from './interfaces';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { joinStrings } from '../internal/utils/strings';
+import { TextFilterProps } from './interfaces';
 import { SearchResults } from './search-results';
+
+import styles from './styles.css.js';
 
 type InternalTextFilterProps = TextFilterProps & InternalBaseComponentProps;
 
@@ -21,6 +23,9 @@ const InternalTextFilter = React.forwardRef(
       filteringAriaLabel,
       filteringPlaceholder,
       filteringClearAriaLabel,
+      controlId,
+      ariaLabelledby,
+      ariaDescribedby,
       disabled,
       countText,
       onChange,
@@ -40,6 +45,7 @@ const InternalTextFilter = React.forwardRef(
     return (
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <InternalInput
+          __inheritFormFieldProps={true}
           ref={inputRef}
           className={styles.input}
           type="search"
@@ -47,8 +53,10 @@ const InternalTextFilter = React.forwardRef(
           placeholder={filteringPlaceholder}
           value={filteringText}
           disabled={disabled}
+          controlId={controlId}
+          ariaLabelledby={ariaLabelledby}
+          ariaDescribedby={joinStrings(showResults ? searchResultsId : undefined, ariaDescribedby)}
           autoComplete={false}
-          ariaDescribedby={showResults ? searchResultsId : undefined}
           clearAriaLabel={filteringClearAriaLabel}
           onChange={event => fireNonCancelableEvent(onChange, { filteringText: event.detail.value })}
           __onDelayedInput={event => fireNonCancelableEvent(onDelayedChange, { filteringText: event.detail.value })}


### PR DESCRIPTION
### Description

Recently encountered a scenario where a user needed to pass in "usage instructions" for a text filter in the table tools. After some discussion, we felt that the constraint text UX was indeed the way to go. We support proper form fields in tables anyway (see [select filter](https://cloudscape.design/examples/react/table-select-filter.html)), so this isn't too far off.

We also discussed and felt it wouldn't be right to support the form field context by itself without also exposing the form field properties (`ariaLabelledby`, `ariaDescribedby`, `controlId`), so this adds them too.

Needs a review with the team before merging.

Related links, issue #, if available: AWSUI-21356

### How has this been tested?

Unit tests!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
