### PR TITLE
chore: Support nested funnels

### DIFF
--- a/pages/funnel-analytics/nested-funnels.page.tsx
+++ b/pages/funnel-analytics/nested-funnels.page.tsx
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { i18nStrings } from '../wizard/common';
+
+import { Box, BreadcrumbGroup, Form, Wizard, WizardProps, Input, Container, Header, SpaceBetween } from '~components';
+
+export default function WizardPage() {
+  const steps: WizardProps.Step[] = [
+    {
+      title: 'Step 1',
+      content: (
+        <SpaceBetween size="l" key="step 1">
+          <div>content</div>
+          <Form>
+            <Container>
+              This page contains funnels nested inside funnels. The code automatically deduplicates them.
+            </Container>
+          </Form>
+          <Form>
+            <Container header={<Header>Header</Header>}>
+              <Container header={<Header>Another header</Header>}>
+                <Form>
+                  Here is a substep nested inside a substep.
+                  <Input readOnly={true} value="" />
+                </Form>
+              </Container>
+            </Container>
+          </Form>
+        </SpaceBetween>
+      ),
+    },
+    {
+      title: 'Step 2',
+      content: (
+        <SpaceBetween size="l" key="step 2">
+          <Form>
+            <Container>
+              This page contains funnels nested inside funnels. The code automatically deduplicates them.
+            </Container>
+          </Form>
+          <Form>
+            <Container header={<Header>Header</Header>}>
+              <Container header={<Header>Another header</Header>}>
+                <Form>
+                  Here is a substep nested inside a substep.
+                  <Input readOnly={true} value="" />
+                </Form>
+              </Container>
+            </Container>
+          </Form>
+        </SpaceBetween>
+      ),
+    },
+  ];
+
+  return (
+    <Box padding="xl">
+      <Form>
+        <SpaceBetween size="xxl">
+          <BreadcrumbGroup
+            items={[
+              { text: 'Resources', href: '#example-link' },
+              { text: 'Create resource', href: '#example-link' },
+            ]}
+            onFollow={e => e.preventDefault()}
+          />
+
+          <Form>
+            <Wizard steps={steps} i18nStrings={i18nStrings} activeStepIndex={0} onNavigate={() => {}} />
+          </Form>
+        </SpaceBetween>
+      </Form>
+    </Box>
+  );
+}

