### PR TITLE
chore: Fix flaky resize oscillation test

### DIFF
--- a/src/table/__integ__/resizable-columns-misc.test.ts
+++ b/src/table/__integ__/resizable-columns-misc.test.ts
@@ -93,7 +93,7 @@ test(
     await page.click('#shrink-container');
     await page.waitForJsTimers();
     // flush observations from the container resize
-    await expect(page.flushObservations()).resolves.not.toEqual([]);
+    await page.flushObservations();
     await page.waitForJsTimers();
     // ensure there are no ongoing resizes after we flushed the expected ones above
     await expect(page.flushObservations()).resolves.toEqual([]);


### PR DESCRIPTION
### Description

The integ tests became flaky - fixing it by removing the seemingly unneeded check.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
