### PR TITLE
Revert "chore: Configure coverage thresholds in Jest"

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -23,14 +23,6 @@ module.exports = merge({}, tsPreset, cloudscapePreset, {
     '/internal\\/vendor/',
     '<rootDir>/pages',
   ],
-  coverageThreshold: {
-    global: {
-      branches: 82,
-      functions: 88,
-      lines: 90,
-      statements: 90,
-    },
-  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.unit.json',


### PR DESCRIPTION
Reverts cloudscape-design/components#1310

This was a temporary measure while Codecov was down.

We cannot have both same time, because if the build fails, it does not run the codecov step and it makes it harder to review coverage issues