### PR TITLE
chore: Add basic linting rules for unsafe `any` usages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -172,6 +172,27 @@
           }
         ]
       }
+    },
+    {
+      "files": ["none"],
+      "excludedFiles": [
+        "src/**/__tests__/**",
+        "src/**/__integ__/**",
+        "src/**/__a11y__/**",
+        "src/test-utils/**",
+        "src/internal/vendor/**"
+      ],
+      "rules": {
+        "@typescript-eslint/no-unsafe-argument": "error",
+        "@typescript-eslint/no-unsafe-assignment": "error",
+        "@typescript-eslint/no-unsafe-call": "error",
+        "@typescript-eslint/no-unsafe-declaration-merging": "error",
+        "@typescript-eslint/no-unsafe-member-access": "error",
+        "@typescript-eslint/no-unsafe-return": "error"
+      },
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description

This PR creates the basic code for using ESLint to check for unsafe usages of the `any` type. It does _not_ enable this rule for any files yet, this will come in later PRs.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
