### PR TITLE
fix: Restore focus to custom popover triggers

### DIFF
--- a/pages/popover/focus-test.page.tsx
+++ b/pages/popover/focus-test.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+import { Button } from '~components';
 import Popover from '~components/popover';
 
 export default function () {
@@ -46,6 +47,29 @@ export default function () {
         renderWithPortal={renderWithPortal}
       >
         Error
+      </Popover>
+      <br />
+      <button type="button" id="focus-trap-target-button">
+        Click to focus
+      </button>{' '}
+      <Popover
+        size="medium"
+        header="Memory error"
+        content={
+          <>
+            <p>
+              This instance contains insufficient memory. Stop the instance, choose a different instance type with more
+              memory, and restart it.
+            </p>
+            <input />
+          </>
+        }
+        dismissAriaLabel="Close"
+        id="focus-trap-button"
+        renderWithPortal={renderWithPortal}
+        triggerType="custom"
+      >
+        <Button>Open</Button>
       </Popover>
       <ul>
         <li>Popover without dismiss button should not trap focus when opened</li>

--- a/src/popover/__integ__/popover.test.ts
+++ b/src/popover/__integ__/popover.test.ts
@@ -22,55 +22,59 @@ const setupTest = (renderWithPortal: boolean, testFn: (page: PopoverFocusPage) =
 };
 
 describe.each([true, false])('With dismiss button (renderWithPortal=%s)', (renderWithPortal: boolean) => {
-  const selector = createWrapper().findPopover('#focus-trap');
-  const triggerSelector = selector.findTrigger().toSelector();
-  const dismissButtonSelector = selector.findDismissButton({ renderWithPortal }).toSelector();
+  describe.each(['string', 'custom'])('(triggerType=%s)', (triggerType: string) => {
+    const elementBeforePopover = triggerType === 'string' ? '#focus-trap-target' : '#focus-trap-target-button';
+    const selector = createWrapper().findPopover(triggerType === 'string' ? '#focus-trap' : '#focus-trap-button');
+    const triggerSelector =
+      triggerType === 'string' ? selector.findTrigger().toSelector() : selector.findTrigger().findButton().toSelector();
+    const dismissButtonSelector = selector.findDismissButton({ renderWithPortal }).toSelector();
 
-  test(
-    'Should trap focus when opened',
-    setupTest(renderWithPortal, async page => {
-      await page.click('#focus-trap-target');
-      await page.keys(['Tab', 'Space']);
-      await page.waitForVisible(dismissButtonSelector);
-      await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
-      await page.keys(['Tab', 'Tab']);
-      await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
-    })
-  );
+    test(
+      'Should trap focus when opened',
+      setupTest(renderWithPortal, async page => {
+        await page.click(elementBeforePopover);
+        await page.keys(['Tab', 'Space']);
+        await page.waitForVisible(dismissButtonSelector);
+        await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
+        await page.keys(['Tab', 'Tab']);
+        await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
+      })
+    );
 
-  test(
-    'Should return focus to the trigger when closed',
-    setupTest(renderWithPortal, async page => {
-      await page.click('#focus-trap-target');
-      await page.keys(['Tab', 'Space']);
-      await page.waitForVisible(dismissButtonSelector);
-      await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
-      await page.keys(['Escape']);
-      await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
-    })
-  );
+    test(
+      'Should return focus to the trigger when closed',
+      setupTest(renderWithPortal, async page => {
+        await page.click(elementBeforePopover);
+        await page.keys(['Tab', 'Space']);
+        await page.waitForVisible(dismissButtonSelector);
+        await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
+        await page.keys(['Escape']);
+        await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+      })
+    );
 
-  test(
-    'Should not prevent focus from moving to the clicked element',
-    setupTest(renderWithPortal, async page => {
-      await page.click(triggerSelector);
-      await page.waitForVisible(dismissButtonSelector);
-      await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
-      await page.click('#focus-trap-target');
-      await expect(page.isFocused('#focus-trap-target')).resolves.toBe(true);
-    })
-  );
+    test(
+      'Should not prevent focus from moving to the clicked element',
+      setupTest(renderWithPortal, async page => {
+        await page.click(triggerSelector);
+        await page.waitForVisible(dismissButtonSelector);
+        await expect(page.isFocused(dismissButtonSelector)).resolves.toBe(true);
+        await page.click(elementBeforePopover);
+        await expect(page.isFocused(elementBeforePopover)).resolves.toBe(true);
+      })
+    );
 
-  test(
-    'Should not restore focus when clicking elsewhere on the page',
-    setupTest(renderWithPortal, async page => {
-      await page.click(triggerSelector);
-      await page.waitForVisible(dismissButtonSelector);
-      await page.click('#text-before-focus-trap');
-      await page.keys(['Tab']);
-      await expect(page.isFocused('#focus-trap-target')).resolves.toBe(true);
-    })
-  );
+    test(
+      'Should not restore focus when clicking elsewhere on the page',
+      setupTest(renderWithPortal, async page => {
+        await page.click(triggerSelector);
+        await page.waitForVisible(dismissButtonSelector);
+        await page.click('#text-before-focus-trap');
+        await page.keys(['Tab']);
+        await expect(page.isFocused('#focus-trap-target')).resolves.toBe(true);
+      })
+    );
+  });
 
   describe.each([true, false])('Inside focusable? %s)', (insideFocusable: boolean) => {
     const popover = createWrapper().findPopover(insideFocusable ? '#focus-trap-within-focusable' : '#focus-trap');

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -147,6 +147,28 @@ describe('Focus behavior', () => {
     expect(document.activeElement).not.toBe(wrapper.findBody()!.getElement());
   });
 
+  it('moves focus back to trigger on dismiss', () => {
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover' });
+    act(() => {
+      wrapper.findTrigger().click();
+    });
+    act(() => {
+      wrapper.findDismissButton()?.click();
+    });
+    expect(document.activeElement).toBe(wrapper.findTrigger().getElement());
+  });
+
+  it('moves focus back to custom trigger on dismiss', () => {
+    const wrapper = renderPopover({ children: <button>Trigger</button>, content: 'Popover', triggerType: 'custom' });
+    act(() => {
+      wrapper.findTrigger().click();
+    });
+    act(() => {
+      wrapper.findDismissButton()?.click();
+    });
+    expect(document.activeElement).toBe(wrapper.findTrigger().getElement().querySelector('button'));
+  });
+
   it('moves focus to the dismiss button on open if dismiss button is present - with portal', () => {
     const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', renderWithPortal: true });
     act(() => {

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -20,6 +20,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
 import { useInternalI18n } from '../internal/i18n/context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 
 export interface InternalPopoverProps extends PopoverProps, InternalBaseComponentProps {
   __onOpen?: NonCancelableEventHandler<null>;
@@ -62,8 +63,12 @@ function InternalPopover(
   const [visible, setVisible] = useState(false);
 
   const focusTrigger = useCallback(() => {
-    triggerRef.current?.focus();
-  }, []);
+    if (triggerType === 'text') {
+      triggerRef.current?.focus();
+    } else {
+      triggerRef.current && getFirstFocusable(triggerRef.current)?.focus();
+    }
+  }, [triggerType]);
 
   const onTriggerClick = useCallback(() => {
     fireNonCancelableEvent(__onOpen);


### PR DESCRIPTION
### Description

Ensure that if a custom popover trigger is used, the focus is returned
to it when the popover is dismissed.

Related links, issue #, if available: AWSUI-21509

### How has this been tested?

New integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
