### PR TITLE
feat: Allow button dropdown with "normal" variant to define a main action

### DIFF
--- a/pages/button-dropdown/permutations-main-action.page.tsx
+++ b/pages/button-dropdown/permutations-main-action.page.tsx
@@ -40,6 +40,7 @@ const permutations = createPermutations<ButtonDropdownProps>([
     ],
     disabled: [false, true],
     loading: [false, true],
+    variant: ['primary', 'normal'],
   },
   {
     mainAction: [{ ...viewInstancesItem }, { ...viewInstancesItem, disabled: true }],
@@ -49,6 +50,7 @@ const permutations = createPermutations<ButtonDropdownProps>([
         { id: '2', ...launchInstanceFromTemplateItem },
       ],
     ],
+    variant: ['primary', 'normal'],
   },
 ]);
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3260,7 +3260,8 @@ It prevents clicks.",
       "type": "string",
     },
     Object {
-      "description": "A standalone action that is shown prior to the dropdown trigger. Use it with \\"primary\\" variant only.
+      "description": "A standalone action that is shown prior to the dropdown trigger.
+Use it with \\"primary\\" and \\"normal\\" variant only.
 Main action properties:
 * \`text\` (string) - Specifies the text shown in the main action.
 * \`external\` (boolean) - Marks the main action as external by adding an icon after the text. The link will open in a new tab when clicked. Note that this only works when \`href\` is also provided.

--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -150,15 +150,15 @@ describe('ButtonDropdown component', () => {
 });
 
 describe('with main action', () => {
-  test('main action is not rendered if variant is not "primary"', () => {
-    const wrapper = renderSplitButtonDropdown({ mainAction: { text: 'Main' }, variant: 'normal' });
+  test('main action is not rendered if variant is not "primary" or "normal"', () => {
+    const wrapper = renderSplitButtonDropdown({ mainAction: { text: 'Main' }, variant: 'icon' });
 
     expect(wrapper.findMainAction()).toBe(null);
 
     expect(warnOnce).toHaveBeenCalledTimes(1);
     expect(warnOnce).toHaveBeenCalledWith(
       'ButtonDropdown',
-      'Main action is only supported for "primary" component variant.'
+      'Main action is only supported for "primary" and "normal" component variant.'
     );
   });
 

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -87,7 +87,8 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    */
   onItemFollow?: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   /**
-   * A standalone action that is shown prior to the dropdown trigger. Use it with "primary" variant only.
+   * A standalone action that is shown prior to the dropdown trigger.
+   * Use it with "primary" and "normal" variant only.
    * Main action properties:
    * * `text` (string) - Specifies the text shown in the main action.
    * * `external` (boolean) - Marks the main action as external by adding an icon after the text. The link will open in a new tab when clicked. Note that this only works when `href` is also provided.

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -55,11 +55,11 @@ const InternalButtonDropdown = React.forwardRef(
     }
 
     if (isDevelopment) {
-      if (mainAction && variant !== 'primary') {
-        warnOnce('ButtonDropdown', 'Main action is only supported for "primary" component variant.');
+      if (mainAction && variant !== 'primary' && variant !== 'normal') {
+        warnOnce('ButtonDropdown', 'Main action is only supported for "primary" and "normal" component variant.');
       }
     }
-    const isMainAction = mainAction && variant === 'primary';
+    const isMainAction = mainAction && (variant === 'primary' || variant === 'normal');
     const isVisualRefresh = useVisualRefresh();
 
     const {
@@ -197,7 +197,7 @@ const InternalButtonDropdown = React.forwardRef(
               {...mainActionProps}
               {...mainActionIconProps}
               className={styles['trigger-button']}
-              variant="primary"
+              variant={variant}
               ariaLabel={mainActionAriaLabel}
               formAction="none"
             >


### PR DESCRIPTION
### Description
Instead of only allowing main actions for primary button dropdown, it can now also be used for the "normal" variant.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
