### PR TITLE
fix: Re-emit error metrics if an error persists after attempting to submit

### DIFF
--- a/pages/form/with-validation.page.tsx
+++ b/pages/form/with-validation.page.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import {
-  AppLayout,
   BreadcrumbGroup,
   Button,
   Checkbox,
@@ -47,66 +46,59 @@ export default function FormScenario() {
   };
 
   return (
-    <AppLayout
-      toolsHide={true}
-      navigationHide={true}
-      breadcrumbs={
-        <BreadcrumbGroup
-          items={[
-            { text: 'Breadcrumbs', href: '#' },
-            { text: 'Create a resource', href: '#' },
-          ]}
-        />
-      }
-      contentType="form"
-      content={
-        finished ? (
-          <Container>Finished</Container>
-        ) : (
-          <Form
-            header={<Header variant="h1">Form</Header>}
-            actions={
-              <SpaceBetween direction="horizontal" size="xs">
-                <Button variant="link" disabled={loading}>
-                  Cancel
-                </Button>
-                <Button variant="primary" onClick={onSubmit} loading={loading} loadingText="Loading">
-                  Submit
-                </Button>
-              </SpaceBetween>
-            }
-            errorText={showFormError ? 'A server-side error happened.' : undefined}
-            errorIconAriaLabel="Error"
-          >
-            <SpaceBetween direction="vertical" size="l">
-              <Container header={<Header variant="h2">Form section 1</Header>}>
-                <SpaceBetween direction="vertical" size="l">
-                  <FormField
-                    label="Form field"
-                    errorText={
-                      attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined
-                    }
-                    constraintText="Maximum length: 4 letters"
-                  >
-                    <Input value={value} onChange={e => setValue(e.detail.value)} disabled={loading} />
-                  </FormField>
-                </SpaceBetween>
-              </Container>
-              <Container header={<Header variant="h2">Form section 2</Header>}>
-                <FormField label="Error simulation">
-                  <Checkbox
-                    checked={simulateServerError}
-                    onChange={e => setSimulateServerError(e.detail.checked)}
-                    disabled={loading}
-                  >
-                    Show a server side error when this form is submitted
-                  </Checkbox>
-                </FormField>
-              </Container>
+    <>
+      <BreadcrumbGroup
+        items={[
+          { text: 'Breadcrumbs', href: '#' },
+          { text: 'Create a resource', href: '#' },
+        ]}
+      />
+      {finished ? (
+        <Container>Finished</Container>
+      ) : (
+        <Form
+          header={<Header variant="h1">Form</Header>}
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" disabled={loading}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={onSubmit} loading={loading} loadingText="Loading">
+                Submit
+              </Button>
             </SpaceBetween>
-          </Form>
-        )
-      }
-    />
+          }
+          errorText={showFormError ? 'A server-side error happened.' : undefined}
+          errorIconAriaLabel="Error"
+        >
+          <SpaceBetween direction="vertical" size="l">
+            <Container header={<Header variant="h2">Form section 1</Header>}>
+              <SpaceBetween direction="vertical" size="l">
+                <FormField
+                  label="Form field"
+                  errorText={
+                    attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined
+                  }
+                  constraintText="Maximum length: 4 letters"
+                >
+                  <Input value={value} onChange={e => setValue(e.detail.value)} disabled={loading} />
+                </FormField>
+              </SpaceBetween>
+            </Container>
+            <Container header={<Header variant="h2">Form section 2</Header>}>
+              <FormField label="Error simulation">
+                <Checkbox
+                  checked={simulateServerError}
+                  onChange={e => setSimulateServerError(e.detail.checked)}
+                  disabled={loading}
+                >
+                  Show a server side error when this form is submitted
+                </Checkbox>
+              </FormField>
+            </Container>
+          </SpaceBetween>
+        </Form>
+      )}
+    </>
   );
 }

