### PR TITLE
feat: Make more tables use role=grid by default

### DIFF
--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -7,6 +7,7 @@ import Table, { TableProps } from '../../../lib/components/table';
 import Header from '../../../lib/components/header';
 import { render } from '@testing-library/react';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
+import styles from '../../../lib/components/table/styles.css.js';
 
 interface Item {
   id: number;
@@ -36,44 +37,63 @@ afterAll(() => {
   jest.restoreAllMocks();
 });
 
-describe('roles', () => {
-  test('table has role="table" when no columns are editable', () => {
-    const wrapper = renderTableWrapper({ columnDefinitions: defaultColumns });
+describe('table role', () => {
+  test('table has role="table" when inline editing, sorting, resizable columns, and selection are not used', () => {
+    const wrapper = renderTableWrapper({ sortingDisabled: true });
     expect(wrapper.find('[role="table"]')).not.toBeNull();
-    expect(wrapper.find('[role="grid"]')).toBeNull();
   });
 
-  test('table has role="grid" when at least one defined column is editable', () => {
+  test('table has role="grid" when inline editing is used', () => {
     const wrapper = renderTableWrapper({
-      columnDefinitions: [
-        ...defaultColumns,
-        { header: 'value', cell: item => item.value, editConfig: { editingCell: () => null } },
-      ],
-      visibleColumns: ['id', 'name'],
+      sortingDisabled: true,
+      columnDefinitions: defaultColumns,
+      submitEdit: () => {},
     });
-    expect(wrapper.find('[role="table"]')).toBeNull();
     expect(wrapper.find('[role="grid"]')).not.toBeNull();
+  });
+
+  test('table has role="grid" when sorting is used', () => {
+    const wrapper = renderTableWrapper();
+    expect(wrapper.find('[role="grid"]')).not.toBeNull();
+  });
+
+  test('table has role="grid" when resizable columns is used', () => {
+    const wrapper = renderTableWrapper({ sortingDisabled: true, resizableColumns: true });
+    expect(wrapper.find('[role="grid"]')).not.toBeNull();
+  });
+
+  test('table has role="grid" when selection is used', () => {
+    const wrapper = renderTableWrapper({ sortingDisabled: true, selectionType: 'single' });
+    expect(wrapper.find('[role="grid"]')).not.toBeNull();
+  });
+
+  test('table role is set only once', () => {
+    const { container, rerender } = render(<Table items={defaultItems} columnDefinitions={defaultColumns} />);
+    expect(container.querySelector('[role="grid"]')).not.toBeNull();
+
+    rerender(<Table items={defaultItems} columnDefinitions={defaultColumns} sortingDisabled={true} />);
+    expect(container.querySelector('[role="grid"]')).not.toBeNull();
   });
 });
 
 describe('labels', () => {
   test('not to have aria-label if omitted', () => {
     const wrapper = renderTableWrapper();
-    expect(wrapper.find('[role=table]')!.getElement()).not.toHaveAttribute('aria-label');
+    expect(wrapper.findByClassName(styles.table)!.getElement()).not.toHaveAttribute('aria-label');
   });
 
   test('sets aria-label on table', () => {
     const wrapper = renderTableWrapper({
       ariaLabels: { itemSelectionLabel: () => '', selectionGroupLabel: '', tableLabel },
     });
-    expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-label')).toEqual(tableLabel);
+    expect(wrapper.findByClassName(styles.table)!.getElement().getAttribute('aria-label')).toEqual(tableLabel);
   });
 
   test('automatically labels table with header if provided', () => {
     const wrapper = renderTableWrapper({
       header: <Header counter="(10)">Labelled table</Header>,
     });
-    expect(wrapper.find('[role=table]')!.getElement()).toHaveAccessibleName('Labelled table');
+    expect(wrapper.findByClassName(styles.table)!.getElement()).toHaveAccessibleName('Labelled table');
   });
 
   test('aria-label has priority over auto-labelling', () => {
@@ -81,7 +101,7 @@ describe('labels', () => {
       header: <Header>Labelled table</Header>,
       ariaLabels: { itemSelectionLabel: () => '', selectionGroupLabel: '', tableLabel },
     });
-    expect(wrapper.find('[role=table]')!.getElement()).toHaveAccessibleName(tableLabel);
+    expect(wrapper.findByClassName(styles.table)!.getElement()).toHaveAccessibleName(tableLabel);
   });
 
   describe('rows', () => {
@@ -89,12 +109,12 @@ describe('labels', () => {
       const wrapper = renderTableWrapper({
         totalItemsCount: 300,
       });
-      expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('301');
+      expect(wrapper.findByClassName(styles.table)!.getElement().getAttribute('aria-rowcount')).toEqual('301');
     });
 
     test('aria-rowcount should be -1 if totalItemsCount is undefined', () => {
       const wrapper = renderTableWrapper({});
-      expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('-1');
+      expect(wrapper.findByClassName(styles.table)!.getElement().getAttribute('aria-rowcount')).toEqual('-1');
     });
 
     test('sets aria-rowindex on table rows', () => {

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -104,7 +104,7 @@ export function TableHeaderCell<ItemType>({
           [styles['header-cell-fake-focus']]: focusedComponent === `sorting-control-${String(columnId)}`,
         })}
         aria-label={
-          column.ariaLabel
+          column.ariaLabel && !sortingDisabled
             ? column.ariaLabel({
                 sorted: sorted,
                 descending: sorted && !!sortingDescending,

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -40,6 +40,7 @@ import { getTableRoleProps, getTableRowRoleProps, getTableWrapperRoleProps } fro
 import { useCellEditing } from './use-cell-editing';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
+import { useTableRole } from './table-role/table-role-helper';
 
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
@@ -185,8 +186,9 @@ const InternalTable = React.forwardRef(
     });
 
     const hasStickyColumns = !!((stickyColumns?.first ?? 0) + (stickyColumns?.last ?? 0) > 0);
-    const hasEditableCells = !!columnDefinitions.find(col => col.editConfig);
-    const tableRole = hasEditableCells ? 'grid-default' : 'table';
+    const hasEditableCells = !!submitEdit;
+    const defaultGridRole = hasEditableCells || !!resizableColumns || !sortingDisabled || !!selectionType;
+    const tableRole = useTableRole(defaultGridRole ? 'grid-default' : 'table');
 
     const theadProps: TheadProps = {
       containerWidth,

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useRef } from 'react';
 import { TableRole } from './interfaces';
 
 type SortingStatus = 'sortable' | 'ascending' | 'descending';
@@ -15,6 +16,23 @@ const getAriaSort = (sortingState: SortingStatus) => stateToAriaSort[sortingStat
 // Depending on its content the table can have different semantic representation which includes the
 // ARIA role of the table component ("table", "grid", "treegrid") but also roles and other semantic attributes
 // of the child elements. The TableRole helper encapsulates table's semantic structure.
+
+// Ensures the table role is assigned once and never changes over time.
+export function useTableRole(tableRole: 'grid-default' | 'table'): TableRole {
+  const tableRoleRef = useRef<null | TableRole>(null);
+
+  if (tableRoleRef.current) {
+    return tableRoleRef.current;
+  }
+
+  if (tableRole === 'grid-default') {
+    tableRoleRef.current = 'grid-default';
+    return 'grid-default';
+  }
+
+  tableRoleRef.current = 'table';
+  return 'table';
+}
 
 export function getTableRoleProps(options: {
   tableRole: TableRole;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
