### PR TITLE
fix: Ensure inline-icon dropdown has active states

### DIFF
--- a/pages/button-dropdown/item-element.permutations.page.tsx
+++ b/pages/button-dropdown/item-element.permutations.page.tsx
@@ -5,7 +5,6 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 import Box from '~components/box';
-import Dropdown from '~components/internal/components/dropdown';
 import ItemElement from '~components/button-dropdown/item-element';
 import { ItemProps } from '~components/button-dropdown/interfaces';
 import img from '../icon/custom-icon.png';
@@ -130,6 +129,16 @@ const permutations = createPermutations<ItemProps>([
     highlightItem: [() => {}],
     isKeyboardHighlighted: [true],
   },
+  {
+    item: [{ id: '1', text: 'Option' }],
+    variant: ['icon', 'inline-icon', 'navigation', 'normal', 'primary'],
+    disabled: [false, true],
+    highlighted: [false, true],
+    last: [false, true],
+    hasCategoryHeader: [false],
+    onItemActivate: [() => {}],
+    highlightItem: [() => {}],
+  },
 ]);
 
 export default function () {
@@ -141,9 +150,7 @@ export default function () {
           permutations={permutations}
           render={permutation => (
             <Box margin={{ bottom: 'xxl' }} className={styles['dropdown-permutation']}>
-              <Dropdown trigger={null} open={true}>
-                <div role="menu">{<ItemElement {...permutation} />}</div>
-              </Dropdown>
+              <div role="menu">{<ItemElement {...permutation} />}</div>
             </Box>
           )}
         />

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -31,6 +31,7 @@
     z-index: 2;
 
     &.variant-icon,
+    &.variant-inline-icon,
     &.variant-normal,
     &.variant-primary {
       background-color: awsui.$color-background-dropdown-item-hover;


### PR DESCRIPTION
### Description

Ensure inline-icon dropdown has active states

Related links, issue #, if available: AWSUI-21904

### How has this been tested?

Updated visual regression tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
