### PR TITLE
fix: Include stepName and subStepName in events

### DIFF
--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -24,6 +24,7 @@ import {
   DATA_ATTR_FIELD_ERROR,
   DATA_ATTR_FIELD_LABEL,
   getFieldSlotSeletor,
+  getNameFromSelector,
   getSubStepAllSelector,
 } from '../internal/analytics/selectors';
 
@@ -119,11 +120,16 @@ export default function InternalFormField({
 
   useEffect(() => {
     if (funnelInteractionId && errorText) {
+      const stepName = getNameFromSelector(stepNameSelector);
+      const subStepName = getNameFromSelector(subStepNameSelector);
+
       FunnelMetrics.funnelSubStepError({
         funnelInteractionId,
         subStepSelector,
+        subStepName,
         subStepNameSelector,
         stepNumber,
+        stepName,
         stepNameSelector,
         fieldErrorSelector: getFieldSlotSeletor(slotIds.error),
         fieldLabelSelector: getFieldSlotSeletor(slotIds.label),

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -21,6 +21,7 @@ import { FunnelProps, FunnelStepProps } from '../interfaces';
 import {
   DATA_ATTR_FUNNEL_STEP,
   getFunnelNameSelector,
+  getNameFromSelector,
   getSubStepAllSelector,
   getSubStepNameSelector,
   getSubStepSelector,
@@ -108,10 +109,13 @@ export const AnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: 
   // to record the beginning of the interaction with the current step.
   // On unmount, it does a similar thing but this time calling 'funnelStepComplete' to record the completion of the interaction.
   useEffect(() => {
+    const stepName = getNameFromSelector(stepNameSelector);
+
     if (funnelInteractionId) {
       FunnelMetrics.funnelStepStart({
         funnelInteractionId,
         stepNumber,
+        stepName,
         stepNameSelector,
         subStepAllSelector: getSubStepAllSelector(),
       });
@@ -122,6 +126,7 @@ export const AnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: 
         FunnelMetrics.funnelStepComplete({
           funnelInteractionId,
           stepNumber,
+          stepName,
           stepNameSelector,
           subStepAllSelector: getSubStepAllSelector(),
         });

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -33,6 +33,7 @@ export type FunnelStartMethod = (props: FunnelStartProps) => string;
 // Define individual method props by extending the base
 export interface FunnelStepProps extends BaseFunnelProps {
   stepNumber: number;
+  stepName?: string | undefined;
   stepNameSelector: string;
   subStepAllSelector: string;
 }
@@ -44,6 +45,7 @@ export interface FunnelStepNavigationProps extends FunnelStepProps {
 
 export interface FunnelSubStepProps extends FunnelStepProps {
   subStepSelector: string;
+  subStepName?: string | undefined;
   subStepNameSelector: string;
 }
 

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -26,3 +26,6 @@ export const getSubStepNameSelector = (subStepId: string) =>
   [`${getSubStepSelector(subStepId)}`, `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_SUBSTEP_NAME}"]`].join(' ');
 
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
+
+export const getNameFromSelector = (selector: string | undefined): string | undefined =>
+  selector ? document.querySelector<HTMLElement>(selector)?.innerText : undefined;

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -19,7 +19,12 @@ import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-fun
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { DATA_ATTR_FUNNEL_VALUE, getFunnelValueSelector, getSubStepAllSelector } from '../internal/analytics/selectors';
+import {
+  DATA_ATTR_FUNNEL_VALUE,
+  getFunnelValueSelector,
+  getNameFromSelector,
+  getSubStepAllSelector,
+} from '../internal/analytics/selectors';
 
 type InternalLinkProps = InternalBaseComponentProps &
   Omit<LinkProps, 'variant'> & {
@@ -65,21 +70,31 @@ const InternalLink = React.forwardRef(
 
     const fireFunnelEvent = (funnelInteractionId: string) => {
       if (variant === 'info') {
+        const stepName = getNameFromSelector(stepNameSelector);
+        const subStepName = getNameFromSelector(subStepNameSelector);
+
         FunnelMetrics.helpPanelInteracted({
           funnelInteractionId,
           stepNumber,
+          stepName,
           stepNameSelector,
           subStepSelector,
+          subStepName,
           subStepNameSelector,
           elementSelector: getFunnelValueSelector(uniqueId),
           subStepAllSelector: getSubStepAllSelector(),
         });
       } else if (external) {
+        const stepName = getNameFromSelector(stepNameSelector);
+        const subStepName = getNameFromSelector(subStepNameSelector);
+
         FunnelMetrics.externalLinkInteracted({
           funnelInteractionId,
           stepNumber,
+          stepName,
           stepNameSelector,
           subStepSelector,
+          subStepName,
           subStepNameSelector,
           elementSelector: getFunnelValueSelector(uniqueId),
           subStepAllSelector: getSubStepAllSelector(),

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -17,7 +17,7 @@ import { useInternalI18n } from '../internal/i18n/context';
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
-import { getSubStepAllSelector } from '../internal/analytics/selectors';
+import { getNameFromSelector, getSubStepAllSelector } from '../internal/analytics/selectors';
 
 import WizardForm from './wizard-form';
 import WizardNavigation from './wizard-navigation';
@@ -63,11 +63,15 @@ export default function InternalWizard({
 
   const navigationEvent = (requestedStepIndex: number, reason: WizardProps.NavigationReason) => {
     if (funnelInteractionId) {
+      const stepNameSelector = `.${styles['form-header-component-wrapper']}`;
+      const stepName = getNameFromSelector(stepNameSelector);
+
       FunnelMetrics.funnelStepNavigation({
         navigationType: reason,
         funnelInteractionId,
         stepNumber: actualActiveStepIndex + 1,
-        stepNameSelector: `.${styles['form-header-component-wrapper']}`,
+        stepName,
+        stepNameSelector,
         destinationStepNumber: requestedStepIndex + 1,
         subStepAllSelector: getSubStepAllSelector(),
       });


### PR DESCRIPTION
### Description

With this change, we include the fields `stepName` and `subStepName` in the metrics event. Previously, we would only emit the selector to the elements containing those names. When a step is completed (i.e. at the point where `funnelStepComplete` is called), this selector does not point at the correct element anymore, because that element has been unmounted. To mitigate this, we save the name already at the start of the effect.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: nBvhAQL0oUIC , Line 33

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
