### PR TITLE
chore: attach package lock to dev-pages package

### DIFF
--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const { writeFile, listPublicItems, listBetaVersions } = require('../utils/files');
 const themes = require('../utils/themes');
-const { task } = require('../utils/gulp-utils');
+const { task, copyTask } = require('../utils/gulp-utils');
 const workspace = require('../utils/workspace');
 const pkg = require('../../package.json');
 
@@ -116,6 +116,7 @@ module.exports = parallel([
   }),
   styleDictionaryPackageJson,
   componentsThemeablePackageJson,
+  copyTask('package-lock', ['package-lock.json'], path.join(workspace.targetPath, 'dev-pages', 'internal')),
   devPagesPackageJson,
 ]);
 module.exports.generatePackageJson = generatePackageJson;


### PR DESCRIPTION
### Description

We have a 2nd build for dev pages which now uses its own lock file. We can propagate this file and reuse.

We also used to do this before: https://github.com/cloudscape-design/components/pull/614, but this time the approach is safe, we publish it is a subfolder, not on the root

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Push into dev-v3-serdiuk branch

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
