### PR TITLE
Refactor sticky columns

### DIFF
--- a/pages/table-fragments/sticky-columns-custom.page.tsx
+++ b/pages/table-fragments/sticky-columns-custom.page.tsx
@@ -3,7 +3,12 @@
 import React, { useState } from 'react';
 import SpaceBetween from '~components/space-between';
 import { Box, Checkbox, Container, Link } from '~components';
-import { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from '~components/table/sticky-columns';
+import {
+  useStickyColumns,
+  useStickyCellStyles,
+  useStickyWrapperStyles,
+  StickyColumnsModel,
+} from '~components/table/sticky-columns';
 import styles from './styles.scss';
 import { generateItems, Instance } from '../table/generate-data';
 import clsx from 'clsx';
@@ -26,6 +31,7 @@ export default function Page() {
     stickyColumnsFirst: 1,
     stickyColumnsLast: 1,
   });
+  const stickyWrapperStyles = useStickyWrapperStyles(stickyColumns);
   return (
     <Box margin="l">
       <SpaceBetween size="xl">
@@ -37,9 +43,9 @@ export default function Page() {
 
         <Container disableContentPaddings={true}>
           <div
-            ref={stickyColumns.refs.wrapper}
+            ref={stickyWrapperStyles.ref}
             className={clsx(styles['custom-table'], useWrapperPaddings && styles['use-wrapper-paddings'])}
-            style={stickyColumns.style.wrapper}
+            style={stickyWrapperStyles.style}
           >
             <table
               ref={stickyColumns.refs.table}

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -31,7 +31,7 @@ import LiveRegion from '../internal/components/live-region';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
 import { TableTdElement } from './body-cell/td-element';
-import { useStickyColumns } from './sticky-columns';
+import { useStickyColumns, useStickyWrapperStyles } from './sticky-columns';
 import { StickyScrollbar } from './sticky-scrollbar';
 import { checkColumnWidths } from './column-widths-utils';
 import { useMobile } from '../internal/hooks/use-mobile';
@@ -176,6 +176,7 @@ const InternalTable = React.forwardRef(
       stickyColumnsFirst: (stickyColumns?.first ?? 0) + (stickyColumns?.first && hasSelection ? 1 : 0),
       stickyColumnsLast: stickyColumns?.last || 0,
     });
+    const stickyWrapperStyles = useStickyWrapperStyles(stickyState);
 
     const hasEditableCells = !!columnDefinitions.find(col => col.editConfig);
     const tableRole = hasEditableCells ? 'grid' : 'table';
@@ -209,7 +210,7 @@ const InternalTable = React.forwardRef(
       tableRole,
     };
 
-    const wrapperRef = useMergeRefs(wrapperMeasureRef, wrapperRefObject, stickyState.refs.wrapper);
+    const wrapperRef = useMergeRefs(wrapperMeasureRef, wrapperRefObject, stickyWrapperStyles.ref);
     const tableRef = useMergeRefs(tableMeasureRef, tableRefObject, stickyState.refs.table);
 
     // Allows keyboard users to scroll horizontally with arrow keys by making the wrapper part of the tab sequence
@@ -307,6 +308,7 @@ const InternalTable = React.forwardRef(
               [styles['has-header']]: hasHeader,
             })}
             onScroll={handleScroll}
