### PR TITLE
fix: Improve bar chart stacked series margins

### DIFF
--- a/pages/bar-chart/common.tsx
+++ b/pages/bar-chart/common.tsx
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const smallBarsData = [
+  {
+    title: 'A',
+    type: 'bar' as const,
+    data: [
+      { x: 'Apples', y: 2 },
+      { x: 'Oranges', y: 5 },
+      { x: 'Pears', y: 10 },
+      { x: 'Grapes', y: 200 },
+      { x: 'Bananas', y: 200 },
+    ],
+  },
+  {
+    title: 'B',
+    type: 'bar' as const,
+    data: [
+      { x: 'Apples', y: 2 },
+      { x: 'Oranges', y: 5 },
+      { x: 'Pears', y: 10 },
+      { x: 'Grapes', y: 5 },
+      { x: 'Bananas', y: 10 },
+    ],
+  },
+  {
+    title: 'C',
+    type: 'bar' as const,
+    data: [
+      { x: 'Apples', y: 2 },
+      { x: 'Oranges', y: 5 },
+      { x: 'Pears', y: 10 },
+      { x: 'Grapes', y: 5 },
+      { x: 'Bananas', y: 10 },
+    ],
+  },
+  {
+    title: 'D',
+    type: 'bar' as const,
+    data: [
+      { x: 'Apples', y: 200 },
+      { x: 'Oranges', y: 200 },
+      { x: 'Pears', y: 200 },
+      { x: 'Grapes', y: 5 },
+      { x: 'Bananas', y: 10 },
+    ],
+  },
+  {
+    title: 'F',
+    type: 'bar' as const,
+    data: [
+      { x: 'Apples', y: 200 },
+      { x: 'Oranges', y: 200 },
+      { x: 'Pears', y: 200 },
+      { x: 'Grapes', y: 200 },
+      { x: 'Bananas', y: 200 },
+    ],
+  },
+  {
+    title: '415',
+    type: 'threshold' as const,
+    y: 415,
+  },
+];

--- a/pages/bar-chart/permutations.page.tsx
+++ b/pages/bar-chart/permutations.page.tsx
@@ -19,6 +19,7 @@ import {
   negativeData,
   multipleNegativeBarsDataWithThreshold,
 } from '../mixed-line-bar-chart/common';
+import { smallBarsData } from './common';
 
 const timeLatencyData = latencyData.map(({ time, p90 }) => ({ x: time, y: p90 }));
 
@@ -130,9 +131,31 @@ const thresholdPermutations = createPermutations<BarChartProps<string>>([
   },
 ]);
 
+const smallGroupsPermutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [smallBarsData],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[0, 1000]],
+    horizontalBars: [true, false],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
 /* eslint-enable react/jsx-key */
 
-const permutations = [...stringPermutations, ...timePermutations, ...numberPermutations, ...thresholdPermutations];
+const permutations = [
+  ...stringPermutations,
+  ...timePermutations,
+  ...numberPermutations,
+  ...thresholdPermutations,
+  ...smallGroupsPermutations,
+];
 
 export default function () {
   return (

--- a/src/mixed-line-bar-chart/bar-series.tsx
+++ b/src/mixed-line-bar-chart/bar-series.tsx
@@ -110,25 +110,45 @@ export default function BarSeries<T extends ChartDataTypes>({
         [styles['series--dimmed']]: dimmed,
       })}
     >
-      {xCoordinates.map(
-        ({ x, y, width, height }, i) =>
-          isFinite(x) &&
-          isFinite(height) && (
-            <rect
-              key={`bar-${i}`}
-              fill={color}
-              x={axis === 'x' ? x : y - height}
-              y={axis === 'x' ? y : x}
-              width={axis === 'x' ? width : height}
-              height={axis === 'x' ? height : width}
-              rx={isRefresh ? '4px' : '0px'}
-              className={clsx(styles.series__rect, {
-                [styles['series--dimmed']]:
-                  highlightedXValue !== null && !matchesX(highlightedXValue, series.data[i].x),
-              })}
-            />
-          )
-      )}
+      {xCoordinates.map(({ x, y, width, height }, i) => {
+        if (!isFinite(x) || !isFinite(height)) {
+          return;
+        }
+
+        // Create margins between stacked series but only when series data is not too small.
+        const baseOffset = stackedBarOffsets ? 2 : 0;
+        const isSmall = height < baseOffset * 2;
+        const appliedOffset = isSmall ? 0 : baseOffset;
+
+        const rx = isRefresh ? (isSmall ? '2px' : '4px') : '0px';
+        const className = clsx(styles.series__rect, {
+          [styles['series--dimmed']]: highlightedXValue !== null && !matchesX(highlightedXValue, series.data[i].x),
+        });
+
+        return axis === 'x' ? (
+          <rect
+            key={`bar-${i}`}
+            fill={color}
+            x={x}
+            y={y + appliedOffset / 2}
+            width={width}
+            height={height - appliedOffset}
+            rx={rx}
+            className={className}
+          />
+        ) : (
+          <rect
+            key={`bar-${i}`}
+            fill={color}
+            x={y - height + appliedOffset / 2}
+            y={x}
+            width={height - appliedOffset}
+            height={width}
+            rx={rx}
+            className={className}
+          />
+        );
+      })}
     </g>
   );
 }

--- a/src/mixed-line-bar-chart/styles.scss
+++ b/src/mixed-line-bar-chart/styles.scss
@@ -28,11 +28,6 @@
   opacity: 0.3;
 }
 
-.series--bar > .series__rect {
-  stroke: awsui.$color-background-container-content;
-  stroke-width: 2px;
-}
-
 .series--threshold {
   stroke-dasharray: awsui.$border-line-chart-dash-array;
   stroke-width: awsui.$border-line-chart-width;


### PR DESCRIPTION
### Description

Make small stacked bar series visible by not applying margins to those.

### How has this been tested?

New permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
