### PR TITLE
chore: Emit `funnelStepChange` events

### DIFF
--- a/pages/funnel-analytics/dynamic-multi-page-flow.page.tsx
+++ b/pages/funnel-analytics/dynamic-multi-page-flow.page.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Wizard, { WizardProps } from '~components/wizard';
+
+import { i18nStrings } from '../wizard/common';
+import Container from '~components/container';
+import Header from '~components/header';
+import Link from '~components/link';
+import { Button, SpaceBetween } from '~components';
+
+export default function WizardPage() {
+  const [subStepCount1, setSubStepCount1] = useState(2);
+  const [subStepCount2, setSubStepCount2] = useState(7);
+
+  const steps: WizardProps.Step[] = [
+    {
+      title: 'Step 1',
+      info: <Link variant="info">Info</Link>,
+      content: (
+        <div>
+          <SpaceBetween size="l">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setSubStepCount1(c => c + 1)}>Increase substep count</Button>
+              <Button onClick={() => setSubStepCount1(c => c - 1)}>Decrease substep count</Button>
+            </SpaceBetween>
+
+            {Array(subStepCount1)
+              .fill(0)
+              .map((_, i) => (
+                <Container key={i} header={<Header>A container in step 1 for substep {i + 1}</Header>}>
+                  This is a text on the substep level
+                </Container>
+              ))}
+          </SpaceBetween>
+        </div>
+      ),
+    },
+    {
+      title: 'Step 2',
+      content: (
+        <div>
+          <SpaceBetween size="l">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setSubStepCount2(c => c + 1)}>Increase substep count</Button>
+              <Button onClick={() => setSubStepCount2(c => c - 1)}>Decrease substep count</Button>
+            </SpaceBetween>
+
+            {Array(subStepCount2)
+              .fill(0)
+              .map((_, i) => (
+                <Container key={i} header={<Header>A container in step 2 for substep {i + 1}</Header>}>
+                  This is a text on the substep level
+                </Container>
+              ))}
+          </SpaceBetween>
+        </div>
+      ),
+    },
+  ];
+
+  return <Wizard steps={steps} i18nStrings={i18nStrings} />;
+}

