### PR TITLE
fix: Improve alignment for property filter custom controls

### DIFF
--- a/pages/property-filter/permutations.page.tsx
+++ b/pages/property-filter/permutations.page.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import PropertyFilter, { PropertyFilterProps } from '~components/property-filter';
+import Select from '~components/select';
+import FormField from '~components/form-field';
 import ScreenshotArea from '../utils/screenshot-area';
 import { allItems, TableItem } from './table.data';
 import { columnDefinitions, i18nStrings, filteringProperties } from './common-props';
@@ -71,6 +73,25 @@ const permutations = createPermutations<Partial<PropertyFilterProps>>([
       },
     ],
     tokenLimit: [0, 2],
+  },
+  {
+    query: [
+      { tokens: [], operation: 'and' },
+      {
+        tokens: [
+          { value: '123', operator: ':' },
+          { value: '234', operator: '!:' },
+          { propertyKey: 'instanceid', value: '345', operator: '=' },
+        ],
+        operation: 'and',
+      },
+    ],
+    customControl: [
+      <Select key={0} placeholder="Select a value" options={[]} selectedOption={null} />,
+      <FormField key={1} label="Select a value">
+        <Select placeholder="Select a value" options={[]} selectedOption={null} />
+      </FormField>,
+    ],
   },
 ]);
 

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -350,7 +350,11 @@ const PropertyFilter = React.forwardRef(
             clearAriaLabel={i18nStrings.clearAriaLabel}
             searchResultsId={showResults ? searchResultsId : undefined}
           />
-          {showResults ? <SearchResults id={searchResultsId}>{countText}</SearchResults> : null}
+          {showResults ? (
+            <div className={styles.results}>
+              <SearchResults id={searchResultsId}>{countText}</SearchResults>
+            </div>
+          ) : null}
         </div>
         {tokens && tokens.length > 0 && (
           <div className={styles.tokens}>

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -12,7 +12,7 @@
 
 .search-field {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   // The xs breakpoint, minus the table tools container padding
   max-width: calc(#{styles.$breakpoint-x-small} - 2 * #{awsui.$space-l});
 }

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -90,6 +90,13 @@
   flex: 1;
 }
 
+.results {
+  // Align with the filter input's vertical padding and border sizes.
+  padding: calc(#{styles.$control-padding-vertical} + #{styles.$control-border-width});
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .token-trigger {
   @include styles.text-wrapping;
 }


### PR DESCRIPTION
### Description

Recently, we made some changes to select filters to place them inside form fields ([see here](https://cloudscape.design/examples/react/table-select-filter.html)). Selects should always come with a visible label, and the placeholder or selected label isn't good enough.

In light of that, we also need to allow users to provide a label for the select inside the property filter's `customControl` slot.

Related links, issue #, if available: n/a

### How has this been tested?

Screenshot tested.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
