### PR TITLE
fix: Fix controlled tools mode when drawers API is used

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -6,6 +6,7 @@ import {
   ContentLayout,
   Header,
   HelpPanel,
+  Link,
   NonCancelableCustomEvent,
   SpaceBetween,
   SplitPanel,
@@ -71,7 +72,15 @@ export default function WithDrawers() {
         <ContentLayout
           header={
             <SpaceBetween size="m">
-              <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
+              <Header
+                variant="h1"
+                description="Sometimes you need custom drawers to get the job done."
+                info={
+                  <Link variant="info" onFollow={() => setIsToolsOpen(true)}>
+                    Info
+                  </Link>
+                }
+              >
                 Testing Custom Drawers!
               </Header>
 

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper().findAppLayout();
+
+for (const visualRefresh of [true, false]) {
+  describe(`visualRefresh=${visualRefresh}`, () => {
+    function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+      return useBrowser(async browser => {
+        const page = new BasePageObject(browser);
+
+        await browser.url(
+          `#/light/app-layout/runtime-drawers?${new URLSearchParams({
+            hasDrawers: 'false',
+            hasTools: 'true',
+            visualRefresh: `${visualRefresh}`,
+          }).toString()}`
+        );
+        await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
+        await testFn(page);
+      });
+    }
+
+    test(
+      'should switch between tools panel and runtime drawers',
+      setupTest(async page => {
+        await page.click(wrapper.findToolsToggle().toSelector());
+        await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain('Here is some info for you!');
+
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+        await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain('I am runtime drawer');
+
+        await page.click(wrapper.findDrawerTriggerById('awsui-internal-tools').toSelector());
+        await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain('Here is some info for you!');
+      })
+    );
+
+    test(
+      'should open and close tools via controlled mode',
+      setupTest(async page => {
+        const toolsContentSelector = wrapper.findTools().getElement();
+        await page.click(createWrapper().findHeader().findInfo().findLink().toSelector());
+        await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(true);
+        await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
+          'Here is some info for you!'
+        );
+
+        await page.click(wrapper.findToolsClose().toSelector());
+        await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(false);
+      })
+    );
+  });
+}

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -86,7 +86,7 @@ export function useDrawers(
   const [activeDrawerId, setActiveDrawerId] = useControllable(
     ownDrawers?.activeDrawerId,
     ownDrawers?.onChange,
-    !toolsProps.toolsHide && toolsProps.toolsOpen ? TOOLS_DRAWER_ID : undefined,
+    undefined,
     {
       componentName: 'AppLayout',
       controlledProp: 'activeDrawerId',
@@ -105,8 +105,12 @@ export function useDrawers(
   if (toolsDrawer && combinedDrawers.length > 0) {
     combinedDrawers.unshift(toolsDrawer);
   }
-  const activeDrawer = combinedDrawers.find(drawer => drawer.id === activeDrawerId);
-  const activeDrawerIdResolved = activeDrawer?.id; // only defined when corresponding drawer exists
+  // support toolsOpen in runtime-drawers-only mode
+  let activeDrawerIdResolved =
+    toolsProps.toolsOpen && (ownDrawers?.items ?? []).length === 0 ? TOOLS_DRAWER_ID : activeDrawerId;
+  const activeDrawer = combinedDrawers.find(drawer => drawer.id === activeDrawerIdResolved);
+  // ensure that id is only defined when the drawer exists
+  activeDrawerIdResolved = activeDrawer?.id;
 
   function onActiveDrawerResize({ id, size }: { id: string; size: number }) {
     setDrawerSizes(oldSizes => ({ ...oldSizes, [id]: size }));

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -118,7 +118,10 @@ function ActiveDrawer() {
           })}
           formAction="none"
           iconName={isMobile ? 'close' : 'angle-right'}
-          onClick={() => (activeDrawerId ? handleDrawersClick(activeDrawerId ?? null) : handleToolsClick(false))}
+          onClick={() => {
+            handleDrawersClick(activeDrawerId ?? undefined);
+            handleToolsClick(false);
+          }}
           ref={isToolsDrawer ? toolsRefs.close : drawersRefs.close}
           variant="icon"
         />
@@ -195,6 +198,15 @@ function DesktopTriggers() {
   const { visibleItems, overflowItems } = splitItems(drawers, getIndexOfOverflowItem(), activeDrawerId);
   const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
+  function handleItemClick(itemId: string | undefined) {
+    if (itemId === TOOLS_DRAWER_ID) {
+      handleToolsClick(!isToolsOpen, true);
+    } else {
+      handleToolsClick(false, true);
+    }
+    handleDrawersClick(itemId);
+  }
+
   return (
     <aside
       className={clsx(
@@ -230,10 +242,7 @@ function DesktopTriggers() {
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
               key={item.id}
-              onClick={() => {
-                isToolsOpen && handleToolsClick(!isToolsOpen, true);
-                handleDrawersClick(item.id);
-              }}
+              onClick={() => handleItemClick(item.id)}
               ref={item.id === previousActiveDrawerId.current ? drawersRefs.toggle : undefined}
               selected={item.id === activeDrawerId}
               badge={item.badge}
@@ -258,7 +267,7 @@ function DesktopTriggers() {
               />
             )}
             onItemClick={({ detail }) => {
-              handleDrawersClick(detail.id);
+              handleItemClick(detail.id);
             }}
           />
         )}
@@ -292,6 +301,8 @@ export function MobileTriggers() {
     drawersAriaLabel,
     drawersOverflowAriaLabel,
     drawersRefs,
+    isToolsOpen,
+    handleToolsClick,
     handleDrawersClick,
     hasDrawerViewportOverlay,
     isMobile,
@@ -310,6 +321,15 @@ export function MobileTriggers() {
   const splitIndex = 2;
 
   const { visibleItems, overflowItems } = splitItems(drawers, splitIndex, activeDrawerId, true);
+
+  function handleItemClick(itemId: string | undefined) {
+    if (itemId === TOOLS_DRAWER_ID) {
+      handleToolsClick(!isToolsOpen, true);
+    } else {
+      handleToolsClick(false, true);
+    }
+    handleDrawersClick(itemId);
+  }
 
   return (
     <aside
@@ -339,7 +359,7 @@ export function MobileTriggers() {
           iconSvg={item.trigger.iconSvg}
           badge={item.badge}
           key={item.id}
-          onClick={() => handleDrawersClick(item.id)}
+          onClick={() => handleItemClick(item.id)}
           variant="icon"
           __nativeAttributes={{ 'aria-haspopup': true, 'data-testid': `awsui-app-layout-trigger-${item.id}` }}
         />
@@ -349,7 +369,7 @@ export function MobileTriggers() {
           items={overflowItems}
           ariaLabel={drawersOverflowAriaLabel}
           onItemClick={({ detail }) => {
-            handleDrawersClick(detail.id);
+            handleItemClick(detail.id);
           }}
         />
       )}


### PR DESCRIPTION
### Description

When drawers API is used `toolsOpen` is ignored. This introduced an issue for controlled mode, which is commonly used to integrate with help panel.


Related links, issue #, if available: n/a

### How has this been tested?

Added extra unit and integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
