### PR TITLE
fix: use default progress bar announcement text when a non-string lab…

### DIFF
--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -190,4 +190,18 @@ describe('Progress updates', () => {
     jest.advanceTimersByTime(6000);
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 2%`);
   });
+  test('Announced progress value can handle a component as a label', () => {
+    jest.useFakeTimers(); // Mock timers
+    const LabelComponent = <>Component</>;
+    const { container, rerender } = render(<ProgressBar label={LabelComponent} value={0} />);
+    const wrapper = createWrapper(container).findProgressBar()!;
+
+    expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`0%`);
+
+    rerender(<ProgressBar label={LabelComponent} value={2} />);
+
+    // 6 seconds passed, live region has a new value
+    jest.advanceTimersByTime(6000);
+    expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`2%`);
+  });
 });

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -39,12 +39,14 @@ export default function ProgressBar({
   const isInFlash = variant === 'flash';
   const isInProgressState = status === 'in-progress';
 
+  const labelText = typeof label === 'string' ? label : '';
   const [assertion, setAssertion] = useState('');
   const throttledAssertion = useMemo(() => {
     return throttle((value: ProgressBarProps['value']) => {
-      setAssertion(`${label ?? ''}: ${value}%`);
+      const assertionText = labelText ? `${labelText}: ${value}%` : `${value}%`;
+      setAssertion(assertionText);
     }, ASSERTION_FREQUENCY);
-  }, [label]);
+  }, [labelText]);
 
   useEffect(() => {
     throttledAssertion(value);


### PR DESCRIPTION
### Description
This change corrects a bug in the progress bar component where progress announcements were incorrect if a something other than a string was passed to the `label` prop. Now if something other than a string is passes as a label, the progress announcement defaults to only reading the percentage. This is similar to previous behavior in which no label is passed where the progress would read `: <percentage>`

### How has this been tested?
This was tested via unit tests. A unit test was added to ensure this works, and existing unit tests related to this code area continue to work. The announcement was also read successfully via a screen reader by altering the "with-updates-page" and testing that experience. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
