### PR TITLE
chore: Update tools-to-drawer treatment

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -31,7 +31,7 @@ describeEachAppLayout(size => {
     expect(wrapper.findContentRegion()).toBeTruthy();
     expect(wrapper.findNotifications()).toBeFalsy();
     expect(wrapper.findBreadcrumbs()).toBeFalsy();
-    expect(wrapper.findDrawersTriggers()![0]).toBeFalsy();
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
@@ -255,7 +255,7 @@ describeEachAppLayout(size => {
       };
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
 
-      wrapper.findDrawersTriggers()![0].click();
+      wrapper.findDrawerTriggerById('security')!.click();
 
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: 'security' }));
     });
@@ -271,7 +271,7 @@ describeEachAppLayout(size => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
 
       // Chrome bubbles up events from specific elements inside <button>s.
-      wrapper.findDrawersTriggers()![0]!.find('span')!.click();
+      wrapper.findDrawerTriggerById('security')!.find('span')!.click();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ detail: 'security' }));
     });
@@ -296,10 +296,12 @@ describeEachAppLayout(size => {
     test('Renders aria-expanded only on toggle', () => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
 
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'false');
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-haspopup', 'true');
-      wrapper.findDrawersTriggers()![0].click();
-      expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-expanded', 'true');
+      const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-expanded', 'false');
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-haspopup', 'true');
+
+      drawerTrigger.click();
+      expect(drawerTrigger.getElement()).toHaveAttribute('aria-expanded', 'true');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-expanded');
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-haspopup');
     });
@@ -331,7 +333,7 @@ describeEachAppLayout(size => {
       const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
       expect(wrapper.findActiveDrawer()).toBeNull();
 
-      act(() => wrapper.findDrawersTriggers()![0].click());
+      wrapper.findDrawerTriggerById('security')!.find('span')!.click();
       expect(wrapper.findActiveDrawer()).not.toBeNull();
 
       act(() => wrapper.findActiveDrawerCloseButton()!.click());

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -181,7 +181,7 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test(`should toggle drawer on click`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
     act(() => wrapper.findDrawersTriggers()![0].click());
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => wrapper.findDrawersTriggers()![0].click());
@@ -191,7 +191,7 @@ describeEachThemeAppLayout(false, () => {
   test(`Moves focus to slider when opened`, () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
 
-    act(() => wrapper.findDrawersTriggers()![0].click());
+    wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveFocus();
   });
 
@@ -231,7 +231,7 @@ describeEachThemeAppLayout(false, () => {
   test('should read relative size on resize handle', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
 
-    act(() => wrapper.findDrawersTriggers()![0].click());
+    wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findDrawersSlider()!.getElement()).toHaveAttribute('aria-valuenow', '0');
   });
 
@@ -243,9 +243,9 @@ describeEachThemeAppLayout(false, () => {
 
   test('Renders aria-controls on toggle only when active', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).not.toHaveAttribute('aria-controls');
-    act(() => wrapper.findDrawersTriggers()![0].click());
-    expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-controls', 'security');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-controls');
+    wrapper.findDrawerTriggerById('security')!.click();
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute('aria-controls', 'security');
   });
 });
 

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -19,13 +19,13 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
 
 describeEachAppLayout(() => {
   test(`should not render drawer when it is not defined`, () => {
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-    expect(wrapper.findDrawersTriggers()!).toHaveLength(1);
+    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     rerender(<AppLayout />);
-    expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
   });
 
-  test('should not render drawers if drawer items are empty', () => {
+  test('should not apply drawers treatment to the tools if the drawers array is empty', () => {
     const emptyDrawerItems = {
       drawers: {
         ariaLabel: 'Drawers',
@@ -34,7 +34,14 @@ describeEachAppLayout(() => {
     };
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...emptyDrawerItems} />);
 
-    expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
+    expect(wrapper.findToolsToggle()).toBeTruthy();
+  });
+
+  test('should apply drawers treatment to the tools if at least one other drawer is provided', () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findToolsToggle()).toBeTruthy();
   });
 
   test('renders drawers with the tools', () => {

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -96,7 +96,7 @@ describe('drawers', () => {
       },
     };
 
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" {...drawers} />);
+    const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} contentType="form" {...drawers} />);
 
     expect(findElement(wrapper)).toBeNull();
     findToggle(wrapper).click();

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -436,18 +436,21 @@ describeEachThemeAppLayout(true, theme => {
 
   test('Does not add a label to the toggle and landmark when they are not defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawerWithoutLabels} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).not.toHaveAttribute('aria-label');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-label');
     expect(wrapper.findDrawersMobileTriggersContainer()!.getElement()).not.toHaveAttribute('aria-label');
   });
 
   test('Adds labels to toggle button and landmark when defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
-    expect(wrapper.findDrawersTriggers()![0].getElement()).toHaveAttribute('aria-label', 'Security trigger button');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Security trigger button'
+    );
     expect(wrapper.findDrawersMobileTriggersContainer()!.getElement()).toHaveAttribute('aria-label', 'Drawers');
   });
 
   test('should render badge when defined', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...manyDrawers} />);
