### PR TITLE
fix: Read table header width upon resizer mounting

### DIFF
--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -203,9 +203,18 @@ export function Resizer({
           'aria-valuemin': minWidth,
         };
 
+  const resizerRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (resizerRef.current) {
+      const headerCell = findHeaderCell(resizerRef.current);
+      setHeaderCellWidth(headerCell.getBoundingClientRect().width);
+    }
+  }, []);
+
   return (
     <>
       <span
+        ref={resizerRef}
         className={clsx(
           styles.resizer,
           isDragging && styles['resizer-active'],
@@ -216,13 +225,11 @@ export function Resizer({
             return;
           }
           event.preventDefault();
-          const headerCell = findUpUntil(event.currentTarget, element => element.tagName.toLowerCase() === 'th')!;
+          const headerCell = findHeaderCell(event.currentTarget);
           setIsDragging(true);
           setHeaderCell(headerCell);
         }}
-        onFocus={event => {
-          const headerCell = findUpUntil(event.currentTarget, element => element.tagName.toLowerCase() === 'th')!;
-          setHeaderCellWidth(headerCell.getBoundingClientRect().width);
+        onFocus={() => {
           setResizerHasFocus(true);
           setHeaderCell(headerCell);
           onFocus?.();
@@ -249,4 +256,8 @@ export function Resizer({
 
 export function ResizeTracker() {
   return <span className={styles.tracker} />;
+}
+
+function findHeaderCell(from: HTMLElement) {
+  return findUpUntil(from, element => element.tagName.toLowerCase() === 'th')!;
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
