### PR TITLE
fix: Asymmetric header vertical padding in closed expandable section

### DIFF
--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -159,7 +159,7 @@
   &.with-paddings {
     padding: shared.$header-padding;
     &.header-variant-cards {
-      padding: awsui.$space-scaled-s awsui.$space-container-horizontal;
+      padding: awsui.$space-container-header-top awsui.$space-container-horizontal;
     }
   }
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -109,6 +109,9 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
     padding-bottom: awsui.$space-container-header-bottom;
     padding-right: container.$header-padding-horizontal;
 
+    &:not(.wrapper-expanded) {
+      padding-bottom: awsui.$space-container-header-top;
+    }
     &.header-deprecated {
       padding-left: container.$header-padding-horizontal;
     }

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -110,6 +110,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
     padding-right: container.$header-padding-horizontal;
 
     &:not(.wrapper-expanded) {
+      // Equal top and bottom padding so standalone header has vertical symmetry.
       padding-bottom: awsui.$space-container-header-top;
     }
     &.header-deprecated {

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -55,14 +55,7 @@ export default function InternalHeader({
       ref={__internalRootRef}
     >
       <div className={clsx(styles.main, styles[`main-variant-${variantOverride}`], isRefresh && styles.refresh)}>
-        <div
-          className={clsx(
-            styles.title,
-            styles[`title-variant-${variantOverride}`],
-            isRefresh && styles.refresh,
-            actions && [styles[`has-actions`]]
-          )}
-        >
+        <div className={clsx(styles.title, styles[`title-variant-${variantOverride}`], isRefresh && styles.refresh)}>
           <HeadingTag className={clsx(styles.heading, styles[`heading-variant-${variantOverride}`])}>
             <span
               {...{ [DATA_ATTR_FUNNEL_KEY]: FUNNEL_KEY_SUBSTEP_NAME }}

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -60,7 +60,7 @@ export default function InternalHeader({
             styles.title,
             styles[`title-variant-${variantOverride}`],
             isRefresh && styles.refresh,
-            description && [styles[`root-has-description`]]
+            actions && [styles[`has-actions`]]
           )}
         >
           <HeadingTag className={clsx(styles.heading, styles[`heading-variant-${variantOverride}`])}>

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -108,17 +108,26 @@
   @include styles.text-wrapping;
   color: awsui.$color-text-heading-default;
 
-  &-variant-h1.refresh {
+  &-variant-h1 {
+    font-size: awsui.$font-heading-xl-size;
     // Use padding rather than center align with min height to avoid having extra bottom space when no actions are present.
     // Having top padding always present ensures that all headers of the same variant start at the same height in the container,
     // whether there are buttons present or not; otherwise configurable dashboard handles are misaligned.
-    padding-top: space-heading-button-diff(awsui.$font-heading-xl-line-height);
+    &.refresh {
+      padding-top: space-heading-button-diff(awsui.$font-heading-xl-line-height);
+    }
   }
-  &-variant-h2.refresh {
-    padding-top: space-heading-button-diff(awsui.$font-heading-l-line-height);
+  &-variant-h2 {
+    font-size: awsui.$font-heading-l-size;
+    &.refresh {
+      padding-top: space-heading-button-diff(awsui.$font-heading-l-line-height);
+    }
   }
-  &-variant-h3.refresh {
-    padding-top: space-heading-button-diff(awsui.$font-heading-m-line-height);
+  &-variant-h3 {
+    font-size: awsui.$font-heading-m-size;
+    &.refresh {
+      padding-top: space-heading-button-diff(awsui.$font-heading-m-line-height);
+    }
   }
   &-variant-h2:not(.refresh),
   &-variant-h3:not(.refresh) {

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -44,6 +44,7 @@
   &.refresh {
     display: flex;
     flex-direction: column;
+    justify-content: center;
     // Can't use justify-content: center because it won't align with configurable dashboard handle icon
   }
 
@@ -108,21 +109,21 @@
     font-size: awsui.$font-heading-xl-size;
     // Use padding rather than center align so that all headers of the same size start at the same height in the container,
     // whether there are buttons present or not; otherwise configurable dashboard handles are misaligned.
-    &.refresh {
-      padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-xl-line-height}) / 2);
-    }
+    // &.refresh.has-actions {
+    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-xl-line-height}) / 2);
+    // }
   }
   &-variant-h2 {
     font-size: awsui.$font-heading-l-size;
-    &.refresh {
-      padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-l-line-height}) / 2);
-    }
+    // &.refresh.has-actions {
+    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-l-line-height}) / 2);
+    // }
   }
   &-variant-h3 {
     font-size: awsui.$font-heading-m-size;
-    &.refresh {
-      padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-m-line-height}) / 2);
-    }
+    // &.refresh.has-actions {
+    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-m-line-height}) / 2);
+    // }
   }
   &-variant-h2:not(.refresh),
   &-variant-h3:not(.refresh) {

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -6,6 +6,10 @@
 @use '../internal/styles/tokens' as awsui;
 @use '../internal/styles' as styles;
 
+@function space-heading-button-diff($heading-height) {
+  @return calc((#{awsui.$size-vertical-input} - #{$heading-height}) / 2);
+}
+
 .root {
   @include styles.styles-reset();
   cursor: inherit;
@@ -44,8 +48,7 @@
   &.refresh {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    // Can't use justify-content: center because it won't align with configurable dashboard handle icon
+    // Can't use justify-content: center because it won't align with configurable dashboard fixed handle icon
   }
 
   &-variant-h1 {
@@ -105,25 +108,17 @@
   @include styles.text-wrapping;
   color: awsui.$color-text-heading-default;
 
-  &-variant-h1 {
-    font-size: awsui.$font-heading-xl-size;
-    // Use padding rather than center align so that all headers of the same size start at the same height in the container,
+  &-variant-h1.refresh {
+    // Use padding rather than center align with min height to avoid having extra bottom space when no actions are present.
+    // Having top padding always present ensures that all headers of the same variant start at the same height in the container,
     // whether there are buttons present or not; otherwise configurable dashboard handles are misaligned.
-    // &.refresh.has-actions {
-    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-xl-line-height}) / 2);
-    // }
+    padding-top: space-heading-button-diff(awsui.$font-heading-xl-line-height);
   }
-  &-variant-h2 {
-    font-size: awsui.$font-heading-l-size;
-    // &.refresh.has-actions {
-    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-l-line-height}) / 2);
-    // }
+  &-variant-h2.refresh {
+    padding-top: space-heading-button-diff(awsui.$font-heading-l-line-height);
   }
-  &-variant-h3 {
-    font-size: awsui.$font-heading-m-size;
-    // &.refresh.has-actions {
-    //   padding-top: calc((#{awsui.$size-vertical-input} - #{awsui.$font-heading-m-line-height}) / 2);
-    // }
+  &-variant-h3.refresh {
+    padding-top: space-heading-button-diff(awsui.$font-heading-m-line-height);
   }
   &-variant-h2:not(.refresh),
   &-variant-h3:not(.refresh) {


### PR DESCRIPTION
### Description

We reduced header bottom padding in VR to improve info density in #1317, this introduced an inconsistency in the expandable section when it is closed, because heading vertical padding is no longer symmetrical. This PR increases the bottom padding of expandable section headers when it is closed so it looks more balanced.

https://github.com/cloudscape-design/components/assets/15003460/e86b4ce3-916a-4b15-ae7f-5e798cdedf28

Ideally, we would not add more space to the interface, however, we cannot reduce the top padding instead because we don't want a shift in the text between open and closed states. We also cannot have header text start at different heights because the board components use fixed alignment with the handles and settings buttons.

Related links, issue #, if available: AWSUI-21867

### How has this been tested?

Ran through dev pipeline, screenshot approval-instance: ce67a9fc-e53b-4d70-965f-0eb94b6ef0ac

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
