### PR TITLE
feat: Move i18nStrings.removeButtonAriaLabel in attribute editor to top level

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1166,6 +1166,12 @@ The display of a row is handled by the \`definition\` property.",
       "type": "ReadonlyArray<T>",
     },
     Object {
+      "description": "Adds an \`aria-label\` to the remove button.",
+      "name": "removeButtonAriaLabel",
+      "optional": true,
+      "type": "(item: T) => string",
+    },
+    Object {
       "description": "Specifies the text that's displayed in the remove button.",
       "i18nTag": true,
       "name": "removeButtonText",

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -193,10 +193,7 @@ describe('Attribute Editor', () => {
 
     test('renders `ariaLabel` on remove button using `removeButtonAriaLabel` on all rows', () => {
       const removeButtonAriaLabel = (item: Item) => `Remove ${item.key}`;
-      const wrapper = renderAttributeEditor({
-        ...defaultProps,
-        i18nStrings: { ...defaultProps.i18nStrings, removeButtonAriaLabel },
-      });
+      const wrapper = renderAttributeEditor({ ...defaultProps, removeButtonAriaLabel });
       defaultProps.items!.forEach((item, index) => {
         expect(
           wrapper

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -193,7 +193,27 @@ describe('Attribute Editor', () => {
 
     test('renders `ariaLabel` on remove button using `removeButtonAriaLabel` on all rows', () => {
       const removeButtonAriaLabel = (item: Item) => `Remove ${item.key}`;
-      const wrapper = renderAttributeEditor({ ...defaultProps, removeButtonAriaLabel });
+      const wrapper = renderAttributeEditor({
+        ...defaultProps,
+        i18nStrings: { ...defaultProps.i18nStrings, removeButtonAriaLabel },
+      });
+      defaultProps.items!.forEach((item, index) => {
+        expect(
+          wrapper
+            .findRow(index + 1)!
+            .findRemoveButton()!
+            .getElement()
+        ).toHaveAccessibleName(`Remove ${item.key}`);
+      });
+    });
+
+    test('uses `removeButtonAriaLabel` over `i18nStrings.removeButtonAriaLabel`', () => {
+      const removeButtonAriaLabel = (item: Item) => `Remove ${item.key}`;
+      const wrapper = renderAttributeEditor({
+        ...defaultProps,
+        i18nStrings: { ...defaultProps.i18nStrings, removeButtonAriaLabel: () => `Don't render` },
+        removeButtonAriaLabel,
+      });
       defaultProps.items!.forEach((item, index) => {
         expect(
           wrapper

--- a/src/attribute-editor/interfaces.ts
+++ b/src/attribute-editor/interfaces.ts
@@ -50,6 +50,10 @@ export namespace AttributeEditorProps {
   export interface I18nStrings<T = any> {
     errorIconAriaLabel?: string;
     itemRemovedAriaLive?: string;
+
+    /**
+     * @deprecated Use `removeButtonAriaLabel` on the component instead.
+     */
     removeButtonAriaLabel?: (item: T) => string;
   }
 }
@@ -75,6 +79,11 @@ export interface AttributeEditorProps<T> extends BaseComponentProps {
    * @i18n
    */
   removeButtonText?: string;
+
+  /**
+   * Adds an `aria-label` to the remove button.
+   */
+  removeButtonAriaLabel?: (item: T) => string;
 
   /**
    * Specifies the items that serve as the data source for all rows.

--- a/src/attribute-editor/internal.tsx
+++ b/src/attribute-editor/internal.tsx
@@ -35,6 +35,7 @@ const InternalAttributeEditor = React.forwardRef(
       empty,
       addButtonText,
       removeButtonText,
+      removeButtonAriaLabel,
       i18nStrings,
       onAddButtonClick,
       onRemoveButtonClick,
@@ -85,7 +86,7 @@ const InternalAttributeEditor = React.forwardRef(
         <InternalBox margin={{ bottom: 'l' }}>
           {isEmpty && <div className={clsx(styles.empty, wasNonEmpty.current && styles['empty-appear'])}>{empty}</div>}
           {items.map((item, index) => (
-            <Row
+            <Row<T>
               key={index}
               index={index}
               breakpoint={breakpoint}
@@ -96,6 +97,7 @@ const InternalAttributeEditor = React.forwardRef(
               removeButtonText={removeButtonText}
               removeButtonRefs={removeButtonRefs.current}
               onRemoveButtonClick={onRemoveButtonClick}
+              removeButtonAriaLabel={removeButtonAriaLabel}
             />
           ))}
         </InternalBox>

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -26,6 +26,7 @@ export interface RowProps<T> {
   removeButtonText?: string;
   removeButtonRefs: Array<ButtonProps.Ref | undefined>;
   onRemoveButtonClick?: NonCancelableEventHandler<AttributeEditorProps.RemoveButtonClickDetail>;
+  removeButtonAriaLabel?: (item: T) => string;
 }
 
 function render<T>(
@@ -49,6 +50,7 @@ export const Row = React.memo(
     removeButtonText,
     removeButtonRefs,
     onRemoveButtonClick,
+    removeButtonAriaLabel,
   }: RowProps<T>) => {
     const i18n = useInternalI18n('attribute-editor');
     const isNarrowViewport = breakpoint === 'default' || breakpoint === 'xxs';
@@ -101,7 +103,7 @@ export const Row = React.memo(
                   ref={ref => {
                     removeButtonRefs[index] = ref ?? undefined;
                   }}
-                  ariaLabel={i18nStrings.removeButtonAriaLabel?.(item)}
+                  ariaLabel={(removeButtonAriaLabel ?? i18nStrings.removeButtonAriaLabel)?.(item)}
                   onClick={handleRemoveClick}
                 >
                   {i18n('removeButtonText', removeButtonText)}
@@ -114,7 +116,7 @@ export const Row = React.memo(
       </InternalBox>
     );
   }
-);
+) as <T>(props: RowProps<T>) => JSX.Element;
 
 interface ButtonContainer {
   index: number;


### PR DESCRIPTION
### Description

As signed off by the dev team, moving these situation-dependent labels out of `i18nStrings` and into the component proper. There's one new string that needs content review, but I'm going to get them reviewed in a big batch.

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests, but that's about it.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