--- a/pages/form/with-validation.page.tsx
+++ b/pages/form/with-validation.page.tsx
@@ -1,0 +1,112 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  AppLayout,
+  BreadcrumbGroup,
+  Button,
+  Checkbox,
+  Container,
+  Form,
+  FormField,
+  Header,
+  Input,
+  SpaceBetween,
+} from '~components';
+
+export default function FormScenario() {
+  const [value, setValue] = useState('');
+  const [simulateServerError, setSimulateServerError] = useState(true);
+
+  const [attemptedToSubmit, setAttemptedToSubmit] = useState(false);
+
+  const [loading, setLoading] = useState(false);
+  const [showFormError, setShowFormError] = useState(false);
+
+  const [finished, setFinished] = useState(false);
+
+  const onSubmit = () => {
+    setAttemptedToSubmit(true);
+    setShowFormError(false);
+
+    if (value.length > 4) {
+      return;
+    }
+
+    setLoading(true);
+
+    setTimeout(() => {
+      setLoading(false);
+
+      if (simulateServerError) {
+        setShowFormError(true);
+      } else {
+        setFinished(true);
+      }
+    }, 2000);
+  };
+
+  return (
+    <AppLayout
+      toolsHide={true}
+      navigationHide={true}
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Breadcrumbs', href: '#' },
+            { text: 'Create a resource', href: '#' },
+          ]}
+        />
+      }
+      contentType="form"
+      content={
+        finished ? (
+          <Container>Finished</Container>
+        ) : (
+          <Form
+            header={<Header variant="h1">Form</Header>}
+            actions={
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button variant="link" disabled={loading}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={onSubmit} loading={loading} loadingText="Loading">
+                  Submit
+                </Button>
+              </SpaceBetween>
+            }
+            errorText={showFormError ? 'A server-side error happened.' : undefined}
+            errorIconAriaLabel="Error"
+          >
+            <SpaceBetween direction="vertical" size="l">
+              <Container header={<Header variant="h2">Form section 1</Header>}>
+                <SpaceBetween direction="vertical" size="l">
+                  <FormField
+                    label="Form field"
+                    errorText={
+                      attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined
+                    }
+                    constraintText="Maximum length: 4 letters"
+                  >
+                    <Input value={value} onChange={e => setValue(e.detail.value)} disabled={loading} />
+                  </FormField>
+                </SpaceBetween>
+              </Container>
+              <Container header={<Header variant="h2">Form section 2</Header>}>
+                <FormField label="Error simulation">
+                  <Checkbox
+                    checked={simulateServerError}
+                    onChange={e => setSimulateServerError(e.detail.checked)}
+                    disabled={loading}
+                  >
+                    Show a server side error when this form is submitted
+                  </Checkbox>
+                </FormField>
+              </Container>
+            </SpaceBetween>
+          </Form>
+        )
+      }
+    />
+  );
+}

