### PR TITLE
fix: Fix tick count for horizontal bar charts and make bottom labels height measure synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a basic example that renders a primary button:
 import Button from '@cloudscape-design/components/button';
 import '@cloudscape-design/global-styles/index.css';
 
-function App {
+function App() {
   return <Button variant="primary">Click me</Button>;
 }
 ```

--- a/src/internal/hooks/container-queries/use-height-measure.ts
+++ b/src/internal/hooks/container-queries/use-height-measure.ts
@@ -14,7 +14,7 @@ export function useHeightMeasure(
 ) {
   const [measuredHeight, setHeight] = useState(0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const stableGetMeasure = useCallback(getMeasure, deps);
+  const stableGetMeasure = useCallback(getMeasure, [...deps, skip]);
   useResizeObserver(stableGetMeasure, entry => !skip && setHeight(entry.borderBoxHeight));
   return !skip ? measuredHeight : undefined;
 }

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -80,6 +80,26 @@ export interface ChartContainerProps<T extends ChartDataTypes> {
   plotContainerRef: React.RefObject<HTMLDivElement>;
 }
 
+interface XAxisProps {
+  axis: 'X';
+  tickCount: number;
+  scale: ChartScale;
+  ticks: ChartDataTypes[];
+  tickFormatter: TickFormatter;
+  title?: string;
+  ariaRoleDescription?: string;
+}
+
+interface YAxisProps {
+  axis: 'Y';
+  tickCount: number;
+  scale: NumericChartScale;
+  ticks: number[];
+  tickFormatter: TickFormatter;
+  title?: string;
+  ariaRoleDescription?: string;
+}
+
 export default function ChartContainer<T extends ChartDataTypes>({
   fitHeight,
   height: explicitPlotHeight,
@@ -121,36 +141,61 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
   const popoverRef = useRef<HTMLElement | null>(null);
 
-  const plotMeasureRef = useRef<SVGLineElement>(null);
-  const measuredHeight = useHeightMeasure(() => plotMeasureRef.current, !fitHeight || !bottomLabelsHeight);
-  const plotHeight = fitHeight ? (bottomLabelsHeight ? measuredHeight ?? 0 : 0) : explicitPlotHeight;
-
-  const isRefresh = useVisualRefresh();
-
-  const linesOnly = series.every(({ series }) => series.type === 'line' || series.type === 'threshold');
-
   const xDomain = (props.xDomain || computeDomainX(series, xScaleType)) as
     | readonly number[]
     | readonly string[]
     | readonly Date[];
   const yDomain = (props.yDomain || computeDomainY(series, yScaleType, stackedBars)) as readonly number[];
 
-  const xTickCount = getXTickCount(plotWidth);
-  const yTickCount = getYTickCount(plotHeight);
+  const linesOnly = series.every(({ series }) => series.type === 'line' || series.type === 'threshold');
 
-  const rangeBottomTop: [number, number] = [0, plotHeight];
-  const rangeTopBottom: [number, number] = [plotHeight, 0];
-  const rangeLeftRight: [number, number] = [0, plotWidth];
-  const xScale = new ChartScale(xScaleType, xDomain, horizontalBars ? rangeBottomTop : rangeLeftRight, linesOnly);
-  const yScale = new NumericChartScale(
-    yScaleType,
-    yDomain,
-    horizontalBars ? rangeLeftRight : rangeTopBottom,
-    props.yDomain ? null : yTickCount
-  );
+  function getXAxisProps(size: number, range: [from: number, until: number]): XAxisProps {
+    const tickCount = getXTickCount(size);
+    const scale = new ChartScale(xScaleType, xDomain, range, linesOnly);
+    const ticks = createXTicks(scale, tickCount);
+    return {
+      axis: 'X',
+      tickCount,
+      scale,
+      ticks,
+      tickFormatter: xTickFormatter as TickFormatter,
+      title: xTitle,
+      ariaRoleDescription: i18nStrings.xAxisAriaRoleDescription,
+    };
+  }
 
-  const xTicks = createXTicks(xScale, xTickCount);
-  const yTicks = createYTicks(yScale, yTickCount);
+  function getYAxisProps(size: number, range: [from: number, until: number]): YAxisProps {
+    const tickCount = getYTickCount(size);
+    const scale = new NumericChartScale(yScaleType, yDomain, range, props.yDomain ? null : tickCount);
+    const ticks = createYTicks(scale, tickCount);
+    return {
+      axis: 'Y',
+      tickCount,
+      scale,
+      ticks,
+      tickFormatter: yTickFormatter as TickFormatter,
+      title: yTitle,
+      ariaRoleDescription: i18nStrings.yAxisAriaRoleDescription,
+    };
+  }
+
+  const bottomAxisProps = !horizontalBars
+    ? getXAxisProps(plotWidth, [0, plotWidth])
+    : getYAxisProps(plotWidth, [0, plotWidth]);
+
+  const plotMeasureRef = useRef<SVGLineElement>(null);
+  const measuredHeight = useHeightMeasure(() => plotMeasureRef.current, !fitHeight || !bottomLabelsHeight);
+  const plotHeight = fitHeight ? (bottomLabelsHeight ? measuredHeight ?? 0 : 0) : explicitPlotHeight;
+
+  const leftAxisProps = !horizontalBars
+    ? getYAxisProps(plotHeight, [plotHeight, 0])
+    : getXAxisProps(plotHeight, [0, plotHeight]);
+
+  const xAxisProps = bottomAxisProps.axis === 'X' ? bottomAxisProps : leftAxisProps.axis === 'X' ? leftAxisProps : null;
+  const yAxisProps = bottomAxisProps.axis === 'Y' ? bottomAxisProps : leftAxisProps.axis === 'Y' ? leftAxisProps : null;
+  if (!xAxisProps || !yAxisProps) {
+    throw new Error('Invariant violation: invalid axis props.');
+  }
 
   /**
    * Interactions
@@ -163,16 +208,9 @@ export default function ChartContainer<T extends ChartDataTypes>({
   // When "horizontalBars" is enabled, the axes are inverted.
   const x = !horizontalBars ? 'x' : 'y';
   const y = !horizontalBars ? 'y' : 'x';
-  const xy = {
-    ticks: { x: xTicks, y: yTicks },
-    scale: { x: xScale, y: yScale },
-    tickFormatter: { x: xTickFormatter, y: yTickFormatter },
-    title: { x: xTitle, y: yTitle },
-    ariaRoleDescription: { x: i18nStrings.xAxisAriaRoleDescription, y: i18nStrings.yAxisAriaRoleDescription },
-  };
 
-  const scaledSeries = makeScaledSeries(visibleSeries, xScale, yScale);
-  const barGroups: ScaledBarGroup<T>[] = makeScaledBarGroups(visibleSeries, xScale, plotWidth, plotHeight, y);
+  const scaledSeries = makeScaledSeries(visibleSeries, xAxisProps.scale, yAxisProps.scale);
+  const barGroups: ScaledBarGroup<T>[] = makeScaledBarGroups(visibleSeries, xAxisProps.scale, plotWidth, plotHeight, y);
 
   const { isPopoverOpen, isPopoverPinned, showPopover, pinPopover, dismissPopover } = usePopover();
 
@@ -248,8 +286,8 @@ export default function ChartContainer<T extends ChartDataTypes>({
     visibleSeries,
     scaledSeries,
     barGroups,
-    xScale,
-    yScale,
+    xScale: xAxisProps.scale,
+    yScale: yAxisProps.scale,
     highlightedPoint,
     highlightedGroupIndex,
     highlightedSeries,
@@ -367,13 +405,13 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
   const onSVGKeyDown = handlers.onKeyDown;
 
-  const xOffset = xScale.isCategorical() ? Math.max(0, xScale.d3Scale.bandwidth() - 1) / 2 : 0;
+  const xOffset = xAxisProps.scale.isCategorical() ? Math.max(0, xAxisProps.scale.d3Scale.bandwidth() - 1) / 2 : 0;
 
   let verticalLineX: number | null = null;
   if (verticalMarkerX !== null) {
     verticalLineX = verticalMarkerX.scaledX;
   } else if (isGroupNavigation && highlightedGroupIndex !== null) {
-    const x = xScale.d3Scale(barGroups[highlightedGroupIndex].x as any) ?? null;
+    const x = xAxisProps.scale.d3Scale(barGroups[highlightedGroupIndex].x as any) ?? null;
     if (x !== null) {
       verticalLineX = xOffset + x;
     }
@@ -449,21 +487,23 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
   const isLineXKeyboardFocused = isPlotFocused && !highlightedPoint && verticalMarkerX;
 
+  const isRefresh = useVisualRefresh();
+
   return (
     <CartesianChartContainer
       ref={containerRef}
       minHeight={explicitPlotHeight + bottomLabelsHeight}
       fitHeight={!!fitHeight}
-      leftAxisLabel={<AxisLabel axis={y} position="left" title={xy.title[y]} />}
+      leftAxisLabel={<AxisLabel axis={y} position="left" title={leftAxisProps.title} />}
       leftAxisLabelMeasure={
         <LabelsMeasure
-          ticks={xy.ticks[y]}
-          scale={xy.scale[y]}
-          tickFormatter={xy.tickFormatter[y] as TickFormatter}
+          ticks={leftAxisProps.ticks}
+          scale={leftAxisProps.scale}
+          tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
           autoWidth={setLeftLabelsWidth}
         />
       }
-      bottomAxisLabel={<AxisLabel axis={x} position="bottom" title={xy.title[x]} />}
+      bottomAxisLabel={<AxisLabel axis={x} position="bottom" title={bottomAxisProps.title} />}
       chartPlot={
         <ChartPlot
           ref={plotRef}
@@ -503,19 +543,21 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
           <LeftLabels
             axis={y}
-            ticks={xy.ticks[y]}
-            scale={xy.scale[y]}
-            tickFormatter={xy.tickFormatter[y] as TickFormatter}
-            title={xy.title[y]}
-            ariaRoleDescription={xy.ariaRoleDescription[y]}
+            ticks={leftAxisProps.ticks}
+            scale={leftAxisProps.scale}
+            tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
+            title={leftAxisProps.title}
+            ariaRoleDescription={leftAxisProps.ariaRoleDescription}
             width={plotWidth}
             height={plotHeight}
           />
 
-          {horizontalBars && <VerticalGridLines scale={yScale} ticks={yTicks} height={plotHeight} />}
+          {horizontalBars && (
+            <VerticalGridLines scale={yAxisProps.scale} ticks={yAxisProps.ticks} height={plotHeight} />
+          )}
 
           {emphasizeBaselineAxis && linesOnly && (
-            <EmphasizedBaseline axis={x} scale={yScale} width={plotWidth} height={plotHeight} />
+            <EmphasizedBaseline axis={x} scale={yAxisProps.scale} width={plotWidth} height={plotHeight} />
           )}
 
           <DataSeries
@@ -527,12 +569,12 @@ export default function ChartContainer<T extends ChartDataTypes>({
             stackedBars={stackedBars}
             isGroupNavigation={isGroupNavigation}
             visibleSeries={visibleSeries}
-            xScale={xScale}
-            yScale={yScale}
+            xScale={xAxisProps.scale}
+            yScale={yAxisProps.scale}
           />
 
           {emphasizeBaselineAxis && !linesOnly && (
-            <EmphasizedBaseline axis={x} scale={yScale} width={plotWidth} height={plotHeight} />
+            <EmphasizedBaseline axis={x} scale={yAxisProps.scale} width={plotWidth} height={plotHeight} />
           )}
 
           <VerticalMarker
@@ -555,7 +597,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
             />
           )}
 
-          {isGroupNavigation && xScale.isCategorical() && (
+          {isGroupNavigation && xAxisProps.scale.isCategorical() && (
             <BarGroups
               ariaLabel={activeAriaLabel}
               isRefresh={isRefresh}
@@ -568,11 +610,11 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
           <BottomLabels
             axis={x}
-            ticks={xy.ticks[x]}
-            scale={xy.scale[x]}
-            tickFormatter={xy.tickFormatter[x] as TickFormatter}
-            title={xy.title[x]}
-            ariaRoleDescription={xy.ariaRoleDescription[x]}
+            ticks={bottomAxisProps.ticks}
+            scale={bottomAxisProps.scale}
+            tickFormatter={bottomAxisProps.tickFormatter as TickFormatter}
+            title={bottomAxisProps.title}
+            ariaRoleDescription={bottomAxisProps.ariaRoleDescription}
             height={plotHeight}
             width={plotWidth}
             offsetLeft={leftLabelsWidth + BOTTOM_LABELS_OFFSET}


### PR DESCRIPTION
### Description

Refactored mixed chart axis props so that the bottom axis props are clearly decoupled from height.
Updated bottom labels height calculation to be synchronous so that the SVG height measurement does not have to wait until the bottom labels height is available.

The change also fixes the tick count number for horizontal bar charts - previously the tick count for Y was always measured against the plot height - now it runs against the correct dimension.

### How has this been tested?

Existing tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
