### PR TITLE
chore: Disallow unsafe usages of `any` in some components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -172,6 +172,43 @@
           }
         ]
       }
+    },
+    {
+      "files": [
+        "src/app-layout/**",
+        "src/area-chart/**",
+        "src/attribute-editor/**",
+        "src/autosuggest/**",
+        "src/button/**",
+        "src/code-editor/**",
+        "src/collection-preferences/**",
+        "src/column-layout/**",
+        "src/date-picker/**",
+        "src/date-range-picker/**",
+        "src/flashbar/**",
+        "src/grid/**",
+        "src/internal/**",
+        "src/link/**",
+        "src/wizard/**"
+      ],
+      "excludedFiles": [
+        "src/**/__tests__/**",
+        "src/**/__integ__/**",
+        "src/**/__a11y__/**",
+        "src/test-utils/**",
+        "src/internal/vendor/**"
+      ],
+      "rules": {
+        "@typescript-eslint/no-unsafe-argument": "error",
+        "@typescript-eslint/no-unsafe-assignment": "error",
+        "@typescript-eslint/no-unsafe-call": "error",
+        "@typescript-eslint/no-unsafe-declaration-merging": "error",
+        "@typescript-eslint/no-unsafe-member-access": "error",
+        "@typescript-eslint/no-unsafe-return": "error"
+      },
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      }
     }
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -175,7 +175,6 @@
     },
     {
       "files": [
-        "src/app-layout/**",
         "src/area-chart/**",
         "src/attribute-editor/**",
         "src/autosuggest/**",

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -86,4 +86,5 @@ export interface InternalDrawerProps {
     onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
     ariaLabel?: string;
   };
+  __disableRuntimeDrawers?: boolean;
 }

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -75,8 +75,8 @@ const AppLayout = React.forwardRef(
     const props = { contentType, headerSelector, footerSelector, ...rest, ariaLabels };
 
     const baseProps = getBaseProps(rest);
-    const ownDrawers = (props as any).drawers;
-    const disableRuntimeDrawers = (props as any).__disableRuntimeDrawers;
+    const ownDrawers = (props as InternalDrawerProps).drawers;
+    const disableRuntimeDrawers = (props as InternalDrawerProps).__disableRuntimeDrawers;
     const combinedDrawers = [...runtimeDrawers.before, ...(ownDrawers?.items ?? []), ...runtimeDrawers.after];
     const finalDrawers = combinedDrawers.length > 0 ? { ...ownDrawers, items: combinedDrawers } : ownDrawers;
 

--- a/src/app-layout/utils/use-observed-element.ts
+++ b/src/app-layout/utils/use-observed-element.ts
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react';
 
 export function useObservedElement(selector: string) {
   const getElement = useCallback(() => {
-    return document.querySelector(selector);
+    return document.querySelector<Element>(selector);
   }, [selector]);
 
   const [height, setHeight] = useState(0);

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -71,7 +71,7 @@ function ActiveDrawer() {
     drawerRef,
   } = useAppLayoutInternals();
 
-  const activeDrawer = drawers?.items.find((item: any) => item.id === activeDrawerId) ?? null;
+  const activeDrawer = drawers?.items.find(item => item.id === activeDrawerId) ?? null;
 
   const computedAriaLabels = {
     closeButton: activeDrawerId ? activeDrawer?.ariaLabels?.closeButton : ariaLabels?.toolsClose,

--- a/src/area-chart/async-store/index.ts
+++ b/src/area-chart/async-store/index.ts
@@ -5,7 +5,7 @@ import { unstable_batchedUpdates } from 'react-dom';
 import { usePrevious } from '../../internal/hooks/use-previous';
 
 type Selector<S, R> = (state: S) => R;
-type Listener<S> = (state: S, prevState: S) => any;
+type Listener<S> = (state: S, prevState: S) => void;
 
 export interface ReadonlyAsyncStore<S> {
   get(): S;

--- a/src/area-chart/model/utils.ts
+++ b/src/area-chart/model/utils.ts
@@ -73,7 +73,7 @@ export function computeDomainY<T>(series: readonly AreaChartProps.Series<T>[], s
 
 // For given data, series and scales, compute all points and group them as
 // x:y, x:series and series:x to allow constant time access to the required point or subset.
-export function computePlotPoints<T>(
+export function computePlotPoints<T extends AreaChartProps.DataTypes>(
   series: readonly AreaChartProps.Series<T>[],
   xScale: ChartScale,
   yScale: NumericChartScale
@@ -209,12 +209,14 @@ function getXValues<T>(series: readonly AreaChartProps.Series<T>[]) {
 }
 
 // Returns data that is visible in the given scale.
-function getVisibleData<T>(data: readonly T[], xScale: ChartScale) {
+function getVisibleData<T extends AreaChartProps.DataTypes>(data: readonly T[], xScale: ChartScale) {
   const scaledOffsetX = xScale.isCategorical() ? Math.max(0, xScale.d3Scale.bandwidth() - 1) / 2 : 0;
 
   const visibleData = [];
   for (const x of data) {
-    const scaledX = xScale.d3Scale(x as any);
+    type Scale = ChartScale['d3Scale'] & ((x: T) => undefined);
+
+    const scaledX = (xScale.d3Scale as Scale)(x);
 
     if (scaledX !== undefined) {
       visibleData.push({ x, scaledX: scaledX + scaledOffsetX });

--- a/src/attribute-editor/row.tsx
+++ b/src/attribute-editor/row.tsx
@@ -34,7 +34,10 @@ function render<T>(
   itemIndex: number,
   slot: AttributeEditorProps.FieldRenderable<T> | React.ReactNode | undefined
 ) {
-  return typeof slot === 'function' ? slot(item, itemIndex) : slot;
+  if (typeof slot === 'function') {
+    return (slot as AttributeEditorProps.FieldRenderable<T>)(item, itemIndex);
+  }
+  return slot;
 }
 
 const GRID_DEFINITION = [{ colspan: { default: 12, xs: 9 } }];

--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -13,7 +13,7 @@ import { HighlightType } from '../internal/components/options-list/utils/use-hig
 import { useInternalI18n } from '../i18n/context';
 
 export interface AutosuggestOptionProps extends BaseComponentProps {
-  nativeAttributes?: Record<string, any>;
+  nativeAttributes?: Record<string, string | boolean>;
   highlightText: string;
   option: AutosuggestItem;
   highlighted: boolean;

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -121,7 +121,7 @@ export const InternalButton = React.forwardRef(
       ...props,
       ...__nativeAttributes,
       // https://github.com/microsoft/TypeScript/issues/36659
-      ref: useMergeRefs(buttonRef as any, __internalRootRef),
+      ref: useMergeRefs(buttonRef, __internalRootRef),
       'aria-label': ariaLabel,
       'aria-describedby': ariaDescribedby,
       'aria-expanded': ariaExpanded,

--- a/src/code-editor/ace-types.ts
+++ b/src/code-editor/ace-types.ts
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as Ace from 'ace-builds';
+
+export type AceObject = typeof Ace;
+
+declare module 'ace-builds' {
+  namespace Ace {
+    interface TextInput {
+      getElement(): HTMLTextAreaElement;
+    }
+
+    interface MouseEvent {
+      editor: Ace.Editor;
+      stop(): void;
+      getDocumentPosition(): Ace.Point;
+    }
+
+    interface GutterKeyboardEvent {
+      getKey(): string;
+      getRow(): number;
+      isInAnnotationLane(): boolean;
+    }
+
+    interface Tooltip {
+      hide(): void;
+    }
+
+    interface Editor {
+      on(name: 'gutterclick', callback: (e: Ace.MouseEvent) => void): void;
+      on(name: 'showGutterTooltip', callback: (e: Ace.Tooltip) => void): void;
+    }
+
+    interface EditSession {
+      on(name: 'changeAnnotation', callback: () => void): void;
+    }
+  }
+}
+
+export function isAceLike(ace: any): ace is AceObject {
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  return (
+    typeof ace.version === 'string' &&
+    typeof ace.edit === 'function' &&
+    typeof ace.config === 'object' &&
+    typeof ace.config.loadModule === 'function' &&
+    typeof ace.Range === 'function'
+  );
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+}

--- a/src/code-editor/setup-editor.ts
+++ b/src/code-editor/setup-editor.ts
@@ -3,9 +3,10 @@
 import React from 'react';
 import { Ace } from 'ace-builds';
 import { PaneStatus, supportsKeyboardAccessibility } from './util';
+import { AceObject } from './ace-types';
 
 export function setupEditor(
-  ace: any,
+  ace: AceObject,
   editor: Ace.Editor,
   setAnnotations: React.Dispatch<React.SetStateAction<Ace.Annotation[]>>,
   setCursorPosition: React.Dispatch<React.SetStateAction<Ace.Point>>,
@@ -27,7 +28,7 @@ export function setupEditor(
     setCursorPosition(editor.getCursorPosition());
   });
 
-  editor.session.on('changeAnnotation' as any, () => {
+  editor.session.on('changeAnnotation', () => {
     const editorAnnotations = editor.session.getAnnotations();
     const newAnnotations = editorAnnotations.filter(a => a.type !== 'info');
     if (editorAnnotations.length !== newAnnotations.length) {
@@ -47,20 +48,20 @@ export function setupEditor(
   }
 
   editor.on('focus', () => {
-    (editor as any).textInput.getElement().setAttribute('tabindex', 0);
+    editor.textInput.getElement().setAttribute('tabindex', '0');
   });
 
   editor.on('blur', () => {
-    (editor as any).textInput.getElement().setAttribute('tabindex', -1);
+    editor.textInput.getElement().setAttribute('tabindex', '-1');
   });
 
   // prevent users to step into editor directly by keyboard
-  (editor as any).textInput.getElement().setAttribute('tabindex', -1);
+  editor.textInput.getElement().setAttribute('tabindex', '-1');
 
   editor.commands.removeCommand('showSettingsMenu', false);
 
   // Prevent default behavior on error/warning icon click
-  editor.on('guttermousedown' as any, (e: any) => {
+  editor.on('guttermousedown', (e: Ace.MouseEvent) => {
     e.stop();
   });
 
@@ -89,13 +90,13 @@ export function setupEditor(
   };
 
   // open error/warning pane when user clicks on gutter icon
-  editor.on('gutterclick' as any, (e: any) => {
-    const { row }: Ace.Point = e.getDocumentPosition();
+  editor.on('gutterclick', (e: Ace.MouseEvent) => {
+    const { row } = e.getDocumentPosition();
     openAnnotation(row);
   });
 
   // open error/warning pane when user presses space/enter on gutter icon
-  editor.on('gutterkeydown', e => {
+  editor.on('gutterkeydown', (e: Ace.GutterKeyboardEvent) => {
     if (e.isInAnnotationLane() && (e.getKey() === 'space' || e.getKey() === 'return')) {
       const row: number = e.getRow();
       openAnnotation(row);
@@ -105,6 +106,7 @@ export function setupEditor(
   // HACK: Wrapped lines are highlighted individually. This is seriously the recommended fix.
   // See: https://github.com/ajaxorg/ace/issues/3067
   editor.setHighlightActiveLine(false);
+  /* eslint-disable */
   (editor as any).$updateHighlightActiveLine = function () {
     const session = this.getSession();
 
@@ -132,6 +134,7 @@ export function setupEditor(
       session._signal('changeBackMarker');
     }
   };
+  /* eslint-enable */
 
   editor.setHighlightActiveLine(true);
 
@@ -144,7 +147,7 @@ export function setupEditor(
 
   // HACK: "disable" error tooltips by hiding them as soon as they appear.
   // See https://github.com/ajaxorg/ace/issues/4004
-  editor.on('showGutterTooltip' as any, (tooltip: any) => {
+  editor.on('showGutterTooltip', (tooltip: Ace.Tooltip) => {
     tooltip.hide();
   });
 }

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -6,6 +6,7 @@ import { AceModes } from './ace-modes';
 import { LightThemes, DarkThemes } from './ace-themes';
 import { CodeEditorProps } from './interfaces';
 import { findUpUntil } from '../internal/utils/dom';
+import { AceObject } from './ace-types';
 
 export type PaneStatus = 'error' | 'warning' | 'hidden';
 
@@ -14,7 +15,7 @@ export const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_
 
 const KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION = [1, 23];
 
-export function supportsKeyboardAccessibility(ace: any): boolean {
+export function supportsKeyboardAccessibility(ace: AceObject): boolean {
   // Split semantic version numbers. We don't need a full semver parser for this.
   const semanticVersion = ace?.version?.split('.').map((part: string) => {
     const parsed = parseInt(part);
@@ -30,7 +31,7 @@ export function supportsKeyboardAccessibility(ace: any): boolean {
   );
 }
 
-export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
+export function getDefaultConfig(ace: AceObject): Partial<Ace.EditorOptions> {
   return {
     behavioursEnabled: true,
     ...(supportsKeyboardAccessibility(ace) ? { enableKeyboardAccessibility: true } : {}),

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -3,7 +3,7 @@
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 
-export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
+export interface CollectionPreferencesProps<CustomPreferenceType = unknown> extends BaseComponentProps {
   /**
    * Specifies the title of the preferences modal dialog. It is also used as an `aria-label` for the trigger button.
    * @i18n
@@ -193,7 +193,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
 }
 
 export namespace CollectionPreferencesProps {
-  export interface Preferences<CustomPreferenceType = any> {
+  export interface Preferences<CustomPreferenceType = unknown> {
     pageSize?: number;
     wrapLines?: boolean;
     stripedRows?: boolean;

--- a/src/collection-preferences/utils.tsx
+++ b/src/collection-preferences/utils.tsx
@@ -51,7 +51,7 @@ export const mergePreferences = (
   ];
   for (const prefName of prefNames) {
     if (newPref[prefName] !== undefined) {
-      newObj[prefName] = newPref[prefName];
+      (newObj as Record<string, unknown>)[prefName] = newPref[prefName];
     }
   }
   return newObj;
@@ -230,7 +230,7 @@ export const StickyColumnsPreference = ({
   );
 };
 
-interface CustomPreferenceProps<T = any> extends Pick<CollectionPreferencesProps<T>, 'customPreference'> {
+interface CustomPreferenceProps<T = unknown> extends Pick<CollectionPreferencesProps<T>, 'customPreference'> {
   onChange: (value: T) => void;
   value: T;
 }

--- a/src/column-layout/flexible-column-layout/index.tsx
+++ b/src/column-layout/flexible-column-layout/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { Key } from 'react';
 import clsx from 'clsx';
 import flattenChildren from 'react-keyed-flatten-children';
 import { InternalColumnLayoutProps } from '../interfaces';
@@ -61,7 +61,7 @@ export default function FlexibleColumnLayout({
       {flattenedChildren.map((child, i) => {
         // If this react child is a primitive value, the key will be undefined
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const key = (child as any).key;
+        const key = (child as Record<'key', Key | undefined>).key;
 
         return (
           <div

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -31,7 +31,7 @@ export function useFlashbar({
   const ref = useRef<HTMLDivElement | null>(null);
   const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
   const mergedRef = useMergeRefs(ref, breakpointRef, __internalRootRef);
-  const isReducedMotion = useReducedMotion(breakpointRef as any);
+  const isReducedMotion = useReducedMotion(ref);
   const isVisualRefresh = useVisualRefresh();
   const [previousItems, setPreviousItems] = useState<ReadonlyArray<FlashbarProps.MessageDefinition>>(items);
   const [nextFocusId, setNextFocusId] = useState<string | null>(null);

--- a/src/grid/internal.tsx
+++ b/src/grid/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { Key } from 'react';
 import clsx, { ClassValue } from 'clsx';
 import flattenChildren from 'react-keyed-flatten-children';
 import { getBaseProps } from '../internal/base-component';
@@ -74,7 +74,7 @@ const InternalGrid = React.forwardRef(
         {flattenedChildren.map((child, i) => {
           // If this react child is a primitive value, the key will be undefined
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const key = (child as any).key;
+          const key = (child as Record<'key', Key>).key;
 
           return (
             <div

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -25,12 +25,13 @@ export interface BaseComponentProps {
   // "Note: If an attribute name is not a valid JS identifier (like a data-* attribute), it is not considered to be an error"
 }
 
-export function getBaseProps(props: BaseComponentProps) {
-  const baseProps: Record<string, any> = {};
+export function getBaseProps(props: Record<string, unknown>) {
+  const baseProps: Record<string, unknown> = {};
+
   Object.keys(props).forEach(prop => {
     if (prop === 'id' || prop === 'className' || prop.match(/^data-/)) {
-      baseProps[prop] = (props as Record<string, any>)[prop];
+      baseProps[prop] = props[prop];
     }
   });
-  return baseProps as BaseComponentProps;
+  return baseProps as BaseComponentProps & Record<`data-${string}`, unknown>;
 }

--- a/src/internal/components/cartesian-chart/label-utils.ts
+++ b/src/internal/components/cartesian-chart/label-utils.ts
@@ -23,7 +23,9 @@ export function formatTicks({
   tickFormatter?: (value: any) => string;
 }): FormattedTick[] {
   return ticks.map(tick => {
-    const position = scale.d3Scale(tick as any) ?? NaN;
+    type Scale = ChartScale['d3Scale'] & ((x: ChartDataTypes) => undefined);
+
+    const position = (scale.d3Scale as Scale)(tick) ?? NaN;
     const label = tickFormatter ? tickFormatter(tick as any) : tick.toString();
     const lines = (label + '').split('\n');
     return { position, lines, space: Math.max(...lines.map(getLabelSpace)) };

--- a/src/internal/components/cartesian-chart/labels-measure.tsx
+++ b/src/internal/components/cartesian-chart/labels-measure.tsx
@@ -28,14 +28,16 @@ function LabelsMeasure({ scale, ticks, tickFormatter, autoWidth }: LabelsMeasure
   }, [autoWidth, width]);
 
   const labelMapper = (value: ChartDataTypes) => {
-    const scaledValue = scale.d3Scale(value as any);
+    type Scale = ChartScale['d3Scale'] & ((x: ChartDataTypes) => undefined);
+
+    const scaledValue = (scale.d3Scale as Scale)(value);
     if (scaledValue === undefined || !isFinite(scaledValue)) {
       return null;
     }
 
     return (
       <div key={`${value}`} className={styles['labels-left__label']} aria-hidden="true">
-        {tickFormatter ? tickFormatter(value as any) : value.toString()}
+        {tickFormatter ? tickFormatter(value) : value.toString()}
       </div>
     );
   };

--- a/src/internal/components/chart-plot/application-controller.tsx
+++ b/src/internal/components/chart-plot/application-controller.tsx
@@ -140,7 +140,7 @@ function muteApplication(app: SVGGElement) {
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames#polyfill
 function getAttributeNames(element: Element) {
   const attributes = element.attributes;
-  const result = new Array(attributes.length);
+  const result = new Array<string>(attributes.length);
   for (let i = 0; i < attributes.length; i++) {
     result[i] = attributes[i].name;
   }

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -26,7 +26,7 @@ export interface InteriorDropdownPosition extends DropdownPosition {
   top: string;
 }
 
-const getClosestParentDimensions = (element: HTMLElement): any => {
+const getClosestParentDimensions = (element: HTMLElement) => {
   const parents = getOverflowParents(element).map(el => {
     const { height, width, top, left } = el.getBoundingClientRect();
     return {
@@ -213,7 +213,10 @@ export const getInteriorDropdownPosition = (
 ): InteriorDropdownPosition => {
   const availableSpace = getInteriorAvailableSpace(trigger, dropdown, overflowParents, isMobile);
   const { bottom: triggerBottom, top: triggerTop, width: triggerWidth } = trigger.getBoundingClientRect();
-  const { top: parentDropdownTop, height: parentDropdownHeight } = getClosestParentDimensions(trigger);
+  const { top: parentDropdownTop, height: parentDropdownHeight } = getClosestParentDimensions(trigger) ?? {
+    top: 0,
+    height: 0,
+  };
 
   let dropLeft;
 

--- a/src/internal/components/focus-lock/utils.ts
+++ b/src/internal/components/focus-lock/utils.ts
@@ -25,18 +25,20 @@ const tabbables = [
   '[autofocus]',
 ].join(',');
 
-export function getFocusables(container: HTMLElement): HTMLElement[] {
-  return Array.prototype.slice
-    .call(container.querySelectorAll(tabbables))
-    .filter((element: HTMLElement) => element.tabIndex !== -1);
+type FocusableElement = Element & { focus(): void };
+
+export function getFocusables(container: HTMLElement): FocusableElement[] {
+  return Array.from(container.querySelectorAll(tabbables)).filter(
+    element => (!('tabIndex' in element) || element.tabIndex !== -1) && 'focus' in element
+  ) as FocusableElement[];
 }
 
-export function getFirstFocusable(container: HTMLElement): null | HTMLElement {
+export function getFirstFocusable(container: HTMLElement): null | FocusableElement {
   const focusables = getFocusables(container);
   return focusables[0] ?? null;
 }
 
-export function getLastFocusable(container: HTMLElement): null | HTMLElement {
+export function getLastFocusable(container: HTMLElement): null | FocusableElement {
   const focusables = getFocusables(container);
   return focusables[focusables.length - 1] ?? null;
 }

--- a/src/internal/components/masked-input/index.tsx
+++ b/src/internal/components/masked-input/index.tsx
@@ -46,9 +46,8 @@ const MaskedInput = React.forwardRef(
       inputRef,
       autofix,
       disableAutocompleteOnBlur,
-      onChange: (value: string) => !rest.readOnly && fireNonCancelableEvent(onChange, { value }),
-      onKeyDown: (event: CustomEvent) =>
-        !rest.readOnly && onKeyDown && fireCancelableEvent(onKeyDown, event.detail, event),
+      onChange: value => !rest.readOnly && fireNonCancelableEvent(onChange, { value }),
+      onKeyDown: event => !rest.readOnly && onKeyDown && fireCancelableEvent(onKeyDown, event.detail, event),
       onBlur: () => fireNonCancelableEvent(onBlur),
       setPosition: setCursorPosition,
     });

--- a/src/internal/components/masked-input/use-mask.ts
+++ b/src/internal/components/masked-input/use-mask.ts
@@ -22,7 +22,7 @@ interface UseMaskHook {
 interface UseMaskProps {
   value: string;
   onChange: (value: string) => void;
-  onKeyDown?: (event: CustomEvent) => void;
+  onKeyDown?: CancelableEventHandler<InputProps.KeyDetail>;
   onBlur?: () => void;
   format: MaskFormat;
   autofix?: boolean;
@@ -74,7 +74,7 @@ const useMask = ({
 
   return {
     value: maskedValue,
-    onKeyDown: (event: CustomEvent) => {
+    onKeyDown: event => {
       const selectionStart = inputRef.current?.selectionStart || 0;
       const selectionEnd = inputRef.current?.selectionEnd || 0;
 
@@ -111,7 +111,10 @@ const useMask = ({
       onBlur && onBlur();
     },
     onPaste: (event: ClipboardEvent) => {
-      const text = (event.clipboardData || (window as any).clipboardData).getData('text');
+      if (!event.clipboardData) {
+        return;
+      }
+      const text = event.clipboardData.getData('text');
 
       const selectionStart = inputRef.current?.selectionStart || 0;
       const selectionEnd = inputRef.current?.selectionEnd || 0;

--- a/src/internal/debounce.ts
+++ b/src/internal/debounce.ts
@@ -5,13 +5,13 @@
 export const DEBOUNCE_DEFAULT_DELAY = 200;
 
 // instead of using this function directly, consider using useDebounceCallback hook
-export default function debounce<CallbackType extends (...args: any[]) => void>(
+export default function debounce<CallbackType extends (...args: unknown[]) => void>(
   func: CallbackType,
   delay: number = DEBOUNCE_DEFAULT_DELAY
 ): CallbackType {
   let timeout: ReturnType<typeof setTimeout> | null;
 
-  return function (...args: any[]) {
+  return function (...args: unknown[]) {
     if (timeout) {
       clearTimeout(timeout);
     }

--- a/src/internal/events/index.ts
+++ b/src/internal/events/index.ts
@@ -48,7 +48,7 @@ export interface BaseNavigationDetail {
 }
 
 export function createCustomEvent<T>({ cancelable, detail }: CustomEventInit<T>): CustomEvent<T> {
-  return new CustomEventStub(cancelable, detail) as CustomEvent;
+  return new CustomEventStub(cancelable, detail) as CustomEvent<T>;
 }
 
 export function fireNonCancelableEvent<T = null>(handler: NonCancelableEventHandler<T> | undefined, detail?: T) {

--- a/src/internal/focus-tracker.ts
+++ b/src/internal/focus-tracker.ts
@@ -21,7 +21,7 @@ export default class FocusTracker {
   }
 
   initialize() {
-    this.currentlyFocused = containsOrEqual(this.node, document.activeElement as any);
+    this.currentlyFocused = document.activeElement ? containsOrEqual(this.node, document.activeElement) : false;
     document.addEventListener('focusin', this.focusInListener);
     document.addEventListener('focusout', this.focusOutListener);
   }

--- a/src/internal/hooks/container-queries/use-container-breakpoints.ts
+++ b/src/internal/hooks/container-queries/use-container-breakpoints.ts
@@ -13,7 +13,7 @@ import { useContainerQuery } from '@cloudscape-design/component-toolkit';
  */
 export function useContainerBreakpoints<T extends readonly Breakpoint[]>(
   triggers?: T
-): [T[number] | 'default' | null, React.Ref<any>] {
+): [T[number] | 'default' | null, React.Ref<unknown>] {
   // triggers.join() gives us a stable value to use for the dependencies argument
   const triggersDep = triggers?.join();
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/internal/hooks/container-queries/use-height-measure.ts
+++ b/src/internal/hooks/container-queries/use-height-measure.ts
@@ -10,7 +10,7 @@ import { useCallback, useState } from 'react';
 export function useHeightMeasure(
   getMeasure: () => null | HTMLElement | SVGElement,
   skip = false,
-  deps: React.DependencyList = []
+  deps: ReadonlyArray<unknown> = []
 ) {
   const [measuredHeight, setHeight] = useState(0);
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/internal/hooks/use-debounce-callback/index.ts
+++ b/src/internal/hooks/use-debounce-callback/index.ts
@@ -3,7 +3,7 @@
 import { useCallback, useRef } from 'react';
 import debounce from '../../debounce';
 
-export function useDebounceCallback<T extends (...args: any[]) => void>(callback: T, delay?: number): T {
+export function useDebounceCallback<T extends (...args: unknown[]) => void>(callback: T, delay?: number): T {
   const callbackRef = useRef<T>();
   callbackRef.current = callback;
 

--- a/src/internal/hooks/use-scroll-sync/index.ts
+++ b/src/internal/hooks/use-scroll-sync/index.ts
@@ -11,7 +11,7 @@ import { supportsStickyPosition } from '../../utils/dom';
  *    <div ref={ref1} onScroll={handleScroll}/>
  *    <div ref={ref2} onScroll={handleScroll}/>
  */
-export function useScrollSync(refs: Array<RefObject<any>>, disabled = !supportsStickyPosition()) {
+export function useScrollSync(refs: Array<RefObject<HTMLElement>>, disabled = !supportsStickyPosition()) {
   const activeElement = useRef<HTMLElement | null>(null);
   const onScroll = (event: React.UIEvent) => {
     const targetElement = event.target as HTMLElement;

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -11,7 +11,7 @@ const useIdFallback = () => {
   return idRef.current;
 };
 
-const useId: typeof useIdFallback = (React as any).useId ?? useIdFallback;
+const useId: typeof useIdFallback = (React as { useId?: () => string }).useId ?? useIdFallback;
 
 export function useUniqueId(prefix?: string) {
   return `${prefix ? prefix : ''}` + useId();

--- a/src/internal/utils/apply-display-name.ts
+++ b/src/internal/utils/apply-display-name.ts
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export function applyDisplayName<T>(component: T, displayName: string): void {
-  (component as any).displayName = displayName;
+  (component as { displayName?: string }).displayName = displayName;
 }

--- a/src/internal/utils/throttle.ts
+++ b/src/internal/utils/throttle.ts
@@ -47,7 +47,7 @@ export function throttle<F extends (...args: any) => any>(
   }
 
   // Decorated client function with delay mechanism.
-  function throttled(this: any, ...args: any) {
+  function throttled(this: unknown, ...args: unknown[]) {
     if (lastInvokeTime === null) {
       lastInvokeTime = Date.now();
       func.apply(this, args);

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -143,7 +143,7 @@ const InternalLink = React.forwardRef(
       ...baseProps,
       // https://github.com/microsoft/TypeScript/issues/36659
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref: useMergeRefs(linkRef as any, __internalRootRef),
+      ref: useMergeRefs(linkRef, __internalRootRef),
       className: clsx(
         styles.link,
         baseProps.className,

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -411,7 +411,9 @@ export default function ChartContainer<T extends ChartDataTypes>({
   if (verticalMarkerX !== null) {
     verticalLineX = verticalMarkerX.scaledX;
   } else if (isGroupNavigation && highlightedGroupIndex !== null) {
-    const x = xAxisProps.scale.d3Scale(barGroups[highlightedGroupIndex].x as any) ?? null;
+    type Scale = ChartScale['d3Scale'] & ((x: ChartDataTypes) => undefined);
+
+    const x = (xAxisProps.scale.d3Scale as Scale)(barGroups[highlightedGroupIndex].x) ?? null;
     if (x !== null) {
       verticalLineX = xOffset + x;
     }

--- a/src/mixed-line-bar-chart/domain.ts
+++ b/src/mixed-line-bar-chart/domain.ts
@@ -99,6 +99,7 @@ export function computeDomainY<T>(
         series: {
           type: 'bar',
           title: 'positive',
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           data: positiveData as any,
         },
       },
@@ -108,6 +109,7 @@ export function computeDomainY<T>(
         series: {
           type: 'bar',
           title: 'negative',
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           data: negativeData as any,
         },
       },

--- a/src/table/utils.ts
+++ b/src/table/utils.ts
@@ -4,12 +4,13 @@ import { InternalContainerProps } from '../container/internal';
 import { StickyColumnsCellState } from './sticky-columns';
 import { TableProps } from './interfaces';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import type { Key } from 'react';
 
 export const applyTrackBy = <T>(trackBy: TableProps.TrackBy<T>, item: T) => {
   if (typeof trackBy === 'function') {
     return trackBy(item);
   }
-  return (item as any)[trackBy];
+  return (item as Record<string, Key>)[trackBy];
 };
 
 export const getItemKey = <T>(trackBy: TableProps.TrackBy<T> | undefined, item: T, index: number) => {


### PR DESCRIPTION
### Description

This PR enables some stricter ESLint rules that detect when we use the `any` type in an unsafe way. It also fixes some of these unsafe usages.
It does not cover all components yet, but the other components might follow in the future.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-21112

### How has this been tested?

Tested locally by running `npm run lint`.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
