### PR TITLE
fix: Unshare funnel hooks properties

### DIFF
--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -19,7 +19,7 @@ import { useInternalI18n } from '../internal/i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 
 import { FunnelMetrics } from '../internal/analytics';
-import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
+import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import {
   DATA_ATTR_FIELD_ERROR,
   DATA_ATTR_FIELD_LABEL,
@@ -93,8 +93,8 @@ export default function InternalFormField({
   const formFieldId = controlId || generatedControlId;
 
   const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
-
-  const { stepNumber, stepNameSelector, subStepSelector, subStepNameSelector } = useFunnelSubStep();
+  const { stepNumber, stepNameSelector } = useFunnelStep();
+  const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
   const slotIds = getSlotIds(formFieldId, label, description, constraintText, errorText);
 

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -21,7 +21,6 @@ describe('useFunnelStep hook', () => {
     const { getByTestId } = render(
       <FunnelStepContext.Provider
         value={{
-          funnelInteractionId: undefined,
           stepNameSelector: 'step_name_selector',
           stepNumber: 0,
         }}

--- a/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
@@ -3,7 +3,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import { FunnelSubStepContext } from '../../../../../lib/components/internal/analytics/context/analytics-context';
+import {
+  FunnelContext,
+  FunnelContextValue,
+  FunnelSubStepContext,
+} from '../../../../../lib/components/internal/analytics/context/analytics-context';
 import { useFunnelSubStep } from '../../../../../lib/components/internal/analytics/hooks/use-funnel';
 import { FunnelMetrics } from '../../../../../lib/components/internal/analytics';
 import { DATA_ATTR_FUNNEL_SUBSTEP } from '../../../../../lib/components/internal/analytics/selectors';
@@ -24,24 +28,23 @@ describe('useFunnelSubStep hook', () => {
 
     const funnelInteractionId = '123';
     const subStepId = '456';
-    const stepNumber = 1;
-    const stepNameSelector = 'step1';
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
     const { getByTestId } = render(
-      <FunnelSubStepContext.Provider
-        value={{
-          subStepId,
-          funnelInteractionId,
-          stepNumber,
-          stepNameSelector,
-          subStepSelector,
-          subStepNameSelector,
-        }}
+      <FunnelContext.Provider
+        value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
       >
-        <ChildComponent />
-      </FunnelSubStepContext.Provider>
+        <FunnelSubStepContext.Provider
+          value={{
+            subStepId,
+            subStepSelector,
+            subStepNameSelector,
+          }}
+        >
+          <ChildComponent />
+        </FunnelSubStepContext.Provider>
+      </FunnelContext.Provider>
     );
 
     const container = getByTestId('container');
@@ -60,35 +63,31 @@ describe('useFunnelSubStep hook', () => {
 
     const funnelInteractionId = '123';
     const subStepId = '456';
-    const stepNumber = 1;
-    const stepNameSelector = 'step1';
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
     const { getByTestId } = render(
-      <FunnelSubStepContext.Provider
-        value={{
-          subStepId,
-          funnelInteractionId,
-          stepNumber,
-          stepNameSelector,
-          subStepSelector,
-          subStepNameSelector,
-        }}
+      <FunnelContext.Provider
+        value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
       >
-        <ChildComponent />
-      </FunnelSubStepContext.Provider>
+        <FunnelSubStepContext.Provider
+          value={{
+            subStepId,
+            subStepSelector,
+            subStepNameSelector,
+          }}
+        >
+          <ChildComponent />
+        </FunnelSubStepContext.Provider>
+      </FunnelContext.Provider>
     );
 
     getByTestId('input').focus();
 
     expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledWith(
       expect.objectContaining({
-        funnelInteractionId,
         subStepSelector,
         subStepNameSelector,
-        stepNumber,
-        stepNameSelector,
         subStepAllSelector: expect.any(String),
       })
     );
@@ -103,27 +102,25 @@ describe('useFunnelSubStep hook', () => {
         </div>
       );
     };
-
     const funnelInteractionId = '123';
     const subStepId = '456';
-    const stepNumber = 1;
-    const stepNameSelector = 'step1';
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
     const { getByTestId } = render(
-      <FunnelSubStepContext.Provider
-        value={{
-          subStepId,
-          funnelInteractionId,
-          stepNumber,
-          stepNameSelector,
-          subStepSelector,
-          subStepNameSelector,
-        }}
+      <FunnelContext.Provider
+        value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
       >
-        <ChildComponent />
-      </FunnelSubStepContext.Provider>
+        <FunnelSubStepContext.Provider
+          value={{
+            subStepId,
+            subStepSelector,
+            subStepNameSelector,
+          }}
+        >
+          <ChildComponent />
+        </FunnelSubStepContext.Provider>
+      </FunnelContext.Provider>
     );
 
     const input = getByTestId('input');
@@ -132,11 +129,8 @@ describe('useFunnelSubStep hook', () => {
 
     expect(FunnelMetrics.funnelSubStepComplete).toHaveBeenCalledWith(
       expect.objectContaining({
-        funnelInteractionId,
         subStepSelector,
         subStepNameSelector,
-        stepNumber,
-        stepNameSelector,
         subStepAllSelector: expect.any(String),
       })
     );

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -10,7 +10,7 @@ import {
   FunnelStepContextValue,
   FunnelState,
 } from '../context/analytics-context';
-import { useFunnel, useFunnelStep } from '../hooks/use-funnel';
+import { useFunnel } from '../hooks/use-funnel';
 import { useUniqueId } from '../../hooks/use-unique-id';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
 
@@ -192,7 +192,7 @@ export const AnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: 
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [funnelInteractionId, stepNumber, stepNameSelector]);
 
-  const contextValue: FunnelStepContextValue = { funnelInteractionId, stepNumber, stepNameSelector, funnelStepProps };
+  const contextValue: FunnelStepContextValue = { stepNumber, stepNameSelector, funnelStepProps };
   return (
     <FunnelStepContext.Provider value={contextValue}>
       {typeof children === 'function' ? children(contextValue) : children}
@@ -204,9 +204,6 @@ interface AnalyticsFunnelSubStepProps {
 }
 
 export const AnalyticsFunnelSubStep = ({ children }: AnalyticsFunnelSubStepProps) => {
-  const { funnelInteractionId } = useFunnel();
-  const { stepNumber, stepNameSelector } = useFunnelStep();
-
   const subStepId = useUniqueId('substep');
   const subStepSelector = getSubStepSelector(subStepId);
   const subStepNameSelector = getSubStepNameSelector(subStepId);
@@ -214,9 +211,6 @@ export const AnalyticsFunnelSubStep = ({ children }: AnalyticsFunnelSubStepProps
   return (
     <FunnelSubStepContext.Provider
       value={{
-        funnelInteractionId,
-        stepNumber,
-        stepNameSelector,
         subStepSelector,
         subStepNameSelector,
         subStepId,

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -3,13 +3,10 @@
 import { MutableRefObject, RefObject, createContext } from 'react';
 import { FunnelType } from '../interfaces';
 
-export interface BaseContextProps {
-  funnelInteractionId: string | undefined;
-}
-
 export type FunnelState = 'default' | 'validating' | 'complete' | 'cancelled';
 
-export interface FunnelContextValue extends BaseContextProps {
+export interface FunnelContextValue {
+  funnelInteractionId: string | undefined;
   funnelType: FunnelType;
   optionalStepNumbers: number[];
   totalFunnelSteps: number;
@@ -23,17 +20,16 @@ export interface FunnelContextValue extends BaseContextProps {
   loadingButtonCount: MutableRefObject<number>;
 }
 
-export interface FunnelStepContextValue extends BaseContextProps {
+export interface FunnelStepContextValue {
   stepNameSelector: string;
   stepNumber: number;
   funnelStepProps?: Record<string, string | number | boolean | undefined>;
 }
 
-export interface FunnelSubStepContextValue extends FunnelStepContextValue {
+export interface FunnelSubStepContextValue {
   subStepId: string;
   subStepSelector: string;
   subStepNameSelector: string;
-  stepNumber: number;
   funnelSubStepProps?: Record<string, string | number | boolean | undefined>;
 }
 
@@ -54,18 +50,12 @@ export const FunnelContext = createContext<FunnelContextValue>({
 });
 
 export const FunnelStepContext = createContext<FunnelStepContextValue>({
-  funnelInteractionId: undefined,
   stepNameSelector: '',
   stepNumber: 0,
-  funnelStepProps: {},
 });
 
 export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({
-  funnelInteractionId: undefined,
   subStepId: '',
-  stepNumber: 0,
-  stepNameSelector: '',
   subStepSelector: '',
   subStepNameSelector: '',
-  funnelStepProps: {},
 });

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -19,8 +19,10 @@ import { FunnelMetrics } from '../';
 export const useFunnelSubStep = () => {
   const subStepRef = useRef<HTMLDivElement | null>(null);
   const context = useContext(FunnelSubStepContext);
-  const { funnelInteractionId, subStepId, subStepSelector, subStepNameSelector, stepNumber, stepNameSelector } =
-    context;
+  const { funnelInteractionId } = useFunnel();
+  const { stepNumber, stepNameSelector } = useFunnelStep();
+
+  const { subStepId, subStepSelector, subStepNameSelector } = context;
 
   const { funnelState } = useFunnel();
 

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -15,7 +15,7 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../internal/i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
-import { useFunnel, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
+import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
@@ -66,7 +66,8 @@ const InternalLink = React.forwardRef(
     const infoLinkLabelFromContext = useContext(InfoLinkLabelContext);
 
     const { funnelInteractionId } = useFunnel();
-    const { stepNumber, stepNameSelector, subStepSelector, subStepNameSelector } = useFunnelSubStep();
+    const { stepNumber, stepNameSelector } = useFunnelStep();
+    const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
     const fireFunnelEvent = (funnelInteractionId: string) => {
       if (variant === 'info') {


### PR DESCRIPTION
### Description

For funnel analytics, there are three different (nested) contexts: the funnel context, the funnel step context, and the funnel substep context. Each has a hook to retrieve the current value. Before this PR, the hooks for the inner contexts would also return properties from the "larger" context (e.g. `useFunnelSubStep` would also return the `stepNumber` from the step context).

However, this means that components that use a "lower-level" hook rely on that lower-level context to be present, in order to access values from a higher context. For example, if a form field is placed outside of a container (which provides the sub step context), there is no **sub**step context available, and the `useFunnelSubStep` hook would return an empty `stepNumber` (even though a **step** context might be present).

After this PR, this sharing of properties does not happen anymore. A component uses a hook for each context that it needs to access. This means that the form field in the example above will now be able to extract the `stepNumber` directly from the step context.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
