### PR TITLE
chore: Fix names in funnelSubStepComplete event

### DIFF
--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -61,12 +61,16 @@ export const useFunnelSubStep = () => {
       */
       latestFocusCleanupFunction.current?.();
 
+      const subStepName = getNameFromSelector(subStepNameSelector);
+      const stepName = getNameFromSelector(stepNameSelector);
+
       FunnelMetrics.funnelSubStepStart({
         funnelInteractionId,
         subStepSelector,
         subStepNameSelector,
-        subStepName: getNameFromSelector(subStepNameSelector),
+        subStepName,
         stepNumber,
+        stepName,
         stepNameSelector,
         subStepAllSelector: getSubStepAllSelector(),
       });
@@ -93,8 +97,9 @@ export const useFunnelSubStep = () => {
             funnelInteractionId,
             subStepSelector,
             subStepNameSelector,
-            subStepName: getNameFromSelector(subStepNameSelector),
+            subStepName,
             stepNumber,
+            stepName,
             stepNameSelector,
             subStepAllSelector: getSubStepAllSelector(),
           });


### PR DESCRIPTION
### Description

This PR fixes incorrect names in the `funnelSubStepComplete` event.

The names are incorrect when the user has focused a text field and then clicks the button to proceed to the next step. In this situation, the `funnelSubStepComplete` event is emitted after the step transition has happened, and thus the element selectors point to wrong elements now.

To mitigate this, we save the names already at the point where we emit the corresponding start event. This matches the approach we're already taking for the `funnelStepComplete` event: https://github.com/cloudscape-design/components/blob/df04533aa56157985792e1ceb8aaf965a77a193d/src/internal/analytics/components/analytics-funnel.tsx#L231-L255

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Manually tested in dev pages

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