--- a/pages/wizard/with-validation.page.tsx
+++ b/pages/wizard/with-validation.page.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { i18nStrings } from './common';
+import { Container, FormField, Header, Input, Link, Wizard, WizardProps } from '~components';
+
+export default function WizardPage() {
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const [value, setValue] = useState('');
+  const [attemptedToSubmit, setAttemptedToSubmit] = useState(false);
+
+  const steps: WizardProps['steps'] = [
+    {
+      title: 'Step 1',
+      content: (
+        <Container header={<Header>A container for step 1</Header>}>
+          <FormField
+            key="1"
+            label="Form field in step 1"
+            errorText={attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined}
+            constraintText="Maximum length: 4 letters"
+          >
+            <Input value={value} onChange={e => setValue(e.detail.value)} />
+          </FormField>
+        </Container>
+      ),
+    },
+    {
+      title: 'Step 2',
+      content: (
+        <Container header={<Header>A container for step 2</Header>}>
+          <FormField
+            key="2"
+            label="Form field in step 2"
+            errorText={attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined}
+            constraintText="Maximum length: 4 letters"
+          >
+            <Input value={value} onChange={e => setValue(e.detail.value)} />
+          </FormField>
+        </Container>
+      ),
+    },
+    {
+      title: 'Step 3',
+      info: <Link variant="info">Info</Link>,
+      content: (
+        <>
+          {Array.from(Array(5).keys()).map(key => (
+            <div key={key}>Item {key}</div>
+          ))}
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <Wizard
+      steps={steps}
+      i18nStrings={i18nStrings}
+      activeStepIndex={activeStepIndex}
+      onNavigate={e => {
+        setAttemptedToSubmit(true);
+        if (value.length > 4 && e.detail.requestedStepIndex > activeStepIndex) {
+          return;
+        }
+        setAttemptedToSubmit(false);
+        setActiveStepIndex(e.detail.requestedStepIndex);
+      }}
+    />
+  );
+}

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -19,7 +19,7 @@ import { useInternalI18n } from '../internal/i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 
 import { FunnelMetrics } from '../internal/analytics';
-import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
+import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import {
   DATA_ATTR_FIELD_ERROR,
   DATA_ATTR_FIELD_LABEL,
@@ -92,8 +92,9 @@ export default function InternalFormField({
   const generatedControlId = controlId || instanceUniqueId;
   const formFieldId = controlId || generatedControlId;
 
-  const { funnelInteractionId, stepNumber, stepNameSelector, subStepSelector, subStepNameSelector } =
-    useFunnelSubStep();
+  const { funnelInteractionId, submissionAttempt } = useFunnel();
+
+  const { stepNumber, stepNameSelector, subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
   const slotIds = getSlotIds(formFieldId, label, description, constraintText, errorText);
 
@@ -138,7 +139,7 @@ export default function InternalFormField({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [funnelInteractionId, errorText]);
+  }, [funnelInteractionId, errorText, submissionAttempt]);
 
   return (
     <div

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -8,6 +8,7 @@ import Button from '../../../lib/components/button';
 import Form from '../../../lib/components/form';
 
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
+import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
 
@@ -140,6 +141,32 @@ describe('Form Analytics', () => {
         funnelInteractionId: expect.any(String),
       })
     );
+  });
+
+  test('increments the submissionAttempt counter when clicking Submit', () => {
+    const ChildComponent = () => {
+      const { submissionAttempt } = useFunnel();
+      return <div data-testid="submission-attempt">{submissionAttempt}</div>;
+    };
+
+    const { container, getByTestId } = render(
+      <Form
+        actions={
+          <Button data-testid="submit" variant="primary">
+            Submit
+          </Button>
+        }
+      >
+        <ChildComponent />
+      </Form>
+    );
+    const formWrapper = createWrapper(container).findForm();
+    const submitButton = formWrapper!.findActions()!.findButton('[data-testid="submit"]');
+
+    expect(getByTestId('submission-attempt').textContent).toBe('0');
+
+    act(() => submitButton!.click());
+    expect(getByTestId('submission-attempt').textContent).toBe('1');
   });
 
   test('sends a funnelError metric when an error is rendered', () => {

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -14,11 +14,12 @@ import { useFunnel, useFunnelStep } from '../internal/analytics/hooks/use-funnel
 export { FormProps };
 
 const FormWithAnalytics = ({ variant = 'full-page', actions, ...props }: FormProps) => {
-  const { funnelProps, funnelSubmit } = useFunnel();
+  const { funnelProps, funnelSubmit, funnelNextOrSubmitAttempt } = useFunnel();
   const { funnelStepProps } = useFunnelStep();
 
   const handleActionButtonClick: ButtonContextProps['onClick'] = ({ variant }) => {
     if (variant === 'primary') {
+      funnelNextOrSubmitAttempt();
       funnelSubmit();
     }
   };

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -32,13 +32,13 @@ export default function InternalForm({
   const i18n = useInternalI18n('form');
   const errorIconAriaLabel = i18n('errorIconAriaLabel', errorIconAriaLabelOverride);
 
-  const { funnelInteractionId } = useFunnel();
+  const { funnelInteractionId, submissionAttempt } = useFunnel();
 
   useEffect(() => {
     if (funnelInteractionId && errorText) {
       FunnelMetrics.funnelError({ funnelInteractionId });
     }
-  }, [funnelInteractionId, errorText]);
+  }, [funnelInteractionId, errorText, submissionAttempt]);
 
   return (
     <div {...baseProps} ref={__internalRootRef} className={clsx(styles.root, baseProps.className)}>

--- a/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
@@ -28,6 +28,8 @@ describe('useFunnel hook', () => {
           totalFunnelSteps: 0,
           funnelSubmit: () => {},
           funnelCancel: () => {},
+          submissionAttempt: 0,
+          funnelNextOrSubmitAttempt: () => {},
         }}
       >
         <ChildComponent />
@@ -64,6 +66,8 @@ describe('useFunnel hook', () => {
           setFunnelInteractionId,
           funnelSubmit,
           funnelCancel,
+          submissionAttempt: 0,
+          funnelNextOrSubmitAttempt: () => {},
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -36,6 +36,7 @@ type AnalyticsFunnelProps = { children?: React.ReactNode } & Pick<
 
 export const AnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) => {
   const [funnelInteractionId, setFunnelInteractionId] = useState<string>('');
+  const [submissionAttempt, setSubmissionAttempt] = useState(0);
   const funnelResultRef = useRef<boolean>(false);
   const isVisualRefresh = useVisualRefresh();
 
@@ -78,6 +79,8 @@ export const AnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) =>
     funnelResultRef.current = true;
   };
 
+  const funnelNextOrSubmitAttempt = () => setSubmissionAttempt(i => i + 1);
+
   const funnelCancel = () => {
     funnelResultRef.current = false;
   };
@@ -90,6 +93,8 @@ export const AnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) =>
     totalFunnelSteps: props.totalFunnelSteps,
     funnelSubmit,
     funnelCancel,
+    submissionAttempt,
+    funnelNextOrSubmitAttempt,
   };
 
   return <FunnelContext.Provider value={funnelContextValue}>{children}</FunnelContext.Provider>;

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -32,6 +32,7 @@ export interface FunnelSubStepContextValue extends FunnelStepContextValue {
   funnelSubStepProps?: Record<string, string | number | boolean | undefined>;
 }
 
+/* istanbul ignore next */
 export const FunnelContext = createContext<FunnelContextValue>({
   funnelInteractionId: undefined,
   setFunnelInteractionId: () => {},

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -14,6 +14,8 @@ export interface FunnelContextValue extends BaseContextProps {
   funnelSubmit: () => void;
   funnelCancel: () => void;
   setFunnelInteractionId: (funnelInteractionId: string) => void;
+  submissionAttempt: number;
+  funnelNextOrSubmitAttempt: () => void;
 }
 
 export interface FunnelStepContextValue extends BaseContextProps {
@@ -38,6 +40,8 @@ export const FunnelContext = createContext<FunnelContextValue>({
   totalFunnelSteps: 0,
   funnelSubmit: () => {},
   funnelCancel: () => {},
+  submissionAttempt: 0,
+  funnelNextOrSubmitAttempt: () => {},
 });
 
 export const FunnelStepContext = createContext<FunnelStepContextValue>({

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -7,6 +7,7 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import Wizard, { WizardProps } from '../../../lib/components/wizard';
 
 import { FunnelMetrics, setFunnelMetrics } from '../../../lib/components/internal/analytics';
+import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { DEFAULT_I18N_SETS, DEFAULT_STEPS } from './common';
 
@@ -114,6 +115,48 @@ describe('Wizard Analytics', () => {
         subStepAllSelector: expect.any(String),
       })
     );
+  });
+
+  const ChildComponent = () => {
+    const { submissionAttempt } = useFunnel();
+    return <div data-testid="submission-attempt">{submissionAttempt}</div>;
+  };
+
+  test('increments the submissionAttempt counter when clicking Next', () => {
+    const { container, getByTestId } = render(
+      <Wizard
+        steps={[
+          { title: 'Counter step', content: <ChildComponent /> },
+          { title: 'Other step', content: <></> },
+        ]}
+        activeStepIndex={0}
+        onNavigate={() => {}}
+        i18nStrings={DEFAULT_I18N_SETS[0]}
+      />
+    );
+    const wizardWrapper = createWrapper(container).findWizard();
+
+    expect(getByTestId('submission-attempt').textContent).toBe('0');
+
+    wizardWrapper!.findPrimaryButton().click();
+    expect(getByTestId('submission-attempt').textContent).toBe('1');
+  });
+
+  test('increments the submissionAttempt counter when clicking Submit', () => {
+    const { container, getByTestId } = render(
+      <Wizard
+        steps={[{ title: 'Counter step', content: <ChildComponent /> }]}
+        activeStepIndex={0}
+        onNavigate={() => {}}
+        i18nStrings={DEFAULT_I18N_SETS[0]}
+      />
+    );
+    const wizardWrapper = createWrapper(container).findWizard();
+
+    expect(getByTestId('submission-attempt').textContent).toBe('0');
+
+    wizardWrapper!.findPrimaryButton().click();
+    expect(getByTestId('submission-attempt').textContent).toBe('1');
   });
 
   test('sends a startStep metric when navigating to a new step when navigating with the navigation', () => {

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -52,7 +52,7 @@ export default function InternalWizard({
     controlledProp: 'activeStepIndex',
     changeHandler: 'onNavigate',
   });
-  const { funnelInteractionId, funnelSubmit, funnelCancel, funnelProps } = useFunnel();
+  const { funnelInteractionId, funnelSubmit, funnelCancel, funnelProps, funnelNextOrSubmitAttempt } = useFunnel();
   const actualActiveStepIndex = activeStepIndex ? Math.min(activeStepIndex, steps.length - 1) : 0;
 
   const farthestStepIndex = useRef<number>(actualActiveStepIndex);
@@ -88,6 +88,8 @@ export default function InternalWizard({
   };
   const onPreviousClick = () => navigationEvent(actualActiveStepIndex - 1, 'previous');
   const onPrimaryClick = () => {
+    funnelNextOrSubmitAttempt();
+
     if (isLastStep) {
       funnelSubmit();
       fireNonCancelableEvent(onSubmit);


### PR DESCRIPTION
### Description

When a form is submitted (either in a Form component or in a page of a Wizard component), and an error is shown in one of the form fields, we emit the `funnelSubStepError` event. If a form-level error happens, we emit the `funnelError` event. When the user tries to submit the form again, and the same error happens, the error is not re-rendered. The result of this was that no new error event is emitted.

After this change, if there are errors after trying to submit a form (or a page, in the case of a Wizard), the error events are emitted again. This is achieved by applying a counter that is incremented on every attempt to submit the form, which causes the `useEffect` hooks to re-run.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: nBvhAQL0oUIC , Line 26

### How has this been tested?

I have added two new testing pages, which I have used for manual testing.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
