### PR TITLE
feat: Add `focus` method to alert

### DIFF
--- a/pages/alert/simple.page.tsx
+++ b/pages/alert/simple.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import Alert from '~components/alert';
+import Button from '~components/button';
 import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
 import SpaceBetween from '~components/space-between';
@@ -16,6 +17,7 @@ export default function AlertScenario() {
     <I18nProvider messages={[messages]} locale="en">
       <article>
         <h1>Simple alert</h1>
+        <Button onClick={() => setVisible(!visible)}>Toggle visibility</Button>
         <ScreenshotArea>
           <SpaceBetween size="s">
             <div className={styles['alert-container']}>
@@ -27,6 +29,7 @@ export default function AlertScenario() {
                 buttonText="Button text"
                 type="warning"
                 onDismiss={() => setVisible(false)}
+                autoFocus={true}
               >
                 Content
                 <br />

--- a/pages/alert/simple.page.tsx
+++ b/pages/alert/simple.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
-import Alert from '~components/alert';
+import React, { useEffect, useRef, useState } from 'react';
+import Alert, { AlertProps } from '~components/alert';
 import Button from '~components/button';
 import Link from '~components/link';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -13,6 +13,14 @@ import messages from '~components/i18n/messages/all.en';
 
 export default function AlertScenario() {
   const [visible, setVisible] = useState(true);
+  const alertRef = useRef<AlertProps.Ref>(null);
+
+  useEffect(() => {
+    if (visible) {
+      alertRef.current?.focus();
+    }
+  }, [visible]);
+
   return (
     <I18nProvider messages={[messages]} locale="en">
       <article>
@@ -29,7 +37,7 @@ export default function AlertScenario() {
                 buttonText="Button text"
                 type="warning"
                 onDismiss={() => setVisible(false)}
-                autoFocus={true}
+                ref={alertRef}
               >
                 Content
                 <br />

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -16,16 +16,16 @@ when the \`dismissible\` property is set to \`true\`.",
       "name": "onDismiss",
     },
   ],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets focus on the alert content.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "Alert",
   "properties": Array [
-    Object {
-      "description": "Automatically focuses the alert when component is mounted.
-Use this when the alert should immediately notify the user of a critical error.",
-      "name": "autoFocus",
-      "optional": true,
-      "type": "boolean",
-    },
     Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
@@ -61,7 +61,7 @@ An \`onDismiss\` event is fired when a user clicks the button.",
       "type": "string",
     },
     Object {
-      "defaultValue": "\\"info\\"",
+      "defaultValue": "'info'",
       "description": "Specifies the type of message you want to display.",
       "inlineType": Object {
         "name": "AlertProps.Type",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -20,6 +20,13 @@ when the \`dismissible\` property is set to \`true\`.",
   "name": "Alert",
   "properties": Array [
     Object {
+      "description": "Automatically focuses the alert when component is mounted.
+Use this when the alert should immediately notify the user of a critical error.",
+      "name": "autoFocus",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -105,6 +105,12 @@ describe('Alert Component', () => {
       wrapper.findDismissButton()!.click();
       expect(onDismissSpy).toHaveBeenCalled();
     });
+    it('can be focused through the API', () => {
+      let ref: AlertProps.Ref | null = null;
+      render(<Alert header="Important" ref={element => (ref = element)} />);
+      ref!.focus();
+      expect(document.activeElement).toHaveTextContent('Important');
+    });
   });
 
   it('renders `action` content', () => {

--- a/src/alert/__tests__/alert.test.tsx
+++ b/src/alert/__tests__/alert.test.tsx
@@ -109,7 +109,7 @@ describe('Alert Component', () => {
       let ref: AlertProps.Ref | null = null;
       render(<Alert header="Important" ref={element => (ref = element)} />);
       ref!.focus();
-      expect(document.activeElement).toHaveTextContent('Important');
+      expect(document.activeElement).toHaveClass(styles['alert-focus-wrapper']);
     });
   });
 

--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -11,47 +11,50 @@ import { getNameFromSelector, getSubStepAllSelector } from '../internal/analytic
 
 export { AlertProps };
 
-export default function Alert({ type = 'info', visible = true, ...props }: AlertProps) {
-  const baseComponentProps = useBaseComponent('Alert');
+const Alert = React.forwardRef(
+  ({ type = 'info', visible = true, ...props }: AlertProps, ref: React.Ref<AlertProps.Ref>) => {
+    const baseComponentProps = useBaseComponent('Alert');
 
-  const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
-  const { stepNumber, stepNameSelector } = useFunnelStep();
-  const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
+    const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
+    const { stepNumber, stepNameSelector } = useFunnelStep();
+    const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
-  useEffect(() => {
-    if (funnelInteractionId && visible && type === 'error' && funnelState.current !== 'complete') {
-      const stepName = getNameFromSelector(stepNameSelector);
-      const subStepName = getNameFromSelector(subStepNameSelector);
+    useEffect(() => {
+      if (funnelInteractionId && visible && type === 'error' && funnelState.current !== 'complete') {
+        const stepName = getNameFromSelector(stepNameSelector);
+        const subStepName = getNameFromSelector(subStepNameSelector);
 
-      errorCount.current++;
+        errorCount.current++;
 
-      if (subStepSelector) {
-        FunnelMetrics.funnelSubStepError({
-          funnelInteractionId,
-          subStepSelector,
-          subStepName,
-          subStepNameSelector,
-          stepNumber,
-          stepName,
-          stepNameSelector,
-          subStepAllSelector: getSubStepAllSelector(),
-        });
-      } else {
-        FunnelMetrics.funnelError({
-          funnelInteractionId,
-        });
+        if (subStepSelector) {
+          FunnelMetrics.funnelSubStepError({
+            funnelInteractionId,
+            subStepSelector,
+            subStepName,
+            subStepNameSelector,
+            stepNumber,
+            stepName,
+            stepNameSelector,
+            subStepAllSelector: getSubStepAllSelector(),
+          });
+        } else {
+          FunnelMetrics.funnelError({
+            funnelInteractionId,
+          });
+        }
+
+        return () => {
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+          errorCount.current--;
+        };
       }
 
-      return () => {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        errorCount.current--;
-      };
-    }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [funnelInteractionId, visible, submissionAttempt, errorCount]);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [funnelInteractionId, visible, submissionAttempt, errorCount]);
-
-  return <InternalAlert type={type} visible={visible} {...props} {...baseComponentProps} />;
-}
+    return <InternalAlert type={type} visible={visible} {...props} {...baseComponentProps} ref={ref} />;
+  }
+);
 
 applyDisplayName(Alert, 'Alert');
+export default Alert;

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -53,6 +53,13 @@ export interface AlertProps extends BaseComponentProps {
    * Although it is technically possible to insert any content, our UX guidelines only allow you to add a button.
    */
   action?: React.ReactNode;
+
+  /**
+   * Automatically focuses the alert when component is mounted.
+   * Use this when the alert should immediately notify the user of a critical error.
+   */
+  autoFocus?: boolean;
+
   /**
    * Fired when the user clicks the close icon that is displayed
    * when the `dismissible` property is set to `true`.

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -60,7 +60,6 @@ export interface AlertProps extends BaseComponentProps {
    * Although it is technically possible to insert any content, our UX guidelines only allow you to add a button.
    */
   action?: React.ReactNode;
-
   /**
    * Fired when the user clicks the close icon that is displayed
    * when the `dismissible` property is set to `true`.

--- a/src/alert/interfaces.ts
+++ b/src/alert/interfaces.ts
@@ -6,6 +6,13 @@ import { NonCancelableEventHandler } from '../internal/events';
 
 export namespace AlertProps {
   export type Type = 'success' | 'error' | 'warning' | 'info';
+
+  export interface Ref {
+    /**
+     * Sets focus on the alert content.
+     */
+    focus(): void;
+  }
 }
 
 export interface AlertProps extends BaseComponentProps {
@@ -53,12 +60,6 @@ export interface AlertProps extends BaseComponentProps {
    * Although it is technically possible to insert any content, our UX guidelines only allow you to add a button.
    */
   action?: React.ReactNode;
-
-  /**
-   * Automatically focuses the alert when component is mounted.
-   * Use this when the alert should immediately notify the user of a critical error.
-   */
-  autoFocus?: boolean;
 
   /**
    * Fired when the user clicks the close icon that is displayed

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -98,9 +98,9 @@ const InternalAlert = React.forwardRef(
                   {header && <div className={styles.header}>{header}</div>}
                   <div className={styles.content}>{children}</div>
                 </div>
-                {hasAction && <div className={styles.action}>{actionButton}</div>}
               </div>
             </div>
+            {hasAction && <div className={styles.action}>{actionButton}</div>}
             {dismissible && (
               <div className={styles.dismiss}>
                 <InternalButton

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
@@ -37,6 +37,7 @@ export default function InternalAlert({
   header,
   buttonText,
   action,
+  autoFocus,
   onDismiss,
   onButtonClick,
   __internalRootRef = null,
@@ -45,6 +46,7 @@ export default function InternalAlert({
   const baseProps = getBaseProps(rest);
   const i18n = useInternalI18n('alert');
 
+  const focusRef = useRef<HTMLDivElement>(null);
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
   const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
@@ -66,6 +68,12 @@ export default function InternalAlert({
     [DATA_ATTR_ANALYTICS_ALERT]: type,
   };
 
+  useEffect(() => {
+    if (autoFocus && visible && focusRef.current) {
+      focusRef.current.focus();
+    }
+  }, [autoFocus, visible, focusRef]);
+
   return (
     <div
       {...baseProps}
@@ -81,15 +89,17 @@ export default function InternalAlert({
     >
       <VisualContext contextName="alert">
         <div className={clsx(styles.alert, styles[`type-${type}`])}>
-          <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
-            <InternalIcon name={typeToIcon[type]} size={size} />
-          </div>
-          <div className={styles.body}>
-            <div className={clsx(styles.message, styles.text)}>
-              {header && <div className={styles.header}>{header}</div>}
-              <div className={styles.content}>{children}</div>
+          <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
+            <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
+              <InternalIcon name={typeToIcon[type]} size={size} />
             </div>
-            {hasAction && <div className={styles.action}>{actionButton}</div>}
+            <div className={styles.body}>
+              <div className={clsx(styles.message, styles.text)}>
+                {header && <div className={styles.header}>{header}</div>}
+                <div className={styles.content}>{children}</div>
+              </div>
+              {hasAction && <div className={styles.action}>{actionButton}</div>}
+            </div>
           </div>
           {dismissible && (
             <div className={styles.dismiss}>

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import clsx from 'clsx';
 import { InternalButton } from '../button/internal';
 import { IconProps } from '../icon/interfaces';
@@ -11,6 +11,7 @@ import styles from './styles.css.js';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import useForwardFocus from '../internal/hooks/forward-focus';
 import { AlertProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -27,94 +28,96 @@ const typeToIcon: Record<AlertProps.Type, IconProps['name']> = {
 
 type InternalAlertProps = SomeRequired<AlertProps, 'type'> & InternalBaseComponentProps;
 
-export default function InternalAlert({
-  type,
-  statusIconAriaLabel,
-  visible = true,
-  dismissible,
-  dismissAriaLabel,
-  children,
-  header,
-  buttonText,
-  action,
-  autoFocus,
-  onDismiss,
-  onButtonClick,
-  __internalRootRef = null,
-  ...rest
-}: InternalAlertProps) {
-  const baseProps = getBaseProps(rest);
-  const i18n = useInternalI18n('alert');
+const InternalAlert = React.forwardRef(
+  (
+    {
+      type,
+      statusIconAriaLabel,
+      visible = true,
+      dismissible,
+      dismissAriaLabel,
+      children,
+      header,
+      buttonText,
+      action,
+      onDismiss,
+      onButtonClick,
+      __internalRootRef = null,
+      ...rest
+    }: InternalAlertProps,
+    ref: React.Ref<AlertProps.Ref>
+  ) => {
+    const baseProps = getBaseProps(rest);
+    const i18n = useInternalI18n('alert');
 
-  const focusRef = useRef<HTMLDivElement>(null);
-  const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
+    const focusRef = useRef<HTMLDivElement>(null);
+    useForwardFocus(ref, focusRef);
 
-  const isRefresh = useVisualRefresh();
-  const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
+    const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
+    const mergedRef = useMergeRefs(breakpointRef, __internalRootRef);
 
-  const actionButton = action || (
-    <InternalButton
-      className={styles['action-button']}
-      onClick={() => fireNonCancelableEvent(onButtonClick)}
-      formAction="none"
-    >
-      {buttonText}
-    </InternalButton>
-  );
+    const isRefresh = useVisualRefresh();
+    const size = isRefresh ? 'normal' : header && children ? 'big' : 'normal';
 
-  const hasAction = Boolean(action || buttonText);
-  const analyticsAttributes = {
-    [DATA_ATTR_ANALYTICS_ALERT]: type,
-  };
+    const actionButton = action || (
+      <InternalButton
+        className={styles['action-button']}
+        onClick={() => fireNonCancelableEvent(onButtonClick)}
+        formAction="none"
+      >
+        {buttonText}
+      </InternalButton>
+    );
 
-  useEffect(() => {
-    if (autoFocus && visible && focusRef.current) {
-      focusRef.current.focus();
-    }
-  }, [autoFocus, visible, focusRef]);
+    const hasAction = Boolean(action || buttonText);
+    const analyticsAttributes = {
+      [DATA_ATTR_ANALYTICS_ALERT]: type,
+    };
 
-  return (
-    <div
-      {...baseProps}
-      {...analyticsAttributes}
-      aria-hidden={!visible}
-      className={clsx(
-        styles.root,
-        { [styles.hidden]: !visible },
-        baseProps.className,
-        styles[`breakpoint-${breakpoint}`]
-      )}
-      ref={mergedRef}
-    >
-      <VisualContext contextName="alert">
-        <div className={clsx(styles.alert, styles[`type-${type}`])}>
-          <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
-            <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
-              <InternalIcon name={typeToIcon[type]} size={size} />
-            </div>
-            <div className={styles.body}>
-              <div className={clsx(styles.message, styles.text)}>
-                {header && <div className={styles.header}>{header}</div>}
-                <div className={styles.content}>{children}</div>
+    return (
+      <div
+        {...baseProps}
+        {...analyticsAttributes}
+        aria-hidden={!visible}
+        className={clsx(
+          styles.root,
+          { [styles.hidden]: !visible },
+          baseProps.className,
+          styles[`breakpoint-${breakpoint}`]
+        )}
+        ref={mergedRef}
+      >
+        <VisualContext contextName="alert">
+          <div className={clsx(styles.alert, styles[`type-${type}`])}>
+            <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
+              <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
+                <InternalIcon name={typeToIcon[type]} size={size} />
               </div>
-              {hasAction && <div className={styles.action}>{actionButton}</div>}
+              <div className={styles.body}>
+                <div className={clsx(styles.message, styles.text)}>
+                  {header && <div className={styles.header}>{header}</div>}
+                  <div className={styles.content}>{children}</div>
+                </div>
+                {hasAction && <div className={styles.action}>{actionButton}</div>}
+              </div>
             </div>
+            {dismissible && (
+              <div className={styles.dismiss}>
+                <InternalButton
+                  className={styles['dismiss-button']}
+                  variant="icon"
+                  iconName="close"
+                  formAction="none"
+                  ariaLabel={i18n('dismissAriaLabel', dismissAriaLabel)}
+                  onClick={() => fireNonCancelableEvent(onDismiss)}
+                />
+              </div>
+            )}
           </div>
-          {dismissible && (
-            <div className={styles.dismiss}>
-              <InternalButton
-                className={styles['dismiss-button']}
-                variant="icon"
-                iconName="close"
-                formAction="none"
-                ariaLabel={i18n('dismissAriaLabel', dismissAriaLabel)}
-                onClick={() => fireNonCancelableEvent(onDismiss)}
-              />
-            </div>
-          )}
-        </div>
-      </VisualContext>
-    </div>
-  );
-}
+        </VisualContext>
+      </div>
+    );
+  }
+);
+
+export default InternalAlert;

--- a/src/alert/internal.tsx
+++ b/src/alert/internal.tsx
@@ -88,19 +88,21 @@ const InternalAlert = React.forwardRef(
         ref={mergedRef}
       >
         <VisualContext contextName="alert">
-          <div className={clsx(styles.alert, styles[`type-${type}`])}>
-            <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
-              <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
-                <InternalIcon name={typeToIcon[type]} size={size} />
-              </div>
-              <div className={styles.body}>
-                <div className={clsx(styles.message, styles.text)}>
-                  {header && <div className={styles.header}>{header}</div>}
-                  <div className={styles.content}>{children}</div>
+          <div className={clsx(styles.alert, styles[`type-${type}`], styles[`icon-size-${size}`])}>
+            <div className={styles['alert-mobile-block']}>
+              <div className={styles['alert-focus-wrapper']} tabIndex={-1} ref={focusRef}>
+                <div className={clsx(styles.icon, styles.text)} role="img" aria-label={statusIconAriaLabel}>
+                  <InternalIcon name={typeToIcon[type]} size={size} />
+                </div>
+                <div className={styles.body}>
+                  <div className={clsx(styles.message, styles.text)}>
+                    {header && <div className={styles.header}>{header}</div>}
+                    <div className={styles.content}>{children}</div>
+                  </div>
                 </div>
               </div>
+              {hasAction && <div className={styles.action}>{actionButton}</div>}
             </div>
-            {hasAction && <div className={styles.action}>{actionButton}</div>}
             {dismissible && (
               <div className={styles.dismiss}>
                 <InternalButton

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -53,6 +53,7 @@
 
 .alert-focus-wrapper {
   display: flex;
+  flex: 1 1 0%;
 
   &:focus {
     outline: none;

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -6,6 +6,7 @@
 @use 'sass:map';
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
+@use '../internal/hooks/focus-visible' as focus-visible;
 
 @use './motion';
 
@@ -48,6 +49,17 @@
 
 .action-button {
   /* used in test-utils */
+}
+
+.alert-focus-wrapper {
+  display: flex;
+
+  &:focus {
+    outline: none;
+  }
+  @include focus-visible.when-visible {
+    @include styles.focus-highlight(awsui.$space-button-focus-outline-gutter);
+  }
 }
 
 .text {

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -26,6 +26,9 @@
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
+  // display: grid;
+  grid-template-columns: auto auto 1fr;
+
   border-radius: awsui.$border-radius-alert;
   border: awsui.$border-field-width solid;
   padding: awsui.$space-alert-vertical awsui.$space-alert-horizontal;
@@ -63,6 +66,11 @@
   }
 }
 
+.alert-mobile-block {
+  display: flex;
+  flex: 1 1 0%;
+}
+
 .text {
   padding: awsui.$border-field-width 0; // To account for vertical misalignment due to button borders
   margin: awsui.$space-scaled-xxs awsui.$space-xxs;
@@ -78,11 +86,24 @@
 }
 
 /* stylelint-disable selector-max-type */
-.root.breakpoint-default > div > .alert > .alert-focus-wrapper > .body {
-  display: block;
-  & > .action {
-    margin-left: awsui.$space-xxs;
-    margin-bottom: awsui.$space-xxs;
+.root.breakpoint-default > div > .alert {
+  // Below the breakpoint, arrange actions below the content
+  & > .alert-mobile-block {
+    display: block;
+    & > .action {
+      margin-bottom: awsui.$space-xxs;
+    }
+  }
+
+  // Indent actions according to the size of the alert icon
+  &.icon-size-medium > .alert-mobile-block > .action {
+    margin-left: calc(#{awsui.$size-icon-medium} + #{awsui.$space-xs});
+  }
+  &.icon-size-big > .alert-mobile-block > .action {
+    margin-left: calc(#{awsui.$size-icon-big} + #{awsui.$space-xs});
+  }
+  &.icon-size-normal > .alert-mobile-block > .action {
+    margin-left: calc(#{awsui.$size-icon-normal} + #{awsui.$space-xs});
   }
 }
 /* stylelint-enable selector-max-type */
@@ -135,7 +156,7 @@ $_text-colors: (
   .type-#{$type} {
     border-color: #{map.get($_border-colors, $type)};
     background-color: #{map.get($_background-colors, $type)};
-    > .alert-focus-wrapper > .icon {
+    > .alert-mobile-block > .alert-focus-wrapper > .icon {
       color: #{map.get($_text-colors, $type)};
     }
   }

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -78,7 +78,7 @@
 }
 
 /* stylelint-disable selector-max-type */
-.root.breakpoint-default > div > .alert > .body {
+.root.breakpoint-default > div > .alert > .alert-focus-wrapper > .body {
   display: block;
   & > .action {
     margin-left: awsui.$space-xxs;
@@ -135,7 +135,7 @@ $_text-colors: (
   .type-#{$type} {
     border-color: #{map.get($_border-colors, $type)};
     background-color: #{map.get($_background-colors, $type)};
-    > .icon {
+    > .alert-focus-wrapper > .icon {
       color: #{map.get($_text-colors, $type)};
     }
   }


### PR DESCRIPTION
### Description
This change adds a `focus` method to the alert component. This allows keyboard focus to be moved to the alert component, similar to how critical flashbar messages can receive focus. This is helpful when an alert with critical information appears dynamically and needs to grab the user's attention.

Related links, issue #, if available: AWSUI-8869

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
