### PR TITLE
chore: Table grid nav updates

### DIFF
--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -15,11 +15,13 @@ import {
   Input,
   Link,
   SegmentedControl,
+  Select,
 } from '~components';
 import styles from './styles.scss';
 import { id as generateId, generateItems, Instance } from '../table/generate-data';
 import AppContext, { AppContextType } from '../app/app-context';
 import {
+  TableRole,
   getTableCellRoleProps,
   getTableColHeaderRoleProps,
   getTableHeaderRowRoleProps,
@@ -34,6 +36,7 @@ import appLayoutLabels from '../app-layout/utils/labels';
 type PageContext = React.Context<
   AppContextType<{
     pageSize: number;
+    tableRole: TableRole;
   }>
 >;
 
@@ -94,10 +97,13 @@ const createColumnDefinitions = ({
   { key: 'type', label: 'Type', render: (item: Instance) => item.type },
 ];
 
+const tableRoleOptions = [{ value: 'table' }, { value: 'grid' }, { value: 'grid-default' }];
+
 export default function Page() {
   const [toolsOpen, setToolsOpen] = useState(false);
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
   const pageSize = urlParams.pageSize ?? 10;
+  const tableRole = urlParams.tableRole ?? 'grid';
 
   const [items, setItems] = useState(generateItems(25));
   const columnDefinitions = useMemo(
@@ -117,7 +123,6 @@ export default function Page() {
 
   const tableRef = useRef<HTMLTableElement>(null);
 
-  const tableRole = 'grid';
   useGridNavigation({ tableRole, pageSize, getTable: () => tableRef.current });
 
   const sortedItems = useMemo(() => {
@@ -149,6 +154,14 @@ export default function Page() {
                       onChange={event => setUrlParams({ pageSize: parseInt(event.detail.value) })}
                     />
                   </FormField>
+
+                  <FormField label="Table role">
+                    <Select
+                      options={tableRoleOptions}
+                      selectedOption={tableRoleOptions.find(option => option.value === tableRole) ?? null}
+                      onChange={event => setUrlParams({ tableRole: event.detail.selectedOption.value as TableRole })}
+                    />
+                  </FormField>
                 </ColumnLayout>
 
                 <Link onFollow={() => setToolsOpen(true)} data-testid="link-before">
@@ -178,7 +191,7 @@ export default function Page() {
                       <th
                         key={column.key}
                         className={styles['custom-table-cell']}
-                        {...getTableColHeaderRoleProps({ tableRole, colIndex })}
+                        {...getTableColHeaderRoleProps({ tableRole, colIndex, isWidget: true })}
                       >
                         <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
                           <button

--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -208,8 +208,7 @@ export default function Page() {
                         <td
                           key={column.key}
                           className={styles['custom-table-cell']}
-                          {...getTableCellRoleProps({ tableRole, colIndex })}
-                          data-widget-cell={column.isWidget}
+                          {...getTableCellRoleProps({ tableRole, colIndex, isWidget: column.isWidget })}
                         >
                           {column.render(item)}
                         </td>

--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -102,7 +102,7 @@ describe('labels', () => {
       const [headerRow, firstRowInTable] = wrapper.findAll('tr');
       // header row is always index 1
       expect(headerRow!.getElement().getAttribute('aria-rowindex')).toEqual('1');
-      // rows in a table are index + 1  as header row is index 1
+      // rows in a table are index + 1 as header row is index 1
       expect(firstRowInTable!.getElement().getAttribute('aria-rowindex')).toEqual('22');
     });
   });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -187,7 +187,7 @@ const InternalTable = React.forwardRef(
     const hasStickyColumns = !!((stickyColumns?.first ?? 0) + (stickyColumns?.last ?? 0) > 0);
 
     const hasEditableCells = !!columnDefinitions.find(col => col.editConfig);
-    const tableRole = hasEditableCells ? 'grid-no-navigation' : 'table';
+    const tableRole = hasEditableCells ? 'grid-default' : 'table';
 
     const theadProps: TheadProps = {
       containerWidth,

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -37,15 +37,15 @@ test(
 
     await page.click('[data-testid="link-before"]');
     await page.keys('Tab');
-    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"] button')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"]')).resolves.toBe(true);
 
     await page.keys('Tab');
     await expect(page.isFocused('[data-testid="link-after"]')).resolves.toBe(true);
 
     await page.keys(['Shift', 'Tab', 'Null']);
-    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"] button')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"]')).resolves.toBe(true);
 
-    await page.keys(['ArrowRight', 'ArrowDown', 'ArrowRight']);
+    await page.keys(['ArrowRight', 'ArrowDown', 'Enter', 'ArrowRight']);
     await expect(page.isFocused('tr[aria-rowindex="2"] [aria-label="Duplicate item"]')).resolves.toBe(true);
 
     await page.keys('Tab');

--- a/src/table/table-role/__tests__/use-grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/use-grid-navigation.test.tsx
@@ -135,6 +135,40 @@ test('supports arrow keys navigation', () => {
   expect(getActiveElement()).toEqual(['button', 'desc']);
 });
 
+test('up/down navigation works when first data row index is not 2', () => {
+  function TestComponent() {
+    const tableRef = useRef<HTMLTableElement>(null);
+    useGridNavigation({ tableRole: 'grid', pageSize: 2, getTable: () => tableRef.current });
+    return (
+      <table role="grid" ref={tableRef}>
+        <thead>
+          <tr aria-rowindex={1}>
+            <th aria-colindex={1}>header-1</th>
+            <th aria-colindex={2}>header-2</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr aria-rowindex={5}>
+            <td aria-colindex={1}>cell-1-1</td>
+            <td aria-colindex={2}>cell-1-2</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+  const { container } = render(<TestComponent />);
+  const table = container.querySelector('table')!;
+
+  container.querySelector('th')?.focus();
+  expect(getActiveElement()).toEqual(['th', 'header-1']);
+
+  fireEvent.keyDown(table, { keyCode: KeyCode.down });
+  expect(getActiveElement()).toEqual(['td', 'cell-1-1']);
+
+  fireEvent.keyDown(table, { keyCode: KeyCode.up });
+  expect(getActiveElement()).toEqual(['th', 'header-1']);
+});
+
 test('supports key combination navigation', () => {
   const { container } = render(<InteractiveTable />);
   const table = container.querySelector('table')!;

--- a/src/table/table-role/grid-navigation.md
+++ b/src/table/table-role/grid-navigation.md
@@ -47,4 +47,6 @@ See: https://www.w3.org/WAI/ARIA/apg/patterns/grid/#gridNav_focus
 
 Widget cells are those including one or multiple elements that utilize arrow keys interaction model such is segmented control, radio group, slider, etc. The widget cells are not determined automatically and must be explicitly specified.
 
-Same as for the multi-element cells the focus is not automatically moved inside when a cell is navigated to. The `Enter`, `F2` and `Escape` commands work the same way. The difference is that when the focus is inside a widget cell the navigation commands are not intercepted. Besides, the default focusing behavior is restored so that the elements inside can be navigated with `Tab` and `Shift + Tab` commands. 
+Same as for the multi-element cells the focus is not automatically moved inside when a cell is navigated to. The `Enter`, `F2` and `Escape` commands work the same way. The difference is that when the focus is inside a widget cell the navigation commands are not intercepted. Besides, the default focusing behavior is restored so that the elements inside can be navigated with `Tab` and `Shift + Tab` commands.
+
+When the focus is within a widget cell all table cells become focusable so that pressing `Tab` and `Shift + Tab` also restores table navigation by moving the focus to the cell itself or the cell next to it (if available).

--- a/src/table/table-role/interfaces.ts
+++ b/src/table/table-role/interfaces.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type TableRole = 'table' | 'grid' | 'grid-no-navigation';
+export type TableRole = 'table' | 'grid' | 'grid-default';
 
 export interface GridNavigationProps {
   tableRole: TableRole;

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -27,7 +27,7 @@ export function getTableRoleProps(options: {
 
   // Browsers have weird mechanism to guess whether it's a data table or a layout table.
   // If we state explicitly, they get it always correctly even with low number of rows.
-  nativeProps.role = options.tableRole === 'grid-no-navigation' ? 'grid' : options.tableRole;
+  nativeProps.role = options.tableRole === 'grid-default' ? 'grid' : options.tableRole;
 
   nativeProps['aria-label'] = options.ariaLabel;
   nativeProps['aria-labelledby'] = options.ariaLabelledBy;
@@ -64,7 +64,7 @@ export function getTableHeaderRowRoleProps(options: { tableRole: TableRole }) {
   const nativeProps: React.HTMLAttributes<HTMLTableRowElement> = {};
 
   // For grids headers are treated similar to data rows and are indexed accordingly.
-  if (options.tableRole === 'grid' || options.tableRole === 'grid-no-navigation') {
+  if (options.tableRole === 'grid' || options.tableRole === 'grid-default') {
     nativeProps['aria-rowindex'] = 1;
   }
 
@@ -74,13 +74,13 @@ export function getTableHeaderRowRoleProps(options: { tableRole: TableRole }) {
 export function getTableRowRoleProps(options: { tableRole: TableRole; rowIndex: number; firstIndex?: number }) {
   const nativeProps: React.HTMLAttributes<HTMLTableRowElement> = {};
 
-  // For grids data cell indices are incremented by 2 to account for the header cells.
-  if (options.tableRole === 'grid' || options.tableRole === 'grid-no-navigation') {
-    nativeProps['aria-rowindex'] = (options.firstIndex ?? 0) + options.rowIndex + 2;
+  // The data cell indices are incremented by 1 to account for the header cells.
+  if (options.tableRole === 'grid') {
+    nativeProps['aria-rowindex'] = (options.firstIndex || 1) + options.rowIndex + 1;
   }
   // For tables indices are only added when the first index is not 0 (not the first page/frame).
   else if (options.firstIndex !== undefined) {
-    nativeProps['aria-rowindex'] = (options.firstIndex ?? 0) + options.rowIndex + 1;
+    nativeProps['aria-rowindex'] = options.firstIndex + options.rowIndex + 1;
   }
 
   return nativeProps;
@@ -90,8 +90,9 @@ export function getTableColHeaderRoleProps(options: {
   tableRole: TableRole;
   colIndex: number;
   sortingStatus?: SortingStatus;
+  isWidget?: boolean;
 }) {
-  const nativeProps: React.ThHTMLAttributes<HTMLTableCellElement> = {};
+  const nativeProps: React.ThHTMLAttributes<HTMLTableCellElement> & { 'data-widget-cell'?: boolean } = {};
 
   nativeProps.scope = 'col';
 
@@ -103,11 +104,20 @@ export function getTableColHeaderRoleProps(options: {
     nativeProps['aria-sort'] = getAriaSort(options.sortingStatus);
   }
 
+  if (options.tableRole === 'grid' && options.isWidget) {
+    nativeProps['data-widget-cell'] = true;
+  }
+
   return nativeProps;
 }
 
-export function getTableCellRoleProps(options: { tableRole: TableRole; colIndex: number; isRowHeader?: boolean }) {
-  const nativeProps: React.TdHTMLAttributes<HTMLTableCellElement> = {};
+export function getTableCellRoleProps(options: {
+  tableRole: TableRole;
+  colIndex: number;
+  isRowHeader?: boolean;
+  isWidget?: boolean;
+}) {
+  const nativeProps: React.TdHTMLAttributes<HTMLTableCellElement> & { 'data-widget-cell'?: boolean } = {};
 
   if (options.tableRole === 'grid') {
     nativeProps['aria-colindex'] = options.colIndex + 1;
@@ -115,6 +125,10 @@ export function getTableCellRoleProps(options: { tableRole: TableRole; colIndex:
 
   if (options.isRowHeader) {
     nativeProps.scope = 'row';
+  }
+
+  if (options.tableRole === 'grid' && options.isWidget) {
+    nativeProps['data-widget-cell'] = true;
   }
 
   return nativeProps;

--- a/src/table/table-role/use-grid-navigation.ts
+++ b/src/table/table-role/use-grid-navigation.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useMemo } from 'react';
-import { findFocusinCell, moveFocusBy, moveFocusIn, updateTableIndices } from './utils';
+import { findFocusinCell, moveFocusBy, moveFocusIn, restoreTableFocusables, updateTableFocusables } from './utils';
 import { FocusedCell, GridNavigationAPI, GridNavigationProps } from './interfaces';
 import { KeyCode } from '../../internal/keycode';
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
@@ -56,8 +56,7 @@ class GridNavigationModel {
     const mutationObserver = new MutationObserver(this.onMutation);
     mutationObserver.observe(table, { childList: true, subtree: true });
 
-    // No need to clean this up as no resources are allocated.
-    updateTableIndices(this.table, this.focusedCell ?? this.prevFocusedCell);
+    updateTableFocusables(this.table, this.focusedCell ?? this.prevFocusedCell);
 
     this.cleanup = () => {
       this.table.removeEventListener('focusin', this.onFocusin);
@@ -65,6 +64,8 @@ class GridNavigationModel {
       this.table.removeEventListener('keydown', this.onKeydown);
 
       mutationObserver.disconnect();
+
+      restoreTableFocusables(this.table);
     };
   }
 
@@ -96,7 +97,7 @@ class GridNavigationModel {
     this.prevFocusedCell = cell;
     this.focusedCell = cell;
 
-    updateTableIndices(this.table, cell);
+    updateTableFocusables(this.table, cell);
   };
 
   private onFocusout = () => {
@@ -219,6 +220,6 @@ class GridNavigationModel {
       }
     }
 
-    updateTableIndices(this.table, this.focusedCell ?? this.prevFocusedCell);
+    updateTableFocusables(this.table, this.focusedCell ?? this.prevFocusedCell);
   };
 }

--- a/src/table/table-role/use-grid-navigation.ts
+++ b/src/table/table-role/use-grid-navigation.ts
@@ -5,7 +5,7 @@ import { useEffect, useMemo } from 'react';
 import { findFocusinCell, moveFocusBy, moveFocusIn, updateTableIndices } from './utils';
 import { FocusedCell, GridNavigationAPI, GridNavigationProps } from './interfaces';
 import { KeyCode } from '../../internal/keycode';
-import { containsOrEqual } from '../../internal/utils/dom';
+import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 
 /**
  * Makes table with role="grid" navigable with keyboard commands.
@@ -212,7 +212,7 @@ class GridNavigationModel {
     for (const record of mutationRecords) {
       if (record.type === 'childList') {
         for (const removedNode of Array.from(record.removedNodes)) {
-          if (containsOrEqual(removedNode, this.prevFocusedCell.element)) {
+          if (removedNode === this.prevFocusedCell.element || nodeContains(removedNode, this.prevFocusedCell.element)) {
             moveFocusBy(this.table, this.prevFocusedCell, { y: 0, x: 0 });
           }
         }

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -128,7 +128,6 @@ export function updateTableFocusables(table: HTMLTableElement, cell: null | Focu
 }
 
 export function restoreTableFocusables(table: HTMLTableElement) {
-  // Restore default focus behavior and make all cells focusable when focus is inside a widget cell.
   for (const focusable of getFocusables(table)) {
     if (focusable instanceof HTMLTableCellElement) {
       focusable.tabIndex = -1;
@@ -152,12 +151,21 @@ function getFirstFocusable(element: HTMLElement) {
 
 function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex: number, delta: number) {
   let targetRow: null | HTMLTableRowElement = null;
-  const rowElements = table.querySelectorAll('tr[aria-rowindex]');
-  for (let elementIndex = 0; elementIndex < rowElements.length; elementIndex++) {
-    const rowIndex = parseInt(rowElements[elementIndex].getAttribute('aria-rowindex') ?? '');
-    targetRow = rowElements[elementIndex] as HTMLTableRowElement;
+  const rowElements = Array.from(table.querySelectorAll('tr[aria-rowindex]'));
+  if (delta < 0) {
+    rowElements.reverse();
+  }
+  for (const element of rowElements) {
+    const rowIndex = parseInt(element.getAttribute('aria-rowindex') ?? '');
+    targetRow = element as HTMLTableRowElement;
 
-    if (rowIndex === targetAriaRowIndex || (delta < 0 && rowIndex >= targetAriaRowIndex)) {
+    if (rowIndex === targetAriaRowIndex) {
+      break;
+    }
+    if (delta >= 0 && rowIndex > targetAriaRowIndex) {
+      break;
+    }
+    if (delta < 0 && rowIndex < targetAriaRowIndex) {
       break;
     }
   }
@@ -166,12 +174,21 @@ function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex:
 
 function findTableRowCellByAriaColIndex(tableRow: HTMLTableRowElement, targetAriaColIndex: number, delta: number) {
   let targetCell: null | HTMLTableCellElement = null;
-  const cellElements = tableRow.querySelectorAll('td[aria-colindex],th[aria-colindex]');
-  for (let elementIndex = 0; elementIndex < cellElements.length; elementIndex++) {
-    const columnIndex = parseInt(cellElements[elementIndex].getAttribute('aria-colindex') ?? '');
-    targetCell = cellElements[elementIndex] as HTMLTableCellElement;
+  const cellElements = Array.from(tableRow.querySelectorAll('td[aria-colindex],th[aria-colindex]'));
+  if (delta < 0) {
+    cellElements.reverse();
+  }
+  for (const element of cellElements) {
+    const columnIndex = parseInt(element.getAttribute('aria-colindex') ?? '');
+    targetCell = element as HTMLTableCellElement;
 
-    if (columnIndex === targetAriaColIndex || (delta < 0 && columnIndex >= targetAriaColIndex)) {
+    if (columnIndex === targetAriaColIndex) {
+      break;
+    }
+    if (delta >= 0 && columnIndex > targetAriaColIndex) {
+      break;
+    }
+    if (delta < 0 && columnIndex < targetAriaColIndex) {
       break;
     }
   }


### PR DESCRIPTION
### Description

Made changes to the table grid navigation based on an integration attempt (see https://github.com/cloudscape-design/components/pull/1480).

The main changes are:
* Moving from focused cell to a cell containing one focusable element focuses the element and not the cell itself.
* When focus is inside a widget cell the Tab/Shift+Tab can be used to move focus back to the table.
* The navigation now works when the first data row index is other than 1.

### How has this been tested?

* New unit tests
* Updated existing integ test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
