### PR TITLE
revert: Make table resize handles no longer requiring activation with keyboard

### DIFF
--- a/pages/table/resizable-columns.page.tsx
+++ b/pages/table/resizable-columns.page.tsx
@@ -14,6 +14,12 @@ import Table, { TableProps } from '~components/table';
 import { NonCancelableCustomEvent } from '~components/interfaces';
 import ScreenshotArea from '../utils/screenshot-area';
 
+declare global {
+  interface Window {
+    __columnWidths: readonly number[];
+  }
+}
+
 interface Item {
   id: number;
   text: string;
@@ -100,6 +106,7 @@ export default function App() {
   const [sorting, setSorting] = useState<TableProps.SortingState<any>>();
 
   function handleWidthChange(event: NonCancelableCustomEvent<TableProps.ColumnWidthsChangeDetail>) {
+    window.__columnWidths = event.detail.widths;
     const widths = zipObject(
       columnDisplay.map(column => column.id!),
       event.detail.widths

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -6,6 +6,12 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 import styles from '../../../lib/components/table/styles.selectors.js';
 import scrollbarStyles from '../../../lib/components/table/sticky-scrollbar/styles.selectors.js';
 
+declare global {
+  interface Window {
+    __columnWidths: readonly number[];
+  }
+}
+
 const scrollbarSelector = `.${scrollbarStyles['sticky-scrollbar-visible']}`;
 const wrapper = createWrapper();
 const tableWrapper = wrapper.findTable();
@@ -41,6 +47,11 @@ class TablePage extends BasePageObject {
     const element = await this.browser.$(columnSelector);
     const size = await element.getSize();
     return size.width;
+  }
+
+  // Returns column width communicated with onColumnWidthsChange
+  readTableWidth(columnIndex: number) {
+    return this.browser.execute(columnIndex => window.__columnWidths[columnIndex - 1], columnIndex);
   }
 
   async getColumnStyle(columnIndex: number) {
@@ -239,7 +250,7 @@ test(
 );
 
 test(
-  'should recover column withs when the inner state is reset',
+  'should recover column widths when the inner state is reset',
   setupTest(async page => {
     await page.resizeColumn(2, 100);
     const oldWidth = await page.getColumnWidth(2);
@@ -253,17 +264,20 @@ test(
   'should resize column to grow by keyboard',
   setupTest(async page => {
     await page.click('#reset-state');
-    const oldWidth = await page.getColumnWidth(1);
+    const originalWidth = await page.getColumnWidth(1);
     await page.keys(['Tab']);
     // wait for the resizer to attach handler
 
-    await page.keys(['Enter', 'ArrowRight', 'ArrowRight', 'Enter']);
-    await page.assertColumnWidth(1, oldWidth + 10 + 10);
+    await page.keys(['ArrowRight']);
+    await page.assertColumnWidth(1, originalWidth + 10);
+    await expect(page.readTableWidth(1)).resolves.toEqual(originalWidth + 10);
 
-    await page.keys(['Space', 'ArrowLeft', 'Space']);
-    await page.assertColumnWidth(1, oldWidth + 10);
+    await page.keys(['ArrowRight']);
+    await page.assertColumnWidth(1, originalWidth + 20);
+    await expect(page.readTableWidth(1)).resolves.toEqual(originalWidth + 20);
 
-    await page.keys(['Enter', 'ArrowRight', 'Escape']);
-    await page.assertColumnWidth(1, oldWidth + 10);
+    await page.keys(['ArrowLeft']);
+    await page.assertColumnWidth(1, originalWidth + 10);
+    await expect(page.readTableWidth(1)).resolves.toEqual(originalWidth + 10);
   })
 );

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import times from 'lodash/times';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
 import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
 import { fireMousedown, fireMouseup, fireMouseMove, fakeBoundingClientRect } from './utils/resize-actions';
-import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
 
 jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => ({
   browserScrollbarSize: () => ({ width: 20, height: 20 }),
@@ -294,94 +293,7 @@ test('should not trigger if the previous and the current widths are the same', (
   expect(onChange).toHaveBeenCalledTimes(0);
 });
 
-describe('resize with keyboard', () => {
-  const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
-  beforeEach(() => {
-    HTMLElement.prototype.getBoundingClientRect = function () {
-      const rect = originalBoundingClientRect.apply(this);
-      if (this.tagName === 'TH') {
-        rect.width = 150;
-      }
-      return rect;
-    };
-  });
-
-  afterEach(() => {
-    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
-  });
-
-  test('ignores arrow keys before entering the dragging mode', () => {
-    const onChange = jest.fn();
-    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
-    const columnResizerWrapper = wrapper.findColumnResizer(1)!;
-
-    columnResizerWrapper.focus();
-    columnResizerWrapper.keydown(KeyCode.right);
-    columnResizerWrapper.keydown(KeyCode.enter);
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-  });
-
-  test.each([KeyCode.space, KeyCode.enter])('activates and commits resize with [%s] key code', keyCode => {
-    const onChange = jest.fn();
-    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
-    const columnResizerWrapper = wrapper.findColumnResizer(1)!;
-
-    columnResizerWrapper.focus();
-    columnResizerWrapper.keydown(keyCode);
-    columnResizerWrapper.keydown(KeyCode.left);
-    columnResizerWrapper.keydown(keyCode);
-
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({ widths: [140, 300] });
-  });
-
-  test.each([KeyCode.escape])('discards resize with [%s] key code', keyCode => {
-    const onChange = jest.fn();
-    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
-    const columnResizerWrapper = wrapper.findColumnResizer(1)!;
-
-    columnResizerWrapper.focus();
-    columnResizerWrapper.keydown(KeyCode.enter);
-    columnResizerWrapper.keydown(KeyCode.right);
-    columnResizerWrapper.keydown(keyCode);
-    columnResizerWrapper.keydown(KeyCode.enter);
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-  });
-
-  test('discards resize on blur', () => {
-    const onChange = jest.fn();
-    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
-    const columnResizerWrapper = wrapper.findColumnResizer(1)!;
-
-    columnResizerWrapper.focus();
-    columnResizerWrapper.keydown(KeyCode.enter);
-    columnResizerWrapper.keydown(KeyCode.right);
-    wrapper.findColumnResizer(2)!.focus();
-    columnResizerWrapper.focus();
-    columnResizerWrapper.keydown(KeyCode.enter);
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-  });
-});
-
 describe('column header content', () => {
-  const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
-  beforeEach(() => {
-    HTMLElement.prototype.getBoundingClientRect = function () {
-      const rect = originalBoundingClientRect.apply(this);
-      if (this.tagName === 'TH') {
-        rect.width = 150;
-      }
-      return rect;
-    };
-  });
-
-  afterEach(() => {
-    HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
-  });
-
   test('resizable columns headers have expected text content', () => {
     const { wrapper } = renderTable(<Table {...defaultProps} />);
 
@@ -389,12 +301,19 @@ describe('column header content', () => {
     expect(wrapper.findColumnHeaders()[1].getElement()!.textContent).toEqual('Description');
   });
 
+  test('resizable columns can be queries with columnheader role', () => {
+    renderTable(<Table {...defaultProps} />);
+
+    expect(screen.getByRole('columnheader', { name: 'Id' }));
+    expect(screen.getByRole('columnheader', { name: 'Description' }));
+  });
+
   test('resize handles have expected accessible names', () => {
     const { wrapper } = renderTable(<Table {...defaultProps} />);
     const getResizeHandle = (columnIndex: number) =>
       wrapper.findColumnHeaders()[columnIndex].findByClassName(resizerStyles.resizer)!.getElement();
 
-    expect(getResizeHandle(0)).toHaveAccessibleName('Id 150');
-    expect(getResizeHandle(1)).toHaveAccessibleName('Description 150');
+    expect(getResizeHandle(0)).toHaveAccessibleName('Id');
+    expect(getResizeHandle(1)).toHaveAccessibleName('Description');
   });
 });

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -37,7 +37,6 @@ interface TableHeaderCellProps<ItemType> {
   cellRef: React.RefCallback<HTMLElement>;
   focusedComponent?: null | string;
   tableRole: TableRole;
-  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 export function TableHeaderCell<ItemType>({
@@ -61,7 +60,6 @@ export function TableHeaderCell<ItemType>({
   stickyState,
   cellRef,
   tableRole,
-  getDescriptionRoot,
 }: TableHeaderCellProps<ItemType>) {
   const i18n = useInternalI18n('table');
   const sortable = !!column.sortingComparator || !!column.sortingField;
@@ -150,7 +148,6 @@ export function TableHeaderCell<ItemType>({
           onFinish={onResizeFinish}
           ariaLabelledby={headerId}
           minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
-          getDescriptionRoot={getDescriptionRoot}
         />
       )}
     </TableThElement>

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -39,7 +39,6 @@ import { getTableRoleProps, getTableRowRoleProps, getTableWrapperRoleProps } fro
 import { useCellEditing } from './use-cell-editing';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
-import ScreenreaderOnly from '../internal/components/screenreader-only';
 
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
@@ -102,10 +101,6 @@ const InternalTable = React.forwardRef(
 
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
-
-    // Used to render table's ARIA description nodes into.
-    const descriptionRef = useRef<HTMLSpanElement>(null);
-    const getDescriptionRoot = useCallback(() => descriptionRef.current, []);
 
     const secondaryWrapperRef = React.useRef<HTMLDivElement>(null);
     const theadRef = useRef<HTMLTableRowElement>(null);
@@ -219,7 +214,6 @@ const InternalTable = React.forwardRef(
       stickyState,
       selectionColumnId,
       tableRole,
-      getDescriptionRoot,
     };
 
     const wrapperRef = useMergeRefs(wrapperMeasureRef, wrapperRefObject, stickyState.refs.wrapper);
@@ -485,10 +479,6 @@ const InternalTable = React.forwardRef(
               onScroll={handleScroll}
               hasStickyColumns={hasStickyColumns}
             />
-
-            <ScreenreaderOnly>
-              <span ref={descriptionRef}></span>
-            </ScreenreaderOnly>
           </InternalContainer>
         </ColumnWidthsProvider>
       </LinkDefaultVariantContext.Provider>

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -9,8 +9,6 @@ import styles from './styles.css.js';
 import { KeyCode } from '../../internal/keycode';
 import { DEFAULT_COLUMN_WIDTH } from '../use-column-widths';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
-import { useUniqueId } from '../../internal/hooks/use-unique-id';
-import Portal from '../../internal/components/portal';
 
 interface ResizerProps {
   onDragMove: (newWidth: number) => void;
@@ -22,7 +20,6 @@ interface ResizerProps {
   showFocusRing?: boolean;
   onFocus?: () => void;
   onBlur?: () => void;
-  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 const AUTO_GROW_START_TIME = 10;
@@ -39,7 +36,6 @@ export function Resizer({
   focusId,
   onFocus,
   onBlur,
-  getDescriptionRoot,
 }: ResizerProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [headerCell, setHeaderCell] = useState<null | HTMLElement>(null);
@@ -162,7 +158,6 @@ export function Resizer({
     };
   }, [headerCell, isDragging, onFinishStable, resizerHasFocus, handlers]);
 
-  const resizerWidthId = useUniqueId();
   const headerCellWidthString = headerCellWidth.toFixed(0);
   const resizerAriaProps = {
     role: 'separator',
@@ -216,9 +211,6 @@ export function Resizer({
         tabIndex={tabIndex}
         data-focus-id={focusId}
       />
-      <Portal container={getDescriptionRoot?.()}>
-        <span id={resizerWidthId}>{headerCellWidthString}</span>
-      </Portal>
     </>
   );
 }

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -41,7 +41,6 @@ export interface TheadProps {
   focusedComponent?: null | string;
   onFocusedComponentChange?: (focusId: null | string) => void;
   tableRole: TableRole;
-  getDescriptionRoot?: () => null | HTMLElement;
 }
 
 const Thead = React.forwardRef(
@@ -70,7 +69,6 @@ const Thead = React.forwardRef(
       focusedComponent,
       onFocusedComponentChange,
       tableRole,
-      getDescriptionRoot,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
@@ -172,7 +170,6 @@ const Thead = React.forwardRef(
                 stickyState={stickyState}
                 cellRef={node => setCell(columnId, node)}
                 tableRole={tableRole}
-                getDescriptionRoot={getDescriptionRoot}
               />
             );
           })}


### PR DESCRIPTION
### Description

This change essentially reverts https://github.com/cloudscape-design/components/pull/1492 due to unexpected changes to the columnheader element in the accessibility tree causing failures of those tests querying columns by role.

The original change is to be reintroduced once it is figured out how to make it safer.

See 6oM9A1dINc3m

### How has this been tested?

Added a test featuring getByRole selector.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
