### PR TITLE
fix: Handle toolsOpen properly when drawers API is used

### DIFF
--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { describeEachAppLayout, renderComponent, singleDrawer, manyDrawers } from './utils';
+import { describeEachAppLayout, renderComponent, singleDrawer, manyDrawers, singleDrawerOpen } from './utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import { render } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
+import { TOOLS_DRAWER_ID } from '../../../lib/components/app-layout/utils/use-drawers';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   useMobile: jest.fn().mockReturnValue(true),
@@ -36,10 +37,26 @@ describeEachAppLayout(() => {
     expect(wrapper.findDrawersTriggers()!).toHaveLength(0);
   });
 
-  test('renderds drawers with the tools', () => {
+  test('renders drawers with the tools', () => {
     const { wrapper } = renderComponent(<AppLayout tools="Test" {...singleDrawer} />);
 
     expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+  });
+
+  test('should respect toolsOpen property when merging into drawers', () => {
+    const { wrapper } = renderComponent(<AppLayout tools="Tools content" toolsOpen={true} {...singleDrawer} />);
+
+    expect(wrapper.findDrawerTriggerById(TOOLS_DRAWER_ID)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('Tools content');
+  });
+
+  test('activeDrawerId has priority over toolsOpen', () => {
+    const { wrapper } = renderComponent(<AppLayout tools="Tools content" toolsOpen={true} {...singleDrawerOpen} />);
+
+    expect(wrapper.findDrawerTriggerById(TOOLS_DRAWER_ID)!.getElement()).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('Security');
   });
 
   test('should open active drawer on click of overflow item', () => {

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { act, render } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
 import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
+import { TOOLS_DRAWER_ID } from '../../../lib/components/app-layout/utils/use-drawers';
 import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -80,12 +81,24 @@ describe('Runtime drawers', () => {
   });
 
   test('opens registered drawer when defaultActive is set', async () => {
-    const { wrapper } = await renderComponent(<AppLayout />);
+    const { wrapper } = await renderComponent(<AppLayout toolsHide={true} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findActiveDrawer()).toBeFalsy();
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, defaultActive: true });
     await delay();
     expect(wrapper.findActiveDrawer()!.getElement()).toBeInTheDocument();
+  });
+
+  test('does not open defaultActive drawer if the tools are already open', async () => {
+    const { wrapper } = await renderComponent(
+      <AppLayout toolsOpen={true} tools="Tools content" ariaLabels={{ toolsToggle: 'tools toggle' }} />
+    );
+    expect(wrapper.findDrawersTriggers()).toHaveLength(0);
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+    awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, defaultActive: true });
+    await delay();
+    expect(wrapper.findDrawerTriggerById(TOOLS_DRAWER_ID)!.getElement()).toHaveAttribute('aria-expanded', 'true');
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('Tools content');
   });
 
   test('updates active drawer if multiple are registered', async () => {

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -154,7 +154,7 @@ const OldAppLayout = React.forwardRef(
       onActiveDrawerChange,
       onActiveDrawerResize,
       ...drawersProps
-    } = useDrawers(props as InternalDrawerProps, { ariaLabels, tools, toolsOpen, toolsHide, toolsWidth }, defaults);
+    } = useDrawers(props as InternalDrawerProps, { ariaLabels, tools, toolsOpen, toolsHide, toolsWidth });
     const hasDrawers = drawers.length > 0;
 
     const { refs: navigationRefs, setFocus: focusNavButtons } = useFocusControl(navigationOpen);
@@ -639,7 +639,9 @@ const OldAppLayout = React.forwardRef(
               (hasDrawers ? (
                 <ResizableDrawer
                   contentClassName={
-                    activeDrawerId === TOOLS_DRAWER_ID ? testutilStyles.tools : testutilStyles['active-drawer']
+                    activeDrawerId === TOOLS_DRAWER_ID
+                      ? clsx(testutilStyles.tools, testutilStyles['active-drawer'])
+                      : testutilStyles['active-drawer']
                   }
                   toggleClassName={testutilStyles['tools-toggle']}
                   closeClassName={

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -3,8 +3,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import { InternalDrawerProps } from '../drawer/interfaces';
-import { AppLayoutState } from '../defaults';
-import { useMobile } from '../../internal/hooks/use-mobile';
 import { useControllable } from '../../internal/hooks/use-controllable';
 import { fireNonCancelableEvent } from '../../internal/events';
 import { awsuiPluginsInternal } from '../../internal/plugins/api';
@@ -82,16 +80,14 @@ export function useDrawers(
     drawers: ownDrawers,
     __disableRuntimeDrawers: disableRuntimeDrawers,
   }: InternalDrawerProps & { __disableRuntimeDrawers?: boolean },
-  toolsProps: ToolsProps,
-  defaults: AppLayoutState
+  toolsProps: ToolsProps
 ) {
-  const isMobile = useMobile();
   const toolsDrawer = getToolsDrawerItem(toolsProps);
 
   const [activeDrawerId, setActiveDrawerId] = useControllable(
     ownDrawers?.activeDrawerId,
     ownDrawers?.onChange,
-    !isMobile && !toolsProps.toolsHide && toolsProps.toolsOpen && defaults.toolsOpen ? TOOLS_DRAWER_ID : undefined,
+    !toolsProps.toolsHide && toolsProps.toolsOpen ? TOOLS_DRAWER_ID : undefined,
     {
       componentName: 'AppLayout',
       controlledProp: 'activeDrawerId',

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -392,17 +392,13 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       onActiveDrawerResize,
       activeDrawerSize,
       ...drawersProps
-    } = useDrawers(
-      props as InternalDrawerProps,
-      {
-        ariaLabels: props.ariaLabels,
-        toolsHide,
-        toolsOpen: isToolsOpen,
-        tools: props.tools,
-        toolsWidth,
-      },
-      contentTypeDefaults
-    );
+    } = useDrawers(props as InternalDrawerProps, {
+      ariaLabels: props.ariaLabels,
+      toolsHide,
+      toolsOpen: isToolsOpen,
+      tools: props.tools,
+      toolsWidth,
+    });
 
     const [drawersMaxWidth, setDrawersMaxWidth] = useState(toolsWidth);
 
@@ -435,9 +431,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     const drawersTriggerCount =
       drawers.length + (splitPanelDisplayed && splitPanelPosition === 'side' ? 1 : 0) + (!toolsHide ? 1 : 0);
     const hasOpenDrawer =
-      activeDrawerId !== undefined ||
-      isToolsOpen ||
-      (splitPanelDisplayed && splitPanelPosition === 'side' && isSplitPanelOpen);
+      activeDrawerId !== undefined || (splitPanelDisplayed && splitPanelPosition === 'side' && isSplitPanelOpen);
     const hasDrawerViewportOverlay =
       isMobile && (!!activeDrawerId || (!navigationHide && isNavigationOpen) || (!toolsHide && isToolsOpen));
 

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -14,6 +14,7 @@ import testutilStyles from '../test-classes/styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import OverflowMenu from '../drawer/overflow-menu';
 import { splitItems } from '../drawer/drawers-helpers';
+import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
 
 /**
  * The Drawers root component is mounted in the AppLayout index file. It will only
@@ -53,12 +54,6 @@ export default function Drawers() {
   );
 }
 
-/**
- * The ActiveDrawer component will render either the drawer content that corresponds
- * to the activeDrawerId or the Tools content if it exists and isToolsOpen is true.
- * The aria labels, click handling, and focus handling will be updated dynamically
- * based on the active drawer or tools content.
- */
 function ActiveDrawer() {
   const {
     activeDrawerId,
@@ -70,9 +65,7 @@ function ActiveDrawer() {
     hasDrawerViewportOverlay,
     isMobile,
     isNavigationOpen,
-    isToolsOpen,
     navigationHide,
-    tools,
     toolsRefs,
     loseDrawersFocus,
     resizeHandle,
@@ -88,8 +81,9 @@ function ActiveDrawer() {
     content: activeDrawerId ? activeDrawer?.ariaLabels?.content : ariaLabels?.tools,
   };
 
-  const isHidden = !activeDrawerId && !isToolsOpen;
+  const isHidden = !activeDrawerId;
   const isUnfocusable = isHidden || (hasDrawerViewportOverlay && isNavigationOpen && !navigationHide);
+  const isToolsDrawer = activeDrawerId === TOOLS_DRAWER_ID;
 
   const size = Math.min(drawersMaxWidth, drawerSize);
 
@@ -99,10 +93,10 @@ function ActiveDrawer() {
       aria-hidden={isHidden}
       aria-label={computedAriaLabels.content}
       className={clsx(styles.drawer, sharedStyles['with-motion'], {
-        [styles['is-drawer-open']]: activeDrawerId || isToolsOpen,
+        [styles['is-drawer-open']]: activeDrawerId,
         [styles.unfocusable]: isUnfocusable,
         [testutilStyles['active-drawer']]: activeDrawerId,
-        [testutilStyles.tools]: isToolsOpen,
+        [testutilStyles.tools]: isToolsDrawer,
       })}
       style={{
         ...(!isMobile && drawerSize && { [customCssProps.drawerSize]: `${size}px` }),
@@ -120,20 +114,17 @@ function ActiveDrawer() {
           ariaLabel={computedAriaLabels.closeButton}
           className={clsx({
             [testutilStyles['active-drawer-close-button']]: activeDrawerId,
-            [testutilStyles['tools-close']]: isToolsOpen,
+            [testutilStyles['tools-close']]: isToolsDrawer,
           })}
           formAction="none"
           iconName={isMobile ? 'close' : 'angle-right'}
           onClick={() => (activeDrawerId ? handleDrawersClick(activeDrawerId ?? null) : handleToolsClick(false))}
-          ref={isToolsOpen ? toolsRefs.close : drawersRefs.close}
+          ref={isToolsDrawer ? toolsRefs.close : drawersRefs.close}
           variant="icon"
         />
       </div>
 
-      <div className={styles['drawer-content']}>
-        {activeDrawerId && activeDrawer?.content}
-        {isToolsOpen && tools}
-      </div>
+      <div className={styles['drawer-content']}>{activeDrawerId && activeDrawer?.content}</div>
     </aside>
   );
 }


### PR DESCRIPTION
### Description

Fixing the case when app layout uses `toolsOpen` controlled mode together with drawers.

It was possible to have double drawers content

<img width="1273" alt="Screenshot 2023-09-07 at 21 13 08" src="https://github.com/cloudscape-design/components/assets/812240/00586ca4-d376-46c2-a4a2-ca9836b5ed58">

Related links, issue #, if available: n/a

### How has this been tested?

Added extra unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
