### PR TITLE
feat: Support iframes in container media content

### DIFF
--- a/pages/container/common.tsx
+++ b/pages/container/common.tsx
@@ -1,12 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
+import { useState } from 'react';
 import { ContainerProps } from '~components/container';
 import Container from '~components/container';
 import Header from '~components/header';
 import Link from '~components/link';
 import SpaceBetween from '~components/space-between';
 import Button from '~components/button';
+
+let nextIframeIndex = 0;
+export const PermutationIframe = () => {
+  const [iframeIndex] = useState(() => nextIframeIndex++);
+  return <iframe title={`iframe ${iframeIndex}`} srcDoc="<h1>This is an iframe</h1>"></iframe>;
+};
 
 export const PermutationContainer = ({ permutation }: { permutation: ContainerProps.Media }) => {
   return (

--- a/pages/container/media-side-permutations.page.tsx
+++ b/pages/container/media-side-permutations.page.tsx
@@ -20,7 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
-      <iframe key="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
+      <iframe key="iframe" title="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
     ],
     width: ['', '33%', '50%'],
   },

--- a/pages/container/media-side-permutations.page.tsx
+++ b/pages/container/media-side-permutations.page.tsx
@@ -11,7 +11,7 @@ import image169 from './images/16-9.png';
 import image43 from './images/4-3.png';
 import image916 from './images/9-16.png';
 import imageVideo from './images/video.png';
-import { PermutationContainer } from './common';
+import { PermutationContainer, PermutationIframe } from './common';
 
 const permutations = createPermutations<ContainerProps.Media>([
   {
@@ -20,7 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
-      <iframe key="iframe" title="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
+      <PermutationIframe key="iframe" />,
     ],
     width: ['', '33%', '50%'],
   },

--- a/pages/container/media-side-permutations.page.tsx
+++ b/pages/container/media-side-permutations.page.tsx
@@ -20,6 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
+      <iframe key="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
     ],
     width: ['', '33%', '50%'],
   },

--- a/pages/container/media-top-permutations.page.tsx
+++ b/pages/container/media-top-permutations.page.tsx
@@ -20,7 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
-      <iframe key="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
+      <iframe key="iframe" title="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
     ],
     height: ['', 100, 200, 300],
   },

--- a/pages/container/media-top-permutations.page.tsx
+++ b/pages/container/media-top-permutations.page.tsx
@@ -11,7 +11,7 @@ import image169 from './images/16-9.png';
 import image43 from './images/4-3.png';
 import image916 from './images/9-16.png';
 import imageVideo from './images/video.png';
-import { PermutationContainer } from './common';
+import { PermutationContainer, PermutationIframe } from './common';
 
 const permutations = createPermutations<ContainerProps.Media>([
   {
@@ -20,7 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
-      <iframe key="iframe" title="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
+      <PermutationIframe key="iframe" />,
     ],
     height: ['', 100, 200, 300],
   },

--- a/pages/container/media-top-permutations.page.tsx
+++ b/pages/container/media-top-permutations.page.tsx
@@ -20,6 +20,7 @@ const permutations = createPermutations<ContainerProps.Media>([
       <img key={'image43'} src={image43} alt="placeholder" />,
       <img key={'image916'} src={image916} alt="placeholder" />,
       <img key={'imageVideo'} src={imageVideo} alt="placeholder" />,
+      <iframe key="iframe" srcDoc="<h1>This is an iframe</h1>"></iframe>,
     ],
     height: ['', 100, 200, 300],
   },

--- a/src/__a11y__/axe.ts
+++ b/src/__a11y__/axe.ts
@@ -29,6 +29,9 @@ export const spec: Axe.Spec = {
   rules: [
     // Skip the empty table header rule which fails for the single selection table header
     { id: 'empty-table-header', enabled: false },
+    // Skip the rule which enforces that axe is included in all iframes, which fails on
+    // very basic iframes on media container tests
+    { id: 'frame-tested', enabled: false },
   ],
 };
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5007,7 +5007,7 @@ all containers to the height of the longest one, to avoid extra vertical scroll 
     Object {
       "description": "Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
 You can define different positions and sizes for the media element within the container.
-* \`content\` - Use this slot to render your media element. We support \`img\`, \`video\` and \`picture\` elements.
+* \`content\` - Use this slot to render your media element. We support \`img\`, \`video\`, \`picture\`, and \`iframe\` elements.
 
 * \`position\` - Defines the media slot's position within the container. Defaults to \`top\`.
 

--- a/src/container/interfaces.ts
+++ b/src/container/interfaces.ts
@@ -19,7 +19,7 @@ export interface ContainerProps extends BaseComponentProps {
    * Use this slot to render a media element. Supported element types are 'img', 'video', and 'picture'.
    * You can define different positions and sizes for the media element within the container.
    *
-   * * `content` - Use this slot to render your media element. We support `img`, `video` and `picture` elements.
+   * * `content` - Use this slot to render your media element. We support `img`, `video`, `picture`, and `iframe` elements.
    *
    * * `position` - Defines the media slot's position within the container. Defaults to `top`.
    *
@@ -72,9 +72,7 @@ export interface ContainerProps extends BaseComponentProps {
 export namespace ContainerProps {
   export interface Media {
     /**
-     *
-     * Use this slot to render your media element. We support `img`, `video` and `picture` elements.
-     *
+     * Use this slot to render your media element. We support `img`, `video`, `picture`, and `iframe` elements.
      */
     content: React.ReactNode;
 

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -91,7 +91,8 @@
   // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant, selector-max-type
   img,
   video,
-  picture {
+  picture,
+  iframe {
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -91,12 +91,18 @@
   // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant, selector-max-type
   img,
   video,
-  picture,
-  iframe {
+  picture {
     width: 100%;
     height: 100%;
     object-fit: cover;
     object-position: center;
+  }
+
+  // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant, selector-max-type
+  iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
   }
 
   &-top {


### PR DESCRIPTION
### Description

We'd like to support automatically scaling the `<iframe>` element as a direct child of the media container. For youtube embeds and such.

Related links, issue #, if available: AWSUI-22100

### How has this been tested?

There are screenshot tests for this styling on images already. ~~Don't know if it's worth adding iframe-specific screenshot tests and scenarios for just `width: 100%; height: 100%`.~~ iframes now have custom styling (removing the border), so added some permutations.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
