### PR TITLE
chore: Mark Table component as a funnel substep

### DIFF
--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -15,6 +15,7 @@ import Button from '../../../../../lib/components/button';
 import FormField from '../../../../../lib/components/form-field';
 import Container from '../../../../../lib/components/container';
 import Cards from '../../../../../lib/components/cards';
+import Table from '../../../../../lib/components/table';
 import ExpandableSection from '../../../../../lib/components/expandable-section';
 
 import { mockedFunnelInteractionId, mockFunnelMetrics } from '../mocks';
@@ -321,6 +322,7 @@ describe('AnalyticsFunnelStep', () => {
           Step Content
           <Container />
           <Cards items={[]} cardDefinition={{}} />
+          <Table items={[]} columnDefinitions={[]} />
           <ExpandableSection variant="container" />
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
@@ -333,7 +335,7 @@ describe('AnalyticsFunnelStep', () => {
       stepNumber,
       stepNameSelector,
       subStepAllSelector: expect.any(String),
-      totalSubSteps: 3,
+      totalSubSteps: 4,
     });
   });
 
@@ -347,6 +349,7 @@ describe('AnalyticsFunnelStep', () => {
           Step Content
           <Container />
           <Cards items={[]} cardDefinition={{}} />
+          <Table items={[]} columnDefinitions={[]} />
           <ExpandableSection variant="container" />
         </AnalyticsFunnelStep>
       </AnalyticsFunnel>
@@ -364,8 +367,45 @@ describe('AnalyticsFunnelStep', () => {
       stepNumber,
       stepNameSelector,
       subStepAllSelector: expect.any(String),
-      totalSubSteps: 3,
+      totalSubSteps: 4,
     });
+  });
+
+  test('treats container-like tables as their own substep', () => {
+    render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={1} stepNameSelector={''}>
+          <Table items={[]} columnDefinitions={[]} variant="container" />
+          <Table items={[]} columnDefinitions={[]} variant="stacked" />
+          <Table items={[]} columnDefinitions={[]} variant="full-page" />
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalSubSteps: 3,
+      })
+    );
+  });
+
+  test('does not treat embedded tables as their own substep', () => {
+    render(
+      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+        <AnalyticsFunnelStep stepNumber={1} stepNameSelector={''}>
+          <Table items={[]} columnDefinitions={[]} variant="embedded" />
+          <Table items={[]} columnDefinitions={[]} variant="borderless" />
+        </AnalyticsFunnelStep>
+      </AnalyticsFunnel>
+    );
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalSubSteps: 0,
+      })
+    );
   });
 
   test('does not call funnelStepComplete when the funnel unmounts without submitting', () => {

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -5,6 +5,7 @@ import { TableForwardRefType, TableProps } from './interfaces';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import InternalTable from './internal';
 import useBaseComponent from '../internal/hooks/use-base-component';
+import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 
 export { TableProps };
 const Table = React.forwardRef(
@@ -13,7 +14,8 @@ const Table = React.forwardRef(
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Table');
-    return (
+
+    const table = (
       <InternalTable
         items={items}
         selectedItems={selectedItems}
@@ -24,6 +26,11 @@ const Table = React.forwardRef(
         ref={ref}
       />
     );
+    if (variant === 'borderless' || variant === 'embedded') {
+      return table;
+    }
+
+    return <AnalyticsFunnelSubStep>{table}</AnalyticsFunnelSubStep>;
   }
 ) as TableForwardRefType;
 


### PR DESCRIPTION
### Description

After this change, the Table component is treated as a substep when it comes to funnel metrics, i.e. it is treated like a container. This does not apply to the embedded variants of the Table, because those are expected to already have a container around them.

See also the equivalent change for Cards: https://github.com/cloudscape-design/components/pull/1362



<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Extended the unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
