### PR TITLE
fix: Click outside focus handling on table inline edit

### DIFF
--- a/src/table/__integ__/inline-editing.test.ts
+++ b/src/table/__integ__/inline-editing.test.ts
@@ -137,3 +137,16 @@ test(
     await page.waitForAssertion(() => expect(page.isFocused(cellInputField$)).resolves.toBe(true));
   })
 );
+
+test(
+  'click focusable element outside when editing cancels editing and focuses clicked element',
+  setupTest(async page => {
+    // Edit a cell
+    await page.click(cellEditButton$);
+    await expect(page.isFocused(cellInputField$)).resolves.toBe(true);
+
+    // Click on the input element outside, it should get focused.
+    await page.click('[data-testid="focus"]');
+    await expect(page.isFocused('[data-testid="focus"]')).resolves.toBe(true);
+  })
+);

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -92,10 +92,10 @@ function TableCellEditable<ItemType>({
           ariaLabels={ariaLabels}
           column={column}
           item={item}
-          onEditEnd={e => {
+          onEditEnd={options => {
             setShowSuccessIcon(false);
-            isFocusMoveNeededRef.current = true;
-            onEditEnd(e);
+            isFocusMoveNeededRef.current = options.refocusCell;
+            onEditEnd(options.cancelled);
           }}
           submitEdit={submitEdit ?? submitHandlerFallback}
         />

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -15,11 +15,16 @@ import { useInternalI18n } from '../../i18n/context';
 // A function that does nothing
 const noop = () => undefined;
 
+interface OnEditEndOptions {
+  cancelled: boolean;
+  refocusCell: boolean;
+}
+
 interface InlineEditorProps<ItemType> {
   ariaLabels: TableProps['ariaLabels'];
   column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
-  onEditEnd: (cancelled: boolean) => void;
+  onEditEnd: (options: OnEditEndOptions) => void;
   submitEdit: TableProps.SubmitEditFunction<ItemType>;
   __onRender?: () => void;
 }
@@ -43,11 +48,11 @@ export function InlineEditor<ItemType>({
     setValue: setCurrentEditValue,
   };
 
-  function finishEdit(cancel = false) {
-    if (!cancel) {
+  function finishEdit({ cancelled = false, refocusCell = true }: Partial<OnEditEndOptions> = {}) {
+    if (!cancelled) {
       setCurrentEditValue(undefined);
     }
-    onEditEnd(cancel);
+    onEditEnd({ cancelled, refocusCell: refocusCell });
   }
 
   async function onSubmitClick(evt: React.FormEvent) {
@@ -68,11 +73,11 @@ export function InlineEditor<ItemType>({
     }
   }
 
-  function onCancel() {
+  function onCancel({ reFocusEditedCell = true } = {}) {
     if (currentEditLoading) {
       return;
     }
-    finishEdit(true);
+    finishEdit({ cancelled: true, refocusCell: reFocusEditedCell });
   }
 
   function handleEscape(event: React.KeyboardEvent): void {
@@ -81,7 +86,7 @@ export function InlineEditor<ItemType>({
     }
   }
 
-  const clickAwayRef = useClickAway(onCancel);
+  const clickAwayRef = useClickAway(() => onCancel({ reFocusEditedCell: false }));
 
   useEffect(() => {
     if (__onRender) {
@@ -127,7 +132,7 @@ export function InlineEditor<ItemType>({
                       formAction="none"
                       iconName="close"
                       variant="inline-icon"
-                      onClick={onCancel}
+                      onClick={() => onCancel()}
                     />
                   ) : null}
                   <Button


### PR DESCRIPTION
### Description

When editing a table cell and clicking somewhere outside, the edit mode ended and the edited cell kept focus by purpose. 

Now, if a focusable element got clicked outside during an edit, editing get cancelled and the outside clicked element  receives focus - the focus handling does not get intercepted anymore.

In case of some change are made during editing, the customer is able to intercept and display a modal about unsaved changes.

Related links, issue #, if available: AWSUI-21967

### How has this been tested?

- Added integration test to cover change.
- Verify the changes on the /table/editable page at the recent PR deployment.


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
