### PR TITLE
chore: Include stepConfiguration and subStepConfiguration properties in start events

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -42,7 +42,15 @@ describe('Form Analytics', () => {
   }
 
   test('sends funnelStart and funnelStepStart metrics when Form is mounted', () => {
-    render(<Form />);
+    render(
+      <>
+        <BreadcrumbGroup items={[{ text: 'My funnel', href: '' }]} />
+        <Form>
+          <Container header={<Header>Substep one</Header>}></Container>
+          <Container header={<Header>Substep two</Header>}></Container>
+        </Form>
+      </>
+    );
     act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
@@ -55,6 +63,7 @@ describe('Form Analytics', () => {
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
         theme: expect.any(String),
+        stepConfiguration: [{ isOptional: false, name: 'My funnel', number: 1 }],
       })
     );
 
@@ -65,6 +74,10 @@ describe('Form Analytics', () => {
         funnelInteractionId: expect.any(String),
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
+        subStepConfiguration: [
+          { name: 'Substep one', number: 1 },
+          { name: 'Substep two', number: 2 },
+        ],
       })
     );
   });

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -16,14 +16,14 @@ import { mockFunnelMetrics, mockInnerText } from '../../internal/analytics/__tes
 import Container from '../../../lib/components/container';
 import Header from '../../../lib/components/header';
 
+mockInnerText();
+
 describe('Form Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     mockFunnelMetrics();
   });
