### PR TITLE
chore: Include Wizard header in step context

### DIFF
--- a/pages/funnel-analytics/with-error-alert-in-wizard.page.tsx
+++ b/pages/funnel-analytics/with-error-alert-in-wizard.page.tsx
@@ -7,6 +7,7 @@ import { i18nStrings } from '../wizard/common';
 import Alert from '~components/alert';
 import Container from '~components/container';
 import Header from '~components/header';
+import Link from '~components/link';
 
 export default function WizardPage() {
   const [errorMode, setErrorMode] = useState(0);
@@ -14,6 +15,7 @@ export default function WizardPage() {
   const steps: WizardProps.Step[] = [
     {
       title: 'Step 1',
+      info: <Link variant="info">Info</Link>,
       content: (
         <div>
           <div>Content 1</div>

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -63,49 +63,57 @@ export default function WizardForm({
 
   return (
     <>
-      <WizardFormHeader isMobile={isMobile || showCollapsedSteps} isVisualRefresh={isVisualRefresh}>
-        <div className={clsx(styles['collapsed-steps'], !showCollapsedSteps && styles['collapsed-steps-hidden'])}>
-          {i18nStrings.collapsedStepsLabel?.(activeStepIndex + 1, steps.length)}
-        </div>
-        <InternalHeader className={styles['form-header-component']} variant="h1" description={description} info={info}>
-          <span className={styles['form-header-component-wrapper']} tabIndex={-1} ref={stepHeaderRef}>
-            {title}
-            {isOptional && <i>{` - ${i18nStrings.optional}`}</i>}
-          </span>
-        </InternalHeader>
-      </WizardFormHeader>
       <AnalyticsFunnelStep
         stepNameSelector={`.${styles['form-header-component-wrapper']}`}
         stepNumber={activeStepIndex + 1}
       >
         {({ funnelStepProps }) => (
-          <InternalForm
-            className={clsx(styles['form-component'])}
-            actions={
-              <WizardActions
-                cancelButtonText={i18nStrings.cancelButton}
-                primaryButtonText={isLastStep ? submitButtonText ?? i18nStrings.submitButton : i18nStrings.nextButton}
-                primaryButtonLoadingText={
-                  isLastStep ? i18nStrings.submitButtonLoadingAnnouncement : i18nStrings.nextButtonLoadingAnnouncement
-                }
-                previousButtonText={i18nStrings.previousButton}
-                onCancelClick={onCancelClick}
-                onPreviousClick={onPreviousClick}
-                onPrimaryClick={onPrimaryClick}
-                onSkipToClick={() => onSkipToClick(skipToTargetIndex)}
-                showPrevious={activeStepIndex !== 0}
-                isPrimaryLoading={isPrimaryLoading}
-                showSkipTo={showSkipTo}
-                skipToButtonText={skipToButtonText}
-              />
-            }
-            secondaryActions={secondaryActions}
-            errorText={errorText}
-            errorIconAriaLabel={i18nStrings.errorIconAriaLabel}
-            {...funnelStepProps}
-          >
-            {content}
-          </InternalForm>
+          <>
+            <WizardFormHeader isMobile={isMobile || showCollapsedSteps} isVisualRefresh={isVisualRefresh}>
+              <div className={clsx(styles['collapsed-steps'], !showCollapsedSteps && styles['collapsed-steps-hidden'])}>
+                {i18nStrings.collapsedStepsLabel?.(activeStepIndex + 1, steps.length)}
+              </div>
+              <InternalHeader
+                className={styles['form-header-component']}
+                variant="h1"
+                description={description}
+                info={info}
+              >
+                <span className={styles['form-header-component-wrapper']} tabIndex={-1} ref={stepHeaderRef}>
+                  {title}
+                  {isOptional && <i>{` - ${i18nStrings.optional}`}</i>}
+                </span>
+              </InternalHeader>
+            </WizardFormHeader>
+
+            <InternalForm
+              className={clsx(styles['form-component'])}
+              actions={
+                <WizardActions
+                  cancelButtonText={i18nStrings.cancelButton}
+                  primaryButtonText={isLastStep ? submitButtonText ?? i18nStrings.submitButton : i18nStrings.nextButton}
+                  primaryButtonLoadingText={
+                    isLastStep ? i18nStrings.submitButtonLoadingAnnouncement : i18nStrings.nextButtonLoadingAnnouncement
+                  }
+                  previousButtonText={i18nStrings.previousButton}
+                  onCancelClick={onCancelClick}
+                  onPreviousClick={onPreviousClick}
+                  onPrimaryClick={onPrimaryClick}
+                  onSkipToClick={() => onSkipToClick(skipToTargetIndex)}
+                  showPrevious={activeStepIndex !== 0}
+                  isPrimaryLoading={isPrimaryLoading}
+                  showSkipTo={showSkipTo}
+                  skipToButtonText={skipToButtonText}
+                />
+              }
+              secondaryActions={secondaryActions}
+              errorText={errorText}
+              errorIconAriaLabel={i18nStrings.errorIconAriaLabel}
+              {...funnelStepProps}
+            >
+              {content}
+            </InternalForm>
+          </>
         )}
       </AnalyticsFunnelStep>
     </>


### PR DESCRIPTION
### Description

Before this PR, the header area of the Wizard component was not included in the step context. This meant that when an info link inside the header was clicked, the resulting `helpPanelInteracted` event did not contain information about the current step. 

This PR moves the step context so that it contains the whole content area of the Wizard (i.e. without the navigation on the side).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually in dev page by inspecting the generated event
<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