+            style={stickyWrapperStyles.style}
             {...wrapperProps}
           >
             {!!renderAriaLive && !!firstIndex && (

--- a/src/table/sticky-columns/index.ts
+++ b/src/table/sticky-columns/index.ts
@@ -2,4 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { StickyColumnsCellState } from './interfaces';
-export { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from './use-sticky-columns';
+export {
+  useStickyColumns,
+  useStickyCellStyles,
+  useStickyWrapperStyles,
+  StickyColumnsModel,
+} from './use-sticky-columns';

--- a/src/table/sticky-columns/index.ts
+++ b/src/table/sticky-columns/index.ts
@@ -1,9 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export {
-  useStickyColumns,
-  useStickyCellStyles,
-  StickyColumnsModel,
-  StickyColumnsCellState,
-} from './use-sticky-columns';
+export { StickyColumnsCellState } from './interfaces';
+export { useStickyColumns, useStickyCellStyles, StickyColumnsModel } from './use-sticky-columns';

--- a/src/table/sticky-columns/interfaces.ts
+++ b/src/table/sticky-columns/interfaces.ts
@@ -8,6 +8,7 @@ export interface StickyColumnsProps {
 }
 
 export interface StickyColumnsState {
+  hasStickyColumns: boolean;
   cellState: Record<PropertyKey, null | StickyColumnsCellState>;
   wrapperState: StickyColumnsWrapperState;
 }

--- a/src/table/sticky-columns/interfaces.ts
+++ b/src/table/sticky-columns/interfaces.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface StickyColumnsProps {
+  visibleColumns: readonly PropertyKey[];
+  stickyColumnsFirst: number;
+  stickyColumnsLast: number;
+}
+
+export interface StickyColumnsState {
+  cellState: Record<PropertyKey, null | StickyColumnsCellState>;
+  wrapperState: StickyColumnsWrapperState;
+}
+
+// Cell state is used to apply respective styles and offsets to sticky cells.
+export interface StickyColumnsCellState {
+  padLeft: boolean;
+  lastLeft: boolean;
+  lastRight: boolean;
+  offset: { left?: number; right?: number };
+}
+
+// Scroll padding is applied to table's wrapper so that the table scrolls when focus goes behind sticky column.
+export interface StickyColumnsWrapperState {
+  scrollPaddingLeft: number;
+  scrollPaddingRight: number;
+}
+
+export interface CellOffsets {
+  offsets: Map<PropertyKey, { first: number; last: number }>;
+  stickyWidthLeft: number;
+  stickyWidthRight: number;
+}

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -6,16 +6,18 @@ import AsyncStore from '../../area-chart/async-store';
 import { useStableEventHandler } from '../../internal/hooks/use-stable-event-handler';
 import { useResizeObserver } from '../../internal/hooks/container-queries';
 import clsx from 'clsx';
+import {
+  CellOffsets,
+  StickyColumnsCellState,
+  StickyColumnsProps,
+  StickyColumnsState,
+  StickyColumnsWrapperState,
+} from './interfaces';
+import { isCellStatesEqual, isWrapperStatesEqual, updateCellOffsets } from './utils';
 
 // We allow the table to have a minimum of 148px of available space besides the sum of the widths of the sticky columns
 // This value is an UX recommendation and is approximately 1/3 of our smallest breakpoint (465px)
 const MINIMUM_SCROLLABLE_SPACE = 148;
-
-interface StickyColumnsProps {
-  visibleColumns: readonly PropertyKey[];
-  stickyColumnsFirst: number;
-  stickyColumnsLast: number;
-}
 
 export interface StickyColumnsModel {
   isEnabled: boolean;
@@ -28,25 +30,6 @@ export interface StickyColumnsModel {
     wrapper: React.RefCallback<HTMLElement>;
     cell: (columnId: PropertyKey, node: null | HTMLElement) => void;
   };
-}
-
-export interface StickyColumnsState {
-  cellState: Record<PropertyKey, null | StickyColumnsCellState>;
-  wrapperState: StickyColumnsWrapperState;
-}
-
-// Cell state is used to apply respective styles and offsets to sticky cells.
-export interface StickyColumnsCellState {
-  padLeft: boolean;
-  lastLeft: boolean;
-  lastRight: boolean;
-  offset: { left?: number; right?: number };
-}
-
-// Scroll padding is applied to table's wrapper so that the table scrolls when focus goes behind sticky column.
-export interface StickyColumnsWrapperState {
-  scrollPaddingLeft: number;
-  scrollPaddingRight: number;
 }
 
 export function useStickyColumns({
@@ -169,7 +152,6 @@ export function useStickyCellStyles({
   columnId,
   getClassName,
 }: UseStickyCellStylesProps): StickyCellStyles {
-  const cellRef = useRef<HTMLElement>(null) as React.MutableRefObject<HTMLElement>;
   const setCell = stickyColumns.refs.cell;
 
   // unsubscribeRef to hold the function to unsubscribe from the store's updates
@@ -177,15 +159,14 @@ export function useStickyCellStyles({
 
   // refCallback updates the cell ref and sets up the store subscription
   const refCallback = useCallback(
-    node => {
+    cellElement => {
       if (unsubscribeRef.current) {
         // Unsubscribe before we do any updates to avoid leaving any subscriptions hanging
         unsubscribeRef.current();
       }
 
       // Update cellRef and the store's state to point to the new DOM node
-      cellRef.current = node;
-      setCell(columnId, node);
+      setCell(columnId, cellElement);
 
       // Update cell styles imperatively to avoid unnecessary re-renders.
       const selector = (state: StickyColumnsState) => state.cellState[columnId];
@@ -196,7 +177,6 @@ export function useStickyCellStyles({
         }
 
         const className = getClassName(state);
-        const cellElement = cellRef.current;
         if (cellElement) {
           Object.keys(className).forEach(key => {
             if (className[key]) {
@@ -212,7 +192,7 @@ export function useStickyCellStyles({
 
       // If the node is not null (i.e., the table cell is being mounted or updated, not unmounted),
       // set up a new subscription to the store's updates
-      if (node) {
+      if (cellElement) {
         unsubscribeRef.current = stickyColumns.store.subscribe(selector, (newState, prevState) => {
           updateCellStyles(selector(newState), selector(prevState));
         });
@@ -233,23 +213,6 @@ export function useStickyCellStyles({
   };
 }
 
-function isCellStatesEqual(s1: null | StickyColumnsCellState, s2: null | StickyColumnsCellState): boolean {
-  if (s1 && s2) {
-    return (
-      s1.padLeft === s2.padLeft &&
-      s1.lastLeft === s2.lastLeft &&
-      s1.lastRight === s2.lastRight &&
-      s1.offset.left === s2.offset.left &&
-      s1.offset.right === s2.offset.right
-    );
-  }
-  return s1 === s2;
-}
-
-function isWrapperStatesEqual(s1: StickyColumnsWrapperState, s2: StickyColumnsWrapperState): boolean {
-  return s1.scrollPaddingLeft === s2.scrollPaddingLeft && s1.scrollPaddingRight === s2.scrollPaddingRight;
-}
-
 interface UpdateCellStylesProps {
   wrapper: HTMLElement;
   table: HTMLElement;
@@ -260,9 +223,11 @@ interface UpdateCellStylesProps {
 }
 
 export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
-  private cellOffsets = new Map<PropertyKey, { first: number; last: number }>();
-  private stickyWidthLeft = 0;
-  private stickyWidthRight = 0;
+  private cellOffsets: CellOffsets = {
+    offsets: new Map(),
+    stickyWidthLeft: 0,
+    stickyWidthRight: 0,
+  };
   private isStuckToTheLeft = false;
   private isStuckToTheRight = false;
   private padLeft = false;
@@ -273,14 +238,17 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
 
   public updateCellStyles(props: UpdateCellStylesProps) {
     const hasStickyColumns = props.stickyColumnsFirst + props.stickyColumnsLast > 0;
-    const hadStickyColumns = this.cellOffsets.size > 0;
+    const hadStickyColumns = this.cellOffsets.offsets.size > 0;
 
     if (hasStickyColumns || hadStickyColumns) {
       this.updateScroll(props);
       this.updateCellOffsets(props);
       this.set(() => ({
         cellState: this.generateCellStyles(props),
-        wrapperState: { scrollPaddingLeft: this.stickyWidthLeft, scrollPaddingRight: this.stickyWidthRight },
+        wrapperState: {
+          scrollPaddingLeft: this.cellOffsets.stickyWidthLeft,
+          scrollPaddingRight: this.cellOffsets.stickyWidthRight,
+        },
       }));
     }
   }
@@ -321,8 +289,8 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
 
       // Determine the offset of the sticky column using the `cellOffsets` state object
       const isFirstColumn = index === 0;
-      const stickyColumnOffsetLeft = this.cellOffsets.get(columnId)?.first ?? 0;
-      const stickyColumnOffsetRight = this.cellOffsets.get(columnId)?.last ?? 0;
+      const stickyColumnOffsetLeft = this.cellOffsets.offsets.get(columnId)?.first ?? 0;
+      const stickyColumnOffsetRight = this.cellOffsets.offsets.get(columnId)?.last ?? 0;
 
       acc[columnId] = {
         padLeft: isFirstColumn && this.padLeft,
@@ -338,31 +306,7 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
   };
 
   private updateCellOffsets = (props: UpdateCellStylesProps): void => {
-    const firstColumnsWidths: number[] = [];
-    for (let i = 0; i < props.visibleColumns.length; i++) {
-      const element = props.cells[props.visibleColumns[i]];
-      const cellWidth = element.getBoundingClientRect().width ?? 0;
-      firstColumnsWidths[i] = (firstColumnsWidths[i - 1] ?? 0) + cellWidth;
-    }
-
-    const lastColumnsWidths: number[] = [];
-    for (let i = props.visibleColumns.length - 1; i >= 0; i--) {
-      const element = props.cells[props.visibleColumns[i]];
-      const cellWidth = element.getBoundingClientRect().width ?? 0;
-      lastColumnsWidths[i] = (lastColumnsWidths[i + 1] ?? 0) + cellWidth;
-    }
-    lastColumnsWidths.reverse();
-
-    this.stickyWidthLeft = firstColumnsWidths[props.stickyColumnsFirst - 1] ?? 0;
-    this.stickyWidthRight = lastColumnsWidths[props.stickyColumnsLast - 1] ?? 0;
-    this.cellOffsets = props.visibleColumns.reduce(
-      (map, columnId, columnIndex) =>
-        map.set(columnId, {
-          first: firstColumnsWidths[columnIndex - 1] ?? 0,
-          last: lastColumnsWidths[props.visibleColumns.length - 1 - columnIndex - 1] ?? 0,
-        }),
-      new Map()
-    );
+    this.cellOffsets = updateCellOffsets(props.cells, props);
   };
 
   private isEnabled = (props: UpdateCellStylesProps): boolean => {
@@ -378,7 +322,7 @@ export default class StickyColumnsStore extends AsyncStore<StickyColumnsState> {
       return false;
     }
 
-    const totalStickySpace = this.stickyWidthLeft + this.stickyWidthRight;
+    const totalStickySpace = this.cellOffsets.stickyWidthLeft + this.cellOffsets.stickyWidthRight;
     const tablePaddingLeft = parseFloat(getComputedStyle(props.table).paddingLeft) || 0;
     const tablePaddingRight = parseFloat(getComputedStyle(props.table).paddingRight) || 0;
     const hasEnoughScrollableSpace =

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -20,7 +20,6 @@ import { isCellStatesEqual, isWrapperStatesEqual, updateCellOffsets } from './ut
 const MINIMUM_SCROLLABLE_SPACE = 148;
 
 export interface StickyColumnsModel {
-  isEnabled: boolean;
   store: StickyColumnsStore;
   style: {
     wrapper?: React.CSSProperties;
@@ -125,7 +124,6 @@ export function useStickyColumns({
   }, []);
 
   return {
-    isEnabled: hasStickyColumns,
     store,
     style: {
       // Provide wrapper styles as props so that a re-render won't cause invalidation.

--- a/src/table/sticky-columns/utils.ts
+++ b/src/table/sticky-columns/utils.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CellOffsets, StickyColumnsCellState, StickyColumnsProps, StickyColumnsWrapperState } from './interfaces';
+
+export function isCellStatesEqual(s1: null | StickyColumnsCellState, s2: null | StickyColumnsCellState): boolean {
+  if (s1 && s2) {
+    return (
+      s1.padLeft === s2.padLeft &&
+      s1.lastLeft === s2.lastLeft &&
+      s1.lastRight === s2.lastRight &&
+      s1.offset.left === s2.offset.left &&
+      s1.offset.right === s2.offset.right
+    );
+  }
+  return s1 === s2;
+}
+
+export function isWrapperStatesEqual(s1: StickyColumnsWrapperState, s2: StickyColumnsWrapperState): boolean {
+  return s1.scrollPaddingLeft === s2.scrollPaddingLeft && s1.scrollPaddingRight === s2.scrollPaddingRight;
+}
+
+export function updateCellOffsets(cells: Record<PropertyKey, HTMLElement>, props: StickyColumnsProps): CellOffsets {
+  const firstColumnsWidths: number[] = [];
+  for (let i = 0; i < Math.min(props.visibleColumns.length, props.stickyColumnsFirst); i++) {
+    const element = cells[props.visibleColumns[i]];
+    const cellWidth = element.getBoundingClientRect().width ?? 0;
+    firstColumnsWidths[i] = (firstColumnsWidths[i - 1] ?? 0) + cellWidth;
+  }
+
+  const lastColumnsWidths: number[] = [];
+  for (let i = Math.min(props.visibleColumns.length, props.stickyColumnsLast) - 1; i >= 0; i--) {
+    const element = cells[props.visibleColumns[i]];
+    const cellWidth = element.getBoundingClientRect().width ?? 0;
+    lastColumnsWidths[i] = (lastColumnsWidths[i + 1] ?? 0) + cellWidth;
+  }
+  lastColumnsWidths.reverse();
+
+  const stickyWidthLeft = firstColumnsWidths[props.stickyColumnsFirst - 1] ?? 0;
+  const stickyWidthRight = lastColumnsWidths[props.stickyColumnsLast - 1] ?? 0;
+  const offsets = props.visibleColumns.reduce(
+    (map, columnId, columnIndex) =>
+      map.set(columnId, {
+        first: firstColumnsWidths[columnIndex - 1] ?? 0,
+        last: lastColumnsWidths[props.visibleColumns.length - 1 - columnIndex - 1] ?? 0,
+      }),
+    new Map()
+  );
+
+  return { offsets, stickyWidthLeft, stickyWidthRight };
+}


### PR DESCRIPTION
### Description

A first step in refactoring table sticky columns. As part of refactoring made a fix to apply table wrapper styles synchronously same as it is done for columns. The goal of refactoring is to make the util lifecycle better explicit with uniform refs and callbacks initialisation and a single useEffect to synchronise properties.

### How has this been tested?

Existing tests + dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
