### PR TITLE
fix: Removes unused ariaLabel from Cards

### DIFF
--- a/pages/cards/permutations.page.tsx
+++ b/pages/cards/permutations.page.tsx
@@ -17,7 +17,6 @@ interface Item {
 }
 
 const ariaLabels: CardsProps<Item>['ariaLabels'] = {
-  selectionGroupLabel: 'group label',
   itemSelectionLabel: ({ selectedItems }, item) =>
     `${item.text} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
 };

--- a/pages/cards/selection.page.tsx
+++ b/pages/cards/selection.page.tsx
@@ -11,7 +11,6 @@ interface Item {
 }
 
 const ariaLabels: CardsProps<Item>['ariaLabels'] = {
-  selectionGroupLabel: 'group label',
   itemSelectionLabel: ({ selectedItems }, item) =>
     `${item.text} is ${!selectedItems.includes(item) ? 'not ' : ''}selected`,
 };

--- a/pages/cards/sticky-header.page.tsx
+++ b/pages/cards/sticky-header.page.tsx
@@ -41,7 +41,6 @@ export default () => {
     filtering: {},
   });
   const ariaLabels: CardsProps.AriaLabels<Item> = {
-    selectionGroupLabel: 'group label',
     itemSelectionLabel: ({ selectedItems }, item) =>
       `${item.name} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
   };

--- a/pages/cards/tall-cards.page.tsx
+++ b/pages/cards/tall-cards.page.tsx
@@ -65,7 +65,6 @@ export default () => {
             },
           ]}
           ariaLabels={{
-            selectionGroupLabel: 'group label',
             itemSelectionLabel: ({ selectedItems }, item) =>
               `${item.name} is ${selectedItems.indexOf(item) < 0 ? 'not ' : ''}selected`,
           }}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3560,7 +3560,6 @@ scroll parent up to reveal the first card or row of cards.",
     Object {
       "description": "Adds labels to the selection components (checkboxes and radio buttons) as follows:
 * \`itemSelectionLabel\` ((SelectionState, Item) => string) - Determines the label for an item.
-* \`selectionGroupLabel\` (string) - Specifies the label for the group selection control.
 * \`cardsLabel\` (string) - Provides alternative text for the cards list.
                            By default the contents of the \`header\` are used.
 You can use the first arguments of type \`SelectionState\` to access the current selection
@@ -3583,7 +3582,7 @@ add a meaningful description to the whole selection.",
           },
           Object {
             "name": "selectionGroupLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -7,7 +7,6 @@ import Header from '../../../lib/components/header';
 import { CardsWrapper, PaginationWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
-import TestI18nProvider from '../../../lib/components/i18n/testing';
 import styles from '../../../lib/components/cards/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
@@ -290,20 +289,6 @@ describe('Cards', () => {
 
       expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
         `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
-      );
-    });
-  });
-
-  describe('i18n', () => {
-    test('supports using selectionGroupLabel from i18n provider', () => {
-      ({ wrapper } = renderCards(
-        <TestI18nProvider messages={{ cards: { 'ariaLabels.selectionGroupLabel': 'Custom label' } }}>
-          <Cards<Item> cardDefinition={cardDefinition} selectionType="multi" items={defaultItems} />
-        </TestI18nProvider>
-      ));
-      expect(getCard(0).findSelectionArea()!.getElement()).toHaveAttribute(
-        'aria-label',
-        expect.stringContaining('Custom label')
       );
     });
   });

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -26,7 +26,6 @@ import LiveRegion from '../internal/components/live-region';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { supportsStickyPosition } from '../internal/utils/dom';
-import { useInternalI18n } from '../i18n/context';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
@@ -84,7 +83,6 @@ const Cards = React.forwardRef(function <T = any>(
   const mergedRef = useMergeRefs(measureRef, refObject, __internalRootRef);
   const getMouseDownTarget = useMouseDownTarget();
 
-  const i18n = useInternalI18n('cards');
   const { isItemSelected, getItemSelectionProps, updateShiftToggle } = useSelection({
     items,
     trackBy,
@@ -94,7 +92,6 @@ const Cards = React.forwardRef(function <T = any>(
     onSelectionChange,
     ariaLabels: {
       itemSelectionLabel: ariaLabels?.itemSelectionLabel,
-      selectionGroupLabel: i18n('ariaLabels.selectionGroupLabel', ariaLabels?.selectionGroupLabel),
     },
   });
   const hasToolsHeader = header || filter || pagination || preferences;

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -149,7 +149,6 @@ export interface CardsProps<T = any> extends BaseComponentProps {
   /**
    * Adds labels to the selection components (checkboxes and radio buttons) as follows:
    * * `itemSelectionLabel` ((SelectionState, Item) => string) - Determines the label for an item.
-   * * `selectionGroupLabel` (string) - Specifies the label for the group selection control.
    * * `cardsLabel` (string) - Provides alternative text for the cards list.
    *                            By default the contents of the `header` are used.
    *
@@ -243,7 +242,6 @@ export namespace CardsProps {
 
   export interface AriaLabels<T> {
     itemSelectionLabel: (data: CardsProps.SelectionState<T>, row: T) => string;
-    selectionGroupLabel: string;
     cardsLabel?: string;
   }
 

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -242,6 +242,8 @@ export namespace CardsProps {
 
   export interface AriaLabels<T> {
     itemSelectionLabel: (data: CardsProps.SelectionState<T>, row: T) => string;
+    /** @deprecated Has no effect. */
+    selectionGroupLabel?: string;
     cardsLabel?: string;
   }
 


### PR DESCRIPTION
### Description
`selectionGroupLabel` doesn't do anything in Cards.

Probably the result of copy-paste from Table. In Table it is used to label "select all" checkbox. In cards we do not have this functionality. 

Related links, issue #, if available: AWSUI-20273

### How has this been tested?
-

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
