### PR TITLE
fix: Restore notification bar button focus ring color

### DIFF
--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -19,6 +19,7 @@ import { throttle } from '../internal/utils/throttle';
 import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { findUpUntil } from '../internal/utils/dom';
 import { useInternalI18n } from '../i18n/context';
+import { getVisualContextClassname } from '../internal/components/visual-context';
 
 export { FlashbarProps };
 
@@ -311,7 +312,8 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
               isVisualRefresh && styles['visual-refresh'],
               isFlashbarStackExpanded ? styles.expanded : styles.collapsed,
               transitioning && styles['animation-running'],
-              items.length === 2 && styles['short-list']
+              items.length === 2 && styles['short-list'],
+              getVisualContextClassname('flashbar') // Visual context is needed for focus ring to be white
             )}
             onClick={toggleCollapseExpand}
             ref={notificationBarRef}


### PR DESCRIPTION
### Description

The focus ring of the notification bar button was almost-white (`grey-100`) because the `flashbar` visual context sets `colorBorderItemFocused` to this color. Since #1340 this context is set at the flash message level instead of the entire Flashbar component level, so this color token fell back to the default blue for this component.

This PR fixes it by applying (back) the `flashbar` visual context to the notification bar.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Manually tested against local server, for Classic and Visual Refresh, light and dark mode.

Visual regression tests exists are in place (that's why this was caught).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
