### PR TITLE
fix: Make table sticky columns util support columns unmount

### DIFF
--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -6,6 +6,7 @@ import {
   StickyColumnsModel,
   useStickyCellStyles,
 } from '../../../../lib/components/table/sticky-columns';
+import { updateCellOffsets } from '../../../../lib/components/table/sticky-columns/utils';
 import { getStickyClassNames } from '../../../../lib/components/table/utils';
 import { renderHook } from '../../../__tests__/render-hook';
 
@@ -319,5 +320,21 @@ describe('getStickyClassNames helper', () => {
       'sticky-cell-last-left': false,
       'sticky-cell-last-right': true,
     });
+  });
+});
+
+test('updateCellOffsets element widths fallback to 0 when elements are missing', () => {
+  const offsets = updateCellOffsets(
+    {},
+    { stickyColumnsFirst: 1, stickyColumnsLast: 1, visibleColumns: ['a', 'b', 'c'] }
+  );
+  expect(offsets).toEqual({
+    offsets: new Map([
+      ['a', { first: 0, last: 0 }],
+      ['b', { first: 0, last: 0 }],
+      ['c', { first: 0, last: 0 }],
+    ]),
+    stickyWidthLeft: 0,
+    stickyWidthRight: 0,
   });
 });

--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -324,17 +324,10 @@ describe('getStickyClassNames helper', () => {
 });
 
 test('updateCellOffsets element widths fallback to 0 when elements are missing', () => {
-  const offsets = updateCellOffsets(
+  const { offsets } = updateCellOffsets(
     {},
     { stickyColumnsFirst: 1, stickyColumnsLast: 1, visibleColumns: ['a', 'b', 'c'] }
   );
-  expect(offsets).toEqual({
-    offsets: new Map([
-      ['a', { first: 0, last: 0 }],
-      ['b', { first: 0, last: 0 }],
-      ['c', { first: 0, last: 0 }],
-    ]),
-    stickyWidthLeft: 0,
-    stickyWidthRight: 0,
-  });
+  expect(offsets.get('a')).toEqual({ first: 0, last: 0 });
+  expect(offsets.get('c')).toEqual({ first: 0, last: 0 });
 });

--- a/src/table/sticky-columns/utils.ts
+++ b/src/table/sticky-columns/utils.ts
@@ -26,14 +26,14 @@ export function updateCellOffsets(cells: Record<PropertyKey, HTMLElement>, props
   const firstColumnsWidths: number[] = [];
   for (let i = 0; i < Math.min(totalColumns, props.stickyColumnsFirst); i++) {
     const element = cells[props.visibleColumns[i]];
-    const cellWidth = element.getBoundingClientRect().width ?? 0;
+    const cellWidth = element?.getBoundingClientRect().width ?? 0;
     firstColumnsWidths[i] = (firstColumnsWidths[i - 1] ?? 0) + cellWidth;
   }
 
   const lastColumnsWidths: number[] = [];
   for (let i = 0; i < Math.min(totalColumns, props.stickyColumnsLast); i++) {
     const element = cells[props.visibleColumns[totalColumns - 1 - i]];
-    const cellWidth = element.getBoundingClientRect().width ?? 0;
+    const cellWidth = element?.getBoundingClientRect().width ?? 0;
     lastColumnsWidths[i] = (lastColumnsWidths[i - 1] ?? 0) + cellWidth;
   }
 


### PR DESCRIPTION
### Description

The sticky columns feature of the table requires cell references stored in a record. When the table un-mounts, those references are removed. In the`updateCellOffsets` utility the null-check was not implemented correctly: `element.getBoundingClientRect().width ?? 0` instead of `element?.getBoundingClientRect().width ?? 0`. As result, the function is failing when table cells un-mount.

The issue was not observed until the resent fix https://github.com/cloudscape-design/components/pull/1508 for cell references assignment. Before the fix the cleanup never happened so upon un-mounting the record retained all references.

### How has this been tested?

Added a unit test to secure regression.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
