### PR TITLE
fix: Nested containers should not create a new subStep context

### DIFF
--- a/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-sub-step.test.tsx
@@ -31,6 +31,8 @@ describe('useFunnelSubStep hook', () => {
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
+    const ref = { current: null };
+
     const { getByTestId } = render(
       <FunnelContext.Provider
         value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
@@ -40,9 +42,13 @@ describe('useFunnelSubStep hook', () => {
             subStepId,
             subStepSelector,
             subStepNameSelector,
+            subStepRef: ref,
+            isNestedSubStep: false,
           }}
         >
-          <ChildComponent />
+          <div ref={ref}>
+            <ChildComponent />
+          </div>
         </FunnelSubStepContext.Provider>
       </FunnelContext.Provider>
     );
@@ -66,6 +72,8 @@ describe('useFunnelSubStep hook', () => {
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
+    const ref = { current: null };
+
     const { getByTestId } = render(
       <FunnelContext.Provider
         value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
@@ -75,9 +83,13 @@ describe('useFunnelSubStep hook', () => {
             subStepId,
             subStepSelector,
             subStepNameSelector,
+            subStepRef: ref,
+            isNestedSubStep: false,
           }}
         >
-          <ChildComponent />
+          <div ref={ref}>
+            <ChildComponent />
+          </div>
         </FunnelSubStepContext.Provider>
       </FunnelContext.Provider>
     );
@@ -107,6 +119,8 @@ describe('useFunnelSubStep hook', () => {
     const subStepSelector = 'subStep1';
     const subStepNameSelector = 'subStepName1';
 
+    const ref = { current: null };
+
     const { getByTestId } = render(
       <FunnelContext.Provider
         value={{ funnelInteractionId, funnelState: { current: 'default' } } as Partial<FunnelContextValue> as any}
@@ -116,9 +130,13 @@ describe('useFunnelSubStep hook', () => {
             subStepId,
             subStepSelector,
             subStepNameSelector,
+            subStepRef: ref,
+            isNestedSubStep: false,
           }}
         >
-          <ChildComponent />
+          <div ref={ref}>
+            <ChildComponent />
+          </div>
         </FunnelSubStepContext.Provider>
       </FunnelContext.Provider>
     );

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 
 import {
   FunnelStepContext,
@@ -9,6 +9,7 @@ import {
   FunnelContextValue,
   FunnelStepContextValue,
   FunnelState,
+  FunnelSubStepContextValue,
 } from '../context/analytics-context';
 import { useFunnel } from '../hooks/use-funnel';
 import { useUniqueId } from '../../hooks/use-unique-id';
@@ -207,16 +208,19 @@ export const AnalyticsFunnelSubStep = ({ children }: AnalyticsFunnelSubStepProps
   const subStepId = useUniqueId('substep');
   const subStepSelector = getSubStepSelector(subStepId);
   const subStepNameSelector = getSubStepNameSelector(subStepId);
+  const subStepRef = useRef<HTMLDivElement | null>(null);
 
-  return (
-    <FunnelSubStepContext.Provider
-      value={{
-        subStepSelector,
-        subStepNameSelector,
-        subStepId,
-      }}
-    >
-      {children}
-    </FunnelSubStepContext.Provider>
-  );
+  const newContext: FunnelSubStepContextValue = {
+    subStepSelector,
+    subStepNameSelector,
+    subStepId,
+    subStepRef,
+    isNestedSubStep: false,
+  };
+
+  const inheritedContext = { ...useContext(FunnelSubStepContext), isNestedSubStep: true };
+
+  const context = inheritedContext.subStepId ? inheritedContext : newContext;
+
+  return <FunnelSubStepContext.Provider value={context}>{children}</FunnelSubStepContext.Provider>;
 };

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -30,6 +30,8 @@ export interface FunnelSubStepContextValue {
   subStepId: string;
   subStepSelector: string;
   subStepNameSelector: string;
+  subStepRef: MutableRefObject<HTMLDivElement | null>;
+  isNestedSubStep: boolean;
   funnelSubStepProps?: Record<string, string | number | boolean | undefined>;
 }
 
@@ -58,4 +60,6 @@ export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({
   subStepId: '',
   subStepSelector: '',
   subStepNameSelector: '',
+  subStepRef: { current: null },
+  isNestedSubStep: false,
 });

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContext, useRef } from 'react';
+import { useContext } from 'react';
 import { FunnelContext, FunnelStepContext, FunnelSubStepContext } from '../context/analytics-context';
 import { DATA_ATTR_FUNNEL_INTERACTION_ID, DATA_ATTR_FUNNEL_SUBSTEP, getSubStepAllSelector } from '../selectors';
 import { FunnelMetrics } from '../';
@@ -17,14 +17,15 @@ import { FunnelMetrics } from '../';
  * The subStepRef is a reference to the DOM element of the funnel sub-step.
  */
 export const useFunnelSubStep = () => {
-  const subStepRef = useRef<HTMLDivElement | null>(null);
   const context = useContext(FunnelSubStepContext);
-  const { funnelInteractionId } = useFunnel();
+  const { funnelInteractionId, funnelState } = useFunnel();
   const { stepNumber, stepNameSelector } = useFunnelStep();
 
-  const { subStepId, subStepSelector, subStepNameSelector } = context;
+  const { subStepId, subStepSelector, subStepNameSelector, subStepRef, isNestedSubStep } = context;
 
-  const { funnelState } = useFunnel();
+  if (isNestedSubStep) {
+    return context;
+  }
 
   const onFocus = (event: React.FocusEvent<HTMLDivElement>) => {
     if (
@@ -70,7 +71,7 @@ export const useFunnelSubStep = () => {
       }
     : {};
 
-  return { funnelSubStepProps, subStepRef, ...context };
+  return { funnelSubStepProps, ...context };
 };
 
 /**


### PR DESCRIPTION
### Description

Before this change, when a container was placed inside another container, the inner container was treated as a new substep. This meant that focus or unfocusing an input element inside the inner container would emit each event twice: once for the inner container/substep, and once for the outer container/substep. Additionally, when tabbing from an input field in the outer container into an input field located in the inner container, a substep change metric would be emitted.

After this change, inner containers do not emit any events on their own, and they are treated as the same substep as their parent container when it comes to detecting a substep change. 

This PR needs to be applied after https://github.com/cloudscape-design/components/pull/1304

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
