### PR TITLE
feat: Table resize handler requires keyboard activation

### DIFF
--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -256,7 +256,13 @@ test(
     const oldWidth = await page.getColumnWidth(1);
     await page.keys(['Tab']);
     // wait for the resizer to attach handler
-    await page.keys(['ArrowRight']);
+
+    // Enter keyboard dragging mode and update column width (to be updated by grow step)
+    await page.keys(['Enter', 'ArrowRight']);
+    await page.assertColumnWidth(1, oldWidth + 10);
+
+    // Exit keyboard dragging mode and attempt column width update (should be the same as before)
+    await page.keys(['Escape', 'ArrowRight']);
     await page.assertColumnWidth(1, oldWidth + 10);
   })
 );

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -257,12 +257,13 @@ test(
     await page.keys(['Tab']);
     // wait for the resizer to attach handler
 
-    // Enter keyboard dragging mode and update column width (to be updated by grow step)
-    await page.keys(['Enter', 'ArrowRight']);
+    await page.keys(['Enter', 'ArrowRight', 'ArrowRight', 'Enter']);
+    await page.assertColumnWidth(1, oldWidth + 10 + 10);
+
+    await page.keys(['Space', 'ArrowLeft', 'Space']);
     await page.assertColumnWidth(1, oldWidth + 10);
 
-    // Exit keyboard dragging mode and attempt column width update (should be the same as before)
-    await page.keys(['Escape', 'ArrowRight']);
+    await page.keys(['Enter', 'ArrowRight', 'Escape']);
     await page.assertColumnWidth(1, oldWidth + 10);
   })
 );

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -202,7 +202,7 @@ export function Resizer({
         };
 
   return (
-    <span>
+    <>
       <span
         className={clsx(
           styles.resizer,
@@ -239,7 +239,7 @@ export function Resizer({
         data-focus-id={focusId}
       />
       <ScreenreaderOnly id={resizerWidthId}>{headerCellWidthString}</ScreenreaderOnly>
-    </span>
+    </>
   );
 }
 

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -185,7 +185,21 @@ export function Resizer({
 
   const resizerWidthId = useUniqueId();
   const resizerRole = isKeyboardDragging ? 'separator' : 'button';
-  const resizerAriaLabelledby = resizerRole === 'button' ? joinStrings(ariaLabelledby, resizerWidthId) : ariaLabelledby;
+  const headerCellWidthString = headerCellWidth.toFixed(0);
+  const resizerAriaProps =
+    resizerRole === 'button'
+      ? {
+          'aria-labelledby': joinStrings(ariaLabelledby, resizerWidthId),
+          'aria-pressed': false,
+        }
+      : {
+          'aria-labelledby': ariaLabelledby,
+          'aria-orientation': 'vertical' as const,
+          'aria-valuenow': headerCellWidth,
+          // aria-valuetext is needed because the VO announces "collapsed" when only aria-valuenow set without aria-valuemax
+          'aria-valuetext': headerCellWidthString,
+          'aria-valuemin': minWidth,
+        };
 
   return (
     <span>
@@ -220,17 +234,11 @@ export function Resizer({
           }
         }}
         role={resizerRole}
-        aria-pressed={isKeyboardDragging ? undefined : false}
-        aria-orientation="vertical"
-        aria-labelledby={resizerAriaLabelledby}
-        aria-valuenow={headerCellWidth}
-        // aria-valuetext is needed because the VO announces "collapsed" when only aria-valuenow set without aria-valuemax
-        aria-valuetext={headerCellWidth.toString()}
-        aria-valuemin={minWidth}
+        {...resizerAriaProps}
         tabIndex={tabIndex}
         data-focus-id={focusId}
       />
-      <ScreenreaderOnly id={resizerWidthId}>{headerCellWidth.toString()}</ScreenreaderOnly>
+      <ScreenreaderOnly id={resizerWidthId}>{headerCellWidthString}</ScreenreaderOnly>
     </span>
   );
 }


### PR DESCRIPTION
### Description

Made resize handles buttons that require activation with Space/Enter before accepting further keyboard input.
Fixed a bug with controlled mode when onWidthChange handler was never called - now it is called upon resize commit with Space/Enter. The operation can also be discarded with Escape.

### How has this been tested?

Updated existing and added new unit- and integration tests. Screenshot tests, dry-run.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
