### PR TITLE
fix: Table column resize handles use ARIA description to communicate current width

### DIFF
--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -366,16 +366,42 @@ describe('resize with keyboard', () => {
   });
 });
 
-test('resizable columns headers have expected text content', () => {
-  const { wrapper } = renderTable(<Table {...defaultProps} />);
+describe('column header roles', () => {
+  const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+  beforeEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      const rect = originalBoundingClientRect.apply(this);
+      if (this.tagName === 'TH') {
+        rect.width = 150;
+      }
+      return rect;
+    };
+  });
 
-  expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
-  expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
-});
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+  });
 
-test('resizable columns headers can be asserted with getByRole', () => {
-  renderTable(<Table {...defaultProps} />);
+  test('resizable columns headers have expected text content', () => {
+    const { wrapper } = renderTable(<Table {...defaultProps} />);
 
-  expect(screen.getByRole('columnheader', { name: 'Id' }));
-  expect(screen.getByRole('columnheader', { name: 'Description' }));
+    expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
+    expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
+  });
+
+  test('resizable columns headers can be asserted with getByRole', () => {
+    renderTable(<Table {...defaultProps} />);
+
+    expect(screen.getByRole('columnheader', { name: 'Id' }));
+    expect(screen.getByRole('columnheader', { name: 'Description' }));
+  });
+
+  test('column resizers have expected accessible description', () => {
+    const { wrapper } = renderTable(<Table {...defaultProps} />);
+    const findResizer = (columnIndex: number) =>
+      wrapper.findColumnHeaders()[columnIndex].findByClassName(resizerStyles.resizer)!.getElement();
+
+    expect(findResizer(0)).toHaveAccessibleDescription('150');
+    expect(findResizer(1)).toHaveAccessibleDescription('150');
+  });
 });

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import times from 'lodash/times';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
 import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
@@ -371,4 +371,11 @@ test('resizable columns headers have expected text content', () => {
 
   expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
   expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
+});
+
+test('resizable columns headers can be asserted with getByRole', () => {
+  renderTable(<Table {...defaultProps} />);
+
+  expect(screen.getByRole('columnheader', { name: 'Id' }));
+  expect(screen.getByRole('columnheader', { name: 'Description' }));
 });

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -10,7 +10,6 @@ import { KeyCode } from '../../internal/keycode';
 import { DEFAULT_COLUMN_WIDTH } from '../use-column-widths';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
-import { joinStrings } from '../../internal/utils/strings';
 import Portal from '../../internal/components/portal';
 
 interface ResizerProps {
@@ -185,14 +184,15 @@ export function Resizer({
     };
   }, [headerCell, isDragging, isKeyboardDragging, onFinishStable, resizerHasFocus, handlers]);
 
-  const resizerWidthId = useUniqueId();
+  const resizerDescriptionId = useUniqueId();
   const resizerRole = isKeyboardDragging ? 'separator' : 'button';
   const headerCellWidthString = headerCellWidth.toFixed(0);
   const resizerAriaProps =
     resizerRole === 'button'
       ? {
-          'aria-labelledby': joinStrings(ariaLabelledby, resizerWidthId),
+          'aria-labelledby': ariaLabelledby,
           'aria-pressed': false,
+          'aria-describedby': resizerDescriptionId,
         }
       : {
           'aria-labelledby': ariaLabelledby,
@@ -203,9 +203,19 @@ export function Resizer({
           'aria-valuemin': minWidth,
         };
 
+  // Setting header width after mounting to be available for resizer description.
+  const resizerRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (resizerRef.current) {
+      const headerCell = findUpUntil(resizerRef.current, element => element.tagName.toLowerCase() === 'th')!;
+      setHeaderCellWidth(headerCell.getBoundingClientRect().width);
+    }
+  }, []);
+
   return (
     <>
       <span
+        ref={resizerRef}
         className={clsx(
           styles.resizer,
           isDragging && styles['resizer-active'],
@@ -241,7 +251,7 @@ export function Resizer({
         data-focus-id={focusId}
       />
       <Portal container={getDescriptionRoot?.()}>
-        <span id={resizerWidthId}>{headerCellWidthString}</span>
+        <span id={resizerDescriptionId}>{headerCellWidthString}</span>
       </Portal>
     </>
   );


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
