### PR TITLE
chore: Apply component export/displayName conventions to I18nProvider

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,10 @@
         {
           "pattern": "./src/*/index.js",
           "message": "Disallowed import '{{ path }}'. Use the internal component for composition or the interface directly."
+        },
+        {
+          "pattern": "./src/i18n/{index,provider}.tsx",
+          "message": "Disallowed import '{{ path }}'. This raises the minimum TypeScript requirements of the current file."
         }
       ]
     ],

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { I18nProvider, I18nProviderProps } from './provider';
+export { I18nProvider as default, I18nProvider, I18nProviderProps } from './provider';

--- a/src/i18n/provider.tsx
+++ b/src/i18n/provider.tsx
@@ -4,10 +4,11 @@
 import React, { useContext } from 'react';
 import IntlMessageFormat from 'intl-messageformat';
 import { MessageFormatElement } from '@formatjs/icu-messageformat-parser';
-
-import { InternalI18nContext, FormatFunction, CustomHandler } from './context';
-import { useTelemetry } from '../internal/hooks/use-telemetry';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import { useTelemetry } from '../internal/hooks/use-telemetry';
+import { applyDisplayName } from '../internal/utils/apply-display-name';
+import { InternalI18nContext, FormatFunction, CustomHandler } from './context';
 
 export interface I18nProviderProps {
   messages: ReadonlyArray<I18nProviderProps.Messages>;
@@ -108,6 +109,8 @@ export function I18nProvider({ messages: messagesArray, locale: providedLocale, 
     </InternalI18nContext.Provider>
   );
 }
+
+applyDisplayName(I18nProvider, 'I18nProvider');
 
 function mergeMessages(sources: ReadonlyArray<I18nProviderProps.Messages>): I18nProviderProps.Messages {
   const result: I18nProviderProps.Messages = {};

--- a/src/i18n/testing.tsx
+++ b/src/i18n/testing.tsx
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+
+// It's okay for import for tests, because it's internal non-user code.
+// eslint-disable-next-line @cloudscape-design/ban-files
 import { I18nProvider } from './provider';
 
 export interface TestI18nProviderProps {


### PR DESCRIPTION
### Description

Noticed this was missing when messing with internal stuff and documenter. The named export has to stay, but we can have a default export on top as well.

And another thing I thought would be nice is the addition of a lint rule that stops us from transitively importing the modern ICU dependencies into TS 3.6+ supported component code.

Related links, issue #, if available: n/a

### How has this been tested?

If it builds, it's good.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
