### PR TITLE
chore: Allow runtime drawers to be open by default

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -5,6 +5,8 @@ import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import HelpPanel from '~components/help-panel';
 import awsuiPlugins from '~components/internal/plugins';
 
+const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
+
 function Content() {
   useEffect(() => {
     console.log('mounted');
@@ -29,6 +31,8 @@ awsuiPlugins.appLayout.registerDrawer({
       <path d="M4,7V5a4,4,0,0,1,8,0V7" fill="none" stroke="currentColor" stroke-width="2" />
     </svg>`,
   },
+
+  defaultActive: !!searchParams.get('force-default-active'),
 
   resizable: true,
   defaultSize: 320,

--- a/src/internal/plugins/controllers/drawers.ts
+++ b/src/internal/plugins/controllers/drawers.ts
@@ -5,6 +5,7 @@ import debounce from '../../debounce';
 
 export type DrawerConfig = Omit<DrawerItem, 'content' | 'trigger'> & {
   orderPriority?: number;
+  defaultActive?: boolean;
   trigger: {
     iconSvg: string;
   };


### PR DESCRIPTION
### Description

Support `awsuiPlugins.appLayout.registerDrawer({ defaultActive: true })` to allow opening it on the initial rendering

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
