### PR TITLE
fix: Merge mouseleave detection logic

### DIFF
--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -98,7 +98,7 @@ function ChartPopover(
   return (
     <div
       {...baseProps}
-      className={clsx(popoverStyles.root, styles.root, baseProps.className, { [styles.dismissable]: dismissButton })}
+      className={clsx(popoverStyles.root, styles.root, baseProps.className)}
       ref={popoverRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/src/internal/utils/__tests__/dom.test.ts
+++ b/src/internal/utils/__tests__/dom.test.ts
@@ -100,6 +100,12 @@ describe('nodeContains', () => {
     expect(nodeContains(null, null)).toBe(false);
   });
 
+  test('returns false if descendant is not a valid node', () => {
+    const div = document.createElement('div');
+    expect(nodeContains(div, window)).toBe(false);
+    expect(nodeContains(div, new EventTarget())).toBe(false);
+  });
+
   const testCases: Record<string, string> = {
     regular: `<div id="parent">
                 <div id="inbetween">
@@ -149,6 +155,8 @@ describe('nodeContains', () => {
           const inbetween = div.querySelector('#inbetween');
           const child = div.querySelector('#child');
 
+          expect(nodeContains(parent, parent)).toBe(true);
+          expect(nodeContains(child, child)).toBe(true);
           expect(nodeContains(parent, child)).toBe(true);
           expect(nodeContains(parent, inbetween)).toBe(true);
           expect(nodeContains(inbetween, child)).toBe(true);

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -103,8 +103,8 @@ export function parseCssVariable(value: string) {
  * @param parent Parent node
  * @param descendant Node that is checked to be a descendant of the parent node
  */
-export function nodeContains(parent: Node | null, descendant: Node | null) {
-  if (!parent || !descendant) {
+export function nodeContains(parent: Node | null, descendant: Node | EventTarget | null) {
+  if (!parent || !descendant || !(descendant instanceof Node)) {
     return false;
   }
 

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -528,6 +528,29 @@ describe('Details popover', () => {
     expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
   });
 
+  test('allow mouse to be move between segment and popover ', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
+
+    expect(wrapper.findDetailPopover()).toBeTruthy();
+
+    fireEvent.mouseOut(wrapper.findDetailPopover()!.getElement(), {
+      relatedTarget: wrapper!.findSegments()[0].getElement(),
+    });
+
+    expect(wrapper.findDetailPopover()).toBeTruthy();
+
+    fireEvent.mouseOut(wrapper!.findSegments()[0].getElement(), {
+      relatedTarget: wrapper.findDetailPopover()!.getElement(),
+    });
+
+    expect(wrapper.findDetailPopover()).toBeTruthy();
+
+    fireEvent.mouseOut(wrapper!.findSegments()[0].getElement(), { relatedTarget: window });
+
+    expect(wrapper.findDetailPopover()).toBeFalsy();
+  });
+
   test('close popover when mouse leaves it ', () => {
     const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
     wrapper.findApplication()!.focus();
@@ -565,11 +588,22 @@ describe('Details popover', () => {
 
   test('dismisses when clicking same segment', () => {
     const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
-    wrapper.findSegments()[0].click();
-    expect(wrapper.findDetailPopover()).toBeDefined();
 
-    wrapper.findSegments()[0].click();
+    fireEvent.mouseDown(wrapper.findSegments()[0].getElement());
+    expect(wrapper.findDetailPopover()).toBeTruthy();
+
+    fireEvent.mouseDown(wrapper.findSegments()[0].getElement());
     expect(wrapper.findDetailPopover()).toBeNull();
+  });
+
+  test('stays open with mouseleave events when pinned', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+
+    fireEvent.mouseDown(wrapper.findSegments()[0].getElement());
+    expect(wrapper.findDetailPopover()).toBeTruthy();
+
+    fireEvent.mouseOut(wrapper.findSegments()[0].getElement());
+    expect(wrapper.findDetailPopover()).toBeTruthy();
   });
 
   test('can be dismissed with click on the dismiss button', () => {

--- a/src/pie-chart/index.tsx
+++ b/src/pie-chart/index.tsx
@@ -87,8 +87,6 @@ const PieChart = function PieChart<T extends PieChartProps.Datum = PieChartProps
     }
   );
 
-  const [pinnedSegment, setPinnedSegment] = useState<T | null>(null);
-
   const visibleData = useMemo(
     () => data.filter(d => visibleSegments?.indexOf(d.datum) !== -1),
     [data, visibleSegments]
@@ -212,8 +210,6 @@ const PieChart = function PieChart<T extends PieChartProps.Datum = PieChartProps
             onHighlightChange={onHighlightChange}
             highlightedSegment={highlightedSegment}
             legendSegment={legendSegment}
-            pinnedSegment={pinnedSegment}
-            setPinnedSegment={setPinnedSegment}
             detailPopoverSize={detailPopoverSize}
             pieData={pieData}
             dataSum={dataSum}

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -20,7 +20,6 @@ interface SegmentsProps<T> {
   segmentAriaRoleDescription?: string;
   onMouseDown: (datum: InternalChartDatum<T>) => void;
   onMouseOver: (datum: InternalChartDatum<T>) => void;
-  onMouseOut: (event: React.MouseEvent<SVGElement>) => void;
 }
 
 export default function Segments<T extends PieChartProps.Datum>({
@@ -33,7 +32,6 @@ export default function Segments<T extends PieChartProps.Datum>({
   segmentAriaRoleDescription,
   onMouseDown,
   onMouseOver,
-  onMouseOut,
 }: SegmentsProps<T>) {
   const i18n = useInternalI18n('pie-chart');
 
@@ -68,7 +66,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   }, [highlightedSegment, pieData, arcFactory]);
 
   return (
-    <g onMouseLeave={event => onMouseOut(event)}>
+    <g>
       {pieData.map(datum => {
         const isHighlighted = highlightedSegment === datum.data.datum;
         const isDimmed = highlightedSegment !== null && !isHighlighted;


### PR DESCRIPTION
### Description

Fixed two major issues

1. `event.relatedTarget` is not always a DOM node. Sometimes it is `window` and this breaks `node.contains(event.relatedTarget)`
2. There are two concurrent mouse leave handlers, for the SVG element and popover. When both fire same time, the second fails with an error, because the segment is already hidden. The new implementation is idempotent

Also did some additional refactoring, see the comments inline

Related links, issue #, if available: AWSUI-21557

### How has this been tested?

1. Added more tests
2. Checked other chart components, they already use `nodeContains`, so we are good

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
