### PR TITLE
fix: Progress bar correctly announces text of a formatted label

### DIFF
--- a/pages/progress-bar/with-updates.page.tsx
+++ b/pages/progress-bar/with-updates.page.tsx
@@ -76,7 +76,11 @@ export default function ProgressBarWithUpdates() {
             status={progressStep10 < 100 ? 'in-progress' : 'success'}
             value={progressStep10}
             variant={'standalone'}
-            label={'Tea'}
+            label={
+              <span>
+                Tea <i>- optional</i>
+              </span>
+            }
             description={'We will make a nice cup of tea ...'}
             additionalInfo={'Take some cookie as a desert'}
             resultText={'Your tea is ready!'}

--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -190,4 +190,17 @@ describe('Progress updates', () => {
     jest.advanceTimersByTime(6000);
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`${label}: 2%`);
   });
+
+  test('correctly extracts react node label for announcement', () => {
+    const wrapper = renderProgressBar({
+      label: (
+        <span>
+          Text-<i>optional</i>
+        </span>
+      ),
+      value: 10,
+      status: 'in-progress',
+    });
+    expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe('Text-optional: 10%');
+  });
 });

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -39,12 +39,12 @@ export default function ProgressBar({
   const isInFlash = variant === 'flash';
   const isInProgressState = status === 'in-progress';
 
-  const [assertion, setAssertion] = useState('');
+  const [announcedValue, setAnnouncedValue] = useState('');
   const throttledAssertion = useMemo(() => {
     return throttle((value: ProgressBarProps['value']) => {
-      setAssertion(`${label ?? ''}: ${value}%`);
+      setAnnouncedValue(`${value}%`);
     }, ASSERTION_FREQUENCY);
-  }, [label]);
+  }, []);
 
   useEffect(() => {
     throttledAssertion(value);
@@ -72,7 +72,11 @@ export default function ProgressBar({
           {isInProgressState ? (
             <>
               <Progress value={value} labelId={labelId} isInFlash={isInFlash} />
-              <LiveRegion delay={0}>{assertion}</LiveRegion>
+              <LiveRegion delay={0}>
+                {label}
+                {label ? ': ' : null}
+                {announcedValue}
+              </LiveRegion>
             </>
           ) : (
             <ResultState


### PR DESCRIPTION
### Description

Existing implementation of the progress assertion assumes that label is a string, which leads to incorrect announcement when ReactNode is passed. 

This fix uses inner text extraction build-in into LiveRegion utility to announce label text 

Related links, issue #, if available: n/a

### How has this been tested?

VO + Safari
Unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
