### PR TITLE
chore: Add a direction setting to the url parameters for internal pages

### DIFF
--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -8,7 +8,7 @@ import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
 interface AppUrlParams {
   density: Density;
-  direction: string;
+  direction: 'ltr' | 'rtl';
   visualRefresh: boolean;
   motionDisabled: boolean;
 }

--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -8,10 +8,10 @@ import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 
 interface AppUrlParams {
   density: Density;
+  direction: string;
   visualRefresh: boolean;
   motionDisabled: boolean;
 }
-
 export interface AppContextType<T = unknown> {
   mode: Mode;
   pageId?: string;
@@ -25,6 +25,7 @@ const appContextDefaults: AppContextType = {
   pageId: undefined,
   urlParams: {
     density: Density.Comfortable,
+    direction: 'ltr',
     visualRefresh: THEME === 'default',
     motionDisabled: false,
   },
@@ -66,6 +67,8 @@ export function AppContextProvider({ children }: { children: React.ReactNode }) 
   const match = useRouteMatch<{ theme: string; mode: Mode; pageId: string }>('/:mode(light|dark)/:pageId*');
   const { mode, pageId } = match ? match.params : { mode: undefined, pageId: undefined };
   const urlParams = parseQuery(location.search) as AppUrlParams;
+
+  document.querySelector('html')?.setAttribute('dir', urlParams.direction);
 
   function setUrlParams(newParams: Partial<AppUrlParams>) {
     const pathname = [mode, pageId].filter(segment => !!segment).join('/') + '/';

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -35,14 +35,10 @@ export default function ThemeSwitcher() {
       </label>
       <label>
         Direction
-        <select onChange={event => setUrlParams({ direction: event.target.value })}>
-          <option value="ltr" selected={urlParams.direction === 'ltr'}>
-            Left-to-Right
-          </option>
+        <select onChange={event => setUrlParams({ direction: event.target.value })} defaultValue={urlParams.direction}>
+          <option value="ltr">Left-to-Right</option>
 
-          <option value={'rtl'} selected={urlParams.direction === 'rtl'}>
-            Right-to-Left
-          </option>
+          <option value={'rtl'}>Right-to-Left</option>
         </select>
       </label>
       <label>

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -34,6 +34,18 @@ export default function ThemeSwitcher() {
         </select>
       </label>
       <label>
+        Direction
+        <select onChange={event => setUrlParams({ direction: event.target.value })}>
+          <option value="ltr" selected={urlParams.direction === 'ltr'}>
+            Left-to-Right
+          </option>
+
+          <option value={'rtl'} selected={urlParams.direction === 'rtl'}>
+            Right-to-Left
+          </option>
+        </select>
+      </label>
+      <label>
         <input {...vrSwitchProps} />
         Visual refresh
       </label>

--- a/pages/app/components/theme-switcher.tsx
+++ b/pages/app/components/theme-switcher.tsx
@@ -35,10 +35,12 @@ export default function ThemeSwitcher() {
       </label>
       <label>
         Direction
-        <select onChange={event => setUrlParams({ direction: event.target.value })} defaultValue={urlParams.direction}>
+        <select
+          onChange={event => setUrlParams({ direction: event.target.value as 'rtl' | 'ltr' })}
+          defaultValue={urlParams.direction}
+        >
           <option value="ltr">Left-to-Right</option>
-
-          <option value={'rtl'}>Right-to-Left</option>
+          <option value="rtl">Right-to-Left</option>
         </select>
       </label>
       <label>

--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -206,7 +206,7 @@ test(
     await page.dragResizerTo({ x: 0, y: height });
     expect((await page.getSplitPanelSize()).height).toEqual(160);
     await page.dragResizerTo({ x: 0, y: 0 });
-    expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
+    expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(252);
   })
 );
 

--- a/src/autosuggest/__integ__/async-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/async-autosuggest.test.ts
@@ -10,7 +10,7 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 const autosuggest = createWrapper().findAutosuggest();
 
 // Necessary scrolling to reach the bottom.
-const SCROLL_PAGE_HEIGHT = 500;
+const SCROLL_PAGE_HEIGHT = 450;
 
 function setup(
   opts: { virtualScrolling?: boolean; expandToViewport?: boolean },
@@ -18,7 +18,7 @@ function setup(
 ) {
   return useBrowser(async browser => {
     const page = new AsyncDropdownComponentPage(browser, autosuggest, opts.expandToViewport);
-    await page.setWindowSize({ width: 800, height: 300 });
+    await page.setWindowSize({ width: 800, height: 400 });
     await browser.url('/#/light/autosuggest/async');
     await page.waitForVisible(autosuggest.findNativeInput().toSelector());
     if (opts.virtualScrolling) {
@@ -138,7 +138,7 @@ describe.each([true, false])('Async autosuggest scrolling (with virtualScrolling
     'the bottom of the dropdown lines up with the highlighted option, when going down the list',
     setup({ virtualScrolling }, async page => {
       await page.respondWith(0, true);
-      await page.keys(['ArrowDown', 'ArrowDown', 'ArrowDown']);
+      await page.keys(['ArrowDown', 'ArrowDown', 'ArrowDown', 'ArrowDown', 'ArrowDown', 'ArrowDown']);
       const { bottom: optionBottom } = await page.getHighlightedPosition();
       const { bottom: dropdownBottom } = await page.getDropdownPosition();
       // a small give for borders and negative margins


### PR DESCRIPTION
This PR adds a direction setting to the url parameters for internal pages. A demo of the feature can be seen in the attached video.

https://github.com/cloudscape-design/components/assets/438181/086c82e3-3942-4144-8489-ea77ce500ab9