### PR TITLE
refactor: Reuse nodeBelongs in focus tracker utility

### DIFF
--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -77,7 +77,7 @@ const DatePicker = React.forwardRef(
     const calendarDescriptionId = useUniqueId('calendar-description-');
     const mergedRef = useMergeRefs(rootRef, __internalRootRef);
 
-    useFocusTracker({ rootRef, onBlur, onFocus, viewportId: expandToViewport ? dropdownId : '' });
+    useFocusTracker({ rootRef, onBlur, onFocus });
 
     const onDropdownCloseHandler = useCallback(() => setIsDropDownOpen(false), [setIsDropDownOpen]);
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -129,7 +129,7 @@ const DateRangePicker = React.forwardRef(
     const rootRef = useRef<HTMLDivElement>(null);
     const dropdownId = useUniqueId('date-range-picker-dropdown');
 
-    useFocusTracker({ rootRef, onBlur, onFocus, viewportId: expandToViewport ? dropdownId : '' });
+    useFocusTracker({ rootRef, onBlur, onFocus });
 
     const [isDropDownOpen, setIsDropDownOpen] = useState<boolean>(false);
 

--- a/src/internal/hooks/use-focus-tracker.ts
+++ b/src/internal/hooks/use-focus-tracker.ts
@@ -9,32 +9,27 @@ interface UseFocusTracker {
     onBlur?: NonCancelableEventHandler<any>;
     onFocus?: NonCancelableEventHandler<any>;
     rootRef: MutableRefObject<HTMLElement | null>;
-    viewportId?: string;
   }): void;
 }
 
-export const useFocusTracker: UseFocusTracker = ({ rootRef, onBlur, onFocus, viewportId }) => {
+export const useFocusTracker: UseFocusTracker = ({ rootRef, onBlur, onFocus }) => {
   const focusTracker = useRef<FocusTracker | null>(null);
 
   useEffect(() => {
     if (!rootRef.current) {
       return;
     }
-    focusTracker.current = new FocusTracker(
-      rootRef.current,
-      {
-        onFocusLeave: () => {
-          fireNonCancelableEvent(onBlur);
-        },
-        onFocusEnter: () => {
-          fireNonCancelableEvent(onFocus);
-        },
+    focusTracker.current = new FocusTracker(rootRef.current, {
+      onFocusLeave: () => {
+        fireNonCancelableEvent(onBlur);
       },
-      viewportId
-    );
+      onFocusEnter: () => {
+        fireNonCancelableEvent(onFocus);
+      },
+    });
     focusTracker.current.initialize();
     return () => {
       focusTracker.current?.destroy();
     };
-  }, [rootRef, onBlur, onFocus, viewportId]);
+  }, [rootRef, onBlur, onFocus]);
 };

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -10,11 +10,11 @@ import { containsOrEqual, findUpUntil } from './dom';
  * @param container Container node
  * @param target Node that is checked to be a descendant of the container
  */
-export function nodeBelongs(container: Node | null, target: Node): boolean {
-  const portal = findUpUntil(
-    target as HTMLElement,
-    node => node instanceof HTMLElement && !!node.dataset.awsuiReferrerId
-  );
+export function nodeBelongs(container: Node | null, target: Node | EventTarget | null): boolean {
+  if (!(target instanceof Node)) {
+    return false;
+  }
+  const portal = findUpUntil(target as HTMLElement, node => !!node.dataset.awsuiReferrerId);
   const referrer = portal instanceof HTMLElement ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
   return referrer ? containsOrEqual(container, referrer) : containsOrEqual(container, target);
 }


### PR DESCRIPTION
### Description

`nodeBelongs` utility already contains check for portals, no need for custom implementation via `viewportId`

This PR is a preparation for `containsOrEqual` removal https://github.com/cloudscape-design/components/pull/1465

### How has this been tested?

PR build ([this test suite](https://github.com/cloudscape-design/components/blob/main/src/date-range-picker/__integ__/events.test.ts) in particular covers the focus tracker functionality)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
