### PR TITLE
chore: Table grid navigation replace widget with dialog

### DIFF
--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -5,6 +5,7 @@ import SpaceBetween from '~components/space-between';
 import {
   AppLayout,
   Button,
+  ButtonDropdown,
   ColumnLayout,
   Container,
   ContentLayout,
@@ -14,7 +15,6 @@ import {
   Icon,
   Input,
   Link,
-  SegmentedControl,
   Select,
 } from '~components';
 import styles from './styles.scss';
@@ -37,17 +37,22 @@ type PageContext = React.Context<
   AppContextType<{
     pageSize: number;
     tableRole: TableRole;
+    actionsMode: ActionsMode;
   }>
 >;
+
+type ActionsMode = 'dropdown' | 'inline';
 
 const createColumnDefinitions = ({
   onDelete,
   onDuplicate,
   onUpdate,
+  actionsMode,
 }: {
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
   onUpdate: (id: string) => void;
+  actionsMode: ActionsMode;
 }) => [
   {
     key: 'id',
@@ -58,11 +63,12 @@ const createColumnDefinitions = ({
     key: 'actions',
     label: 'Actions',
     render: (item: Instance) => (
-      <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
-        <Button variant="inline-icon" iconName="remove" ariaLabel="Delete item" onClick={() => onDelete(item.id)} />
-        <Button variant="inline-icon" iconName="copy" ariaLabel="Duplicate item" onClick={() => onDuplicate(item.id)} />
-        <Button variant="inline-icon" iconName="refresh" ariaLabel="Update item" onClick={() => onUpdate(item.id)} />
-      </div>
+      <ItemActionsCell
+        mode={actionsMode}
+        onDelete={() => onDelete(item.id)}
+        onDuplicate={() => onDuplicate(item.id)}
+        onUpdate={() => onUpdate(item.id)}
+      />
     ),
   },
   {
@@ -75,35 +81,23 @@ const createColumnDefinitions = ({
     label: 'Image ID',
     render: (item: Instance) => <Link>{item.imageId}</Link>,
   },
-  {
-    key: 'state-toggle',
-    label: 'State toggle',
-    render: (item: Instance) => (
-      <SegmentedControl
-        selectedId={item.state === 'RUNNING' || item.state === 'STOPPING' ? 'On' : 'Off'}
-        onChange={event => alert(`Changed item state to "${event.detail.selectedId}"`)}
-        label="Instance state"
-        options={[
-          { text: 'On', id: 'On' },
-          { text: 'Off', id: 'Off' },
-        ]}
-      />
-    ),
-    isWidget: true,
-  },
-  { key: 'dnsName', label: 'DNS name', render: (item: Instance) => item.dnsName ?? '?' },
-  { key: 'dnsName2', label: 'DNS name 2', render: (item: Instance) => (item.dnsName ?? '?') + ':2' },
-  { key: 'dnsName3', label: 'DNS name 3', render: (item: Instance) => (item.dnsName ?? '?') + ':3' },
+  { key: 'dnsName', label: 'DNS name', render: (item: Instance) => <DnsEditCell item={item} /> },
   { key: 'type', label: 'Type', render: (item: Instance) => item.type },
 ];
 
 const tableRoleOptions = [{ value: 'table' }, { value: 'grid' }, { value: 'grid-default' }];
+
+const actionsModeOptions = [
+  { value: 'dropdown', label: 'Dropdown' },
+  { value: 'inline', label: 'Inline (anti-pattern)' },
+];
 
 export default function Page() {
   const [toolsOpen, setToolsOpen] = useState(false);
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
   const pageSize = urlParams.pageSize ?? 10;
   const tableRole = urlParams.tableRole ?? 'grid';
+  const actionsMode = urlParams.actionsMode ?? 'dropdown';
 
   const [items, setItems] = useState(generateItems(25));
   const columnDefinitions = useMemo(
@@ -114,8 +108,9 @@ export default function Page() {
           setItems(prev => prev.flatMap(item => (item.id !== id ? [item] : [item, { ...item, id: generateId() }]))),
         onUpdate: (id: string) =>
           setItems(prev => prev.map(item => (item.id !== id ? item : { ...item, id: generateId() }))),
+        actionsMode,
       }),
-    []
+    [actionsMode]
   );
 
   const [sortingKey, setSortingKey] = useState<null | string>(null);
@@ -162,6 +157,16 @@ export default function Page() {
                       onChange={event => setUrlParams({ tableRole: event.detail.selectedOption.value as TableRole })}
                     />
                   </FormField>
+
+                  <FormField label="Actions mode">
+                    <Select
+                      options={actionsModeOptions}
+                      selectedOption={actionsModeOptions.find(option => option.value === actionsMode) ?? null}
+                      onChange={event =>
+                        setUrlParams({ actionsMode: event.detail.selectedOption.value as ActionsMode })
+                      }
+                    />
+                  </FormField>
                 </ColumnLayout>
 
                 <Link onFollow={() => setToolsOpen(true)} data-testid="link-before">
@@ -191,7 +196,7 @@ export default function Page() {
                       <th
                         key={column.key}
                         className={styles['custom-table-cell']}
-                        {...getTableColHeaderRoleProps({ tableRole, colIndex, isWidget: true })}
+                        {...getTableColHeaderRoleProps({ tableRole, colIndex })}
                       >
                         <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
                           <button
@@ -221,7 +226,7 @@ export default function Page() {
                         <td
                           key={column.key}
                           className={styles['custom-table-cell']}
-                          {...getTableCellRoleProps({ tableRole, colIndex, isWidget: column.isWidget })}
+                          {...getTableCellRoleProps({ tableRole, colIndex })}
                         >
                           {column.render(item)}
                         </td>
@@ -235,6 +240,94 @@ export default function Page() {
         </ContentLayout>
       }
     />
+  );
+}
+
+function ItemActionsCell({
+  onDelete,
+  onDuplicate,
+  onUpdate,
+  mode,
+}: {
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onUpdate: () => void;
+  mode: ActionsMode;
+}) {
+  if (mode === 'dropdown') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <ButtonDropdown
+          aria-label="Item actions"
+          variant="inline-icon"
+          items={[
+            { id: 'delete', text: 'Delete' },
+            { id: 'duplicate', text: 'Duplicate' },
+            { id: 'update', text: 'Update' },
+          ]}
+          onItemClick={event => {
+            switch (event.detail.id) {
+              case 'delete':
+                return onDelete();
+              case 'duplicate':
+                return onDuplicate();
+              case 'update':
+                return onUpdate();
+            }
+          }}
+          expandToViewport={true}
+        />
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
+      <Button variant="inline-icon" iconName="remove" ariaLabel="Delete item" onClick={onDelete} />
+      <Button variant="inline-icon" iconName="copy" ariaLabel="Duplicate item" onClick={onDuplicate} />
+      <Button variant="inline-icon" iconName="refresh" ariaLabel="Update item" onClick={onUpdate} />
+    </div>
+  );
+}
+
+function DnsEditCell({ item }: { item: Instance }) {
+  const [active, setActive] = useState(false);
+  const [value, setValue] = useState(item.dnsName ?? '');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  return !active ? (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Edit DNS name"
+      onClick={() => setActive(true)}
+      onKeyDown={event => {
+        if (event.key === 'Enter' || event.key === 'F2') {
+          setActive(true);
+        }
+      }}
+    >
+      {item.dnsName}
+    </div>
+  ) : (
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-label="Edit DND name"
+      onBlur={event => {
+        if (!dialogRef.current!.contains(event.relatedTarget)) {
+          setActive(false);
+        }
+      }}
+      onKeyDown={event => {
+        if (event.key === 'Enter' || event.key === 'Escape' || event.key === 'F2') {
+          setActive(false);
+        }
+      }}
+      style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}
+    >
+      <Input autoFocus={true} value={value} onChange={event => setValue(event.detail.value)} />
+      <Button iconName="check" onClick={() => setActive(false)} />
+      <Button iconName="close" onClick={() => setActive(false)} />
+    </div>
   );
 }
 
@@ -276,12 +369,6 @@ function GridNavigationHelpPanel() {
         </li>
         <li>
           <b>Control+End</b> (to the last item in the grid)
-        </li>
-        <li>
-          <b>Enter</b> (to move focus inside widget cell)
-        </li>
-        <li>
-          <b>Escape</b> (to move widget focus back to cell)
         </li>
       </ul>
     </HelpPanel>

--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -258,7 +258,7 @@ function ItemActionsCell({
     return (
       <div style={{ display: 'flex', justifyContent: 'center' }}>
         <ButtonDropdown
-          aria-label="Item actions"
+          ariaLabel="Item actions"
           variant="inline-icon"
           items={[
             { id: 'delete', text: 'Delete' },

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -8,11 +8,11 @@ test(
   'cell action remains focused when row re-renders',
   useBrowser({ width: 1800, height: 800 }, async browser => {
     const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
+    await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
     await page.waitForVisible('table');
 
     await page.click('button[aria-label="Update item"]');
-    await expect(page.isFocused('tr[aria-rowindex="2"] > td[aria-colindex="2"]')).resolves.toBe(true);
+    await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
   })
 );
 
@@ -20,11 +20,11 @@ test(
   'cell focus stays in the same position when row gets removed',
   useBrowser({ width: 1800, height: 800 }, async browser => {
     const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
+    await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
     await page.waitForVisible('table');
 
     await page.click('button[aria-label="Delete item"]');
-    await expect(page.isFocused('tr[aria-rowindex="2"] > td[aria-colindex="2"]')).resolves.toBe(true);
+    await expect(page.isFocused('button[aria-label="Delete item"]')).resolves.toBe(true);
   })
 );
 
@@ -37,22 +37,22 @@ test(
 
     await page.click('[data-testid="link-before"]');
     await page.keys('Tab');
-    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"] button')).resolves.toBe(true);
 
     await page.keys('Tab');
     await expect(page.isFocused('[data-testid="link-after"]')).resolves.toBe(true);
 
     await page.keys(['Shift', 'Tab', 'Null']);
-    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"] button')).resolves.toBe(true);
 
-    await page.keys(['ArrowRight', 'ArrowDown', 'Enter', 'ArrowRight']);
-    await expect(page.isFocused('tr[aria-rowindex="2"] [aria-label="Duplicate item"]')).resolves.toBe(true);
+    await page.keys(['ArrowRight', 'ArrowDown']);
+    await expect(page.isFocused('tr[aria-rowindex="2"] [aria-label="Item actions"]')).resolves.toBe(true);
 
     await page.keys('Tab');
     await expect(page.isFocused('[data-testid="link-after"]')).resolves.toBe(true);
 
     await page.keys(['Shift', 'Tab', 'Null']);
-    await expect(page.isFocused('tr[aria-rowindex="2"] [aria-label="Duplicate item"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="2"] [aria-label="Item actions"]')).resolves.toBe(true);
 
     await page.keys(['Shift', 'Tab', 'Null']);
     await expect(page.isFocused('[data-testid="link-before"]')).resolves.toBe(true);

--- a/src/table/table-role/__tests__/use-grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/use-grid-navigation.test.tsx
@@ -50,7 +50,7 @@ function SimpleTable({ tableRole = 'grid' }: { tableRole?: 'grid' | 'table' }) {
   );
 }
 
-function InteractiveTable({ actionsWidget = false, pageSize = 2 }: { actionsWidget?: boolean; pageSize?: number }) {
+function InteractiveTable({ actionsDialog = false, pageSize = 2 }: { actionsDialog?: boolean; pageSize?: number }) {
   const tableRef = useRef<HTMLTableElement>(null);
   useGridNavigation({ tableRole: 'grid', pageSize, getTable: () => tableRef.current });
   return (
@@ -70,7 +70,7 @@ function InteractiveTable({ actionsWidget = false, pageSize = 2 }: { actionsWidg
             <a href="#">link-1-1</a>
           </td>
           <td aria-colindex={2}>cell-1-2</td>
-          <td aria-colindex={3} data-widget-cell={actionsWidget}>
+          <td aria-colindex={3} data-widget-cell={actionsDialog}>
             <button>action-1-3-1</button> <button>action-1-3-2</button>
           </td>
         </tr>
@@ -79,7 +79,7 @@ function InteractiveTable({ actionsWidget = false, pageSize = 2 }: { actionsWidg
             <a href="#">link-2-1</a>
           </td>
           <td aria-colindex={2}>cell-2-2</td>
-          <td aria-colindex={3} data-widget-cell={actionsWidget}>
+          <td aria-colindex={3} data-widget-cell={actionsDialog}>
             <button>action-2-3-1</button> <button>action-2-3-2</button>
           </td>
         </tr>
@@ -199,7 +199,7 @@ test('supports key combination navigation', () => {
 });
 
 test('supports multi-element cell navigation', () => {
-  const { container } = render(<InteractiveTable actionsWidget={false} />);
+  const { container } = render(<InteractiveTable actionsDialog={false} />);
   const table = container.querySelector('table')!;
 
   (container.querySelectorAll('button') as NodeListOf<HTMLElement>)[0].focus();
@@ -233,7 +233,7 @@ test('supports multi-element cell navigation', () => {
 });
 
 test('supports widget cell navigation', () => {
-  const { container } = render(<InteractiveTable actionsWidget={true} />);
+  const { container } = render(<InteractiveTable actionsDialog={true} />);
   const table = container.querySelector('table')!;
 
   (container.querySelectorAll('button') as NodeListOf<HTMLElement>)[0].focus();
@@ -509,7 +509,7 @@ test('elements focus is restored if table changes role after being rendered as g
 });
 
 test('when focus is inside widget cell the cell and the cell next to it are focusable', () => {
-  const { container } = render(<InteractiveTable actionsWidget={true} />);
+  const { container } = render(<InteractiveTable actionsDialog={true} />);
   const table = container.querySelector('table')!;
   const widgetCell = container.querySelector('[aria-rowindex="2"]')!.querySelector('[aria-colindex="3"]')!;
   const nextCell = container.querySelector('[aria-rowindex="3"]')!.querySelector('[aria-colindex="1"]')!;

--- a/src/table/table-role/grid-navigation.md
+++ b/src/table/table-role/grid-navigation.md
@@ -1,52 +1,48 @@
 # Table grid navigation
 
-Tables with interactive elements especially those featuring row selection or inline cell editing are assigned or can be assigned the role "grid" which implies extended keyboard navigation as per https://www.w3.org/WAI/ARIA/apg/patterns/grid.
+Tables with interactive elements require ARIA role "grid" and extended keyboard navigation as per https://www.w3.org/WAI/ARIA/apg/patterns/grid.
 
-## Navigation commands
+## Basic keyboard navigation
+
+The grid cells both text-only or even empty and those with one or multiple interactive elements are navigable. When a cell does not have interactive elements as its content the cell itself receives focus. Otherwise - one of the content elements is focused (can be the first, the last, or even the nth depending on the move direction).
 
 The list of supported navigation commands is:
 
-- `Right Arrow`: Moves focus one cell to the right. If focus is on the right-most cell in the row, focus does not move.
-- `Left Arrow`: Moves focus one cell to the left. If focus is on the left-most cell in the row, focus does not move.
-- `Down Arrow`: Moves focus one cell down. If focus is on the bottom cell in the column, focus does not move.
-- `Up Arrow`: Moves focus one cell up. If focus is on the top cell in the column, focus does not move.
-- `Page Down`: Moves focus down an customer-determined number of rows. If focus is in the last row of the grid, focus does not move.
-- `Page Up`: Moves focus up an customer-determined number of rows. If focus is in the first row of the grid, focus does not move.
-- `Home`: moves focus to the first cell in the row.
-- `End`: moves focus to the last cell in the row.
-- `Control + Home`: moves focus to the first cell in the first row.
-- `Control + End`: moves focus to the last cell in the last row.
+- `Right Arrow`: Moves focus one cell or element to the right. The focus does not move if it is already on the last cell/element in the row.
+- `Left Arrow`: Moves focus one cell to the left. The focus does not move if it is already on the first cell/element in the row.
+- `Down Arrow`: Moves focus one cell down. The focus does not move if it is already on the bottom row. When the focus is on the nth element inside a cell the element index is maintained (when possible) when moving down.
+- `Up Arrow`: Moves focus one cell up. The focus does not move if it is already on the top row. When the focus is on the nth element inside a cell the element index is maintained (when possible) when moving up.
+- `Page Down`: Moves focus down by one page (the page size is set as 10). The focus does not move if it is already on the bottom row. When the focus is on the nth element inside a cell the element index is maintained (when possible) when moving down.
+- `Page Up`: Moves focus up by one page (the page size is set as 10). The focus does not move if it is already on the top row. When the focus is on the nth element inside a cell the element index is maintained (when possible) when moving down.
+- `Home`: moves focus to the first cell or element in the row.
+- `End`: moves focus to the last cell or element in the row.
+- `Control + Home`: moves focus to the first cell or element in the first row.
+- `Control + End`: moves focus to the last cell or element in the last row.
 
-## Focus control
-
-### Single tab stop
+## Single tab stop
 
 The grid is a composite component and has a single tab stop. The actual focused element when the focus moves into the grid is determined as:
 
-- If the grid has not been focused by the user after the component mount the focus moves to the first cell (including the heading row).
+- If the grid has not been focused by the user after the component mount the focus moves to the first cell or element (including the heading row).
 - If the grid has been focused before and the focused element position is still available the focus moves to that position.
 - If the grid has been focused before and the focused element position is no longer available the focus moves to the closest row/column to the one focused before.
 
 See: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_general_within
 
-### Cell and element focus
+## Dialog cells
 
-When a grid cell has a single focusable element inside (a link, a row selection checkbox, an input) that element receives focus when navigating to the containing cell. When a cell has zero or multiple focusable elements - the cell itself receives focus.
+The grid might include interactive elements such as text inputs, radio groups, etc. Such elements can conflict with the grid navigation as of listening to the same keyboard input. To resolve the conflict a dialog pattern is employed when the content becomes interactive upon pressing `Enter` or `F2`.
 
-To access the focusable elements inside a multi-element cell the following keyboard commands are supported:
+When the focused element inside of a cell or one of its parents has `role="dialog"` or `awsui-table-suppress-navigation="true"` attributes the focus suppression and keyboard navigation commands no longer apply with an exception of the `Escape` and `F2` keyboard listeners that move the focus back to the cell.
 
-- `Enter`: when a multi-element cell is in focus places focus to the first focusable element inside. A subsequent `Enter` command is not intercepted.
-- `F2`: when a multi-element cell is in focus places focus to the first focusable element inside. A subsequent `F2` command moves focus back to the cell.
-- `Escape`: when focus is inside the multi-element cell focuses the cell. A subsequent `Escape` command is not intercepted.
+For example, when the input or a button from the example below is focused the grid navigation is suppressed.
 
-All navigation commands continue working when the focus is inside the multi-element cell. Besides, the `Left Arrow` and `Right Arrow` move focus between the cell elements. When using `Down Arrow`, `Up Arrow`, `Page Up` and `Page Down` the element position inside the cell is maintained if possible.
-
-See: https://www.w3.org/WAI/ARIA/apg/patterns/grid/#gridNav_focus
-
-### Widget cells
-
-Widget cells are those including one or multiple elements that utilize arrow keys interaction model such is segmented control, radio group, slider, etc. The widget cells are not determined automatically and must be explicitly specified.
-
-Same as for the multi-element cells the focus is not automatically moved inside when a cell is navigated to. The `Enter`, `F2` and `Escape` commands work the same way. The difference is that when the focus is inside a widget cell the navigation commands are not intercepted. Besides, the default focusing behavior is restored so that the elements inside can be navigated with `Tab` and `Shift + Tab` commands.
-
-When the focus is within a widget cell all table cells become focusable so that pressing `Tab` and `Shift + Tab` also restores table navigation by moving the focus to the cell itself or the cell next to it (if available).
+```html
+<td>
+  <div role="dialog">
+    <input value="editable cell value" />
+    <button>save</button>
+    <button>discard</button>
+  </div>
+</td>
+```

--- a/src/table/table-role/grid-navigation.md
+++ b/src/table/table-role/grid-navigation.md
@@ -31,9 +31,7 @@ See: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_general_w
 
 ## Dialog cells
 
-The grid might include interactive elements such as text inputs, radio groups, etc. Such elements can conflict with the grid navigation as of listening to the same keyboard input. To resolve the conflict a dialog pattern is employed when the content becomes interactive upon pressing `Enter` or `F2`.
-
-When the focused element inside of a cell or one of its parents has `role="dialog"` or `awsui-table-suppress-navigation="true"` attributes the focus suppression and keyboard navigation commands no longer apply with an exception of the `Escape` and `F2` keyboard listeners that move the focus back to the cell.
+The grid might include interactive elements such as text inputs, radio groups, etc. Such elements can conflict with the grid navigation as of listening to the same keyboard input. The conflict can be resolved by making the cell elements conditionally interactive - for example when `Enter` or `F2` key is pressed. Once interactive, the element needs to be wrapped with `role="dialog"` or `data-awsui-table-suppress-navigation="true"` for grid navigation focus and keyboard behaviors to be suppressed.
 
 For example, when the input or a button from the example below is focused the grid navigation is suppressed.
 

--- a/src/table/table-role/grid-navigation.md
+++ b/src/table/table-role/grid-navigation.md
@@ -1,10 +1,10 @@
 # Table grid navigation
 
-Tables with interactive elements require ARIA role "grid" and extended keyboard navigation as per https://www.w3.org/WAI/ARIA/apg/patterns/grid.
+Grid navigation is a keyboard navigation mechanism as per [Grid pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid) recommended for tables having interactive elements such as resize handles, selection controls, or resource links.
 
 ## Basic keyboard navigation
 
-The grid cells both text-only or even empty and those with one or multiple interactive elements are navigable. When a cell does not have interactive elements as its content the cell itself receives focus. Otherwise - one of the content elements is focused (can be the first, the last, or even the nth depending on the move direction).
+The grid cells are navigable no matter if they have zero, one, or multiple focusable elements in the content. When there are no focusable elements in a cell the cell itself receives focus. Otherwise - one of the content elements is focused (can be the first, the last, or even the nth depending on the move direction).
 
 The list of supported navigation commands is:
 

--- a/src/table/table-role/interfaces.ts
+++ b/src/table/table-role/interfaces.ts
@@ -19,5 +19,5 @@ export interface FocusedCell {
   rowElement: HTMLTableRowElement;
   cellElement: HTMLTableCellElement;
   element: HTMLElement;
-  widget: boolean;
+  dialog: boolean;
 }

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -90,9 +90,8 @@ export function getTableColHeaderRoleProps(options: {
   tableRole: TableRole;
   colIndex: number;
   sortingStatus?: SortingStatus;
-  isWidget?: boolean;
 }) {
-  const nativeProps: React.ThHTMLAttributes<HTMLTableCellElement> & { 'data-widget-cell'?: boolean } = {};
+  const nativeProps: React.ThHTMLAttributes<HTMLTableCellElement> = {};
 
   nativeProps.scope = 'col';
 
@@ -104,20 +103,11 @@ export function getTableColHeaderRoleProps(options: {
     nativeProps['aria-sort'] = getAriaSort(options.sortingStatus);
   }
 
-  if (options.tableRole === 'grid' && options.isWidget) {
-    nativeProps['data-widget-cell'] = true;
-  }
-
   return nativeProps;
 }
 
-export function getTableCellRoleProps(options: {
-  tableRole: TableRole;
-  colIndex: number;
-  isRowHeader?: boolean;
-  isWidget?: boolean;
-}) {
-  const nativeProps: React.TdHTMLAttributes<HTMLTableCellElement> & { 'data-widget-cell'?: boolean } = {};
+export function getTableCellRoleProps(options: { tableRole: TableRole; colIndex: number; isRowHeader?: boolean }) {
+  const nativeProps: React.TdHTMLAttributes<HTMLTableCellElement> = {};
 
   if (options.tableRole === 'grid') {
     nativeProps['aria-colindex'] = options.colIndex + 1;
@@ -125,10 +115,6 @@ export function getTableCellRoleProps(options: {
 
   if (options.isRowHeader) {
     nativeProps.scope = 'row';
-  }
-
-  if (options.tableRole === 'grid' && options.isWidget) {
-    nativeProps['data-widget-cell'] = true;
   }
 
   return nativeProps;

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -135,7 +135,10 @@ function isDialogElement(target: HTMLElement) {
     if (tagName === 'td' || tagName === 'th') {
       return false;
     }
-    if (current.role === 'dialog' || current.getAttribute('data-awsui-table-suppress-navigation') === 'true') {
+    if (
+      current.getAttribute('role') === 'dialog' ||
+      current.getAttribute('data-awsui-table-suppress-navigation') === 'true'
+    ) {
       return true;
     }
     current = current.parentElement;

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -4,41 +4,50 @@
 import { getFocusables as getActualFocusables } from '../../internal/components/focus-lock/utils';
 import { FocusedCell } from './interfaces';
 
+// For the grid to have a single Tab stop all interactive element indices are updated to be -999.
+// The elements having tab index -999 are eligible for keyboard navigation but not for Tab navigation.
+const PSEUDO_FOCUSABLE_TAB_INDEX = -999;
+
 /**
  * Finds focused cell props corresponding the focused element inside the table.
  * The function relies on ARIA colindex/rowindex attributes being set.
  */
 export function findFocusinCell(event: FocusEvent): null | FocusedCell {
-  const element = event.target;
-
-  if (!(element instanceof HTMLElement)) {
+  if (!(event.target instanceof HTMLElement)) {
     return null;
   }
 
-  const cellElement = element.closest('td,th') as null | HTMLTableCellElement;
-  const rowElement = cellElement?.closest('tr');
+  function focusOnElement(element: HTMLElement): null | FocusedCell {
+    const cellElement = element.closest('td,th') as null | HTMLTableCellElement;
+    const rowElement = cellElement?.closest('tr');
 
-  if (!cellElement || !rowElement) {
-    return null;
+    if (!cellElement || !rowElement) {
+      return null;
+    }
+
+    const colIndex = parseInt(cellElement.getAttribute('aria-colindex') ?? '');
+    const rowIndex = parseInt(rowElement.getAttribute('aria-rowindex') ?? '');
+    if (isNaN(colIndex) || isNaN(rowIndex)) {
+      return null;
+    }
+
+    const cellFocusables = getFocusables(cellElement);
+    const elementIndex = cellFocusables.indexOf(element);
+    const dialog = isDialogElement(element);
+
+    // Focusing on the cell is not eligible when it contains focusable targets.
+    if (cellFocusables.length > 0 && elementIndex === -1) {
+      return focusOnElement(cellFocusables[0]);
+    }
+
+    return { rowIndex, colIndex, rowElement, cellElement, element, elementIndex, dialog };
   }
 
-  const colIndex = parseInt(cellElement.getAttribute('aria-colindex') ?? '');
-  const rowIndex = parseInt(rowElement.getAttribute('aria-rowindex') ?? '');
-  if (isNaN(colIndex) || isNaN(rowIndex)) {
-    return null;
-  }
-
-  const cellFocusables = getFocusables(cellElement);
-  const elementIndex = cellFocusables.indexOf(element);
-
-  const widget = isWidgetCell(cellElement);
-
-  return { rowIndex, colIndex, elementIndex, rowElement, cellElement, element, widget };
+  return focusOnElement(event.target);
 }
 
 /**
- * Moves table focus in the provided direction. The focus can transition between cells or between
- * focusable elements within a cell unless the cell is marked as a widget.
+ * Moves table focus in the provided direction. The focus can transition between cells or interactive elements inside cells.
  */
 export function moveFocusBy(table: HTMLTableElement, from: FocusedCell, delta: { y: number; x: number }) {
   const targetAriaRowIndex = from.rowIndex + delta.y;
@@ -47,53 +56,36 @@ export function moveFocusBy(table: HTMLTableElement, from: FocusedCell, delta: {
     return;
   }
 
-  // Move focus to the next focusable element within a cell if eligible.
+  // Move focus to the next interactive cell content element if eligible.
   const cellFocusables = getFocusables(from.cellElement);
-  const eligibleForElementFocus =
-    delta.x && !isWidgetCell(from.element) && (cellFocusables.length === 1 || from.element !== from.cellElement);
+  const eligibleForElementFocus = delta.x && cellFocusables.length > 0;
   const targetElementIndex = from.elementIndex === -1 ? -1 : from.elementIndex + delta.x;
   if (eligibleForElementFocus && 0 <= targetElementIndex && targetElementIndex < cellFocusables.length) {
     focus(cellFocusables[targetElementIndex]);
     return;
   }
 
+  // Find next cell target to focus on.
   const targetAriaColIndex = from.colIndex + delta.x;
   const targetCell = findTableRowCellByAriaColIndex(targetRow, targetAriaColIndex, delta.x);
   if (!targetCell) {
     return;
   }
 
-  // For widget cells always focus on the cell element itself.
-  if (isWidgetCell(targetCell)) {
-    return focus(targetCell);
-  }
-
-  // For zero delta (exiting command) and multi-element cell focus cell itself.
+  // Focus on cell interactive content element if available or on the cell itself otherwise.
   const targetCellFocusables = getFocusables(targetCell);
-  if (delta.x === 0 && delta.y === 0 && targetCellFocusables.length > 1) {
-    return focus(targetCell);
-  }
-
-  // For non-widget cell focus on the focusable element inside if exactly one is available.
-  const focusIndex =
-    delta.x === 0 && from.elementIndex !== -1 ? from.elementIndex : targetCellFocusables.length === 1 ? 0 : -1;
+  const focusIndex = delta.x < 0 ? targetCellFocusables.length - 1 : delta.x > 0 ? 0 : from.elementIndex;
   const focusTarget = targetCellFocusables[focusIndex] ?? targetCell;
   focus(focusTarget);
-}
-
-/**
- * Moves focus to the first focusable element inside the cell.
- */
-export function moveFocusIn(from: FocusedCell) {
-  focus(getFirstFocusable(from.cellElement));
 }
 
 /**
  * Overrides focusability of the table elements to make focus targets controllable with keyboard commands.
  */
 export function updateTableFocusables(table: HTMLTableElement, cell: null | FocusedCell) {
-  // Restore default focus behavior and make all cells focusable when focus is inside a widget cell.
-  if (cell && cell.widget && cell.element !== cell.cellElement) {
+  // Restore default focus behavior and make all cells focusable when focus in on a dialog element.
+  // This allows existing the dialog cell with Tab or Shift+Tab.
+  if (cell && cell.dialog) {
     for (const focusable of getFocusables(table)) {
       focusable.tabIndex = 0;
     }
@@ -103,12 +95,10 @@ export function updateTableFocusables(table: HTMLTableElement, cell: null | Focu
   const tableCells = Array.from(table.querySelectorAll('td,th') as NodeListOf<HTMLTableCellElement>);
 
   for (const cell of tableCells) {
-    cell.tabIndex = -1;
-    cell.setAttribute('data-focusable', 'true');
+    cell.tabIndex = PSEUDO_FOCUSABLE_TAB_INDEX;
   }
   for (const focusable of getActualFocusables(table)) {
-    focusable.tabIndex = -1;
-    focusable.setAttribute('data-focusable', 'true');
+    focusable.tabIndex = PSEUDO_FOCUSABLE_TAB_INDEX;
   }
 
   // The only focusable element of the table.
@@ -117,11 +107,8 @@ export function updateTableFocusables(table: HTMLTableElement, cell: null | Focu
   if (cell && table.contains(cell.element)) {
     focusTarget = cell.element;
   } else if (tableCells.length > 0) {
-    const cellFocusables = getFocusables(tableCells[0]);
-    const eligibleForElementFocus = !isWidgetCell(tableCells[0]) && cellFocusables.length === 1;
-    focusTarget = eligibleForElementFocus ? cellFocusables[0] : focusTarget;
+    focusTarget = getFocusables(tableCells[0])[0] ?? focusTarget;
   }
-
   if (focusTarget) {
     focusTarget.tabIndex = 0;
   }
@@ -137,16 +124,29 @@ export function restoreTableFocusables(table: HTMLTableElement) {
   }
 }
 
-function isWidgetCell(cell: HTMLElement) {
-  return cell.getAttribute('data-widget-cell') === 'true';
+/**
+ * Returns true if the target element or one of its parents is a dialog or is marked with data-awsui-table-suppress-navigation.
+ * For dialog cells when in focus the tab indices are not overridden and keyboard events are not intercepted.
+ */
+function isDialogElement(target: HTMLElement) {
+  let current: null | HTMLElement = target;
+  while (current) {
+    const tagName = current.tagName.toLowerCase();
+    if (tagName === 'td' || tagName === 'th') {
+      return false;
+    }
+    if (current.role === 'dialog' || current.getAttribute('data-awsui-table-suppress-navigation') === 'true') {
+      return true;
+    }
+    current = current.parentElement;
+  }
+  return false;
 }
 
 function getFocusables(element: HTMLElement) {
-  return Array.from(element.querySelectorAll('[data-focusable="true"]')) as HTMLElement[];
-}
-
-function getFirstFocusable(element: HTMLElement) {
-  return getFocusables(element)[0] as null | HTMLElement;
+  return Array.from(
+    element.querySelectorAll(`[tabIndex="0"],[tabIndex="${PSEUDO_FOCUSABLE_TAB_INDEX}"]`)
+  ) as HTMLElement[];
 }
 
 function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex: number, delta: number) {


### PR DESCRIPTION
### Description

Updated the grid navigation based on the team's feedback. The "widget" cells are no longer explicitly present, instead - the focus handling is now done uniformly for all cells and elements.

Whenever there is a need to support cell content requiring arrow-based navigation the consumer must ensure the content only becomes fully interactive upon activation, same as the built-in inline editing feature works. The table no longer interferes when the focused element or one of its parents has role="dialog" or data-awsui-table-suppress-navigation="true".

Updated the docs and the test page accordingly.

### How has this been tested?

Updated unit- and integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
