### PR TITLE
chore: Expose more component configuration in DOM metadata property

### DIFF
--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -12,7 +12,7 @@ import { getNameFromSelector, getSubStepAllSelector } from '../internal/analytic
 export { AlertProps };
 
 export default function Alert({ type = 'info', visible = true, ...props }: AlertProps) {
-  const baseComponentProps = useBaseComponent('Alert');
+  const baseComponentProps = useBaseComponent('Alert', { type, dismissible: props.dismissible, visible });
 
   const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
   const { stepNumber, stepNameSelector } = useFunnelStep();

--- a/src/autosuggest/index.tsx
+++ b/src/autosuggest/index.tsx
@@ -14,7 +14,7 @@ const Autosuggest = React.forwardRef(
     { filteringType = 'auto', statusType = 'finished', disableBrowserAutocorrect = false, ...props }: AutosuggestProps,
     ref: React.Ref<AutosuggestProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('Autosuggest');
+    const baseComponentProps = useBaseComponent('Autosuggest', { placeholder: props.placeholder });
     const externalProps = getExternalProps(props);
     return (
       <InternalAutosuggest

--- a/src/breadcrumb-group/index.tsx
+++ b/src/breadcrumb-group/index.tsx
@@ -12,7 +12,7 @@ export default function BreadcrumbGroup<T extends BreadcrumbGroupProps.Item = Br
   items = [],
   ...props
 }: BreadcrumbGroupProps<T>) {
-  const baseComponentProps = useBaseComponent('BreadcrumbGroup');
+  const baseComponentProps = useBaseComponent('BreadcrumbGroup', { items });
   return <InternalBreadcrumbGroup items={items} {...props} {...baseComponentProps} />;
 }
 

--- a/src/button-dropdown/index.tsx
+++ b/src/button-dropdown/index.tsx
@@ -28,7 +28,7 @@ const ButtonDropdown = React.forwardRef(
     }: ButtonDropdownProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('ButtonDropdown');
+    const baseComponentProps = useBaseComponent('ButtonDropdown', { variant, disabled, loading });
     const baseProps = getBaseProps(props);
     return (
       <InternalButtonDropdown

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -57,7 +57,7 @@ const Cards = React.forwardRef(function <T = any>(
   }: CardsProps<T>,
   ref: React.Ref<CardsProps.Ref>
 ) {
-  const { __internalRootRef } = useBaseComponent('Cards');
+  const { __internalRootRef } = useBaseComponent('Cards', { loading, selectedItems, selectionType, items, trackBy });
   const baseProps = getBaseProps(rest);
   const isRefresh = useVisualRefresh();
   const isMobile = useMobile();

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -9,7 +9,7 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 export { CheckboxProps };
 
 const Checkbox = React.forwardRef(({ ...props }: CheckboxProps, ref: React.Ref<CheckboxProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('Checkbox');
+  const baseComponentProps = useBaseComponent('Checkbox', { disabled: props.disabled, checked: props.checked });
   return <InternalCheckbox {...props} {...baseComponentProps} ref={ref} />;
 });
 

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -58,7 +58,7 @@ const DatePicker = React.forwardRef(
     }: DatePickerProps,
     ref: Ref<DatePickerProps.Ref>
   ) => {
-    const { __internalRootRef } = useBaseComponent('DatePicker');
+    const { __internalRootRef } = useBaseComponent('DatePicker', { value, readOnly, disabled });
     checkControlled('DatePicker', 'value', value, 'onChange', onChange);
 
     const contextLocale = useLocale();

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -109,7 +109,13 @@ const DateRangePicker = React.forwardRef(
     }: DateRangePickerProps,
     ref: Ref<DateRangePickerProps.Ref>
   ) => {
-    const { __internalRootRef } = useBaseComponent('DateRangePicker');
+    const { __internalRootRef } = useBaseComponent('DateRangePicker', {
+      value,
+      dateOnly,
+      rangeSelectorMode,
+      disabled,
+      readOnly,
+    });
     checkControlled('DateRangePicker', 'value', value, 'onChange', onChange);
 
     const normalizedTimeOffset = normalizeTimeOffset(value, getTimeOffset, timeOffset);

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -25,7 +25,7 @@ export function useFlashbar({
   onItemsRemoved?: (items: FlashbarProps.MessageDefinition[]) => void;
   onItemsChanged?: (options?: { allItemsHaveId?: boolean; isReducedMotion?: boolean }) => void;
 }) {
-  const { __internalRootRef } = useBaseComponent(componentName);
+  const { __internalRootRef } = useBaseComponent(componentName, { items });
   const allItemsHaveId = useMemo(() => items.every(item => 'id' in item), [items]);
   const baseProps = getBaseProps(restProps);
   const ref = useRef<HTMLDivElement | null>(null);

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -9,7 +9,7 @@ import { IconProps } from './interfaces';
 export { IconProps };
 
 export default function Icon({ size = 'normal', variant = 'normal', ...props }: IconProps) {
-  const baseComponentProps = useBaseComponent('Icon');
+  const baseComponentProps = useBaseComponent('Icon', { name: props.name });
   return <InternalIcon size={size} variant={variant} {...props} {...baseComponentProps} />;
 }
 

--- a/src/multiselect/index.tsx
+++ b/src/multiselect/index.tsx
@@ -21,7 +21,7 @@ const Multiselect = React.forwardRef(
     }: MultiselectProps,
     ref: React.Ref<MultiselectProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('Multiselect');
+    const baseComponentProps = useBaseComponent('Multiselect', { selectedOptions, options });
     return (
       <InternalMultiselect
         options={options}

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -9,7 +9,12 @@ import InternalPagination from './internal';
 export { PaginationProps };
 
 export default function Pagination(props: PaginationProps) {
-  const baseComponentProps = useBaseComponent('Pagination');
+  const baseComponentProps = useBaseComponent('Pagination', {
+    currentPageIndex: props.currentPageIndex,
+    pagesCount: props.pagesCount,
+    openEnd: props.openEnd,
+    disabled: props.disabled,
+  });
   return <InternalPagination {...props} {...baseComponentProps} />;
 }
 

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -31,7 +31,7 @@ export default function ProgressBar({
   onResultButtonClick,
   ...rest
 }: ProgressBarProps) {
-  const { __internalRootRef } = useBaseComponent('ProgressBar');
+  const { __internalRootRef } = useBaseComponent('ProgressBar', { status, value });
   const baseProps = getBaseProps(rest);
   const generatedName = useUniqueId('awsui-progress-bar-');
 

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -79,7 +79,7 @@ const PropertyFilter = React.forwardRef(
     }: PropertyFilterProps,
     ref: React.Ref<Ref>
   ) => {
-    const { __internalRootRef } = useBaseComponent('PropertyFilter');
+    const { __internalRootRef } = useBaseComponent('PropertyFilter', { disabled });
     const [removedTokenIndex, setRemovedTokenIndex] = useState<null | number>(null);
 
     const inputRef = useRef<AutosuggestInputRef>(null);

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -9,7 +9,7 @@ import InternalRadioGroup from './internal';
 export { RadioGroupProps };
 
 const RadioGroup = React.forwardRef((props: RadioGroupProps, ref: React.Ref<RadioGroupProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('RadioGroup');
+  const baseComponentProps = useBaseComponent('RadioGroup', { value: props.value, items: props.items });
   return <InternalRadioGroup ref={ref} {...props} {...baseComponentProps} />;
 });
 

--- a/src/segmented-control/index.tsx
+++ b/src/segmented-control/index.tsx
@@ -9,7 +9,10 @@ import InternalSegmentedControl from './internal';
 export { SegmentedControlProps };
 
 export default function SegmentedControl(props: SegmentedControlProps) {
-  const baseComponentProps = useBaseComponent('SegmentedControl');
+  const baseComponentProps = useBaseComponent('SegmentedControl', {
+    selectedId: props.selectedId,
+    options: props.options,
+  });
   return <InternalSegmentedControl {...props} {...baseComponentProps} />;
 }
 

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -23,6 +23,8 @@ const Select = React.forwardRef(
     const baseComponentProps = useBaseComponent('Select', {
       placeholder: restProps.placeholder,
       disabled: restProps.disabled,
+      options,
+      selectedOption: restProps.selectedOption,
     });
     const externalProps = getExternalProps(restProps);
     return (

--- a/src/side-navigation/index.tsx
+++ b/src/side-navigation/index.tsx
@@ -22,7 +22,7 @@ export default function SideNavigation({
   onChange,
   ...props
 }: SideNavigationProps) {
-  const { __internalRootRef } = useBaseComponent('SideNavigation');
+  const { __internalRootRef } = useBaseComponent('SideNavigation', { items, activeHref });
   const baseProps = getBaseProps(props);
   const parentMap = useMemo(() => generateExpandableItemsMapping(items), [items]);
 

--- a/src/status-indicator/index.tsx
+++ b/src/status-indicator/index.tsx
@@ -8,7 +8,7 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 export { StatusIndicatorProps };
 
 export default function StatusIndicator({ type = 'success', wrapText = true, ...props }: StatusIndicatorProps) {
-  const baseComponentProps = useBaseComponent('StatusIndicator');
+  const baseComponentProps = useBaseComponent('StatusIndicator', { type });
   return <InternalStatusIndicator type={type} wrapText={wrapText} {...props} {...baseComponentProps} />;
 }
 

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -12,7 +12,10 @@ const Table = React.forwardRef(
     { items = [], selectedItems = [], variant = 'container', contentDensity = 'comfortable', ...props }: TableProps<T>,
     ref: React.Ref<TableProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('Table');
+    const baseComponentProps = useBaseComponent('Table', {
+      loading: props.loading,
+      selectionType: props.selectionType,
+    });
     return (
       <InternalTable
         items={items}

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -40,7 +40,7 @@ export default function Tabs({
   for (const tab of tabs) {
     checkSafeUrl('Tabs', tab.href);
   }
-  const { __internalRootRef } = useBaseComponent('Tabs');
+
   const [idNamespace] = useState(() => nextGeneratedId());
 
   const [activeTabId, setActiveTabId] = useControllable(controlledTabId, onChange, firstEnabledTab(tabs)?.id ?? '', {
@@ -48,6 +48,8 @@ export default function Tabs({
     controlledProp: 'activeTabId',
     changeHandler: 'onChange',
   });
+
+  const { __internalRootRef } = useBaseComponent('Tabs', { tabs, activeTabId });
 
   const baseProps = getBaseProps(rest);
 

--- a/src/tag-editor/index.tsx
+++ b/src/tag-editor/index.tsx
@@ -50,7 +50,7 @@ const TagEditor = React.forwardRef(
     }: TagEditorProps,
     ref: React.Ref<TagEditorProps.Ref>
   ) => {
-    const baseComponentProps = useBaseComponent('TagEditor');
+    const baseComponentProps = useBaseComponent('TagEditor', { loading, tags });
     const i18n = useInternalI18n('tag-editor');
 
     const remainingTags = tagLimit - tags.filter(tag => !tag.markedForRemoval).length;

--- a/src/text-filter/index.tsx
+++ b/src/text-filter/index.tsx
@@ -9,7 +9,7 @@ import InternalTextFilter from './internal';
 export { TextFilterProps };
 
 const TextFilter = React.forwardRef((props: TextFilterProps, ref: React.Ref<TextFilterProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('TextFilter');
+  const baseComponentProps = useBaseComponent('TextFilter', { disabled: props.disabled });
   return <InternalTextFilter {...props} {...baseComponentProps} ref={ref} />;
 });
 

--- a/src/tiles/index.tsx
+++ b/src/tiles/index.tsx
@@ -9,7 +9,7 @@ import InternalTiles from './internal';
 export { TilesProps };
 
 const Tiles = React.forwardRef((props: TilesProps, ref: React.Ref<TilesProps.Ref>) => {
-  const baseComponentProps = useBaseComponent('Tiles');
+  const baseComponentProps = useBaseComponent('Tiles', { value: props.value, items: props.items });
   return <InternalTiles ref={ref} {...props} {...baseComponentProps} />;
 });
 

--- a/src/toggle/index.tsx
+++ b/src/toggle/index.tsx
@@ -9,7 +9,7 @@ import InternalToggle from './internal';
 export { ToggleProps };
 
 const Toggle = React.forwardRef<ToggleProps.Ref, ToggleProps>((props, ref) => {
-  const baseComponentProps = useBaseComponent('Toggle');
+  const baseComponentProps = useBaseComponent('Toggle', { disabled: props.disabled, checked: props.checked });
   return <InternalToggle {...props} {...baseComponentProps} ref={ref} />;
 });
 

--- a/src/token-group/index.tsx
+++ b/src/token-group/index.tsx
@@ -9,7 +9,7 @@ import InternalTokenGroup from './internal';
 export { TokenGroupProps };
 
 export default function TokenGroup({ items = [], alignment = 'horizontal', ...props }: TokenGroupProps) {
-  const baseComponentProps = useBaseComponent('TokenGroup');
+  const baseComponentProps = useBaseComponent('TokenGroup', { items });
   return <InternalTokenGroup items={items} alignment={alignment} {...props} {...baseComponentProps} />;
 }
 

--- a/src/tutorial-panel/index.tsx
+++ b/src/tutorial-panel/index.tsx
@@ -22,7 +22,7 @@ export default function TutorialPanel({
   downloadUrl,
   ...restProps
 }: TutorialPanelProps) {
-  const { __internalRootRef } = useBaseComponent('TutorialPanel');
+  const { __internalRootRef } = useBaseComponent('TutorialPanel', { loading });
 
   const baseProps = getBaseProps(restProps);
   const context = useContext(hotspotContext);

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -11,7 +11,7 @@ import InternalWizard from './internal';
 import { WizardProps } from './interfaces';
 
 function Wizard({ isLoadingNextStep = false, allowSkipTo = false, ...props }: WizardProps) {
-  const baseComponentProps = useBaseComponent('Wizard');
+  const baseComponentProps = useBaseComponent('Wizard', { steps: props.steps, isLoadingNextStep });
   const externalProps = getExternalProps(props);
 
   return (


### PR DESCRIPTION
### Description

This change extends the `__awsuiMetadata__` property of 28 components to include information about their configured properties.

It builds on https://github.com/cloudscape-design/components/pull/1391, build failures are expected until the other PR is merged.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Manual testing in the dev pages

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
