### PR TITLE
fix: Always offset sticky scrollbar if sticky columns are present

### DIFF
--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -184,6 +184,7 @@ const InternalTable = React.forwardRef(
       stickyColumnsLast: stickyColumns?.last || 0,
     });
 
+    const hasStickyColumns = !!((stickyColumns?.first ?? 0) + (stickyColumns?.last ?? 0) > 0);
     const hasEditableCells = !!columnDefinitions.find(col => col.editConfig);
     const tableRole = hasEditableCells ? 'grid-no-navigation' : 'table';
 
@@ -476,6 +477,7 @@ const InternalTable = React.forwardRef(
               wrapperRef={wrapperRefObject}
               tableRef={tableRefObject}
               onScroll={handleScroll}
+              hasStickyColumns={hasStickyColumns}
             />
           </InternalContainer>
         </ColumnWidthsProvider>

--- a/src/table/sticky-scrollbar/__tests__/sticky-scrollbar.test.tsx
+++ b/src/table/sticky-scrollbar/__tests__/sticky-scrollbar.test.tsx
@@ -19,6 +19,15 @@ it('adds an offset if the scrollbar is an overlay', () => {
   expect(container.querySelector(`.${styles['sticky-scrollbar-offset']}`)).not.toBeNull();
 });
 
+it('adds an offset if the scrollbar occupies space but the table has sticky columns', () => {
+  const tableRef = { current: document.createElement('table') };
+  const wrapperRef = { current: document.createElement('div') };
+
+  browserScrollbarSizeMock.mockImplementationOnce(() => ({ height: 20, width: 100 }));
+  const { container } = render(<StickyScrollbar tableRef={tableRef} wrapperRef={wrapperRef} hasStickyColumns={true} />);
+  expect(container.querySelector(`.${styles['sticky-scrollbar-offset']}`)).not.toBeNull();
+});
+
 it('does not add an offset if the scrollbar occupies space', () => {
   const tableRef = { current: document.createElement('table') };
   const wrapperRef = { current: document.createElement('div') };

--- a/src/table/sticky-scrollbar/sticky-scrollbar.tsx
+++ b/src/table/sticky-scrollbar/sticky-scrollbar.tsx
@@ -13,11 +13,15 @@ interface StickyScrollbarProps {
   wrapperRef: React.RefObject<HTMLDivElement>;
   tableRef: React.RefObject<HTMLTableElement>;
   onScroll?: React.UIEventHandler<HTMLDivElement>;
+  hasStickyColumns?: boolean;
 }
 
 export default forwardRef(StickyScrollbar);
 
-function StickyScrollbar({ wrapperRef, tableRef, onScroll }: StickyScrollbarProps, ref: React.Ref<HTMLDivElement>) {
+function StickyScrollbar(
+  { wrapperRef, tableRef, onScroll, hasStickyColumns }: StickyScrollbarProps,
+  ref: React.Ref<HTMLDivElement>
+) {
   const isVisualRefresh = useVisualRefresh();
   const scrollbarRef = React.useRef<HTMLDivElement>(null);
   const scrollbarContentRef = React.useRef<HTMLDivElement>(null);
@@ -27,7 +31,7 @@ function StickyScrollbar({ wrapperRef, tableRef, onScroll }: StickyScrollbarProp
    * If the height of the scrollbar is 0, we're likely on a platform that uses
    * overlay scrollbars (e.g. Mac).
    */
-  const offsetScrollbar = browserScrollbarSize().height === 0;
+  const offsetScrollbar = hasStickyColumns || browserScrollbarSize().height === 0;
 
   /**
    * Use the appropriate AppLayout context (Classic or Visual Refresh) to determine


### PR DESCRIPTION
### Description

Corrects a regression with the sticky scrollbar. The offset isn't just about the positioning, it's also about the z-index. We can never skip the "offset" for sticky scrollbars because otherwise, the scrollbar would go underneath the sticky columns.

We can separate the z-index and "offset" concerns, but also, we don't really need to. Let's just revert back to the known state. 

Related links, issue #, if available: n/a

### How has this been tested?

Another unit test!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
