### PR TITLE
feat: Move xTickFormatter, yTickFormatter, and detailTotalFormatter in charts to top level

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -963,6 +963,23 @@ When controlling this directly, make sure to update the value based on filtering
       "type": "string",
     },
     Object {
+      "description": "Function to format the displayed label of an x axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "xTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<T>",
+    },
+    Object {
       "description": "The title of the x axis.",
       "name": "xTitle",
       "optional": true,
@@ -992,6 +1009,23 @@ When controlling this directly, make sure to update the value based on filtering
       "name": "yScaleType",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Function to format the displayed label of a y axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "yTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<number>",
     },
     Object {
       "description": "The title of the y axis.",
@@ -2132,6 +2166,23 @@ Use \`categorical\` for bar charts.",
       "type": "string",
     },
     Object {
+      "description": "Function to format the displayed label of an x axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "xTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<T>",
+    },
+    Object {
       "description": "The title of the x axis.",
       "name": "xTitle",
       "optional": true,
@@ -2161,6 +2212,23 @@ When controlling this directly, make sure to update the value based on filtering
       "name": "yScaleType",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Function to format the displayed label of a y axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "yTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<number>",
     },
     Object {
       "description": "The title of the y axis.",
@@ -7828,6 +7896,23 @@ When controlling this directly, make sure to update the value based on filtering
       "type": "string",
     },
     Object {
+      "description": "Function to format the displayed label of an x axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "xTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<T>",
+    },
+    Object {
       "description": "The title of the x axis.",
       "name": "xTitle",
       "optional": true,
@@ -7857,6 +7942,23 @@ When controlling this directly, make sure to update the value based on filtering
       "name": "yScaleType",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Function to format the displayed label of a y axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "yTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<number>",
     },
     Object {
       "description": "The title of the y axis.",
@@ -8407,6 +8509,23 @@ Use \`categorical\` for charts with bars.",
       "type": "string",
     },
     Object {
+      "description": "Function to format the displayed label of an x axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "xTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<T>",
+    },
+    Object {
       "description": "The title of the x axis.",
       "name": "xTitle",
       "optional": true,
@@ -8436,6 +8555,23 @@ When controlling this directly, make sure to update the value based on filtering
       "name": "yScaleType",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Function to format the displayed label of a y axis tick.",
+      "inlineType": Object {
+        "name": "CartesianChartProps.TickFormatter",
+        "parameters": Array [
+          Object {
+            "name": "value",
+            "type": "T",
+          },
+        ],
+        "returnType": "string",
+        "type": "function",
+      },
+      "name": "yTickFormatter",
+      "optional": true,
+      "type": "CartesianChartProps.TickFormatter<number>",
     },
     Object {
       "description": "The title of the y axis.",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -756,6 +756,17 @@ Do not use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "type": "string",
     },
     Object {
+      "description": "Function to format the displayed values total.",
+      "inlineType": Object {
+        "name": "AreaChartProps.TickFormatter",
+        "properties": Array [],
+        "type": "object",
+      },
+      "name": "detailTotalFormatter",
+      "optional": true,
+      "type": "AreaChartProps.TickFormatter<number>",
+    },
+    Object {
       "description": "Text that is displayed when the chart is in error state, i.e. when \`statusType\` is set to \`\\"error\\"\`.",
       "i18nTag": true,
       "name": "errorText",

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -371,13 +371,7 @@ test('tick formatters are assigned', () => {
 
 test('detail total formatter is assigned', () => {
   const { wrapper } = renderAreaChart(
-    <AreaChart
-      series={[areaSeries1]}
-      statusType="finished"
-      i18nStrings={{
-        detailTotalFormatter: (y: number) => `=${y}`,
-      }}
-    />
+    <AreaChart series={[areaSeries1]} statusType="finished" detailTotalFormatter={(y: number) => `=${y}`} />
   );
 
   // Show popover for the first data point.

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -356,10 +356,8 @@ test('tick formatters are assigned', () => {
     <AreaChart
       series={[areaSeries1]}
       statusType="finished"
-      i18nStrings={{
-        xTickFormatter: (x: number) => `x${x}`,
-        yTickFormatter: (y: number) => `y${y}`,
-      }}
+      xTickFormatter={(x: number) => `x${x}`}
+      yTickFormatter={(y: number) => `y${y}`}
     />
   );
 

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -356,8 +356,10 @@ test('tick formatters are assigned', () => {
     <AreaChart
       series={[areaSeries1]}
       statusType="finished"
-      xTickFormatter={(x: number) => `x${x}`}
-      yTickFormatter={(y: number) => `y${y}`}
+      i18nStrings={{
+        xTickFormatter: (x: number) => `x${x}`,
+        yTickFormatter: (y: number) => `y${y}`,
+      }}
     />
   );
 
@@ -371,7 +373,27 @@ test('tick formatters are assigned', () => {
 
 test('detail total formatter is assigned', () => {
   const { wrapper } = renderAreaChart(
-    <AreaChart series={[areaSeries1]} statusType="finished" detailTotalFormatter={(y: number) => `=${y}`} />
+    <AreaChart
+      series={[areaSeries1]}
+      statusType="finished"
+      i18nStrings={{ detailTotalFormatter: (y: number) => `=${y}` }}
+    />
+  );
+
+  // Show popover for the first data point.
+  wrapper.findApplication()!.focus();
+
+  expect(wrapper.findDetailPopover()!.findContent()!.getElement()).toHaveTextContent('Area Series 13=3');
+});
+
+test('uses detailTotalFormatter over i18nStrings.detailTotalFormatter', () => {
+  const { wrapper } = renderAreaChart(
+    <AreaChart
+      series={[areaSeries1]}
+      statusType="finished"
+      detailTotalFormatter={(y: number) => `=${y}`}
+      i18nStrings={{ detailTotalFormatter: (y: number) => `+${y}` }}
+    />
   );
 
   // Show popover for the first data point.

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -32,6 +32,8 @@ interface ChartContainerProps<T extends AreaChartProps.DataTypes>
     AreaChartProps<T>,
     | 'xTitle'
     | 'yTitle'
+    | 'xTickFormatter'
+    | 'yTickFormatter'
     | 'detailPopoverSize'
     | 'detailPopoverFooter'
     | 'ariaLabel'
@@ -56,8 +58,8 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   ariaLabelledby,
   ariaDescription,
   i18nStrings: {
-    xTickFormatter,
-    yTickFormatter,
+    xTickFormatter: deprecatedXTickFormatter,
+    yTickFormatter: deprecatedYTickFormatter,
     detailTotalFormatter,
     detailTotalLabel,
     chartAriaRoleDescription,
@@ -65,6 +67,8 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
     yAxisAriaRoleDescription,
     detailPopoverDismissAriaLabel,
   } = {},
+  xTickFormatter = deprecatedXTickFormatter,
+  yTickFormatter = deprecatedYTickFormatter,
 }: ChartContainerProps<T>) {
   const [leftLabelsWidth, setLeftLabelsWidth] = useState(0);
   const [bottomLabelsHeight, setBottomLabelsHeight] = useState(0);

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -34,6 +34,7 @@ interface ChartContainerProps<T extends AreaChartProps.DataTypes>
     | 'yTitle'
     | 'xTickFormatter'
     | 'yTickFormatter'
+    | 'detailTotalFormatter'
     | 'detailPopoverSize'
     | 'detailPopoverFooter'
     | 'ariaLabel'
@@ -60,7 +61,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   i18nStrings: {
     xTickFormatter: deprecatedXTickFormatter,
     yTickFormatter: deprecatedYTickFormatter,
-    detailTotalFormatter,
+    detailTotalFormatter: deprecatedDetailTotalFormatter,
     detailTotalLabel,
     chartAriaRoleDescription,
     xAxisAriaRoleDescription,
@@ -69,6 +70,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   } = {},
   xTickFormatter = deprecatedXTickFormatter,
   yTickFormatter = deprecatedYTickFormatter,
+  detailTotalFormatter = deprecatedDetailTotalFormatter,
 }: ChartContainerProps<T>) {
   const [leftLabelsWidth, setLeftLabelsWidth] = useState(0);
   const [bottomLabelsHeight, setBottomLabelsHeight] = useState(0);

--- a/src/area-chart/interfaces.ts
+++ b/src/area-chart/interfaces.ts
@@ -17,6 +17,11 @@ export interface AreaChartProps<T extends AreaChartProps.DataTypes>
   series: ReadonlyArray<AreaChartProps.Series<T>>;
 
   /**
+   * Function to format the displayed values total.
+   */
+  detailTotalFormatter?: AreaChartProps.TickFormatter<number>;
+
+  /**
    * An object containing all the necessary localized strings required by the component.
    * @i18n
    */
@@ -60,7 +65,7 @@ export namespace AreaChartProps {
   export interface I18nStrings<T> extends CartesianChartProps.I18nStrings<T> {
     /** The title of the values total in the popover. */
     detailTotalLabel?: string;
-    /** Function to format the displayed values total. */
+    /** @deprecated Use `detailTotalFormatter` on the component instead. */
     detailTotalFormatter?: TickFormatter<number>;
   }
 }

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -35,6 +35,9 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
   yScaleType,
   xDomain,
   yDomain,
+  xTickFormatter,
+  yTickFormatter,
+  detailTotalFormatter,
   highlightedSeries: controlledHighlightedSeries,
   visibleSeries: controlledVisibleSeries,
   series: externalSeries,
@@ -171,6 +174,9 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
             detailPopoverFooter={detailPopoverFooter}
             xTitle={xTitle}
             yTitle={yTitle}
+            xTickFormatter={xTickFormatter}
+            yTickFormatter={yTickFormatter}
+            detailTotalFormatter={detailTotalFormatter}
             ariaLabel={ariaLabel}
             ariaLabelledby={ariaLabelledby}
             ariaDescription={ariaDescription}

--- a/src/internal/components/cartesian-chart/interfaces.ts
+++ b/src/internal/components/cartesian-chart/interfaces.ts
@@ -74,6 +74,16 @@ export interface CartesianChartProps<T extends ChartDataTypes, Series> extends B
   i18nStrings?: CartesianChartProps.I18nStrings<T>;
 
   /**
+   * Function to format the displayed label of an x axis tick.
+   */
+  xTickFormatter?: CartesianChartProps.TickFormatter<T>;
+
+  /**
+   * Function to format the displayed label of a y axis tick.
+   */
+  yTickFormatter?: CartesianChartProps.TickFormatter<number>;
+
+  /**
    * An optional pixel value number that fixes the height of the chart area.
    * If not set explicitly, the component will use a default height that is defined internally.
    */
@@ -224,10 +234,10 @@ export namespace CartesianChartProps {
     /** Name of the ARIA role description of the y axis, e.g. "y axis" */
     yAxisAriaRoleDescription?: string;
 
-    /** Function to format the displayed label of an x axis tick. */
+    /** @deprecated Use `xTickFormatter` on the component instead. */
     xTickFormatter?: TickFormatter<T>;
 
-    /** Function to format the displayed label of a y axis tick. */
+    /** @deprecated Use `yTickFormatter` on the component instead. */
     yTickFormatter?: TickFormatter<number>;
   }
 }

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -577,7 +577,7 @@ describe('Axes', () => {
           height={250}
           xDomain={[0, 12]}
           yDomain={[0, 100]}
-          xTickFormatter={(value: number) => value.toFixed(2)}
+          i18nStrings={{ xTickFormatter: (value: number) => value.toFixed(2) }}
         />
       );
 
@@ -585,6 +585,21 @@ describe('Axes', () => {
       expect(wrapper.findXTicks()[1].getElement()).toHaveTextContent('2.00');
       expect(wrapper.findXTicks()[2].getElement()).toHaveTextContent('4.00');
     });
+  });
+
+  test('users top-level tick formatters over i18nStrings tick formatters', () => {
+    const { wrapper } = renderMixedChart(
+      <MixedLineBarChart
+        series={[lineSeries]}
+        height={250}
+        xDomain={[0, 12]}
+        yDomain={[0, 100]}
+        xTickFormatter={(value: number) => value.toFixed(2) + ' sec'}
+        yTickFormatter={(value: number) => value.toFixed(2) + ' kB'}
+      />
+    );
+    expect(wrapper.findXTicks()[0].getElement()).toHaveTextContent('0.00 sec');
+    expect(wrapper.findYTicks()[0].getElement()).toHaveTextContent('0.00 kB');
   });
 
   test('categorical axis', () => {

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -577,7 +577,7 @@ describe('Axes', () => {
           height={250}
           xDomain={[0, 12]}
           yDomain={[0, 100]}
-          i18nStrings={{ xTickFormatter: (value: number) => value.toFixed(2) }}
+          xTickFormatter={(value: number) => value.toFixed(2)}
         />
       );
 

--- a/src/mixed-line-bar-chart/internal.tsx
+++ b/src/mixed-line-bar-chart/internal.tsx
@@ -45,6 +45,8 @@ export default function InternalMixedLineBarChart<T extends number | string | Da
   yScaleType,
   xDomain,
   yDomain,
+  xTickFormatter,
+  yTickFormatter,
   highlightedSeries: controlledHighlightedSeries,
   visibleSeries: controlledVisibleSeries,
   series: externalSeries,
@@ -251,8 +253,8 @@ export default function InternalMixedLineBarChart<T extends number | string | Da
             yScaleType={yScaleType}
             xDomain={xDomain}
             yDomain={yDomain}
-            xTickFormatter={i18nStrings?.xTickFormatter}
-            yTickFormatter={i18nStrings?.yTickFormatter}
+            xTickFormatter={xTickFormatter ?? i18nStrings?.xTickFormatter}
+            yTickFormatter={yTickFormatter ?? i18nStrings?.yTickFormatter}
             emphasizeBaselineAxis={emphasizeBaselineAxis}
             stackedBars={stackedBars}
             horizontalBars={horizontalBars}


### PR DESCRIPTION
### Description

As signed off by the dev team, moving these situation-dependent labels out of `i18nStrings` and into the component proper. No new strings, we're all good on content review (unless `@deprecated` messages count?).

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests. I left a couple of original accesses in the tests just to be safe :)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
