### PR TITLE
fix: Prevent recovery button from wrapping to next line in dropdown footers

### DIFF
--- a/pages/multiselect/screenshot.page.tsx
+++ b/pages/multiselect/screenshot.page.tsx
@@ -27,6 +27,7 @@ const options: MultiselectProps.Options = [
 export default function () {
   const [selected, setSelected] = useState<MultiselectProps.Options>(options.slice(0, 3));
   const [virtualScroll, setVirtualScroll] = useState<boolean>(false);
+  const [showError, setShowError] = useState<boolean>(false);
 
   return (
     <>
@@ -34,6 +35,10 @@ export default function () {
 
       <button id="toggle-virtual" onClick={() => setVirtualScroll(vs => !vs)}>
         Toggle virtual scroll
+      </button>
+
+      <button id="toggle-error" onClick={() => setShowError(show => !show)}>
+        Toggle error
       </button>
 
       <ScreenshotArea
@@ -48,6 +53,9 @@ export default function () {
           options={options}
           filteringType="manual"
           finishedText="End of all results"
+          errorText="verylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspaces"
+          recoveryText="Retry"
+          statusType={showError ? 'error' : 'finished'}
           onChange={event => setSelected(event.detail.selectedOptions)}
           i18nStrings={i18nStrings}
           tokenLimit={2}

--- a/pages/status-indicator/permutations.page.tsx
+++ b/pages/status-indicator/permutations.page.tsx
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import StatusIndicator, { StatusIndicatorProps } from '~components/status-indicator';
+import StatusIndicator, { InternalStatusIndicatorProps } from '~components/status-indicator/internal';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
-const permutations = createPermutations<StatusIndicatorProps>([
+const permutations = createPermutations<InternalStatusIndicatorProps>([
   {
     type: ['error', 'warning', 'success', 'info', 'stopped', 'pending', 'in-progress', 'loading'],
   },
@@ -17,6 +17,7 @@ const permutations = createPermutations<StatusIndicatorProps>([
   {
     type: ['info'],
     wrapText: [true, false],
+    __display: ['inline', 'inline-block'],
     children: [
       'Simple',
       'very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text very long text',
@@ -33,10 +34,12 @@ export default function StatusIndicatorPermutations() {
         <PermutationsView
           permutations={permutations}
           render={permutation => (
-            <div style={{ width: permutation.wrapText ? 'auto' : 200 }}>
-              <StatusIndicator {...permutation} iconAriaLabel={`status ${permutation.type}`}>
-                {permutation.children ?? <>Status {permutation.type}</>}
-              </StatusIndicator>
+            <div style={{ overflow: 'hidden' }}>
+              <div style={{ width: permutation.wrapText ? 'auto' : 200 }}>
+                <StatusIndicator {...permutation} iconAriaLabel={`status ${permutation.type}`}>
+                  {permutation.children ?? <>Status {permutation.type}</>}
+                </StatusIndicator>
+              </div>
             </div>
           )}
         />

--- a/src/internal/components/dropdown-status/index.tsx
+++ b/src/internal/components/dropdown-status/index.tsx
@@ -76,6 +76,7 @@ export const useDropdownStatus: UseDropdownStatus = ({
       <span>
         <InternalStatusIndicator
           type="error"
+          __display="inline"
           __animate={previousStatusType !== 'error'}
           iconAriaLabel={errorIconAriaLabel}
         >

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -46,7 +46,9 @@ export interface StatusIndicatorProps extends BaseComponentProps {
   wrapText?: boolean;
 }
 
-interface InternalStatusIndicatorProps extends SomeRequired<StatusIndicatorProps, 'type'>, InternalBaseComponentProps {
+export interface InternalStatusIndicatorProps
+  extends SomeRequired<StatusIndicatorProps, 'type'>,
+    InternalBaseComponentProps {
   /**
    * Play an animation on the error icon when first rendered
    */
@@ -56,6 +58,11 @@ interface InternalStatusIndicatorProps extends SomeRequired<StatusIndicatorProps
    * Size of icon.
    */
   __size?: IconProps.Size;
+
+  /**
+   * The CSS behavior of the status indicator container element.
+   */
+  __display?: 'inline' | 'inline-block';
 }
 
 export namespace StatusIndicatorProps {
@@ -74,6 +81,7 @@ export default function StatusIndicator({
   __animate = false,
   __internalRootRef,
   __size = 'normal',
+  __display = 'inline-block',
   ...rest
 }: InternalStatusIndicatorProps) {
   const baseProps = getBaseProps(rest);
@@ -93,6 +101,7 @@ export default function StatusIndicator({
       <span
         className={clsx(
           styles.container,
+          styles[`display-${__display}`],
           wrapText === false && styles['overflow-ellipsis'],
           __animate && styles['container-fade-in']
         )}

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -46,9 +46,16 @@ $_color-overrides: (
 }
 
 .container {
-  display: inline-block;
   word-break: break-all;
   word-wrap: break-word;
+
+  &.display-inline {
+    display: inline;
+  }
+
+  &.display-inline-block {
+    display: inline-block;
+  }
 }
 
 .overflow-ellipsis {


### PR DESCRIPTION
### Description

The status indicator is a display-block component, for wrapping reasons. This also means we can't place any inline text next to it without it breaking to the next line if it takes up multiple lines. We can't switch the default to inline because it breaks wrapping in many circumstances (e.g. key-value pairs), so I'm adding this as an internal property for now.

Related links, issue #, if available: AWSUI-21388

### How has this been tested?

Permutation tests. With `wrapText={false}`, it will overflow past the page (which is, I guess, expected), so I added a wrapper div that hides overflow past the page.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
