### PR TITLE
fix: Fix date input to no longer autocomplete when it's empty

### DIFF
--- a/src/internal/components/masked-input/__tests__/masked-input.test.tsx
+++ b/src/internal/components/masked-input/__tests__/masked-input.test.tsx
@@ -162,6 +162,14 @@ describe('Masked Input component', () => {
       );
     });
 
+    test('should not autocorrect empty input', () => {
+      const { wrapper, onChangeSpy } = renderMaskedInput({ ...defaultProps, value: '' });
+      expect(wrapper.findNativeInput().getElement().value).toBe('');
+      wrapper.blur();
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
     test('should correct "1:" to "01:" and set cursor position correctly', () => {
       const { wrapper, onChangeSpy } = renderMaskedInput({
         ...defaultProps,
@@ -225,6 +233,28 @@ describe('Masked Input component', () => {
     });
 
     expect(wrapper.findNativeInput().getElement().value).toBe('12:34');
+  });
+
+  test('should autocomplete when pressing Enter', () => {
+    const { wrapper, onChangeSpy } = renderMaskedInput({ ...defaultProps, value: '01' });
+    expect(wrapper.findNativeInput().getElement()).toHaveValue('01:');
+
+    wrapper.findNativeInput().keydown(KeyCode.enter);
+    expect(onChangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          value: '01:00:00',
+        },
+      })
+    );
+  });
+
+  test('should not autocomplete when pressing Enter if input is empty', () => {
+    const { wrapper, onChangeSpy } = renderMaskedInput();
+    expect(wrapper.findNativeInput().getElement()).toHaveValue('');
+
+    wrapper.findNativeInput().keydown(KeyCode.enter);
+    expect(onChangeSpy).not.toHaveBeenCalled();
   });
 
   describe('Limiting range', () => {

--- a/src/internal/components/masked-input/keyboard-handler.ts
+++ b/src/internal/components/masked-input/keyboard-handler.ts
@@ -96,6 +96,10 @@ export const keyHandler = (
 };
 
 export const enterHandler = (value: string, format: MaskFormat): HandlerResult => {
+  // Do not autocomplete if input is empty
+  if (!value) {
+    return { value: '', position: 0 };
+  }
   const autoCompletedValue = format.autoComplete(value);
   const position = autoCompletedValue.length;
   return { value: autoCompletedValue, position };


### PR DESCRIPTION
### Description
Masked inputs such as date input autocomplete the value basked on the defined mask when the field is blurred or the user presses Enter. However, the input should not autocomplete when its value is empty. This change fixes a bug where pressing Enter in an empty date input would change the value to "2000-01-01".

Related links, issue #, if available: AWSUI-17211

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
