### PR TITLE
feat: Publish themeable typography design tokens

### DIFF
--- a/src/__tests__/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/__snapshots__/design-tokens.test.ts.snap
@@ -1876,12 +1876,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -3975,12 +4059,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -6074,12 +6242,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -8173,12 +8425,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -10272,12 +10608,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -12371,12 +12791,96 @@ Object {
       },
     },
     "font-family-base": Object {
-      "$description": "The default font family that will be applied globally to the product interface. ",
+      "$description": "The default font family that will be applied globally to the product interface.",
       "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
     },
     "font-family-monospace": Object {
       "$description": "The monospace font family that will be applied globally to the product interface.",
       "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+    },
+    "font-size-body-m": Object {
+      "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+      "$value": "14px",
+    },
+    "font-size-body-s": Object {
+      "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+      "$value": "12px",
+    },
+    "font-size-display-l": Object {
+      "$description": "The default font size for large display text.",
+      "$value": "44px",
+    },
+    "font-size-heading-l": Object {
+      "$description": "The default font size for h2s.",
+      "$value": "18px",
+    },
+    "font-size-heading-m": Object {
+      "$description": "The default font size for h3s.",
+      "$value": "18px",
+    },
+    "font-size-heading-s": Object {
+      "$description": "The default font size for h4s.",
+      "$value": "16px",
+    },
+    "font-size-heading-xl": Object {
+      "$description": "The default font size for h1s.",
+      "$value": "28px",
+    },
+    "font-size-heading-xs": Object {
+      "$description": "The default font size for h5s.",
+      "$value": "16px",
+    },
+    "font-weight-heading-l": Object {
+      "$description": "The default font weight for h2s.",
+      "$value": "700",
+    },
+    "font-weight-heading-m": Object {
+      "$description": "The default font weight for h3s.",
+      "$value": "400",
+    },
+    "font-weight-heading-s": Object {
+      "$description": "The default font weight for h4s.",
+      "$value": "700",
+    },
+    "font-weight-heading-xl": Object {
+      "$description": "The default font weight for h1s.",
+      "$value": "400",
+    },
+    "font-weight-heading-xs": Object {
+      "$description": "The default font weight for h5s.",
+      "$value": "400",
+    },
+    "line-height-body-m": Object {
+      "$description": "The default line height for regular body text.",
+      "$value": "22px",
+    },
+    "line-height-body-s": Object {
+      "$description": "The default line height for small body text.",
+      "$value": "16px",
+    },
+    "line-height-display-l": Object {
+      "$description": "The default line height for large display text.",
+      "$value": "56px",
+    },
+    "line-height-heading-l": Object {
+      "$description": "The default line height for h2s.",
+      "$value": "22px",
+    },
+    "line-height-heading-m": Object {
+      "$description": "The default line height for h3s.",
+      "$value": "22px",
+    },
+    "line-height-heading-s": Object {
+      "$description": "The default line height for h4s.",
+      "$value": "20px",
+    },
+    "line-height-heading-xl": Object {
+      "$description": "The default line height for h1s.",
+      "$value": "36px",
+    },
+    "line-height-heading-xs": Object {
+      "$description": "The default line height for h5s.",
+      "$value": "20px",
     },
     "motion-duration-complex": Object {
       "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -14475,12 +14979,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -16574,12 +17162,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -18673,12 +19345,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -20772,12 +21528,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -22871,12 +23711,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -24970,12 +25894,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -27069,12 +28077,96 @@ Object {
           },
         },
         "font-family-base": Object {
-          "$description": "The default font family that will be applied globally to the product interface. ",
+          "$description": "The default font family that will be applied globally to the product interface.",
           "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
         },
         "font-family-monospace": Object {
           "$description": "The monospace font family that will be applied globally to the product interface.",
           "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": Object {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": Object {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": Object {
+          "$description": "The default font size for large display text.",
+          "$value": "42px",
+        },
+        "font-size-heading-l": Object {
+          "$description": "The default font size for h2s.",
+          "$value": "20px",
+        },
+        "font-size-heading-m": Object {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": Object {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": Object {
+          "$description": "The default font size for h1s.",
+          "$value": "24px",
+        },
+        "font-size-heading-xs": Object {
+          "$description": "The default font size for h5s.",
+          "$value": "14px",
+        },
+        "font-weight-heading-l": Object {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": Object {
+          "$description": "The default font weight for h3s.",
+          "$value": "700",
+        },
+        "font-weight-heading-s": Object {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": Object {
+          "$description": "The default font weight for h1s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xs": Object {
+          "$description": "The default font weight for h5s.",
+          "$value": "700",
+        },
+        "line-height-body-m": Object {
+          "$description": "The default line height for regular body text.",
+          "$value": "20px",
+        },
+        "line-height-body-s": Object {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": Object {
+          "$description": "The default line height for large display text.",
+          "$value": "48px",
+        },
+        "line-height-heading-l": Object {
+          "$description": "The default line height for h2s.",
+          "$value": "24px",
+        },
+        "line-height-heading-m": Object {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": Object {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": Object {
+          "$description": "The default line height for h1s.",
+          "$value": "30px",
+        },
+        "line-height-heading-xs": Object {
+          "$description": "The default line height for h5s.",
+          "$value": "18px",
         },
         "motion-duration-complex": Object {
           "$description": "The duration for drawing more attention or accommodating for more complexity.",
@@ -29168,12 +30260,96 @@ Object {
       },
     },
     "font-family-base": Object {
-      "$description": "The default font family that will be applied globally to the product interface. ",
+      "$description": "The default font family that will be applied globally to the product interface.",
       "$value": "'Open Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
     },
     "font-family-monospace": Object {
       "$description": "The monospace font family that will be applied globally to the product interface.",
       "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+    },
+    "font-size-body-m": Object {
+      "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+      "$value": "14px",
+    },
+    "font-size-body-s": Object {
+      "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+      "$value": "12px",
+    },
+    "font-size-display-l": Object {
+      "$description": "The default font size for large display text.",
+      "$value": "42px",
+    },
+    "font-size-heading-l": Object {
+      "$description": "The default font size for h2s.",
+      "$value": "20px",
+    },
+    "font-size-heading-m": Object {
+      "$description": "The default font size for h3s.",
+      "$value": "18px",
+    },
+    "font-size-heading-s": Object {
+      "$description": "The default font size for h4s.",
+      "$value": "16px",
+    },
+    "font-size-heading-xl": Object {
+      "$description": "The default font size for h1s.",
+      "$value": "24px",
+    },
+    "font-size-heading-xs": Object {
+      "$description": "The default font size for h5s.",
+      "$value": "14px",
+    },
+    "font-weight-heading-l": Object {
+      "$description": "The default font weight for h2s.",
+      "$value": "700",
+    },
+    "font-weight-heading-m": Object {
+      "$description": "The default font weight for h3s.",
+      "$value": "700",
+    },
+    "font-weight-heading-s": Object {
+      "$description": "The default font weight for h4s.",
+      "$value": "700",
+    },
+    "font-weight-heading-xl": Object {
+      "$description": "The default font weight for h1s.",
+      "$value": "700",
+    },
+    "font-weight-heading-xs": Object {
+      "$description": "The default font weight for h5s.",
+      "$value": "700",
+    },
+    "line-height-body-m": Object {
+      "$description": "The default line height for regular body text.",
+      "$value": "20px",
+    },
+    "line-height-body-s": Object {
+      "$description": "The default line height for small body text.",
+      "$value": "16px",
+    },
+    "line-height-display-l": Object {
+      "$description": "The default line height for large display text.",
+      "$value": "48px",
+    },
+    "line-height-heading-l": Object {
+      "$description": "The default line height for h2s.",
+      "$value": "24px",
+    },
+    "line-height-heading-m": Object {
+      "$description": "The default line height for h3s.",
+      "$value": "22px",
+    },
+    "line-height-heading-s": Object {
+      "$description": "The default line height for h4s.",
+      "$value": "20px",
+    },
+    "line-height-heading-xl": Object {
+      "$description": "The default line height for h1s.",
+      "$value": "30px",
+    },
+    "line-height-heading-xs": Object {
+      "$description": "The default line height for h5s.",
+      "$value": "18px",
     },
     "motion-duration-complex": Object {
       "$description": "The duration for drawing more attention or accommodating for more complexity.",

--- a/style-dictionary/visual-refresh/metadata/typography.ts
+++ b/style-dictionary/visual-refresh/metadata/typography.ts
@@ -3,11 +3,20 @@
 import { StyleDictionary } from '../../utils/interfaces';
 
 const metadata: StyleDictionary.MetadataIndex = {
+  fontButtonLetterSpacing: {
+    description: 'The default letter spacing for button text.',
+  },
+  fontButtonWeight: {
+    description: 'The default font weight for button text.',
+  },
   fontChartDetailSize: {
     description: 'Used for secondary chart text, e.g. mixed chart axes and pie chart label descriptions.',
   },
+  fontDisplayLabelWeight: {
+    description: 'The default font weight for labels. For example, keys in key-value pairs, or form field labels.',
+  },
   fontFamilyBase: {
-    description: 'The default font family that will be applied globally to the product interface. ',
+    description: 'The default font family that will be applied globally to the product interface.',
     themeable: true,
     public: true,
   },
@@ -18,6 +27,129 @@ const metadata: StyleDictionary.MetadataIndex = {
   },
   fontHeaderH2DescriptionLineHeight: { sassName: '$font-header-h2-description-line-height' },
   fontHeaderH2DescriptionSize: { sassName: '$font-header-h2-description-size' },
+  fontSizeBodyM: {
+    description: 'The default font size for regular body text. For example, <p> tags in text content, or button text.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeBodyS: {
+    description: 'The default font size for small body text. For example, form field descriptions, or badge text.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeDisplayL: {
+    description: 'The default font size for large display text.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeHeadingXl: {
+    description: 'The default font size for h1s.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeHeadingL: {
+    description: 'The default font size for h2s.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeHeadingM: {
+    description: 'The default font size for h3s.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeHeadingS: {
+    description: 'The default font size for h4s.',
+    themeable: true,
+    public: true,
+  },
+  fontSizeHeadingXs: {
+    description: 'The default font size for h5s.',
+    themeable: true,
+    public: true,
+  },
+  fontWeightHeadingXl: {
+    description: 'The default font weight for h1s.',
+    themeable: true,
+    public: true,
+  },
+  fontWeightHeadingL: {
+    description: 'The default font weight for h2s.',
+    themeable: true,
+    public: true,
+  },
+  fontWeightHeadingM: {
+    description: 'The default font weight for h3s.',
+    themeable: true,
+    public: true,
+  },
+  fontWeightHeadingS: {
+    description: 'The default font weight for h4s.',
+    themeable: true,
+    public: true,
+  },
+  fontWeightHeadingXs: {
+    description: 'The default font weight for h5s.',
+    themeable: true,
+    public: true,
+  },
+  letterSpacingBodyS: {
+    description: 'The default letter spacing for small body text.',
+  },
+  letterSpacingDisplayL: {
+    description: 'The default letter spacing for large display text.',
+  },
+  letterSpacingHeadingXl: {
+    description: 'The default letter spacing for h1s.',
+  },
+  letterSpacingHeadingL: {
+    description: 'The default letter spacing for h2s.',
+  },
+  letterSpacingHeadingM: {
+    description: 'The default letter spacing for h3s.',
+  },
+  letterSpacingHeadingS: {
+    description: 'The default letter spacing for h4s.',
+  },
+  lineHeightBodyM: {
+    description: 'The default line height for regular body text.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightBodyS: {
+    description: 'The default line height for small body text.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightDisplayL: {
+    description: 'The default line height for large display text.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightHeadingXl: {
+    description: 'The default line height for h1s.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightHeadingL: {
+    description: 'The default line height for h2s.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightHeadingM: {
+    description: 'The default line height for h3s.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightHeadingS: {
+    description: 'The default line height for h4s.',
+    themeable: true,
+    public: true,
+  },
+  lineHeightHeadingXs: {
+    description: 'The default line height for h5s.',
+    themeable: true,
+    public: true,
+  },
 };
 
 export default metadata;


### PR DESCRIPTION
### Description

This change publishes base typography tokens (font size, line height, font weight) for body, heading, and display text styles. These tokens will also be themeable.

Related links, if available: Website: CR-100498948, Demos: CR-10050128, theming-core [#58](https://github.com/cloudscape-design/theming-core/pull/58)
Issue #: [#1330](https://github.com/cloudscape-design/components/issues/1330)

### How has this been tested?

Ran through dev pipeline: AwsUi-v3-katiegeo

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
