### PR TITLE
chore: Configure coverage thresholds in Jest

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -23,6 +23,14 @@ module.exports = merge({}, tsPreset, cloudscapePreset, {
     '/internal\\/vendor/',
     '<rootDir>/pages',
   ],
+  coverageThreshold: {
+    global: {
+      branches: 82,
+      functions: 88,
+      lines: 90,
+      statements: 90,
+    },
+  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.unit.json',


### PR DESCRIPTION
### Description

Make Jest to fail the build if the coverage numbers do not meet the threshold.

Replaces codecov reporting

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
