### PR TITLE
fix: More liberal i18n exports

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -46,7 +46,9 @@ function getComponentsExports() {
     result[`./i18n/messages/${subset}.${locale}`] = `./i18n/messages/${subset}.${locale}.js`;
     result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
   }
-
+  // hack for webpack https://github.com/webpack/webpack/issues/13865
+  // this path does not need to resolve anywhere, but it needs to be allowed
+  result[`./i18n/messages`] = { webpack: 'nowhere' };
   // i18n beta specific imports (delete after people switch over)
   result['./internal/i18n'] = './internal/i18n/index.js';
   result[`./internal/i18n/messages/all.all`] = `./internal/i18n/messages/all.all.js`;

--- a/src/__tests__/public-exports.test.ts
+++ b/src/__tests__/public-exports.test.ts
@@ -9,8 +9,9 @@ const packageJson = require('../../lib/components/package.json');
 
 test('all exports declarations resolve to a file', () => {
   for (const exportPath of Object.values<string>(packageJson.exports)) {
-    // context export is a folder, cannot be resolved
-    if (exportPath === './internal/context/') {
+    // this path is a hack, does not resolve to a
+    // file
+    if (exportPath === './i18n/messages') {
       continue;
     }
     expect(() => require.resolve(exportPath, { paths: [path.join(__dirname, '../../lib/components')] })).not.toThrow();


### PR DESCRIPTION
### Description

Current exports declaration is incompatible with dynamic imports. 

```js
const { default: messages } = await import(`@cloudscape-design/components/i18n/messages/all.${locale}.js`);
```

`locale` is unknown build-time, so it is not possible for the bundler to validate if the export is valid or not.

Related webpack issue: https://github.com/webpack/webpack/issues/13865 (it is open, but due to its age, unlikely to resolve soon)

### How has this been tested?

Applied the patched package.json file locally, checked that the import works now

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
