### PR TITLE
chore: Unsupport iconName in runtime drawers api

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -24,7 +24,10 @@ awsuiPlugins.appLayout.registerDrawer({
   },
 
   trigger: {
-    iconName: 'security',
+    iconSvg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+      <rect x="2" y="7" width="12" height="7" fill="none" stroke="currentColor" stroke-width="2" />
+      <path d="M4,7V5a4,4,0,0,1,8,0V7" fill="none" stroke="currentColor" stroke-width="2" />
+    </svg>`,
   },
 
   resizable: true,

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -26,7 +26,7 @@ function delay() {
 const drawerDefaults: DrawerConfig = {
   id: 'test',
   ariaLabels: {},
-  trigger: {},
+  trigger: { iconSvg: '' },
   mountContent: () => {},
   unmountContent: () => {},
 };
@@ -71,6 +71,16 @@ describe('Runtime drawers', () => {
     });
     const { wrapper } = await renderComponent(<AppLayout />);
     expect(wrapper.find('[data-testid="custom-icon"]')).toBeTruthy();
+  });
+
+  test('does not support iconName', async () => {
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      // @ts-expect-error testing that unsupported feature does not fail in runtime
+      trigger: { iconName: `<rect data-testid="custom-icon" />` },
+    });
+    const { wrapper } = await renderComponent(<AppLayout />);
+    expect(wrapper.findDrawersTriggers()[0].find('svg')).toBeFalsy();
   });
 
   test('persists drawer config between mounts/unmounts', async () => {

--- a/src/app-layout/runtime-api.tsx
+++ b/src/app-layout/runtime-api.tsx
@@ -30,15 +30,12 @@ export interface DrawersLayout {
 export function convertRuntimeDrawers(drawers: Array<RuntimeDrawerConfig>): DrawersLayout {
   const converted = drawers.map(({ mountContent, unmountContent, trigger, ...runtimeDrawer }) => ({
     ...runtimeDrawer,
-    trigger: trigger.iconSvg
-      ? {
-          ...trigger,
-          iconSvg: (
-            // eslint-disable-next-line react/no-danger
-            <span dangerouslySetInnerHTML={{ __html: trigger.iconSvg }} />
-          ),
-        }
-      : trigger,
+    trigger: {
+      iconSvg: (
+        // eslint-disable-next-line react/no-danger
+        <span dangerouslySetInnerHTML={{ __html: trigger.iconSvg }} />
+      ),
+    },
     content: (
       <RuntimeContentWrapper key={runtimeDrawer.id} mountContent={mountContent} unmountContent={unmountContent} />
     ),

--- a/src/internal/plugins/drawers-controller.ts
+++ b/src/internal/plugins/drawers-controller.ts
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { DrawerItem } from '../../app-layout/drawer/interfaces';
-import { IconProps } from '../../icon/interfaces';
 
-export type DrawerConfig = Omit<DrawerItem, 'content'> & {
+export type DrawerConfig = Omit<DrawerItem, 'content' | 'trigger'> & {
   orderPriority?: number;
   trigger: {
-    iconName?: IconProps.Name;
-    iconSvg?: string;
+    iconSvg: string;
   };
   mountContent: (container: HTMLElement) => void;
   unmountContent: (container: HTMLElement) => void;


### PR DESCRIPTION
### Description

There is no guarantee that this iconName is going to be available in the receiving app layout, because it could be a different bundle.

Since we have no actual use-cases for `iconName` property it would be safer to unsupport the feature before it becomes problematic

### How has this been tested?

1. Updated dev page to exclude built-in icons
2. Added a unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
