### PR TITLE
feat: Allow dropdowns of autosuggest, select, and multiselect to expand beyond their trigger width

### DIFF
--- a/pages/autosuggest/virtual-resize.page.tsx
+++ b/pages/autosuggest/virtual-resize.page.tsx
@@ -39,7 +39,6 @@ export default function AutosuggestPage() {
           ariaLabel={'simple autosuggest'}
           selectedAriaLabel="Selected"
           virtualScroll={true}
-          expandToViewport={false}
         />
       </div>
     </div>

--- a/pages/autosuggest/virtual-resize.page.tsx
+++ b/pages/autosuggest/virtual-resize.page.tsx
@@ -10,7 +10,8 @@ declare const window: ExtendedWindow;
 
 const options = [
   {
-    value: 'A very long option label that wraps upon resizing',
+    value:
+      'A very very very very very very very very very very very very very long option label that wraps upon resizing',
     tags: ['tag1', 'tag2'],
     filteringTags: ['bla', 'opt'],
     description: 'description1',
@@ -38,6 +39,7 @@ export default function AutosuggestPage() {
           ariaLabel={'simple autosuggest'}
           selectedAriaLabel="Selected"
           virtualScroll={true}
+          expandToViewport={false}
         />
       </div>
     </div>

--- a/pages/select/virtual-resize.page.tsx
+++ b/pages/select/virtual-resize.page.tsx
@@ -10,7 +10,8 @@ declare const window: ExtendedWindow;
 
 const options = [
   {
-    value: 'A very long option label that wraps upon resizing',
+    value:
+      'A very very very very very very very very very very very very very long option label that wraps upon resizing',
     tags: ['tag1', 'tag2'],
     filteringTags: ['bla', 'opt'],
     description: 'description1',

--- a/pages/tag-editor/simple.page.tsx
+++ b/pages/tag-editor/simple.page.tsx
@@ -10,10 +10,15 @@ import Button from '~components/button';
 import { I18N_STRINGS } from './shared';
 
 const KEYS = range(15).map(i => `Tag ${i + 1}`);
-const VALUES = range(15).map(i => `Value ${i + 1}`);
+const VALUES = range(15).map(
+  i =>
+    `arn:aws:cloudformation:us-east-1:3850${i % 10}95${
+      (i + 3) % 10
+    }34:stack/apples-to-apples/324534634-234234-66-324235`
+);
 
 async function requestKeys(input: string): Promise<string[]> {
-  await new Promise(resolve => setTimeout(resolve, 2000));
+  await new Promise(resolve => setTimeout(resolve, 500));
   return KEYS.filter(key => key.indexOf(input) !== -1);
 }
 
@@ -21,7 +26,7 @@ async function requestValues(key: string, input: string): Promise<string[]> {
   if (!key) {
     return Promise.reject();
   }
-  await new Promise(resolve => setTimeout(resolve, 2000));
+  await new Promise(resolve => setTimeout(resolve, 500));
   return VALUES.map(value => `${key} - ${value}`).filter(value => value.indexOf(input) !== -1);
 }
 

--- a/pages/tag-editor/simple.page.tsx
+++ b/pages/tag-editor/simple.page.tsx
@@ -10,15 +10,10 @@ import Button from '~components/button';
 import { I18N_STRINGS } from './shared';
 
 const KEYS = range(15).map(i => `Tag ${i + 1}`);
-const VALUES = range(15).map(
-  i =>
-    `arn:aws:cloudformation:us-east-1:3850${i % 10}95${
-      (i + 3) % 10
-    }34:stack/apples-to-apples/324534634-234234-66-324235`
-);
+const VALUES = range(15).map(i => `Value ${i + 1}`);
 
 async function requestKeys(input: string): Promise<string[]> {
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await new Promise(resolve => setTimeout(resolve, 2000));
   return KEYS.filter(key => key.indexOf(input) !== -1);
 }
 
@@ -26,7 +21,7 @@ async function requestValues(key: string, input: string): Promise<string[]> {
   if (!key) {
     return Promise.reject();
   }
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await new Promise(resolve => setTimeout(resolve, 2000));
   return VALUES.map(value => `${key} - ${value}`).filter(value => value.indexOf(input) !== -1);
 }
 

--- a/src/internal/__tests__/breakpoints.test.ts
+++ b/src/internal/__tests__/breakpoints.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { getMatchingBreakpoint, matchBreakpointMapping } from '../breakpoints';
+import { getMatchingBreakpoint, matchBreakpointMapping, getBreakpointValue } from '../breakpoints';
 
 describe('getMatchingBreakpoint', () => {
   it('returns the correct breakpoint value', () => {
@@ -43,5 +43,22 @@ describe('matchBreakpointMapping', () => {
 
   it('returns null if the object is empty', () => {
     expect(matchBreakpointMapping({}, 'xl')).toBeNull();
+  });
+});
+
+describe('getBreakpointValue', () => {
+  it.each([
+    ['xl', 1840],
+    ['l', 1320],
+    ['m', 1120],
+    ['s', 912],
+    ['xs', 688],
+    ['xxs', 465],
+  ] as const)('returns correct value for %s', (breakpoint, value) => {
+    expect(getBreakpointValue(breakpoint)).toBe(value);
+  });
+
+  it('returns -1 for the default breakpoint', () => {
+    expect(getBreakpointValue('default')).toBe(-1);
   });
 });

--- a/src/internal/breakpoints.ts
+++ b/src/internal/breakpoints.ts
@@ -41,3 +41,7 @@ export function getMatchingBreakpoint(width: number, breakpointFilter?: readonly
   }
   return 'default';
 }
+
+export function getBreakpointValue(breakpoint: Breakpoint): number {
+  return BREAKPOINT_MAPPING.find(bp => bp[0] === breakpoint)![1];
+}

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -8,7 +8,7 @@ import Dropdown from '../dropdown';
 import { FormFieldValidationControlProps, useFormFieldContext } from '../../context/form-field-context';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
-import { getBreakpointValue } from '../../breakpoints';
+// import { getBreakpointValue } from '../../breakpoints';
 import InternalInput from '../../../input/internal';
 import {
   BaseChangeDetail,
@@ -255,7 +255,7 @@ const AutosuggestInput = React.forwardRef(
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <Dropdown
           minWidth={dropdownWidth}
-          maxWidth={getBreakpointValue('xxs')}
+          // maxWidth={getBreakpointValue('xxs')}
           stretchWidth={!dropdownWidth}
           stretchBeyondTriggerWidth={true}
           contentKey={dropdownContentKey}

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -8,6 +8,7 @@ import Dropdown from '../dropdown';
 import { FormFieldValidationControlProps, useFormFieldContext } from '../../context/form-field-context';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
+import { getBreakpointValue } from '../../breakpoints';
 import InternalInput from '../../../input/internal';
 import {
   BaseChangeDetail,
@@ -254,7 +255,9 @@ const AutosuggestInput = React.forwardRef(
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <Dropdown
           minWidth={dropdownWidth}
+          maxWidth={getBreakpointValue('xxs')}
           stretchWidth={!dropdownWidth}
+          stretchBeyondTriggerWidth={true}
           contentKey={dropdownContentKey}
           onFocus={handleFocus}
           onBlur={handleBlur}

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -8,7 +8,6 @@ import Dropdown from '../dropdown';
 import { FormFieldValidationControlProps, useFormFieldContext } from '../../context/form-field-context';
 import { BaseComponentProps, getBaseProps } from '../../base-component';
 import { BaseKeyDetail, fireCancelableEvent, fireNonCancelableEvent, NonCancelableEventHandler } from '../../events';
-// import { getBreakpointValue } from '../../breakpoints';
 import InternalInput from '../../../input/internal';
 import {
   BaseChangeDetail,
@@ -255,7 +254,6 @@ const AutosuggestInput = React.forwardRef(
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
         <Dropdown
           minWidth={dropdownWidth}
-          // maxWidth={getBreakpointValue('xxs')}
           stretchWidth={!dropdownWidth}
           stretchBeyondTriggerWidth={true}
           contentKey={dropdownContentKey}

--- a/src/internal/components/dropdown/__integ__/alignment.test.ts
+++ b/src/internal/components/dropdown/__integ__/alignment.test.ts
@@ -25,11 +25,7 @@ describe('Dropdown and trigger element alignment', () => {
         const dropdownBox = await page.getBoundingBox(wrapper.findDropdown({ expandToViewport }).toSelector());
         const triggerBox = await page.getBoundingBox(wrapper.findNativeInput().toSelector());
         expect(dropdownBox.left).toEqual(triggerBox.left);
-
-        // TODO: Remove the condition once AWSUI-16369 is resolved
-        if (!expandToViewport) {
-          expect(dropdownBox.width).toEqual(triggerBox.width);
-        }
+        expect(dropdownBox.width).toBeGreaterThanOrEqual(triggerBox.width);
       })();
     });
   });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -113,7 +113,7 @@ describe('getDropdownPosition', () => {
   test('adjusts left offset if preferCenter=true', () => {
     const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(200, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, true)).toEqual({
+    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, undefined, true)).toEqual({
       ...defaults,
       width: '200px',
       left: '-50px',
@@ -123,7 +123,7 @@ describe('getDropdownPosition', () => {
   test('does not change offset if preferCenter=true, but it does not fit', () => {
     const trigger = getSizedElement(100, 50, 300, 15);
     const dropdown = getSizedElement(200, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, true)).toEqual({
+    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, undefined, true)).toEqual({
       ...defaults,
       width: '200px',
     });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -29,13 +29,17 @@ describe('getDropdownPosition', () => {
   test('prefers dropping down by default', () => {
     const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual(defaults);
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual(defaults);
   });
 
   test('drops up if space above is not enough', () => {
     const trigger = getSizedElement(100, 50, 900, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       dropUp: true,
       height: '853px',
@@ -45,7 +49,9 @@ describe('getDropdownPosition', () => {
   test('drops left if dropdown is too wide', () => {
     const trigger = getSizedElement(100, 50, 300, 500);
     const dropdown = getSizedElement(600, 400);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       dropLeft: true,
       width: '550px',
@@ -55,7 +61,9 @@ describe('getDropdownPosition', () => {
   test('falls back to central position when there is not enough space from both sides', () => {
     const trigger = getSizedElement(900, 50, 300, 50);
     const dropdown = getSizedElement(900, 400);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       width: '900px',
     });
@@ -64,7 +72,14 @@ describe('getDropdownPosition', () => {
   test('supports dropdown minWidth override', () => {
     const trigger = getSizedElement(500, 50, 300, 100);
     const dropdown = getSizedElement(200, 400);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], 300)).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize],
+        minWidth: 300,
+      })
+    ).toEqual({
       ...defaults,
       width: '300px',
     });
@@ -73,7 +88,14 @@ describe('getDropdownPosition', () => {
   test('dropdown can grow beyond the minWidth', () => {
     const trigger = getSizedElement(500, 50, 300, 100);
     const dropdown = getSizedElement(600, 400);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], 300)).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize],
+        minWidth: 300,
+      })
+    ).toEqual({
       ...defaults,
       width: '600px',
     });
@@ -82,7 +104,14 @@ describe('getDropdownPosition', () => {
   test('minWidth cannot be more than trigger width', () => {
     const trigger = getSizedElement(200, 50, 300, 100);
     const dropdown = getSizedElement(100, 400);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], 300)).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize],
+        minWidth: 300,
+      })
+    ).toEqual({
       ...defaults,
       width: '200px',
     });
@@ -92,7 +121,9 @@ describe('getDropdownPosition', () => {
     const trigger = getSizedElement(100, 50, 300, windowSize.width - 110);
     const dropdown = getSizedElement(100, 400);
 
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       dropLeft: true, // TODO: this value is incorrect, should be fixed, see AWSUI-16369 for details
     });
@@ -101,9 +132,17 @@ describe('getDropdownPosition', () => {
   test('takes parent overflow elements when they are found', () => {
     const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize])).toEqual(defaults);
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual(defaults);
     const scrollableContainer = { top: 100, left: 0, height: 400, width: 400 };
-    expect(getDropdownPosition(trigger, dropdown, [windowSize, scrollableContainer])).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize, scrollableContainer],
+      })
+    ).toEqual({
       ...defaults,
       dropUp: true,
       height: '140px',
@@ -113,7 +152,14 @@ describe('getDropdownPosition', () => {
   test('adjusts left offset if preferCenter=true', () => {
     const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(200, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, undefined, true)).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize],
+        preferCenter: true,
+      })
+    ).toEqual({
       ...defaults,
       width: '200px',
       left: '-50px',
@@ -123,9 +169,52 @@ describe('getDropdownPosition', () => {
   test('does not change offset if preferCenter=true, but it does not fit', () => {
     const trigger = getSizedElement(100, 50, 300, 15);
     const dropdown = getSizedElement(200, 300);
-    expect(getDropdownPosition(trigger, dropdown, [windowSize], undefined, undefined, true)).toEqual({
+    expect(
+      getDropdownPosition({
+        triggerElement: trigger,
+        dropdownElement: dropdown,
+        overflowParents: [windowSize],
+        preferCenter: true,
+      })
+    ).toEqual({
       ...defaults,
       width: '200px',
+    });
+  });
+
+  describe('with stretchBeyondTriggerWidth=true', () => {
+    test('can expand beyond trigger width', () => {
+      const triggerElement = getSizedElement(100, 50, 300, 15);
+      const dropdownElement = getSizedElement(200, 300);
+
+      expect(
+        getDropdownPosition({
+          triggerElement,
+          dropdownElement,
+          overflowParents: [windowSize],
+          stretchBeyondTriggerWidth: true,
+        })
+      ).toEqual({
+        ...defaults,
+        width: '200px',
+      });
+    });
+
+    test('cannot expand beyond the XXS breakpoint', () => {
+      const triggerElement = getSizedElement(100, 50, 300, 15);
+      const dropdownElement = getSizedElement(1000, 300);
+
+      expect(
+        getDropdownPosition({
+          triggerElement,
+          dropdownElement,
+          overflowParents: [windowSize],
+          stretchBeyondTriggerWidth: true,
+        })
+      ).toEqual({
+        ...defaults,
+        width: '465px',
+      });
     });
   });
 });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -216,5 +216,22 @@ describe('getDropdownPosition', () => {
         width: '465px',
       });
     });
+
+    test('will always grow to the width of the trigger if possible', () => {
+      const triggerElement = getSizedElement(700, 50, 300, 15);
+      const dropdownElement = getSizedElement(400, 300);
+
+      expect(
+        getDropdownPosition({
+          triggerElement,
+          dropdownElement,
+          overflowParents: [windowSize],
+          stretchBeyondTriggerWidth: true,
+        })
+      ).toEqual({
+        ...defaults,
+        width: '700px',
+      });
+    });
   });
 });

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -125,15 +125,19 @@ export const getDropdownPosition = (
   preferCenter = false,
   stretchWidth = false,
   stretchHeight = false,
-  isMobile?: boolean
+  isMobile?: boolean,
+  stretchBeyondTriggerWidth?: boolean
 ): DropdownPosition => {
   const availableSpace = getAvailableSpace(trigger, dropdown, overflowParents, stretchWidth, stretchHeight, isMobile);
   const triggerWidth = trigger.getBoundingClientRect().width;
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
-  const maxWidth = desiredMaxWidth ? desiredMaxWidth : Number.MAX_VALUE;
+  const maxWidth =
+    stretchBeyondTriggerWidth && desiredMaxWidth ? Math.max(desiredMaxWidth, triggerWidth) : Number.MAX_VALUE;
   const requiredWidth = dropdown.getBoundingClientRect().width;
   // dropdown should not be smaller than the trigger
   const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
+
+  // console.log({ triggerWidth, minWidth, maxWidth, requiredWidth, idealWidth });
 
   let dropLeft: boolean;
   let left: number | null = null;
@@ -231,7 +235,8 @@ export const calculatePosition = (
   stretchHeight: boolean,
   isMobile: boolean,
   minWidth?: number,
-  maxWidth?: number
+  maxWidth?: number,
+  stretchBeyondTriggerWidth?: boolean
 ): [DropdownPosition, DOMRect] => {
   // cleaning previously assigned values,
   // so that they are not reused in case of screen resize and similar events
@@ -257,7 +262,8 @@ export const calculatePosition = (
         preferCenter,
         stretchWidth,
         stretchHeight,
-        isMobile
+        isMobile,
+        stretchBeyondTriggerWidth
       );
   const triggerBox = triggerElement.getBoundingClientRect();
   return [position, triggerBox];

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -42,7 +42,7 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
 
 // By default, most dropdowns should expand their content as necessary, but to a maximum of 465px (the XXS breakpoint).
 // This value was determined by UX but may be subject to change in the future, depending on the feedback.
-const defaultMaxDropdownWidth = getBreakpointValue('xxs');
+export const defaultMaxDropdownWidth = getBreakpointValue('xxs');
 
 export const getAvailableSpace = (
   trigger: HTMLElement,

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -40,9 +40,9 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
   return parents.shift();
 };
 
-// By default, most dropdowns should expand their content as necessary, but to a maximum of 465px (the XS breakpoint).
+// By default, most dropdowns should expand their content as necessary, but to a maximum of 465px (the XXS breakpoint).
 // This value was determined by UX but may be subject to change in the future, depending on the feedback.
-const defaultMaxDropdownWidth = getBreakpointValue('xs');
+const defaultMaxDropdownWidth = getBreakpointValue('xxs');
 
 export const getAvailableSpace = (
   trigger: HTMLElement,
@@ -121,28 +121,44 @@ export const getInteriorAvailableSpace = (
   );
 };
 
-export const getDropdownPosition = (
-  trigger: HTMLElement,
-  dropdown: HTMLElement,
-  overflowParents: ReadonlyArray<Dimensions>,
-  desiredMinWidth?: number,
-  desiredMaxWidth?: number,
+export const getDropdownPosition = ({
+  triggerElement,
+  dropdownElement,
+  overflowParents,
+  minWidth: desiredMinWidth,
   preferCenter = false,
   stretchWidth = false,
   stretchHeight = false,
-  isMobile?: boolean,
-  stretchBeyondTriggerWidth?: boolean
-): DropdownPosition => {
+  isMobile = false,
+  stretchBeyondTriggerWidth = false,
+}: {
+  triggerElement: HTMLElement;
+  dropdownElement: HTMLElement;
+  overflowParents: ReadonlyArray<Dimensions>;
+  minWidth?: number;
+  preferCenter?: boolean;
+  stretchWidth?: boolean;
+  stretchHeight?: boolean;
+  isMobile?: boolean;
+  stretchBeyondTriggerWidth?: boolean;
+}): DropdownPosition => {
   // Determine the space available around the dropdown that it can grow in
-  const availableSpace = getAvailableSpace(trigger, dropdown, overflowParents, stretchWidth, stretchHeight, isMobile);
+  const availableSpace = getAvailableSpace(
+    triggerElement,
+    dropdownElement,
+    overflowParents,
+    stretchWidth,
+    stretchHeight,
+    isMobile
+  );
   // Determine the width of the trigger
-  const triggerWidth = trigger.getBoundingClientRect().width;
+  const triggerWidth = triggerElement.getBoundingClientRect().width;
   // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
   // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
   const maxWidth = stretchBeyondTriggerWidth ? Math.max(defaultMaxDropdownWidth, triggerWidth) : Number.MAX_VALUE;
   // Determine the actual dropdown width, the size that it "wants" to be
-  const requiredWidth = dropdown.getBoundingClientRect().width;
+  const requiredWidth = dropdownElement.getBoundingClientRect().width;
   // Try to achieve the required/desired width within the given parameters
   const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
 
@@ -175,7 +191,7 @@ export const getDropdownPosition = (
     }
   }
 
-  const dropUp = availableSpace.below < dropdown.offsetHeight && availableSpace.above > availableSpace.below;
+  const dropUp = availableSpace.below < dropdownElement.offsetHeight && availableSpace.above > availableSpace.below;
   const availableHeight = dropUp ? availableSpace.above : availableSpace.below;
   // Try and crop the bottom item when all options can't be displayed, affordance for "there's more"
   const croppedHeight = stretchHeight ? availableHeight : Math.floor(availableHeight / 31) * 31 + 16;
@@ -242,7 +258,6 @@ export const calculatePosition = (
   stretchHeight: boolean,
   isMobile: boolean,
   minWidth?: number,
-  maxWidth?: number,
   stretchBeyondTriggerWidth?: boolean
 ): [DropdownPosition, DOMRect] => {
   // cleaning previously assigned values,
@@ -260,18 +275,17 @@ export const calculatePosition = (
   const overflowParents = getOverflowParentDimensions(dropdownElement, interior, expandToViewport, stretchHeight);
   const position = interior
     ? getInteriorDropdownPosition(triggerElement, dropdownElement, overflowParents, isMobile)
-    : getDropdownPosition(
+    : getDropdownPosition({
         triggerElement,
         dropdownElement,
         overflowParents,
         minWidth,
-        maxWidth,
         preferCenter,
         stretchWidth,
         stretchHeight,
         isMobile,
-        stretchBeyondTriggerWidth
-      );
+        stretchBeyondTriggerWidth,
+      });
   const triggerBox = triggerElement.getBoundingClientRect();
   return [position, triggerBox];
 };

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { getBreakpointValue } from '../../breakpoints';
 import { Dimensions, getOverflowParents, getOverflowParentDimensions } from '../../utils/scrollable-containers';
 import styles from './styles.css.js';
 
@@ -38,6 +39,10 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
 
   return parents.shift();
 };
+
+// By default, most dropdowns should expand their content as necessary, but to a maximum of 465px (the XS breakpoint).
+// This value was determined by UX but may be subject to change in the future, depending on the feedback.
+const defaultMaxDropdownWidth = getBreakpointValue('xs');
 
 export const getAvailableSpace = (
   trigger: HTMLElement,
@@ -128,15 +133,18 @@ export const getDropdownPosition = (
   isMobile?: boolean,
   stretchBeyondTriggerWidth?: boolean
 ): DropdownPosition => {
+  // Determine the space available around the dropdown that it can grow in
   const availableSpace = getAvailableSpace(trigger, dropdown, overflowParents, stretchWidth, stretchHeight, isMobile);
+  // Determine the width of the trigger
   const triggerWidth = trigger.getBoundingClientRect().width;
+  // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
-  const maxWidth = stretchBeyondTriggerWidth ? Math.max(465, triggerWidth) : Number.MAX_VALUE;
+  // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
+  const maxWidth = stretchBeyondTriggerWidth ? Math.max(defaultMaxDropdownWidth, triggerWidth) : Number.MAX_VALUE;
+  // Determine the actual dropdown width, the size that it "wants" to be
   const requiredWidth = dropdown.getBoundingClientRect().width;
-  // dropdown should not be smaller than the trigger
+  // Try to achieve the required/desired width within the given parameters
   const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
-
-  // console.log({ triggerWidth, minWidth, maxWidth, requiredWidth, idealWidth });
 
   let dropLeft: boolean;
   let left: number | null = null;

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -120,7 +120,8 @@ export const getDropdownPosition = (
   trigger: HTMLElement,
   dropdown: HTMLElement,
   overflowParents: ReadonlyArray<Dimensions>,
-  minWidth?: number,
+  desiredMinWidth?: number,
+  desiredMaxWidth?: number,
   preferCenter = false,
   stretchWidth = false,
   stretchHeight = false,
@@ -128,10 +129,11 @@ export const getDropdownPosition = (
 ): DropdownPosition => {
   const availableSpace = getAvailableSpace(trigger, dropdown, overflowParents, stretchWidth, stretchHeight, isMobile);
   const triggerWidth = trigger.getBoundingClientRect().width;
-  minWidth = minWidth ? Math.min(triggerWidth, minWidth) : triggerWidth;
+  const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
+  const maxWidth = desiredMaxWidth ? desiredMaxWidth : Number.MAX_VALUE;
   const requiredWidth = dropdown.getBoundingClientRect().width;
   // dropdown should not be smaller than the trigger
-  const idealWidth = Math.max(requiredWidth, minWidth);
+  const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
 
   let dropLeft: boolean;
   let left: number | null = null;
@@ -228,7 +230,8 @@ export const calculatePosition = (
   stretchWidth: boolean,
   stretchHeight: boolean,
   isMobile: boolean,
-  minWidth?: number
+  minWidth?: number,
+  maxWidth?: number
 ): [DropdownPosition, DOMRect] => {
   // cleaning previously assigned values,
   // so that they are not reused in case of screen resize and similar events
@@ -250,6 +253,7 @@ export const calculatePosition = (
         dropdownElement,
         overflowParents,
         minWidth,
+        maxWidth,
         preferCenter,
         stretchWidth,
         stretchHeight,

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -131,8 +131,7 @@ export const getDropdownPosition = (
   const availableSpace = getAvailableSpace(trigger, dropdown, overflowParents, stretchWidth, stretchHeight, isMobile);
   const triggerWidth = trigger.getBoundingClientRect().width;
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
-  const maxWidth =
-    stretchBeyondTriggerWidth && desiredMaxWidth ? Math.max(desiredMaxWidth, triggerWidth) : Number.MAX_VALUE;
+  const maxWidth = stretchBeyondTriggerWidth ? Math.max(465, triggerWidth) : Number.MAX_VALUE;
   const requiredWidth = dropdown.getBoundingClientRect().width;
   // dropdown should not be smaller than the trigger
   const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -7,7 +7,12 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { fireNonCancelableEvent } from '../../events';
 import { DropdownProps } from './interfaces';
-import { DropdownPosition, InteriorDropdownPosition, calculatePosition } from './dropdown-fit-handler';
+import {
+  DropdownPosition,
+  InteriorDropdownPosition,
+  calculatePosition,
+  defaultMaxDropdownWidth,
+} from './dropdown-fit-handler';
 import { Transition, TransitionStatus } from '../transition';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
 import { usePortalModeClasses } from '../../hooks/use-portal-mode-classes';
@@ -108,6 +113,7 @@ const TransitionContent = ({
       data-open={open}
       data-animating={state !== 'exited'}
       aria-hidden={!open}
+      style={stretchBeyondTriggerWidth ? { maxWidth: defaultMaxDropdownWidth } : {}}
       onMouseDown={onMouseDown}
     >
       <div className={clsx(styles['dropdown-content-wrapper'], isRefresh && styles.refresh)}>

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -272,10 +272,6 @@ const Dropdown = ({
         if (scrollable) {
           dropdownRef.current.classList.add(styles.nowrap);
         }
-        // if (stretchBeyondTriggerWidth) {
-        //   // let dropdown width grow according to the content
-        //   dropdownRef.current.classList.add(styles['expand-dropdown-width']);
-        // }
         setDropdownPosition(
           ...calculatePosition(
             dropdownRef.current,
@@ -294,7 +290,9 @@ const Dropdown = ({
           dropdownRef.current,
           verticalContainerRef.current
         );
-        dropdownRef.current.classList.remove(styles.nowrap);
+        if (scrollable) {
+          dropdownRef.current.classList.remove(styles.nowrap);
+        }
       }
     };
     onDropdownOpen();

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -135,10 +135,12 @@ const Dropdown = ({
   stretchWidth = true,
   stretchHeight = false,
   stretchToTriggerWidth = true,
+  stretchBeyondTriggerWidth = false,
   expandToViewport = false,
   preferCenter = false,
   interior = false,
   minWidth,
+  maxWidth,
   scrollable = true,
   loopFocus = expandToViewport,
   onFocus,
@@ -180,7 +182,7 @@ const Dropdown = ({
       verticalContainer.style.maxHeight = position.height;
     }
 
-    if (entireWidth && !expandToViewport) {
+    if (entireWidth && !expandToViewport && !stretchBeyondTriggerWidth) {
       if (stretchToTriggerWidth) {
         target.classList.add(styles['occupy-entire-width']);
       }
@@ -267,6 +269,10 @@ const Dropdown = ({
         if (scrollable) {
           dropdownRef.current.classList.add(styles.nowrap);
         }
+        if (stretchBeyondTriggerWidth) {
+          // let dropdown width grow according to the content
+          dropdownRef.current.classList.add(styles['expand-dropdown-width']);
+        }
         setDropdownPosition(
           ...calculatePosition(
             dropdownRef.current,
@@ -278,14 +284,13 @@ const Dropdown = ({
             stretchWidth,
             stretchHeight,
             isMobile,
-            minWidth
+            minWidth,
+            maxWidth
           ),
           dropdownRef.current,
           verticalContainerRef.current
         );
-        if (scrollable) {
-          dropdownRef.current.classList.remove(styles.nowrap);
-        }
+        dropdownRef.current.classList.remove(styles.nowrap, styles['expand-dropdown-width']);
       }
     };
     onDropdownOpen();

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -52,6 +52,7 @@ interface TransitionContentProps {
   dropdownRef: React.RefObject<HTMLDivElement>;
   verticalContainerRef: React.RefObject<HTMLDivElement>;
   expandToViewport?: boolean;
+  stretchBeyondTriggerWidth?: boolean;
   header?: React.ReactNode;
   children?: React.ReactNode;
   footer?: React.ReactNode;
@@ -74,6 +75,7 @@ const TransitionContent = ({
   dropdownRef,
   verticalContainerRef,
   expandToViewport,
+  stretchBeyondTriggerWidth,
   header,
   children,
   footer,
@@ -96,6 +98,7 @@ const TransitionContent = ({
         [styles['is-empty']]: !header && !children,
         [styles.refresh]: isRefresh,
         [styles['use-portal']]: expandToViewport && !interior,
+        [styles['stretch-beyond-trigger-width']]: stretchBeyondTriggerWidth,
       })}
       ref={contentRef}
       id={id}
@@ -182,7 +185,7 @@ const Dropdown = ({
       verticalContainer.style.maxHeight = position.height;
     }
 
-    if (entireWidth && !expandToViewport && !stretchBeyondTriggerWidth) {
+    if (entireWidth && !expandToViewport) {
       if (stretchToTriggerWidth) {
         target.classList.add(styles['occupy-entire-width']);
       }
@@ -269,10 +272,10 @@ const Dropdown = ({
         if (scrollable) {
           dropdownRef.current.classList.add(styles.nowrap);
         }
-        if (stretchBeyondTriggerWidth) {
-          // let dropdown width grow according to the content
-          dropdownRef.current.classList.add(styles['expand-dropdown-width']);
-        }
+        // if (stretchBeyondTriggerWidth) {
+        //   // let dropdown width grow according to the content
+        //   dropdownRef.current.classList.add(styles['expand-dropdown-width']);
+        // }
         setDropdownPosition(
           ...calculatePosition(
             dropdownRef.current,
@@ -285,12 +288,13 @@ const Dropdown = ({
             stretchHeight,
             isMobile,
             minWidth,
-            maxWidth
+            maxWidth,
+            stretchBeyondTriggerWidth
           ),
           dropdownRef.current,
           verticalContainerRef.current
         );
-        dropdownRef.current.classList.remove(styles.nowrap, styles['expand-dropdown-width']);
+        dropdownRef.current.classList.remove(styles.nowrap);
       }
     };
     onDropdownOpen();
@@ -409,6 +413,7 @@ const Dropdown = ({
                 interior={interior}
                 header={header}
                 expandToViewport={expandToViewport}
+                stretchBeyondTriggerWidth={stretchBeyondTriggerWidth}
                 footer={footer}
                 onMouseDown={onMouseDown}
                 isRefresh={isRefresh}

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -143,7 +143,6 @@ const Dropdown = ({
   preferCenter = false,
   interior = false,
   minWidth,
-  maxWidth,
   scrollable = true,
   loopFocus = expandToViewport,
   onFocus,
@@ -284,7 +283,6 @@ const Dropdown = ({
             stretchHeight,
             isMobile,
             minWidth,
-            maxWidth,
             stretchBeyondTriggerWidth
           ),
           dropdownRef.current,

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -119,7 +119,7 @@ export interface DropdownProps extends ExpandToViewport {
    */
   minWidth?: number;
   /**
-   * Sets the maximum width of the dropdown (in px)
+   * Sets the maximum width of the dropdown (in px) when it's growing beyond the trigger width.
    */
   maxWidth?: number;
   /**

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -100,6 +100,11 @@ export interface DropdownProps extends ExpandToViewport {
   stretchToTriggerWidth?: boolean;
 
   /**
+   * Whether the dropdown content can grow beyond the width of the trigger.
+   */
+  stretchBeyondTriggerWidth?: boolean;
+
+  /**
    * Determines that the dropdown should preferably be aligned to the center of the trigger
    * instead of dropping left or right.
    */
@@ -113,6 +118,10 @@ export interface DropdownProps extends ExpandToViewport {
    * Sets the min width of the dropdown (in px)
    */
   minWidth?: number;
+  /**
+   * Sets the maximum width of the dropdown (in px)
+   */
+  maxWidth?: number;
   /**
    * Whether the dropdown will have a scrollbar or not
    */

--- a/src/internal/components/dropdown/interfaces.ts
+++ b/src/internal/components/dropdown/interfaces.ts
@@ -119,10 +119,6 @@ export interface DropdownProps extends ExpandToViewport {
    */
   minWidth?: number;
   /**
-   * Sets the maximum width of the dropdown (in px) when it's growing beyond the trigger width.
-   */
-  maxWidth?: number;
-  /**
    * Whether the dropdown will have a scrollbar or not
    */
   scrollable?: boolean;

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -71,8 +71,8 @@
     min-width: 100%;
   }
   &.stretch-beyond-trigger-width {
-    width: 100%;
-    min-width: 465px;
+    width: max-content;
+    max-width: 465px;
   }
   &.hide-upper-border > .dropdown-content-wrapper {
     border-top: none;

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -72,6 +72,7 @@
   }
   &.stretch-beyond-trigger-width {
     width: max-content;
+    // This maps to the XXS container breakpoint as defined in src/internal/breakpoints.ts
     max-width: 465px;
   }
   &.hide-upper-border > .dropdown-content-wrapper {

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -72,8 +72,6 @@
   }
   &.stretch-beyond-trigger-width {
     width: max-content;
-    // This maps to the XXS container breakpoint as defined in src/internal/breakpoints.ts
-    max-width: 465px;
   }
   &.hide-upper-border > .dropdown-content-wrapper {
     border-top: none;

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -115,3 +115,7 @@
 .stretch-trigger-height {
   height: 100%;
 }
+
+.expand-dropdown-width {
+  width: max-content;
+}

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -70,6 +70,10 @@
   &.occupy-entire-width {
     min-width: 100%;
   }
+  &.stretch-beyond-trigger-width {
+    width: 100%;
+    min-width: 465px;
+  }
   &.hide-upper-border > .dropdown-content-wrapper {
     border-top: none;
   }
@@ -114,8 +118,4 @@
 
 .stretch-trigger-height {
   height: 100%;
-}
-
-.expand-dropdown-width {
-  width: max-content;
 }

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -316,6 +316,7 @@ const InternalMultiselect = React.forwardRef(
             ) : null
           }
           expandToViewport={expandToViewport}
+          stretchBeyondTriggerWidth={true}
         >
           <ListComponent
             listBottom={

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -28,7 +28,6 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { OptionGroup } from '../internal/components/option/interfaces.js';
 import { SomeRequired } from '../internal/types';
-// import { getBreakpointValue } from '../internal/breakpoints.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
 import { useInternalI18n } from '../i18n/context.js';
@@ -240,7 +239,6 @@ const InternalSelect = React.forwardRef(
           }
           open={isOpen}
           stretchTriggerHeight={__inFilteringToken}
-          // maxWidth={getBreakpointValue('xxs')}
           stretchBeyondTriggerWidth={true}
           trigger={trigger}
           header={filter}

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -28,7 +28,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { OptionGroup } from '../internal/components/option/interfaces.js';
 import { SomeRequired } from '../internal/types';
-import { getBreakpointValue } from '../internal/breakpoints.js';
+// import { getBreakpointValue } from '../internal/breakpoints.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
 import { useInternalI18n } from '../i18n/context.js';
@@ -240,7 +240,7 @@ const InternalSelect = React.forwardRef(
           }
           open={isOpen}
           stretchTriggerHeight={__inFilteringToken}
-          maxWidth={getBreakpointValue('xxs')}
+          // maxWidth={getBreakpointValue('xxs')}
           stretchBeyondTriggerWidth={true}
           trigger={trigger}
           header={filter}

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -28,6 +28,7 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { OptionGroup } from '../internal/components/option/interfaces.js';
 import { SomeRequired } from '../internal/types';
+import { getBreakpointValue } from '../internal/breakpoints.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
 import { useInternalI18n } from '../i18n/context.js';
@@ -239,6 +240,8 @@ const InternalSelect = React.forwardRef(
           }
           open={isOpen}
           stretchTriggerHeight={__inFilteringToken}
+          maxWidth={getBreakpointValue('xxs')}
+          stretchBeyondTriggerWidth={true}
           trigger={trigger}
           header={filter}
           onMouseDown={handleMouseDown}


### PR DESCRIPTION
### Description
The main change in this PR is allowing the dropdowns of select, multiselect, and autosuggest to expand their width according to their content (up to a pre-defined maximum or 465px). Additionally, there are some other changes that support this new feature:

* Fixed a bug where dropdowns with `expandToViewport={true}` could expand beyond the trigger width (AWSUI-16369)
* Changed `getDropdownPosition` from using (9) positional arguments to using an object as argument

Related links, issue #, if available: AWSUI-19898, AWSUI-16369

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
