### PR TITLE
chore: Emit `funnelChange` events

### DIFF
--- a/pages/funnel-analytics/dynamic-multi-page-flow.page.tsx
+++ b/pages/funnel-analytics/dynamic-multi-page-flow.page.tsx
@@ -12,6 +12,7 @@ import { Button, SpaceBetween } from '~components';
 export default function WizardPage() {
   const [subStepCount1, setSubStepCount1] = useState(2);
   const [subStepCount2, setSubStepCount2] = useState(7);
+  const [extraStepCount, setExtraStepCount] = useState(1);
 
   const steps: WizardProps.Step[] = [
     {
@@ -22,7 +23,9 @@ export default function WizardPage() {
           <SpaceBetween size="l">
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={() => setSubStepCount1(c => c + 1)}>Increase substep count</Button>
-              <Button onClick={() => setSubStepCount1(c => c - 1)}>Decrease substep count</Button>
+              <Button onClick={() => setSubStepCount1(c => c - 1)} disabled={subStepCount1 <= 0}>
+                Decrease substep count
+              </Button>
             </SpaceBetween>
 
             {Array(subStepCount1)
@@ -43,7 +46,9 @@ export default function WizardPage() {
           <SpaceBetween size="l">
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={() => setSubStepCount2(c => c + 1)}>Increase substep count</Button>
-              <Button onClick={() => setSubStepCount2(c => c - 1)}>Decrease substep count</Button>
+              <Button onClick={() => setSubStepCount2(c => c - 1)} disabled={subStepCount2 <= 0}>
+                Decrease substep count
+              </Button>
             </SpaceBetween>
 
             {Array(subStepCount2)
@@ -59,5 +64,36 @@ export default function WizardPage() {
     },
   ];
 
-  return <Wizard steps={steps} i18nStrings={i18nStrings} />;
+  const extraSteps = Array(extraStepCount)
+    .fill(0)
+    .map((_, index) => ({
+      title: `Step ${steps.length + index + 1}`,
+      isOptional: index % 3 === 0,
+      content: (
+        <div>
+          <SpaceBetween size="l">
+            <Container header={<Header>A container in step {steps.length + index + 1}</Header>}>
+              This is a text on the substep level
+            </Container>
+            <Container header={<Header>Another container in step {steps.length + index + 1}</Header>}>
+              This is a text on the substep level
+            </Container>
+          </SpaceBetween>
+        </div>
+      ),
+    }));
+
+  return (
+    <>
+      <SpaceBetween size="l">
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button onClick={() => setExtraStepCount(c => c + 1)}>Increase step count</Button>
+          <Button onClick={() => setExtraStepCount(c => c - 1)} disabled={extraStepCount <= 0}>
+            Decrease step count
+          </Button>
+        </SpaceBetween>
+        <Wizard steps={[...steps, ...extraSteps]} i18nStrings={i18nStrings} />
+      </SpaceBetween>
+    </>
+  );
 }

--- a/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
+++ b/pages/funnel-analytics/dynamic-single-page-flow.page.tsx
@@ -24,7 +24,9 @@ export default function WizardPage() {
           <SpaceBetween size="l">
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={() => setContainerCount(c => c + 1)}>Increase substep count</Button>
-              <Button onClick={() => setContainerCount(c => c - 1)}>Decrease substep count</Button>
+              <Button onClick={() => setContainerCount(c => c - 1)} disabled={containerCount <= 0}>
+                Decrease substep count
+              </Button>
             </SpaceBetween>
 
             {Array(containerCount)

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -30,7 +30,7 @@ import {
 } from '../selectors';
 import { useDebounceCallback } from '../../hooks/use-debounce-callback';
 
-export const FUNNEL_VERSION = '1.0';
+export const FUNNEL_VERSION = '1.1';
 
 type AnalyticsFunnelProps = { children?: React.ReactNode } & Pick<
   FunnelProps,

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -227,7 +227,7 @@ function useStepChangeListener(handler: (stepConfiguration: SubStepConfiguration
       return;
     }
 
-    const subSteps = Array.from(document.querySelectorAll(getSubStepAllSelector())) as HTMLElement[];
+    const subSteps = Array.from(document.querySelectorAll<HTMLElement>(getSubStepAllSelector()));
 
     const subStepConfiguration = subSteps.map((substep, index) => {
       const name = substep.querySelector(getSubStepNameSelector())?.textContent ?? '';

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -377,129 +377,204 @@ describe('Wizard Analytics', () => {
     expect(document.querySelector(getFunnelKeySelector(FUNNEL_KEY_STEP_NAME))?.textContent).toBe('Step 2 - optional');
   });
 
-  test('send a funnelStepChange event when the substeps change', () => {
-    const { rerender } = render(
-      <Wizard
-        steps={[
-          {
-            title: 'Step 1',
-            content: (
-              <>
-                <Container header={<Header>Substep 1</Header>}></Container>
-                <Container header={<Header>Substep 2</Header>}></Container>
-                <Container header={<Header>Substep 3</Header>}></Container>
-              </>
-            ),
-          },
-        ]}
-        activeStepIndex={0}
-        onNavigate={() => {}}
-        i18nStrings={DEFAULT_I18N_SETS[0]}
-      />
-    );
-    act(() => void jest.runAllTimers());
-    expect(FunnelMetrics.funnelStepChange).not.toHaveBeenCalled();
+  describe('funnelStepChange', () => {
+    test('sends a funnelStepChange event when the substeps change', () => {
+      const { rerender } = render(
+        <Wizard
+          steps={[
+            {
+              title: 'Step 1',
+              content: (
+                <>
+                  <Container header={<Header>Substep 1</Header>}></Container>
+                  <Container header={<Header>Substep 2</Header>}></Container>
+                  <Container header={<Header>Substep 3</Header>}></Container>
+                </>
+              ),
+            },
+          ]}
+          activeStepIndex={0}
+          onNavigate={() => {}}
+          i18nStrings={DEFAULT_I18N_SETS[0]}
+        />
+      );
+      act(() => void jest.runAllTimers());
+      expect(FunnelMetrics.funnelStepChange).not.toHaveBeenCalled();
 
-    rerender(
-      <Wizard
-        steps={[
-          {
-            title: 'Step 1',
-            content: (
-              <>
-                <Container header={<Header>Substep 1</Header>}></Container>
-                <Container header={<Header>Substep 3</Header>}></Container>
-              </>
-            ),
-          },
-        ]}
-        activeStepIndex={0}
-        onNavigate={() => {}}
-        i18nStrings={DEFAULT_I18N_SETS[0]}
-      />
-    );
-    act(() => void jest.runAllTimers());
-    expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(1);
+      rerender(
+        <Wizard
+          steps={[
+            {
+              title: 'Step 1',
+              content: (
+                <>
+                  <Container header={<Header>Substep 1</Header>}></Container>
+                  <Container header={<Header>Substep 3</Header>}></Container>
+                </>
+              ),
+            },
+          ]}
+          activeStepIndex={0}
+          onNavigate={() => {}}
+          i18nStrings={DEFAULT_I18N_SETS[0]}
+        />
+      );
+      act(() => void jest.runAllTimers());
+      expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(1);
 
-    expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        subStepConfiguration: [
-          { name: 'Substep 1', number: 1 },
-          { name: 'Substep 3', number: 2 },
-        ],
-      })
-    );
+      expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subStepConfiguration: [
+            { name: 'Substep 1', number: 1 },
+            { name: 'Substep 3', number: 2 },
+          ],
+        })
+      );
 
-    rerender(
-      <Wizard
-        steps={[
-          {
-            title: 'Step 1',
-            content: (
-              <>
-                <Container header={<Header>Substep 0</Header>}></Container>
-                <Container header={<Header>Substep 1</Header>}></Container>
-                <Container header={<Header>Substep 2</Header>}></Container>
-                <Container header={<Header>Substep 3</Header>}></Container>
-                <Container header={<Header>Substep 4</Header>}></Container>
-              </>
-            ),
-          },
-        ]}
-        activeStepIndex={0}
-        onNavigate={() => {}}
-        i18nStrings={DEFAULT_I18N_SETS[0]}
-      />
-    );
-    act(() => void jest.runAllTimers());
-    expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(2);
+      rerender(
+        <Wizard
+          steps={[
+            {
+              title: 'Step 1',
+              content: (
+                <>
+                  <Container header={<Header>Substep 0</Header>}></Container>
+                  <Container header={<Header>Substep 1</Header>}></Container>
+                  <Container header={<Header>Substep 2</Header>}></Container>
+                  <Container header={<Header>Substep 3</Header>}></Container>
+                  <Container header={<Header>Substep 4</Header>}></Container>
+                </>
+              ),
+            },
+          ]}
+          activeStepIndex={0}
+          onNavigate={() => {}}
+          i18nStrings={DEFAULT_I18N_SETS[0]}
+        />
+      );
+      act(() => void jest.runAllTimers());
+      expect(FunnelMetrics.funnelStepChange).toHaveBeenCalledTimes(2);
 
-    expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        subStepConfiguration: [
-          { name: 'Substep 0', number: 1 },
-          { name: 'Substep 1', number: 2 },
-          { name: 'Substep 2', number: 3 },
-          { name: 'Substep 3', number: 4 },
-          { name: 'Substep 4', number: 5 },
-        ],
-      })
-    );
+      expect(FunnelMetrics.funnelStepChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          subStepConfiguration: [
+            { name: 'Substep 0', number: 1 },
+            { name: 'Substep 1', number: 2 },
+            { name: 'Substep 2', number: 3 },
+            { name: 'Substep 3', number: 4 },
+            { name: 'Substep 4', number: 5 },
+          ],
+        })
+      );
+    });
+
+    test('does not send a funnelStepChange event when navigating to another step', () => {
+      const steps = [
+        {
+          title: 'Step 1 with three containers',
+          content: (
+            <>
+              <Container header={<Header>Substep 1</Header>}></Container>
+              <Container header={<Header>Substep 2</Header>}></Container>
+              <Container header={<Header>Substep 3</Header>}></Container>
+            </>
+          ),
+        },
+        // The second step has a different amount of substeps than the previous one,
+        // but that should not be counted as a funnelStepChange event.
+        {
+          title: 'Step 2 with two containers',
+          content: (
+            <>
+              <Container header={<Header>Substep 1</Header>}></Container>
+              <Container header={<Header>Substep 2</Header>}></Container>
+            </>
+          ),
+        },
+      ];
+
+      const { rerender } = render(
+        <Wizard steps={steps} activeStepIndex={0} onNavigate={() => {}} i18nStrings={DEFAULT_I18N_SETS[0]} />
+      );
+      act(() => void jest.runAllTimers());
+
+      rerender(<Wizard steps={steps} activeStepIndex={1} onNavigate={() => {}} i18nStrings={DEFAULT_I18N_SETS[0]} />);
+      act(() => void jest.runAllTimers());
+
+      expect(FunnelMetrics.funnelStepChange).not.toHaveBeenCalled();
+    });
   });
 
-  test('does not send a funnelStepChange event when navigating to another step', () => {
-    const steps = [
-      {
-        title: 'Step 1 with three containers',
-        content: (
-          <>
-            <Container header={<Header>Substep 1</Header>}></Container>
-            <Container header={<Header>Substep 2</Header>}></Container>
-            <Container header={<Header>Substep 3</Header>}></Container>
-          </>
-        ),
-      },
-      // The second step has a different amount of substeps than the previous one,
-      // but that should not be counted as a funnelStepChange event.
-      {
-        title: 'Step 2 with two containers',
-        content: (
-          <>
-            <Container header={<Header>Substep 1</Header>}></Container>
-            <Container header={<Header>Substep 2</Header>}></Container>
-          </>
-        ),
-      },
-    ];
-
+  test('sends a funnelChange event when the steps change', () => {
     const { rerender } = render(
-      <Wizard steps={steps} activeStepIndex={0} onNavigate={() => {}} i18nStrings={DEFAULT_I18N_SETS[0]} />
+      <Wizard
+        steps={[
+          {
+            title: 'Select resource',
+            content: <></>,
+          },
+          {
+            title: 'Select type',
+            content: <></>,
+          },
+        ]}
+        i18nStrings={DEFAULT_I18N_SETS[0]}
+      />
     );
     act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelChange).not.toHaveBeenCalled();
 
-    rerender(<Wizard steps={steps} activeStepIndex={1} onNavigate={() => {}} i18nStrings={DEFAULT_I18N_SETS[0]} />);
+    rerender(
+      <Wizard
+        steps={[
+          {
+            title: 'Select resource',
+            content: <></>,
+          },
+        ]}
+        i18nStrings={DEFAULT_I18N_SETS[0]}
+      />
+    );
     act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelChange).toHaveBeenCalledTimes(1);
 
-    expect(FunnelMetrics.funnelStepChange).not.toHaveBeenCalled();
+    expect(FunnelMetrics.funnelChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stepConfiguration: [{ name: 'Select resource', number: 1, isOptional: false }],
+      })
+    );
+
+    rerender(
+      <Wizard
+        steps={[
+          {
+            title: 'Select resource',
+            content: <></>,
+          },
+          {
+            title: 'Select type',
+            content: <></>,
+            isOptional: true,
+          },
+          {
+            title: 'Select configuration',
+            content: <></>,
+          },
+        ]}
+        i18nStrings={DEFAULT_I18N_SETS[0]}
+      />
+    );
+    act(() => void jest.runAllTimers());
+    expect(FunnelMetrics.funnelChange).toHaveBeenCalledTimes(2);
+
+    expect(FunnelMetrics.funnelChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        stepConfiguration: [
+          { name: 'Select resource', number: 1, isOptional: false },
+          { name: 'Select type', number: 2, isOptional: true },
+          { name: 'Select configuration', number: 3, isOptional: false },
+        ],
+      })
+    );
   });
 });

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -43,6 +43,9 @@ describe('Wizard Analytics', () => {
     jest.useFakeTimers();
     mockFunnelMetrics();
   });
