### PR TITLE
fix: Emit funnelStepComplete after completion, but not after cancellation

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -45,20 +45,12 @@ describe('Form Analytics', () => {
     );
   });
 
-  test('sends a funnelStepComplete metric when Form is unmounted', () => {
+  test('does not send a funnelStepComplete metric when Form is unmounted', () => {
     const { unmount } = render(<Form />);
 
     unmount();
 
-    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
-    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith(
-      expect.objectContaining({
-        stepNumber: 1,
-        stepNameSelector: expect.any(String),
-        subStepAllSelector: expect.any(String),
-        funnelInteractionId: expect.any(String),
-      })
-    );
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
   });
 
   test('sends a funnelCancelled metric when Form is unmounted', () => {
@@ -119,7 +111,7 @@ describe('Form Analytics', () => {
    * 1. The submit button is the only primary button in the form
    * 2. The submit button is clicked before the Form is unmounted
    */
-  test('sends a funnelComplete metric when Form is unmounted after clicking a primary button in the actions slot', () => {
+  test('sends a funnelComplete and funnelStepComplete metric when Form is unmounted after clicking a primary button in the actions slot', () => {
     const { container, unmount } = render(
       <Form
         actions={
@@ -139,6 +131,16 @@ describe('Form Analytics', () => {
     expect(FunnelMetrics.funnelComplete).toHaveBeenCalledWith(
       expect.objectContaining({
         funnelInteractionId: expect.any(String),
+      })
+    );
+
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepNumber: 1,
+        funnelInteractionId: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
       })
     );
   });

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -341,7 +341,7 @@ describe('AnalyticsFunnelStep', () => {
     });
   });
 
-  test('calls funnelStepComplete with the correct arguments when the everything unmounts', () => {
+  test('does not call funnelStepComplete when the funnel unmounts without submitting', () => {
     const stepNumber = 1;
     const stepNameSelector = '.step-name-selector';
 
@@ -353,17 +353,9 @@ describe('AnalyticsFunnelStep', () => {
       </AnalyticsFunnel>
     );
 
-    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
-
     unmount();
 
-    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
-    expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith({
-      funnelInteractionId: mockedFunnelInteractionId,
-      stepNumber,
-      stepNameSelector,
-      subStepAllSelector: expect.any(String),
-    });
+    expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
   });
 
   test('calls funnelStepStart and funnelStepComplete when stepNumber changes', () => {

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -85,7 +85,7 @@ export const AnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) =>
         FunnelMetrics.funnelSuccessful({ funnelInteractionId });
       } else {
         FunnelMetrics.funnelCancelled({ funnelInteractionId });
-        funnelState.current === 'cancelled';
+        funnelState.current = 'cancelled';
       }
     };
   }, []);
@@ -180,7 +180,7 @@ export const AnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: 
 
     return () => {
       //eslint-disable-next-line react-hooks/exhaustive-deps
-      if (funnelInteractionId && funnelState.current === 'default') {
+      if (funnelInteractionId && funnelState.current !== 'cancelled') {
         FunnelMetrics.funnelStepComplete({
           funnelInteractionId,
           stepNumber,

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -49,7 +49,7 @@ export const useFunnelSubStep = () => {
       funnelInteractionId &&
       subStepRef.current &&
       !subStepRef.current.contains(event.relatedTarget) &&
-      funnelState.current === 'default'
+      funnelState.current !== 'cancelled'
     ) {
       FunnelMetrics.funnelSubStepComplete({
         funnelInteractionId,


### PR DESCRIPTION
### Description

`funnelStepComplete` should be emitted when the funnel is complete. This makes processing the events afterwards easier, since every step has a start and and end event now. The one exception is that no events should be emitted when the flow is cancelled.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests and manual testing in dev pages

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
