### PR TITLE
chore: Update tools-to-drawer treatment

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -31,7 +31,7 @@ describeEachAppLayout(size => {
     expect(wrapper.findContentRegion()).toBeTruthy();
     expect(wrapper.findNotifications()).toBeFalsy();
     expect(wrapper.findBreadcrumbs()).toBeFalsy();
-    expect(wrapper.findDrawersTriggers()![0]).toBeFalsy();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
@@ -255,7 +255,7 @@ describeEachAppLayout(size => {
       };
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
 
-      wrapper.findDrawersTriggers()![0].click();
+      wrapper.findDrawerTriggerById('security')!.click();
 
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: 'security' }));
     });
@@ -271,7 +271,7 @@ describeEachAppLayout(size => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
 
       // Chrome bubbles up events from specific elements inside <button>s.
-      wrapper.findDrawersTriggers()![0]!.find('span')!.click();
+      wrapper.findDrawerTriggerById('security')!.find('span')!.click();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: 'security' }));
     });
@@ -296,10 +296,12 @@ describeEachAppLayout(size => {
     test('Renders aria-expanded only on toggle', () => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
 
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'false');
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-haspopup', 'true');
-      wrapper.findDrawersTriggers()![0].click();
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'true');
+      const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-expanded', 'false');
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-haspopup', 'true');
+
+      drawerTrigger.click();
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-expanded', 'true');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-expanded');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-haspopup');
     });
@@ -331,7 +333,7 @@ describeEachAppLayout(size => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
       expect(wrapper.findActiveDrawer()).toBeNull();
 
-      act(() => wrapper.findDrawersTriggers()![0].click());
+      wrapper.findDrawerTriggerById('security')!.find('span')!.click();
       expect(wrapper.findActiveDrawer()).not.toBeNull();
 
       act(() => wrapper.findActiveDrawerCloseButton()!.click());

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -181,7 +181,7 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test(`should toggle drawer on click`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
     act(() => wrapper.findDrawersTriggers()![0].click());
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => wrapper.findDrawersTriggers()![0].click());
@@ -191,7 +191,7 @@ describeEachThemeAppLayout(false, () => {
   test(`Moves focus to slider when opened`, () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
 
-    act(() => wrapper.findDrawersTriggers()![0].click());
+    wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveFocus();
   });
 
@@ -231,7 +231,7 @@ describeEachThemeAppLayout(false, () => {
   test('should read relative size on resize handle', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
 
-    act(() => wrapper.findDrawersTriggers()![0].click());
+    wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveAttribute('aria-valuenow', '0');
   });
 
@@ -243,9 +243,9 @@ describeEachThemeAppLayout(false, () => {
 
   test('Renders aria-controls on toggle only when active', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).not.toHaveAttribute('aria-controls');
-    act(() => wrapper.findDrawersTriggers()![0].click());
-    expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-controls', 'security');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-controls');
+    wrapper.findDrawerTriggerById('security')!.click();
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute('aria-controls', 'security');
   });
 });
 

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -18,7 +18,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
 
 describeEachAppLayout(() => {
   test(`should not render drawer when it is not defined`, () => {
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
     expect(wrapper.findDrawersTriggers()!).toHaveLength(1);
     rerender(<AppLayout />);
     expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
@@ -31,13 +31,13 @@ describeEachAppLayout(() => {
         items: [],
       },
     };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...emptyDrawerItems} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...emptyDrawerItems} />);
 
     expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
   });
 
-  test('renderds drawers with the tools', () => {
-    const { wrapper } = renderComponent(<AppLayout tools="Test" {...singleDrawer} />);
+  test('renders drawers with the tools', () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
 
     expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -96,7 +96,7 @@ describe('drawers', () => {
       },
     };
 
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" {...drawers} />);
+    const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} contentType="form" {...drawers} />);
 
     expect(findElement(wrapper)).toBeNull();
     findToggle(wrapper).click();

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -436,18 +436,21 @@ describeEachThemeAppLayout(true, theme => {
 
   test('Does not add a label to the toggle and landmark when they are not defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawerWithoutLabels} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).not.toHaveAttribute('aria-label');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-label');
     expect(wrapper.findDrawersMobileTriggersContainer()!.getElement()).not.toHaveAttribute('aria-label');
   });
 
   test('Adds labels to toggle button and landmark when defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-label', 'Security trigger button');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Security trigger button'
+    );
     expect(wrapper.findDrawersMobileTriggersContainer()!.getElement()).toHaveAttribute('aria-label', 'Drawers');
   });
 
   test('should render badge when defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...manyDrawers} />);
-    expect(wrapper.findDrawersTriggers()[0]!.getElement().children[0]).toHaveClass(iconStyles.badge);
+    expect(wrapper.findDrawerTriggerById('security')!.getElement().children[0]).toHaveClass(iconStyles.badge);
   });
 });

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -24,8 +24,7 @@ interface ToolsProps {
 }
 
 function getToolsDrawerItem(props: ToolsProps) {
-  // TODO: remove props.tools check, because it is incompatible with no-drawers behavior
-  if (props.toolsHide || !props.tools) {
+  if (props.toolsHide) {
     return null;
   }
   const { iconName, getLabels } = togglesConfig.tools;


### PR DESCRIPTION
### Description

Fixing merge logic between separate tools slot and drawers.

Behavior in the current public API

```js
<AppLayout /> // renders empty tools drawer [1]
<AppLayout toolsHide={true} /> // hides tools drawer
```

How this will change when `drawers` public property is introduced

```js
<AppLayout drawers={[]} />; // renders one drawer for the tools (looks identical to [1] from above)
<AppLayout tools="some tools" drawers={[]} />; // renders tools with drawers treatment
<AppLayout tools="some tools" drawers={[drawer]} />; // renders two drawers
```

Related links, issue #, if available: n/a

### How has this been tested?

Updated existing unit tests and added a few extra ones for corner-cases

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
