### PR TITLE
fix: JSDOM compatibility in mixed line bar chart

### DIFF
--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -15,7 +15,10 @@ export function nodeBelongs(container: Node | null, target: Node | EventTarget |
   if (!(target instanceof Node)) {
     return false;
   }
-  const portal = findUpUntil(target as HTMLElement, node => !!node.dataset.awsuiReferrerId);
+  const portal = findUpUntil(
+    target as HTMLElement,
+    node => node instanceof HTMLElement && !!node.dataset.awsuiReferrerId
+  );
   const referrer = portal instanceof HTMLElement ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
   return referrer ? nodeContains(container, referrer) : nodeContains(container, target);
 }

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -772,7 +772,7 @@ describe('Filter', () => {
 
   describe('Dropdown', () => {
     const openDropdown = (wrapper: MixedLineBarChartWrapper) => {
-      wrapper.findDefaultFilter()?.openDropdown();
+      wrapper.findDefaultFilter()!.openDropdown();
       return wrapper.findDefaultFilter()!.findDropdown()!;
     };
 
@@ -803,6 +803,17 @@ describe('Filter', () => {
       expect(dropdownWrapper.findOptions()).toHaveLength(defaultData.length);
       expect(dropdownWrapper.findSelectedOptions()).toHaveLength(1);
       expect(dropdownWrapper.findSelectedOptions()[0].getElement()).toHaveTextContent(defaultData[1].title);
+    });
+
+    test('allows filtering segments', () => {
+      const { wrapper } = renderMixedChart(<MixedLineBarChart series={defaultData} />);
+
+      expect(wrapper.findSeries()).toHaveLength(2);
+
+      wrapper.findDefaultFilter()!.openDropdown();
+      wrapper.findDefaultFilter()!.selectOption(1);
+      wrapper.findDefaultFilter()!.closeDropdown();
+      expect(wrapper.findSeries()).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
### Description

In JSDOM, when calling `element.blur()`, `event.relatedTarget` can be `Document` instance, which has no `dataset` property. 

In real browsers, it is `null` in this case, and works as expected

Related links, issue #, if available: AWSUI-22179

### How has this been tested?

Added an extra unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
