### PR TITLE
fix: Make resize handle width available before it gets focused

### DIFF
--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -366,9 +366,35 @@ describe('resize with keyboard', () => {
   });
 });
 
-test('resizable columns headers have expected text content', () => {
-  const { wrapper } = renderTable(<Table {...defaultProps} />);
+describe('column header content', () => {
+  const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+  beforeEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      const rect = originalBoundingClientRect.apply(this);
+      if (this.tagName === 'TH') {
+        rect.width = 150;
+      }
+      return rect;
+    };
+  });
 
-  expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
-  expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
+  });
+
+  test('resizable columns headers have expected text content', () => {
+    const { wrapper } = renderTable(<Table {...defaultProps} />);
+
+    expect(wrapper.findColumnHeaders()[0].getElement()!.textContent).toEqual('Id');
+    expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
+  });
+
+  test('resize handles have expected accessible names', () => {
+    const { wrapper } = renderTable(<Table {...defaultProps} />);
+    const getResizeHandle = (columnIndex: number) =>
+      wrapper.findColumnHeaders()[columnIndex].findByClassName(resizerStyles.resizer)!.getElement();
+
+    expect(getResizeHandle(0)).toHaveAccessibleName('Id 150');
+    expect(getResizeHandle(1)).toHaveAccessibleName('Description 150');
+  });
 });

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -203,9 +203,19 @@ export function Resizer({
           'aria-valuemin': minWidth,
         };
 
+  // Read header width after mounting for it to be available in the element's ARIA label before it gets focused.
+  const resizerRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (resizerRef.current) {
+      const headerCell = findUpUntil(resizerRef.current, element => element.tagName.toLowerCase() === 'th')!;
+      setHeaderCellWidth(headerCell.getBoundingClientRect().width);
+    }
+  }, []);
+
   return (
     <>
       <span
+        ref={resizerRef}
         className={clsx(
           styles.resizer,
           isDragging && styles['resizer-active'],


### PR DESCRIPTION
### Description

The resize handle width is set to the element's ARIA label and should be available before the element receives focus as otherwise it reads as `0`.

See 6oM9A1dINc3m

### How has this been tested?

Added new unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