-
-  mockInnerText();
 
   test('sends funnelStart and funnelStepStart metrics when Form is mounted', () => {
     render(

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -12,7 +12,7 @@ import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
-import { mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
+import { mockFunnelMetrics, mockInnerText } from '../../internal/analytics/__tests__/mocks';
 import Container from '../../../lib/components/container';
 import Header from '../../../lib/components/header';
 
@@ -23,23 +23,7 @@ describe('Form Analytics', () => {
     mockFunnelMetrics();
   });
 
-  if (!('innerText' in HTMLElement.prototype)) {
-    // JSDom does not support the `innerText` property. For this test, `textContent` is close enough.
-
-    beforeEach(() =>
-      Object.defineProperty(HTMLElement.prototype, 'innerText', {
-        get() {
-          return this.textContent;
-        },
-        set(v) {
-          this.textContent = v;
-        },
-        configurable: true,
-      })
-    );
-
-    afterEach(() => delete (HTMLElement.prototype as Partial<HTMLElement>).innerText);
-  }
+  mockInnerText();
 
   test('sends funnelStart and funnelStepStart metrics when Form is mounted', () => {
     render(

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -332,10 +332,29 @@ describe('AnalyticsFunnelStep', () => {
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith({
       funnelInteractionId: mockedFunnelInteractionId,
+      stepName: undefined,
       stepNumber,
       stepNameSelector,
       subStepAllSelector: expect.any(String),
       totalSubSteps: 4,
+      subStepConfiguration: [
+        {
+          name: '',
+          number: 1,
+        },
+        {
+          name: '',
+          number: 2,
+        },
+        {
+          name: '',
+          number: 3,
+        },
+        {
+          name: '',
+          number: 4,
+        },
+      ],
     });
   });
 

--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -18,7 +18,7 @@ import Cards from '../../../../../lib/components/cards';
 import Table from '../../../../../lib/components/table';
 import ExpandableSection from '../../../../../lib/components/expandable-section';
 
-import { mockedFunnelInteractionId, mockFunnelMetrics } from '../mocks';
+import { mockedFunnelInteractionId, mockFunnelMetrics, mockInnerText } from '../mocks';
 
 describe('AnalyticsFunnel', () => {
   beforeEach(() => {
@@ -300,6 +300,8 @@ describe('AnalyticsFunnelStep', () => {
     mockFunnelMetrics();
   });
 
+  mockInnerText();
+
   test('renders children components', () => {
     const { getByText } = render(
       <AnalyticsFunnelStep stepNumber={1} stepNameSelector=".step-name-selector">
@@ -317,22 +319,26 @@ describe('AnalyticsFunnelStep', () => {
     const stepNameSelector = '.step-name-selector';
 
     render(
-      <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
-        <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
-          Step Content
-          <Container />
-          <Cards items={[]} cardDefinition={{}} />
-          <Table items={[]} columnDefinitions={[]} />
-          <ExpandableSection variant="container" />
-        </AnalyticsFunnelStep>
-      </AnalyticsFunnel>
+      <>
+        <div className="step-name-selector">My funnel step</div>
+
+        <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
+          <AnalyticsFunnelStep stepNumber={stepNumber} stepNameSelector={stepNameSelector}>
+            Step Content
+            <Container />
+            <Cards items={[]} cardDefinition={{}} />
+            <Table items={[]} columnDefinitions={[]} />
+            <ExpandableSection variant="container" />
+          </AnalyticsFunnelStep>
+        </AnalyticsFunnel>
+      </>
     );
     act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledTimes(1);
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith({
       funnelInteractionId: mockedFunnelInteractionId,
-      stepName: undefined,
+      stepName: 'My funnel step',
       stepNumber,
       stepNameSelector,
       subStepAllSelector: expect.any(String),

--- a/src/internal/analytics/__tests__/mocks.ts
+++ b/src/internal/analytics/__tests__/mocks.ts
@@ -24,3 +24,23 @@ export function mockFunnelMetrics() {
     externalLinkInteracted: jest.fn(),
   });
 }
+
+export function mockInnerText() {
+  if (!('innerText' in HTMLElement.prototype)) {
+    // JSDom does not support the `innerText` property. For tests, `textContent` is usually close enough.
+
+    beforeEach(() =>
+      Object.defineProperty(HTMLElement.prototype, 'innerText', {
+        get() {
+          return this.textContent;
+        },
+        set(v) {
+          this.textContent = v;
+        },
+        configurable: true,
+      })
+    );
+
+    afterEach(() => delete (HTMLElement.prototype as Partial<HTMLElement>).innerText);
+  }
+}

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -30,7 +30,7 @@ import {
 } from '../selectors';
 import { useDebounceCallback } from '../../hooks/use-debounce-callback';
 
-export const FUNNEL_VERSION = '1.1';
+export const FUNNEL_VERSION = '1.2';
 
 type AnalyticsFunnelProps = { children?: React.ReactNode; stepConfiguration?: StepConfiguration[] } & Pick<
   FunnelProps,

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -210,7 +210,7 @@ function getSubStepConfiguration() {
   const subSteps = Array.from(document.querySelectorAll<HTMLElement>(getSubStepAllSelector()));
 
   const subStepConfiguration = subSteps.map((substep, index) => {
-    const name = substep.querySelector(getSubStepNameSelector())?.textContent ?? '';
+    const name = substep.querySelector<HTMLElement>(getSubStepNameSelector())?.innerText ?? '';
     return {
       name,
       number: index + 1,

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -210,7 +210,7 @@ function getSubStepConfiguration() {
   const subSteps = Array.from(document.querySelectorAll<HTMLElement>(getSubStepAllSelector()));
 
   const subStepConfiguration = subSteps.map((substep, index) => {
-    const name = substep.querySelector<HTMLElement>(getSubStepNameSelector())?.innerText ?? '';
+    const name = substep.querySelector<HTMLElement>(getSubStepNameSelector())?.innerText.trim() ?? '';
     return {
       name,
       number: index + 1,

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -18,7 +18,7 @@ import { useVisualRefresh } from '../../hooks/use-visual-mode';
 import { PACKAGE_VERSION } from '../../environment';
 
 import { FunnelMetrics } from '../index';
-import { FunnelProps, FunnelStepProps, SubStepConfiguration } from '../interfaces';
+import { FunnelProps, FunnelStepProps, StepConfiguration, SubStepConfiguration } from '../interfaces';
 
 import {
   DATA_ATTR_FUNNEL_STEP,
@@ -32,7 +32,7 @@ import { useDebounceCallback } from '../../hooks/use-debounce-callback';
 
 export const FUNNEL_VERSION = '1.1';
 
-type AnalyticsFunnelProps = { children?: React.ReactNode } & Pick<
+type AnalyticsFunnelProps = { children?: React.ReactNode; stepConfiguration?: StepConfiguration[] } & Pick<
   FunnelProps,
   'funnelType' | 'optionalStepNumbers' | 'totalFunnelSteps'
 >;
@@ -52,7 +52,7 @@ export const AnalyticsFunnel = (props: AnalyticsFunnelProps) => {
   return <InnerAnalyticsFunnel {...props} />;
 };
 
-const InnerAnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) => {
+const InnerAnalyticsFunnel = ({ children, stepConfiguration, ...props }: AnalyticsFunnelProps) => {
   const [funnelInteractionId, setFunnelInteractionId] = useState<string>('');
   const [submissionAttempt, setSubmissionAttempt] = useState(0);
   const isVisualRefresh = useVisualRefresh();
@@ -86,6 +86,10 @@ const InnerAnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) => {
       // Reset the state, in case the component was re-mounted.
       funnelState.current = 'default';
 
+      const singleStepFlowStepConfiguration = [
+        { number: 1, isOptional: false, name: getNameFromSelector(getFunnelNameSelector()) ?? '' },
+      ];
+
       const funnelInteractionId = FunnelMetrics.funnelStart({
         funnelNameSelector: getFunnelNameSelector(),
         optionalStepNumbers: props.optionalStepNumbers,
@@ -94,6 +98,7 @@ const InnerAnalyticsFunnel = ({ children, ...props }: AnalyticsFunnelProps) => {
         componentVersion: PACKAGE_VERSION,
         theme: isVisualRefresh ? 'vr' : 'classic',
         funnelVersion: FUNNEL_VERSION,
+        stepConfiguration: stepConfiguration ?? singleStepFlowStepConfiguration,
       });
 
       setFunnelInteractionId(funnelInteractionId);
@@ -201,6 +206,19 @@ export const AnalyticsFunnelStep = (props: AnalyticsFunnelStepProps) => {
   return <InnerAnalyticsFunnelStep {...props} key={props.stepNumber} />;
 };
 
+function getSubStepConfiguration() {
+  const subSteps = Array.from(document.querySelectorAll<HTMLElement>(getSubStepAllSelector()));
+
+  const subStepConfiguration = subSteps.map((substep, index) => {
+    const name = substep.querySelector(getSubStepNameSelector())?.textContent ?? '';
+    return {
+      name,
+      number: index + 1,
+    };
+  });
+  return subStepConfiguration;
+}
+
 function useStepChangeListener(handler: (stepConfiguration: SubStepConfiguration[]) => void) {
   /*
    Chosen so that it's hopefully shorter than a user interaction, but gives enough time for the
@@ -227,17 +245,7 @@ function useStepChangeListener(handler: (stepConfiguration: SubStepConfiguration
       return;
     }
 
-    const subSteps = Array.from(document.querySelectorAll<HTMLElement>(getSubStepAllSelector()));
-
-    const subStepConfiguration = subSteps.map((substep, index) => {
-      const name = substep.querySelector(getSubStepNameSelector())?.textContent ?? '';
-      return {
-        name,
-        number: index + 1,
-      };
-    });
-
-    handler(subStepConfiguration);
+    handler(getSubStepConfiguration());
   }, SUBSTEP_CHANGE_DEBOUNCE);
 
   return stepChangeCallback;
@@ -298,6 +306,7 @@ const InnerAnalyticsFunnelStep = ({ children, stepNumber, stepNameSelector }: An
         stepNameSelector,
         subStepAllSelector: getSubStepAllSelector(),
         totalSubSteps: subStepCount.current,
+        subStepConfiguration: getSubStepConfiguration(),
       });
     }
 

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -29,4 +29,4 @@ export const getSubStepNameSelector = (subStepId?: string) =>
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
 
 export const getNameFromSelector = (selector: string | undefined): string | undefined =>
-  selector ? document.querySelector<HTMLElement>(selector)?.innerText : undefined;
+  selector ? document.querySelector<HTMLElement>(selector)?.innerText?.trim() : undefined;

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -14,6 +14,7 @@ import { getFunnelKeySelector, FUNNEL_KEY_STEP_NAME } from '../../../lib/compone
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { DEFAULT_I18N_SETS, DEFAULT_STEPS } from './common';
+import { mockInnerText } from '../../internal/analytics/__tests__/mocks';
 
 const mockedFunnelInteractionId = 'mocked-funnel-id';
 function mockFunnelMetrics() {
@@ -36,6 +37,8 @@ function mockFunnelMetrics() {
     externalLinkInteracted: jest.fn(),
   });
 }
+
+mockInnerText();
 
 describe('Wizard Analytics', () => {
   beforeEach(() => {

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -61,6 +61,11 @@ describe('Wizard Analytics', () => {
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
         theme: expect.any(String),
+        stepConfiguration: [
+          { isOptional: false, name: 'Step 1', number: 1 },
+          { isOptional: true, name: 'Step 2', number: 2 },
+          { isOptional: false, name: 'Step 3', number: 3 },
+        ],
       })
     );
   });
@@ -77,6 +82,10 @@ describe('Wizard Analytics', () => {
         funnelInteractionId: expect.any(String),
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
+        subStepConfiguration: [
+          { name: 'Step 1, substep one', number: 1 },
+          { name: 'Step 1, substep two', number: 2 },
+        ],
       })
     );
   });
@@ -325,7 +334,12 @@ describe('Wizard Analytics', () => {
     const steps = [
       {
         title: 'Step 1',
-        content: <Form>Content 1</Form>,
+        content: (
+          <Form>
+            <Container header={<Header>Step 1, substep one</Header>}></Container>
+            <Container header={<Header>Step 1, substep two</Header>}></Container>
+          </Form>
+        ),
       },
       {
         title: 'Step 2',
@@ -356,6 +370,11 @@ describe('Wizard Analytics', () => {
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
         theme: expect.any(String),
+        stepConfiguration: [
+          { isOptional: false, name: 'Step 1', number: 1 },
+          { isOptional: true, name: 'Step 2', number: 2 },
+          { isOptional: false, name: 'Step 3', number: 3 },
+        ],
       })
     );
 
@@ -366,6 +385,10 @@ describe('Wizard Analytics', () => {
         funnelInteractionId: expect.any(String),
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
+        subStepConfiguration: [
+          { name: 'Step 1, substep one', number: 1 },
+          { name: 'Step 1, substep two', number: 2 },
+        ],
       })
     );
   });

--- a/src/wizard/__tests__/common.tsx
+++ b/src/wizard/__tests__/common.tsx
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import React from 'react';
 import { WizardProps } from '../interfaces';
+import Container from '../../../lib/components/container';
+import Header from '../../../lib/components/header';
 
 export const DEFAULT_I18N_SETS = [
   {
@@ -33,15 +36,30 @@ export const DEFAULT_I18N_SETS = [
 export const DEFAULT_STEPS = [
   {
     title: 'Step 1',
-    content: 'Content 1',
+    content: (
+      <>
+        <Container header={<Header>Step 1, substep one</Header>}></Container>
+        <Container header={<Header>Step 1, substep two</Header>}></Container>
+      </>
+    ),
   },
   {
     title: 'Step 2',
-    content: 'Content 2',
+    content: (
+      <>
+        <Container header={<Header>Step 2, substep one</Header>}></Container>
+        <Container header={<Header>Step 2, substep two</Header>}></Container>
+      </>
+    ),
     isOptional: true,
   },
   {
     title: 'Step 3',
-    content: 'Content 3',
+    content: (
+      <>
+        <Container header={<Header>Step 3, substep one</Header>}></Container>
+        <Container header={<Header>Step 3, substep two</Header>}></Container>
+      </>
+    ),
   },
 ] as ReadonlyArray<WizardProps.Step>;

--- a/src/wizard/__tests__/wizard.test.tsx
+++ b/src/wizard/__tests__/wizard.test.tsx
@@ -407,7 +407,7 @@ test('raises a warning when setting activeStepIndex without onNavigate listener'
 test('does not perform navigation when used in controlled mode', () => {
   const [wrapper] = renderDefaultWizard({ activeStepIndex: 1, onNavigate: () => {} });
   const checkStep = () => {
-    expect(wrapper.findContent()!.getElement()).toHaveTextContent(DEFAULT_STEPS[1].content as string);
+    expect(wrapper.findContent()!.getElement()).toHaveTextContent('Step 2, substep oneStep 2, substep two');
   };
   wrapper.findPreviousButton()!.click();
   checkStep();
@@ -420,7 +420,11 @@ test('does not perform navigation when used in controlled mode', () => {
 test('performs navigation when used in uncontrolled mode', () => {
   const [wrapper] = renderDefaultWizard();
   const checkStep = (index: number) => {
-    expect(wrapper.findContent()!.getElement()).toHaveTextContent(DEFAULT_STEPS[index].content as string);
+    if (index === 0) {
+      expect(wrapper.findContent()!.getElement()).toHaveTextContent('Step 1, substep oneStep 1, substep two');
+    } else {
+      expect(wrapper.findContent()!.getElement()).toHaveTextContent('Step 2, substep oneStep 2, substep two');
+    }
   };
   checkStep(0);
   wrapper.findPrimaryButton().click();

--- a/src/wizard/analytics.ts
+++ b/src/wizard/analytics.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useRef, useEffect } from 'react';
+import { FunnelMetrics } from '../internal/analytics';
+import { WizardProps } from './interfaces';
+
+export function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: WizardProps['steps']) {
+  const listenForStepChanges = useRef(false);
+
+  useEffect(() => {
+    // We prevent emitting the event before the funnel has stabilised.
+    const handle = setTimeout(() => (listenForStepChanges.current = true), 0);
+
+    return () => {
+      clearTimeout(handle);
+      listenForStepChanges.current = false;
+    };
+  }, [funnelInteractionId]);
+
+  const stepTitles = steps.map(step => step.title).join();
+  useEffect(() => {
+    if (!funnelInteractionId || !listenForStepChanges.current) {
+      return;
+    }
+
+    FunnelMetrics.funnelChange({
+      funnelInteractionId,
+      stepConfiguration: getStepConfiguration(steps),
+    });
+
+    // This dependency array does not include `steps`, because `steps` is not stable across renders.
+    // We use `stepTitles` as a stable proxy.
+    //
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [funnelInteractionId, stepTitles]);
+}
+
+export function getStepConfiguration(steps: WizardProps['steps']) {
+  return steps.map((step, index) => ({
+    name: step.title,
+    number: index + 1,
+    isOptional: step.isOptional ?? false,
+  }));
+}

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -7,7 +7,7 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 
 import { AnalyticsFunnel } from '../internal/analytics/components/analytics-funnel';
 
-import InternalWizard from './internal';
+import InternalWizard, { getStepConfiguration } from './internal';
 import { WizardProps } from './interfaces';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
 
@@ -29,6 +29,7 @@ function Wizard({ isLoadingNextStep = false, allowSkipTo = false, ...props }: Wi
         .map((step, index) => (step.isOptional ? index + 1 : -1))
         .filter(step => step !== -1)}
       totalFunnelSteps={props.steps.length}
+      stepConfiguration={getStepConfiguration(props.steps)}
     >
       <InternalWizard
         isLoadingNextStep={isLoadingNextStep}

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -7,7 +7,8 @@ import useBaseComponent from '../internal/hooks/use-base-component';
 
 import { AnalyticsFunnel } from '../internal/analytics/components/analytics-funnel';
 
-import InternalWizard, { getStepConfiguration } from './internal';
+import InternalWizard from './internal';
+import { getStepConfiguration } from './analytics';
 import { WizardProps } from './interfaces';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
 

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -208,15 +208,9 @@ function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: Wi
       return;
     }
 
-    const stepConfiguration = steps.map((step, index) => ({
-      name: step.title,
-      number: index + 1,
-      isOptional: step.isOptional ?? false,
-    }));
-
     FunnelMetrics.funnelChange({
       funnelInteractionId,
-      stepConfiguration,
+      stepConfiguration: getStepConfiguration(steps),
     });
 
     // This dependency array does not include `steps`, because `steps` is not stable across renders.
@@ -224,4 +218,12 @@ function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: Wi
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [funnelInteractionId, stepTitles]);
+}
+
+export function getStepConfiguration(steps: WizardProps['steps']) {
+  return steps.map((step, index) => ({
+    name: step.title,
+    number: index + 1,
+    isOptional: step.isOptional ?? false,
+  }));
 }


### PR DESCRIPTION
### Description

Previously, we've included the `stepConfiguration` and `subStepConfiguration` properties in the `funnelChange` and `funnelStepChange` events (https://github.com/cloudscape-design/components/pull/1509, https://github.com/cloudscape-design/components/pull/1511).

With this PR, we also include these properties in the corresponding start event, so that they can be used as a reference when the change events are emitted (otherwise it is difficult to figure out what changed).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Extended unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
