### PR TITLE
chore: Expose component configuration in DOM metadata property

### DIFF
--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -39,7 +39,7 @@ const Button = React.forwardRef(
     }: ButtonProps,
     ref: React.Ref<ButtonProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('Button');
+    const baseComponentProps = useBaseComponent('Button', { variant, disabled, loading });
     const baseProps = getBaseProps(props);
     return (
       <InternalButton

--- a/src/internal/hooks/use-base-component/index.ts
+++ b/src/internal/hooks/use-base-component/index.ts
@@ -15,9 +15,9 @@ export interface InternalBaseComponentProps {
  * attached to the (internal) component's root DOM node. The hook takes care of attaching the metadata to this
  * root DOM node and emits the telemetry for this component.
  */
-export default function useBaseComponent<T = any>(componentName: string) {
+export default function useBaseComponent<T = any>(componentName: string, componentConfiguration?: Record<string, any>) {
   useTelemetry(componentName);
   useFocusVisible();
-  const elementRef = useComponentMetadata<T>(componentName, PACKAGE_VERSION);
+  const elementRef = useComponentMetadata<T>(componentName, PACKAGE_VERSION, componentConfiguration);
   return { __internalRootRef: elementRef };
 }

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -20,7 +20,10 @@ const Select = React.forwardRef(
     }: SelectProps,
     ref: React.Ref<SelectProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('Select');
+    const baseComponentProps = useBaseComponent('Select', {
+      placeholder: restProps.placeholder,
+      disabled: restProps.disabled,
+    });
     const externalProps = getExternalProps(restProps);
     return (
       <InternalSelect


### PR DESCRIPTION
### Description

This PR extends some components (Select, Button) with more metadata. This metadata is exposed in the `__awsuiMetadata__` property of the component's root node. More components are covered in https://github.com/cloudscape-design/components/pull/1398.

See also https://github.com/cloudscape-design/component-toolkit/pull/35

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: document FZakAmaNW5fQ

### How has this been tested?

Extended unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