--- a/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
+++ b/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Container from '~components/container';
+import Header from '~components/header';
+import { Box, BreadcrumbGroup, Button, Form, SpaceBetween } from '~components';
+
+export default function WizardPage() {
+  const [containerCount, setContainerCount] = useState(2);
+
+  return (
+    <Box padding="xl">
+      <SpaceBetween size="xxl">
+        <BreadcrumbGroup
+          items={[
+            { text: 'Resources', href: '#example-link' },
+            { text: 'Create resource', href: '#example-link' },
+          ]}
+          onFollow={e => e.preventDefault()}
+        />
+
+        <Form>
+          <SpaceBetween size="l">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={() => setContainerCount(c => c + 1)}>Increase substep count</Button>
+              <Button onClick={() => setContainerCount(c => c - 1)}>Decrease substep count</Button>
+            </SpaceBetween>
+
+            {Array(containerCount)
+              .fill(0)
+              .map((_, i) => (
+                <Container key={i} header={<Header>A container for substep {i + 1}</Header>}>
+                  This is a text on the substep level
+                </Container>
+              ))}
+          </SpaceBetween>
+        </Form>
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
+++ b/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
@@ -20,7 +20,7 @@ export default function WizardPage() {
           onFollow={e => e.preventDefault()}
         />
 
-        <Form>
+        <Form header={<Header variant="h1">A form with dynamic substeps</Header>}>
           <SpaceBetween size="l">
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={() => setContainerCount(c => c + 1)}>Increase substep count</Button>

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -13,6 +13,8 @@ import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
+import Container from '../../../lib/components/container';
+import Header from '../../../lib/components/header';
 
 describe('Form Analytics', () => {
   beforeEach(() => {
@@ -296,5 +298,59 @@ describe('Form Analytics', () => {
 
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
+  });
+
+  test('send a funnelStepChange event when the substeps change', () => {
+    const { rerender } = render(
+      <Form>
+        <Container header={<Header>Substep 1</Header>}></Container>
+        <Container header={<Header>Substep 2</Header>}></Container>
+        <Container header={<Header>Substep 3</Header>}></Container>
+      </Form>
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStepChange).not.toHaveBeenCalled();
+
+    rerender(
+      <Form>
+        <Container header={<Header>Substep 1</Header>}></Container>
+        <Container header={<Header>Substep 3</Header>}></Container>
+      </Form>
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(1);
+
+    expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        subStepConfiguration: [
+          { name: 'Substep 1', number: 1 },
+          { name: 'Substep 3', number: 2 },
+        ],
+      })
+    );
+
+    rerender(
+      <Form>
+        <Container header={<Header>Substep 0</Header>}></Container>
+        <Container header={<Header>Substep 1</Header>}></Container>
+        <Container header={<Header>Substep 2</Header>}></Container>
+        <Container header={<Header>Substep 3</Header>}></Container>
+        <Container header={<Header>Substep 4</Header>}></Container>
+      </Form>
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(2);
+
+    expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        subStepConfiguration: [
+          { name: 'Substep 0', number: 1 },
+          { name: 'Substep 1', number: 2 },
+          { name: 'Substep 2', number: 3 },
+          { name: 'Substep 3', number: 4 },
+          { name: 'Substep 4', number: 5 },
+        ],
+      })
+    );
   });
 });

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -26,6 +26,7 @@ describe('useFunnelStep hook', () => {
           subStepCount: { current: 0 },
           isInStep: true,
           funnelInteractionId: 'a placeholder funnel interaction ID',
+          onStepChange: jest.fn(),
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -30,6 +30,8 @@ export interface FunnelStepContextValue {
   subStepCount: MutableRefObject<number>;
   isInStep: boolean;
   funnelInteractionId: string | undefined;
+  /** This function is called when the list of substeps in this step changes.  */
+  onStepChange: () => void;
 }
 
 export interface FunnelSubStepContextValue {
@@ -79,6 +81,7 @@ export const FunnelStepContext = createContext<FunnelStepContextValue>({
   subStepCount: { current: 0 },
   isInStep: false,
   funnelInteractionId: undefined,
+  onStepChange: () => {},
 });
 
 export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -83,11 +83,11 @@ export interface FunnelChangeProps extends BaseFunnelProps {
 
 export interface FunnelStepChangeProps extends BaseFunnelProps {
   stepNumber: number;
-  stepName?: string;
-  stepNameSelector?: string;
-  subStepAllSelector?: string;
-  totalSubSteps?: number;
-  subStepConfiguration?: SubStepConfiguration[];
+  stepName: string;
+  stepNameSelector: string;
+  subStepAllSelector: string;
+  totalSubSteps: number;
+  subStepConfiguration: SubStepConfiguration[];
 }
 
 export interface StepConfiguration {

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -23,8 +23,8 @@ export const getFunnelValueSelector = (value: string) => `[${DATA_ATTR_FUNNEL_VA
 
 export const getSubStepAllSelector = () => `[${DATA_ATTR_FUNNEL_SUBSTEP}]`;
 export const getSubStepSelector = (subStepId: string) => `[${DATA_ATTR_FUNNEL_SUBSTEP}="${subStepId}"]`;
-export const getSubStepNameSelector = (subStepId: string) =>
-  [`${getSubStepSelector(subStepId)}`, `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_SUBSTEP_NAME}"]`].join(' ');
+export const getSubStepNameSelector = (subStepId?: string) =>
+  [subStepId ? getSubStepSelector(subStepId) : '', `[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_SUBSTEP_NAME}"]`].join(' ');
 
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
 


### PR DESCRIPTION
### Description

This PR emits the `funnelStepChange` event whenever a funnel step is modified, i.e. when the substeps of the step change.

The events have been added in https://github.com/cloudscape-design/components/pull/1507.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests and tested manually in new dev pages.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
