### PR TITLE
chore: Creates internal drawer component

### DIFF
--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -7,12 +7,13 @@ import { getLimitedValue } from '../../split-panel/utils/size-utils';
 import { usePointerEvents } from '../utils/use-pointer-events';
 import { useKeyboardEvents } from '../utils/use-keyboard-events';
 import { SizeControlProps } from '../utils/interfaces';
-import { Drawer } from './index';
+import { Drawer as InternalDrawer } from './index';
 import testutilStyles from '../test-classes/styles.css.js';
 
 import ResizeHandler from '../../split-panel/icons/resize-handler';
 import splitPanelStyles from '../../split-panel/styles.css.js';
 import { ResizableDrawerProps } from './interfaces';
+import Drawer from '../../internal/components/drawer';
 
 export const ResizableDrawer = ({
   onResize,
@@ -80,7 +81,7 @@ export const ResizableDrawer = ({
   );
 
   return (
-    <Drawer
+    <InternalDrawer
       {...props}
       ref={drawerRefObject}
       resizeHandle={
@@ -94,6 +95,7 @@ export const ResizableDrawer = ({
       }}
     >
       {children}
-    </Drawer>
+      <Drawer>hello!</Drawer>
+    </InternalDrawer>
   );
 };

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -13,7 +13,6 @@ import testutilStyles from '../test-classes/styles.css.js';
 import ResizeHandler from '../../split-panel/icons/resize-handler';
 import splitPanelStyles from '../../split-panel/styles.css.js';
 import { ResizableDrawerProps } from './interfaces';
-import Drawer from '../../internal/components/drawer';
 
 export const ResizableDrawer = ({
   onResize,
@@ -95,7 +94,6 @@ export const ResizableDrawer = ({
       }}
     >
       {children}
-      <Drawer>hello!</Drawer>
     </InternalDrawer>
   );
 };

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -7,7 +7,7 @@ import { getLimitedValue } from '../../split-panel/utils/size-utils';
 import { usePointerEvents } from '../utils/use-pointer-events';
 import { useKeyboardEvents } from '../utils/use-keyboard-events';
 import { SizeControlProps } from '../utils/interfaces';
-import { Drawer as InternalDrawer } from './index';
+import { Drawer } from './index';
 import testutilStyles from '../test-classes/styles.css.js';
 
 import ResizeHandler from '../../split-panel/icons/resize-handler';
@@ -80,7 +80,7 @@ export const ResizableDrawer = ({
   );
 
   return (
-    <InternalDrawer
+    <Drawer
       {...props}
       ref={drawerRefObject}
       resizeHandle={
@@ -94,6 +94,6 @@ export const ResizableDrawer = ({
       }}
     >
       {children}
-    </InternalDrawer>
+    </Drawer>
   );
 };

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -167,7 +167,7 @@ export interface I18nFormatArgTypes {
     "i18nStrings.warningIconAriaLabel": never;
   }
   "drawer": {
-    "loadingText": never;
+    "i18nStrings.loadingText": never;
   }
   "form": {
     "errorIconAriaLabel": never;

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -156,6 +156,9 @@ export interface I18nFormatArgTypes {
       "unit": string | number;
     }
   }
+  "drawer": {
+    "loadingText": never;
+  }
   "flashbar": {
     "i18nStrings.ariaLabel": never;
     "i18nStrings.errorIconAriaLabel": never;

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -166,6 +166,9 @@ export interface I18nFormatArgTypes {
     "i18nStrings.successIconAriaLabel": never;
     "i18nStrings.warningIconAriaLabel": never;
   }
+  "drawer": {
+    "loadingText": never;
+  }
   "form": {
     "errorIconAriaLabel": never;
   }

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -156,9 +156,6 @@ export interface I18nFormatArgTypes {
       "unit": string | number;
     }
   }
-  "drawer": {
-    "loadingText": never;
-  }
   "flashbar": {
     "i18nStrings.ariaLabel": never;
     "i18nStrings.errorIconAriaLabel": never;

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
   "drawer": {
-    "loadingText": "Inhalte werden geladen"
+    "i18nStrings.loadingText": "Inhalte werden geladen"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Benachrichtigungen",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Letzte {amount} {unit}} other {Letzte {amount} {unit}s}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
+  "drawer": {
+    "loadingText": "Inhalte werden geladen"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Benachrichtigungen",
     "i18nStrings.errorIconAriaLabel": "Fehler",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Last {amount} {unit}} other {Last {amount} {unit}s}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
+  "drawer": {
+    "loadingText": "Loading content"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
   "drawer": {
-    "loadingText": "Loading content"
+    "i18nStrings.loadingText": "Loading content"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -116,7 +116,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
   "drawer": {
-    "loadingText": "Loading content"
+    "i18nStrings.loadingText": "Loading content"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -115,6 +115,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Last {amount} {unit}} other {Last {amount} {unit}s}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
+  "drawer": {
+    "loadingText": "Loading content"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "Cargando contenido"
+    "i18nStrings.loadingText": "Cargando contenido"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificaciones",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Último {amount} {unit}} other {Últimos {amount} {unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "Cargando contenido"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificaciones",
     "i18nStrings.errorIconAriaLabel": "Error",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Dernier {amount} {unit}} other {Dernières {amount} {unit}s}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
+  "drawer": {
+    "loadingText": "Chargement du contenu en cours"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",
     "i18nStrings.errorIconAriaLabel": "Erreur",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
   "drawer": {
-    "loadingText": "Chargement du contenu en cours"
+    "i18nStrings.loadingText": "Chargement du contenu en cours"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifications",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {{amount} {unit} terakhir} other {{amount} {unit} terakhir}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "Memuat konten"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifikasi",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "Memuat konten"
+    "i18nStrings.loadingText": "Memuat konten"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifikasi",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "Caricamento dei contenuti"
+    "i18nStrings.loadingText": "Caricamento dei contenuti"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifiche",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Ultimo {amount} {unit}} other {Ultimi {amount} {unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "Caricamento dei contenuti"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notifiche",
     "i18nStrings.errorIconAriaLabel": "Errore",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {最後の {amount} {unit}} other {最後の {amount} {unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "コンテンツのロード中"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "エラー",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "コンテンツのロード中"
+    "i18nStrings.loadingText": "コンテンツのロード中"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "콘텐츠 로드 중"
+    "i18nStrings.loadingText": "콘텐츠 로드 중"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "알림",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {마지막 {amount}{unit}} other {마지막 {amount}{unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "콘텐츠 로드 중"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "알림",
     "i18nStrings.errorIconAriaLabel": "오류",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
   "drawer": {
-    "loadingText": "Carregando conteúdo"
+    "i18nStrings.loadingText": "Carregando conteúdo"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificações",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {Último(a) {amount} {unit}} other {Últimos(as) {amount} {unit}s}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
   },
+  "drawer": {
+    "loadingText": "Carregando conteúdo"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "Notificações",
     "i18nStrings.errorIconAriaLabel": "Erro",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "正在加载内容"
+    "i18nStrings.loadingText": "正在加载内容"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {最近 {amount} {unit}} other {最近 {amount} {unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "正在加载内容"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "错误",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -114,6 +114,9 @@
     "i18nStrings.formatRelativeRange": "{amount, plural, one {最後 {amount} {unit}} other {最後 {amount} {unit}}}",
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
+  "drawer": {
+    "loadingText": "載入內容"
+  },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",
     "i18nStrings.errorIconAriaLabel": "錯誤",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -115,7 +115,7 @@
     "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
   },
   "drawer": {
-    "loadingText": "載入內容"
+    "i18nStrings.loadingText": "載入內容"
   },
   "flashbar": {
     "i18nStrings.ariaLabel": "通知",

--- a/src/internal/components/drawer/__tests__/drawer.test.tsx
+++ b/src/internal/components/drawer/__tests__/drawer.test.tsx
@@ -29,8 +29,10 @@ test('renders header if it is provided', () => {
 });
 
 test('renders loading state', () => {
-  const { container } = render(<Drawer loading={true} loadingText="Loading content" />);
-  expect(createWrapper(container).findStatusIndicator()!.getElement()).toHaveTextContent('Loading content');
+  const { wrapper, header, content } = renderDrawer(<Drawer loading={true} loadingText="Loading content" />);
+  expect(wrapper.findStatusIndicator()!.getElement()).toHaveTextContent('Loading content');
+  expect(header).toBeNull();
+  expect(content).toBeNull();
 });
 
 describe('i18n', () => {

--- a/src/internal/components/drawer/__tests__/drawer.test.tsx
+++ b/src/internal/components/drawer/__tests__/drawer.test.tsx
@@ -3,56 +3,41 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
-import HelpPanel from '../../../../../lib/components/help-panel';
+import Drawer from '../../../../../lib/components/internal/components/drawer';
 import TestI18nProvider from '../../../../../lib/components/i18n/testing';
+import styles from '../../../../../lib/components/internal/components/drawer/styles.css.js';
 
-function renderHelpPanel(jsx: React.ReactElement) {
+function renderDrawer(jsx: React.ReactElement) {
   const { container } = render(jsx);
-  return createWrapper(container).findHelpPanel()!;
+  const wrapper = createWrapper(container).findByClassName(styles.drawer)!;
+  const header = wrapper.findByClassName(styles.header);
+  const content = wrapper.findByClassName(styles['test-utils-drawer-content']);
+  return { wrapper, header, content };
 }
 
 test('renders only children by default', () => {
-  const wrapper = renderHelpPanel(<HelpPanel>test content</HelpPanel>);
-  expect(wrapper.findHeader()).toBeNull();
-  expect(wrapper.findFooter()).toBeNull();
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
+  const { header, content } = renderDrawer(<Drawer>test content</Drawer>);
+
+  expect(header).toBeNull();
+  expect(content!.getElement()).toHaveTextContent('test content');
 });
 
 test('renders header if it is provided', () => {
-  const wrapper = renderHelpPanel(<HelpPanel header="Bla bla">there is a header above</HelpPanel>);
-  expect(wrapper.findFooter()).toBeNull();
-  expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Bla bla');
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('there is a header above');
-});
-
-test('renders footer if it is provided', () => {
-  const wrapper = renderHelpPanel(<HelpPanel footer="Some footer">test content</HelpPanel>);
-  expect(wrapper.findHeader()).toBeNull();
-  expect(wrapper.findFooter()!.getElement()).toHaveTextContent('Some footer');
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
-});
-
-test('renders everything together', () => {
-  const wrapper = renderHelpPanel(
-    <HelpPanel header="Test header" footer="Test footer">
-      test content
-    </HelpPanel>
-  );
-  expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Test header');
-  expect(wrapper.findFooter()!.getElement()).toHaveTextContent('Test footer');
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
+  const { header, content } = renderDrawer(<Drawer header="Bla bla">there is a header above</Drawer>);
+  expect(header!.getElement()).toHaveTextContent('Bla bla');
+  expect(content!.getElement()).toHaveTextContent('there is a header above');
 });
 
 test('renders loading state', () => {
-  const { container } = render(<HelpPanel loading={true} loadingText="Loading content" />);
+  const { container } = render(<Drawer loading={true} loadingText="Loading content" />);
   expect(createWrapper(container).findStatusIndicator()!.getElement()).toHaveTextContent('Loading content');
 });
 
 describe('i18n', () => {
   test('supports providing loadingText from i18n provider', () => {
     const { container } = render(
-      <TestI18nProvider messages={{ 'help-panel': { loadingText: 'Custom loading text' } }}>
-        <HelpPanel loading={true} />
+      <TestI18nProvider messages={{ drawer: { loadingText: 'Custom loading text' } }}>
+        <Drawer loading={true} />
       </TestI18nProvider>
     );
     expect(createWrapper(container).findStatusIndicator()!.getElement()).toHaveTextContent('Custom loading text');

--- a/src/internal/components/drawer/__tests__/drawer.test.tsx
+++ b/src/internal/components/drawer/__tests__/drawer.test.tsx
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../../../lib/components/test-utils/dom';
+import HelpPanel from '../../../../../lib/components/help-panel';
+import TestI18nProvider from '../../../../../lib/components/i18n/testing';
+
+function renderHelpPanel(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  return createWrapper(container).findHelpPanel()!;
+}
+
+test('renders only children by default', () => {
+  const wrapper = renderHelpPanel(<HelpPanel>test content</HelpPanel>);
+  expect(wrapper.findHeader()).toBeNull();
+  expect(wrapper.findFooter()).toBeNull();
+  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
+});
+
+test('renders header if it is provided', () => {
+  const wrapper = renderHelpPanel(<HelpPanel header="Bla bla">there is a header above</HelpPanel>);
+  expect(wrapper.findFooter()).toBeNull();
+  expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Bla bla');
+  expect(wrapper.findContent()!.getElement()).toHaveTextContent('there is a header above');
+});
+
+test('renders footer if it is provided', () => {
+  const wrapper = renderHelpPanel(<HelpPanel footer="Some footer">test content</HelpPanel>);
+  expect(wrapper.findHeader()).toBeNull();
+  expect(wrapper.findFooter()!.getElement()).toHaveTextContent('Some footer');
+  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
+});
+
+test('renders everything together', () => {
+  const wrapper = renderHelpPanel(
+    <HelpPanel header="Test header" footer="Test footer">
+      test content
+    </HelpPanel>
+  );
+  expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Test header');
+  expect(wrapper.findFooter()!.getElement()).toHaveTextContent('Test footer');
+  expect(wrapper.findContent()!.getElement()).toHaveTextContent('test content');
+});
+
+test('renders loading state', () => {
+  const { container } = render(<HelpPanel loading={true} loadingText="Loading content" />);
+  expect(createWrapper(container).findStatusIndicator()!.getElement()).toHaveTextContent('Loading content');
+});
+
+describe('i18n', () => {
+  test('supports providing loadingText from i18n provider', () => {
+    const { container } = render(
+      <TestI18nProvider messages={{ 'help-panel': { loadingText: 'Custom loading text' } }}>
+        <HelpPanel loading={true} />
+      </TestI18nProvider>
+    );
+    expect(createWrapper(container).findStatusIndicator()!.getElement()).toHaveTextContent('Custom loading text');
+  });
+});

--- a/src/internal/components/drawer/__tests__/drawer.test.tsx
+++ b/src/internal/components/drawer/__tests__/drawer.test.tsx
@@ -29,7 +29,9 @@ test('renders header if it is provided', () => {
 });
 
 test('renders loading state', () => {
-  const { wrapper, header, content } = renderDrawer(<Drawer loading={true} loadingText="Loading content" />);
+  const { wrapper, header, content } = renderDrawer(
+    <Drawer loading={true} i18nStrings={{ loadingText: 'Loading content' }} />
+  );
   expect(wrapper.findStatusIndicator()!.getElement()).toHaveTextContent('Loading content');
   expect(header).toBeNull();
   expect(content).toBeNull();
@@ -38,7 +40,7 @@ test('renders loading state', () => {
 describe('i18n', () => {
   test('supports providing loadingText from i18n provider', () => {
     const { container } = render(
-      <TestI18nProvider messages={{ drawer: { loadingText: 'Custom loading text' } }}>
+      <TestI18nProvider messages={{ drawer: { 'i18nStrings.loadingText': 'Custom loading text' } }}>
         <Drawer loading={true} />
       </TestI18nProvider>
     );

--- a/src/internal/components/drawer/index.tsx
+++ b/src/internal/components/drawer/index.tsx
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from 'clsx';
+import React from 'react';
+import { getBaseProps } from '../../base-component';
+import InternalStatusIndicator from '../../../status-indicator/internal';
+import styles from './styles.css.js';
+import { applyDisplayName } from '../../utils/apply-display-name';
+import useBaseComponent from '../../hooks/use-base-component';
+import { DrawerProps } from './interfaces';
+import LiveRegion from '../../components/live-region';
+import { useInternalI18n } from '../../../i18n/context';
+
+export { DrawerProps };
+
+export default function Drawer({ header, children, loading, loadingText, ...restProps }: DrawerProps) {
+  const { __internalRootRef } = useBaseComponent('Drawer');
+  const baseProps = getBaseProps(restProps);
+  const i18n = useInternalI18n('drawer');
+  const containerProps = {
+    ...baseProps,
+    className: clsx(baseProps.className, styles.drawer),
+  };
+  return loading ? (
+    <div {...containerProps} ref={__internalRootRef}>
+      <InternalStatusIndicator type="loading">
+        <LiveRegion visible={true}>{i18n('loadingText', loadingText)}</LiveRegion>
+      </InternalStatusIndicator>
+    </div>
+  ) : (
+    <div {...containerProps} ref={__internalRootRef}>
+      {header && <div className={clsx(styles.header)}>{header}</div>}
+      <div className={clsx(styles.content)}>{children}</div>
+    </div>
+  );
+}
+
+applyDisplayName(Drawer, 'Drawer');

--- a/src/internal/components/drawer/index.tsx
+++ b/src/internal/components/drawer/index.tsx
@@ -4,9 +4,9 @@ import clsx from 'clsx';
 import React from 'react';
 import { getBaseProps } from '../../base-component';
 import InternalStatusIndicator from '../../../status-indicator/internal';
-import styles from './styles.css.js';
 import { applyDisplayName } from '../../utils/apply-display-name';
 import useBaseComponent from '../../hooks/use-base-component';
+import styles from './styles.css.js';
 import { DrawerProps } from './interfaces';
 import LiveRegion from '../../components/live-region';
 import { useInternalI18n } from '../../../i18n/context';
@@ -30,7 +30,7 @@ export default function Drawer({ header, children, loading, loadingText, ...rest
   ) : (
     <div {...containerProps} ref={__internalRootRef}>
       {header && <div className={clsx(styles.header)}>{header}</div>}
-      <div className={clsx(styles.content)}>{children}</div>
+      <div className={clsx(styles['test-utils-drawer-content'])}>{children}</div>
     </div>
   );
 }

--- a/src/internal/components/drawer/index.tsx
+++ b/src/internal/components/drawer/index.tsx
@@ -4,17 +4,12 @@ import clsx from 'clsx';
 import React from 'react';
 import { getBaseProps } from '../../base-component';
 import InternalStatusIndicator from '../../../status-indicator/internal';
-import { applyDisplayName } from '../../utils/apply-display-name';
-import useBaseComponent from '../../hooks/use-base-component';
 import styles from './styles.css.js';
 import { DrawerProps } from './interfaces';
 import LiveRegion from '../../components/live-region';
 import { useInternalI18n } from '../../../i18n/context';
 
-export { DrawerProps };
-
 export default function Drawer({ header, children, loading, loadingText, ...restProps }: DrawerProps) {
-  const { __internalRootRef } = useBaseComponent('Drawer');
   const baseProps = getBaseProps(restProps);
   const i18n = useInternalI18n('drawer');
   const containerProps = {
@@ -22,17 +17,15 @@ export default function Drawer({ header, children, loading, loadingText, ...rest
     className: clsx(baseProps.className, styles.drawer),
   };
   return loading ? (
-    <div {...containerProps} ref={__internalRootRef}>
+    <div {...containerProps}>
       <InternalStatusIndicator type="loading">
         <LiveRegion visible={true}>{i18n('loadingText', loadingText)}</LiveRegion>
       </InternalStatusIndicator>
     </div>
   ) : (
-    <div {...containerProps} ref={__internalRootRef}>
+    <div {...containerProps}>
       {header && <div className={clsx(styles.header)}>{header}</div>}
       <div className={clsx(styles['test-utils-drawer-content'])}>{children}</div>
     </div>
   );
 }
-
-applyDisplayName(Drawer, 'Drawer');

--- a/src/internal/components/drawer/index.tsx
+++ b/src/internal/components/drawer/index.tsx
@@ -9,7 +9,7 @@ import { DrawerProps } from './interfaces';
 import LiveRegion from '../../components/live-region';
 import { useInternalI18n } from '../../../i18n/context';
 
-export default function Drawer({ header, children, loading, loadingText, ...restProps }: DrawerProps) {
+export default function Drawer({ header, children, loading, i18nStrings, ...restProps }: DrawerProps) {
   const baseProps = getBaseProps(restProps);
   const i18n = useInternalI18n('drawer');
   const containerProps = {
@@ -19,7 +19,7 @@ export default function Drawer({ header, children, loading, loadingText, ...rest
   return loading ? (
     <div {...containerProps}>
       <InternalStatusIndicator type="loading">
-        <LiveRegion visible={true}>{i18n('loadingText', loadingText)}</LiveRegion>
+        <LiveRegion visible={true}>{i18n('i18nStrings.loadingText', i18nStrings?.loadingText)}</LiveRegion>
       </InternalStatusIndicator>
     </div>
   ) : (

--- a/src/internal/components/drawer/interfaces.ts
+++ b/src/internal/components/drawer/interfaces.ts
@@ -5,17 +5,15 @@ import React from 'react';
 
 export interface DrawerProps extends BaseComponentProps {
   /**
-   * Header of the help panel.
+   * Header of the drawer.
    *
-   * It should contain the only `h2` used in the help panel.
+   * It should contain the only `h2` used in the drawer.
    */
   header?: React.ReactNode;
 
   /**
-   * Main content of the help panel.
+   * Main content of the drawer.
    *
-   * Use `p, a, h3, h4, h5, span, div, ul, ol, li, code, pre, dl, dt, dd, hr, br, i, em, b, strong` tags to format the content.
-   * Use `code` for inline code or `pre` for code blocks.
    */
   children?: React.ReactNode;
 

--- a/src/internal/components/drawer/interfaces.ts
+++ b/src/internal/components/drawer/interfaces.ts
@@ -18,12 +18,12 @@ export interface DrawerProps extends BaseComponentProps {
   children?: React.ReactNode;
 
   /**
-   * Renders the panel in a loading state. We recommend that you also set a `loadingText`.
+   * Renders the drawer in a loading state. We recommend that you also set a `loadingText`.
    */
   loading?: boolean;
 
   /**
-   * Specifies the text that's displayed when the panel is in a loading state.
+   * Specifies the text that's displayed when the drawer is in a loading state.
    * @i18n
    */
   loadingText?: string;

--- a/src/internal/components/drawer/interfaces.ts
+++ b/src/internal/components/drawer/interfaces.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BaseComponentProps } from '../../base-component';
+import React from 'react';
+
+export interface DrawerProps extends BaseComponentProps {
+  /**
+   * Header of the help panel.
+   *
+   * It should contain the only `h2` used in the help panel.
+   */
+  header?: React.ReactNode;
+
+  /**
+   * Main content of the help panel.
+   *
+   * Use `p, a, h3, h4, h5, span, div, ul, ol, li, code, pre, dl, dt, dd, hr, br, i, em, b, strong` tags to format the content.
+   * Use `code` for inline code or `pre` for code blocks.
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Renders the panel in a loading state. We recommend that you also set a `loadingText`.
+   */
+  loading?: boolean;
+
+  /**
+   * Specifies the text that's displayed when the panel is in a loading state.
+   * @i18n
+   */
+  loadingText?: string;
+}

--- a/src/internal/components/drawer/interfaces.ts
+++ b/src/internal/components/drawer/interfaces.ts
@@ -23,8 +23,15 @@ export interface DrawerProps extends BaseComponentProps {
   loading?: boolean;
 
   /**
-   * Specifies the text that's displayed when the drawer is in a loading state.
+   * An object containing all the necessary localized strings required by the component.
    * @i18n
+   */
+  i18nStrings?: I18nStrings;
+}
+
+export interface I18nStrings {
+  /**
+    Specifies the text that's displayed when the panel is in a loading state.
    */
   loadingText?: string;
 }

--- a/src/internal/components/drawer/styles.scss
+++ b/src/internal/components/drawer/styles.scss
@@ -4,35 +4,38 @@
 */
 
 /* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
-@use '../internal/styles/tokens' as awsui;
-@use '../internal/styles' as styles;
+@use '../../styles/tokens' as awsui;
+@use '../../styles' as styles;
 
 .drawer {
   @include styles.styles-reset;
   word-wrap: break-word;
   padding: awsui.$space-scaled-l awsui.$space-panel-side-right awsui.$space-scaled-xxxl awsui.$space-panel-side-left;
+}
 
-  .header {
+.header {
+  @include styles.font-panel-header;
+  color: awsui.$color-text-heading-default;
+  padding-bottom: awsui.$space-scaled-l;
+  padding-left: awsui.$space-panel-side-left;
+  // padding to make sure the header doesn't overlap with the close icon
+  padding-right: calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
+  border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  margin: 0 calc(-1 * #{awsui.$space-panel-side-right}) awsui.$space-scaled-l calc(-1 * #{awsui.$space-panel-side-left});
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @include styles.font-panel-header;
-    color: awsui.$color-text-heading-default;
-    padding-bottom: awsui.$space-scaled-l;
-    padding-left: awsui.$space-panel-side-left;
-    // padding to make sure the header doesn't overlap with the close icon
-    padding-right: calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
-    border: none;
-    border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
-    margin: 0 calc(-1 * #{awsui.$space-panel-side-right}) awsui.$space-scaled-l
-      calc(-1 * #{awsui.$space-panel-side-left});
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      @include styles.font-panel-header;
-      padding-top: 0;
-      padding-bottom: 0;
-      margin-top: 0;
-      margin-bottom: 0;
-    }
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
+}
+
+.test-utils-drawer-content {
+  /* used in test-utils */
 }

--- a/src/internal/components/drawer/styles.scss
+++ b/src/internal/components/drawer/styles.scss
@@ -1,0 +1,38 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+/* stylelint-disable @cloudscape-design/no-implicit-descendant, selector-max-type */
+@use '../internal/styles/tokens' as awsui;
+@use '../internal/styles' as styles;
+
+.drawer {
+  @include styles.styles-reset;
+  word-wrap: break-word;
+  padding: awsui.$space-scaled-l awsui.$space-panel-side-right awsui.$space-scaled-xxxl awsui.$space-panel-side-left;
+
+  .header {
+    @include styles.font-panel-header;
+    color: awsui.$color-text-heading-default;
+    padding-bottom: awsui.$space-scaled-l;
+    padding-left: awsui.$space-panel-side-left;
+    // padding to make sure the header doesn't overlap with the close icon
+    padding-right: calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
+    border: none;
+    border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+    margin: 0 calc(-1 * #{awsui.$space-panel-side-right}) awsui.$space-scaled-l
+      calc(-1 * #{awsui.$space-panel-side-left});
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      @include styles.font-panel-header;
+      padding-top: 0;
+      padding-bottom: 0;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
This is the first step to creating a Drawer component, which will release along with the public release of the drawers changes to the AppLayout. The goal of this PR is to get the code reviewed so that when the time comes to release the component publicly, it is mostly a "flip of a switch" to move the component out of the `internal` folder.

The purpose of the Drawer component is to provide a wrapper for the contents of a drawer, similar to the HelpPanel in the current tools slot or the SplitPanel in the splitPanel slot. It is built as a clone of the HelpPanel component, without the style overrides.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
