### PR TITLE
chore: Add vr class from window symbol value

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -17,8 +17,9 @@ import Header from './components/header';
 import StrictModeWrapper from './components/strict-mode-wrapper';
 import AppContext, { AppContextProvider, parseQuery } from './app-context';
 
+const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
 interface ExtendedWindow extends Window {
-  [key: symbol]: (() => boolean) | undefined;
+  [awsuiVisualRefreshFlag]?: () => boolean;
 }
 declare const window: ExtendedWindow;
 
@@ -77,15 +78,9 @@ function App() {
 
 const history = createHashHistory();
 const { visualRefresh } = parseQuery(history.location.search);
-const { windowVR } = parseQuery(history.location.search);
 
 // The VR class needs to be set before any React rendering occurs.
-if (windowVR !== true && windowVR !== false) {
-  window[Symbol.for('isVisualRefresh')] = undefined;
-  document.body.classList.toggle('awsui-visual-refresh', visualRefresh);
-} else {
-  window[Symbol.for('isVisualRefresh')] = () => windowVR;
-}
+window[awsuiVisualRefreshFlag] = () => visualRefresh;
 
 render(
   <HashRouter>

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -17,6 +17,11 @@ import Header from './components/header';
 import StrictModeWrapper from './components/strict-mode-wrapper';
 import AppContext, { AppContextProvider, parseQuery } from './app-context';
 
+interface ExtendedWindow extends Window {
+  [key: symbol]: (() => boolean) | undefined;
+}
+declare const window: ExtendedWindow;
+
 function isAppLayoutPage(pageId?: string) {
   const appLayoutPages = ['app-layout', 'content-layout', 'grid-navigation-custom'];
   return pageId !== undefined && appLayoutPages.some(match => pageId.includes(match));
@@ -72,9 +77,15 @@ function App() {
 
 const history = createHashHistory();
 const { visualRefresh } = parseQuery(history.location.search);
+const { windowVR } = parseQuery(history.location.search);
 
 // The VR class needs to be set before any React rendering occurs.
-document.body.classList.toggle('awsui-visual-refresh', visualRefresh);
+if (windowVR !== true && windowVR !== false) {
+  window[Symbol.for('isVisualRefresh')] = undefined;
+  document.body.classList.toggle('awsui-visual-refresh', visualRefresh);
+} else {
+  window[Symbol.for('isVisualRefresh')] = () => windowVR;
+}
 
 render(
   <HashRouter>

--- a/src/app-layout/__integ__/awsui-applayout.test.ts
+++ b/src/app-layout/__integ__/awsui-applayout.test.ts
@@ -5,7 +5,6 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import mobileStyles from '../../../lib/components/app-layout/mobile-toolbar/styles.selectors.js';
 import { viewports } from './constants';
-import styles from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
 
 const wrapper = createWrapper().findAppLayout();
 const mobileSelector = `.${mobileStyles['mobile-bar']}`;
@@ -33,21 +32,13 @@ class AppLayoutPage extends BasePageObject {
 }
 
 function setupTest(
-  {
-    viewport = viewports.desktop,
-    pageName = 'default',
-    trackResizeObserverErrors = true,
-    visualRefresh = false,
-    windowVR = false,
-  },
+  { viewport = viewports.desktop, pageName = 'default', trackResizeObserverErrors = true, visualRefresh = false },
   testFn: (page: AppLayoutPage) => Promise<void>
 ) {
   return useBrowser(async browser => {
     const page = new AppLayoutPage(browser);
     await page.setWindowSize(viewport);
-    await browser.url(
-      `#/light/app-layout/${pageName}?visualRefresh=${visualRefresh}${windowVR ? '&windowVR=true' : ''}`
-    );
+    await browser.url(`#/light/app-layout/${pageName}?visualRefresh=${visualRefresh}`);
     if (trackResizeObserverErrors) {
       await page.trackResizeObserverErrors();
     }
@@ -184,12 +175,5 @@ test(
     await page.click(wrapper.findNotifications().findFlashbar().findItems().get(1).findDismissButton().toSelector());
     const { height: newHeight } = await page.getBoundingBox(wrapper.findNotifications().toSelector());
     expect(newHeight).toEqual(0);
-  })
-);
-
-test(
-  'render page in VR when window[Symbol.for(`isVisualRefresh`)] returns true',
-  setupTest({ pageName: 'with-table', trackResizeObserverErrors: false, windowVR: true }, async page => {
-    await expect(page.isExisting(wrapper.find(`.${styles.background}`).toSelector())).resolves.toBe(true);
   })
 );

--- a/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
+++ b/src/internal/hooks/use-visual-mode/__tests__/use-visual-mode.test.tsx
@@ -4,6 +4,12 @@ import React from 'react';
 import { useVisualRefresh, clearVisualRefreshState } from '../index';
 import { render, screen } from '@testing-library/react';
 
+declare global {
+  interface Window {
+    [key: symbol]: (() => boolean) | undefined;
+  }
+}
+
 jest.mock('../../../environment', () => ({ ALWAYS_VISUAL_REFRESH: false }), { virtual: true });
 
 describe('useVisualRefresh', () => {
@@ -37,5 +43,26 @@ describe('useVisualRefresh', () => {
     rerender(<App />);
     expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/Dynamic visual refresh change detected/));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+  });
+
+  describe('Window Symbol isVisualRefresh ', () => {
+    afterEach(() => {
+      window[Symbol.for('isVisualRefresh')] = undefined;
+    });
+
+    test('should return true when Window Symbol isVisualRefresh is true', () => {
+      window[Symbol.for('isVisualRefresh')] = () => true;
+      render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    });
+
+    test('should not change theme when Window Symbol isVisualRefresh is set later', () => {
+      const { rerender } = render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+
+      window[Symbol.for('isVisualRefresh')] = () => true;
+      rerender(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    });
   });
 });

--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -5,6 +5,11 @@ import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 import { isDevelopment } from '../../is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
+interface ExtendedWindow extends Window {
+  [key: symbol]: (() => boolean) | undefined;
+}
+declare const window: ExtendedWindow;
+
 export const useVisualRefresh = ALWAYS_VISUAL_REFRESH ? () => true : useVisualRefreshDynamic;
 
 // We expect VR is to be set only once and before the application is rendered.
@@ -21,6 +26,9 @@ function detectVisualRefresh() {
 
 export function useVisualRefreshDynamic() {
   if (visualRefreshState === undefined) {
+    if (typeof window !== 'undefined' && window[Symbol.for('isVisualRefresh')]?.()) {
+      document.body.classList.add('awsui-visual-refresh');
+    }
     visualRefreshState = detectVisualRefresh();
   }
   if (isDevelopment) {

--- a/src/internal/hooks/use-visual-mode/index.ts
+++ b/src/internal/hooks/use-visual-mode/index.ts
@@ -5,8 +5,9 @@ import { ALWAYS_VISUAL_REFRESH } from '../../environment';
 import { isDevelopment } from '../../is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
+const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
 interface ExtendedWindow extends Window {
-  [key: symbol]: (() => boolean) | undefined;
+  [awsuiVisualRefreshFlag]?: () => boolean;
 }
 declare const window: ExtendedWindow;
 
@@ -26,10 +27,11 @@ function detectVisualRefresh() {
 
 export function useVisualRefreshDynamic() {
   if (visualRefreshState === undefined) {
-    if (typeof window !== 'undefined' && window[Symbol.for('isVisualRefresh')]?.()) {
-      document.body.classList.add('awsui-visual-refresh');
-    }
     visualRefreshState = detectVisualRefresh();
+    if (!visualRefreshState && typeof window !== 'undefined' && window[awsuiVisualRefreshFlag]?.()) {
+      document.body.classList.add('awsui-visual-refresh');
+      visualRefreshState = true;
+    }
   }
   if (isDevelopment) {
     const newVisualRefreshState = detectVisualRefresh();


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

When window[Symbol.for('awsui-visual-refresh-flag')] returns true, renders page in VR.
GlobalStyles: 100722878
Updating Dashboard...

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
