### PR TITLE
feat: Move filteringAriaLabel and filteringPlaceholder in property filter to top level

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10037,6 +10037,13 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
+      "description": "Label that will be passed down to the Autosuggest \`ariaLabel\` property.
+See the [Autosuggest API](/system/components/autosuggest/?tabId=api) page for more details.",
+      "name": "filteringAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
       "name": "filteringErrorText",
       "optional": true,
@@ -10078,6 +10085,12 @@ const filteringOptions = [
       "name": "filteringOptions",
       "optional": true,
       "type": "ReadonlyArray<PropertyFilterProps.FilteringOption>",
+    },
+    Object {
+      "description": "Placeholder for the filtering input.",
+      "name": "filteringPlaceholder",
+      "optional": true,
+      "type": "string",
     },
     Object {
       "description": "An array of properties by which the data set can be filtered. Each element has the following properties:
@@ -10176,7 +10189,7 @@ operations are communicated to the user in another way.",
           },
           Object {
             "name": "filteringAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -10288,7 +10301,7 @@ operations are communicated to the user in another way.",
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "PropertyFilterProps.I18nStrings",
     },
     Object {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10038,7 +10038,7 @@ in a slight, visible lag when scrolling complex pages.",
     },
     Object {
       "description": "Label that will be passed down to the Autosuggest \`ariaLabel\` property.
-See the [Autosuggest API](/system/components/autosuggest/?tabId=api) page for more details.",
+See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more details.",
       "name": "filteringAriaLabel",
       "optional": true,
       "type": "string",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10037,7 +10037,7 @@ in a slight, visible lag when scrolling complex pages.",
       "type": "boolean",
     },
     Object {
-      "description": "Label that will be passed down to the Autosuggest \`ariaLabel\` property.
+      "description": "The label that will be passed down to the Autosuggest \`ariaLabel\` property.
 See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more details.",
       "name": "filteringAriaLabel",
       "optional": true,

--- a/src/property-filter/__tests__/common.ts
+++ b/src/property-filter/__tests__/common.ts
@@ -10,10 +10,8 @@ import {
 } from '../interfaces';
 
 export const i18nStrings = {
-  filteringAriaLabel: 'your choice',
   dismissAriaLabel: 'Dismiss',
 
-  filteringPlaceholder: 'Search',
   groupValuesText: 'Values',
   groupPropertiesText: 'Properties',
   operatorsText: 'Operators',

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -89,6 +89,8 @@ const filteringOptions: readonly FilteringOption[] = [
 const defaultProps: PropertyFilterProps = {
   filteringProperties,
   filteringOptions,
+  filteringPlaceholder: 'Search',
+  filteringAriaLabel: 'your choice',
   onChange: () => {},
   query: { tokens: [], operation: 'and' },
   i18nStrings,
@@ -181,7 +183,7 @@ describe('property filter parts', () => {
     test('recieves `placeholder`, `ariaLabel` and `disabled` properties passed to the component', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({
         disabled: true,
-        i18nStrings: { ...i18nStrings, filteringPlaceholder: 'placeholder' },
+        filteringPlaceholder: 'placeholder',
       });
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('placeholder', 'placeholder');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('disabled');

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -64,6 +64,8 @@ const PropertyFilter = React.forwardRef(
       onLoadItems,
       virtualScroll,
       customControl,
+      filteringPlaceholder,
+      filteringAriaLabel,
       filteringEmpty,
       filteringLoadingText,
       filteringFinishedText,
@@ -86,38 +88,41 @@ const PropertyFilter = React.forwardRef(
     const i18n = useInternalI18n('property-filter');
     const i18nStrings: PropertyFilterProps.I18nStrings = {
       ...rest.i18nStrings,
-      allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings.allPropertiesLabel),
-      applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings.applyActionText),
-      cancelActionText: i18n('i18nStrings.cancelActionText', rest.i18nStrings.cancelActionText),
-      clearFiltersText: i18n('i18nStrings.clearFiltersText', rest.i18nStrings.clearFiltersText),
-      editTokenHeader: i18n('i18nStrings.editTokenHeader', rest.i18nStrings.editTokenHeader),
-      groupPropertiesText: i18n('i18nStrings.groupPropertiesText', rest.i18nStrings.groupPropertiesText),
-      groupValuesText: i18n('i18nStrings.groupValuesText', rest.i18nStrings.groupValuesText),
-      operationAndText: i18n('i18nStrings.operationAndText', rest.i18nStrings.operationAndText),
-      operationOrText: i18n('i18nStrings.operationOrText', rest.i18nStrings.operationOrText),
-      operatorContainsText: i18n('i18nStrings.operatorContainsText', rest.i18nStrings.operatorContainsText),
+      allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings?.allPropertiesLabel),
+      applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings?.applyActionText),
+      cancelActionText: i18n('i18nStrings.cancelActionText', rest.i18nStrings?.cancelActionText),
+      clearFiltersText: i18n('i18nStrings.clearFiltersText', rest.i18nStrings?.clearFiltersText),
+      editTokenHeader: i18n('i18nStrings.editTokenHeader', rest.i18nStrings?.editTokenHeader),
+      groupPropertiesText: i18n('i18nStrings.groupPropertiesText', rest.i18nStrings?.groupPropertiesText),
+      groupValuesText: i18n('i18nStrings.groupValuesText', rest.i18nStrings?.groupValuesText),
+      operationAndText: i18n('i18nStrings.operationAndText', rest.i18nStrings?.operationAndText),
+      operationOrText: i18n('i18nStrings.operationOrText', rest.i18nStrings?.operationOrText),
+      operatorContainsText: i18n('i18nStrings.operatorContainsText', rest.i18nStrings?.operatorContainsText),
       operatorDoesNotContainText: i18n(
         'i18nStrings.operatorDoesNotContainText',
-        rest.i18nStrings.operatorDoesNotContainText
+        rest.i18nStrings?.operatorDoesNotContainText
       ),
-      operatorDoesNotEqualText: i18n('i18nStrings.operatorDoesNotEqualText', rest.i18nStrings.operatorDoesNotEqualText),
-      operatorEqualsText: i18n('i18nStrings.operatorEqualsText', rest.i18nStrings.operatorEqualsText),
+      operatorDoesNotEqualText: i18n(
+        'i18nStrings.operatorDoesNotEqualText',
+        rest.i18nStrings?.operatorDoesNotEqualText
+      ),
+      operatorEqualsText: i18n('i18nStrings.operatorEqualsText', rest.i18nStrings?.operatorEqualsText),
       operatorGreaterOrEqualText: i18n(
         'i18nStrings.operatorGreaterOrEqualText',
-        rest.i18nStrings.operatorGreaterOrEqualText
+        rest.i18nStrings?.operatorGreaterOrEqualText
       ),
-      operatorGreaterText: i18n('i18nStrings.operatorGreaterText', rest.i18nStrings.operatorGreaterText),
-      operatorLessOrEqualText: i18n('i18nStrings.operatorLessOrEqualText', rest.i18nStrings.operatorLessOrEqualText),
-      operatorLessText: i18n('i18nStrings.operatorLessText', rest.i18nStrings.operatorLessText),
-      operatorText: i18n('i18nStrings.operatorText', rest.i18nStrings.operatorText),
-      operatorsText: i18n('i18nStrings.operatorsText', rest.i18nStrings.operatorsText),
-      propertyText: i18n('i18nStrings.propertyText', rest.i18nStrings.propertyText),
-      tokenLimitShowFewer: i18n('i18nStrings.tokenLimitShowFewer', rest.i18nStrings.tokenLimitShowFewer),
-      tokenLimitShowMore: i18n('i18nStrings.tokenLimitShowMore', rest.i18nStrings.tokenLimitShowMore),
-      valueText: i18n('i18nStrings.valueText', rest.i18nStrings.valueText),
+      operatorGreaterText: i18n('i18nStrings.operatorGreaterText', rest.i18nStrings?.operatorGreaterText),
+      operatorLessOrEqualText: i18n('i18nStrings.operatorLessOrEqualText', rest.i18nStrings?.operatorLessOrEqualText),
+      operatorLessText: i18n('i18nStrings.operatorLessText', rest.i18nStrings?.operatorLessText),
+      operatorText: i18n('i18nStrings.operatorText', rest.i18nStrings?.operatorText),
+      operatorsText: i18n('i18nStrings.operatorsText', rest.i18nStrings?.operatorsText),
+      propertyText: i18n('i18nStrings.propertyText', rest.i18nStrings?.propertyText),
+      tokenLimitShowFewer: i18n('i18nStrings.tokenLimitShowFewer', rest.i18nStrings?.tokenLimitShowFewer),
+      tokenLimitShowMore: i18n('i18nStrings.tokenLimitShowMore', rest.i18nStrings?.tokenLimitShowMore),
+      valueText: i18n('i18nStrings.valueText', rest.i18nStrings?.valueText),
       removeTokenButtonAriaLabel: i18n(
         'i18nStrings.removeTokenButtonAriaLabel',
-        rest.i18nStrings.removeTokenButtonAriaLabel,
+        rest.i18nStrings?.removeTokenButtonAriaLabel,
         format => token =>
           format({
             token__operator: OPERATOR_I18N_MAPPING[token.operator],
@@ -305,8 +310,8 @@ const PropertyFilter = React.forwardRef(
             ref={inputRef}
             virtualScroll={virtualScroll}
             enteredTextLabel={i18nStrings.enteredTextLabel ?? (value => value)}
-            ariaLabel={i18nStrings.filteringAriaLabel}
-            placeholder={i18nStrings.filteringPlaceholder}
+            ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
+            placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
             ariaLabelledby={rest.ariaLabelledby}
             ariaDescribedby={rest.ariaDescribedby}
             controlId={rest.controlId}

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -31,7 +31,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * An object containing all the necessary localized strings required by the component.
    * @i18n
    */
-  i18nStrings: PropertyFilterProps.I18nStrings;
+  i18nStrings?: PropertyFilterProps.I18nStrings;
   /**
    * Accepts a human-readable, localized string that indicates the number of results. For example, "1 match" or "165 matches."
    * If the total number of results is unknown, also include an indication that there may be more results than
@@ -141,6 +141,15 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   tokenLimit?: number;
   /**
+   * Label that will be passed down to the Autosuggest `ariaLabel` property.
+   * See the [Autosuggest API](/system/components/autosuggest/?tabId=api) page for more details.
+   */
+  filteringAriaLabel?: string;
+  /**
+   * Placeholder for the filtering input.
+   */
+  filteringPlaceholder?: string;
+  /**
    * Displayed when there are no options to display.
    * This is only shown when `statusType` is set to `finished` or not set at all.
    */
@@ -198,14 +207,17 @@ export namespace PropertyFilterProps {
 
   export interface I18nStrings {
     /**
-     * Label that will be passed down to the Autosuggest `ariaLabel` property.
-     * See the [Autosuggest API](/system/components/autosuggest/?tabId=api) page for more details.
+     * @deprecated Use `filteringAriaLabel` on the component instead.
      */
-    filteringAriaLabel: string;
+    filteringAriaLabel?: string;
+
+    /**
+     * @deprecated Use `filteringPlaceholder` on the component instead.
+     */
+    filteringPlaceholder?: string;
+
     dismissAriaLabel?: string;
     clearAriaLabel?: string;
-
-    filteringPlaceholder?: string;
     groupValuesText?: string;
     groupPropertiesText?: string;
     operatorsText?: string;

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -142,7 +142,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   tokenLimit?: number;
   /**
    * Label that will be passed down to the Autosuggest `ariaLabel` property.
-   * See the [Autosuggest API](/system/components/autosuggest/?tabId=api) page for more details.
+   * See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more details.
    */
   filteringAriaLabel?: string;
   /**

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -141,7 +141,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   tokenLimit?: number;
   /**
-   * Label that will be passed down to the Autosuggest `ariaLabel` property.
+   * The label that will be passed down to the Autosuggest `ariaLabel` property.
    * See the [Autosuggest API](/components/autosuggest/?tabId=api) page for more details.
    */
   filteringAriaLabel?: string;


### PR DESCRIPTION
### Description

As signed off by the dev team, moving these situation-dependent labels out of `i18nStrings` and into the component proper. ~~Needs a content review though.~~ All done!

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests, but that's about it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
