### PR TITLE
chore: Repalce containsOrEqual with utility from the toolkit

### DIFF
--- a/src/internal/utils/__tests__/dom.test.ts
+++ b/src/internal/utils/__tests__/dom.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { findUpUntil, parseCssVariable, containsOrEqual } from '../../../../lib/components/internal/utils/dom';
+import { findUpUntil, parseCssVariable } from '../../../../lib/components/internal/utils/dom';
 
 describe('findUpUntil', () => {
   test('returns null if there is no match', () => {
@@ -84,32 +84,5 @@ describe('parseCssVariable', () => {
         'rgba(0, 10, 200, 0.5)'
       );
     });
-  });
-});
-
-describe('containsOrEqual', () => {
-  test('returns "true", when the node and the container are the same element', () => {
-    const div = document.createElement('div');
-    div.innerHTML = `
-      <div id="container1"></div>
-    `;
-    expect(containsOrEqual(div.querySelector('#container1'), div.querySelector('#container1') as Node)).toBe(true);
-  });
-  test('returns "true", when the node is descendant from the container', () => {
-    const div = document.createElement('div');
-    div.innerHTML = `
-      <div id="container1">
-        <div id="node"></div>
-      </div>
-    `;
-    expect(containsOrEqual(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(true);
-  });
-  test('returns "false", when the node is not a child of the container', () => {
-    const div = document.createElement('div');
-    div.innerHTML = `
-      <div id="container1"></div>
-      <div id="node"></div>
-    `;
-    expect(containsOrEqual(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(false);
   });
 });

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -95,16 +95,3 @@ export function parseCssVariable(value: string) {
   const match = expr.body.match(cssVariableExpression);
   return match ? match[1] : value;
 }
-
-/**
- * Checks whether the given node is a descendant of a container.
- * @deprecated use nodeContains from component-toolkit
- * @param container Container node
- * @param node Node that is checked to be a descendant of the container
- */
-export function containsOrEqual(container: Node | null, node: Node): boolean {
-  if (container === null) {
-    return false;
-  }
-  return container === node || container.contains(node);
-}

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { containsOrEqual, findUpUntil } from './dom';
+import { findUpUntil } from './dom';
+import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 
 /**
  * Checks whether the given node (target) belongs to the container.
- * The function is similar to containsOrEqual but also accounts for dropdowns with expandToViewport=true.
+ * The function is similar to nodeContains but also accounts for dropdowns with expandToViewport=true.
  *
  * @param container Container node
  * @param target Node that is checked to be a descendant of the container
@@ -16,5 +17,5 @@ export function nodeBelongs(container: Node | null, target: Node | EventTarget |
   }
   const portal = findUpUntil(target as HTMLElement, node => !!node.dataset.awsuiReferrerId);
   const referrer = portal instanceof HTMLElement ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
-  return referrer ? containsOrEqual(container, referrer) : containsOrEqual(container, target);
+  return referrer ? nodeContains(container, referrer) : nodeContains(container, target);
 }


### PR DESCRIPTION
### Description

Remove a duplicate of a utility which already exists in the toolkit

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
