### PR TITLE
fix: Update test for `nodeBelongs`

### DIFF
--- a/src/internal/utils/__tests__/node-belongs.test.ts
+++ b/src/internal/utils/__tests__/node-belongs.test.ts
@@ -3,8 +3,16 @@
 import { nodeBelongs } from '../../../../lib/components/internal/utils/node-belongs';
 
 describe('nodeBelongs', () => {
+  let div: HTMLDivElement;
+
+  beforeEach(() => {
+    div = document.createElement('div');
+    document.documentElement.appendChild(div);
+  });
+
+  afterEach(() => document.documentElement.removeChild(div));
+
   test('returns "true", when the node and the container are the same element', () => {
-    const div = document.createElement('div');
     div.innerHTML = `
       <div id="container1"></div>
     `;
@@ -12,7 +20,6 @@ describe('nodeBelongs', () => {
   });
 
   test('returns "true", when the node is descendant from the container', () => {
-    const div = document.createElement('div');
     div.innerHTML = `
       <div id="container1">
         <div id="node"></div>
@@ -22,7 +29,6 @@ describe('nodeBelongs', () => {
   });
 
   test('returns "false", when the node is not a child of the container', () => {
-    const div = document.createElement('div');
     div.innerHTML = `
       <div id="container1"></div>
       <div id="node"></div>
@@ -31,7 +37,6 @@ describe('nodeBelongs', () => {
   });
 
   test('returns "true" when node belongs to a portal issued from within the container', () => {
-    const div = document.createElement('div');
     div.innerHTML = `
       <div id="container1">
         <div id="portal"></div>
@@ -40,12 +45,6 @@ describe('nodeBelongs', () => {
         <div id="node"></div>
       </div>
     `;
-    document.documentElement.appendChild(div);
-
-    try {
-      expect(nodeBelongs(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(true);
-    } finally {
-      document.documentElement.removeChild(div);
-    }
+    expect(nodeBelongs(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(true);
   });
 });


### PR DESCRIPTION
### Description

While the test intends to check an element that is inside a portal, it actually tested the portal element itself. This meant that the test was still green without the Portal traversal logic (can be tested by deleting the line `<div data-awsui-referrer-id="node"></div>` or swapping `nodeBelongs` out for `nodeContains`). After this PR, the test checks an element that is inside the target of the portal.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
