### PR TITLE
fix: Allow onKeyDown handler to prevent default behavior

### DIFF
--- a/pages/autosuggest/form-submit.page.tsx
+++ b/pages/autosuggest/form-submit.page.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import Autosuggest from '~components/autosuggest';
+import Alert from '~components/alert';
+import React, { useState } from 'react';
+
+export default function () {
+  const [isSubmitted, setSubmitted] = useState(false);
+  return (
+    <>
+      <h1>Autosuggest in a form</h1>
+      <form
+        onSubmit={event => {
+          event.preventDefault();
+          setSubmitted(true);
+        }}
+      >
+        <Autosuggest
+          data-testid="autosuggest-with-keydown"
+          placeholder="Should not submit the form"
+          value=""
+          empty="No suggestions"
+          onKeyDown={event => {
+            if (event.detail.key === 'Enter') {
+              event.preventDefault();
+            }
+          }}
+        />
+        <Autosuggest
+          data-testid="autosuggest-no-keydown"
+          placeholder="Can submit the form"
+          value=""
+          empty="No suggestions"
+        />
+        <button type="submit">Submit</button>
+      </form>
+      {isSubmitted && (
+        <Alert data-testid="submit-message" dismissible={true} onDismiss={() => setSubmitted(false)}>
+          Form sent!
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/src/autosuggest/__integ__/form-submit.test.ts
+++ b/src/autosuggest/__integ__/form-submit.test.ts
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper, { AutosuggestWrapper } from '../../../lib/components/test-utils/selectors';
+
+class FormSubmitPageObject extends BasePageObject {
+  isDropdownOpen(wrapper: AutosuggestWrapper) {
+    return this.isDisplayed(wrapper.findDropdown().findOpenDropdown().toSelector());
+  }
+
+  isFormSubmitted() {
+    return this.isDisplayed('[data-testid="submit-message"]');
+  }
+}
+
+function setupTest(testFn: (page: FormSubmitPageObject) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new FormSubmitPageObject(browser);
+    await browser.url('#/light/autosuggest/form-submit');
+    await testFn(page);
+  });
+}
+
+test(
+  'Should submit form on double enter key',
+  setupTest(async page => {
+    const autosuggestNoKeydown = createWrapper().findAutosuggest('[data-testid="autosuggest-no-keydown"]');
+    await page.click(autosuggestNoKeydown.findNativeInput().toSelector());
+    await expect(page.isDropdownOpen(autosuggestNoKeydown)).resolves.toBe(true);
+    await page.keys('Enter');
+    // first key closes the dropdown
+    await expect(page.isDropdownOpen(autosuggestNoKeydown)).resolves.toBe(false);
+    await expect(page.isFormSubmitted()).resolves.toBe(false);
+    await page.keys('Enter');
+    // second key submits the form
+    await expect(page.isDropdownOpen(autosuggestNoKeydown)).resolves.toBe(false);
+    await expect(page.isFormSubmitted()).resolves.toBe(true);
+  })
+);
+
+test(
+  'Should allow preventing form submission',
+  setupTest(async page => {
+    const autosuggestWithKeydown = createWrapper().findAutosuggest('[data-testid="autosuggest-with-keydown"]');
+    await page.click(autosuggestWithKeydown.findNativeInput().toSelector());
+    await expect(page.isDropdownOpen(autosuggestWithKeydown)).resolves.toBe(true);
+    await page.keys('Enter');
+    // first key closes the dropdown
+    await expect(page.isDropdownOpen(autosuggestWithKeydown)).resolves.toBe(false);
+    await expect(page.isFormSubmitted()).resolves.toBe(false);
+    await page.keys('Enter');
+    // second key tries to submit the form, but it is prevented
+    await expect(page.isDropdownOpen(autosuggestWithKeydown)).resolves.toBe(false);
+    await expect(page.isFormSubmitted()).resolves.toBe(false);
+  })
+);

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -129,12 +129,12 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     fireNonCancelableEvent(onFocus, null);
   };
 
-  const handleKeyUp = (e: CustomEvent<BaseKeyDetail>) => {
-    fireCancelableEvent(onKeyUp, e.detail);
+  const handleKeyUp = (event: CustomEvent<BaseKeyDetail>) => {
+    fireCancelableEvent(onKeyUp, event.detail, event);
   };
 
-  const handleKeyDown = (e: CustomEvent<BaseKeyDetail>) => {
-    fireCancelableEvent(onKeyDown, e.detail);
+  const handleKeyDown = (event: CustomEvent<BaseKeyDetail>) => {
+    fireCancelableEvent(onKeyDown, event.detail, event);
   };
 
   const handlePressArrowDown = () => {

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -143,18 +143,20 @@ const AutosuggestInput = React.forwardRef(
       preventOpenOnFocusRef.current = false;
     };
 
-    const handleKeyDown = (e: CustomEvent<BaseKeyDetail>) => {
-      switch (e.detail.keyCode) {
+    const fireKeydown = (event: CustomEvent<BaseKeyDetail>) => fireCancelableEvent(onKeyDown, event.detail, event);
+
+    const handleKeyDown = (event: CustomEvent<BaseKeyDetail>) => {
+      switch (event.detail.keyCode) {
         case KeyCode.down: {
           onPressArrowDown?.();
           openDropdown();
-          e.preventDefault();
+          event.preventDefault();
           break;
         }
         case KeyCode.up: {
           onPressArrowUp?.();
           openDropdown();
-          e.preventDefault();
+          event.preventDefault();
           break;
         }
         case KeyCode.enter: {
@@ -162,9 +164,9 @@ const AutosuggestInput = React.forwardRef(
             if (!onPressEnter?.()) {
               closeDropdown();
             }
-            e.preventDefault();
+            event.preventDefault();
           }
-          fireCancelableEvent(onKeyDown, e.detail);
+          fireKeydown(event);
           break;
         }
         case KeyCode.escape: {
@@ -173,12 +175,12 @@ const AutosuggestInput = React.forwardRef(
           } else if (value) {
             fireNonCancelableEvent(onChange, { value: '' });
           }
-          e.preventDefault();
-          fireCancelableEvent(onKeyDown, e.detail);
+          event.preventDefault();
+          fireKeydown(event);
           break;
         }
         default: {
-          fireCancelableEvent(onKeyDown, e.detail);
+          fireKeydown(event);
         }
       }
     };


### PR DESCRIPTION
### Description

Fixed disconnection between public onKeyDown handler and its internal counterpart

Related links, issue #, if available: AWSUI-21652

### How has this been tested?

Added extra tests. Could not use JSDOM, because the default onKeyDown behavior is not supported there

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
