### PR TITLE
fix: Only provide date strings to isValidRange when date range picker is set to dateOnly

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -391,15 +391,13 @@ describe('Date range picker', () => {
     // When endDate hasn't been selected
     wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
     wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenNthCalledWith(
-      1,
+    expect(isValidRange).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '' })
     );
     // When full range has been selected
     wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
     wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenNthCalledWith(
-      1,
+    expect(isValidRange).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '2023-09-13' })
     );
   });

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -383,6 +383,25 @@ describe('Date range picker', () => {
     });
   });
 
+  test('calls isValidRange without time part when dateOnly is enabled', () => {
+    const isValidRange = jest.fn().mockReturnValue({ valid: false, errorMessage: 'Error' });
+    const { wrapper } = renderDateRangePicker({ ...defaultProps, dateOnly: true, isValidRange });
+    act(() => wrapper.openDropdown());
+    changeMode(wrapper, 'absolute');
+    // When endDate hasn't been selected
+    act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
+    act(() => wrapper.findDropdown()!.findApplyButton().click());
+    expect(isValidRange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '' })
+    );
+    // When full range has been selected
+    act(() => wrapper.findDropdown()!.findDateAt('right', 3, 4).click());
+    act(() => wrapper.findDropdown()!.findApplyButton().click());
+    expect(isValidRange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '2023-09-13' })
+    );
+  });
+
   describe('i18n', () => {
     test('supports using mode selector and modal footer props from i18n provider', () => {
       const { container } = render(

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -383,23 +383,28 @@ describe('Date range picker', () => {
     });
   });
 
-  test('calls isValidRange without time part when dateOnly is enabled', () => {
-    const isValidRange = jest.fn().mockReturnValue({ valid: false, errorMessage: 'Error' });
-    const { wrapper } = renderDateRangePicker({ ...defaultProps, dateOnly: true, isValidRange });
-    wrapper.openDropdown();
-    changeMode(wrapper, 'absolute');
-    // When endDate hasn't been selected
-    wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
-    wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '' })
-    );
-    // When full range has been selected
-    wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
-    wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '2023-09-13' })
-    );
+  describe('isValidRange', () => {
+    beforeEach(() => Mockdate.set(new Date('2020-10-01T12:30:20')));
+    afterEach(() => Mockdate.reset());
+
+    test('calls isValidRange without time part when dateOnly is enabled', () => {
+      const isValidRange = jest.fn().mockReturnValue({ valid: false, errorMessage: 'Error' });
+      const { wrapper } = renderDateRangePicker({ ...defaultProps, dateOnly: true, isValidRange });
+      wrapper.openDropdown();
+      changeMode(wrapper, 'absolute');
+      // When endDate hasn't been selected
+      wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
+      wrapper.findDropdown()!.findApplyButton().click();
+      expect(isValidRange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ type: 'absolute', startDate: '2020-09-16', endDate: '' })
+      );
+      // When full range has been selected
+      wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
+      wrapper.findDropdown()!.findApplyButton().click();
+      expect(isValidRange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ type: 'absolute', startDate: '2020-09-16', endDate: '2020-10-14' })
+      );
+    });
   });
 
   describe('i18n', () => {

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -391,13 +391,15 @@ describe('Date range picker', () => {
     // When endDate hasn't been selected
     wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
     wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenCalledWith(
+    expect(isValidRange).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '' })
     );
     // When full range has been selected
     wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
     wrapper.findDropdown()!.findApplyButton().click();
-    expect(isValidRange).toHaveBeenCalledWith(
+    expect(isValidRange).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '2023-09-13' })
     );
   });

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -386,17 +386,17 @@ describe('Date range picker', () => {
   test('calls isValidRange without time part when dateOnly is enabled', () => {
     const isValidRange = jest.fn().mockReturnValue({ valid: false, errorMessage: 'Error' });
     const { wrapper } = renderDateRangePicker({ ...defaultProps, dateOnly: true, isValidRange });
-    act(() => wrapper.openDropdown());
+    wrapper.openDropdown();
     changeMode(wrapper, 'absolute');
     // When endDate hasn't been selected
-    act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
-    act(() => wrapper.findDropdown()!.findApplyButton().click());
+    wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
+    wrapper.findDropdown()!.findApplyButton().click();
     expect(isValidRange).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '' })
     );
     // When full range has been selected
-    act(() => wrapper.findDropdown()!.findDateAt('right', 3, 4).click());
-    act(() => wrapper.findDropdown()!.findApplyButton().click());
+    wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
+    wrapper.findDropdown()!.findApplyButton().click();
     expect(isValidRange).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'absolute', startDate: '2023-08-16', endDate: '2023-09-13' })
     );

--- a/src/date-range-picker/dropdown.tsx
+++ b/src/date-range-picker/dropdown.tsx
@@ -16,8 +16,8 @@ import Calendar from './calendar';
 import { DateRangePickerProps } from './interfaces';
 import ModeSwitcher from './mode-switcher';
 import RelativeRangePicker from './relative-range';
-import { formatValue, getDefaultMode, joinAbsoluteValue, splitAbsoluteValue } from './utils';
 import { normalizeTimeOffset } from './time-offset';
+import { formatValue, getDefaultMode, joinAbsoluteValue, splitAbsoluteValue } from './utils';
 
 import styles from './styles.css.js';
 

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -196,7 +196,12 @@ const DateRangePicker = React.forwardRef(
     };
 
     const onApply = (newValue: null | DateRangePickerProps.Value): DateRangePickerProps.ValidationResult => {
-      const validationResult = isValidRange(newValue);
+      const formattedValue = formatValue(newValue, {
+        dateOnly,
+        timeOffset: normalizeTimeOffset(newValue, getTimeOffset, timeOffset),
+      });
+
+      const validationResult = isValidRange(formattedValue);
       if (validationResult?.valid === false) {
         return validationResult;
       }
@@ -213,12 +218,7 @@ const DateRangePicker = React.forwardRef(
           }
         }
       }
-      fireNonCancelableEvent(onChange, {
-        value: formatValue(newValue, {
-          dateOnly,
-          timeOffset: normalizeTimeOffset(newValue, getTimeOffset, timeOffset),
-        }),
-      });
+      fireNonCancelableEvent(onChange, { value: formattedValue });
       return validationResult || { valid: true };
     };
 
@@ -345,6 +345,8 @@ const DateRangePicker = React.forwardRef(
                 i18nStrings={i18nStrings}
                 onClear={onClear}
                 onApply={onApply}
+                getTimeOffset={getTimeOffset}
+                timeOffset={timeOffset}
                 relativeOptions={relativeOptions}
                 isValidRange={isValidRange}
                 dateOnly={dateOnly}


### PR DESCRIPTION
### Description

Obviously trying to break the record for oldest PR merged into the repo here - but let me get this merged once and for all!

The title explains the PR pretty well - but the bigger question is whether it'll break anyone. Sending it through my pipeline to check.

Related links, issue #, if available: AWSUI-18012

### How has this been tested?

Added a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
