### PR TITLE
fix: Fixes aria expanded and aria controls in AppLayout

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -148,7 +148,13 @@ describeEachAppLayout(() => {
       });
 
       test('Renders aria-expanded only on toggle', () => {
-        const { wrapper } = renderComponent(<AppLayout />);
+        const props = {
+          [openProp]: false,
+          [handler]: () => {},
+        };
+
+        const { wrapper } = renderComponent(<AppLayout {...props} />);
+
         expect(findToggle(wrapper).getElement()).toHaveAttribute('aria-expanded', 'false');
         expect(findToggle(wrapper).getElement()).toHaveAttribute('aria-haspopup', 'true');
         expect(findClose(wrapper).getElement()).not.toHaveAttribute('aria-expanded');
@@ -281,6 +287,7 @@ describeEachAppLayout(() => {
       expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'false');
       expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-haspopup', 'true');
       wrapper.findDrawersTriggers()![0].click();
+      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'true');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-expanded');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-haspopup');
     });

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -241,9 +241,10 @@ describeEachThemeAppLayout(false, () => {
     expect(wrapper.findDrawersTriggers()!.length).toBeLessThan(100);
   });
 
-  test('Renders aria-controls on toggle', () => {
+  test('Renders aria-controls on toggle only when active', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-
+    expect(wrapper.findDrawersTriggers()![0].getElement()).not.toHaveAttribute('aria-controls');
+    act(() => wrapper.findDrawersTriggers()![0].click());
     expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-controls', 'security');
   });
 });

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -240,6 +240,12 @@ describeEachThemeAppLayout(false, () => {
 
     expect(wrapper.findDrawersTriggers()!.length).toBeLessThan(100);
   });
