### PR TITLE
feat: Provide loader function for dynamically imported i18n messages

### DIFF
--- a/build-tools/tasks/generate-i18n-messages.js
+++ b/build-tools/tasks/generate-i18n-messages.js
@@ -8,28 +8,26 @@ const { parse } = require('@formatjs/icu-messageformat-parser');
 const { targetPath } = require('../utils/workspace');
 const { writeFile } = require('../utils/files');
 
+const sourceDir = path.resolve(__dirname, '../../src/i18n');
+const sourceMessagesDir = path.resolve(sourceDir, 'messages');
+const destinationDir = path.resolve(targetPath, 'components/i18n');
+const destinationMessagesDir = path.resolve(destinationDir, 'messages');
+const internalDestinationDir = path.resolve(targetPath, 'components/internal/i18n');
+const internalDestinationMessagesDir = path.resolve(internalDestinationDir, 'messages');
+
 const namespace = '@cloudscape-design/components';
-
-const destinationDir = path.join(targetPath, 'components/i18n/messages');
-const internalDestinationDir = path.join(targetPath, 'components/internal/i18n/messages');
-
 const messagesDeclarationFile = `import { I18nProviderProps } from "../provider";
 declare const messages: I18nProviderProps.Messages;
 export default messages;
 `;
 
-const indexDeclarationFile = `import { I18nProviderProps } from "../provider";
-export function importMessages(locale: string): Promise<ReadonlyArray<I18nProviderProps.Messages>>;
-`;
-
 module.exports = function generateI18nMessages() {
-  const messagesDir = path.resolve(__dirname, '../../src/i18n/messages');
-  const files = fs.readdirSync(messagesDir);
-
+  const files = fs.readdirSync(sourceMessagesDir);
   const allParsedMessages = {};
 
+  // Generate individual locale messages files.
   for (const fileName of files) {
-    const filePath = path.join(messagesDir, fileName);
+    const filePath = path.join(sourceMessagesDir, fileName);
     const messages = require(filePath);
     const [subset, locale] = fileName.split('.');
 
@@ -42,7 +40,7 @@ module.exports = function generateI18nMessages() {
     allParsedMessages[locale] = { ...(allParsedMessages[locale] ?? {}), ...parsedMessages };
     const resultFormat = { [namespace]: { [locale]: parsedMessages } };
 
-    for (const directory of [destinationDir, internalDestinationDir]) {
+    for (const directory of [destinationMessagesDir, internalDestinationMessagesDir]) {
       writeFile(path.join(directory, `${subset}.${locale}.json`), JSON.stringify(resultFormat));
       writeFile(path.join(directory, `${subset}.${locale}.d.ts`), messagesDeclarationFile);
       writeFile(path.join(directory, `${subset}.${locale}.js`), `export default ${JSON.stringify(resultFormat)}`);
@@ -50,32 +48,33 @@ module.exports = function generateI18nMessages() {
   }
 
   // Generate a ".all" file containing all locales.
-  const resultFormat = { [namespace]: allParsedMessages };
+  const allResultFormat = { [namespace]: allParsedMessages };
+  for (const directory of [destinationMessagesDir, internalDestinationMessagesDir]) {
+    writeFile(path.join(directory, 'all.all.json'), JSON.stringify(allResultFormat));
+    writeFile(path.join(directory, 'all.all.d.ts'), messagesDeclarationFile);
+    writeFile(path.join(directory, 'all.all.js'), `export default ${JSON.stringify(allResultFormat)}`);
+  }
 
   // Generate a dynamic provider function for automatic bundler splitting and imports.
-  const indexFile = [
+  const dynamicFile = [
     `export function importMessages(locale) {`,
-    `  switch (locale) {`,
+    `  switch (locale.toLowerCase()) {`,
     ...files.flatMap(fileName => {
       const [subset, locale] = fileName.split('.');
       if (subset !== 'all') {
-        return [];
+        return []; // For now, this only supports loading all messages for the locale.
       }
-      return [`  case "${locale}":`, `    return import("./${subset}.${locale}.js").then(mod => [mod.default]);`];
+      return [
+        `  case "${locale.toLowerCase()}":`,
+        `    return import("./messages/${subset}.${locale}.js").then(mod => [mod.default]);`,
+      ];
     }),
     `  }`,
     `  return Promise.resolve([]);`,
     `}`,
   ].join('\n');
-
-  for (const directory of [destinationDir, internalDestinationDir]) {
-    writeFile(path.join(directory, 'all.all.json'), JSON.stringify(resultFormat));
-    writeFile(path.join(directory, 'all.all.d.ts'), messagesDeclarationFile);
-    writeFile(path.join(directory, 'all.all.js'), `export default ${JSON.stringify(resultFormat)}`);
-
-    writeFile(path.join(directory, 'index.js'), indexFile);
-    writeFile(path.join(directory, 'index.d.ts'), indexDeclarationFile);
-  }
+  fs.copyFileSync(path.join(sourceDir, 'dynamic.d.ts'), path.join(destinationDir, 'dynamic.d.ts'));
+  writeFile(path.join(destinationDir, 'dynamic.js'), dynamicFile);
 
   return Promise.resolve();
 };

--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -39,13 +39,12 @@ function getComponentsExports() {
 
   // Internationalization and messages
   result['./i18n'] = './i18n/index.js';
-  result[`./i18n/messages`] = `./i18n/messages/index.js`;
+  result[`./i18n/messages/all.all`] = `./i18n/messages/all.all.js`;
+  result[`./i18n/messages/all.all.json`] = `./i18n/messages/all.all.json`;
   for (const translationFile of fs.readdirSync('src/i18n/messages')) {
     const [subset, locale] = translationFile.split('.');
-    if (subset && locale) {
-      result[`./i18n/messages/${subset}.${locale}`] = `./i18n/messages/${subset}.${locale}.js`;
-      result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
-    }
+    result[`./i18n/messages/${subset}.${locale}`] = `./i18n/messages/${subset}.${locale}.js`;
+    result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
   }
 
   return result;

--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -39,12 +39,13 @@ function getComponentsExports() {
 
   // Internationalization and messages
   result['./i18n'] = './i18n/index.js';
-  result[`./i18n/messages/all.all`] = `./i18n/messages/all.all.js`;
-  result[`./i18n/messages/all.all.json`] = `./i18n/messages/all.all.json`;
+  result[`./i18n/messages`] = `./i18n/messages/index.js`;
   for (const translationFile of fs.readdirSync('src/i18n/messages')) {
     const [subset, locale] = translationFile.split('.');
-    result[`./i18n/messages/${subset}.${locale}`] = `./i18n/messages/${subset}.${locale}.js`;
-    result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
+    if (subset && locale) {
+      result[`./i18n/messages/${subset}.${locale}`] = `./i18n/messages/${subset}.${locale}.js`;
+      result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
+    }
   }
 
   return result;

--- a/pages/alert/simple.page.tsx
+++ b/pages/alert/simple.page.tsx
@@ -8,7 +8,7 @@ import SpaceBetween from '~components/space-between';
 import styles from './styles.scss';
 
 import { I18nProvider } from '~components/i18n';
-import messages from '~components/i18n/messages/all.all';
+import messages from '~components/i18n/messages/all.en';
 
 export default function AlertScenario() {
   const [visible, setVisible] = useState(true);

--- a/pages/i18n/dynamic.page.tsx
+++ b/pages/i18n/dynamic.page.tsx
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+import { TagEditor } from '~components';
+import { I18nProvider, I18nProviderProps } from '~components/i18n';
+
+import { importMessages } from '~components/i18n/messages';
+
+const LOCALE = 'ja';
+
+export default function I18nDynamicPage() {
+  const [messages, setMessages] = useState<ReadonlyArray<I18nProviderProps.Messages> | null>(null);
+
+  useEffect(() => {
+    importMessages(LOCALE).then(setMessages);
+  }, []);
+
+  if (messages === null) {
+    return 'Loading...';
+  }
+
+  return (
+    <I18nProvider locale={LOCALE} messages={messages}>
+      <h1>Dynamically imported messages</h1>
+      <TagEditor
+        tags={[
+          { key: 'Tag 1', value: 'Value 1', existing: false },
+          { key: 'Tag 2', value: 'Value 2', existing: true, markedForRemoval: true },
+          { key: 'Tag 2', value: '', existing: false },
+        ]}
+      />
+    </I18nProvider>
+  );
+}

--- a/pages/i18n/dynamic.page.tsx
+++ b/pages/i18n/dynamic.page.tsx
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import { TagEditor } from '~components';
-import { I18nProvider, I18nProviderProps } from '~components/i18n';
-
-import { importMessages } from '~components/i18n/messages';
+import { I18nProvider, I18nProviderProps, importMessages } from '~components/i18n';
 
 const LOCALE = 'ja';
 
 export default function I18nDynamicPage() {
   const [messages, setMessages] = useState<ReadonlyArray<I18nProviderProps.Messages> | null>(null);
-
   useEffect(() => {
     importMessages(LOCALE).then(setMessages);
   }, []);

--- a/pages/property-filter/hooks.page.tsx
+++ b/pages/property-filter/hooks.page.tsx
@@ -12,7 +12,7 @@ import { columnDefinitions, i18nStrings, filteringProperties } from './common-pr
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
 import { I18nProvider } from '~components/i18n';
-import messages from '~components/i18n/messages/all.all';
+import messages from '~components/i18n/messages/all.en';
 
 export default function () {
   const [locale, setLocale] = useState('en');

--- a/pages/webpack.config.base.js
+++ b/pages/webpack.config.base.js
@@ -96,7 +96,8 @@ module.exports = ({
           awsui: {
             test: module =>
               module.resource &&
-              (module.resource.includes(componentsPath) || module.resource.includes(designTokensPath)),
+              (module.resource.includes(componentsPath) || module.resource.includes(designTokensPath)) &&
+              !module.resource.includes(path.resolve(componentsPath, 'i18n/messages')),
             name: 'awsui',
             chunks: 'all',
           },

--- a/src/i18n/__integ__/i18n.test.ts
+++ b/src/i18n/__integ__/i18n.test.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import jaStaticMessages from '../../../lib/components/i18n/messages/all.ja.json';
+
+const wrapper = createWrapper().findTagEditor();
+
+const setupTest = (testFn: (page: BasePageObject) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('/#/light/i18n/dynamic');
+    await testFn(page);
+  });
+};
+
+test(
+  'dynamic messages are loaded correctly',
+  setupTest(async page => {
+    const text = jaStaticMessages['@cloudscape-design/components'].ja['tag-editor']['i18nStrings.addButton'][0].value;
+    await page.waitForVisible(wrapper.findAddButton().toSelector());
+    await expect(page.getText(wrapper.findAddButton().toSelector())).resolves.toBe(text);
+  })
+);

--- a/src/i18n/__tests__/dynamic.test.tsx
+++ b/src/i18n/__tests__/dynamic.test.tsx
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { importMessages } from '../../../lib/components/i18n';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('logs a warning if an unknown locale was provided', async () => {
+  jest.spyOn(console, 'warn');
+  const messages = await importMessages('klh');
+  expect(messages).toEqual([]);
+  expect(console.warn).toHaveBeenCalledWith(`[AwsUi] [importMessages] Unknown locale "klh" provided to importMessages`);
+});

--- a/src/i18n/dynamic.d.ts
+++ b/src/i18n/dynamic.d.ts
@@ -1,4 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+// It's fine for importMessages to raise TypeScript requirements because
+// it will usually be accompanied by the I18nProvider anyway.
+// eslint-disable-next-line @cloudscape-design/ban-files
 import { I18nProviderProps } from './provider';
+
 export function importMessages(locale: string): Promise<ReadonlyArray<I18nProviderProps.Messages>>;

--- a/src/i18n/dynamic.d.ts
+++ b/src/i18n/dynamic.d.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { I18nProviderProps } from './provider';
+export function importMessages(locale: string): Promise<ReadonlyArray<I18nProviderProps.Messages>>;

--- a/src/i18n/get-matchable-locales.ts
+++ b/src/i18n/get-matchable-locales.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function getMatchableLocales(ietfLanguageTag: string): string[] {
+  const parts = ietfLanguageTag.split('-');
+  if (parts.length === 1) {
+    return [ietfLanguageTag];
+  }
+
+  const localeStrings: string[] = [];
+  for (let i = parts.length; i > 0; i--) {
+    localeStrings.push(parts.slice(0, i).join('-'));
+  }
+  return localeStrings;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { I18nProvider as default, I18nProvider, I18nProviderProps } from './provider';
+export { importMessages } from './dynamic';

--- a/src/i18n/provider.tsx
+++ b/src/i18n/provider.tsx
@@ -9,6 +9,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { useTelemetry } from '../internal/hooks/use-telemetry';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { InternalI18nContext, FormatFunction, CustomHandler } from './context';
+import { getMatchableLocales } from './get-matchable-locales';
 
 export interface I18nProviderProps {
   messages: ReadonlyArray<I18nProviderProps.Messages>;
@@ -136,17 +137,4 @@ function mergeMessages(sources: ReadonlyArray<I18nProviderProps.Messages>): I18n
     }
   }
   return result;
-}
-
-function getMatchableLocales(ietfLanguageTag: string): string[] {
-  const parts = ietfLanguageTag.split('-');
-  if (parts.length === 1) {
-    return [ietfLanguageTag];
-  }
-
-  const localeStrings: string[] = [];
-  for (let i = parts.length; i > 0; i--) {
-    localeStrings.push(parts.slice(0, i).join('-'));
-  }
-  return localeStrings;
 }


### PR DESCRIPTION
**This PR adds an `importMessages` export to `/i18n`**. All users have to do (on setups that work with dynamic imports) is:

```tsx
import { I18nProvider, I18nProviderProps, importMessages } from "@cloudscape-design/components/i18n";

const locale: string = getLocaleSomehow();
const messages: ReadonlyArray<I18nProviderProps.Messages> = await importMessages(locale);

ReactDOM.createRoot(rootElement).render(
  <I18nProvider locale={locale} messages={messages}>
    <App />
  </I18nProvider>
);
```

`importMessages` returns an array if we ever need to give it additional functionality in the future, but I'm not super sure about it. But you can pass this array directly into the component (which expects an array anyway). The alternate option of statically importing strings as JS/JSON still exists for people who only need one locale or don't, uh, particularly care about bundle size.

### Description

Bundlers are fun. Dynamic imports are much better supported than they were, say, a year ago, but they're still janky, especially across node_modules. So while we recommend ``import(`.../i18n/messages/all.${locale}.js`)`` in our docs, bundlers sometimes still freak out over it. That leaves the only option being constructing a big painful switch-case statement with non-interpolated dynamic imports (e.g. ``case "en": import(`.../i18n/messages/all.en.js`)``). Instead, we can just absorb that complexity and provide the function built-in.

Of course, we don't want webpack creating a dozen locale chunks unnecessarily. Thankfully, bundlers won't create language chunks until the `importMessages` is actually imported. Tested with this with our internal webpack setup, but it works on the same principle as our root `index.ts` file by simply being a "re-export" file that's easy to tree shake.

Related links, issue #, if available: AWSUI-21586

### How has this been tested?

Created an integration test for the dynamic loading story. No unit tests because Jest doesn't do dynamic imports 😅

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
