### PR TITLE
fix: Cleanup sticky columns listeners when table cells unmount

### DIFF
--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -15,6 +15,7 @@ import AppContext, { AppContextType } from '../app/app-context';
 
 type DemoContext = React.Context<
   AppContextType<{
+    loading: boolean;
     resizableColumns: boolean;
     stickyHeader: boolean;
     sortingDisabled: boolean;
@@ -165,6 +166,10 @@ export default () => {
       <SpaceBetween size="xl">
         <SpaceBetween direction="horizontal" size="m">
           <FormField label="Table flags">
+            <Checkbox checked={urlParams.loading} onChange={event => setUrlParams({ loading: event.detail.checked })}>
+              Loading
+            </Checkbox>
+
             <Checkbox
               checked={urlParams.resizableColumns}
               onChange={event => setUrlParams({ resizableColumns: event.detail.checked })}

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -14,6 +14,17 @@ const testItem = {
   test: 'testData',
 };
 
+const stickyCellRef = jest.fn();
+
+jest.mock('../../../lib/components/table/sticky-columns', () => ({
+  ...jest.requireActual('../../../lib/components/table/sticky-columns'),
+  useStickyCellStyles: () => ({ ref: stickyCellRef }),
+}));
+
+afterEach(() => {
+  stickyCellRef.mockReset();
+});
+
 const column: TableProps.ColumnDefinition<typeof testItem> = {
   id: 'test',
   header: 'Test',
@@ -150,6 +161,16 @@ describe('TableBodyCell', () => {
       },
     };
     render(<TestComponent2 column={col} />);
+  });
+
+  it('should call sticky columns ref on mount and unmount', () => {
+    const { unmount } = render(<TestComponent />);
+
+    expect(stickyCellRef).toHaveBeenCalledWith(expect.any(HTMLTableCellElement));
+
+    unmount();
+
+    expect(stickyCellRef).toHaveBeenCalledWith(null);
   });
 
   describe('success icon behaviour', () => {

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -6,6 +6,7 @@ import styles from './styles.css.js';
 import { getStickyClassNames } from '../utils';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { TableRole, getTableCellRoleProps } from '../table-role';
+import { useMergeRefs } from '../../internal/hooks/use-merge-refs/index.js';
 
 export interface TableTdElementProps {
   className?: string;
@@ -74,6 +75,9 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       columnId,
       getClassName: props => getStickyClassNames(styles, props),
     });
+
+    const mergedRef = useMergeRefs(stickyStyles.ref, ref);
+
     return (
       <Element
         style={{ ...style, ...stickyStyles.style }}
@@ -96,12 +100,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         onClick={onClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        ref={node => {
-          stickyStyles.ref(node);
-          if (node && ref) {
-            (ref as React.MutableRefObject<HTMLTableCellElement>).current = node;
-          }
-        }}
+        ref={mergedRef}
         {...nativeAttributes}
       >
         {children}

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -97,11 +97,9 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         ref={node => {
-          if (node) {
-            stickyStyles.ref(node);
-            if (ref) {
-              (ref as React.MutableRefObject<HTMLTableCellElement>).current = node;
-            }
+          stickyStyles.ref(node);
+          if (node && ref) {
+            (ref as React.MutableRefObject<HTMLTableCellElement>).current = node;
           }
         }}
         {...nativeAttributes}

--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -64,7 +64,7 @@ test('styles update when sticky column properties change', () => {
   });
   createMockTable(result.current, 500, 500, 100, 200, 300);
 
-  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles');
+  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles' as any);
 
   expect(updateCellStylesSpy).not.toHaveBeenCalled();
 
@@ -89,7 +89,7 @@ test('styles update when wrapper scrolls', () => {
   );
   result.current.refs.wrapper(tableWrapper);
   result.current.refs.table(table);
-  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles');
+  const updateCellStylesSpy = jest.spyOn(result.current.store, 'updateCellStyles' as any);
 
   expect(updateCellStylesSpy).not.toHaveBeenCalled();
 
@@ -239,6 +239,38 @@ test('performs styles cleanup', () => {
   rerender({ visibleColumns, stickyColumnsFirst: 0, stickyColumnsLast: 0 });
 
   expect(elements.cells[0]).not.toHaveClass('sticky-cell');
+});
+
+test('cell subscriptions are cleaned up on ref change and un-mount', () => {
+  const unsubscribe = jest.fn();
+  const subscribe = jest.fn().mockImplementation(() => unsubscribe);
+  const stickyColumns = {
+    store: {
+      get: () => ({ cellState: {}, wrapperState: { scrollPaddingLeft: 0, scrollPaddingRight: 0 } }),
+      subscribe,
+      unsubscribe: () => {},
+    },
+    style: { wrapper: {} },
+    refs: { table: () => {}, wrapper: () => {}, cell: () => {} },
+  };
+  const { result, unmount } = renderHook(() =>
+    useStickyCellStyles({ stickyColumns, columnId: '1', getClassName: () => ({}) })
+  );
+
+  result.current.ref(document.createElement('td'));
+
+  expect(subscribe).toHaveBeenCalledTimes(1);
+  expect(unsubscribe).toHaveBeenCalledTimes(0);
+
+  result.current.ref(document.createElement('td'));
+
+  expect(subscribe).toHaveBeenCalledTimes(2);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+  unmount();
+
+  expect(subscribe).toHaveBeenCalledTimes(2);
+  expect(unsubscribe).toHaveBeenCalledTimes(2);
 });
 
 describe('getStickyClassNames helper', () => {

--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -241,9 +241,9 @@ test('performs styles cleanup', () => {
   expect(elements.cells[0]).not.toHaveClass('sticky-cell');
 });
 
-test('cell subscriptions are cleaned up on ref change and un-mount', () => {
+test('cell subscriptions are cleaned up on ref change', () => {
   const unsubscribe = jest.fn();
-  const subscribe = jest.fn().mockImplementation(() => unsubscribe);
+  const subscribe = jest.fn(() => unsubscribe);
   const stickyColumns = {
     store: {
       get: () => ({ cellState: {}, wrapperState: { scrollPaddingLeft: 0, scrollPaddingRight: 0 } }),
@@ -253,9 +253,7 @@ test('cell subscriptions are cleaned up on ref change and un-mount', () => {
     style: { wrapper: {} },
     refs: { table: () => {}, wrapper: () => {}, cell: () => {} },
   };
-  const { result, unmount } = renderHook(() =>
-    useStickyCellStyles({ stickyColumns, columnId: '1', getClassName: () => ({}) })
-  );
+  const { result } = renderHook(() => useStickyCellStyles({ stickyColumns, columnId: '1', getClassName: () => ({}) }));
 
   result.current.ref(document.createElement('td'));
 
@@ -267,7 +265,7 @@ test('cell subscriptions are cleaned up on ref change and un-mount', () => {
   expect(subscribe).toHaveBeenCalledTimes(2);
   expect(unsubscribe).toHaveBeenCalledTimes(1);
 
-  unmount();
+  result.current.ref(null);
 
   expect(subscribe).toHaveBeenCalledTimes(2);
   expect(unsubscribe).toHaveBeenCalledTimes(2);

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import AsyncStore from '../../area-chart/async-store';
+import AsyncStore, { ReadonlyAsyncStore } from '../../area-chart/async-store';
 import clsx from 'clsx';
 import { useResizeObserver, useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import {
@@ -19,7 +19,7 @@ import { isCellStatesEqual, isWrapperStatesEqual, updateCellOffsets } from './ut
 const MINIMUM_SCROLLABLE_SPACE = 148;
 
 export interface StickyColumnsModel {
-  store: StickyColumnsStore;
+  store: ReadonlyAsyncStore<StickyColumnsState>;
   style: {
     wrapper?: React.CSSProperties;
   };
@@ -200,6 +200,11 @@ export function useStickyCellStyles({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [columnId, setCell, stickyColumns.store]
   );
+
+  // Subscriptions created in the refCallback must be cancelled when the component un-mounts.
+  useEffect(() => {
+    return () => unsubscribeRef.current?.();
+  }, []);
 
   // Provide cell styles as props so that a re-render won't cause invalidation.
   const cellStyles = stickyColumns.store.get().cellState[columnId];

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -201,11 +201,6 @@ export function useStickyCellStyles({
     [columnId, setCell, stickyColumns.store]
   );
 
-  // Subscriptions created in the refCallback must be cancelled when the component un-mounts.
-  useEffect(() => {
-    return () => unsubscribeRef.current?.();
-  }, []);
-
   // Provide cell styles as props so that a re-render won't cause invalidation.
   const cellStyles = stickyColumns.store.get().cellState[columnId];
   return {


### PR DESCRIPTION
### Description

The missing subscription cleanup function caused a memory leak.

ref: AWSUI-22191

### How has this been tested?

New unit test added.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
