### PR TITLE
chore: Exclude buttons from substep names

### DIFF
--- a/src/internal/analytics/__tests__/selectors.test.tsx
+++ b/src/internal/analytics/__tests__/selectors.test.tsx
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Header from '../../../../lib/components/header';
+import Button from '../../../../lib/components/button';
+import { getNameFromSelector } from '../../../../lib/components/internal/analytics/selectors';
+
+test('getNameFromSelector ignores the text in buttons', () => {
+  Object.defineProperty(HTMLElement.prototype, 'innerText', {
+    get() {
+      return this.textContent;
+    },
+  });
+
+  render(
+    <Header data-testid="test">
+      This is the header text<Button>This is the button text</Button>
+    </Header>
+  );
+
+  expect(getNameFromSelector('[data-testid=test]')).toBe('This is the header text');
+});

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -27,5 +27,13 @@ export const getSubStepNameSelector = (subStepId: string) =>
 
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
 
-export const getNameFromSelector = (selector: string | undefined): string | undefined =>
-  selector ? document.querySelector<HTMLElement>(selector)?.innerText : undefined;
+export function getNameFromSelector(selector: string | undefined): string | undefined {
+  const element = selector ? document.querySelector<HTMLElement>(selector) : undefined;
+  if (!element) {
+    return undefined;
+  }
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll('button, [role=button]').forEach(e => e.remove());
+
+  return clone.innerText;
+}


### PR DESCRIPTION
### Description

When a funnel emits substep-related events (e.g. `subStepError`), it determines the name of that substep. Before this PR, it used the `innerText` property directly to get the text. However, sometimes developers place a button inside the header text, which leads to an unexpected substep name.

After this PR, any buttons inside the header text are ignored when determining the substep name.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Tested manually in a dev page. Unfortunately JSDOM does not support the `innerText` property because it relies on CSS to determine what text is visible and what text isn't, so I was unable to add a unit test for this.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
