### PR TITLE
fix: Use default id generation for tile ids

### DIFF
--- a/src/tiles/tile.tsx
+++ b/src/tiles/tile.tsx
@@ -23,7 +23,6 @@ interface TileProps {
 export const Tile = React.forwardRef(
   ({ item, selected, name, breakpoint, onChange }: TileProps, forwardedRef: React.Ref<HTMLInputElement>) => {
     const internalRef = useRef<HTMLInputElement>(null);
-    const controlId = item.controlId || `${name}-value-${item.value}`;
     const isVisualRefresh = useVisualRefresh();
 
     const mergedRef = useMergeRefs(internalRef, forwardedRef);
@@ -58,7 +57,7 @@ export const Tile = React.forwardRef(
             label={item.label}
             description={item.description}
             disabled={item.disabled}
-            controlId={controlId}
+            controlId={item.controlId}
           />
         </div>
         {item.image && <div className={clsx(styles.image, { [styles.disabled]: !!item.disabled })}>{item.image}</div>}


### PR DESCRIPTION
### Description

The previous custom logic would create invalid ids if the value included spaces.
There's no need to have the value in the id at all, so fall back to default id generation.

Related links, issue #, if available: n/a

### How has this been tested?

Checked output, and existing unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