+  afterEach(() => {
+    act(() => void jest.runAllTimers());
+  });
 
   test('calls funnelStart when the component is mounted', () => {
     render(<Wizard steps={DEFAULT_STEPS} i18nStrings={DEFAULT_I18N_SETS[0]} />);

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -187,7 +187,7 @@ export default function InternalWizard({
 }
 
 /**
- * This hook observes the step configuration and events the `funnelChange` event when the steps change.
+ * This hook observes the step configuration and emits the `funnelChange` event when the steps change.
  */
 function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: WizardProps['steps']) {
   const listenForStepChanges = useRef(false);

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
@@ -99,6 +99,8 @@ export default function InternalWizard({
     }
   };
 
+  useFunnelChangeEvent(funnelInteractionId, steps);
+
   const i18n = useInternalI18n('wizard');
   const skipToButtonLabel = i18n(
     'i18nStrings.skipToButtonLabel',
@@ -182,4 +184,44 @@ export default function InternalWizard({
       </div>
     </div>
   );
+}
+
+/**
+ * This hook observes the step configuration and events the `funnelChange` event when the steps change.
+ */
+function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: WizardProps['steps']) {
+  const listenForStepChanges = useRef(false);
+
+  useEffect(() => {
+    // We prevent emitting the event before the funnel has stabilised.
+    const handle = setTimeout(() => (listenForStepChanges.current = true), 50);
+
+    return () => {
+      clearTimeout(handle);
+      listenForStepChanges.current = false;
+    };
+  }, [funnelInteractionId]);
+
+  const stepTitles = steps.map(step => step.title).join();
+  useEffect(() => {
+    if (!funnelInteractionId || !listenForStepChanges.current) {
+      return;
+    }
+
+    const stepConfiguration = steps.map((step, index) => ({
+      name: step.title,
+      number: index + 1,
+      isOptional: step.isOptional ?? false,
+    }));
+
+    FunnelMetrics.funnelChange({
+      funnelInteractionId,
+      stepConfiguration,
+    });
+
+    // This dependency array does not include `steps`, because `steps` is not stable across renders.
+    // We use `stepTitles` as a stable proxy.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [funnelInteractionId, stepTitles]);
 }

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -194,7 +194,7 @@ function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: Wi
 
   useEffect(() => {
     // We prevent emitting the event before the funnel has stabilised.
-    const handle = setTimeout(() => (listenForStepChanges.current = true), 50);
+    const handle = setTimeout(() => (listenForStepChanges.current = true), 0);
 
     return () => {
       clearTimeout(handle);


### PR DESCRIPTION
### Description

This PR emits the funnelChange event whenever a funnel is modified, i.e. when the steps of the funnel change.

The events have been added in https://github.com/cloudscape-design/components/pull/1507.

See also https://github.com/cloudscape-design/components/pull/1509 for the related funnel**Step**Change event, which handles changes in substeps rather than in steps.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->


### How has this been tested?
Manually tested in updated dev page, and added unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
