### PR TITLE
feat: Move i18nStrings.submitText in wizard to top level

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14696,7 +14696,7 @@ Defaults to \`false\`.
 - \`cancelButton\` (string) - The text of the button that enables the user to exit the flow.
 - \`previousButton\` (string) - The text of the button that enables the user to return to the previous step.
 - \`nextButton\` (string) - The text of the button that enables the user to move to the next step.
-- \`submitButton\` (string) - The text of the button that enables the user to submit the form.
+- \`submitButton\` (deprecated) (string) - The text of the button that enables the user to submit the form.
 - \`optional\` (string) - The text displayed next to the step title and form header title when a step is declared optional.
 - \`nextButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *next* button is in a loading state.
 - \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.",
@@ -14741,7 +14741,7 @@ Defaults to \`false\`.
           },
           Object {
             "name": "submitButton",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -14768,7 +14768,7 @@ Defaults to \`false\`.
         "type": "object",
       },
       "name": "i18nStrings",
-      "optional": false,
+      "optional": true,
       "type": "WizardProps.I18nStrings",
     },
     Object {
@@ -14802,6 +14802,12 @@ Use this if you need to wait for a response from the server before the user can 
       "name": "steps",
       "optional": false,
       "type": "ReadonlyArray<WizardProps.Step>",
+    },
+    Object {
+      "description": "The text of the button that enables the user to submit the form.",
+      "name": "submitButtonText",
+      "optional": true,
+      "type": "string",
     },
   ],
   "regions": Array [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14696,7 +14696,7 @@ Defaults to \`false\`.
 - \`cancelButton\` (string) - The text of the button that enables the user to exit the flow.
 - \`previousButton\` (string) - The text of the button that enables the user to return to the previous step.
 - \`nextButton\` (string) - The text of the button that enables the user to move to the next step.
-- \`submitButton\` (deprecated) (string) - The text of the button that enables the user to submit the form.
+- \`submitButton\` (string) - The text of the button that enables the user to submit the form. **Deprecated**, replaced by the \`submitButtonText\` component property.
 - \`optional\` (string) - The text displayed next to the step title and form header title when a step is declared optional.
 - \`nextButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *next* button is in a loading state.
 - \`submitButtonLoadingAnnouncement\` (string) - The text that a screen reader announces when the *submit* button is in a loading state.",

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -31,7 +31,7 @@ type DefaultWizardProps = Optional<WizardProps, 'i18nStrings' | 'steps'>;
 const renderDefaultWizard = (
   wizardProps?: DefaultWizardProps
 ): [WizardWrapper, (props: DefaultWizardProps) => void] => {
-  const defaultProps = { i18nStrings: DEFAULT_I18N_SETS[0], submitButtonText: 'Create record', steps: DEFAULT_STEPS };
+  const defaultProps = { i18nStrings: DEFAULT_I18N_SETS[0], steps: DEFAULT_STEPS };
   const [wrapper, rerender] = renderWizard({ ...defaultProps, ...wizardProps });
   return [wrapper, (newProps: DefaultWizardProps) => rerender({ ...defaultProps, ...newProps })];
 };
@@ -45,12 +45,18 @@ afterEach(() => {
 });
 
 describe('i18nStrings', () => {
+  test('uses submitButtonText over i18nStrings.submitButton', () => {
+    const [wrapper] = renderDefaultWizard({ submitButtonText: 'Create DB instance' });
+    for (let i = 0; i < DEFAULT_STEPS.length - 1; i++) {
+      wrapper.findPrimaryButton().click();
+    }
+    expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent('Create DB instance');
+  });
+
   DEFAULT_I18N_SETS.forEach((i18nStrings, index) => {
     test(`match provided i18nStrings, i18nSets[${index}], shown on the wizard component`, () => {
-      const submitButtonText = 'Submit';
       const [wrapper] = renderWizard({
         i18nStrings,
-        submitButtonText,
         steps: DEFAULT_STEPS,
       });
 
@@ -84,7 +90,7 @@ describe('i18nStrings', () => {
 
       // navigate to next step
       wrapper.findPrimaryButton().click();
-      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(submitButtonText);
+      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(i18nStrings.submitButton!);
     });
   });
 });

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -31,7 +31,7 @@ type DefaultWizardProps = Optional<WizardProps, 'i18nStrings' | 'steps'>;
 const renderDefaultWizard = (
   wizardProps?: DefaultWizardProps
 ): [WizardWrapper, (props: DefaultWizardProps) => void] => {
-  const defaultProps = { i18nStrings: DEFAULT_I18N_SETS[0], steps: DEFAULT_STEPS };
+  const defaultProps = { i18nStrings: DEFAULT_I18N_SETS[0], submitButtonText: 'Create record', steps: DEFAULT_STEPS };
   const [wrapper, rerender] = renderWizard({ ...defaultProps, ...wizardProps });
   return [wrapper, (newProps: DefaultWizardProps) => rerender({ ...defaultProps, ...newProps })];
 };
@@ -47,8 +47,10 @@ afterEach(() => {
 describe('i18nStrings', () => {
   DEFAULT_I18N_SETS.forEach((i18nStrings, index) => {
     test(`match provided i18nStrings, i18nSets[${index}], shown on the wizard component`, () => {
+      const submitButtonText = 'Submit';
       const [wrapper] = renderWizard({
         i18nStrings,
+        submitButtonText,
         steps: DEFAULT_STEPS,
       });
 
@@ -82,7 +84,7 @@ describe('i18nStrings', () => {
 
       // navigate to next step
       wrapper.findPrimaryButton().click();
-      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(i18nStrings.submitButton);
+      expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(submitButtonText);
     });
   });
 });
@@ -216,7 +218,7 @@ describe('Primary button', () => {
       if (index < DEFAULT_STEPS.length - 1) {
         expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].nextButton!);
       } else {
-        expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].submitButton);
+        expect(wrapper.findPrimaryButton().getElement()).toHaveTextContent(DEFAULT_I18N_SETS[0].submitButton!);
       }
       wrapper.findPrimaryButton().click();
     });

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -48,13 +48,18 @@ export interface WizardProps extends BaseComponentProps {
    * - `cancelButton` (string) - The text of the button that enables the user to exit the flow.
    * - `previousButton` (string) - The text of the button that enables the user to return to the previous step.
    * - `nextButton` (string) - The text of the button that enables the user to move to the next step.
-   * - `submitButton` (string) - The text of the button that enables the user to submit the form.
+   * - `submitButton` (deprecated) (string) - The text of the button that enables the user to submit the form.
    * - `optional` (string) - The text displayed next to the step title and form header title when a step is declared optional.
    * - `nextButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *next* button is in a loading state.
    * - `submitButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *submit* button is in a loading state.
    * @i18n
    */
-  i18nStrings: WizardProps.I18nStrings;
+  i18nStrings?: WizardProps.I18nStrings;
+
+  /**
+   * The text of the button that enables the user to submit the form.
+   */
+  submitButtonText?: string;
 
   /**
    * Renders the *next* or *submit* button in a loading state.
@@ -115,6 +120,11 @@ export namespace WizardProps {
   }
 
   export interface I18nStrings {
+    /**
+     * @deprecated Use `submitButtonText` on the component instead.
+     */
+    submitButton?: string;
+
     stepNumberLabel?(stepNumber: number): string;
     collapsedStepsLabel?(stepNumber: number, stepsCount: number): string;
     skipToButtonLabel?(targetStep: WizardProps.Step, targetStepNumber: number): string;
@@ -123,7 +133,6 @@ export namespace WizardProps {
     cancelButton?: string;
     previousButton?: string;
     nextButton?: string;
-    submitButton: string;
     optional?: string;
     nextButtonLoadingAnnouncement?: string;
     submitButtonLoadingAnnouncement?: string;

--- a/src/wizard/interfaces.ts
+++ b/src/wizard/interfaces.ts
@@ -48,7 +48,7 @@ export interface WizardProps extends BaseComponentProps {
    * - `cancelButton` (string) - The text of the button that enables the user to exit the flow.
    * - `previousButton` (string) - The text of the button that enables the user to return to the previous step.
    * - `nextButton` (string) - The text of the button that enables the user to move to the next step.
-   * - `submitButton` (deprecated) (string) - The text of the button that enables the user to submit the form.
+   * - `submitButton` (string) - The text of the button that enables the user to submit the form. **Deprecated**, replaced by the `submitButtonText` component property.
    * - `optional` (string) - The text displayed next to the step title and form header title when a step is declared optional.
    * - `nextButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *next* button is in a loading state.
    * - `submitButtonLoadingAnnouncement` (string) - The text that a screen reader announces when the *submit* button is in a loading state.

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -31,6 +31,7 @@ type InternalWizardProps = WizardProps & InternalBaseComponentProps;
 export default function InternalWizard({
   steps,
   activeStepIndex: controlledActiveStepIndex,
+  submitButtonText,
   isLoadingNextStep = false,
   allowSkipTo = false,
   secondaryActions,
@@ -101,7 +102,7 @@ export default function InternalWizard({
   const i18n = useInternalI18n('wizard');
   const skipToButtonLabel = i18n(
     'i18nStrings.skipToButtonLabel',
-    rest.i18nStrings.skipToButtonLabel,
+    rest.i18nStrings?.skipToButtonLabel,
     format => task => format({ task__title: task.title })
   );
 
@@ -118,11 +119,11 @@ export default function InternalWizard({
       rest.i18nStrings?.collapsedStepsLabel,
       format => (stepNumber, stepsCount) => format({ stepNumber, stepsCount })
     ),
-    navigationAriaLabel: i18n('i18nStrings.navigationAriaLabel', rest.i18nStrings.navigationAriaLabel),
-    cancelButton: i18n('i18nStrings.cancelButton', rest.i18nStrings.cancelButton),
-    previousButton: i18n('i18nStrings.previousButton', rest.i18nStrings.previousButton),
-    nextButton: i18n('i18nStrings.nextButton', rest.i18nStrings.nextButton),
-    optional: i18n('i18nStrings.optional', rest.i18nStrings.optional),
+    navigationAriaLabel: i18n('i18nStrings.navigationAriaLabel', rest.i18nStrings?.navigationAriaLabel),
+    cancelButton: i18n('i18nStrings.cancelButton', rest.i18nStrings?.cancelButton),
+    previousButton: i18n('i18nStrings.previousButton', rest.i18nStrings?.previousButton),
+    nextButton: i18n('i18nStrings.nextButton', rest.i18nStrings?.nextButton),
+    optional: i18n('i18nStrings.optional', rest.i18nStrings?.optional),
   };
 
   if (activeStepIndex && activeStepIndex >= steps.length) {
@@ -167,6 +168,7 @@ export default function InternalWizard({
             isVisualRefresh={isVisualRefresh}
             showCollapsedSteps={smallContainer}
             i18nStrings={i18nStrings}
+            submitButtonText={submitButtonText}
             activeStepIndex={actualActiveStepIndex}
             isPrimaryLoading={isLoadingNextStep}
             allowSkipTo={allowSkipTo}

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -18,6 +18,7 @@ interface WizardFormProps {
   isVisualRefresh: boolean;
   showCollapsedSteps: boolean;
   i18nStrings: WizardProps.I18nStrings;
+  submitButtonText?: string;
   isPrimaryLoading: boolean;
   allowSkipTo: boolean;
   secondaryActions?: React.ReactNode;
@@ -33,6 +34,7 @@ export default function WizardForm({
   isVisualRefresh,
   showCollapsedSteps,
   i18nStrings,
+  submitButtonText,
   isPrimaryLoading,
   allowSkipTo,
   secondaryActions,
@@ -82,7 +84,7 @@ export default function WizardForm({
             actions={
               <WizardActions
                 cancelButtonText={i18nStrings.cancelButton}
-                primaryButtonText={isLastStep ? i18nStrings.submitButton : i18nStrings.nextButton}
+                primaryButtonText={isLastStep ? submitButtonText ?? i18nStrings.submitButton : i18nStrings.nextButton}
                 primaryButtonLoadingText={
                   isLastStep ? i18nStrings.submitButtonLoadingAnnouncement : i18nStrings.nextButtonLoadingAnnouncement
                 }


### PR DESCRIPTION
### Description

As signed off by the dev team, moving these situation-dependent labels out of `i18nStrings` and into the component proper. No new strings, we're all good on content review (unless `@deprecated` messages count?).

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests, but that's about it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
