### PR TITLE
fix: Resizable columns text content to not include column width

### DIFF
--- a/src/internal/components/portal/index.tsx
+++ b/src/internal/components/portal/index.tsx
@@ -4,7 +4,7 @@ import React, { useLayoutEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 export interface PortalProps {
-  container?: Element;
+  container?: null | Element;
   children: React.ReactNode;
 }
 

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -365,3 +365,10 @@ describe('resize with keyboard', () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 });
+
+test('resizable columns headers have expected text content', () => {
+  const { wrapper } = renderTable(<Table {...defaultProps} />);
+
+  expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
+  expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
+});

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -37,6 +37,7 @@ interface TableHeaderCellProps<ItemType> {
   cellRef: React.RefCallback<HTMLElement>;
   focusedComponent?: null | string;
   tableRole: TableRole;
+  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -60,6 +61,7 @@ export function TableHeaderCell<ItemType>({
   stickyState,
   cellRef,
   tableRole,
+  getDescriptionRoot,
 }: TableHeaderCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
@@ -140,17 +142,16 @@ export function TableHeaderCell<ItemType>({
         )}
       </div>
       {resizableColumns && (
-        <>
-          <Resizer
-            tabIndex={tabIndex}
-            focusId={`resize-control-${String(columnId)}`}
-            showFocusRing={focusedComponent === `resize-control-${String(columnId)}`}
-            onDragMove={newWidth => updateColumn(columnId, newWidth)}
-            onFinish={onResizeFinish}
-            ariaLabelledby={headerId}
-            minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
-          />
-        </>
+        <Resizer
+          tabIndex={tabIndex}
+          focusId={`resize-control-${String(columnId)}`}
+          showFocusRing={focusedComponent === `resize-control-${String(columnId)}`}
+          onDragMove={newWidth => updateColumn(columnId, newWidth)}
+          onFinish={onResizeFinish}
+          ariaLabelledby={headerId}
+          minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
+          getDescriptionRoot={getDescriptionRoot}
+        />
       )}
     </TableThElement>
   );

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -39,6 +39,7 @@ import { getTableRoleProps, getTableRowRoleProps, getTableWrapperRoleProps } fro
 import { useCellEditing } from './use-cell-editing';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
@@ -101,6 +102,10 @@ const InternalTable = React.forwardRef(
 
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
+
+    // Used to render table's ARIA description nodes into.
+    const descriptionRef = useRef<HTMLSpanElement>(null);
+    const getDescriptionRoot = useCallback(() => descriptionRef.current, []);
 
     const secondaryWrapperRef = React.useRef<HTMLDivElement>(null);
     const theadRef = useRef<HTMLTableRowElement>(null);
@@ -214,6 +219,7 @@ const InternalTable = React.forwardRef(
       stickyState,
       selectionColumnId,
       tableRole,
+      getDescriptionRoot,
     };
 
     const wrapperRef = useMergeRefs(wrapperMeasureRef, wrapperRefObject, stickyState.refs.wrapper);
@@ -471,6 +477,7 @@ const InternalTable = React.forwardRef(
               </table>
               {resizableColumns && <ResizeTracker />}
             </div>
+
             <StickyScrollbar
               ref={scrollbarRef}
               wrapperRef={wrapperRefObject}
@@ -478,6 +485,10 @@ const InternalTable = React.forwardRef(
               onScroll={handleScroll}
               hasStickyColumns={hasStickyColumns}
             />
+
+            <ScreenreaderOnly>
+              <span ref={descriptionRef}></span>
+            </ScreenreaderOnly>
           </InternalContainer>
         </ColumnWidthsProvider>
       </LinkDefaultVariantContext.Provider>

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -9,7 +9,6 @@ import styles from './styles.css.js';
 import { KeyCode } from '../../internal/keycode';
 import { DEFAULT_COLUMN_WIDTH } from '../use-column-widths';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
-import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { joinStrings } from '../../internal/utils/strings';
 import Portal from '../../internal/components/portal';
@@ -24,6 +23,7 @@ interface ResizerProps {
   showFocusRing?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
+  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 const AUTO_GROW_START_TIME = 10;
@@ -40,6 +40,7 @@ export function Resizer({
   focusId,
   onFocus,
   onBlur,
+  getDescriptionRoot,
 }: ResizerProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [isKeyboardDragging, setIsKeyboardDragging] = useState(false);
@@ -239,8 +240,8 @@ export function Resizer({
         tabIndex={tabIndex}
         data-focus-id={focusId}
       />
-      <Portal>
-        <ScreenreaderOnly id={resizerWidthId}>{headerCellWidthString}</ScreenreaderOnly>
+      <Portal container={getDescriptionRoot?.()}>
+        <span id={resizerWidthId}>{headerCellWidthString}</span>
       </Portal>
     </>
   );

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -12,6 +12,7 @@ import { useStableCallback } from '@cloudscape-design/component-toolkit/internal
 import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { joinStrings } from '../../internal/utils/strings';
+import Portal from '../../internal/components/portal';
 
 interface ResizerProps {
   onDragMove: (newWidth: number) => void;
@@ -238,7 +239,9 @@ export function Resizer({
         tabIndex={tabIndex}
         data-focus-id={focusId}
       />
-      <ScreenreaderOnly id={resizerWidthId}>{headerCellWidthString}</ScreenreaderOnly>
+      <Portal>
+        <ScreenreaderOnly id={resizerWidthId}>{headerCellWidthString}</ScreenreaderOnly>
+      </Portal>
     </>
   );
 }

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -41,6 +41,7 @@ export interface TheadProps {
   focusedComponent?: null | string;
   onFocusedComponentChange?: (focusId: null | string) => void;
   tableRole: TableRole;
+  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 const Thead = React.forwardRef(
@@ -69,6 +70,7 @@ const Thead = React.forwardRef(
       focusedComponent,
       onFocusedComponentChange,
       tableRole,
+      getDescriptionRoot,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
@@ -170,6 +172,7 @@ const Thead = React.forwardRef(
                 stickyState={stickyState}
                 cellRef={node => setCell(columnId, node)}
                 tableRole={tableRole}
+                getDescriptionRoot={getDescriptionRoot}
               />
             );
           })}


### PR DESCRIPTION
### Description

When asserting column headers text content is must not include anything but the header text.

Ref: AWSUI-22297

### How has this been tested?

Added a new unit test to secure the property.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
