### PR TITLE
refactor: Deduplicate drawers handling code between classic and refresh implementations

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import {
   AppLayout,
   ContentLayout,
@@ -14,11 +14,15 @@ import {
 import appLayoutLabels from './utils/labels';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
 import './utils/external-widget';
+import AppContext, { AppContextType } from '../app/app-context';
+
+type DemoContext = React.Context<AppContextType<{ hasTools: boolean | undefined; hasDrawers: boolean | undefined }>>;
 
 export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
-  const [hasDrawers, setHasDrawers] = useState(true);
-  const [hasTools, setHasTools] = useState(false);
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const hasTools = urlParams.hasTools ?? false;
+  const hasDrawers = urlParams.hasDrawers ?? true;
   const [isToolsOpen, setIsToolsOpen] = useState(false);
 
   const [widths, setWidths] = useState<{ [id: string]: number }>({
@@ -72,11 +76,11 @@ export default function WithDrawers() {
               </Header>
 
               <SpaceBetween size="xs">
-                <Toggle checked={hasTools} onChange={({ detail }) => setHasTools(detail.checked)}>
+                <Toggle checked={hasTools} onChange={({ detail }) => setUrlParams({ hasTools: detail.checked })}>
                   Use Tools
                 </Toggle>
 
-                <Toggle checked={hasDrawers} onChange={({ detail }) => setHasDrawers(detail.checked)}>
+                <Toggle checked={hasDrawers} onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}>
                   Use Drawers
                 </Toggle>
               </SpaceBetween>

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -17,13 +17,13 @@ import ScreenshotArea from '../utils/screenshot-area';
 import type { DrawerItem } from '~components/app-layout/drawer/interfaces';
 import AppContext, { AppContextType } from '../app/app-context';
 
-type DemoContext = React.Context<AppContextType<{ hasTools: boolean }>>;
+type DemoContext = React.Context<AppContextType<{ hasTools: boolean | undefined; hasDrawers: boolean | undefined }>>;
 
 export default function WithDrawers() {
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
-  const [hasDrawers, setHasDrawers] = useState(true);
-  const [hideTools, setHideTools] = useState(!urlParams.hasTools);
+  const hasTools = urlParams.hasTools ?? false;
+  const hasDrawers = urlParams.hasDrawers ?? true;
 
   const drawers = !hasDrawers
     ? null
@@ -102,9 +102,8 @@ export default function WithDrawers() {
 
                 <SpaceBetween size="xs">
                   <Toggle
-                    checked={!hideTools}
+                    checked={hasTools}
                     onChange={e => {
-                      setHideTools(!e.detail.checked);
                       setUrlParams({ hasTools: e.detail.checked });
                     }}
                   >
@@ -113,7 +112,7 @@ export default function WithDrawers() {
 
                   <Toggle
                     checked={hasDrawers}
-                    onChange={({ detail }) => setHasDrawers(detail.checked)}
+                    onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}
                     data-id="toggle-drawers"
                   >
                     Has Drawers
@@ -145,7 +144,7 @@ export default function WithDrawers() {
           </SplitPanel>
         }
         tools={<Info />}
-        toolsHide={hideTools}
+        toolsHide={!hasTools}
         {...drawers}
       />
     </ScreenshotArea>

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -193,13 +193,6 @@ describeEachThemeAppLayout(false, () => {
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveFocus();
   });
 
-  test(`Should fire resize when expected`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
-
-    act(() => wrapper.findDrawersTriggers()![0].click());
-    expect(wrapper.findDrawersSlider()!.getElement()).toHaveFocus();
-  });
-
   test('should change size via keyboard events on slider handle', () => {
     const onResize = jest.fn();
     const drawers: Required<InternalDrawerProps> = {

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -27,4 +27,10 @@ describeEachAppLayout(() => {
 
     expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
   });
+
+  test('renderds drawers with the tools', () => {
+    const { wrapper } = renderComponent(<AppLayout tools="Test" {...singleDrawer} />);
+
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+  });
 });

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -56,6 +56,15 @@ describe('Runtime drawers', () => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
+  test('combines runtime drawers with the tools', async () => {
+    awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, ariaLabels: { triggerButton: 'Runtime drawer' } });
+    const { wrapper } = await renderComponent(<AppLayout tools="test" ariaLabels={{ toolsToggle: 'Tools' }} />);
+    expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+      'Tools',
+      'Runtime drawer',
+    ]);
+  });
+
   test('accepts drawers registration after initial rendering', async () => {
     const { wrapper } = await renderComponent(<AppLayout />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -269,6 +269,7 @@ test('should change split panel position in uncontrolled mode', () => {
   expect(wrapper.findSplitPanel()!.findOpenPanelBottom()).not.toBeNull();
   wrapper.findSplitPanel()!.findPreferencesButton()!.click();
   expect(screen.getByRole('radio', { name: 'Bottom' })).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Side' })).toBeEnabled();
   screen.getByRole('radio', { name: 'Side' }).click();
   screen.getByRole('button', { name: 'Confirm' }).click();
   expect(wrapper.findSplitPanel()!.findOpenPanelSide()).not.toBeNull();

--- a/src/app-layout/defaults.ts
+++ b/src/app-layout/defaults.ts
@@ -37,7 +37,7 @@ const defaults: Record<AppLayoutProps.ContentType, AppLayoutState> = {
   },
 };
 
-interface AppLayoutState {
+export interface AppLayoutState {
   navigationOpen?: boolean;
   toolsOpen?: boolean;
   minContentWidth?: number;

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -6,7 +6,7 @@ import { ToggleButton, CloseButton, togglesConfig } from '../toggles';
 
 import testutilStyles from '../test-classes/styles.css.js';
 import styles from './styles.css.js';
-import { DesktopDrawerProps, DrawerTriggersBarProps, DrawerItem, DrawerItemAriaLabels } from './interfaces';
+import { DesktopDrawerProps, DrawerTriggersBarProps, DrawerItem } from './interfaces';
 
 // We are using two landmarks per drawer, i.e. two NAVs and two ASIDEs, because of several
 // known bugs in NVDA that cause focus changes within a container to sometimes not be
@@ -50,16 +50,9 @@ export const Drawer = React.forwardRef(
   ) => {
     const openButtonWrapperRef = useRef<HTMLElement | null>(null);
     const { TagName, iconName, getLabels } = togglesConfig[type];
-    const { mainLabel, closeLabel, openLabel } = getLabels(ariaLabels);
+    const { mainLabel, closeLabel, openLabel } = drawersAriaLabels ?? getLabels(ariaLabels);
     const drawerContentWidthOpen = isMobile ? undefined : width;
     const drawerContentWidth = isOpen ? drawerContentWidthOpen : undefined;
-
-    const getDrawersLabels = (labels: DrawerItemAriaLabels = {}) => ({
-      drawerMainLabel: labels?.content,
-      drawerOpenLabel: labels?.triggerButton,
-      drawerCloseLabel: labels?.closeButton,
-    });
-    const { drawerMainLabel, drawerCloseLabel } = getDrawersLabels(drawersAriaLabels);
 
     const regularOpenButton = (
       <TagName ref={openButtonWrapperRef} aria-label={mainLabel} className={styles.toggle} aria-hidden={isOpen}>
@@ -113,11 +106,11 @@ export const Drawer = React.forwardRef(
         >
           {!isMobile && regularOpenButton}
           {resizeHandle}
-          <TagName aria-label={drawers ? drawerMainLabel : mainLabel} aria-hidden={!isOpen}>
+          <TagName aria-label={mainLabel} aria-hidden={!isOpen}>
             <CloseButton
               ref={toggleRefs.close}
               className={closeClassName}
-              ariaLabel={drawers ? drawerCloseLabel : closeLabel}
+              ariaLabel={closeLabel}
               onClick={() => {
                 onToggle(false);
                 drawers?.onChange({ activeDrawerId: undefined });

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -20,7 +20,7 @@ export interface DesktopDrawerProps {
   topOffset: number | undefined;
   bottomOffset: number | undefined;
   ariaLabels: AppLayoutProps.Labels | undefined;
-  drawersAriaLabels?: DrawerItemAriaLabels | undefined;
+  drawersAriaLabels?: { mainLabel: string | undefined; closeLabel: string | undefined; openLabel: string | undefined };
   children: React.ReactNode;
   type: keyof typeof togglesConfig;
   isMobile: boolean;

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -87,6 +87,11 @@ export const ResizableDrawer = ({
         !isMobile &&
         activeDrawer?.resizable && <div className={splitPanelStyles['slider-wrapper-side']}>{resizeHandle}</div>
       }
+      drawersAriaLabels={{
+        openLabel: activeDrawer?.ariaLabels?.triggerButton,
+        mainLabel: activeDrawer?.ariaLabels?.content,
+        closeLabel: activeDrawer?.ariaLabels?.closeButton,
+      }}
     >
       {children}
     </Drawer>

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { getBaseProps } from '../internal/base-component';
 import { useControllable } from '../internal/hooks/use-controllable';
 import { useMobile } from '../internal/hooks/use-mobile';
@@ -34,8 +34,6 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import ContentWrapper, { ContentWrapperProps } from './content-wrapper';
 import { Drawer, DrawerTriggersBar } from './drawer';
 import { ResizableDrawer } from './drawer/resizable-drawer';
-import { DrawerItem, InternalDrawerProps } from './drawer/interfaces';
-import { togglesConfig } from './toggles';
 import { SideSplitPanelDrawer } from './split-panel-drawer';
 import useAppLayoutOffsets from './utils/use-content-width';
 import { isDevelopment } from '../internal/is-development';
@@ -45,8 +43,8 @@ import RefreshedAppLayout from './visual-refresh';
 import { useInternalI18n } from '../i18n/context';
 import { useSplitPanelFocusControl } from './utils/use-split-panel-focus-control';
 import { useDrawerFocusControl } from './utils/use-drawer-focus-control';
-import { awsuiPluginsInternal } from '../internal/plugins/api';
-import { DrawersLayout, convertRuntimeDrawers } from './runtime-api';
+import { TOOLS_DRAWER_ID, useDrawers } from './utils/use-drawers';
+import { InternalDrawerProps } from './drawer/interfaces';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 
 export { AppLayoutProps };
@@ -57,7 +55,6 @@ const AppLayout = React.forwardRef(
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent<HTMLDivElement>('AppLayout');
-    const [runtimeDrawers, setRuntimeDrawers] = useState<DrawersLayout>({ before: [], after: [] });
     const isRefresh = useVisualRefresh();
 
     const i18n = useInternalI18n('app-layout');
@@ -75,31 +72,10 @@ const AppLayout = React.forwardRef(
     const props = { contentType, headerSelector, footerSelector, ...rest, ariaLabels };
 
     const baseProps = getBaseProps(rest);
-    const ownDrawers = (props as any).drawers;
-    const disableRuntimeDrawers = (props as any).__disableRuntimeDrawers;
-    const combinedDrawers = [...runtimeDrawers.before, ...(ownDrawers?.items ?? []), ...runtimeDrawers.after];
-    const finalDrawers = combinedDrawers.length > 0 ? { ...ownDrawers, items: combinedDrawers } : ownDrawers;
-
-    useEffect(() => {
-      if (disableRuntimeDrawers) {
-        return;
-      }
-      const unsubscribe = awsuiPluginsInternal.appLayout.onDrawersRegistered(drawers =>
-        setRuntimeDrawers(convertRuntimeDrawers(drawers))
-      );
-      return () => {
-        unsubscribe();
-        setRuntimeDrawers({ before: [], after: [] });
-      };
-    }, [disableRuntimeDrawers]);
 
     return (
       <div ref={__internalRootRef} {...baseProps}>
-        {isRefresh ? (
-          <RefreshedAppLayout {...props} {...{ drawers: finalDrawers }} ref={ref} />
-        ) : (
-          <OldAppLayout {...props} {...{ drawers: finalDrawers }} ref={ref} />
-        )}
+        {isRefresh ? <RefreshedAppLayout {...props} ref={ref} /> : <OldAppLayout {...props} ref={ref} />}
       </div>
     );
   }
@@ -152,9 +128,6 @@ const OldAppLayout = React.forwardRef(
       }
     }
 
-    const drawers = (props as InternalDrawerProps).drawers;
-    const hasDrawers = drawers && drawers.items.length > 0;
-
     const rootRef = useRef<HTMLDivElement>(null);
     const isMobile = useMobile();
 
@@ -173,60 +146,29 @@ const OldAppLayout = React.forwardRef(
       { componentName: 'AppLayout', controlledProp: 'toolsOpen', changeHandler: 'onToolsChange' }
     );
 
-    const [activeDrawerId, setActiveDrawerId] = useControllable(
-      drawers?.activeDrawerId,
-      drawers?.onChange,
-      isMobile ? false : tools ? defaults.toolsOpen : '',
-      {
-        componentName: 'AppLayout',
-        controlledProp: 'activeDrawerId',
-        changeHandler: 'onChange',
-      }
-    );
-
-    const { iconName, getLabels } = togglesConfig.tools;
-    const { mainLabel, closeLabel, openLabel } = getLabels(ariaLabels);
-
-    const toolsItem = {
-      id: 'tools',
-      content: tools,
-      resizable: false,
-      ariaLabels: {
-        triggerButton: openLabel,
-        closeButton: closeLabel,
-        content: mainLabel,
-      },
-      trigger: {
-        iconName: iconName,
-      },
-    };
-
-    const getAllDrawerItems = () => {
-      if (!hasDrawers) {
-        return;
-      }
-      return tools ? [toolsItem, ...drawers.items] : drawers.items;
-    };
-
-    const selectedDrawer =
-      tools && toolsOpen
-        ? toolsItem
-        : hasDrawers
-        ? getAllDrawerItems()?.filter((drawerItem: DrawerItem) => drawerItem.id === activeDrawerId)[0]
-        : undefined;
+    const {
+      drawers,
+      activeDrawer,
+      activeDrawerSize,
+      activeDrawerId,
+      onActiveDrawerChange,
+      onActiveDrawerResize,
+      ...drawersProps
+    } = useDrawers(props as InternalDrawerProps, { ariaLabels, tools, toolsOpen, toolsHide, toolsWidth }, defaults);
+    const hasDrawers = drawers.length > 0;
 
     const { refs: navigationRefs, setFocus: focusNavButtons } = useFocusControl(navigationOpen);
     const {
       refs: toolsRefs,
       setFocus: focusToolsButtons,
       loseFocus: loseToolsFocus,
-    } = useFocusControl(toolsOpen || selectedDrawer !== undefined, true);
+    } = useFocusControl(toolsOpen || activeDrawer !== undefined, true);
     const {
       refs: drawerRefs,
       setFocus: focusDrawersButtons,
       loseFocus: loseDrawersFocus,
       setLastInteraction: setDrawerLastInteraction,
-    } = useDrawerFocusControl([selectedDrawer?.resizable], toolsOpen || selectedDrawer !== undefined, true);
+    } = useDrawerFocusControl([activeDrawer?.resizable], toolsOpen || activeDrawer !== undefined, true);
 
     const onNavigationToggle = useCallback(
       (open: boolean) => {
@@ -264,7 +206,6 @@ const OldAppLayout = React.forwardRef(
       disableBodyScroll
     );
     const [isSplitpanelForcedPosition, setIsSplitpanelForcedPosition] = useState(false);
-    const [isResizeInvalid, setIsResizeInvalid] = useState(false);
 
     const [notificationsHeight, notificationsRef] = useContainerQuery(rect => rect.contentBoxHeight);
     const anyPanelOpen = navigationVisible || toolsVisible;
@@ -292,33 +233,6 @@ const OldAppLayout = React.forwardRef(
       }
     );
 
-    const drawerItems = useMemo(() => drawers?.items || [], [drawers?.items]);
-
-    const getDrawerItemSizes = useCallback(() => {
-      const sizes: { [id: string]: number } = {};
-      if (!drawerItems) {
-        return {};
-      }
-
-      for (const item of drawerItems) {
-        if (item.defaultSize) {
-          sizes[item.id] = item.defaultSize || toolsWidth;
-        }
-      }
-      return sizes;
-    }, [drawerItems, toolsWidth]);
-
-    const [drawerSizes, setDrawerSizes] = useState(() => getDrawerItemSizes());
-
-    useEffect(() => {
-      // Ensure we only set new drawer items by performing a shallow merge
-      // of the latest drawer item sizes, and previous drawer item sizes.
-      setDrawerSizes(prev => ({ ...getDrawerItemSizes(), ...prev }));
-    }, [getDrawerItemSizes]);
-
-    const drawerSize =
-      selectedDrawer?.id && drawerSizes[selectedDrawer?.id] ? drawerSizes[selectedDrawer?.id] : toolsWidth;
-
     const splitPanelPosition = splitPanelPreferences?.position || 'bottom';
     const [splitPanelReportedToggle, setSplitPanelReportedToggle] = useState<SplitPanelSideToggleProps>({
       displayed: false,
@@ -330,15 +244,15 @@ const OldAppLayout = React.forwardRef(
     const effectiveNavigationWidth = navigationHide ? 0 : navigationOpen ? navigationWidth : closedDrawerWidth;
 
     const getEffectiveToolsWidth = () => {
-      if (toolsHide && (!splitPanelDisplayed || splitPanelPreferences?.position !== 'side') && !drawers) {
+      if (toolsHide && (!splitPanelDisplayed || splitPanelPreferences?.position !== 'side') && drawers.length === 0) {
         return 0;
       }
 
-      if (selectedDrawer?.resizable) {
-        return drawerSize;
+      if (activeDrawer && activeDrawerSize) {
+        return activeDrawerSize;
       }
 
-      if (toolsOpen || activeDrawerId) {
+      if (toolsOpen) {
         return toolsWidth;
       }
 
@@ -410,15 +324,14 @@ const OldAppLayout = React.forwardRef(
       }
 
       // Either use the computed width of the drawer or the drawerSize as defined.
-      const width = parseInt(getComputedStyle(mainContentRef.current).width || `${drawerSize}`);
+      const width = parseInt(getComputedStyle(mainContentRef.current).width || `${activeDrawerSize}`);
 
       // when disableContentPaddings is true there is less available space,
       // so we subtract space-scaled-2x-xxxl * 2 for left and right padding
       const contentPadding = disableContentPaddings ? 80 : 0;
       const spaceAvailable = width - defaults.minContentWidth - contentPadding;
-      const spaceTaken = drawerSize;
 
-      return Math.max(0, spaceTaken + spaceAvailable);
+      return Math.max(0, activeDrawerSize + spaceAvailable);
     });
 
     const getSplitPanelMaxHeight = useStableCallback(() => {
@@ -451,16 +364,16 @@ const OldAppLayout = React.forwardRef(
       effectiveToolsWidth -
       effectiveNavigationWidth -
       (disableContentPaddings ? 0 : toggleButtonsBarWidth);
+    const isResizeInvalid = isMobile || (defaults.minContentWidth || 0) > contentWidthWithSplitPanel;
 
     useEffect(() => {
       const contentWidth = contentWidthWithSplitPanel - splitPanelSize;
 
       setIsSplitpanelForcedPosition(isMobile || (defaults.minContentWidth || 0) > contentWidth);
-      setIsResizeInvalid(isMobile || (defaults.minContentWidth || 0) > contentWidthWithSplitPanel);
       // This is a workaround to avoid a forced position due to splitPanelSize, which is
       // user controlled variable.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [contentWidthWithSplitPanel, drawerSize, defaults.minContentWidth, isMobile]);
+    }, [contentWidthWithSplitPanel, activeDrawerSize, defaults.minContentWidth, isMobile]);
 
     const navigationClosedWidth = navigationHide || isMobile ? 0 : closedDrawerWidth;
     const toolsClosedWidth = toolsHide || isMobile || (!hasDrawers && toolsHide) ? 0 : closedDrawerWidth;
@@ -476,9 +389,9 @@ const OldAppLayout = React.forwardRef(
       }
 
       if (hasDrawers) {
-        if (activeDrawerId) {
-          if (!isResizeInvalid && drawerSize) {
-            return drawerSize + closedDrawerWidth;
+        if (activeDrawer) {
+          if (!isResizeInvalid && activeDrawerSize) {
+            return activeDrawerSize + closedDrawerWidth;
           }
 
           return toolsWidth + closedDrawerWidth;
@@ -529,7 +442,7 @@ const OldAppLayout = React.forwardRef(
         // tools padding is displayed in one of the three cases
         // 1. Nothing on the that screen edge (no tools panel and no split panel)
         toolsHide ||
-        (hasDrawers && !activeDrawerId && (!splitPanelDisplayed || finalSplitPanePosition !== 'side')) ||
+        (hasDrawers && !activeDrawer && (!splitPanelDisplayed || finalSplitPanePosition !== 'side')) ||
         // 2. Tools panel is present and open
         toolsVisible ||
         // 3. Split panel is open in side position
@@ -579,20 +492,19 @@ const OldAppLayout = React.forwardRef(
               unfocusable={anyPanelOpen}
               mobileBarRef={mobileBarRef}
               drawers={
-                drawers
+                hasDrawers
                   ? {
-                      items: tools && !toolsHide ? [toolsItem, ...drawers.items] : drawers.items,
-                      activeDrawerId: selectedDrawer?.id,
+                      items: drawers,
+                      activeDrawerId: activeDrawerId,
                       onChange: changeDetail => {
-                        if (selectedDrawer?.id !== changeDetail.activeDrawerId) {
-                          onToolsToggle(changeDetail.activeDrawerId === 'tools');
+                        onActiveDrawerChange(changeDetail.activeDrawerId);
+                        if (changeDetail.activeDrawerId !== activeDrawerId) {
+                          onToolsToggle(changeDetail.activeDrawerId === TOOLS_DRAWER_ID);
                           focusDrawersButtons();
-                          setActiveDrawerId(changeDetail.activeDrawerId);
                           setDrawerLastInteraction({ type: 'open' });
-                          fireNonCancelableEvent(drawers.onChange, changeDetail.activeDrawerId);
                         }
                       },
-                      ariaLabel: drawers.ariaLabel,
+                      ariaLabel: drawersProps.ariaLabel,
                     }
                   : undefined
               }
@@ -717,21 +629,20 @@ const OldAppLayout = React.forwardRef(
               </SideSplitPanelDrawer>
             )}
 
-            {((hasDrawers && selectedDrawer?.id) || (!hasDrawers && !toolsHide)) &&
+            {((hasDrawers && activeDrawerId) || (!hasDrawers && !toolsHide)) &&
               (hasDrawers ? (
                 <ResizableDrawer
                   contentClassName={
-                    selectedDrawer?.id === 'tools' ? testutilStyles.tools : testutilStyles['active-drawer']
+                    activeDrawerId === TOOLS_DRAWER_ID ? testutilStyles.tools : testutilStyles['active-drawer']
                   }
                   toggleClassName={testutilStyles['tools-toggle']}
                   closeClassName={
-                    selectedDrawer?.id === 'tools'
+                    activeDrawerId === TOOLS_DRAWER_ID
                       ? testutilStyles['tools-close']
                       : testutilStyles['active-drawer-close-button']
                   }
                   ariaLabels={ariaLabels}
-                  drawersAriaLabels={selectedDrawer?.ariaLabels}
-                  width={!isResizeInvalid ? drawerSize : toolsWidth}
+                  width={!isResizeInvalid ? activeDrawerSize : toolsWidth}
                   bottomOffset={footerHeight}
                   topOffset={headerHeight}
                   isMobile={isMobile}
@@ -739,31 +650,23 @@ const OldAppLayout = React.forwardRef(
                   isOpen={toolsOpen || activeDrawerId !== undefined}
                   toggleRefs={toolsRefs}
                   type="tools"
-                  onLoseFocus={hasDrawers ? loseDrawersFocus : loseToolsFocus}
-                  activeDrawer={selectedDrawer}
+                  onLoseFocus={loseDrawersFocus}
+                  activeDrawer={activeDrawer}
                   drawers={{
-                    items: tools && !toolsHide ? [toolsItem, ...drawers.items] : drawers.items,
-                    activeDrawerId: selectedDrawer?.id,
+                    items: drawers,
+                    activeDrawerId: activeDrawerId,
                     onChange: changeDetail => {
                       onToolsToggle(false);
                       setDrawerLastInteraction({ type: 'close' });
-                      setActiveDrawerId(changeDetail.activeDrawerId);
-                      fireNonCancelableEvent(drawers.onChange, changeDetail.activeDrawerId);
+                      onActiveDrawerChange(changeDetail.activeDrawerId);
                     },
                   }}
-                  size={!isResizeInvalid ? drawerSize : toolsWidth}
-                  onResize={changeDetail => {
-                    fireNonCancelableEvent(drawers.onResize, changeDetail);
-                    const drawerItem = drawerItems.find(({ id }) => id === changeDetail.id);
-                    if (drawerItem?.onResize) {
-                      fireNonCancelableEvent(drawerItem.onResize, changeDetail);
-                    }
-                    setDrawerSizes({ ...drawerSizes, [changeDetail.id]: changeDetail.size });
-                  }}
+                  size={!isResizeInvalid ? activeDrawerSize : toolsWidth}
+                  onResize={changeDetail => onActiveDrawerResize(changeDetail)}
                   refs={drawerRefs}
                   getMaxWidth={getDrawerMaxWidth}
                 >
-                  {selectedDrawer?.content}
+                  {activeDrawer?.content}
                 </ResizableDrawer>
               ) : (
                 <Drawer
@@ -792,18 +695,17 @@ const OldAppLayout = React.forwardRef(
                 topOffset={headerHeight}
                 isMobile={isMobile}
                 drawers={{
-                  items: tools && !toolsHide ? [toolsItem, ...drawers.items] : drawers.items,
-                  activeDrawerId: selectedDrawer?.id,
+                  items: drawers,
+                  activeDrawerId: activeDrawerId,
                   onChange: changeDetail => {
-                    if (selectedDrawer?.id !== changeDetail.activeDrawerId) {
-                      onToolsToggle(changeDetail.activeDrawerId === 'tools');
+                    if (activeDrawerId !== changeDetail.activeDrawerId) {
+                      onToolsToggle(changeDetail.activeDrawerId === TOOLS_DRAWER_ID);
                       focusDrawersButtons();
-                      setActiveDrawerId(changeDetail.activeDrawerId);
                       setDrawerLastInteraction({ type: 'open' });
-                      fireNonCancelableEvent(drawers.onChange, changeDetail.activeDrawerId);
                     }
+                    onActiveDrawerChange(changeDetail.activeDrawerId);
                   },
-                  ariaLabel: drawers.ariaLabel,
+                  ariaLabel: drawersProps.ariaLabel,
                 }}
               />
             )}

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
+import { InternalDrawerProps } from '../drawer/interfaces';
+import { AppLayoutState } from '../defaults';
+import { useMobile } from '../../internal/hooks/use-mobile';
+import { useControllable } from '../../internal/hooks/use-controllable';
+import { fireNonCancelableEvent } from '../../internal/events';
+import { awsuiPluginsInternal } from '../../internal/plugins/api';
+import { convertRuntimeDrawers, DrawersLayout } from '../runtime-api';
+import { AppLayoutProps } from '../interfaces';
+import { togglesConfig } from '../toggles';
+
+export const TOOLS_DRAWER_ID = 'awsui-internal-tools';
+
+interface ToolsProps {
+  toolsHide: boolean | undefined;
+  toolsOpen: boolean | undefined;
+  toolsWidth: number;
+  tools: React.ReactNode | undefined;
+  ariaLabels: AppLayoutProps.Labels | undefined;
+}
+
+function getToolsDrawerItem(props: ToolsProps) {
+  // TODO: remove props.tools check, because it is incompatible with no-drawers behavior
+  if (props.toolsHide || !props.tools) {
+    return null;
+  }
+  const { iconName, getLabels } = togglesConfig.tools;
+  const { mainLabel, closeLabel, openLabel } = getLabels(props.ariaLabels);
+  return {
+    id: TOOLS_DRAWER_ID,
+    content: props.tools,
+    resizable: false,
+    ariaLabels: {
+      triggerButton: openLabel,
+      closeButton: closeLabel,
+      content: mainLabel,
+    },
+    trigger: {
+      iconName: iconName,
+    },
+  };
+}
+
+function useRuntimeDrawers(
+  disableRuntimeDrawers: boolean | undefined,
+  onActiveDrawerChange: (id: string | undefined) => void
+) {
+  const [runtimeDrawers, setRuntimeDrawers] = useState<DrawersLayout>({ before: [], after: [] });
+
+  useEffect(() => {
+    if (disableRuntimeDrawers) {
+      return;
+    }
+    const unsubscribe = awsuiPluginsInternal.appLayout.onDrawersRegistered(drawers => {
+      setRuntimeDrawers(convertRuntimeDrawers(drawers));
+    });
+    return () => {
+      unsubscribe();
+      setRuntimeDrawers({ before: [], after: [] });
+    };
+  }, [disableRuntimeDrawers, onActiveDrawerChange]);
+
+  return runtimeDrawers;
+}
+
+export function useDrawers(
+  {
+    drawers: ownDrawers,
+    __disableRuntimeDrawers: disableRuntimeDrawers,
+  }: InternalDrawerProps & { __disableRuntimeDrawers?: boolean },
+  toolsProps: ToolsProps,
+  defaults: AppLayoutState
+) {
+  const isMobile = useMobile();
+  const toolsDrawer = getToolsDrawerItem(toolsProps);
+
+  const [activeDrawerId, setActiveDrawerId] = useControllable(
+    ownDrawers?.activeDrawerId,
+    ownDrawers?.onChange,
+    !isMobile && !toolsProps.toolsHide && toolsProps.toolsOpen && defaults.toolsOpen ? TOOLS_DRAWER_ID : undefined,
+    {
+      componentName: 'AppLayout',
+      controlledProp: 'activeDrawerId',
+      changeHandler: 'onChange',
+    }
+  );
+  const [drawerSizes, setDrawerSizes] = useState<Record<string, number>>({});
+
+  const onActiveDrawerChange = useStableCallback((newDrawerId: string | undefined) => {
+    setActiveDrawerId(newDrawerId);
+    fireNonCancelableEvent(ownDrawers?.onChange, newDrawerId);
+  });
+
+  const runtimeDrawers = useRuntimeDrawers(disableRuntimeDrawers, onActiveDrawerChange);
+  const combinedDrawers = [...runtimeDrawers.before, ...(ownDrawers?.items ?? []), ...runtimeDrawers.after];
+  if (toolsDrawer && combinedDrawers.length > 0) {
+    combinedDrawers.unshift(toolsDrawer);
+  }
+  const activeDrawer = combinedDrawers.find(drawer => drawer.id === activeDrawerId);
+  const activeDrawerIdResolved = activeDrawer?.id; // only defined when corresponding drawer exists
+
+  function onActiveDrawerResize({ id, size }: { id: string; size: number }) {
+    setDrawerSizes(oldSizes => ({ ...oldSizes, [id]: size }));
+    fireNonCancelableEvent(ownDrawers?.onResize, { id, size });
+  }
+
+  return {
+    ariaLabel: ownDrawers?.ariaLabel,
+    drawers: combinedDrawers,
+    activeDrawer,
+    activeDrawerId: activeDrawerIdResolved,
+    activeDrawerSize: activeDrawerIdResolved
+      ? drawerSizes[activeDrawerIdResolved] ?? activeDrawer?.defaultSize ?? toolsProps.toolsWidth
+      : toolsProps.toolsWidth,
+    onActiveDrawerChange,
+    onActiveDrawerResize,
+  };
+}

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -25,23 +25,25 @@ import { SplitPanelFocusControlRefs, useSplitPanelFocusControl } from '../utils/
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
 import { useObservedElement } from '../utils/use-observed-element';
 import { useMobile } from '../../internal/hooks/use-mobile';
-import { InternalDrawerProps } from '../drawer/interfaces';
+import { DrawerItem, InternalDrawerProps } from '../drawer/interfaces';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import useResize from '../utils/use-resize';
 import styles from './styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import useBackgroundOverlap from './use-background-overlap';
+import { useDrawers } from '../utils/use-drawers';
 
 interface AppLayoutInternals extends AppLayoutProps {
-  activeDrawerId?: string | null;
-  drawers?: InternalDrawerProps['drawers'];
+  activeDrawerId: string | undefined;
+  drawers: Array<DrawerItem>;
+  drawersAriaLabel: string | undefined;
   drawersRefs: DrawerFocusControlRefs;
   drawerSize: number;
   drawersMaxWidth: number;
   drawerRef: React.Ref<HTMLElement>;
   resizeHandle: React.ReactElement;
   drawersTriggerCount: number;
-  handleDrawersClick: (activeDrawerId: string | null, skipFocusControl?: boolean) => void;
+  handleDrawersClick: (activeDrawerId: string | undefined, skipFocusControl?: boolean) => void;
   handleSplitPanelClick: () => void;
   handleNavigationClick: (isOpen: boolean) => void;
   handleSplitPanelPreferencesChange: (detail: AppLayoutProps.SplitPanelPreferences) => void;
@@ -394,68 +396,58 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       [props.onSplitPanelPreferencesChange, setSplitPanelPreferences, setSplitPanelLastInteraction]
     );
 
-    /**
-     * The activeDrawerWidth is required in JavaScript to acccurately calculate whether a SplitPanel
-     * in the side position should be forced to the bottom based on available horiziontal space.
-     *
-     * The handleDrawersClick will either open a new drawer or close the currently open drawer by setting
-     * the activeDrawerId value. The active drawer can also be closed if a user clicks the Tools trigger
-     * button. This will skip the focus handling because the focus should be going to the Tools close
-     * button and not one of the drawers trigger buttons.
-     *
-     * The drawersTriggerCount is computed in order to determine whether the triggers should be persistent
-     * in the UI when a drawer is open. The trigger button container is suppressed when a drawer is open
-     * and their is only one trigger button.
-     *
-     * The hasDrawerViewportOverlay property is used to determine if any drawer is obscuring the entire
-     * viewport. This currently applies to Navigation, Tools, and Drawers in mobile viewports.
-     */
-    const drawers = (props as InternalDrawerProps).drawers;
-
-    const [activeDrawerId, setActiveDrawerId] = useControllable(drawers?.activeDrawerId, drawers?.onChange, null, {
-      componentName: 'AppLayout',
-      controlledProp: 'drawers.activeDrawerId',
-      changeHandler: 'onChange',
-    });
+    const {
+      drawers,
+      activeDrawer,
+      activeDrawerId,
+      onActiveDrawerChange,
+      onActiveDrawerResize,
+      activeDrawerSize,
+      ...drawersProps
+    } = useDrawers(
+      props as InternalDrawerProps,
+      {
+        ariaLabels: props.ariaLabels,
+        toolsHide,
+        toolsOpen: isToolsOpen,
+        tools: props.tools,
+        toolsWidth,
+      },
+      contentTypeDefaults
+    );
 
     const [drawersMaxWidth, setDrawersMaxWidth] = useState(toolsWidth);
-
-    const activeDrawer = drawers?.items.find(drawer => drawer.id === activeDrawerId);
 
     const {
       refs: drawersRefs,
       setFocus: focusDrawersButtons,
       loseFocus: loseDrawersFocus,
       setLastInteraction: setDrawerLastInteraction,
-    } = useDrawerFocusControl([activeDrawerId, activeDrawer?.resizable], activeDrawerId !== undefined, true);
+    } = useDrawerFocusControl([activeDrawerId, activeDrawer?.resizable], true, true);
 
     const drawerRef = useRef<HTMLDivElement>(null);
     const { resizeHandle, drawerSize } = useResize(drawerRef, {
-      activeDrawerId,
-      drawers,
+      onActiveDrawerResize,
+      activeDrawerSize,
+      activeDrawer,
       drawersRefs,
       isToolsOpen,
       drawersMaxWidth,
     });
 
-    const handleDrawersClick = useCallback(
-      function handleDrawersChange(id: string | null, skipFocusControl?: boolean) {
-        const newActiveDrawerId = id !== activeDrawerId ? id : null;
+    const handleDrawersClick = (id: string | undefined, skipFocusControl?: boolean) => {
+      const newActiveDrawerId = id !== activeDrawerId ? id : undefined;
 
-        setActiveDrawerId(newActiveDrawerId);
-        !skipFocusControl && focusDrawersButtons();
-        fireNonCancelableEvent(drawers?.onChange, newActiveDrawerId!);
-        setDrawerLastInteraction({ type: activeDrawerId ? 'close' : 'open' });
-      },
-      [activeDrawerId, drawers?.onChange, focusDrawersButtons, setActiveDrawerId, setDrawerLastInteraction]
-    );
+      onActiveDrawerChange(newActiveDrawerId);
+
+      !skipFocusControl && focusDrawersButtons();
+      setDrawerLastInteraction({ type: activeDrawerId ? 'close' : 'open' });
+    };
 
     const drawersTriggerCount =
-      (drawers?.items.length ?? 0) +
-      (splitPanelDisplayed && splitPanelPosition === 'side' ? 1 : 0) +
-      (!toolsHide ? 1 : 0);
+      drawers.length + (splitPanelDisplayed && splitPanelPosition === 'side' ? 1 : 0) + (!toolsHide ? 1 : 0);
     const hasOpenDrawer =
-      activeDrawerId !== null ||
+      activeDrawerId !== undefined ||
       isToolsOpen ||
       (splitPanelDisplayed && splitPanelPosition === 'side' && isSplitPanelOpen);
     const hasDrawerViewportOverlay =
@@ -595,6 +587,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           activeDrawerId,
           contentType,
           drawers,
+          drawersAriaLabel: drawersProps.ariaLabel,
           drawersRefs,
           drawersMaxWidth,
           drawerSize,

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -24,7 +24,7 @@ export default function Drawers() {
 
   const isUnfocusable = hasDrawerViewportOverlay && isNavigationOpen && !navigationHide;
 
-  if (!drawers) {
+  if (drawers.length === 0) {
     return null;
   }
 
@@ -71,7 +71,7 @@ function ActiveDrawer() {
     drawerRef,
   } = useAppLayoutInternals();
 
-  const activeDrawer = drawers?.items.find((item: any) => item.id === activeDrawerId) ?? null;
+  const activeDrawer = drawers.find(item => item.id === activeDrawerId) ?? null;
 
   const computedAriaLabels = {
     closeButton: activeDrawerId ? activeDrawer?.ariaLabels?.closeButton : ariaLabels?.toolsClose,
@@ -136,8 +136,8 @@ function ActiveDrawer() {
 function DesktopTriggers() {
   const {
     activeDrawerId,
-    ariaLabels,
     drawers,
+    drawersAriaLabel,
     drawersRefs,
     drawersTriggerCount,
     handleDrawersClick,
@@ -152,9 +152,6 @@ function DesktopTriggers() {
     splitPanelPosition,
     splitPanelRefs,
     splitPanelToggle,
-    tools,
-    toolsHide,
-    toolsRefs,
   } = useAppLayoutInternals();
 
   const hasMultipleTriggers = drawersTriggerCount > 1;
@@ -179,7 +176,7 @@ function DesktopTriggers() {
           [styles['has-open-drawer']]: hasOpenDrawer,
         }
       )}
-      aria-label={drawers?.ariaLabel}
+      aria-label={drawersAriaLabel}
     >
       <div
         className={clsx(styles['drawers-trigger-content'], {
@@ -187,21 +184,7 @@ function DesktopTriggers() {
           [styles['has-open-drawer']]: hasOpenDrawer,
         })}
       >
-        {!toolsHide && tools && (
-          <TriggerButton
-            ariaLabel={ariaLabels?.toolsToggle}
-            className={clsx(styles['drawers-trigger'], testutilStyles['tools-toggle'])}
-            iconName="status-info"
-            onClick={() => {
-              activeDrawerId && handleDrawersClick(null, true);
-              handleToolsClick(!isToolsOpen);
-            }}
-            ref={toolsRefs.toggle}
-            selected={isToolsOpen}
-          />
-        )}
-
-        {drawers?.items.map(item => (
+        {drawers.map(item => (
           <TriggerButton
             ariaLabel={item.ariaLabels?.triggerButton}
             className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
@@ -242,17 +225,12 @@ function DesktopTriggers() {
 export function MobileTriggers() {
   const {
     activeDrawerId,
-    ariaLabels,
     drawers,
+    drawersAriaLabel,
     drawersRefs,
     handleDrawersClick,
-    handleToolsClick,
     hasDrawerViewportOverlay,
     isMobile,
-    isToolsOpen,
-    tools,
-    toolsHide,
-    toolsRefs,
   } = useAppLayoutInternals();
 
   const previousActiveDrawerId = useRef(activeDrawerId);
@@ -261,7 +239,7 @@ export function MobileTriggers() {
     previousActiveDrawerId.current = activeDrawerId;
   }
 
-  if (!isMobile || !drawers) {
+  if (!isMobile || drawers.length === 0) {
     return null;
   }
 
@@ -275,24 +253,9 @@ export function MobileTriggers() {
           [styles.unfocusable]: hasDrawerViewportOverlay,
         }
       )}
-      aria-label={drawers.ariaLabel}
+      aria-label={drawersAriaLabel}
     >
-      {!toolsHide && tools && (
-        <InternalButton
-          ariaLabel={ariaLabels?.toolsToggle ?? undefined}
-          ariaExpanded={isToolsOpen}
-          className={testutilStyles['tools-toggle']}
-          disabled={hasDrawerViewportOverlay}
-          formAction="none"
-          iconName="status-info"
-          onClick={() => handleToolsClick(true)}
-          ref={toolsRefs.toggle}
-          variant="icon"
-          __nativeAttributes={{ 'aria-haspopup': true }}
-        />
-      )}
-
-      {drawers.items.map(item => (
+      {drawers.map(item => (
         <InternalButton
           ariaExpanded={item.id === activeDrawerId}
           ariaLabel={item.ariaLabels?.triggerButton}

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -25,7 +25,7 @@ export default function MobileToolbar() {
     toolsRefs,
   } = useAppLayoutInternals();
 
-  if (!isMobile || (navigationHide && !breadcrumbs && toolsHide && !drawers)) {
+  if (!isMobile || (navigationHide && !breadcrumbs && toolsHide && drawers.length === 0)) {
     return null;
   }
 
@@ -66,7 +66,7 @@ export default function MobileToolbar() {
         <div className={clsx(styles['mobile-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>{breadcrumbs}</div>
       )}
 
-      {isMobile && !toolsHide && !drawers && (
+      {isMobile && !toolsHide && drawers.length === 0 && (
         <aside
           aria-hidden={isToolsOpen}
           aria-label={ariaLabels?.tools ?? undefined}

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -56,7 +56,7 @@ export default function Tools({ children }: ToolsProps) {
    * If the drawers property is defined the Tools and SplitPanel will be mounted and rendered
    * by the Drawers component.
    */
-  if ((toolsHide && !hasSplitPanel) || drawers) {
+  if ((toolsHide && !hasSplitPanel) || drawers.length > 0) {
     return null;
   }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
