### PR TITLE
feat: Add text-status-warning color to Box

### DIFF
--- a/pages/box/variants.page.tsx
+++ b/pages/box/variants.page.tsx
@@ -31,6 +31,7 @@ const permutations = createPermutations<BoxProps>([
       'text-status-success',
       'text-status-info',
       'text-status-inactive',
+      'text-status-warning',
     ],
   },
   {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2323,6 +2323,7 @@ Object {
 - \`text-status-success\` - Specifies the color for success text and icons.
 - \`text-status-info\` - Specifies the color for info text and icon.
 - \`text-status-inactive\` - Specifies the color for inactive and loading text and icons.
+- \`text-status-warning\` - Specifies the color for warning text and icons.
 
 Note: If you don't set it, the text color depends on the variant.
 ",
@@ -2337,6 +2338,7 @@ Note: If you don't set it, the text color depends on the variant.
           "text-status-success",
           "text-status-info",
           "text-status-inactive",
+          "text-status-warning",
         ],
       },
       "name": "color",

--- a/src/box/__tests__/box.test.tsx
+++ b/src/box/__tests__/box.test.tsx
@@ -140,6 +140,7 @@ describe('Box', () => {
       'text-status-success',
       'text-status-info',
       'text-status-inactive',
+      'text-status-warning',
     ],
     'color'
   );

--- a/src/box/base-styles.scss
+++ b/src/box/base-styles.scss
@@ -40,6 +40,7 @@ $font-styles: (
     text-status-success: awsui.$color-text-status-success,
     text-status-info: awsui.$color-text-status-info,
     text-status-inactive: awsui.$color-text-status-inactive,
+    text-status-warning: awsui.$color-text-status-warning,
     inherit: inherit,
   ),
   font-size: (

--- a/src/box/interfaces.ts
+++ b/src/box/interfaces.ts
@@ -102,6 +102,7 @@ export interface BoxProps extends BaseComponentProps {
    * - `text-status-success` - Specifies the color for success text and icons.
    * - `text-status-info` - Specifies the color for info text and icon.
    * - `text-status-inactive` - Specifies the color for inactive and loading text and icons.
+   * - `text-status-warning` - Specifies the color for warning text and icons.
    *
    * Note: If you don't set it, the text color depends on the variant.
    */
@@ -151,7 +152,8 @@ export namespace BoxProps {
     | 'text-status-error'
     | 'text-status-success'
     | 'text-status-info'
-    | 'text-status-inactive';
+    | 'text-status-inactive'
+    | 'text-status-warning';
   export type SpacingSize = 'n' | 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl';
   export interface Spacing {
     top?: BoxProps.SpacingSize;


### PR DESCRIPTION
### Description

Add the new warning color to the Box component, to match with Alert, StatusIndicator etc.

Related links, issue #, if available: AWSUI-21899

### How has this been tested?

Added new tests/permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
