### PR TITLE
fix: Break words in split panel header

### DIFF
--- a/pages/app-layout/with-split-panel.page.tsx
+++ b/pages/app-layout/with-split-panel.page.tsx
@@ -77,7 +77,7 @@ export default function () {
         splitPanel={
           splitPanelEnabled && (
             <SplitPanel
-              header="Split panel header"
+              header="Split panel header withlongwordthatshouldbesplitinsteadofmakingthepanelscroll"
               i18nStrings={{
                 preferencesTitle: 'Preferences',
                 preferencesPositionLabel: 'Split panel position',

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -31,7 +31,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
 .drawer {
   flex-shrink: 0;
   position: relative;
-  word-wrap: break-word;
+  @include styles.text-wrapping;
   background-color: awsui.$color-background-layout-panel-content;
   // should be above tools and navigation panels to avoid their shadows
   z-index: 840;


### PR DESCRIPTION
### Description

Allow long words in split panel header to be broken

Related links, issue #, if available: #1431

### How has this been tested?

Local testing & updated screenshot test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
