### PR TITLE
feat: Generate JSON schema for Design Tokens

### DIFF
--- a/build-tools/tasks/styles.js
+++ b/build-tools/tasks/styles.js
@@ -79,6 +79,7 @@ function stylesTask(theme) {
       designTokensOutputDir,
       designTokensFileName: theme.designTokensOutput,
       descriptions,
+      jsonSchema: true,
     });
   });
 }

--- a/src/__tests__/design-tokens.test.ts
+++ b/src/__tests__/design-tokens.test.ts
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { requireDesignTokensFile } from './utils';
 
+const themeNames = ['classic', 'visual-refresh'];
+
 describe('Design tokens artifacts', () => {
-  test.each<string>(['classic', 'visual-refresh'])(
-    `Design tokens JSON for %s matches the snapshot`,
-    (themeName: string) => {
-      const jsonContent = requireDesignTokensFile(`index-${themeName}.json`);
-      expect(jsonContent).toMatchSnapshot(themeName);
-    }
-  );
+  test.each<string>(themeNames)(`Design tokens JSON for %s matches the snapshot`, (themeName: string) => {
+    const jsonContent = requireDesignTokensFile(`index-${themeName}.json`);
+    expect(jsonContent).toMatchSnapshot(themeName);
+  });
+  test.each<string>(themeNames)(`Design tokens JSON schema is generated`, (themeName: string) => {
+    const jsonSchema = requireDesignTokensFile(`index-${themeName}-schema.json`);
+    expect(jsonSchema).not.toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Description

Adopt API introduced in https://github.com/cloudscape-design/theming-core/pull/55.

### How has this been tested?

Built locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ Will come later
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes, new unit tests added.
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
