### PR TITLE
fix: Disallow dropping multiple files onto non-multiple FileUpload

### DIFF
--- a/src/file-upload/__tests__/file-upload-dropzone.test.tsx
+++ b/src/file-upload/__tests__/file-upload-dropzone.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Dropzone, useDropzoneVisible } from '../../../lib/components/file-upload/dropzone';
 import selectors from '../../../lib/components/file-upload/dropzone/styles.selectors.js';
+import FileUpload, { FileUploadProps } from '../../../lib/components/file-upload';
 
 const file1 = new File([new Blob(['Test content 1'], { type: 'text/plain' })], 'test-file-1.txt', {
   type: 'text/plain',
@@ -28,6 +29,15 @@ function TestDropzoneVisible() {
   const isDropzoneVisible = useDropzoneVisible();
   return <div>{isDropzoneVisible ? 'visible' : 'hidden'}</div>;
 }
+
+const i18nStrings: FileUploadProps.I18nStrings = {
+  uploadButtonText: multiple => (multiple ? 'Choose files' : 'Choose file'),
+  dropzoneText: multiple => (multiple ? 'Drag files to upload' : 'Drag file to upload'),
+  removeFileAriaLabel: fileIndex => `Remove file ${fileIndex + 1}`,
+  errorIconAriaLabel: 'Error',
+  limitShowFewer: 'Show fewer files',
+  limitShowMore: 'Show more files',
+};
 
 describe('File upload dropzone', () => {
   test('Dropzone becomes visible once global dragover event is received', () => {
@@ -65,6 +75,12 @@ describe('File upload dropzone', () => {
     await waitFor(() => {
       expect(screen.getByText('hidden')).toBeDefined();
     });
+  });
+
+  test('dropzone is rendered in component', () => {
+    render(<FileUpload value={[]} i18nStrings={i18nStrings} />);
+    fireEvent(document, createDragEvent('dragover'));
+    expect(screen.getByText('Drag file to upload')).toBeDefined();
   });
 
   test('dropzone renders provided children', () => {

--- a/src/file-upload/dropzone/index.tsx
+++ b/src/file-upload/dropzone/index.tsx
@@ -8,6 +8,7 @@ import InternalIcon from '../../icon/internal';
 
 interface DropzoneProps {
   onChange: (files: File[]) => void;
+  multiple?: boolean;
   children: React.ReactNode;
 }
 
@@ -58,15 +59,19 @@ export function useDropzoneVisible() {
   return isDropzoneVisible;
 }
 
-export function Dropzone({ onChange, children }: DropzoneProps) {
+export function Dropzone({ onChange, multiple, children }: DropzoneProps) {
   const [isDropzoneHovered, setDropzoneHovered] = useState(false);
 
   const onDragOver = (event: React.DragEvent) => {
     event.preventDefault();
-    setDropzoneHovered(true);
 
     if (event.dataTransfer) {
-      event.dataTransfer.dropEffect = 'copy';
+      if (event.dataTransfer.items.length > 1 && !multiple) {
+        event.dataTransfer.dropEffect = 'none';
+      } else {
+        setDropzoneHovered(true);
+        event.dataTransfer.dropEffect = 'copy';
+      }
     }
   };
 
@@ -83,6 +88,9 @@ export function Dropzone({ onChange, children }: DropzoneProps) {
     event.preventDefault();
     setDropzoneHovered(false);
 
+    if (event.dataTransfer.files.length > 1 && !multiple) {
+      return;
+    }
     onChange(Array.from(event.dataTransfer.files));
   };
 

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -80,7 +80,7 @@ function InternalFileUpload(
     }
   };
 
-  const isDropzoneVisible = useDropzoneVisible();
+  const isDropzoneVisible = useDropzoneVisible(multiple);
 
   const formFieldContext = useFormFieldContext(restProps);
   const ariaDescribedBy = joinStrings(
@@ -101,9 +101,7 @@ function InternalFileUpload(
     >
       <InternalBox>
         {isDropzoneVisible ? (
-          <Dropzone onChange={handleFilesChange} multiple={multiple}>
-            {i18nStrings.dropzoneText(multiple)}
-          </Dropzone>
+          <Dropzone onChange={handleFilesChange}>{i18nStrings.dropzoneText(multiple)}</Dropzone>
         ) : (
           <FileInput
             ref={ref}

--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -101,7 +101,9 @@ function InternalFileUpload(
     >
       <InternalBox>
         {isDropzoneVisible ? (
-          <Dropzone onChange={handleFilesChange}>{i18nStrings.dropzoneText(multiple)}</Dropzone>
+          <Dropzone onChange={handleFilesChange} multiple={multiple}>
+            {i18nStrings.dropzoneText(multiple)}
+          </Dropzone>
         ) : (
           <FileInput
             ref={ref}


### PR DESCRIPTION
### Description

Disallow dropping multiple files onto non-multiple FileUpload.

This ensures that drop behavior matches file selector behavior, 
and better matches with browser native inputs.

Related links, issue #, if available: AWSUI-21885

### How has this been tested?

New unit tests & local testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
