### PR TITLE
feat: Move i18nStrings.inContextInputPlaceholder in s3 resource selector to top level

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10926,6 +10926,12 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "string",
     },
     Object {
+      "description": "Adds a placeholder to the S3 URI input.",
+      "name": "inputPlaceholder",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Whether the S3 URI input field is in invalid state.",
       "name": "invalid",
       "optional": true,

--- a/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
+++ b/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
@@ -54,6 +54,12 @@ test('renders element labels', () => {
   expect(wrapper.findBrowseButton().getElement()).toHaveTextContent(i18nStrings.inContextBrowseButton!);
 });
 
+test('prefers inputPlaceholder over i18nStrings.inContextInputPlaceholder', () => {
+  const placeholder = 's3://bucket/component/test';
+  const wrapper = renderComponent(<S3ResourceSelector {...defaultProps} inputPlaceholder={placeholder} />);
+  expect(wrapper.findUriInput().findNativeInput().getElement()).toHaveAttribute('placeholder', placeholder);
+});
+
 test('inherits aria-describedby from the surrounding FormField', () => {
   const wrapper = renderComponent(
     <FormField controlId="test-control" description="test">

--- a/src/s3-resource-selector/index.tsx
+++ b/src/s3-resource-selector/index.tsx
@@ -21,6 +21,7 @@ const S3ResourceSelector = React.forwardRef(
   (
     {
       i18nStrings,
+      inputPlaceholder,
       alert,
       resource,
       viewHref,
@@ -94,6 +95,7 @@ const S3ResourceSelector = React.forwardRef(
           ref={inContextRef}
           selectableItemsTypes={selectableItemsTypes}
           i18nStrings={i18nStrings}
+          inputPlaceholder={inputPlaceholder}
           resource={resource}
           viewHref={viewHref}
           invalid={invalid}

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -52,6 +52,11 @@ export interface S3ResourceSelectorProps extends BaseComponentProps {
   inputAriaDescribedby?: string;
 
   /**
+   * Adds a placeholder to the S3 URI input.
+   */
+  inputPlaceholder?: string;
+
+  /**
    * An array of the item types that are selectable in the table view. The array may contain the following items:
    * 'buckets', 'objects', or 'versions'. Example: ['buckets', 'objects']. By default, no items are selectable.
    * This property determines whether the component operates in Read mode or Write mode:
@@ -194,6 +199,9 @@ export namespace S3ResourceSelectorProps {
   export type SelectableItems = 'buckets' | 'objects' | 'versions';
 
   export interface I18nStrings {
+    /**
+     * @deprecated Use `inputPlaceholder` on the component instead.
+     */
     inContextInputPlaceholder?: string;
     inContextInputClearAriaLabel?: string;
     inContextSelectPlaceholder?: string;

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -19,6 +19,7 @@ import { useInternalI18n } from '../../internal/i18n/context';
 
 interface S3InContextProps {
   i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined;
+  inputPlaceholder: string | undefined;
   resource: S3ResourceSelectorProps.Resource;
   viewHref: string | undefined;
   invalid: boolean | undefined;
@@ -37,6 +38,7 @@ export const S3InContext = React.forwardRef(
   (
     {
       i18nStrings,
+      inputPlaceholder,
       resource,
       viewHref,
       invalid,
@@ -98,7 +100,7 @@ export const S3InContext = React.forwardRef(
               value={uri}
               ariaDescribedby={inputAriaDescribedby}
               clearAriaLabel={i18nStrings?.inContextInputClearAriaLabel}
-              placeholder={i18nStrings?.inContextInputPlaceholder}
+              placeholder={inputPlaceholder ?? i18nStrings?.inContextInputPlaceholder}
               onChange={handleUriChange}
               invalid={invalid}
               onFocus={() => (isInputBlurredRef.current = false)}


### PR DESCRIPTION
### Description

As signed off by the dev team, moving these situation-dependent labels out of `i18nStrings` and into the component proper. Added a string, probably needs content review even if it's pretty simple.

Related links, issue #, if available: n/a

### How has this been tested?

Added a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
