### PR TITLE
fix: Only add aria-controls when dropdown is open

### DIFF
--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -464,9 +464,9 @@ describe('a11y properties', () => {
     const { wrapper } = renderMultiselect(<Multiselect selectedOptions={[]} options={defaultOptions} />);
     const hasPopup = wrapper.findTrigger().getElement().getAttribute('aria-haspopup');
     expect(hasPopup).toBe('listbox');
+    wrapper.openDropdown();
     const controlledId = wrapper.findTrigger().getElement().getAttribute('aria-controls');
     expect(controlledId).toBeTruthy();
-    wrapper.openDropdown();
     expect(wrapper.findDropdown().getElement().querySelector(`#${controlledId}`)!.getAttribute('role')).toBe('listbox');
   });
   test('trigger should aria-control the dropdown (role="dialog") when filtering enabled', () => {
@@ -475,9 +475,9 @@ describe('a11y properties', () => {
     );
     const hasPopup = wrapper.findTrigger().getElement().getAttribute('aria-haspopup');
     expect(hasPopup).toBe('dialog');
+    wrapper.openDropdown();
     const controlledId = wrapper.findTrigger().getElement().getAttribute('aria-controls');
     expect(controlledId).toBeTruthy();
-    wrapper.openDropdown();
     expect(
       wrapper.findDropdown().getElement().parentNode!.querySelector(`#${controlledId}`)!.getAttribute('role')
     ).toBe('dialog');

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -310,9 +310,9 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
       const { wrapper } = renderSelect();
       const hasPopup = wrapper.findTrigger().getElement().getAttribute('aria-haspopup');
       expect(hasPopup).toBe('listbox');
+      wrapper.openDropdown();
       const controlledId = wrapper.findTrigger().getElement().getAttribute('aria-controls');
       expect(controlledId).toBeTruthy();
-      wrapper.openDropdown();
       expect(
         wrapper.findDropdown({ expandToViewport }).getElement().querySelector(`#${controlledId}`)!.getAttribute('role')
       ).toBe('listbox');
@@ -321,9 +321,9 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
       const { wrapper } = renderSelect({ filteringType: 'auto' });
       const hasPopup = wrapper.findTrigger().getElement().getAttribute('aria-haspopup');
       expect(hasPopup).toBe('dialog');
+      wrapper.openDropdown();
       const controlledId = wrapper.findTrigger().getElement().getAttribute('aria-controls');
       expect(controlledId).toBeTruthy();
-      wrapper.openDropdown();
       expect(
         wrapper
           .findDropdown({ expandToViewport })

--- a/src/select/utils/use-select.ts
+++ b/src/select/utils/use-select.ts
@@ -148,7 +148,7 @@ export function useSelect({
       onFocus: () => closeDropdown(),
       autoFocus,
       ariaHasPopup: hasFilter ? 'dialog' : 'listbox',
-      ariaControls: hasFilter ? dialogId : menuId,
+      ariaControls: isOpen ? (hasFilter ? dialogId : menuId) : undefined,
     };
     if (!disabled) {
       triggerProps.onMouseDown = (event: CustomEvent) => {


### PR DESCRIPTION
### Description

Fix an issue identified in pipeline testing (referenced ID is not in the DOM when popovers are closed)

Related links, issue #, if available: n/a

### How has this been tested?

Tested in dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
