### PR TITLE
feat: Add new test utils `findHeaderText` and `findHeaderDescriptions` to expandable section

### DIFF
--- a/src/expandable-section/__tests__/expandable-section.test.tsx
+++ b/src/expandable-section/__tests__/expandable-section.test.tsx
@@ -54,12 +54,14 @@ describe('Expandable Section', () => {
   });
 
   describe('slots', () => {
-    test('populates header slot correctly', () => {
+    test('populates header text correctly', () => {
       const wrapper = renderExpandableSection({
         headerText: 'Test Header',
       });
-      const header = wrapper.findHeader().getElement();
-      expect(header).toHaveTextContent('Test Header');
+      // Keep the test util for the deprecated header slot for coverage
+      expect(wrapper.findHeader().getElement()).toHaveTextContent('Test Header');
+      // New test util
+      expect(wrapper.findHeaderText()?.getElement()).toHaveTextContent('Test Header');
     });
     describe('populates description slot correctly', () => {
       for (const variant of variantsWithDescription) {
@@ -69,8 +71,10 @@ describe('Expandable Section', () => {
             headerText: 'Test Header',
             headerDescription: 'Description',
           });
-          const header = wrapper.findHeader().getElement();
-          expect(header).toHaveTextContent('Description');
+          // Keep the test util for the deprecated header slot for coverage
+          expect(wrapper.findHeader().getElement()).toHaveTextContent('Description');
+          // New test util
+          expect(wrapper.findHeaderDescription()?.getElement()).toHaveTextContent('Description');
         });
       }
     });
@@ -133,8 +137,7 @@ describe('Expandable Section', () => {
             headerDescription: 'Description',
             variant,
           });
-          const header = wrapper.findHeader().getElement();
-          expect(header).not.toHaveTextContent('Description');
+          expect(wrapper.findHeaderDescription()).toBeNull();
         });
       }
     });

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -168,7 +168,9 @@ const ExpandableHeaderTextWrapper = ({
       {...headerButtonListeners}
     >
       <span className={clsx(styles['icon-container'], styles[`icon-container-${variant}`])}>{icon}</span>
-      <span id={id}>{children}</span>
+      <span id={id} className={styles['header-text']}>
+        {children}
+      </span>
     </span>
   );
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -189,6 +189,10 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
       }
     }
   }
+
+  &-text {
+    /* used in test-utils */
+  }
 }
 
 .content {

--- a/src/test-utils/dom/expandable-section/index.ts
+++ b/src/test-utils/dom/expandable-section/index.ts
@@ -3,6 +3,7 @@
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import styles from '../../../expandable-section/styles.selectors.js';
 import containerStyles from '../../../container/styles.selectors.js';
+import headerStyles from '../../../header/styles.selectors.js';
 
 export default class ExpandableSectionWrapper extends ComponentWrapper {
   static rootSelector = styles.root;
@@ -30,5 +31,13 @@ export default class ExpandableSectionWrapper extends ComponentWrapper {
 
   findExpandIcon(): ElementWrapper {
     return this.findByClassName(styles['icon-container'])!;
+  }
+
+  findHeaderText(): ElementWrapper | null {
+    return this.findByClassName(styles['header-text']);
+  }
+
+  findHeaderDescription(): ElementWrapper | null {
+    return this.findByClassName(headerStyles.description);
   }
 }


### PR DESCRIPTION
### Description

Introduces two new test utils for expandable section that allows people to find the header text and descriptions, even when not using the container variant.

Related links, issue #, if available: AWSUI-21436

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
