### PR TITLE
chore: Mark only h2-level headings as substep names

### DIFF
--- a/src/header/__tests__/header.test.tsx
+++ b/src/header/__tests__/header.test.tsx
@@ -9,11 +9,14 @@ import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_SUBSTEP_NAME } from '../../../lib/comp
 
 function renderHeader(jsx: React.ReactElement) {
   const { container } = render(jsx);
-  return createWrapper(container).findHeader()!;
+  return {
+    wrapper: createWrapper(container).findHeader()!,
+    container,
+  };
 }
 
 test('renders title even if it is empty', () => {
-  const wrapper = renderHeader(<Header />);
+  const { wrapper } = renderHeader(<Header />);
   expect(wrapper.findHeadingText()).toBeTruthy();
   expect(wrapper.findCounter()).toBeNull();
   expect(wrapper.findInfo()).toBeNull();
@@ -22,7 +25,7 @@ test('renders title even if it is empty', () => {
 });
 
 test('renders everything provided', () => {
-  const wrapper = renderHeader(
+  const { wrapper } = renderHeader(
     <Header info="Info" description="Description" counter="123" actions={<button>Click me</button>}>
       Test title
     </Header>
@@ -35,33 +38,33 @@ test('renders everything provided', () => {
 });
 
 test('renders h2 tag and variant by default', () => {
-  const wrapper = renderHeader(<Header>title</Header>);
+  const { wrapper } = renderHeader(<Header>title</Header>);
   expect(wrapper.find('h2')!.getElement()).toHaveTextContent('title');
   expect(wrapper.find('h1')).toBeNull();
   expect(wrapper.getElement()).toHaveClass(styles['root-variant-h2']);
 });
 
 test('supports title tag name override', () => {
-  const wrapper = renderHeader(<Header headingTagOverride="h1">title</Header>);
+  const { wrapper } = renderHeader(<Header headingTagOverride="h1">title</Header>);
   expect(wrapper.find('h2')).toBeNull();
   expect(wrapper.find('h1')!.getElement()).toHaveTextContent('title');
   expect(wrapper.getElement()).toHaveClass(styles['root-variant-h2']);
 });
 
 test('renders h1 variant', () => {
-  const wrapper = renderHeader(<Header variant="h1">title</Header>);
+  const { wrapper } = renderHeader(<Header variant="h1">title</Header>);
   expect(wrapper.find('h1')!.getElement()).toHaveTextContent('title');
   expect(wrapper.findHeadingText().getElement()).toHaveClass(styles['heading-text-variant-h1']);
 });
 
 test('renders h3 variant', () => {
-  const wrapper = renderHeader(<Header variant="h3">title</Header>);
+  const { wrapper } = renderHeader(<Header variant="h3">title</Header>);
   expect(wrapper.find('h3')!.getElement()).toHaveTextContent('title');
   expect(wrapper.getElement()).toHaveClass(styles['root-variant-h3']);
 });
 
 test('supports title tag name override with non-default variant', () => {
-  const wrapper = renderHeader(
+  const { wrapper } = renderHeader(
     <Header headingTagOverride="h2" variant="h3">
       title
     </Header>
@@ -72,13 +75,28 @@ test('supports title tag name override with non-default variant', () => {
 });
 
 describe('Analytics', () => {
-  test(`adds ${DATA_ATTR_FUNNEL_KEY} attribute for the heading text`, () => {
-    const wrapper = renderHeader(
+  test(`adds ${DATA_ATTR_FUNNEL_KEY} attribute for headings of level 2`, () => {
+    const { wrapper } = renderHeader(
       <Header headingTagOverride="h2" variant="h3">
         title
       </Header>
     );
 
     expect(wrapper.findHeadingText().getElement()).toHaveAttribute(DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_SUBSTEP_NAME);
+  });
+
+  test(`does not add ${DATA_ATTR_FUNNEL_KEY} attribute for headings of other levels`, () => {
+    const { container } = renderHeader(
+      <>
+        <Header headingTagOverride="h4" variant="h3">
+          title
+        </Header>
+        <Header headingTagOverride="h3" variant="h2">
+          title
+        </Header>
+        <Header variant="h3">title</Header>
+      </>
+    );
+    expect(container.querySelector(`[${DATA_ATTR_FUNNEL_KEY}]`)).toBeNull();
   });
 });

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -63,7 +63,7 @@ export default function InternalHeader({
         <div className={clsx(styles.title, styles[`title-variant-${variantOverride}`], isRefresh && styles.refresh)}>
           <HeadingTag className={clsx(styles.heading, styles[`heading-variant-${variantOverride}`])}>
             <span
-              {...{ [DATA_ATTR_FUNNEL_KEY]: FUNNEL_KEY_SUBSTEP_NAME }}
+              {...(HeadingTag === 'h2' ? { [DATA_ATTR_FUNNEL_KEY]: FUNNEL_KEY_SUBSTEP_NAME } : {})}
               className={clsx(styles['heading-text'], styles[`heading-text-variant-${variantOverride}`])}
               id={headingId}
             >


### PR DESCRIPTION
### Description

Currently we're attaching the attribute `data-analytics-funnel="substep-name"` to every heading generated by the Heading component. However, these should only be applied to headings of Containers or container-like elements, i.e. second-level headings. This PR updates the Heading component to apply the attribute only on such headings.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Extended unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
