### PR TITLE
chore: Offset sticky scrollbar when sticky columns are enabled for all table variants

### DIFF
--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -230,7 +230,10 @@ export default () => {
         <Table
           {...collectionProps}
           data-test-id="small-table"
-          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          stickyColumns={{
+            first: parseInt(urlParams.stickyColumnsFirst || '0'),
+            last: parseInt(urlParams.stickyColumnsLast || '0'),
+          }}
           {...urlParams}
           columnDefinitions={columnsConfig}
           selectedItems={selectedItems}
@@ -242,7 +245,10 @@ export default () => {
         <Table
           {...collectionProps}
           data-test-id="large-table"
-          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          stickyColumns={{
+            first: parseInt(urlParams.stickyColumnsFirst || '0'),
+            last: parseInt(urlParams.stickyColumnsLast || '0'),
+          }}
           {...urlParams}
           ariaLabels={{ ...ariaLabels, tableLabel: 'Large table' }}
           columnDefinitions={COLUMN_DEFINITIONS}
@@ -254,7 +260,10 @@ export default () => {
         <Table
           {...collectionProps}
           data-test-id="inline-editing-table"
-          stickyColumns={{ first: parseInt(urlParams.stickyColumnsFirst), last: parseInt(urlParams.stickyColumnsLast) }}
+          stickyColumns={{
+            first: parseInt(urlParams.stickyColumnsFirst || '0'),
+            last: parseInt(urlParams.stickyColumnsLast || '0'),
+          }}
           {...urlParams}
           columnDefinitions={[
             {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -178,10 +178,6 @@ const InternalTable = React.forwardRef(
     });
 
     const hasStickyColumns = !!((stickyColumns?.first ?? 0) + (stickyColumns?.last ?? 0) > 0);
-    const isFullPageInVisualRefresh = isVisualRefresh && variant === 'full-page';
-    // All Classic variants and the "full-page" VR variant of the table with sticky columns should offset the scrollbar
-    // for it not to overlap interactive elements (such as checkboxes, radio buttons or links in cells)
-    const shouldOffsetStickyScrollbar = hasStickyColumns && (isVisualRefresh ? isFullPageInVisualRefresh : true);
 
     const hasEditableCells = !!columnDefinitions.find(col => col.editConfig);
     const tableRole = hasEditableCells ? 'grid' : 'table';
@@ -458,7 +454,7 @@ const InternalTable = React.forwardRef(
               wrapperRef={wrapperRefObject}
               tableRef={tableRefObject}
               onScroll={handleScroll}
-              offsetScrollbar={shouldOffsetStickyScrollbar}
+              offsetScrollbar={hasStickyColumns}
             />
           </InternalContainer>
         </ColumnWidthsProvider>

--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -28,7 +28,8 @@
 
   &-offset {
     // "offset" styles are needed for when sticky columns are enabled.
-    // We move the scrollbar lower for it not to overlap interactive elements (such as checkboxes or links)
+    // We move the scrollbar lower, so it doesn't overlap interactive elements (such as checkboxes or links)
+
     z-index: 800; // Higher than sticky columns
     &:not(.is-visual-refresh) {
       background-color: awsui.$color-background-container-content;
@@ -44,5 +45,5 @@
 }
 
 .is-visual-refresh {
-  // Used for decting visual refresh
+  // Used for detecting Visual Refresh
 }


### PR DESCRIPTION
Follow up from https://github.com/cloudscape-design/components/pull/1305.

We actually want this treatment for all table variants of VR as well.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
