### PR TITLE
chore: Track primary buttons anywhere in funnels

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -84,7 +84,7 @@ describe('Form Analytics', () => {
     );
   });
 
-  test('does not send a funnelComplete metricv when the form is unmounted after clicking a primary button in a modal', () => {
+  test('does not send a funnelComplete metric when the form is unmounted after clicking a primary button in a modal', () => {
     const { container } = render(
       <Form>
         <Modal

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -25,17 +25,9 @@ const FormWithAnalytics = ({ variant = 'full-page', actions, ...props }: FormPro
   };
 
   return (
-    <InternalForm
-      variant={variant}
-      actions={
-        actions && (
-          <ButtonContext.Provider value={{ onClick: handleActionButtonClick }}>{actions}</ButtonContext.Provider>
-        )
-      }
-      {...props}
-      {...funnelProps}
-      {...funnelStepProps}
-    />
+    <ButtonContext.Provider value={{ onClick: handleActionButtonClick }}>
+      <InternalForm variant={variant} actions={actions} {...props} {...funnelProps} {...funnelStepProps} />
+    </ButtonContext.Provider>
   );
 };
 

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -24,6 +24,7 @@ import FocusLock from '../internal/components/focus-lock';
 import { useInternalI18n } from '../i18n/context';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
+import { ButtonContext } from '../internal/context/button-context';
 
 type InternalModalProps = SomeRequired<ModalProps, 'size'> & InternalBaseComponentProps;
 
@@ -115,62 +116,64 @@ function InnerModal({
   const [footerHeight, footerRef] = useContainerQuery(rect => rect.borderBoxHeight);
 
   return (
-    <FormFieldContext.Provider value={{}}>
-      <div
-        {...baseProps}
-        className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
-        role="dialog"
-        aria-modal={true}
-        aria-labelledby={headerId}
-        onMouseDown={onOverlayMouseDown}
-        onClick={onOverlayClick}
-        ref={mergedRef}
-        style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
-      >
-        <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
-          <div
-            className={clsx(
-              styles.dialog,
-              styles[size],
-              styles[`breakpoint-${breakpoint}`],
-              isRefresh && styles.refresh
-            )}
-            onKeyDown={escKeyHandler}
-          >
-            <div className={styles.container}>
-              <div className={styles.header}>
-                <InternalHeader
-                  variant="h2"
-                  __disableActionsWrapping={true}
-                  actions={
-                    <InternalButton
-                      ariaLabel={closeAriaLabel}
-                      className={styles['dismiss-control']}
-                      variant="modal-dismiss"
-                      iconName="close"
-                      formAction="none"
-                      onClick={onCloseButtonClick}
-                    />
-                  }
-                >
-                  <span id={headerId} className={styles['header--text']}>
-                    {header}
-                  </span>
-                </InternalHeader>
-              </div>
-              <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
-                {children}
-                <div ref={stickySentinelRef} />
-              </div>
-              {footer && (
-                <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
-                  {footer}
-                </div>
+    <ButtonContext.Provider value={{ onClick: () => {} }}>
+      <FormFieldContext.Provider value={{}}>
+        <div
+          {...baseProps}
+          className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
+          role="dialog"
+          aria-modal={true}
+          aria-labelledby={headerId}
+          onMouseDown={onOverlayMouseDown}
+          onClick={onOverlayClick}
+          ref={mergedRef}
+          style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
+        >
+          <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
+            <div
+              className={clsx(
+                styles.dialog,
+                styles[size],
+                styles[`breakpoint-${breakpoint}`],
+                isRefresh && styles.refresh
               )}
+              onKeyDown={escKeyHandler}
+            >
+              <div className={styles.container}>
+                <div className={styles.header}>
+                  <InternalHeader
+                    variant="h2"
+                    __disableActionsWrapping={true}
+                    actions={
+                      <InternalButton
+                        ariaLabel={closeAriaLabel}
+                        className={styles['dismiss-control']}
+                        variant="modal-dismiss"
+                        iconName="close"
+                        formAction="none"
+                        onClick={onCloseButtonClick}
+                      />
+                    }
+                  >
+                    <span id={headerId} className={styles['header--text']}>
+                      {header}
+                    </span>
+                  </InternalHeader>
+                </div>
+                <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
+                  {children}
+                  <div ref={stickySentinelRef} />
+                </div>
+                {footer && (
+                  <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
+                    {footer}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        </FocusLock>
-      </div>
-    </FormFieldContext.Provider>
+          </FocusLock>
+        </div>
+      </FormFieldContext.Provider>
+    </ButtonContext.Provider>
   );
 }


### PR DESCRIPTION
### Description

Before this PR, we only tracked primary button clicks in the `actions` slot of a Form. However, there are some creation flows where the primary button is not in the usual `actions` slot, but somewhere else in the Form.  
With this PR, we track primary buttons anywhere inside the Form. There is an exception for primary buttons in Modals, since that button usually only closes the Modal without submitting anything.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added a unit test, and tested locally with a dev page.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
