### PR TITLE
chore: Don't report funnel errors for hidden errors

### DIFF
--- a/src/alert/__tests__/alert-analytics.test.tsx
+++ b/src/alert/__tests__/alert-analytics.test.tsx
@@ -19,6 +19,19 @@ describe('Alert Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFunnelMetrics();
+
+    // These numbers were chosen at random
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 300,
+      height: 200,
+      x: 30,
+      y: 50,
+      left: 30,
+      top: 50,
+      bottom: 100,
+      right: 400,
+      toJSON: () => '',
+    });
   });
 
   test('sends funnelSubStepError metric when the alert is placed inside a substep', () => {

--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -26,21 +26,26 @@ const Alert = React.forwardRef(
 
         errorCount.current++;
 
-        if (subStepSelector) {
-          FunnelMetrics.funnelSubStepError({
-            funnelInteractionId,
-            subStepSelector,
-            subStepName,
-            subStepNameSelector,
-            stepNumber,
-            stepName,
-            stepNameSelector,
-            subStepAllSelector: getSubStepAllSelector(),
-          });
-        } else {
-          FunnelMetrics.funnelError({
-            funnelInteractionId,
-          });
+        // We don't want to report an error if it is hidden, e.g. inside an Expandable Section.
+        const errorIsVisible = (baseComponentProps.__internalRootRef.current?.getBoundingClientRect()?.width ?? 0) > 0;
+
+        if (errorIsVisible) {
+          if (subStepSelector) {
+            FunnelMetrics.funnelSubStepError({
+              funnelInteractionId,
+              subStepSelector,
+              subStepName,
+              subStepNameSelector,
+              stepNumber,
+              stepName,
+              stepNameSelector,
+              subStepAllSelector: getSubStepAllSelector(),
+            });
+          } else {
+            FunnelMetrics.funnelError({
+              funnelInteractionId,
+            });
+          }
         }
 
         return () => {

--- a/src/form-field/__tests__/form-field-analytics.test.tsx
+++ b/src/form-field/__tests__/form-field-analytics.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { act, render } from '@testing-library/react';
 
 import FormField from '../../../lib/components/form-field';
+import ExpandableSection from '../../../lib/components/expandable-section';
 
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 import { DATA_ATTR_FIELD_LABEL, DATA_ATTR_FIELD_ERROR } from '../../../lib/components/internal/analytics/selectors';
@@ -21,6 +22,19 @@ describe('FormField Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFunnelMetrics();
+
+    // These numbers were chosen at random
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 300,
+      height: 200,
+      x: 30,
+      y: 50,
+      left: 30,
+      top: 50,
+      bottom: 100,
+      right: 400,
+      toJSON: () => '',
+    });
   });
 
   test('sends funnelSubStepError metric when errorText is present', () => {
@@ -103,6 +117,31 @@ describe('FormField Analytics', () => {
 
   test('does not send a funnelSubStepError metric when outside of a funnel context', () => {
     render(<FormField errorText="Error" />);
+    expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelStepError).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
+  });
+
+  test('does not send a funnelSubStepError metric when hidden', () => {
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      bottom: 0,
+      right: 0,
+      toJSON: () => '',
+    });
+
+    render(
+      <ExpandableSection expanded={false} onChange={() => {}}>
+        <FormField errorText="Error" />
+      </ExpandableSection>
+    );
+    expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelStepError).not.toHaveBeenCalled();
     expect(FunnelMetrics.funnelSubStepError).not.toHaveBeenCalled();
   });
 

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -126,18 +126,23 @@ export default function InternalFormField({
 
       errorCount.current++;
 
-      FunnelMetrics.funnelSubStepError({
-        funnelInteractionId,
-        subStepSelector,
-        subStepName,
-        subStepNameSelector,
-        stepNumber,
-        stepName,
-        stepNameSelector,
-        fieldErrorSelector: getFieldSlotSeletor(slotIds.error),
-        fieldLabelSelector: getFieldSlotSeletor(slotIds.label),
-        subStepAllSelector: getSubStepAllSelector(),
-      });
+      // We don't want to report an error if it is hidden, e.g. inside an Expandable Section.
+      const errorIsVisible = (__internalRootRef?.current?.getBoundingClientRect()?.width ?? 0) > 0;
+
+      if (errorIsVisible) {
+        FunnelMetrics.funnelSubStepError({
+          funnelInteractionId,
+          subStepSelector,
+          subStepName,
+          subStepNameSelector,
+          stepNumber,
+          stepName,
+          stepNameSelector,
+          fieldErrorSelector: getFieldSlotSeletor(slotIds.error),
+          fieldLabelSelector: getFieldSlotSeletor(slotIds.label),
+          subStepAllSelector: getSubStepAllSelector(),
+        });
+      }
 
       return () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Description

When a form field with an error is inside an expandable section, it currently emits an error event, even though it is not visible to the user, i.e. the user has not actually encountered the error yet. With this PR, we suppress the error event in that case.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually in dev pages. This change is very difficult to test in a unit test, because it relies on the browser's layout calculation to determine whether the element is visible. Our simulated browser environment in the unit tests does not provide this information, and mocking that API would leave very little to actually test.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
