### PR TITLE
fix: Properly extend runtime API with new methods

### DIFF
--- a/src/internal/plugins/__tests__/api.test.ts
+++ b/src/internal/plugins/__tests__/api.test.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { loadApi } from '../../../../lib/components/internal/plugins/api';
+import { DrawerConfig } from '../../../../lib/components/internal/plugins/controllers/drawers';
+
+function delay() {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
+const storageKey = Symbol.for('awsui-plugin-api');
+
+afterEach(() => {
+  delete (window as any)[storageKey];
+});
+
+test('loading api multiple times does not reset the state', async () => {
+  let api = loadApi();
+  const onRegister = jest.fn();
+
+  api.awsuiPluginsInternal.appLayout.onDrawersRegistered(onRegister);
+  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-1' } as DrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }]);
+  onRegister.mockReset();
+
+  api = loadApi();
+  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-2' } as DrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2' }]);
+});
+
+test('partial API can be extended', () => {
+  const api = loadApi();
+  // @ts-expect-error testing runtime issues
+  delete api.awsuiPlugins.alert;
+  // @ts-expect-error testing runtime issues
+  delete api.awsuiPluginsInternal.alert;
+  expect(api.awsuiPlugins.alert).toBeUndefined();
+  expect(api.awsuiPluginsInternal.alert).toBeUndefined();
+
+  loadApi();
+  expect(api.awsuiPlugins.alert).toBeDefined();
+  expect(api.awsuiPluginsInternal.alert).toBeDefined();
+});

--- a/src/internal/plugins/controllers/action-buttons.ts
+++ b/src/internal/plugins/controllers/action-buttons.ts
@@ -23,6 +23,15 @@ export interface ActionConfig {
 
 export type ActionRegistrationListener = (action: Array<ActionConfig>) => void;
 
+export interface ActionsApiPublic {
+  registerAction(config: ActionConfig): void;
+}
+
+export interface ActionsApiInternal {
+  clearRegisteredActions(): void;
+  onActionRegistered(listener: ActionRegistrationListener): () => void;
+}
+
 export class ActionButtonsController {
   private listeners: Array<ActionRegistrationListener> = [];
   private actions: Array<ActionConfig> = [];
@@ -48,4 +57,15 @@ export class ActionButtonsController {
       this.listeners = this.listeners.filter(item => item !== listener);
     };
   };
+
+  installPublic(api: Partial<ActionsApiPublic> = {}): ActionsApiPublic {
+    api.registerAction ??= this.registerAction;
+    return api as ActionsApiPublic;
+  }
+
+  installInternal(internalApi: Partial<ActionsApiInternal> = {}): ActionsApiInternal {
+    internalApi.clearRegisteredActions ??= this.clearRegisteredActions;
+    internalApi.onActionRegistered ??= this.onActionRegistered;
+    return internalApi as ActionsApiInternal;
+  }
 }

--- a/src/internal/plugins/controllers/drawers.ts
+++ b/src/internal/plugins/controllers/drawers.ts
@@ -13,6 +13,15 @@ export type DrawerConfig = Omit<DrawerItem, 'content' | 'trigger'> & {
 };
 export type DrawersRegistrationListener = (drawers: Array<DrawerConfig>) => void;
 
+export interface DrawersApiPublic {
+  registerDrawer(config: DrawerConfig): void;
+}
+
+export interface DrawersApiInternal {
+  clearRegisteredDrawers(): void;
+  onDrawersRegistered(listener: DrawersRegistrationListener): () => void;
+}
+
 export class DrawersController {
   private drawers: Array<DrawerConfig> = [];
   private drawersRegistrationListener: DrawersRegistrationListener | null = null;
@@ -40,4 +49,15 @@ export class DrawersController {
   clearRegisteredDrawers = () => {
     this.drawers = [];
   };
+
+  installPublic(api: Partial<DrawersApiPublic> = {}): DrawersApiPublic {
+    api.registerDrawer ??= this.registerDrawer;
+    return api as DrawersApiPublic;
+  }
+
+  installInternal(internalApi: Partial<DrawersApiInternal> = {}): DrawersApiInternal {
+    internalApi.clearRegisteredDrawers ??= this.clearRegisteredDrawers;
+    internalApi.onDrawersRegistered ??= this.onDrawersRegistered;
+    return internalApi as DrawersApiInternal;
+  }
 }


### PR DESCRIPTION
### Description

Ensure that runtime API always have latest methods

When there is an instance of runtime API already registered, the 2nd one skips. If the first instance is from an old version, some methods can be missing.

Related links, issue #, if available: AWSUI-21953

### How has this been tested?

* Added extra unit tests to reproduce the issue standalone
* Dry-runs to affected version sets

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
