### PR TITLE
fix: Correctly count maximum number of flashbar items based on message colors

### DIFF
--- a/pages/flashbar/collapsible.permutations.page.tsx
+++ b/pages/flashbar/collapsible.permutations.page.tsx
@@ -21,6 +21,13 @@ const permutations = createPermutations<FlashbarProps>([
         sampleNotifications.error,
         sampleNotifications.success,
       ],
+      [
+        sampleNotifications.info,
+        sampleNotifications['in-progress'],
+        sampleNotifications.warning,
+        sampleNotifications.error,
+        sampleNotifications.success,
+      ],
     ],
   },
 ]);

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -9,7 +9,7 @@ import InternalIcon from '../icon/internal';
 import { TransitionGroup } from 'react-transition-group';
 import { Transition } from '../internal/components/transition';
 import styles from './styles.css.js';
-import { counterTypes, getFlashTypeCount, getItemType, getVisibleCollapsedItems, StackableItem } from './utils';
+import { counterTypes, getFlashTypeCount, getItemColor, getVisibleCollapsedItems, StackableItem } from './utils';
 import { animate, getDOMRects } from '../internal/animate';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { IconProps } from '../icon/interfaces';
@@ -174,7 +174,7 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
 
   const countByType = getFlashTypeCount(items);
 
-  const numberOfColorsInStack = new Set(items.map(getItemType)).size;
+  const numberOfColorsInStack = new Set(items.map(getItemColor)).size;
   const maxSlots = Math.max(numberOfColorsInStack, 3);
   const stackDepth = Math.min(maxSlots, items.length);
 

--- a/src/flashbar/utils.ts
+++ b/src/flashbar/utils.ts
@@ -34,7 +34,7 @@ export function getItemType(item: FlashbarProps.MessageDefinition) {
   }
 }
 
-function getItemColor(item: FlashbarProps.MessageDefinition) {
+export function getItemColor(item: FlashbarProps.MessageDefinition) {
   return getColorFromType(getItemType(item));
 }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
