### PR TITLE
fix: Fix split panel entry animations

### DIFF
--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -24,6 +24,8 @@ section.split-panel-bottom {
   grid-column: 1 / 6;
   grid-row: 10;
   height: auto;
+  overflow-y: hidden;
+
   /*
   The position sticky will work in conjunction with the align self: end; property.
   If the grid row scrolls beyond the viewport, the sticky bottom position

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -139,7 +139,7 @@ function SplitPanelSide() {
           style={{
             [customCssProps.splitPanelMaxWidth]: `${splitPanelMaxWidth}px`,
             [customCssProps.splitPanelMinWidth]: `${splitPanelMinWidth}px`,
-            [customCssProps.splitPanelReportedHeaderSize]: `${splitPanelReportedSize}px`,
+            [customCssProps.splitPanelReportedSize]: `${splitPanelReportedSize}px`,
           }}
         >
           <div className={clsx(styles['animated-content'])}>{splitPanelPosition === 'side' && splitPanel}</div>


### PR DESCRIPTION
### Description

Two fixes, basically:
- Bottom split panel scrolls out the page while it's opening: this was fixed by the suggestion in AWSUI-21941. Seems fair to me; that's what we do in the side panel. Speaking of which...
- Side split panel doesn't animate width: I found this while playing with the demo. Don't know if we accidentally broke this or if it ever worked, but... fixed!

Related links, issue #, if available: AWSUI-21941

### How has this been tested?

Manually - through the Animations panel in Chrome's devtools. Not sure how I'd test animation transition state programmatically.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
