### PR TITLE
chore: Mark the current funnel step name with a data attribute

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -7,11 +7,22 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import Button from '../../../lib/components/button';
 import Form from '../../../lib/components/form';
 import Modal from '../../../lib/components/modal';
+import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
 
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
+
+// JSDom does not support the `textContent` property. For this test, `textContent` is close enough.
+Object.defineProperty(HTMLElement.prototype, 'innerText', {
+  get() {
+    return this.textContent;
+  },
+  set(v) {
+    this.textContent = v;
+  },
+});
 
 describe('Form Analytics', () => {
   beforeEach(() => {
@@ -44,6 +55,27 @@ describe('Form Analytics', () => {
         funnelInteractionId: expect.any(String),
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
+      })
+    );
+  });
+
+  test('includes the current breadcrumb as the step name in the funnelStepStart event', () => {
+    render(
+      <>
+        <BreadcrumbGroup
+          items={[
+            { text: 'Resources', href: '' },
+            { text: 'My creation flow', href: '' },
+          ]}
+        />
+        <Form />
+      </>
+    );
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stepName: 'My creation flow',
       })
     );
   });

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -14,6 +14,7 @@ export const DATA_ATTR_ANALYTICS_ALERT = 'data-analytics-alert';
 export const DATA_ATTR_ANALYTICS_FLASHBAR = 'data-analytics-flashbar';
 
 export const FUNNEL_KEY_FUNNEL_NAME = 'funnel-name';
+export const FUNNEL_KEY_STEP_NAME = 'step-name';
 export const FUNNEL_KEY_SUBSTEP_NAME = 'substep-name';
 
 export const getFunnelNameSelector = () => `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_FUNNEL_NAME}"]`;

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -8,6 +8,7 @@ import Wizard, { WizardProps } from '../../../lib/components/wizard';
 import Form from '../../../lib/components/form';
 
 import { FunnelMetrics, setFunnelMetrics } from '../../../lib/components/internal/analytics';
+import { getFunnelKeySelector, FUNNEL_KEY_STEP_NAME } from '../../../lib/components/internal/analytics/selectors';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { DEFAULT_I18N_SETS, DEFAULT_STEPS } from './common';
@@ -360,5 +361,15 @@ describe('Wizard Analytics', () => {
         subStepAllSelector: expect.any(String),
       })
     );
+  });
+
+  test('marks the step title with the correct data attribute', () => {
+    const { container } = render(<Wizard steps={DEFAULT_STEPS} i18nStrings={DEFAULT_I18N_SETS[0]} />);
+
+    expect(document.querySelector(getFunnelKeySelector(FUNNEL_KEY_STEP_NAME))?.textContent).toBe('Step 1');
+
+    createWrapper(container).findWizard()!.findPrimaryButton().click();
+
+    expect(document.querySelector(getFunnelKeySelector(FUNNEL_KEY_STEP_NAME))?.textContent).toBe('Step 2 - optional');
   });
 });

--- a/src/wizard/wizard-form.tsx
+++ b/src/wizard/wizard-form.tsx
@@ -11,6 +11,7 @@ import WizardFormHeader from './wizard-form-header';
 import styles from './styles.css.js';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 import { AnalyticsFunnelStep } from '../internal/analytics/components/analytics-funnel';
+import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_STEP_NAME } from '../internal/analytics/selectors';
 
 interface WizardFormProps {
   steps: ReadonlyArray<WizardProps.Step>;
@@ -79,7 +80,12 @@ export default function WizardForm({
                 description={description}
                 info={info}
               >
-                <span className={styles['form-header-component-wrapper']} tabIndex={-1} ref={stepHeaderRef}>
+                <span
+                  {...{ [DATA_ATTR_FUNNEL_KEY]: FUNNEL_KEY_STEP_NAME }}
+                  className={styles['form-header-component-wrapper']}
+                  tabIndex={-1}
+                  ref={stepHeaderRef}
+                >
                   {title}
                   {isOptional && <i>{` - ${i18nStrings.optional}`}</i>}
                 </span>


### PR DESCRIPTION
### Description

This PR adds a data attribute to the Wizard. This attribute can be used to determine the name of the current step.

The Form component (the single-page counterpart to the Wizard) does not receive a similar attribute, because we do not consider it to have a proper step name. Instead, we're already using the funnel name as the step name. See the value for `stepNameSelector` in this line:
https://github.com/cloudscape-design/components/blob/99e8bbfd1a4012be17e3acbb617e4fcda7e65298/src/form/index.tsx#L39

I've added a test to make this explicit.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
