### PR TITLE
fix: Ensure we generate valid ids

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -19,8 +19,6 @@ Axe.configure(spec);
 const htmlValidator = new HtmlValidate({
   extends: ['html-validate:recommended'],
   rules: {
-    // set relaxed to exclude error that id does not begin with letter
-    'valid-id': ['error', { relaxed: true }],
     'no-inline-style': 'off',
     'prefer-native-element': ['error', { exclude: ['listbox', 'button', 'region'] }],
     //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -14,5 +14,5 @@ const useIdFallback = () => {
 const useId: typeof useIdFallback = (React as any).useId ?? useIdFallback;
 
 export function useUniqueId(prefix?: string) {
-  return `${prefix ? prefix : ''}` + useId();
+  return `${prefix ? prefix : 'i'}` + useId();
 }

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -14,5 +14,6 @@ const useIdFallback = () => {
 const useId: typeof useIdFallback = (React as any).useId ?? useIdFallback;
 
 export function useUniqueId(prefix?: string) {
+  // if no prefix provided, add a letter at the beginning to ensure valid HTML id
   return `${prefix ? prefix : 'i'}` + useId();
 }


### PR DESCRIPTION
### Description

ids should start with a letter, so ensure that we do that by default,
and enable validity checking in our tests.

Related links, issue #, if available: n/a

### How has this been tested?

Updated tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
