### PR TITLE
chore: Use 1-based indexing for optional funnel steps

### DIFF
--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -48,7 +48,7 @@ describe('Wizard Analytics', () => {
       expect.objectContaining({
         funnelType: 'multi-page',
         totalFunnelSteps: 3, // Length of DEFAULT_STEPS.length,
-        optionalStepNumbers: [1], // DEFAULT_STEPS[1] is optional
+        optionalStepNumbers: [2], // DEFAULT_STEPS[1] is optional
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
@@ -343,7 +343,7 @@ describe('Wizard Analytics', () => {
       expect.objectContaining({
         funnelType: 'multi-page',
         totalFunnelSteps: 3,
-        optionalStepNumbers: [1],
+        optionalStepNumbers: [2],
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -25,7 +25,9 @@ function Wizard({ isLoadingNextStep = false, allowSkipTo = false, ...props }: Wi
   return (
     <AnalyticsFunnel
       funnelType="multi-page"
-      optionalStepNumbers={props.steps.map((step, index) => (step.isOptional ? index : -1)).filter(step => step !== -1)}
+      optionalStepNumbers={props.steps
+        .map((step, index) => (step.isOptional ? index + 1 : -1))
+        .filter(step => step !== -1)}
       totalFunnelSteps={props.steps.length}
     >
       <InternalWizard


### PR DESCRIPTION
### Description

When a Wizard emits its `funnelStart` event, that event contains information about which steps are optional. Currently this list uses zero-based indexing, which is inconsistent with e.g. the `stepNumber` property of the `funnelStepStart` event. This PR changes it to be 1-based indexing.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
