### PR TITLE
revert: Revert "chore: Increase sticky scrollbar z-index (#1201)"

### DIFF
--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -11,7 +11,6 @@
   overflow-y: hidden;
   bottom: 0;
   width: 100%;
-  z-index: 800; // Higher than sticky-columns
 
   &-content {
     height: 15px;


### PR DESCRIPTION
This reverts commit 6f71624769d9164b35902c0dfbea81b0dd358aa2.

Some problems emerged with the scrollbar overlapping elements under some circumstances.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
