### PR TITLE
fix: Height of dark header with sticky table in compact mode

### DIFF
--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -30,7 +30,7 @@ div.background {
 
     &.has-sticky-notifications {
       height: calc(
-        var(#{custom-props.$notificationsGap}) + var(#{custom-props.$notificationsHeight}) + #{awsui.$space-s} + var(#{custom-props.$overlapHeight})
+        var(#{custom-props.$notificationsGap}) + var(#{custom-props.$notificationsHeight}) + #{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight})
       );
     }
   }

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -156,7 +156,7 @@ explicitly set in script.
   &.has-sticky-notifications.has-sticky-background {
     #{custom-props.$offsetTopWithNotifications}: calc(
       var(#{custom-props.$offsetTop}) + var(#{custom-props.$notificationsGap}) +
-        var(#{custom-props.$notificationsHeight}) + #{awsui.$space-scaled-s}
+        var(#{custom-props.$notificationsHeight}) + #{awsui.$space-static-s}
     );
   }
   /* stylelint-enable scss/operator-no-newline-after */

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -156,7 +156,7 @@ explicitly set in script.
   &.has-sticky-notifications.has-sticky-background {
     #{custom-props.$offsetTopWithNotifications}: calc(
       var(#{custom-props.$offsetTop}) + var(#{custom-props.$notificationsGap}) +
-        var(#{custom-props.$notificationsHeight}) + #{awsui.$space-static-s}
+        var(#{custom-props.$notificationsHeight}) + #{awsui.$space-scaled-s}
     );
   }
   /* stylelint-enable scss/operator-no-newline-after */


### PR DESCRIPTION
### Description

The top offset was being calculated using a scaled variable, where it should be static. This PR fixes it.

Before: https://d1dnby8l05mrxs.cloudfront.net/polaris/index.html#/light/app-layout/with-table/?density=compact&visualRefresh=true&motionDisabled=true&stickyNotifications=true

After: https://d21d5uik3ws71m.cloudfront.net/components/159e004804283aadc52ec8652c1e273725c1bd63/index.html#/light/app-layout/with-table/?density=compact&visualRefresh=true&motionDisabled=true&stickyNotifications=true

Issue: AWSUI-21408

## How has this been tested?

Run through my dev pipeline: `dev-v3-rucarva`.
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
