### PR TITLE
fix: Don't override ariaLabel when explicitly set on switch components

### DIFF
--- a/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
+++ b/src/internal/components/abstract-switch/__tests__/abstract-switch.test.tsx
@@ -33,24 +33,8 @@ describe('Abstract switch', () => {
     expect(container).toValidateA11y();
   });
 
-  describe('aria-labelledby', () => {
-    test('should not have a labelId if a label is not provided', () => {
-      const wrapper = renderAbstractSwitch({
-        controlClassName: '',
-        outlineClassName: '',
-        styledControl: <div />,
-        controlId: 'custom-id',
-        description: 'Description goes here',
-        nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
-        onClick: noop,
-      });
-
-      const nativeControl = wrapper.find('.switch-element')!.getElement();
-      expect(nativeControl).not.toHaveAttribute('aria-labelledby');
-      expect(wrapper.find('#custom-id-label')).toBeNull();
-    });
-
-    test('should be set to labelId if a label is provided', () => {
+  describe('labels and descriptions', () => {
+    test('should be default use `label` and `description`', () => {
       const wrapper = renderAbstractSwitch({
         controlClassName: '',
         outlineClassName: '',
@@ -64,33 +48,49 @@ describe('Abstract switch', () => {
 
       const nativeControl = wrapper.find('.switch-element')!.getElement();
 
-      expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label');
-      expect(nativeControl).toHaveAttribute('aria-describedby', 'custom-id-description');
-
-      expect(wrapper.find('#custom-id-label')?.getElement()).toHaveTextContent('Label goes here');
-      expect(wrapper.find('#custom-id-description')?.getElement()).toHaveTextContent('Description goes here');
+      expect(nativeControl).toHaveAccessibleName('Label goes here');
+      expect(nativeControl).toHaveAccessibleDescription('Description goes here');
     });
 
-    test('should include labelId if an ariaLabelledBy id is provided', () => {
+    test('label can be overwritten by `ariaLabel`', () => {
       const wrapper = renderAbstractSwitch({
         controlClassName: '',
         outlineClassName: '',
         styledControl: <div />,
+        label: 'Label goes here',
         controlId: 'custom-id',
-        ariaLabelledby: 'some-custom-label',
-        ariaDescribedby: 'some-custom-description',
-        label: 'label',
-        description: 'description',
+        ariaLabel: 'Custom aria label',
         nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
         onClick: noop,
       });
 
       const nativeControl = wrapper.find('.switch-element')!.getElement();
-      expect(nativeControl).toHaveAttribute('aria-labelledby', 'custom-id-label some-custom-label');
-      expect(nativeControl).toHaveAttribute('aria-describedby', 'some-custom-description custom-id-description');
 
-      expect(wrapper.find('#custom-id-label')).not.toBe(null);
-      expect(wrapper.find('#custom-id-description')).not.toBe(null);
+      expect(nativeControl).toHaveAccessibleName('Custom aria label');
+    });
+
+    test('can add additional labelledby and describedby references', () => {
+      const wrapper = renderAbstractSwitch({
+        controlClassName: '',
+        outlineClassName: '',
+        styledControl: (
+          <div>
+            <span id="some-custom-label">Custom label</span>
+            <span id="some-custom-description">Custom description</span>
+          </div>
+        ),
+        controlId: 'custom-id',
+        ariaLabelledby: 'some-custom-label',
+        ariaDescribedby: 'some-custom-description',
+        label: 'Default label',
+        description: 'Default description',
+        nativeControl: nativeControlProps => <input {...nativeControlProps} className="switch-element" type="radio" />,
+        onClick: noop,
+      });
+
+      const nativeControl = wrapper.find('.switch-element')!.getElement();
+      expect(nativeControl).toHaveAccessibleName('Default label Custom label');
+      expect(nativeControl).toHaveAccessibleDescription('Custom description Default description');
     });
   });
 });

--- a/src/internal/components/abstract-switch/index.tsx
+++ b/src/internal/components/abstract-switch/index.tsx
@@ -54,7 +54,7 @@ export default function AbstractSwitch({
   const descriptionId = `${id}-description`;
 
   const ariaLabelledByIds = [];
-  if (label) {
+  if (label && !ariaLabel) {
     ariaLabelledByIds.push(labelId);
   }
   if (ariaLabelledby) {


### PR DESCRIPTION
### Description

The auto-generated `aria-labelledby` would previously override any custom `ariaLabel`,
which basically means `ariaLabel` was a no-op. This prevents that override.

Related links, issue #, if available: n/a

### How has this been tested?

Updated tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