-    expect(wrapper.findDrawersTriggers()[0]!.getElement().children[0]).toHaveClass(iconStyles.badge);
+    expect(wrapper.findDrawerTriggerById('security')!.getElement().children[0]).toHaveClass(iconStyles.badge);
   });
 });

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -48,19 +48,22 @@ describe('Runtime drawers', () => {
   test('runtime drawers integration can be dynamically enabled and disabled', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout />);
-    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    // the 2nd trigger is for tools
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
     rerender(<AppLayout {...({ __disableRuntimeDrawers: true } as any)} />);
     await delay();
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     rerender(<AppLayout />);
     await delay();
-    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    // the 2nd trigger is for tools
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
   test('renders drawers via runtime config', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper } = await renderComponent(<AppLayout />);
-    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    // the 2nd trigger is for tools
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
   test('combines runtime drawers with the tools', async () => {
@@ -73,7 +76,7 @@ describe('Runtime drawers', () => {
   });
 
   test('accepts drawers registration after initial rendering', async () => {
-    const { wrapper } = await renderComponent(<AppLayout />);
+    const { wrapper } = await renderComponent(<AppLayout toolsHide={true} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     await delay();
@@ -113,7 +116,7 @@ describe('Runtime drawers', () => {
       defaultActive: true,
       mountContent: container => (container.textContent = 'second drawer content'),
     });
-    const { wrapper } = await renderComponent(<AppLayout />);
+    const { wrapper } = await renderComponent(<AppLayout toolsHide={true} />);
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('second drawer content');
   });
 
@@ -124,7 +127,7 @@ describe('Runtime drawers', () => {
       defaultActive: true,
       mountContent: container => (container.textContent = 'first drawer content'),
     });
-    const { wrapper } = await renderComponent(<AppLayout />);
+    const { wrapper } = await renderComponent(<AppLayout toolsHide={true} />);
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('first drawer content');
     awsuiPlugins.appLayout.registerDrawer({
       ...drawerDefaults,
@@ -179,7 +182,7 @@ describe('Runtime drawers', () => {
       mountContent: container => (container.textContent = 'first drawer content'),
     });
     const { wrapper } = await renderComponent(<AppLayout />);
-    wrapper.findDrawersTriggers()[0].click();
+    wrapper.findDrawerTriggerById('first')!.click();
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('first drawer content');
     awsuiPlugins.appLayout.registerDrawer({
       ...drawerDefaults,
@@ -206,16 +209,16 @@ describe('Runtime drawers', () => {
       trigger: { iconName: `<rect data-testid="custom-icon" />` },
     });
     const { wrapper } = await renderComponent(<AppLayout />);
-    expect(wrapper.findDrawersTriggers()[0].find('svg')).toBeFalsy();
+    expect(wrapper.findDrawerTriggerById(drawerDefaults.id)!.find('svg')).toBeFalsy();
   });
 
   test('persists drawer config between mounts/unmounts', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout key="first" />);
-    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
     rerender(<AppLayout key="second" />);
     await delay();
-    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
   test('drawer content lifecycle', async () => {
@@ -228,7 +231,7 @@ describe('Runtime drawers', () => {
     });
     const { wrapper } = await renderComponent(<AppLayout />);
     expect(mountContent).toHaveBeenCalledTimes(0);
-    wrapper.findDrawersTriggers()[0].click();
+    wrapper.findDrawerTriggerById(drawerDefaults.id)!.click();
     expect(mountContent).toHaveBeenCalledTimes(1);
     expect(unmountContent).toHaveBeenCalledTimes(0);
     wrapper.findActiveDrawerCloseButton()!.click();
@@ -248,9 +251,9 @@ describe('Runtime drawers', () => {
       mountContent: container => (container.textContent = 'second drawer content'),
     });
     const { wrapper } = await renderComponent(<AppLayout />);
-    wrapper.findDrawersTriggers()[0].click();
+    wrapper.findDrawerTriggerById('first')!.click();
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('first drawer content');
-    wrapper.findDrawersTriggers()[1].click();
+    wrapper.findDrawerTriggerById('second')!.click();
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('second drawer content');
   });
 
@@ -259,8 +262,9 @@ describe('Runtime drawers', () => {
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'bbb', ariaLabels: { triggerButton: 'bbb' } });
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'aaa', ariaLabels: { triggerButton: 'aaa' } });
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'ccc', ariaLabels: { triggerButton: 'ccc' } });
-      const { wrapper } = await renderComponent(<AppLayout />);
+      const { wrapper } = await renderComponent(<AppLayout ariaLabels={{ toolsToggle: 'tools toggle' }} />);
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'tools toggle',
         'aaa',
         'bbb',
         'ccc',
@@ -282,8 +286,9 @@ describe('Runtime drawers', () => {
         ariaLabels: { triggerButton: 'ccc' },
         orderPriority: 10,
       });
-      const { wrapper } = await renderComponent(<AppLayout />);
+      const { wrapper } = await renderComponent(<AppLayout ariaLabels={{ toolsToggle: 'tools toggle' }} />);
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'tools toggle',
         'ccc',
         'aaa',
         'bbb',
@@ -310,8 +315,11 @@ describe('Runtime drawers', () => {
           items: [{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd' } }],
         },
       };
-      const { wrapper } = await renderComponent(<AppLayout {...(drawers as any)} />);
+      const { wrapper } = await renderComponent(
+        <AppLayout {...(drawers as any)} ariaLabels={{ toolsToggle: 'tools toggle' }} />
+      );
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
+        'tools toggle',
         'bbb',
         'ddd',
         'aaa',

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -11,6 +11,7 @@ import OverflowMenu from './overflow-menu';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 import { splitItems } from './drawers-helpers';
+import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
 
 // We are using two landmarks per drawer, i.e. two NAVs and two ASIDEs, because of several
 // known bugs in NVDA that cause focus changes within a container to sometimes not be
@@ -215,7 +216,11 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                 return (
                   <DrawerTrigger
                     key={index}
-                    testUtilsClassName={testutilStyles['drawers-trigger']}
+                    testUtilsClassName={
+                      item.id === TOOLS_DRAWER_ID
+                        ? clsx(testutilStyles['drawers-trigger'], testutilStyles['tools-toggle'])
+                        : testutilStyles['drawers-trigger']
+                    }
                     ariaExpanded={drawers?.activeDrawerId === item.id}
                     ariaLabel={item.ariaLabels?.triggerButton}
                     ariaControls={drawers?.activeDrawerId === item.id ? item.id : undefined}

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -11,6 +11,7 @@ import styles from './styles.css.js';
 import sharedStyles from '../styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
 import { splitItems } from '../drawer/drawers-helpers';
+import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
 
 interface MobileToggleProps {
   className?: string;
@@ -136,7 +137,11 @@ export function MobileToolbar({
               onClick={() => drawers.onChange({ activeDrawerId: item.id })}
             >
               <ToggleButton
-                className={testutilStyles['drawers-trigger']}
+                className={
+                  item.id === TOOLS_DRAWER_ID
+                    ? clsx(testutilStyles['drawers-trigger'], testutilStyles['tools-toggle'])
+                    : testutilStyles['drawers-trigger']
+                }
                 iconName={item.trigger.iconName}
                 iconSvg={item.trigger.iconSvg}
                 badge={item.badge}

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -22,8 +22,7 @@ interface ToolsProps {
 }
 
 function getToolsDrawerItem(props: ToolsProps) {
-  // TODO: remove props.tools check, because it is incompatible with no-drawers behavior
-  if (props.toolsHide || !props.tools) {
+  if (props.toolsHide) {
     return null;
   }
   const { iconName, getLabels } = togglesConfig.tools;

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -222,7 +222,11 @@ function DesktopTriggers() {
               ariaLabel={item.ariaLabels?.triggerButton}
               ariaExpanded={item.id === activeDrawerId}
               ariaControls={activeDrawerId === item.id ? item.id : undefined}
-              className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
+              className={clsx(
+                styles['drawers-trigger'],
+                testutilStyles['drawers-trigger'],
+                item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
+              )}
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
               key={item.id}
@@ -323,7 +327,11 @@ export function MobileTriggers() {
         <InternalButton
           ariaExpanded={item.id === activeDrawerId}
           ariaLabel={item.ariaLabels?.triggerButton}
-          className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'])}
+          className={clsx(
+            styles['drawers-trigger'],
+            testutilStyles['drawers-trigger'],
+            item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
+          )}
           disabled={hasDrawerViewportOverlay}
           ref={item.id === previousActiveDrawerId.current ? drawersRefs.toggle : undefined}
           formAction="none"


### PR DESCRIPTION
### Description

Fixing merge logic between separate tools slot and drawers.

Behavior in the current public API

```js
<AppLayout /> // renders empty tools drawer [1]
<AppLayout tools="content" /> // renders tools drawer with content [2]
<AppLayout toolsHide={true} /> // hides tools drawer
```

How this will change when `drawers` public property is introduced

```js
<AppLayout drawers={[]} /> // renders one drawer for the tools (looks identical to [1] from above)
<AppLayout tools="content" drawers={[]} /> // same as [2] from above
<AppLayout tools="some tools" drawers={[drawer]} /> // renders two drawers, the first one is "tools"
```

Related links, issue #, if available: n/a

### How has this been tested?

Updated existing unit tests and added a few extra ones for corner-cases

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