--- a/pages/funnel-analytics/nested-funnels.page.tsx
+++ b/pages/funnel-analytics/nested-funnels.page.tsx
@@ -34,7 +34,9 @@ export default function WizardPage() {
               <Container header={<Header>Another header</Header>}>
                 <Form>
                   Here is a substep nested inside a substep.
-                  <Input readOnly={true} value="" />
+                  <FormField label="An input field">
+                    <Input readOnly={true} value="" />
+                  </FormField>
                 </Form>
               </Container>
             </Container>

--- a/pages/funnel-analytics/nested-funnels.page.tsx
+++ b/pages/funnel-analytics/nested-funnels.page.tsx
@@ -4,7 +4,18 @@ import React from 'react';
 
 import { i18nStrings } from '../wizard/common';
 
-import { Box, BreadcrumbGroup, Form, Wizard, WizardProps, Input, Container, Header, SpaceBetween } from '~components';
+import {
+  Box,
+  BreadcrumbGroup,
+  Form,
+  Wizard,
+  WizardProps,
+  Input,
+  Container,
+  Header,
+  SpaceBetween,
+  FormField,
+} from '~components';
 
 export default function WizardPage() {
   const steps: WizardProps.Step[] = [
@@ -45,7 +56,9 @@ export default function WizardPage() {
               <Container header={<Header>Another header</Header>}>
                 <Form>
                   Here is a substep nested inside a substep.
-                  <Input readOnly={true} value="" />
+                  <FormField label="An input field">
+                    <Input readOnly={true} value="" />
+                  </FormField>
                 </Form>
               </Container>
             </Container>

--- a/src/alert/__tests__/alert-analytics.test.tsx
+++ b/src/alert/__tests__/alert-analytics.test.tsx
@@ -18,6 +18,7 @@ import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
 describe('Alert Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     mockFunnelMetrics();
   });
 
@@ -31,6 +32,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelError).not.toHaveBeenCalled();
 
@@ -54,6 +56,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
 
@@ -77,6 +80,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
     expect(FunnelMetrics.funnelError).not.toHaveBeenCalled();
@@ -95,6 +99,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
     expect(FunnelMetrics.funnelError).not.toHaveBeenCalled();
@@ -121,10 +126,12 @@ describe('Alert Analytics', () => {
     );
 
     const { rerender } = render(jsx);
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
 
     act(() => funnelNextOrSubmitAttempt!());
     rerender(jsx);
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(2);
   });
@@ -145,6 +152,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     rerender(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
@@ -155,6 +163,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelError).not.toHaveBeenCalled();
@@ -168,6 +177,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     rerender(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
@@ -176,6 +186,7 @@ describe('Alert Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelError).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();

--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { InternalButton } from '../../../lib/components/button/internal';
 import Button from '../../../lib/components/button';
 import styles from '../../../lib/components/button/styles.css.js';
@@ -33,6 +33,7 @@ test('supports __iconClass property', () => {
 describe('Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     mockFunnelMetrics();
   });
 
@@ -49,6 +50,7 @@ describe('Analytics', () => {
         <Button iconName="external" href="https://example.com" />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     createWrapper(container).findButton()!.click();
 
     expect(FunnelMetrics.externalLinkInteracted).toHaveBeenCalled();
@@ -67,6 +69,7 @@ describe('Analytics', () => {
         <Button target="_blank" data-testid="2" />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     createWrapper(container).findButton('[data-testid="1"]')!.click();
     createWrapper(container).findButton('[data-testid="2"]')!.click();
 
@@ -79,6 +82,7 @@ describe('Analytics', () => {
         <Button target="_blank" href="https://example.com" />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     createWrapper(container).findButton()!.click();
 
     expect(FunnelMetrics.externalLinkInteracted).toHaveBeenCalled();
@@ -96,6 +100,7 @@ describe('Analytics', () => {
         <Button href="https://example.com" />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     createWrapper(container).findButton()!.click();
 
     expect(FunnelMetrics.externalLinkInteracted).not.toHaveBeenCalled();

--- a/src/container/__tests__/analytics.test.tsx
+++ b/src/container/__tests__/analytics.test.tsx
@@ -35,6 +35,7 @@ describe('Funnel Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(getByTestId('container')).toHaveAttribute(DATA_ATTR_FUNNEL_SUBSTEP, expect.any(String));
   });
@@ -49,6 +50,7 @@ describe('Funnel Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledTimes(0);
 
@@ -74,6 +76,7 @@ describe('Funnel Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepStart).not.toHaveBeenCalled();
 
@@ -101,6 +104,7 @@ describe('Funnel Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepStart).not.toHaveBeenCalled();
 
@@ -127,6 +131,7 @@ describe('Funnel Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepStart).not.toHaveBeenCalled();
 

--- a/src/expandable-section/__tests__/analytics.test.tsx
+++ b/src/expandable-section/__tests__/analytics.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 import ExpandableSection from '../../../lib/components/expandable-section';
 
@@ -38,6 +38,7 @@ describe('Expandable section funnel analytics', () => {
           </AnalyticsFunnelStep>
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
 
       expect(getByTestId('container')).toHaveAttribute(DATA_ATTR_FUNNEL_SUBSTEP, expect.any(String));
     });
@@ -52,6 +53,7 @@ describe('Expandable section funnel analytics', () => {
           </AnalyticsFunnelStep>
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
 
       expect(FunnelMetrics.funnelSubStepStart).toHaveBeenCalledTimes(0);
 
@@ -76,6 +78,7 @@ describe('Expandable section funnel analytics', () => {
           </AnalyticsFunnelStep>
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
 
       expect(getByTestId('container')).not.toHaveAttribute(DATA_ATTR_FUNNEL_SUBSTEP, expect.any(String));
     });
@@ -90,6 +93,7 @@ describe('Expandable section funnel analytics', () => {
           </AnalyticsFunnelStep>
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
 
       expect(FunnelMetrics.funnelSubStepStart).not.toHaveBeenCalled();
 

--- a/src/form-field/__tests__/form-field-analytics.test.tsx
+++ b/src/form-field/__tests__/form-field-analytics.test.tsx
@@ -20,6 +20,7 @@ import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
 describe('FormField Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     mockFunnelMetrics();
   });
 
@@ -33,6 +34,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledWith(
@@ -58,6 +60,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     rerender(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
@@ -68,6 +71,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(2);
   });
@@ -93,10 +97,12 @@ describe('FormField Analytics', () => {
     );
 
     const { rerender } = render(jsx);
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
 
     act(() => funnelNextOrSubmitAttempt!());
     rerender(jsx);
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(2);
   });
@@ -130,6 +136,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     rerender(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
@@ -140,6 +147,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
   });
@@ -154,6 +162,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).toHaveBeenCalledTimes(1);
     jest.clearAllMocks(); // Reset all mock function call counters
@@ -167,6 +176,7 @@ describe('FormField Analytics', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
   });

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 
 import { FunnelMetrics } from '../../../../../lib/components/internal/analytics';
 import { DATA_ATTR_FUNNEL_INTERACTION_ID } from '../../../../../lib/components/internal/analytics/selectors';
@@ -32,6 +32,7 @@ describe('AnalyticsFunnel', () => {
         <div>Child Content</div>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     const childElement = getByText('Child Content');
     expect(childElement).toBeInTheDocument();
@@ -56,6 +57,7 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     // Check if the root element has a specific data attribute
     expect(getByTestId('root')).toHaveAttribute(DATA_ATTR_FUNNEL_INTERACTION_ID, expect.any(String));
@@ -63,6 +65,7 @@ describe('AnalyticsFunnel', () => {
 
   test('calls funnelStart when the component renders', () => {
     render(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
@@ -85,6 +88,7 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
     await waitFor(() => {
@@ -110,6 +114,7 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent renderError={false} />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
 
@@ -118,8 +123,8 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent renderError={true} />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
-    jest.runAllTimers();
     expect(FunnelMetrics.funnelComplete).not.toHaveBeenCalled();
   });
 
@@ -136,13 +141,14 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
     unmount();
 
     expect(FunnelMetrics.funnelComplete).toHaveBeenCalledTimes(1);
 
-    jest.runAllTimers();
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelComplete).toHaveBeenCalledTimes(1);
   });
 
@@ -160,6 +166,7 @@ describe('AnalyticsFunnel', () => {
         <Button />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
 
@@ -170,7 +177,7 @@ describe('AnalyticsFunnel', () => {
       </AnalyticsFunnel>
     );
 
-    jest.runOnlyPendingTimers();
+    act(() => void jest.runOnlyPendingTimers());
 
     expect(FunnelMetrics.funnelComplete).not.toHaveBeenCalled();
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
@@ -203,6 +210,7 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
@@ -224,11 +232,12 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
 
-    jest.runAllTimers();
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
   });
@@ -246,11 +255,12 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
 
     fireEvent.click(getByText('Submit')); // Trigger the button click event
 
-    jest.runAllTimers();
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelSuccessful).not.toHaveBeenCalled();
 
@@ -272,6 +282,7 @@ describe('AnalyticsFunnel', () => {
         <ChildComponent />
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
     expect(FunnelMetrics.funnelCancelled).not.toHaveBeenCalled();
 
     unmount();
@@ -294,6 +305,7 @@ describe('AnalyticsFunnelStep', () => {
         <div>Child Content</div>
       </AnalyticsFunnelStep>
     );
+    act(() => void jest.runAllTimers());
 
     const childElement = getByText('Child Content');
     expect(childElement).toBeInTheDocument();
@@ -313,6 +325,7 @@ describe('AnalyticsFunnelStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith({
@@ -338,10 +351,12 @@ describe('AnalyticsFunnelStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
 
     rerender(<AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />);
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepComplete).toHaveBeenCalledWith({
@@ -364,6 +379,7 @@ describe('AnalyticsFunnelStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     unmount();
 
@@ -381,6 +397,7 @@ describe('AnalyticsFunnelStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
@@ -403,6 +420,7 @@ describe('AnalyticsFunnelStep', () => {
         Step Content
       </AnalyticsFunnelStep>
     );
+    act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepStart).not.toHaveBeenCalled();
   });
@@ -413,6 +431,7 @@ describe('AnalyticsFunnelStep', () => {
         Step Content
       </AnalyticsFunnelStep>
     );
+    act(() => void jest.runAllTimers());
 
     unmount();
     expect(FunnelMetrics.funnelStepComplete).not.toHaveBeenCalled();
@@ -432,6 +451,7 @@ describe('AnalyticsFunnelSubStep', () => {
         <div>Substep Content</div>
       </AnalyticsFunnelSubStep>
     );
+    act(() => void jest.runAllTimers());
 
     const childElement = getByText('Substep Content');
     expect(childElement).toBeInTheDocument();
@@ -443,6 +463,7 @@ describe('AnalyticsFunnelSubStep', () => {
         <div data-testid="substep-content">Substep Content</div>
       </AnalyticsFunnelSubStep>
     );
+    act(() => void jest.runAllTimers());
 
     fireEvent.focus(getByTestId('substep-content'));
 
@@ -473,6 +494,7 @@ describe('AnalyticsFunnelSubStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     getByTestId('input').focus();
 
@@ -512,6 +534,7 @@ describe('AnalyticsFunnelSubStep', () => {
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
     );
+    act(() => void jest.runAllTimers());
 
     getByTestId('input').focus();
 
@@ -556,6 +579,7 @@ describe('AnalyticsFunnelSubStep', () => {
         <input data-testid="outside" />
       </>
     );
+    act(() => void jest.runAllTimers());
 
     simulateUserClick(getByTestId('input'));
 

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -24,6 +24,7 @@ describe('useFunnelStep hook', () => {
           stepNameSelector: 'step_name_selector',
           stepNumber: 0,
           subStepCount: { current: 0 },
+          isInStep: true,
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -25,6 +25,7 @@ describe('useFunnelStep hook', () => {
           stepNumber: 0,
           subStepCount: { current: 0 },
           isInStep: true,
+          funnelInteractionId: 'a placeholder funnel interaction ID',
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel.test.tsx
@@ -34,6 +34,8 @@ describe('useFunnel hook', () => {
           loadingButtonCount: { current: 0 },
           errorCount: { current: 0 },
           latestFocusCleanupFunction: { current: undefined },
+          isInFunnel: true,
+          wizardCount: { current: 0 },
         }}
       >
         <ChildComponent />
@@ -76,6 +78,8 @@ describe('useFunnel hook', () => {
           loadingButtonCount: { current: 0 },
           errorCount: { current: 0 },
           latestFocusCleanupFunction: { current: undefined },
+          isInFunnel: true,
+          wizardCount: { current: 0 },
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -216,9 +216,15 @@ const InnerAnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: An
   // On unmount, it does a similar thing but this time calling 'funnelStepComplete' to record the completion of the interaction.
   useEffect(() => {
     if (!funnelInteractionId) {
+      // This step is not inside an active funnel.
       return;
     }
     if (parentStepExists && parentStepFunnelInteractionId) {
+      /*
+       This step is inside another step, which already reports events as
+       part of an active funnel (i.e. that step is not a parent of a Wizard).
+       Thus, this current step does not need to report any events.
+       */
       return;
     }
 
@@ -268,6 +274,11 @@ const InnerAnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: An
     funnelInteractionId,
   };
 
+  /*
+    If this step is inside another step which already reports events as part of an active
+    funnel (i.e. that step is not a parent of a Wizard), the current step becomes invisible
+    in the hierarchy by passing the context of its parent through.
+  */
   const effectiveContextValue = parentStepExists && parentStepFunnelInteractionId ? parentStep : contextValue;
 
   return (

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -29,6 +29,7 @@ export interface FunnelStepContextValue {
   funnelStepProps?: Record<string, string | number | boolean | undefined>;
   subStepCount: MutableRefObject<number>;
   isInStep: boolean;
+  funnelInteractionId: string | undefined;
 }
 
 export interface FunnelSubStepContextValue {
@@ -77,6 +78,7 @@ export const FunnelStepContext = createContext<FunnelStepContextValue>({
   stepNumber: 0,
   subStepCount: { current: 0 },
   isInStep: false,
+  funnelInteractionId: undefined,
 });
 
 export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -19,6 +19,8 @@ export interface FunnelContextValue {
   errorCount: MutableRefObject<number>;
   loadingButtonCount: MutableRefObject<number>;
   latestFocusCleanupFunction: MutableRefObject<undefined | (() => void)>;
+  isInFunnel: boolean;
+  wizardCount: MutableRefObject<number>;
 }
 
 export interface FunnelStepContextValue {
@@ -26,6 +28,7 @@ export interface FunnelStepContextValue {
   stepNumber: number;
   funnelStepProps?: Record<string, string | number | boolean | undefined>;
   subStepCount: MutableRefObject<number>;
+  isInStep: boolean;
 }
 
 export interface FunnelSubStepContextValue {
@@ -65,12 +68,15 @@ export const FunnelContext = createContext<FunnelContextValue>({
   errorCount: { current: 0 },
   loadingButtonCount: { current: 0 },
   latestFocusCleanupFunction: { current: undefined },
+  isInFunnel: false,
+  wizardCount: { current: 0 },
 });
 
 export const FunnelStepContext = createContext<FunnelStepContextValue>({
   stepNameSelector: '',
   stepNumber: 0,
   subStepCount: { current: 0 },
+  isInStep: false,
 });
 
 export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import Link, { LinkProps } from '../../../lib/components/link';
 import styles from '../../../lib/components/link/styles.css.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -21,6 +21,10 @@ function renderLink(props: LinkProps = {}) {
 }
 
 describe('Link component', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
   test('content is rendered correctly', () => {
     const wrapper = renderLink({ href: '#', children: 'I am a link!' });
     expect(wrapper.getElement()).toHaveTextContent('I am a link!');
@@ -237,6 +241,7 @@ describe('Link component', () => {
           <Link href="#" external={true} />
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
       const wrapper = createWrapper(container).findLink()!;
       wrapper.click();
 
@@ -255,6 +260,7 @@ describe('Link component', () => {
           <Link variant="info" />
         </AnalyticsFunnel>
       );
+      act(() => void jest.runAllTimers());
       const wrapper = createWrapper(container).findLink()!;
       wrapper.click();
 

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -313,7 +313,7 @@ describe('Wizard Analytics', () => {
     );
   });
 
-  test('handles the funnel even if nested inside a single-page funnel', () => {
+  test('sends a "multi-step" funnelStart metric if Wizard is nested in Form (single-page) funnel', () => {
     const steps = [
       {
         title: 'Step 1',

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -350,5 +350,15 @@ describe('Wizard Analytics', () => {
         theme: expect.any(String),
       })
     );
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepNumber: 1,
+        funnelInteractionId: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+      })
+    );
   });
 });

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useEffect } from 'react';
 import { getExternalProps } from '../internal/utils/external-props';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -9,10 +9,18 @@ import { AnalyticsFunnel } from '../internal/analytics/components/analytics-funn
 
 import InternalWizard from './internal';
 import { WizardProps } from './interfaces';
+import { useFunnel } from '../internal/analytics/hooks/use-funnel';
 
 function Wizard({ isLoadingNextStep = false, allowSkipTo = false, ...props }: WizardProps) {
   const baseComponentProps = useBaseComponent('Wizard');
+  const { wizardCount } = useFunnel();
   const externalProps = getExternalProps(props);
+
+  useEffect(() => {
+    wizardCount.current++;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => void wizardCount.current--;
+  }, [wizardCount]);
 
   return (
     <AnalyticsFunnel


### PR DESCRIPTION
### Description

This PR adds support for placing funnels inside other funnels (i.e. currently the Form and the Wizard components).
When a Form is placed inside another Form, the inner Form is now ignored.
When a Wizard is placed inside or around a Form, the Wizard now always takes precedence.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
