### PR TITLE
chore: Remove /internal/i18n in favor of /i18n

### DIFF
--- a/build-tools/tasks/generate-i18n-messages.js
+++ b/build-tools/tasks/generate-i18n-messages.js
@@ -11,7 +11,6 @@ const { writeFile } = require('../utils/files');
 const namespace = '@cloudscape-design/components';
 
 const destinationDir = path.join(targetPath, 'components/i18n/messages');
-const internalDestinationDir = path.join(targetPath, 'components/internal/i18n/messages');
 const declarationFile = `import { I18nProviderProps } from "../provider";
 declare const messages: I18nProviderProps.Messages;
 export default messages;
@@ -36,21 +35,16 @@ module.exports = function generateI18nMessages() {
     );
     allParsedMessages[locale] = { ...(allParsedMessages[locale] ?? {}), ...parsedMessages };
     const resultFormat = { [namespace]: { [locale]: parsedMessages } };
-
-    for (const directory of [destinationDir, internalDestinationDir]) {
-      writeFile(path.join(directory, `${subset}.${locale}.json`), JSON.stringify(resultFormat));
-      writeFile(path.join(directory, `${subset}.${locale}.d.ts`), declarationFile);
-      writeFile(path.join(directory, `${subset}.${locale}.js`), `export default ${JSON.stringify(resultFormat)}`);
-    }
+    writeFile(path.join(destinationDir, `${subset}.${locale}.json`), JSON.stringify(resultFormat));
+    writeFile(path.join(destinationDir, `${subset}.${locale}.d.ts`), declarationFile);
+    writeFile(path.join(destinationDir, `${subset}.${locale}.js`), `export default ${JSON.stringify(resultFormat)}`);
   }
 
   // Generate a ".all" file containing all locales.
   const resultFormat = { [namespace]: allParsedMessages };
-  for (const directory of [destinationDir, internalDestinationDir]) {
-    writeFile(path.join(directory, `all.all.json`), JSON.stringify(resultFormat));
-    writeFile(path.join(directory, `all.all.d.ts`), declarationFile);
-    writeFile(path.join(directory, `all.all.js`), `export default ${JSON.stringify(resultFormat)}`);
-  }
+  writeFile(path.join(destinationDir, `all.all.json`), JSON.stringify(resultFormat));
+  writeFile(path.join(destinationDir, `all.all.d.ts`), declarationFile);
+  writeFile(path.join(destinationDir, `all.all.js`), `export default ${JSON.stringify(resultFormat)}`);
 
   return Promise.resolve();
 };

--- a/build-tools/tasks/package-json.js
+++ b/build-tools/tasks/package-json.js
@@ -47,16 +47,6 @@ function getComponentsExports() {
     result[`./i18n/messages/${subset}.${locale}.json`] = `./i18n/messages/${subset}.${locale}.json`;
   }
 
-  // i18n beta specific imports (delete after people switch over)
-  result['./internal/i18n'] = './internal/i18n/index.js';
-  result[`./internal/i18n/messages/all.all`] = `./internal/i18n/messages/all.all.js`;
-  result[`./internal/i18n/messages/all.all.json`] = `./internal/i18n/messages/all.all.json`;
-  for (const translationFile of fs.readdirSync('src/i18n/messages')) {
-    const [subset, locale] = translationFile.split('.');
-    result[`./internal/i18n/messages/${subset}.${locale}`] = `./internal/i18n/messages/${subset}.${locale}.js`;
-    result[`./internal/i18n/messages/${subset}.${locale}.json`] = `./internal/i18n/messages/${subset}.${locale}.json`;
-  }
-
   return result;
 }
 

--- a/pages/alert/simple.page.tsx
+++ b/pages/alert/simple.page.tsx
@@ -7,7 +7,7 @@ import ScreenshotArea from '../utils/screenshot-area';
 import SpaceBetween from '~components/space-between';
 import styles from './styles.scss';
 
-import { I18nProvider } from '~components/internal/i18n';
+import { I18nProvider } from '~components/i18n';
 import messages from '~components/i18n/messages/all.all';
 
 export default function AlertScenario() {

--- a/pages/property-filter/hooks.page.tsx
+++ b/pages/property-filter/hooks.page.tsx
@@ -11,7 +11,7 @@ import { allItems, TableItem } from './table.data';
 import { columnDefinitions, i18nStrings, filteringProperties } from './common-props';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
-import { I18nProvider } from '~components/internal/i18n';
+import { I18nProvider } from '~components/i18n';
 import messages from '~components/i18n/messages/all.all';
 
 export default function () {

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -15,7 +15,7 @@ import { AlertProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { DATA_ATTR_ANALYTICS_ALERT } from '../internal/analytics/selectors';
 
 const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -43,7 +43,7 @@ import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import RefreshedAppLayout from './visual-refresh';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { useSplitPanelFocusControl } from './utils/use-split-panel-focus-control';
 import { useDrawerFocusControl } from './utils/use-drawer-focus-control';
 import { awsuiPluginsInternal } from '../internal/plugins/api';

--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -9,7 +9,7 @@ import popoverStyles from '../../../lib/components/popover/styles.css.js';
 import chartWrapperStyles from '../../../lib/components/internal/components/chart-wrapper/styles.css.js';
 import cartesianStyles from '../../../lib/components/internal/components/cartesian-chart/styles.css.js';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import { cloneDeep } from 'lodash';
 import '../../__a11y__/to-validate-a11y';
 

--- a/src/area-chart/elements/use-highlight-details.ts
+++ b/src/area-chart/elements/use-highlight-details.ts
@@ -3,7 +3,7 @@
 import { useSelector } from '../async-store';
 import { CartesianChartProps } from '../../internal/components/cartesian-chart/interfaces';
 import { ChartSeriesDetailItem } from '../../internal/components/chart-series-details';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 import { AreaChartProps } from '../interfaces';
 import { ChartModel } from '../model';
 

--- a/src/attribute-editor/__tests__/attribute-editor.test.tsx
+++ b/src/attribute-editor/__tests__/attribute-editor.test.tsx
@@ -7,7 +7,7 @@ import AttributeEditor, { AttributeEditorProps } from '../../../lib/components/a
 import styles from '../../../lib/components/attribute-editor/styles.css.js';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 import Input from '../../../lib/components/input';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 interface Item {
   key: string;

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -12,7 +12,7 @@ import InternalGrid from '../grid/internal';
 import { InternalButton } from '../button/internal';
 import clsx from 'clsx';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 const Divider = () => <InternalBox className={styles.divider} padding={{ top: 'l' }} />;
 

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -10,7 +10,7 @@ import { getTestOptionIndexes } from '../internal/components/options-list/utils/
 import styles from './styles.css.js';
 import { AutosuggestItem } from './interfaces';
 import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export interface AutosuggestOptionProps extends BaseComponentProps {
   nativeAttributes?: Record<string, any>;

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -26,7 +26,7 @@ import { useAutosuggestLoadMore } from './load-more-controller';
 import { OptionsLoadItemsDetail } from '../internal/components/dropdown/interfaces';
 import AutosuggestInput, { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 import { useFormFieldContext } from '../contexts/form-field';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 import styles from './styles.css.js';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';

--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 import styles from '../../../lib/components/breadcrumb-group/styles.css.js';
 import itemStyles from '../../../lib/components/breadcrumb-group/item/styles.css.js';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';

--- a/src/breadcrumb-group/internal.tsx
+++ b/src/breadcrumb-group/internal.tsx
@@ -15,7 +15,7 @@ import { getBaseProps } from '../internal/base-component';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 /**
  * Provided for backwards compatibility

--- a/src/calendar/internal.tsx
+++ b/src/calendar/internal.tsx
@@ -17,7 +17,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { getBaseDate } from './utils/navigation';
 import { useDateCache } from '../internal/hooks/use-date-cache/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id/index.js';
-import { useInternalI18n } from '../internal/i18n/context.js';
+import { useInternalI18n } from '../i18n/context.js';
 
 export type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -6,7 +6,7 @@ import Cards, { CardsProps } from '../../../lib/components/cards';
 import { CardsWrapper, PaginationWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import styles from '../../../lib/components/cards/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -22,7 +22,7 @@ import LiveRegion from '../internal/components/live-region';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { supportsStickyPosition } from '../internal/utils/dom';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -18,7 +18,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 import { createWrapper } from '@cloudscape-design/test-utils-core/dom';
 import '../../__a11y__/to-validate-a11y';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -31,7 +31,7 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { useCurrentMode } from '@cloudscape-design/component-toolkit/internal';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { StatusBar } from './status-bar';
 import { useFormFieldContext } from '../internal/context/form-field-context';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -7,7 +7,7 @@ import LiveRegion from '../internal/components/live-region/index';
 import { TabButton } from './tab-button';
 import { InternalButton } from '../button/internal';
 import { CodeEditorProps } from './interfaces';
-import { useInternalI18n } from '../internal/i18n/context.js';
+import { useInternalI18n } from '../i18n/context.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 
 interface StatusBarProps {

--- a/src/collection-preferences/__tests__/collection-preferences.test.tsx
+++ b/src/collection-preferences/__tests__/collection-preferences.test.tsx
@@ -13,7 +13,7 @@ import {
   stripedRowsPreference,
   contentDisplayPreference,
 } from './shared';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const expectVisibleModal = (wrapper: CollectionPreferencesWrapper, visible = true) => {
   if (visible) {

--- a/src/collection-preferences/content-display/index.tsx
+++ b/src/collection-preferences/content-display/index.tsx
@@ -13,7 +13,7 @@ import useDragAndDropReorder from './use-drag-and-drop-reorder';
 import useLiveAnnouncements from './use-live-announcements';
 import Portal from '../../internal/components/portal';
 import ContentDisplayOption from './content-display-option';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 const componentPrefix = 'content-display';
 

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -28,7 +28,7 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import ContentDisplayPreference from './content-display';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { CollectionPreferencesProps };
 

--- a/src/collection-preferences/utils.tsx
+++ b/src/collection-preferences/utils.tsx
@@ -10,7 +10,7 @@ import InternalSpaceBetween from '../space-between/internal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { CollectionPreferencesProps } from './interfaces';
 import styles from './styles.css.js';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export const copyPreferences = ({
   pageSize,

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -26,7 +26,7 @@ import FocusLock from '../internal/components/focus-lock';
 import { parseDate } from '../internal/utils/date-time';
 import LiveRegion from '../internal/components/live-region';
 import { useFormFieldContext } from '../contexts/form-field.js';
-import { useLocale } from '../internal/i18n/context.js';
+import { useLocale } from '../i18n/context.js';
 
 export { DatePickerProps };
 

--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -7,7 +7,7 @@ import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/d
 import { i18nStrings } from './i18n-strings';
 import { isValidRange } from './is-valid-range';
 import '../../__a11y__/to-validate-a11y';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const defaultProps: DateRangePickerProps = {
   locale: 'en-US',

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -10,7 +10,7 @@ import { i18nStrings } from './i18n-strings';
 import { changeMode } from './change-mode';
 import { isValidRange } from './is-valid-range';
 import '../../__a11y__/to-validate-a11y';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const defaultProps: DateRangePickerProps = {
   locale: 'en-US',

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -12,7 +12,7 @@ import { isValidRange } from './is-valid-range';
 import { changeMode } from './change-mode';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import styles from '../../../lib/components/date-range-picker/styles.css.js';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),

--- a/src/date-range-picker/calendar/index.tsx
+++ b/src/date-range-picker/calendar/index.tsx
@@ -20,7 +20,7 @@ import { getBaseDate } from '../../calendar/utils/navigation';
 import { useMobile } from '../../internal/hooks/use-mobile/index.js';
 import RangeInputs from './range-inputs.js';
 import { findDateToFocus, findMonthToDisplay } from './utils';
-import { useInternalI18n } from '../../internal/i18n/context.js';
+import { useInternalI18n } from '../../i18n/context.js';
 
 export interface DateRangePickerCalendarProps extends BaseComponentProps {
   value: DateRangePickerProps.PendingAbsoluteValue;

--- a/src/date-range-picker/calendar/range-inputs.tsx
+++ b/src/date-range-picker/calendar/range-inputs.tsx
@@ -9,7 +9,7 @@ import InternalFormField from '../../form-field/internal';
 import InternalDateInput from '../../date-input/internal';
 import { TimeInputProps } from '../../time-input/interfaces';
 import InternalTimeInput from '../../time-input/internal';
-import { useInternalI18n } from '../../internal/i18n/context.js';
+import { useInternalI18n } from '../../i18n/context.js';
 
 type I18nStrings = Pick<
   RangeCalendarI18nStrings,

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -17,7 +17,7 @@ import clsx from 'clsx';
 import InternalAlert from '../alert/internal';
 import LiveRegion from '../internal/components/live-region';
 import { getDefaultMode, joinAbsoluteValue, splitAbsoluteValue } from './utils';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export const VALID_RANGE: DateRangePickerProps.ValidRangeResult = { valid: true };
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -28,7 +28,7 @@ import { usePrevious } from '../internal/hooks/use-previous/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { formatDateRange, isIsoDateOnly } from '../internal/utils/date-time';
 import { formatValue } from './utils.js';
-import { useInternalI18n } from '../internal/i18n/context.js';
+import { useInternalI18n } from '../i18n/context.js';
 
 export { DateRangePickerProps };
 

--- a/src/date-range-picker/mode-switcher.tsx
+++ b/src/date-range-picker/mode-switcher.tsx
@@ -5,7 +5,7 @@ import { DateRangePickerProps } from './interfaces';
 import InternalSegmentedControl from '../segmented-control/internal';
 
 import styles from './styles.css.js';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 interface ModeSwitcherProps extends Pick<DateRangePickerProps, 'i18nStrings'> {
   mode: 'absolute' | 'relative';

--- a/src/date-range-picker/relative-range/index.tsx
+++ b/src/date-range-picker/relative-range/index.tsx
@@ -11,7 +11,7 @@ import InternalRadioGroup from '../../radio-group/internal';
 import InternalSelect from '../../select/internal';
 import InternalSpaceBetween from '../../space-between/internal';
 import styles from './styles.css.js';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 export interface RelativeRangePickerProps {
   dateOnly: boolean;

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -20,7 +20,7 @@ import { useFlashbar } from './common';
 import { throttle } from '../internal/utils/throttle';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { findUpUntil } from '../internal/utils/dom';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { FlashbarProps };
 

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -11,7 +11,7 @@ import { getVisualContextClassname } from '../internal/components/visual-context
 
 import styles from './styles.css.js';
 import { useFlashbar } from './common';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { FlashbarProps };
 

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -15,7 +15,7 @@ import { getAriaDescribedBy, getGridDefinition, getSlotIds } from './util';
 import styles from './styles.css.js';
 import { InternalFormFieldProps } from './interfaces';
 import { joinStrings } from '../internal/utils/strings';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 
 import { FunnelMetrics } from '../internal/analytics';

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
 import { FormLayoutProps, FormProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import LiveRegion from '../internal/components/live-region';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
 import { FunnelMetrics } from '../internal/analytics';

--- a/src/help-panel/__tests__/help-panel.test.tsx
+++ b/src/help-panel/__tests__/help-panel.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import HelpPanel from '../../../lib/components/help-panel';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 function renderHelpPanel(jsx: React.ReactElement) {
   const { container } = render(jsx);

--- a/src/help-panel/index.tsx
+++ b/src/help-panel/index.tsx
@@ -9,7 +9,7 @@ import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { HelpPanelProps } from './interfaces';
 import LiveRegion from '../internal/components/live-region';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { HelpPanelProps };
 

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -14,7 +14,7 @@ import { useDebounceCallback } from '../internal/hooks/use-debounce-callback';
 import { FormFieldValidationControlProps, useFormFieldContext } from '../internal/context/form-field-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import styles from './styles.css.js';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export interface InternalInputProps
   extends BaseComponentProps,

--- a/src/internal/components/cartesian-chart/bottom-labels.tsx
+++ b/src/internal/components/cartesian-chart/bottom-labels.tsx
@@ -9,7 +9,7 @@ import { TICK_LENGTH, TICK_LINE_HEIGHT, TICK_MARGIN } from './constants';
 
 import styles from './styles.css.js';
 import { formatTicks, getVisibleTicks } from './label-utils';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 
 interface BottomLabelsProps {
   axis?: 'x' | 'y';

--- a/src/internal/components/cartesian-chart/left-labels.tsx
+++ b/src/internal/components/cartesian-chart/left-labels.tsx
@@ -9,7 +9,7 @@ import { TICK_LENGTH, TICK_MARGIN } from './constants';
 import styles from './styles.css.js';
 import { formatTicks, getVisibleTicks } from './label-utils';
 import { ChartDataTypes } from '../../../mixed-line-bar-chart/interfaces';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 
 const OFFSET_PX = 12;
 

--- a/src/internal/components/chart-filter/__tests__/i18n.test.tsx
+++ b/src/internal/components/chart-filter/__tests__/i18n.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ChartFilter from '../../../../../lib/components/internal/components/chart-filter';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
-import TestI18nProvider from '../../../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../../../lib/components/i18n/testing';
 
 const datum0 = {};
 const datum1 = {};

--- a/src/internal/components/chart-filter/index.tsx
+++ b/src/internal/components/chart-filter/index.tsx
@@ -9,7 +9,7 @@ import InternalMultiselect from '../../../multiselect/internal';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { MultiselectProps } from '../../../multiselect/interfaces';
 import SeriesMarker, { ChartSeriesMarkerType } from '../chart-series-marker';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 
 import styles from './styles.css.js';
 

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -7,7 +7,7 @@ import InternalBox from '../../../box/internal';
 import { KeyCode } from '../../keycode';
 import SeriesMarker, { ChartSeriesMarkerType } from '../chart-series-marker';
 import styles from './styles.css.js';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 
 export interface ChartLegendItem<T> {
   label: string;

--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -11,7 +11,7 @@ import LiveRegion from '../live-region/index';
 import ApplicationController, { ApplicationRef } from './application-controller';
 import FocusOutline from './focus-outline';
 import { Offset } from '../interfaces';
-import { useInternalI18n } from '../../i18n/context.js';
+import { useInternalI18n } from '../../../i18n/context';
 
 const DEFAULT_PLOT_FOCUS_OFFSET = 3;
 const DEFAULT_ELEMENT_FOCUS_OFFSET = 3;

--- a/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
+++ b/src/internal/components/chart-status-container/__tests__/i18n.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
-import TestI18nProvider from '../../../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../../../lib/components/i18n/testing';
 import ChartStatusContainer from '../../../../../lib/components/internal/components/chart-status-container';
 import styles from '../../../../../lib/components/internal/components/chart-status-container/styles.css.js';
 

--- a/src/internal/components/chart-status-container/index.tsx
+++ b/src/internal/components/chart-status-container/index.tsx
@@ -8,7 +8,7 @@ import InternalStatusIndicator from '../../../status-indicator/internal';
 import InternalLink from '../../../link/internal';
 
 import styles from './styles.css.js';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 
 interface ChartStatusContainerProps extends BaseComponentProps {
   statusType: 'loading' | 'finished' | 'error';

--- a/src/internal/components/token-list/token-limit-toggle.tsx
+++ b/src/internal/components/token-list/token-limit-toggle.tsx
@@ -7,7 +7,7 @@ import { fireNonCancelableEvent, NonCancelableEventHandler } from '../../events'
 import { I18nStrings } from './interfaces';
 
 import styles from './styles.css.js';
-import { useInternalI18n } from '../../i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 interface TokenLimitToggleProps {
   controlId?: string;
   allHidden: boolean;

--- a/src/internal/i18n/context.ts
+++ b/src/internal/i18n/context.ts
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export * from '../../i18n/context';

--- a/src/internal/i18n/index.ts
+++ b/src/internal/i18n/index.ts
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export { I18nProvider, I18nProviderProps } from '../../i18n';

--- a/src/internal/i18n/provider.ts
+++ b/src/internal/i18n/provider.ts
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export { I18nProvider, I18nProviderProps } from '../../i18n/provider';

--- a/src/internal/i18n/testing.ts
+++ b/src/internal/i18n/testing.ts
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export { default, TestI18nProviderProps } from '../../i18n/testing';

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -6,7 +6,7 @@ import Link, { LinkProps } from '../../../lib/components/link';
 import styles from '../../../lib/components/link/styles.css.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { linkRelExpectations, linkTargetExpectations } from '../../__tests__/target-rel-test-helper';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import FormField from '../../../lib/components/form-field';
 import Header from '../../../lib/components/header';
 

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -13,7 +13,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -21,7 +21,7 @@ import { ModalProps } from './interfaces';
 import styles from './styles.css.js';
 import { SomeRequired } from '../internal/types';
 import FocusLock from '../internal/components/focus-lock';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -8,7 +8,7 @@ import tokenGroupStyles from '../../../lib/components/token-group/styles.css.js'
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const defaultOptions: MultiselectProps.Options = [
   { label: 'First', value: '1' },

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -35,7 +35,7 @@ import { MultiselectProps } from './interfaces';
 import styles from './styles.css.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { joinStrings } from '../internal/utils/strings';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 type InternalMultiselectProps = MultiselectProps & InternalBaseComponentProps;
 

--- a/src/pagination/internal.tsx
+++ b/src/pagination/internal.tsx
@@ -9,7 +9,7 @@ import styles from './styles.css.js';
 import { getPaginationState, range } from './utils';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { PaginationProps } from './interfaces';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 const defaultAriaLabels: Required<PaginationProps.Labels> = {
   nextPageLabel: '',

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -10,7 +10,7 @@ import styles from '../../../lib/components/pie-chart/styles.css.js';
 import chartWrapperStyles from '../../../lib/components/internal/components/chart-wrapper/styles.css.js';
 import * as colors from '../../../lib/design-tokens';
 import { act } from 'react-dom/test-utils';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const variants: Array<PieChartProps<PieChartProps.Datum>['variant']> = ['pie', 'donut'];
 const sizes: Array<PieChartProps<PieChartProps.Datum>['size']> = ['small', 'medium', 'large'];

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -17,7 +17,7 @@ import { defaultDetails, getDimensionsBySize } from './utils';
 import Segments from './segments';
 import ChartPlot, { ChartPlotRef } from '../internal/components/chart-plot';
 import { SomeRequired } from '../internal/types';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import clsx from 'clsx';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -8,7 +8,7 @@ import { Dimension } from './utils';
 import { InternalChartDatum } from './pie-chart';
 import styles from './styles.css.js';
 import clsx from 'clsx';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 interface SegmentsProps<T> {
   pieData: Array<PieArcDatum<InternalChartDatum<T>>>;

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentFormatFunction } from '../internal/i18n/context';
+import { ComponentFormatFunction } from '../i18n/context';
 import { PieChartProps } from './interfaces';
 import styles from './styles.css.js';
 

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -8,7 +8,7 @@ import '../../__a11y__/to-validate-a11y';
 
 import styles from '../../../lib/components/popover/styles.selectors.js';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 class PopoverInternalWrapper extends PopoverWrapper {
   findBody({ renderWithPortal } = { renderWithPortal: false }): ElementWrapper | null {

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -10,7 +10,7 @@ import { InternalButton } from '../button/internal';
 import FocusLock from '../internal/components/focus-lock';
 
 import styles from './styles.css.js';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export interface PopoverBodyProps {
   dismissButton: boolean;

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -18,7 +18,7 @@ import { NonCancelableEventHandler, fireNonCancelableEvent } from '../internal/e
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { usePortalModeClasses } from '../internal/hooks/use-portal-mode-classes';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -32,7 +32,7 @@ import { PropertyEditor } from './property-editor';
 import { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 import { matchTokenValue } from './utils';
 import { PropertyFilterOperator } from '@cloudscape-design/collection-hooks';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import TokenList from '../internal/components/token-list';
 import { SearchResults } from '../text-filter/search-results';
 

--- a/src/s3-resource-selector/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/__tests__/main.test.tsx
@@ -6,7 +6,7 @@ import S3ResourceSelector, { S3ResourceSelectorProps } from '../../../lib/compon
 import createWrapper, { S3ResourceSelectorWrapper } from '../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from './fixtures';
 import FormField from '../../../lib/components/form-field';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 jest.setTimeout(10_000);
 

--- a/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
+++ b/src/s3-resource-selector/__tests__/s3-in-context.test.tsx
@@ -7,7 +7,7 @@ import FormField from '../../../lib/components/form-field';
 import S3ResourceSelector from '../../../lib/components/s3-resource-selector';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from './fixtures';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const defaultProps = {
   resource: { uri: '' },

--- a/src/s3-resource-selector/s3-in-context/index.tsx
+++ b/src/s3-resource-selector/s3-in-context/index.tsx
@@ -15,7 +15,7 @@ import { validate, getErrorText } from './validation';
 import styles from './styles.css.js';
 import { SearchInput } from './search-input';
 import LiveRegion from '../../internal/components/live-region';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 interface S3InContextProps {
   i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined;

--- a/src/s3-resource-selector/s3-in-context/validation.ts
+++ b/src/s3-resource-selector/s3-in-context/validation.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentFormatFunction } from '../../internal/i18n/context';
+import { ComponentFormatFunction } from '../../i18n/context';
 import { S3ResourceSelectorProps } from '../interfaces';
 
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -14,7 +14,7 @@ import useForwardFocus, { ForwardFocusRef } from '../../internal/hooks/forward-f
 import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
 import { S3ResourceSelectorProps } from '../interfaces';
 import { EmptyState } from './empty-state';
-import { ComponentFormatFunction } from '../../internal/i18n/context';
+import { ComponentFormatFunction } from '../../i18n/context';
 
 interface BasicS3TableStrings<T> {
   labelRefresh?: string;

--- a/src/s3-resource-selector/s3-modal/buckets-table.tsx
+++ b/src/s3-resource-selector/s3-modal/buckets-table.tsx
@@ -8,7 +8,7 @@ import { S3ResourceSelectorProps } from '../interfaces';
 import { compareDates, getColumnAriaLabel, includes } from './table-utils';
 import { formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 interface BucketsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -14,7 +14,7 @@ import { ObjectsTable } from './objects-table';
 import { VersionsTable } from './versions-table';
 import styles from './styles.css.js';
 import { joinObjectPath } from '../utils';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 export interface S3ModalProps {
   alert: React.ReactNode;

--- a/src/s3-resource-selector/s3-modal/objects-table.tsx
+++ b/src/s3-resource-selector/s3-modal/objects-table.tsx
@@ -10,7 +10,7 @@ import { ForwardFocusRef } from '../../internal/hooks/forward-focus';
 import { formatSize, formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
 import { joinObjectPath } from '../utils';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 interface ObjectsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;

--- a/src/s3-resource-selector/s3-modal/table-utils.ts
+++ b/src/s3-resource-selector/s3-modal/table-utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { S3ResourceSelectorProps } from '../interfaces';
 import { TableProps } from '../../table/interfaces';
-import { ComponentFormatFunction } from '../../internal/i18n/context';
+import { ComponentFormatFunction } from '../../i18n/context';
 
 export function includes<T>(array: ReadonlyArray<T> | undefined, item: T) {
   return !!array && array.indexOf(item) > -1;

--- a/src/s3-resource-selector/s3-modal/versions-table.tsx
+++ b/src/s3-resource-selector/s3-modal/versions-table.tsx
@@ -8,7 +8,7 @@ import { ForwardFocusRef } from '../../internal/hooks/forward-focus';
 import { formatSize, formatDefault } from './column-formats';
 import { BasicS3Table, getSharedI18Strings } from './basic-table';
 import { joinObjectPath } from '../utils';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 interface VersionsTableProps {
   forwardFocusRef: React.Ref<ForwardFocusRef>;

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -30,7 +30,7 @@ import { OptionGroup } from '../internal/components/option/interfaces.js';
 import { SomeRequired } from '../internal/types';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
-import { useInternalI18n } from '../internal/i18n/context.js';
+import { useInternalI18n } from '../i18n/context.js';
 
 export interface InternalSelectProps extends SomeRequired<SelectProps, 'options'>, InternalBaseComponentProps {
   __inFilteringToken?: boolean;

--- a/src/split-panel/__tests__/split-panel.test.tsx
+++ b/src/split-panel/__tests__/split-panel.test.tsx
@@ -11,7 +11,7 @@ import {
 import createWrapper, { SplitPanelWrapper } from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/split-panel/styles.css.js';
 import { defaultSplitPanelContextProps } from './helpers';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const onKeyDown = jest.fn();
 jest.mock('../../../lib/components/app-layout/utils/use-keyboard-events', () => ({

--- a/src/split-panel/index.tsx
+++ b/src/split-panel/index.tsx
@@ -25,7 +25,7 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { SplitPanelContentSide } from './side';
 import { SplitPanelContentBottom } from './bottom';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { SplitPanelProps };
 

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -9,7 +9,7 @@ import { renderHook } from '../../__tests__/render-hook';
 import styles from '../../../lib/components/table/header-cell/styles.css.js';
 import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
 import { useStickyColumns } from '../../../lib/components/table/sticky-columns';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const testItem = {
   test: 'test',

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -8,7 +8,7 @@ import { TableProps } from '../interfaces';
 import { TableTdElement, TableTdElementProps } from './td-element';
 import { InlineEditor } from './inline-editor';
 import LiveRegion from '../../internal/components/live-region/index.js';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 import { usePrevious } from '../../internal/hooks/use-previous';
 
 const submitHandlerFallback = () => {

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -10,7 +10,7 @@ import styles from './styles.css.js';
 import { Optional } from '../../internal/types';
 import FocusLock, { FocusLockRef } from '../../internal/components/focus-lock';
 import LiveRegion from '../../internal/components/live-region';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 
 // A function that does nothing
 const noop = () => undefined;

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -11,7 +11,7 @@ import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { InteractiveComponent } from '../thead';
 import { getStickyClassNames } from '../utils';
-import { useInternalI18n } from '../../internal/i18n/context';
+import { useInternalI18n } from '../../i18n/context';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -7,7 +7,7 @@ import Tabs, { TabsProps } from '../../../lib/components/tabs';
 import styles from '../../../lib/components/tabs/styles.css.js';
 import createWrapper, { TabsWrapper } from '../../../lib/components/test-utils/dom';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 let mockHorizontalOverflow = false;
 jest.mock('../../../lib/components/tabs/scroll-utils', () => {

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -15,7 +15,7 @@ import {
 } from './scroll-utils';
 import { hasModifierKeys, isPlainLeftClick } from '../internal/events';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 
 export interface TabHeaderBarProps {

--- a/src/tag-editor/__tests__/tag-editor.test.tsx
+++ b/src/tag-editor/__tests__/tag-editor.test.tsx
@@ -7,7 +7,7 @@ import TagEditor, { TagEditorProps } from '../../../lib/components/tag-editor';
 import createWrapper, { TagEditorWrapper } from '../../../lib/components/test-utils/dom';
 
 import { i18nStrings, MAX_KEY_LENGTH, MAX_VALUE_LENGTH } from './common';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 const defaultProps = {
   i18nStrings,

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -24,7 +24,7 @@ import styles from './styles.css.js';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import LiveRegion from '../internal/components/live-region';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export { TagEditorProps };
 

--- a/src/tag-editor/validation.ts
+++ b/src/tag-editor/validation.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentFormatFunction } from '../internal/i18n/context';
+import { ComponentFormatFunction } from '../i18n/context';
 import { TagEditorProps } from './interfaces';
 
 /**

--- a/src/token-group/__tests__/token-group.test.tsx
+++ b/src/token-group/__tests__/token-group.test.tsx
@@ -11,7 +11,7 @@ import icons from '../../../lib/components/icon/icons';
 import selectors from '../../../lib/components/token-group/styles.selectors.js';
 import optionSelectors from '../../../lib/components/internal/components/option/styles.selectors.js';
 import tokenListSelectors from '../../../lib/components/internal/components/token-list/styles.selectors.js';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 function renderTokenGroup(props: TokenGroupProps = {}): TokenGroupWrapper {
   const { container } = render(<TokenGroup {...props} />);

--- a/src/top-navigation/__tests__/top-navigation.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation.test.tsx
@@ -10,7 +10,7 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import TopNavigationWrapper, {
   OverflowMenu as OverflowMenuWrapper,
 } from '../../../lib/components/test-utils/dom/top-navigation';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 
 export const I18N_STRINGS: TopNavigationProps.I18nStrings = {
   searchIconAriaLabel: 'Search',

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -19,7 +19,7 @@ import { ButtonTrigger } from '../internal/components/menu-dropdown';
 import styles from './styles.css.js';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { SomeRequired } from '../internal/types';
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 export type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
 

--- a/src/top-navigation/parts/overflow-menu/index.tsx
+++ b/src/top-navigation/parts/overflow-menu/index.tsx
@@ -10,7 +10,7 @@ import { HeaderProps } from './header';
 
 import styles from '../../styles.css.js';
 import { TopNavigationProps } from '../../interfaces';
-import { useInternalI18n } from '../../../internal/i18n/context';
+import { useInternalI18n } from '../../../i18n/context';
 interface OverflowMenuProps {
   headerText?: string;
   items?: TopNavigationProps['utilities'];

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -7,7 +7,7 @@ import liveRegionStyles from '../../../lib/components/internal/components/live-r
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Button from '../../../lib/components/button';
 import Wizard, { WizardProps } from '../../../lib/components/wizard';
-import TestI18nProvider from '../../../lib/components/internal/i18n/testing';
+import TestI18nProvider from '../../../lib/components/i18n/testing';
 import styles from '../../../lib/components/wizard/styles.selectors.js';
 
 import { DEFAULT_I18N_SETS, DEFAULT_STEPS } from './common';

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -13,7 +13,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
-import { useInternalI18n } from '../internal/i18n/context';
+import { useInternalI18n } from '../i18n/context';
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';


### PR DESCRIPTION
### Description

Okay, so... everyone we asked to use `/internal/i18n` before we released it has switched out to `/i18n`. Let's nip this tech debt in the bud.

Most of it is path updates. The only meaningful changes are under `build-tools` and `src/internal/i18n` (now gone).

Related links, issue #, if available: n/a

### How has this been tested?

Existing tests should pass. Also manually inspected the built messages to make sure everything checked out.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
