### PR TITLE
refactor: Introduce table th element

### DIFF
--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -49,11 +49,10 @@ it('renders a fake focus outline on the sort control', () => {
   const { container } = render(
     <TableWrapper>
       <TableHeaderCell<typeof testItem>
-        focusedComponent={{ type: 'column', col: 0 }}
+        focusedComponent="sorting-control-id"
         column={column}
         colIndex={0}
         tabIndex={0}
-        onFocusedComponentChange={() => {}}
         updateColumn={() => {}}
         onClick={() => {}}
         onResizeFinish={() => {}}
@@ -73,12 +72,11 @@ it('renders a fake focus outline on the resize control', () => {
   const { container } = render(
     <TableWrapper>
       <TableHeaderCell<typeof testItem>
-        focusedComponent={{ type: 'resizer', col: 0 }}
+        focusedComponent="resize-control-id"
         column={column}
         colIndex={0}
         tabIndex={0}
         resizableColumns={true}
-        onFocusedComponentChange={() => {}}
         updateColumn={() => {}}
         onClick={() => {}}
         onResizeFinish={() => {}}
@@ -104,7 +102,6 @@ describe('i18n', () => {
             colIndex={0}
             tabIndex={0}
             resizableColumns={true}
-            onFocusedComponentChange={() => {}}
             updateColumn={() => {}}
             onClick={() => {}}
             onResizeFinish={() => {}}

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -10,11 +10,10 @@ import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { InteractiveComponent } from '../thead';
-import { getStickyClassNames } from '../utils';
 import { useInternalI18n } from '../../i18n/context';
-import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
-import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
-import { TableRole, getTableColHeaderRoleProps } from '../table-role';
+import { StickyColumnsModel } from '../sticky-columns';
+import { TableRole } from '../table-role';
+import { TableThElement } from './th-element';
 
 interface TableHeaderCellProps<ItemType> {
   className?: string;
@@ -88,32 +87,19 @@ export function TableHeaderCell<ItemType>({
 
   const headerId = useUniqueId('table-header-');
 
-  const stickyStyles = useStickyCellStyles({
-    stickyColumns: stickyState,
-    columnId,
-    getClassName: props => getStickyClassNames(styles, props),
-  });
-
-  const mergedRef = useMergeRefs(stickyStyles.ref, cellRef);
-
   return (
-    <th
-      className={clsx(
-        className,
-        {
-          [styles['header-cell-resizable']]: !!resizableColumns,
-          [styles['header-cell-sortable']]: sortingStatus,
-          [styles['header-cell-sorted']]: sortingStatus === 'ascending' || sortingStatus === 'descending',
-          [styles['header-cell-disabled']]: sortingDisabled,
-          [styles['header-cell-ascending']]: sortingStatus === 'ascending',
-          [styles['header-cell-descending']]: sortingStatus === 'descending',
-          [styles['header-cell-hidden']]: hidden,
-        },
-        stickyStyles.className
-      )}
-      style={{ ...style, ...stickyStyles.style }}
-      ref={mergedRef}
-      {...getTableColHeaderRoleProps({ tableRole, sortingStatus, colIndex })}
+    <TableThElement
+      className={className}
+      style={style}
+      cellRef={cellRef}
+      sortingStatus={sortingStatus}
+      sortingDisabled={sortingDisabled}
+      hidden={hidden}
+      colIndex={colIndex}
+      resizableColumns={resizableColumns}
+      columnId={columnId}
+      stickyState={stickyState}
+      tableRole={tableRole}
     >
       <div
         className={clsx(styles['header-cell-content'], {
@@ -171,6 +157,6 @@ export function TableHeaderCell<ItemType>({
           />
         </>
       )}
-    </th>
+    </TableThElement>
   );
 }

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -9,7 +9,6 @@ import { getSortingIconName, getSortingStatus, isSorted } from './utils';
 import styles from './styles.css.js';
 import { Resizer } from '../resizer';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
-import { InteractiveComponent } from '../thead';
 import { useInternalI18n } from '../../i18n/context';
 import { StickyColumnsModel } from '../sticky-columns';
 import { TableRole } from '../table-role';
@@ -36,8 +35,7 @@ interface TableHeaderCellProps<ItemType> {
   columnId: PropertyKey;
   stickyState: StickyColumnsModel;
   cellRef: React.RefCallback<HTMLElement>;
-  focusedComponent?: InteractiveComponent | null;
-  onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
+  focusedComponent?: null | string;
   tableRole: TableRole;
 }
 
@@ -51,7 +49,6 @@ export function TableHeaderCell<ItemType>({
   sortingDisabled,
   wrapLines,
   focusedComponent,
-  onFocusedComponentChange,
   hidden,
   onClick,
   colIndex,
@@ -102,8 +99,9 @@ export function TableHeaderCell<ItemType>({
       tableRole={tableRole}
     >
       <div
+        data-focus-id={`sorting-control-${String(columnId)}`}
         className={clsx(styles['header-cell-content'], {
-          [styles['header-cell-fake-focus']]: focusedComponent?.type === 'column' && focusedComponent.col === colIndex,
+          [styles['header-cell-fake-focus']]: focusedComponent === `sorting-control-${String(columnId)}`,
         })}
         aria-label={
           column.ariaLabel
@@ -120,8 +118,6 @@ export function TableHeaderCell<ItemType>({
               tabIndex: tabIndex,
               role: 'button',
               onClick: handleClick,
-              onFocus: () => onFocusedComponentChange?.({ type: 'column', col: colIndex }),
-              onBlur: () => onFocusedComponentChange?.(null),
             }
           : {})}
       >
@@ -147,12 +143,11 @@ export function TableHeaderCell<ItemType>({
         <>
           <Resizer
             tabIndex={tabIndex}
-            showFocusRing={focusedComponent?.type === 'resizer' && focusedComponent.col === colIndex}
+            focusId={`resize-control-${String(columnId)}`}
+            showFocusRing={focusedComponent === `resize-control-${String(columnId)}`}
             onDragMove={newWidth => updateColumn(columnId, newWidth)}
             onFinish={onResizeFinish}
             ariaLabelledby={headerId}
-            onFocus={() => onFocusedComponentChange?.({ type: 'resizer', col: colIndex })}
-            onBlur={() => onFocusedComponentChange?.(null)}
             minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
           />
         </>

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React from 'react';
+import { SortingStatus } from './utils';
+import styles from './styles.css.js';
+import { getStickyClassNames } from '../utils';
+import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
+import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
+import { TableRole, getTableColHeaderRoleProps } from '../table-role';
+
+interface TableThElementProps {
+  className?: string;
+  style?: React.CSSProperties;
+  sortingStatus?: SortingStatus;
+  sortingDisabled?: boolean;
+  hidden?: boolean;
+  colIndex: number;
+  resizableColumns?: boolean;
+  columnId: PropertyKey;
+  stickyState: StickyColumnsModel;
+  cellRef?: React.RefCallback<HTMLElement>;
+  tableRole: TableRole;
+  children: React.ReactNode;
+}
+
+export function TableThElement({
+  className,
+  style,
+  sortingStatus,
+  sortingDisabled,
+  hidden,
+  colIndex,
+  resizableColumns,
+  columnId,
+  stickyState,
+  cellRef,
+  tableRole,
+  children,
+}: TableThElementProps) {
+  const stickyStyles = useStickyCellStyles({
+    stickyColumns: stickyState,
+    columnId,
+    getClassName: props => getStickyClassNames(styles, props),
+  });
+
+  const mergedRef = useMergeRefs(stickyStyles.ref, cellRef);
+
+  return (
+    <th
+      className={clsx(
+        className,
+        {
+          [styles['header-cell-resizable']]: !!resizableColumns,
+          [styles['header-cell-sortable']]: sortingStatus,
+          [styles['header-cell-sorted']]: sortingStatus === 'ascending' || sortingStatus === 'descending',
+          [styles['header-cell-disabled']]: sortingDisabled,
+          [styles['header-cell-ascending']]: sortingStatus === 'ascending',
+          [styles['header-cell-descending']]: sortingStatus === 'descending',
+          [styles['header-cell-hidden']]: hidden,
+        },
+        stickyStyles.className
+      )}
+      style={{ ...style, ...stickyStyles.style }}
+      ref={mergedRef}
+      {...getTableColHeaderRoleProps({ tableRole, sortingStatus, colIndex })}
+    >
+      {children}
+    </th>
+  );
+}

--- a/src/table/header-cell/utils.ts
+++ b/src/table/header-cell/utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { TableProps } from '../interfaces';
 
-type SortingStatus = 'sortable' | 'ascending' | 'descending';
+export type SortingStatus = 'sortable' | 'ascending' | 'descending';
 const stateToIcon = {
   sortable: 'caret-down',
   ascending: 'caret-up-filled',

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -339,7 +339,7 @@ const InternalTable = React.forwardRef(
                 <Thead
                   ref={theadRef}
                   hidden={stickyHeader}
-                  onFocusedComponentChange={component => stickyHeaderRef.current?.setFocus(component)}
+                  onFocusedComponentChange={focusId => stickyHeaderRef.current?.setFocus(focusId)}
                   {...theadProps}
                 />
                 <tbody>

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -16,7 +16,7 @@ interface ResizerProps {
   ariaLabelledby?: string;
   minWidth?: number;
   tabIndex?: number;
-
+  focusId?: string;
   showFocusRing?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
@@ -33,6 +33,7 @@ export function Resizer({
   minWidth = DEFAULT_COLUMN_WIDTH,
   tabIndex,
   showFocusRing,
+  focusId,
   onFocus,
   onBlur,
 }: ResizerProps) {
@@ -171,6 +172,7 @@ export function Resizer({
       aria-valuetext={headerCellWidth.toString()}
       aria-valuemin={minWidth}
       tabIndex={tabIndex}
+      data-focus-id={focusId}
     />
   );
 }

--- a/src/table/selection-control/index.tsx
+++ b/src/table/selection-control/index.tsx
@@ -8,7 +8,6 @@ import InternalCheckbox from '../../checkbox/internal';
 import RadioButton from '../../radio-group/radio-button';
 
 import styles from './styles.css.js';
-import { InteractiveComponent } from '../thead';
 import { SelectionProps } from '../use-selection';
 
 export interface SelectionControlProps extends SelectionProps {
@@ -17,9 +16,7 @@ export interface SelectionControlProps extends SelectionProps {
   onFocusDown?: KeyboardEventHandler;
   ariaLabel?: string;
   tabIndex?: -1;
-
-  focusedComponent?: InteractiveComponent | null;
-  onFocusedComponentChange?: (element: InteractiveComponent | null) => void;
+  focusedComponent?: null | string;
 }
 
 export default function SelectionControl({
@@ -30,9 +27,7 @@ export default function SelectionControl({
   onFocusDown,
   name,
   ariaLabel,
-
   focusedComponent,
-  onFocusedComponentChange,
   ...sharedProps
 }: SelectionControlProps) {
   const controlId = useUniqueId();
@@ -79,10 +74,9 @@ export default function SelectionControl({
   const selector = isMultiSelection ? (
     <InternalCheckbox
       {...sharedProps}
-      showOutline={focusedComponent?.type === 'selection'}
-      onFocus={() => onFocusedComponentChange?.({ type: 'selection' })}
-      onBlur={() => onFocusedComponentChange?.(null)}
+      showOutline={focusedComponent === 'selection-control'}
       controlId={controlId}
+      data-focus-id="selection-control"
       indeterminate={indeterminate}
     />
   ) : (
@@ -104,7 +98,7 @@ export default function SelectionControl({
       >
         {selector}
       </label>
-      {/* HACK: IE11 collapses td's height to 0, if it contains only an absouletely positioned label */}
+      {/* HACK: IE11 collapses td's height to 0, if it contains only an absolutely positioned label */}
       <span className={clsx(styles.stud)} aria-hidden={true}>
         &nbsp;
       </span>

--- a/src/table/sticky-header.tsx
+++ b/src/table/sticky-header.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import React, { forwardRef, useContext, useImperativeHandle, useRef, useState } from 'react';
 import { StickyHeaderContext } from '../container/use-sticky-header';
 import { TableProps } from './interfaces';
-import Thead, { InteractiveComponent, TheadProps } from './thead';
+import Thead, { TheadProps } from './thead';
 import { useStickyHeader } from './use-sticky-header';
 import styles from './styles.css.js';
 import { getVisualContextClassname } from '../internal/components/visual-context';
@@ -13,7 +13,7 @@ import { TableRole, getTableRoleProps } from './table-role';
 export interface StickyHeaderRef {
   scrollToTop(): void;
   scrollToRow(node: null | HTMLElement): void;
-  setFocus(element: InteractiveComponent | null): void;
+  setFocus(focusId: null | string): void;
 }
 
 interface StickyHeaderProps {
@@ -50,7 +50,7 @@ function StickyHeader(
   const secondaryTableRef = useRef<HTMLTableElement>(null);
   const { isStuck } = useContext(StickyHeaderContext);
 
-  const [focusedComponent, setFocusedComponent] = useState<InteractiveComponent | null>(null);
+  const [focusedComponent, setFocusedComponent] = useState<null | string>(null);
   const { scrollToRow, scrollToTop } = useStickyHeader(
     tableRef,
     theadRef,

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -6,16 +6,16 @@ import { TableProps } from './interfaces';
 import SelectionControl from './selection-control';
 import { focusMarkers, SelectionProps } from './use-selection';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
-import { getColumnKey, getStickyClassNames } from './utils';
+import { getColumnKey } from './utils';
 import { TableHeaderCell } from './header-cell';
 import { useColumnWidths } from './use-column-widths';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
-import cellStyles from './header-cell/styles.css.js';
 import headerCellStyles from './header-cell/styles.css.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
-import { StickyColumnsModel, useStickyCellStyles } from './sticky-columns';
-import { getTableColHeaderRoleProps, getTableHeaderRowRoleProps, TableRole } from './table-role';
+import { StickyColumnsModel } from './sticky-columns';
+import { getTableHeaderRowRoleProps, TableRole } from './table-role';
+import { TableThElement } from './header-cell/th-element';
 
 export type InteractiveComponent =
   | { type: 'selection' }
@@ -96,26 +96,17 @@ const Thead = React.forwardRef(
 
     const { columnWidths, totalWidth, updateColumn, setCell } = useColumnWidths();
 
-    const stickyStyles = useStickyCellStyles({
-      stickyColumns: stickyState,
-      columnId: selectionColumnId,
-      getClassName: props => getStickyClassNames(cellStyles, props),
-    });
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
         <tr {...focusMarkers.all} ref={outerRef} aria-rowindex={1} {...getTableHeaderRowRoleProps({ tableRole })}>
           {selectionType ? (
-            <th
-              className={clsx(
-                headerCellClass,
-                selectionCellClass,
-                hidden && headerCellStyles['header-cell-hidden'],
-                stickyStyles.className
-              )}
-              style={stickyStyles.style}
-              ref={stickyStyles.ref}
-              scope="col"
-              {...getTableColHeaderRoleProps({ tableRole, colIndex: 0 })}
+            <TableThElement
+              className={clsx(headerCellClass, selectionCellClass, hidden && headerCellStyles['header-cell-hidden'])}
+              hidden={hidden}
+              tableRole={tableRole}
+              colIndex={0}
+              columnId={selectionColumnId}
+              stickyState={stickyState}
             >
               {selectionType === 'multi' ? (
                 <SelectionControl
@@ -130,7 +121,7 @@ const Thead = React.forwardRef(
               ) : (
                 <ScreenreaderOnly>{singleSelectionHeaderAriaLabel}</ScreenreaderOnly>
               )}
-            </th>
+            </TableThElement>
           ) : null}
 
           {columnDefinitions.map((column, colIndex) => {


### PR DESCRIPTION
### Description

Introduce an element to be shared for all header cells including selection cell needed for the upcoming change: https://github.com/cloudscape-design/components/pull/1480.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