+
+  test('Renders aria-controls on toggle', () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+
+    expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-controls', 'security');
+  });
 });
 
 // In VR we use a custom CSS property so we cannot test the style declaration.

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -66,7 +66,7 @@ export const Drawer = React.forwardRef(
           iconName={iconName}
           ariaLabel={openLabel}
           onClick={() => onToggle(true)}
-          ariaExpanded={false}
+          ariaExpanded={isOpen ? undefined : false}
         />
       </TagName>
     );

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -133,7 +133,7 @@ interface DrawerTriggerProps {
   testUtilsClassName?: string;
   ariaLabel: string | undefined;
   ariaExpanded: boolean;
-  ariaControls: string | undefined;
+  ariaControls?: string;
   badge: boolean | undefined;
   itemId?: string;
   isActive: boolean;
@@ -203,6 +203,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
         style={{ top: topOffset, bottom: bottomOffset }}
         className={clsx(styles['drawer-content'])}
         role="toolbar"
+        aria-orientation="vertical"
       >
         {!isMobile && (
           <aside
@@ -217,7 +218,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                     testUtilsClassName={testutilStyles['drawers-trigger']}
                     ariaExpanded={drawers?.activeDrawerId === item.id}
                     ariaLabel={item.ariaLabels?.triggerButton}
-                    ariaControls={item.id}
+                    ariaControls={drawers?.activeDrawerId === item.id ? item.id : undefined}
                     trigger={item.trigger}
                     badge={item.badge}
                     itemId={item.id}

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -73,6 +73,7 @@ export const Drawer = React.forwardRef(
 
     return (
       <div
+        id={drawers?.activeDrawerId}
         ref={ref}
         className={clsx(styles.drawer, {
           [styles['drawer-closed']]: !isOpen,
@@ -132,6 +133,7 @@ interface DrawerTriggerProps {
   testUtilsClassName?: string;
   ariaLabel: string | undefined;
   ariaExpanded: boolean;
+  ariaControls: string | undefined;
   badge: boolean | undefined;
   itemId?: string;
   isActive: boolean;
@@ -141,7 +143,17 @@ interface DrawerTriggerProps {
 
 const DrawerTrigger = React.forwardRef(
   (
-    { testUtilsClassName, ariaLabel, ariaExpanded, badge, itemId, isActive, trigger, onClick }: DrawerTriggerProps,
+    {
+      testUtilsClassName,
+      ariaLabel,
+      ariaExpanded,
+      ariaControls,
+      badge,
+      itemId,
+      isActive,
+      trigger,
+      onClick,
+    }: DrawerTriggerProps,
     ref: React.Ref<{ focus: () => void }>
   ) => (
     <div className={clsx(styles['drawer-trigger'], isActive && styles['drawer-trigger-active'])} onClick={onClick}>
@@ -152,6 +164,7 @@ const DrawerTrigger = React.forwardRef(
         iconSvg={trigger.iconSvg}
         ariaLabel={ariaLabel}
         ariaExpanded={ariaExpanded}
+        ariaControls={ariaControls}
         badge={badge}
         testId={itemId && `awsui-app-layout-trigger-${itemId}`}
       />
@@ -189,6 +202,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
         ref={triggersContainerRef}
         style={{ top: topOffset, bottom: bottomOffset }}
         className={clsx(styles['drawer-content'])}
+        role="toolbar"
       >
         {!isMobile && (
           <aside
@@ -203,6 +217,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                     testUtilsClassName={testutilStyles['drawers-trigger']}
                     ariaExpanded={drawers?.activeDrawerId === item.id}
                     ariaLabel={item.ariaLabels?.triggerButton}
+                    ariaControls={item.id}
                     trigger={item.trigger}
                     badge={item.badge}
                     itemId={item.id}

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -201,7 +201,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                   <DrawerTrigger
                     key={index}
                     testUtilsClassName={testutilStyles['drawers-trigger']}
-                    ariaExpanded={drawers?.activeDrawerId !== undefined}
+                    ariaExpanded={drawers?.activeDrawerId === item.id}
                     ariaLabel={item.ariaLabels?.triggerButton}
                     trigger={item.trigger}
                     badge={item.badge}

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -129,7 +129,7 @@ export function MobileToolbar({
           aria-label={drawers.ariaLabel}
           className={clsx(styles['drawers-container'], testutilStyles['drawers-mobile-triggers-container'])}
         >
-          {visibleItems.map((item: DrawerItem, index: number) => (
+          {visibleItems.map((item, index) => (
             <div
               className={clsx(styles['mobile-toggle'], styles['mobile-toggle-type-drawer'])}
               key={index}
@@ -141,7 +141,7 @@ export function MobileToolbar({
                 iconSvg={item.trigger.iconSvg}
                 badge={item.badge}
                 ariaLabel={item.ariaLabels?.triggerButton}
-                ariaExpanded={drawers.activeDrawerId !== undefined}
+                ariaExpanded={drawers.activeDrawerId === item.id}
                 testId={`awsui-app-layout-trigger-${item.id}`}
               />
             </div>

--- a/src/app-layout/toggles/index.tsx
+++ b/src/app-layout/toggles/index.tsx
@@ -43,7 +43,7 @@ export const ToggleButton = React.forwardRef(
         type="button"
         onClick={onClick}
         disabled={disabled}
-        aria-expanded={ariaExpanded ? undefined : false}
+        aria-expanded={ariaExpanded}
         aria-haspopup={ariaExpanded ? undefined : true}
         data-testid={testId}
       >

--- a/src/app-layout/toggles/index.tsx
+++ b/src/app-layout/toggles/index.tsx
@@ -32,7 +32,18 @@ export const togglesConfig = {
 
 export const ToggleButton = React.forwardRef(
   (
-    { className, ariaLabel, ariaExpanded, iconName, iconSvg, disabled, testId, onClick, badge }: AppLayoutButtonProps,
+    {
+      className,
+      ariaLabel,
+      ariaExpanded,
+      ariaControls,
+      iconName,
+      iconSvg,
+      disabled,
+      testId,
+      onClick,
+      badge,
+    }: AppLayoutButtonProps,
     ref: React.Ref<{ focus(): void }>
   ) => {
     return (
@@ -44,7 +55,8 @@ export const ToggleButton = React.forwardRef(
         onClick={onClick}
         disabled={disabled}
         aria-expanded={ariaExpanded}
-        aria-haspopup={ariaExpanded ? undefined : true}
+        aria-haspopup={ariaExpanded}
+        aria-controls={ariaControls}
         data-testid={testId}
       >
         <InternalIcon svg={iconSvg} name={iconName} badge={badge} />

--- a/src/app-layout/toggles/index.tsx
+++ b/src/app-layout/toggles/index.tsx
@@ -55,7 +55,7 @@ export const ToggleButton = React.forwardRef(
         onClick={onClick}
         disabled={disabled}
         aria-expanded={ariaExpanded}
-        aria-haspopup={ariaExpanded}
+        aria-haspopup={ariaExpanded ? undefined : true}
         aria-controls={ariaControls}
         data-testid={testId}
       >

--- a/src/app-layout/toggles/interfaces.ts
+++ b/src/app-layout/toggles/interfaces.ts
@@ -7,6 +7,7 @@ export interface AppLayoutButtonProps {
   className?: string;
   ariaLabel: string | undefined;
   ariaExpanded?: boolean;
+  ariaControls?: string;
   iconName?: IconProps.Name;
   iconSvg?: React.ReactNode;
   onClick?: () => void;

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -32,6 +32,7 @@ import styles from './styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import useBackgroundOverlap from './use-background-overlap';
 import { useDrawers } from '../utils/use-drawers';
+import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
 interface AppLayoutInternals extends AppLayoutProps {
   activeDrawerId: string | undefined;
@@ -77,6 +78,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   setSplitPanelReportedHeaderHeight: (value: number) => void;
   headerHeight: number;
   footerHeight: number;
+  splitPanelControlId: string;
   splitPanelMaxWidth: number;
   splitPanelMinWidth: number;
   splitPanelPosition: AppLayoutProps.SplitPanelPosition;
@@ -86,6 +88,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   setSplitPanelToggle: (toggle: SplitPanelSideToggleProps) => void;
   splitPanelDisplayed: boolean;
   splitPanelRefs: SplitPanelFocusControlRefs;
+  toolsControlId: string;
   toolsRefs: FocusControlRefs;
 }
 
@@ -372,6 +375,8 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       ariaLabel: undefined,
     });
     const splitPanelDisplayed = !!(splitPanelToggle.displayed || isSplitPanelOpen);
+    const splitPanelControlId = useUniqueId('split-panel-');
+    const toolsControlId = useUniqueId('tools-');
 
     const [splitPanelSize, setSplitPanelSize] = useControllable(
       props.splitPanelSize,
@@ -633,6 +638,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           setSplitPanelReportedSize,
           setSplitPanelReportedHeaderHeight,
           splitPanel,
+          splitPanelControlId,
           splitPanelDisplayed,
           splitPanelMaxWidth,
           splitPanelMinWidth,
@@ -644,6 +650,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           splitPanelToggle,
           setSplitPanelToggle,
           splitPanelRefs,
+          toolsControlId,
           toolsHide,
           toolsOpen: isToolsOpen,
           toolsWidth,

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -230,7 +230,7 @@ function DesktopTriggers() {
             <TriggerButton
               ariaLabel={item.ariaLabels?.triggerButton}
               ariaExpanded={item.id === activeDrawerId}
-              ariaControls={item.id}
+              ariaControls={activeDrawerId === item.id ? item.id : undefined}
               className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -225,6 +225,7 @@ function DesktopTriggers() {
           return (
             <TriggerButton
               ariaLabel={item.ariaLabels?.triggerButton}
+              ariaExpanded={item.id === activeDrawerId}
               className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
@@ -245,11 +246,12 @@ function DesktopTriggers() {
           <OverflowMenu
             items={overflowItems}
             ariaLabel={drawersOverflowAriaLabel}
-            customTriggerBuilder={({ onClick, triggerRef, ariaLabel, testUtilsClass }) => (
+            customTriggerBuilder={({ onClick, triggerRef, ariaLabel, testUtilsClass, ariaExpanded }) => (
               <div className={clsx(styles['trigger-wrapper'])}>
                 <TriggerButton
                   ref={triggerRef}
                   ariaLabel={ariaLabel}
+                  ariaExpanded={ariaExpanded}
                   className={clsx(
                     styles['drawers-trigger'],
                     {
@@ -272,6 +274,7 @@ function DesktopTriggers() {
         {hasSplitPanel && splitPanelToggle.displayed && (
           <TriggerButton
             ariaLabel={splitPanelToggle.ariaLabel}
+            ariaExpanded={!!isSplitPanelOpen}
             className={clsx(styles['drawers-trigger'], splitPanelStyles['open-button'])}
             iconName="view-vertical"
             onClick={() => handleSplitPanelClick()}

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -95,6 +95,7 @@ function ActiveDrawer() {
 
   return (
     <aside
+      id={activeDrawerId}
       aria-hidden={isHidden}
       aria-label={computedAriaLabels.content}
       className={clsx(styles.drawer, sharedStyles['with-motion'], {
@@ -158,6 +159,7 @@ function DesktopTriggers() {
     isSplitPanelOpen,
     isToolsOpen,
     splitPanel,
+    splitPanelControlId,
     splitPanelDisplayed,
     splitPanelPosition,
     splitPanelRefs,
@@ -220,12 +222,15 @@ function DesktopTriggers() {
           [styles['has-multiple-triggers']]: hasMultipleTriggers,
           [styles['has-open-drawer']]: hasOpenDrawer,
         })}
+        role="toolbar"
+        aria-orientation="vertical"
       >
         {visibleItems.map(item => {
           return (
             <TriggerButton
               ariaLabel={item.ariaLabels?.triggerButton}
               ariaExpanded={item.id === activeDrawerId}
+              ariaControls={item.id}
               className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
@@ -274,6 +279,7 @@ function DesktopTriggers() {
         {hasSplitPanel && splitPanelToggle.displayed && (
           <TriggerButton
             ariaLabel={splitPanelToggle.ariaLabel}
+            ariaControls={splitPanelControlId}
             ariaExpanded={!!isSplitPanelOpen}
             className={clsx(styles['drawers-trigger'], splitPanelStyles['open-button'])}
             iconName="view-vertical"

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -75,6 +75,7 @@ export default function Navigation() {
             >
               <TriggerButton
                 ariaLabel={ariaLabels?.navigationToggle}
+                ariaExpanded={isNavigationOpen ? undefined : false}
                 iconName="menu"
                 className={testutilStyles['navigation-toggle']}
                 onClick={() => handleNavigationClick(true)}

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -120,6 +120,7 @@ function SplitPanelSide() {
     splitPanelMaxWidth,
     splitPanelMinWidth,
     splitPanelReportedSize,
+    splitPanelControlId,
   } = useAppLayoutInternals();
 
   if (!splitPanel) {
@@ -130,6 +131,7 @@ function SplitPanelSide() {
     <Transition in={isSplitPanelOpen ?? false} exit={false}>
       {(state, transitionEventsRef) => (
         <section
+          id={splitPanelControlId}
           aria-hidden={!isSplitPanelOpen || splitPanelPosition === 'bottom' ? true : false}
           className={clsx(styles['split-panel-side'], styles[`position-${splitPanelPosition}`], {
             [styles.animating]: state === 'entering',

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -104,7 +104,6 @@ export default function Tools({ children }: ToolsProps) {
                 <div className={clsx(styles['hide-tools'])}>
                   <InternalButton
                     ariaLabel={ariaLabels?.toolsClose ?? undefined}
-                    ariaExpanded={isToolsOpen}
                     iconName={isMobile ? 'close' : 'angle-right'}
                     onClick={() => handleToolsClick(false)}
                     variant="icon"

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -37,11 +37,13 @@ export default function Tools({ children }: ToolsProps) {
     isToolsOpen,
     loseToolsFocus,
     splitPanel,
+    splitPanelControlId,
     splitPanelDisplayed,
     splitPanelPosition,
     splitPanelRefs,
     splitPanelToggle,
     tools,
+    toolsControlId,
     toolsHide,
     toolsRefs,
     toolsWidth,
@@ -84,6 +86,7 @@ export default function Tools({ children }: ToolsProps) {
 
           {!toolsHide && (
             <aside
+              id={toolsControlId}
               aria-hidden={!isToolsOpen ? true : false}
               aria-label={ariaLabels?.tools ?? undefined}
               className={clsx(
@@ -131,6 +134,7 @@ export default function Tools({ children }: ToolsProps) {
               {!toolsHide && (
                 <TriggerButton
                   ariaLabel={ariaLabels?.toolsToggle}
+                  ariaControls={toolsControlId}
                   ariaExpanded={isToolsOpen}
                   iconName="status-info"
                   onClick={() => handleToolsClick(!isToolsOpen)}
@@ -143,6 +147,7 @@ export default function Tools({ children }: ToolsProps) {
               {hasSplitPanel && splitPanelToggle.displayed && (
                 <TriggerButton
                   ariaLabel={splitPanelToggle.ariaLabel}
+                  ariaControls={splitPanelControlId}
                   ariaExpanded={!!isSplitPanelOpen}
                   iconName="view-vertical"
                   onClick={() => handleSplitPanelClick()}

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -101,6 +101,7 @@ export default function Tools({ children }: ToolsProps) {
                 <div className={clsx(styles['hide-tools'])}>
                   <InternalButton
                     ariaLabel={ariaLabels?.toolsClose ?? undefined}
+                    ariaExpanded={isToolsOpen}
                     iconName={isMobile ? 'close' : 'angle-right'}
                     onClick={() => handleToolsClick(false)}
                     variant="icon"
@@ -130,6 +131,7 @@ export default function Tools({ children }: ToolsProps) {
               {!toolsHide && (
                 <TriggerButton
                   ariaLabel={ariaLabels?.toolsToggle}
+                  ariaExpanded={isToolsOpen}
                   iconName="status-info"
                   onClick={() => handleToolsClick(!isToolsOpen)}
                   selected={hasSplitPanel && isToolsOpen}
@@ -141,6 +143,7 @@ export default function Tools({ children }: ToolsProps) {
               {hasSplitPanel && splitPanelToggle.displayed && (
                 <TriggerButton
                   ariaLabel={splitPanelToggle.ariaLabel}
+                  ariaExpanded={!!isSplitPanelOpen}
                   iconName="view-vertical"
                   onClick={() => handleSplitPanelClick()}
                   selected={hasSplitPanel && isSplitPanelOpen}

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -39,7 +39,7 @@ function TriggerButton(
     <div className={clsx(styles['trigger-wrapper'])}>
       <button
         aria-expanded={ariaExpanded}
-        aria-controls={ariaControls ?? undefined}
+        aria-controls={ariaControls}
         aria-haspopup={true}
         aria-label={ariaLabel}
         className={clsx(

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -12,7 +12,7 @@ export interface TriggerButtonProps {
   className?: string;
   iconName?: IconProps.Name;
   iconSvg?: React.ReactNode;
-  ariaExpanded: boolean;
+  ariaExpanded: boolean | undefined;
   ariaControls?: string;
   testId?: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -12,6 +12,7 @@ export interface TriggerButtonProps {
   className?: string;
   iconName?: IconProps.Name;
   iconSvg?: React.ReactNode;
+  ariaExpanded: boolean;
   testId?: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   selected?: boolean;
@@ -19,13 +20,23 @@ export interface TriggerButtonProps {
 }
 
 function TriggerButton(
-  { ariaLabel, className, iconName, iconSvg, onClick, testId, badge, selected = false }: TriggerButtonProps,
+  {
+    ariaLabel,
+    className,
+    iconName,
+    iconSvg,
+    ariaExpanded,
+    onClick,
+    testId,
+    badge,
+    selected = false,
+  }: TriggerButtonProps,
   ref: React.Ref<ButtonProps.Ref>
 ) {
   return (
     <div className={clsx(styles['trigger-wrapper'])}>
       <button
-        aria-expanded={false}
+        aria-expanded={ariaExpanded}
         aria-haspopup={true}
         aria-label={ariaLabel}
         className={clsx(

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -13,6 +13,7 @@ export interface TriggerButtonProps {
   iconName?: IconProps.Name;
   iconSvg?: React.ReactNode;
   ariaExpanded: boolean;
+  ariaControls?: string;
   testId?: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   selected?: boolean;
@@ -26,6 +27,7 @@ function TriggerButton(
     iconName,
     iconSvg,
     ariaExpanded,
+    ariaControls,
     onClick,
     testId,
     badge,
@@ -37,6 +39,7 @@ function TriggerButton(
     <div className={clsx(styles['trigger-wrapper'])}>
       <button
         aria-expanded={ariaExpanded}
+        aria-controls={ariaControls ?? undefined}
         aria-haspopup={true}
         aria-label={ariaLabel}
         className={clsx(

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -259,4 +259,5 @@ export interface CustomTriggerProps {
   disabled: boolean;
   isOpen: boolean;
   onClick: () => void;
+  ariaExpanded: boolean;
 }

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -163,6 +163,7 @@ const InternalButtonDropdown = React.forwardRef(
         <div className={styles['dropdown-trigger']}>
           {customTriggerBuilder({
             testUtilsClass: styles['test-utils-button-trigger'],
+            ariaExpanded: canBeOpened && isOpen,
             onClick: clickHandler,
             triggerRef,
             ariaLabel,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

We weren't properly using `aria-expanded` or `aria-controls` for the triggers in AppLayout. This adds those attributes to drawers, tools, navigation, and split panel when appropriate.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
