### PR TITLE
chore: Add higher-specificity rule for inline-editable sticky cell styles

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -277,6 +277,9 @@ $border-placeholder: awsui.$border-item-width solid transparent;
             'horizontal': calc(-1 * #{awsui.$space-scaled-xxs}),
           )
         );
+        &.sticky-cell {
+          position: sticky;
+        }
       }
       &:hover {
         position: relative;
@@ -303,6 +306,9 @@ $border-placeholder: awsui.$border-item-width solid transparent;
         &.body-cell-first-row:not(.body-cell-selected) {
           padding-top: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
           padding-bottom: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+        }
+        &.sticky-cell {
+          position: sticky;
         }
       }
     }


### PR DESCRIPTION

### Description

When the inline editing cells are on a sticky column, they lose their stickiness on hover / focus. This is due to the specificity of the `position` rule not being high enough in these cases. This PR fixes this.

Related links, issue #, if available: AWSUI-21418

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
