### PR TITLE
feat: Public Drawers

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -163,7 +163,7 @@ export default function WithDrawers() {
       tools={<Info helpPathSlug={helpPathSlug} />}
       toolsOpen={isToolsOpen}
       toolsHide={!hasTools}
-      {...drawers}
+      {...(drawers as any)}
     />
   );
 }

--- a/pages/app-layout/utils/drawers.tsx
+++ b/pages/app-layout/utils/drawers.tsx
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { AppLayoutProps, HelpPanel, SpaceBetween } from '~components';
+import styles from '../styles.scss';
+
+const getAriaLabels = (title: string, badge: boolean) => {
+  return {
+    closeButton: `${title} close button`,
+    drawerName: `${title}`,
+    triggerButton: `${title} trigger button${badge ? ' (Unread notifications)' : ''}`,
+    resizeHandle: `${title} resize handle`,
+  };
+};
+
+function Security() {
+  return (
+    <HelpPanel header={<h2>Security</h2>}>
+      <SpaceBetween size="l">
+        <div className={styles.contentPlaceholder} />
+        <div className={styles.contentPlaceholder} />
+        <div className={styles.contentPlaceholder} />
+      </SpaceBetween>
+    </HelpPanel>
+  );
+}
+
+export const drawerItems: Array<AppLayoutProps.Drawer> = [
+  {
+    ariaLabels: getAriaLabels('Security', false),
+    content: <Security />,
+    id: 'security',
+    resizable: true,
+    onResize: (event: any) => {
+      // A drawer implementer may choose to listen to THEIR drawer's
+      // resize event,should they want to persist, or otherwise respond
+      // to their drawer being resized.
+      console.log('Security Drawer is now: ', event.detail.size);
+    },
+    trigger: {
+      iconName: 'security',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Pro help', true),
+    content: <HelpPanel header={<h2>Pro help</h2>}>Pro help.</HelpPanel>,
+    badge: true,
+    defaultSize: 600,
+    id: 'pro-help',
+    trigger: {
+      iconName: 'contact',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Links', false),
+    resizable: true,
+    defaultSize: 500,
+    content: <HelpPanel header={<h2>Links</h2>}>Links.</HelpPanel>,
+    id: 'links',
+    trigger: {
+      iconName: 'share',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 1', true),
+    content: <HelpPanel header={<h2>Test 1</h2>}>Test 1.</HelpPanel>,
+    badge: true,
+    id: 'test-1',
+    trigger: {
+      iconName: 'contact',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 2', false),
+    resizable: true,
+    defaultSize: 500,
+    content: <HelpPanel header={<h2>Test 2</h2>}>Test 2.</HelpPanel>,
+    id: 'test-2',
+    trigger: {
+      iconName: 'share',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 3', true),
+    content: <HelpPanel header={<h2>Test 3</h2>}>Test 3.</HelpPanel>,
+    badge: true,
+    id: 'test-3',
+    trigger: {
+      iconName: 'contact',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 4', false),
+    resizable: true,
+    defaultSize: 500,
+    content: <HelpPanel header={<h2>Test 4</h2>}>Test 4.</HelpPanel>,
+    id: 'test-4',
+    trigger: {
+      iconName: 'edit',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 5', false),
+    resizable: true,
+    defaultSize: 500,
+    content: <HelpPanel header={<h2>Test 5</h2>}>Test 5.</HelpPanel>,
+    id: 'test-5',
+    trigger: {
+      iconName: 'add-plus',
+    },
+  },
+  {
+    ariaLabels: getAriaLabels('Test 6', false),
+    resizable: true,
+    defaultSize: 500,
+    content: <HelpPanel header={<h2>Test 6</h2>}>Test 6.</HelpPanel>,
+    id: 'test-6',
+    trigger: {
+      iconName: 'call',
+    },
+  },
+];
+
+export const drawerLabels = {
+  drawers: 'Drawers',
+  drawersOverflow: 'Drawers overflow',
+  drawersOverflowWithBadge: 'Drawers overflow with badge',
+};

--- a/pages/app-layout/with-beta-drawers.page.tsx
+++ b/pages/app-layout/with-beta-drawers.page.tsx
@@ -1,7 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState, useContext, useRef } from 'react';
-import { AppLayout, ContentLayout, Header, SpaceBetween, SplitPanel, Toggle, Button } from '~components';
+
+// To-do: Delete this page once all instances of beta drawers is gone.
+import React, { useState, useContext } from 'react';
+import {
+  AppLayout,
+  ContentLayout,
+  Header,
+  NonCancelableCustomEvent,
+  SpaceBetween,
+  SplitPanel,
+  Toggle,
+} from '~components';
 import { AppLayoutProps } from '~components/app-layout';
 import appLayoutLabels from './utils/labels';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
@@ -23,18 +33,29 @@ export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
   const hasDrawers = urlParams.hasDrawers ?? true;
   const disableContentPaddings = urlParams.disableContentPaddings ?? false;
-  const appLayoutRef = useRef<AppLayoutProps.Ref>(null);
 
-  function openDrawer(id: string) {
-    setActiveDrawerId(id);
-    appLayoutRef.current?.focusActiveDrawer();
-  }
+  const betaDrawers = !hasDrawers
+    ? null
+    : {
+        drawers: {
+          ariaLabel: 'Drawers',
+          overflowAriaLabel: 'Overflow drawers',
+          overflowWithBadgeAriaLabel: 'Overflow drawers (Unread notifications)',
+          activeDrawerId: activeDrawerId,
+          items: drawerItems,
+          onResize: (event: NonCancelableCustomEvent<string>) => {
+            console.log(event.detail);
+          },
+          onChange: (event: NonCancelableCustomEvent<string>) => {
+            setActiveDrawerId(event.detail);
+          },
+        },
+      };
 
   return (
     <ScreenshotArea gutters={false}>
       <AppLayout
-        ref={appLayoutRef}
-        ariaLabels={{ ...appLayoutLabels, ...drawerLabels }}
+        ariaLabels={Object.assign(appLayoutLabels, drawerLabels)}
         breadcrumbs={<Breadcrumbs />}
         content={
           <ContentLayout
@@ -42,7 +63,7 @@ export default function WithDrawers() {
             header={
               <SpaceBetween size="m">
                 <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
-                  Testing Custom Drawers!
+                  Testing Beta Drawers!
                 </Header>
 
                 <SpaceBetween size="xs">
@@ -54,12 +75,6 @@ export default function WithDrawers() {
                     Has Drawers
                   </Toggle>
                 </SpaceBetween>
-                <Button onClick={() => openDrawer('security')} data-testid="open-drawer-button">
-                  Open drawer
-                </Button>
-                <Button onClick={() => openDrawer('pro-help')} data-testid="open-drawer-button-2">
-                  Open second drawer
-                </Button>
               </SpaceBetween>
             }
           >
@@ -97,9 +112,7 @@ export default function WithDrawers() {
             </SpaceBetween>
           </SplitPanel>
         }
-        drawers={hasDrawers ? drawerItems : undefined}
-        onDrawerChange={event => setActiveDrawerId(event.detail.activeDrawerId)}
-        activeDrawerId={activeDrawerId}
+        {...(betaDrawers as any)}
       />
     </ScreenshotArea>
   );

--- a/pages/app-layout/with-drawers-empty.page.tsx
+++ b/pages/app-layout/with-drawers-empty.page.tsx
@@ -7,12 +7,6 @@ import { Breadcrumbs, Containers } from './utils/content-blocks';
 import ScreenshotArea from '../utils/screenshot-area';
 
 export default function WithDrawers() {
-  const drawers = {
-    drawers: {
-      items: [],
-    },
-  };
-
   return (
     <ScreenshotArea gutters={false}>
       <AppLayout
@@ -51,7 +45,7 @@ export default function WithDrawers() {
             This is the Split Panel!
           </SplitPanel>
         }
-        {...drawers}
+        drawers={[]}
       />
     </ScreenshotArea>
   );

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -400,6 +400,12 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
+      "description": "Fired when the active drawer is toggled.",
+      "detailType": "unknown",
+      "name": "onDrawerChange",
+    },
+    Object {
+      "cancelable": false,
       "description": "Fired when the navigation drawer is toggled.",
       "detailInlineType": Object {
         "name": "AppLayoutProps.ChangeDetail",
@@ -523,6 +529,12 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
   "name": "AppLayout",
   "properties": Array [
     Object {
+      "description": "The active drawer id. If you want to clear the active drawer, use \`null\`.",
+      "name": "activeDrawerId",
+      "optional": true,
+      "type": "null | string",
+    },
+    Object {
       "description": "Aria labels for the drawer operating buttons. Use this property to ensure accessibility.
 * \`navigation\` (string) - Label for the landmark that wraps the navigation drawer.
 * \`navigationClose\` (string) - Label for the button that closes the navigation drawer.
@@ -531,6 +543,9 @@ to control the state by listening to \`toolsChange\` and providing \`toolsOpen\`
 * \`tools\` (string) - Label for the landmark that wraps the tools drawer.
 * \`toolsClose\` (string) - Label for the button that closes the tools drawer.
 * \`toolsToggle\` (string) - Label for the button that opens the tools drawer.
+* \`drawers\` (string) - Label for the landmark that the active drawer.
+* \`drawersOverflow\` (string) - Label for the ellipsis button with any overflow drawers.
+* \`drawersOverflowWithBadge\` (string) - Label for the ellipsis button with any overflow drawers, with a badge.
 
 Example:
 \`\`\`
@@ -542,12 +557,30 @@ Example:
   tools: \\"Help panel\\",
   toolsClose: \\"Close help panel\\",
   toolsToggle: \\"Open help panel\\"
+  drawers: \\"Drawers\\",
+  drawersOverflow: \\"Overflow drawers\\",
+  drawersOverflowWithBadge: \\"Overflow drawers (Unread notifications)\\"
 }
 \`\`\`",
       "i18nTag": true,
       "inlineType": Object {
         "name": "AppLayoutProps.Labels",
         "properties": Array [
+          Object {
+            "name": "drawers",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "drawersOverflow",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
+            "name": "drawersOverflowWithBadge",
+            "optional": true,
+            "type": "string",
+          },
           Object {
             "name": "navigation",
             "optional": true,
@@ -637,6 +670,22 @@ Individual properties will always take precedence over the default coming from t
       "name": "disableContentPaddings",
       "optional": true,
       "type": "boolean",
+    },
+    Object {
+      "description": "Drawers property.
+Each Drawer is an item in the drawers wrapper with the following properties:
+* id (string) - the id of the drawer.
+* content (React.ReactNode) - the content in the drawer.
+* trigger (DrawerTrigger) - the button that opens and closes the active drawer.
+* ariaLabels (DrawerAriaLabels) - the labels for the interactive elements of the drawer.
+* badge (boolean) - Adds a badge to the corner of the icon to indicate a state change. For example: Unread notifications.
+* resizable (boolean) - if the drawer is resizable or not.
+* defaultSize (number) - starting size of the drawer. if not set, defaults to 290.
+* onResize (({ size: number }) => void) - Fired when the active drawer is resized.
+",
+      "name": "drawers",
+      "optional": true,
+      "type": "Array<AppLayoutProps.Drawer>",
     },
     Object {
       "defaultValue": "'#b #f'",

--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -10,6 +10,7 @@ import {
   renderComponent,
   singleDrawer,
   singleDrawerOpen,
+  singleDrawerPublic,
 } from './utils';
 import AppLayout from '../../../lib/components/app-layout';
 
@@ -253,7 +254,7 @@ describeEachAppLayout(size => {
           items: singleDrawer.drawers.items,
         },
       };
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
+      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersClosed as any)} />);
 
       wrapper.findDrawerTriggerById('security')!.click();
 
@@ -268,7 +269,7 @@ describeEachAppLayout(size => {
           items: singleDrawer.drawers.items,
         },
       };
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersClosed} />);
+      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersClosed as any)} />);
 
       // Chrome bubbles up events from specific elements inside <button>s.
       wrapper.findDrawerTriggerById('security')!.find('span')!.click();
@@ -286,7 +287,7 @@ describeEachAppLayout(size => {
         },
       };
 
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersOpen} />);
+      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersOpen as any)} />);
 
       wrapper.findActiveDrawerCloseButton()!.click();
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -294,7 +295,7 @@ describeEachAppLayout(size => {
     });
 
     test('Renders aria-expanded only on toggle', () => {
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+      const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
 
       const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
       expect(drawerTrigger.getElement()).toHaveAttribute('aria-expanded', 'false');
@@ -307,7 +308,7 @@ describeEachAppLayout(size => {
     });
 
     test('Close button does have a label if it is defined', () => {
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawerOpen} />);
+      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(singleDrawerOpen as any)} />);
 
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveAttribute(
         'aria-label',
@@ -323,14 +324,14 @@ describeEachAppLayout(size => {
         },
       };
 
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersOpen} />);
+      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersOpen as any)} />);
 
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-label');
     });
 
     test('Opens and closes drawer in uncontrolled mode', () => {
       // use content type with initial closed state for all drawers
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+      const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
       expect(wrapper.findActiveDrawer()).toBeNull();
 
       wrapper.findDrawerTriggerById('security')!.find('span')!.click();

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -14,6 +14,7 @@ import {
   manyDrawers,
   isDrawerTriggerWithBadge,
   getActiveDrawerWidth,
+  singleDrawerPublic,
 } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import styles from '../../../lib/components/app-layout/styles.css.js';
@@ -153,13 +154,13 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test('should render an active drawer', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawerOpen} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(singleDrawerOpen as any)} />);
 
     expect(wrapper.findActiveDrawer()).toBeTruthy();
   });
 
   test(`should toggle drawer on click`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout toolsHide={true} drawers={singleDrawerPublic} />);
     act(() => wrapper.findDrawersTriggers()![0].click());
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => wrapper.findDrawersTriggers()![0].click());
@@ -167,7 +168,7 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test(`Moves focus to slider when opened`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(resizableDrawer as any)} />);
 
     wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findActiveDrawerResizeHandle()!.getElement()).toHaveFocus();
@@ -188,7 +189,7 @@ describeEachThemeAppLayout(false, () => {
         ],
       },
     };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawers} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawers as any)} />);
     wrapper.findActiveDrawerResizeHandle()!.keydown(KeyCode.left);
 
     expect(onResize).toHaveBeenCalledWith({ size: expect.any(Number), id: 'security' });
@@ -210,7 +211,7 @@ describeEachThemeAppLayout(false, () => {
         ],
       },
     };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersOpen} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersOpen as any)} />);
     wrapper.findActiveDrawerResizeHandle()!.fireEvent(new MouseEvent('pointerdown', { bubbles: true }));
     const resizeEvent = new MouseEvent('pointermove', { bubbles: true });
     wrapper.findActiveDrawerResizeHandle()!.fireEvent(resizeEvent);
@@ -221,27 +222,27 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test('should read relative size on resize handle', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(resizableDrawer as any)} />);
 
     wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findActiveDrawerResizeHandle()!.getElement()).toHaveAttribute('aria-valuenow', '0');
   });
 
   test('should render overflow item when expected', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...manyDrawers} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(manyDrawers as any)} />);
 
     expect(wrapper.findDrawersTriggers()!.length).toBeLessThan(100);
   });
 
   test('Renders aria-controls on toggle only when active', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-controls');
     wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute('aria-controls', 'security');
   });
 
   test('should render badge when defined', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...manyDrawers} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(manyDrawers as any)} />);
 
     expect(isDrawerTriggerWithBadge(wrapper, manyDrawers.drawers.items[0].id)).toEqual(true);
     expect(isDrawerTriggerWithBadge(wrapper, manyDrawers.drawers.items[1].id)).toEqual(false);
@@ -271,7 +272,7 @@ describeEachThemeAppLayout(false, () => {
         ],
       },
     };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(resizableDrawer as any)} />);
 
     wrapper.findDrawersTriggers()![0].click();
     expect(getActiveDrawerWidth(wrapper)).toEqual('500px');
@@ -287,7 +288,7 @@ describe('Classic only features', () => {
   });
 
   test(`should toggle single drawer on click of container`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout toolsHide={true} {...(singleDrawer as any)} />);
     act(() => screen.getByLabelText('Drawers').click());
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => screen.getByLabelText('Drawers').click());
@@ -295,14 +296,14 @@ describe('Classic only features', () => {
   });
 
   test(`should not toggle many drawers on click of container`, () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...manyDrawers} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...(manyDrawers as any)} />);
     act(() => screen.getByLabelText('Drawers').click());
     expect(wrapper.findActiveDrawer()).toBeFalsy();
   });
 
   test('renders roles only when aria labels are not provided', () => {
     const { wrapper } = renderComponent(
-      <AppLayout navigationHide={true} contentType="form" {...drawerWithoutLabels} />
+      <AppLayout navigationHide={true} contentType="form" {...(drawerWithoutLabels as any)} />
     );
     const drawersAside = within(wrapper.findByClassName(drawerStyles['drawer-closed'])!.getElement()).getByRole(
       'region'
@@ -317,7 +318,7 @@ describe('Classic only features', () => {
   });
 
   test('renders roles and aria labels when provided', () => {
-    const { wrapper } = renderComponent(<AppLayout navigationHide={true} contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} ariaLabels={{ drawers: 'Drawers' }} />);
     const drawersAside = within(wrapper.findByClassName(drawerStyles['drawer-closed'])!.getElement()).getByRole(
       'region'
     );
@@ -343,7 +344,7 @@ describe('VR only features', () => {
   });
 
   test('renders roles only when aria labels are not provided', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawerWithoutLabels} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawerWithoutLabels as any)} />);
 
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-label');
     expect(
@@ -356,7 +357,7 @@ describe('VR only features', () => {
   });
 
   test('renders roles and aria labels when provided', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} ariaLabels={{ drawers: 'Drawers' }} />);
 
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
       'aria-label',

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -9,6 +9,7 @@ import {
   manyDrawersWithBadges,
   findActiveDrawerLandmark,
   singleDrawerOpen,
+  singleDrawerPublic,
 } from './utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
@@ -27,7 +28,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
 
 describeEachAppLayout(size => {
   test(`should not render drawer when it is not defined`, () => {
-    const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
+    const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} drawers={singleDrawerPublic} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     rerender(<AppLayout />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
@@ -40,21 +41,21 @@ describeEachAppLayout(size => {
         items: [],
       },
     };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...emptyDrawerItems} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(emptyDrawerItems as any)} />);
 
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findToolsToggle()).toBeFalsy();
   });
 
   test('ignores tools when drawers API is used', () => {
-    const { wrapper } = renderComponent(<AppLayout tools="Test" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout tools="Test" drawers={singleDrawerPublic} />);
 
     expect(wrapper.findToolsToggle()).toBeFalsy();
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
   test('should open active drawer on click of overflow item', () => {
-    const { container } = render(<AppLayout contentType="form" {...manyDrawers} />);
+    const { container } = render(<AppLayout contentType="form" {...(manyDrawers as any)} />);
     const wrapper = createWrapper(container).findAppLayout()!;
     const buttonDropdown = createWrapper(container).findButtonDropdown();
 
@@ -65,12 +66,12 @@ describeEachAppLayout(size => {
   });
 
   test('renders correct aria-label on overflow menu', () => {
-    const { container, rerender } = render(<AppLayout contentType="form" {...manyDrawers} />);
+    const { container, rerender } = render(<AppLayout contentType="form" {...(manyDrawers as any)} />);
     const buttonDropdown = createWrapper(container).findButtonDropdown();
 
     expect(buttonDropdown!.findNativeButton().getElement()).toHaveAttribute('aria-label', 'Overflow drawers');
 
-    rerender(<AppLayout contentType="form" {...manyDrawersWithBadges} />);
+    rerender(<AppLayout contentType="form" {...(manyDrawersWithBadges as any)} />);
     expect(buttonDropdown!.findNativeButton().getElement()).toHaveAttribute(
       'aria-label',
       'Overflow drawers (Unread notifications)'
@@ -78,7 +79,7 @@ describeEachAppLayout(size => {
   });
 
   test('renders aria-labels', async () => {
-    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = await renderComponent(<AppLayout drawers={singleDrawerPublic} />);
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
       'aria-label',
       'Security trigger button'
@@ -101,7 +102,7 @@ describeEachAppLayout(size => {
         ],
       },
     };
-    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...drawers} />);
+    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...(drawers as any)} />);
 
     wrapper.findDrawerTriggerById('security')!.click();
     expect(wrapper.findActiveDrawerResizeHandle()).toBeFalsy();
@@ -120,9 +121,14 @@ describeEachAppLayout(size => {
 
   test('focuses drawer close button', () => {
     let ref: AppLayoutProps.Ref | null = null;
-    const { wrapper } = renderComponent(<AppLayout ref={newRef => (ref = newRef)} {...singleDrawerOpen} />);
+    const { wrapper } = renderComponent(<AppLayout ref={newRef => (ref = newRef)} {...(singleDrawerOpen as any)} />);
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => ref!.focusActiveDrawer());
     expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveFocus();
+  });
+
+  test('registers public drawers api', () => {
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 });

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -80,7 +80,7 @@ describe('drawers', () => {
 
   test('property is controlled', () => {
     const onChange = jest.fn();
-    const drawers = {
+    const drawers: any = {
       drawers: {
         onChange: onChange,
         activeDrawerId: null,
@@ -88,7 +88,7 @@ describe('drawers', () => {
       },
     };
 
-    const drawersOpen = {
+    const drawersOpen: any = {
       drawers: {
         onChange: onChange,
         activeDrawerId: 'security',

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -8,10 +8,10 @@ import {
   drawerWithoutLabels,
   isDrawerClosed,
   renderComponent,
-  singleDrawer,
   singleDrawerOpen,
   manyDrawers,
   splitPanelI18nStrings,
+  singleDrawerPublic,
 } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import SplitPanel from '../../../lib/components/split-panel';
@@ -126,7 +126,7 @@ describeEachThemeAppLayout(true, theme => {
   });
 
   test('renders open drawer state', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawerOpen} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(singleDrawerOpen as any)} />);
     expect(document.body).toHaveClass(blockBodyScrollClassName);
     expect(wrapper.findNavigation()).toBeTruthy();
     expect(wrapper.findTools()).toBeFalsy(); // no tools rendered in drawers mode
@@ -397,7 +397,7 @@ describeEachThemeAppLayout(true, theme => {
     });
 
     test('content and toolbar is unfocusable when a drawer is open', () => {
-      const { wrapper, isUsingGridLayout } = renderComponent(<AppLayout {...props} {...singleDrawerOpen} />);
+      const { wrapper, isUsingGridLayout } = renderComponent(<AppLayout {...props} {...(singleDrawerOpen as any)} />);
 
       if (isUsingGridLayout) {
         expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(6);
@@ -453,18 +453,18 @@ describeEachThemeAppLayout(true, theme => {
   });
 
   test('should render an active drawer', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawerOpen} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(singleDrawerOpen as any)} />);
 
     expect(wrapper.findActiveDrawer()).toBeTruthy();
   });
 
   test('should render badge when defined', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...manyDrawers} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(manyDrawers as any)} />);
     expect(wrapper.findDrawerTriggerById('security')!.getElement().children[0]).toHaveClass(iconStyles.badge);
   });
 
   test('renders roles only when aria labels are not provided', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawerWithoutLabels} />);
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawerWithoutLabels as any)} />);
     const drawersAside = within(findMobileToolbar(wrapper)!.getElement()).getByRole('region');
 
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-label');
@@ -475,7 +475,7 @@ describeEachThemeAppLayout(true, theme => {
   });
 
   test('renders roles and aria labels when provided', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} ariaLabels={{ drawers: 'Drawers' }} />);
     const drawersAside = within(findMobileToolbar(wrapper)!.getElement()).getByRole('region');
 
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -418,7 +418,7 @@ describeEachAppLayout(size => {
         onChange: event => onChange(event.detail),
       },
     };
-    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...drawers} />);
+    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...(drawers as any)} />);
     expect(onChange).toHaveBeenCalledWith(drawerDefaults.id);
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveTextContent('runtime drawer content');
   });

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { render } from '@testing-library/react';
-import AppLayout from '../../../lib/components/app-layout';
+import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import { SplitPanelProps } from '../../../lib/components/split-panel';
 import createWrapper, { AppLayoutWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
@@ -268,3 +268,19 @@ export const drawerWithoutLabels: { drawers: BetaDrawersProps } = {
     ],
   },
 };
+
+export const singleDrawerPublic: Array<AppLayoutProps.Drawer> = [
+  {
+    ariaLabels: {
+      closeButton: 'Security close button',
+      drawerName: 'Security drawer content',
+      triggerButton: 'Security trigger button',
+      resizeHandle: 'Security resize handle',
+    },
+    content: <span>Security</span>,
+    id: 'security',
+    trigger: {
+      iconName: 'security',
+    },
+  },
+];

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -12,7 +12,7 @@ import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 import { splitItems } from './drawers-helpers';
 import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
-import { PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 
 // We are using two landmarks per drawer, i.e. two NAVs and two ASIDEs, because of several
 // known bugs in NVDA that cause focus changes within a container to sometimes not be
@@ -140,7 +140,7 @@ interface DrawerTriggerProps {
   badge: boolean | undefined;
   itemId?: string;
   isActive: boolean;
-  trigger: PublicDrawer['trigger'];
+  trigger: AppLayoutProps.Drawer['trigger'];
   onClick: (() => void) | undefined;
 }
 

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { togglesConfig } from '../toggles';
-import { PublicAriaLabelsWithDrawers, PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 import { IconProps } from '../../icon/interfaces';
 import { NonCancelableEventHandler } from '../../internal/events';
 
@@ -39,22 +39,22 @@ export interface DesktopDrawerProps {
 }
 
 export interface ResizableDrawerProps extends DesktopDrawerProps {
-  activeDrawer?: PublicDrawer;
+  activeDrawer: AppLayoutProps.Drawer | undefined;
   onResize: (resizeDetail: { size: number; id: string }) => void;
   size: number;
   getMaxWidth: () => number;
   refs: FocusControlRefs;
-  toolsContent?: React.ReactNode;
+  toolsContent: React.ReactNode;
 }
 
 export interface DrawerTriggersBarProps {
   topOffset: number | undefined;
   bottomOffset: number | undefined;
   isMobile: boolean;
-  drawers: Array<PublicDrawer>;
+  drawers: Array<AppLayoutProps.Drawer>;
   activeDrawerId: string | null;
   onDrawerChange: (newDrawerId: string | null) => void;
-  ariaLabels: PublicAriaLabelsWithDrawers | undefined;
+  ariaLabels: AppLayoutProps['ariaLabels'];
   drawerRefs: FocusControlRefs;
 }
 

--- a/src/app-layout/drawer/overflow-menu.tsx
+++ b/src/app-layout/drawer/overflow-menu.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import InternalButtonDropdown from '../../button-dropdown/internal';
 import { ButtonDropdownProps, InternalButtonDropdownProps } from '../../button-dropdown/interfaces';
 import { CancelableEventHandler } from '../../internal/events';
-import { PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 
 interface OverflowMenuProps {
-  items: Array<PublicDrawer>;
+  items: Array<AppLayoutProps.Drawer>;
   onItemClick: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   customTriggerBuilder?: InternalButtonDropdownProps['customTriggerBuilder'];
   ariaLabel?: string;

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -38,7 +38,7 @@ import { useStableCallback, warnOnce } from '@cloudscape-design/component-toolki
 import RefreshedAppLayout from './visual-refresh';
 import { useInternalI18n } from '../i18n/context';
 import { useSplitPanelFocusControl } from './utils/use-split-panel-focus-control';
-import { TOOLS_DRAWER_ID, useDrawers, UseDrawersProps } from './utils/use-drawers';
+import { TOOLS_DRAWER_ID, useDrawers } from './utils/use-drawers';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { togglesConfig } from './toggles';
 
@@ -61,6 +61,9 @@ const AppLayout = React.forwardRef(
       tools: i18n('ariaLabels.tools', rest.ariaLabels?.tools),
       toolsClose: i18n('ariaLabels.toolsClose', rest.ariaLabels?.toolsClose),
       toolsToggle: i18n('ariaLabels.toolsToggle', rest.ariaLabels?.toolsToggle),
+      drawers: i18n('ariaLabels.drawers', rest.ariaLabels?.drawers),
+      drawersOverflow: i18n('ariaLabels.drawersOverflow', rest.ariaLabels?.drawersOverflow),
+      drawersOverflowWithBadge: i18n('ariaLabels.drawersOverflowWithBadge', rest.ariaLabels?.drawersOverflowWithBadge),
     };
 
     // This re-builds the props including the default values
@@ -110,7 +113,10 @@ const OldAppLayout = React.forwardRef(
       onSplitPanelToggle,
       onNavigationChange,
       onToolsChange,
-      ...props
+      drawers: controlledDrawers,
+      onDrawerChange,
+      activeDrawerId: controlledActiveDrawerId,
+      ...rest
     }: AppLayoutProps,
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
@@ -154,14 +160,24 @@ const OldAppLayout = React.forwardRef(
       ariaLabelsWithDrawers,
       onActiveDrawerChange,
       onActiveDrawerResize,
-    } = useDrawers(props as UseDrawersProps, ariaLabels, {
+    } = useDrawers(
+      {
+        drawers: controlledDrawers,
+        onDrawerChange,
+        activeDrawerId: controlledActiveDrawerId,
+        ...rest,
+      },
       ariaLabels,
-      tools,
-      toolsOpen,
-      toolsHide,
-      toolsWidth,
-      onToolsToggle,
-    });
+      {
+        ariaLabels,
+        tools,
+        toolsOpen,
+        toolsHide,
+        toolsWidth,
+        onToolsToggle,
+      }
+    );
+    ariaLabels = ariaLabelsWithDrawers;
     const hasDrawers = !!drawers;
 
     const { refs: navigationRefs, setFocus: focusNavButtons } = useFocusControl(navigationOpen);
@@ -496,7 +512,7 @@ const OldAppLayout = React.forwardRef(
             anyPanelOpen={anyPanelOpen}
             toggleRefs={{ navigation: navigationRefs.toggle, tools: toolsRefs.toggle }}
             topOffset={headerHeight}
-            ariaLabels={ariaLabelsWithDrawers}
+            ariaLabels={ariaLabels}
             navigationHide={navigationHide}
             toolsHide={toolsHide}
             onNavigationOpen={() => onNavigationToggle(true)}
@@ -698,7 +714,7 @@ const OldAppLayout = React.forwardRef(
                 }
                 onActiveDrawerChange(newDrawerId);
               }}
-              ariaLabels={ariaLabelsWithDrawers}
+              ariaLabels={ariaLabels}
             />
           )}
         </div>

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -13,6 +13,31 @@ export interface AppLayoutProps extends BaseComponentProps {
   contentType?: AppLayoutProps.ContentType;
 
   /**
+   * Drawers property.
+ 
+   * Each Drawer is an item in the drawers wrapper with the following properties:
+   * * id (string) - the id of the drawer.
+   * * content (React.ReactNode) - the content in the drawer.
+   * * trigger (DrawerTrigger) - the button that opens and closes the active drawer. 
+   * * ariaLabels (DrawerAriaLabels) - the labels for the interactive elements of the drawer.
+   * * badge (boolean) - Adds a badge to the corner of the icon to indicate a state change. For example: Unread notifications.
+   * * resizable (boolean) - if the drawer is resizable or not.
+   * * defaultSize (number) - starting size of the drawer. if not set, defaults to 290.
+   * * onResize (({ size: number }) => void) - Fired when the active drawer is resized.
+   */
+  drawers?: Array<AppLayoutProps.Drawer>;
+
+  /**
+   * The active drawer id. If you want to clear the active drawer, use `null`.
+   */
+  activeDrawerId?: string | null;
+
+  /**
+   * Fired when the active drawer is toggled.
+   */
+  onDrawerChange?: NonCancelableEventHandler<{ activeDrawerId: string | null }>;
+
+  /**
    * If `true`, disables outer paddings for the content slot.
    */
   disableContentPaddings?: boolean;
@@ -93,6 +118,9 @@ export interface AppLayoutProps extends BaseComponentProps {
    * * `tools` (string) - Label for the landmark that wraps the tools drawer.
    * * `toolsClose` (string) - Label for the button that closes the tools drawer.
    * * `toolsToggle` (string) - Label for the button that opens the tools drawer.
+   * * `drawers` (string) - Label for the landmark that the active drawer.
+   * * `drawersOverflow` (string) - Label for the ellipsis button with any overflow drawers.
+   * * `drawersOverflowWithBadge` (string) - Label for the ellipsis button with any overflow drawers, with a badge.
    *
    * Example:
    * ```
@@ -104,6 +132,9 @@ export interface AppLayoutProps extends BaseComponentProps {
    *   tools: "Help panel",
    *   toolsClose: "Close help panel",
    *   toolsToggle: "Open help panel"
+   *   drawers: "Drawers",
+   *   drawersOverflow: "Overflow drawers",
+   *   drawersOverflowWithBadge: "Overflow drawers (Unread notifications)"
    * }
    * ```
    * @i18n
@@ -231,6 +262,27 @@ export namespace AppLayoutProps {
     focusSplitPanel(): void;
   }
 
+  export interface Drawer {
+    id: string;
+    content: React.ReactNode;
+    trigger: {
+      iconName?: IconProps.Name;
+      iconSvg?: React.ReactNode;
+    };
+    ariaLabels: DrawerAriaLabels;
+    badge?: boolean;
+    resizable?: boolean;
+    defaultSize?: number;
+    onResize?: NonCancelableEventHandler<{ size: number }>;
+  }
+
+  export interface DrawerAriaLabels {
+    drawerName: string;
+    closeButton?: string;
+    triggerButton?: string;
+    resizeHandle?: string;
+  }
+
   export interface Labels {
     notifications?: string;
 
@@ -241,6 +293,10 @@ export namespace AppLayoutProps {
     tools?: string;
     toolsToggle?: string;
     toolsClose?: string;
+
+    drawers?: string;
+    drawersOverflow?: string;
+    drawersOverflowWithBadge?: string;
   }
 
   export interface ChangeDetail {
@@ -257,31 +313,4 @@ export namespace AppLayoutProps {
   // Duplicated the positions because using this definition in SplitPanelPreferences would display
   // 'AppLayoutProps.SplitPanelPosition' on the API docs instead of the string values.
   export type SplitPanelPosition = 'side' | 'bottom';
-}
-
-export interface PublicDrawer {
-  id: string;
-  content: React.ReactNode;
-  trigger: {
-    iconName?: IconProps.Name;
-    iconSvg?: React.ReactNode;
-  };
-  ariaLabels: PublicDrawerAriaLabels;
-  badge?: boolean;
-  resizable?: boolean;
-  defaultSize?: number;
-  onResize?: NonCancelableEventHandler<{ size: number }>;
-}
-
-export interface PublicAriaLabelsWithDrawers extends AppLayoutProps.Labels {
-  drawers?: string;
-  drawersOverflow?: string;
-  drawersOverflowWithBadge?: string;
-}
-
-export interface PublicDrawerAriaLabels {
-  drawerName: string;
-  closeButton?: string;
-  triggerButton?: string;
-  resizeHandle?: string;
 }

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import React, { useEffect } from 'react';
 import { ButtonProps } from '../../button/interfaces';
-import { AppLayoutProps, PublicAriaLabelsWithDrawers, PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 import { ToggleButton, togglesConfig } from '../toggles';
 import OverflowMenu from '../drawer/overflow-menu';
 import styles from './styles.css.js';
@@ -54,12 +54,12 @@ interface MobileToolbarProps {
   navigationHide: boolean | undefined;
   toolsHide: boolean | undefined;
   topOffset?: number;
-  ariaLabels: PublicAriaLabelsWithDrawers | undefined;
+  ariaLabels: AppLayoutProps.Labels | undefined;
   mobileBarRef: React.Ref<HTMLDivElement>;
   children: React.ReactNode;
   onNavigationOpen: () => void;
   onToolsOpen: () => void;
-  drawers: Array<PublicDrawer> | undefined;
+  drawers: Array<AppLayoutProps.Drawer> | undefined;
   activeDrawerId: string | null;
   onDrawerChange: (newDrawerId: string | null) => void;
 }

--- a/src/app-layout/runtime-api.tsx
+++ b/src/app-layout/runtime-api.tsx
@@ -4,17 +4,22 @@ import React from 'react';
 import { DrawerConfig as RuntimeDrawerConfig } from '../internal/plugins/controllers/drawers';
 import { RuntimeContentWrapper } from '../internal/plugins/helpers';
 import { sortByPriority } from '../internal/plugins/helpers/utils';
-import { PublicDrawer } from './interfaces';
+import { AppLayoutProps } from './interfaces';
 import { fireNonCancelableEvent } from '../internal/events';
 
 export interface DrawersLayout {
-  before: Array<PublicDrawer>;
-  after: Array<PublicDrawer>;
+  before: Array<AppLayoutProps.Drawer>;
+  after: Array<AppLayoutProps.Drawer>;
 }
 
 export function convertRuntimeDrawers(drawers: Array<RuntimeDrawerConfig>): DrawersLayout {
   const converted = drawers.map(
-    ({ mountContent, unmountContent, trigger, ...runtimeDrawer }): PublicDrawer & { orderPriority?: number } => ({
+    ({
+      mountContent,
+      unmountContent,
+      trigger,
+      ...runtimeDrawer
+    }): AppLayoutProps.Drawer & { orderPriority?: number } => ({
       ...runtimeDrawer,
       ariaLabels: { drawerName: runtimeDrawer.ariaLabels.content ?? '', ...runtimeDrawer.ariaLabels },
       trigger: {

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -4,11 +4,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import { BetaDrawersProps } from '../drawer/interfaces';
 import { useControllable } from '../../internal/hooks/use-controllable';
-import { fireNonCancelableEvent, NonCancelableCustomEvent, NonCancelableEventHandler } from '../../internal/events';
+import { fireNonCancelableEvent, NonCancelableCustomEvent } from '../../internal/events';
 import { awsuiPluginsInternal } from '../../internal/plugins/api';
 import { sortByPriority } from '../../internal/plugins/helpers/utils';
 import { convertRuntimeDrawers, DrawersLayout } from '../runtime-api';
-import { AppLayoutProps, PublicAriaLabelsWithDrawers, PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 import { togglesConfig } from '../toggles';
 
 export const TOOLS_DRAWER_ID = 'awsui-internal-tools';
@@ -22,7 +22,7 @@ interface ToolsProps {
   ariaLabels: AppLayoutProps.Labels | undefined;
 }
 
-function getToolsDrawerItem(props: ToolsProps): PublicDrawer | null {
+function getToolsDrawerItem(props: ToolsProps): AppLayoutProps.Drawer | null {
   if (props.toolsHide) {
     return null;
   }
@@ -83,7 +83,7 @@ function isBetaDrawers(drawers: unknown): drawers is BetaDrawersProps {
 function convertBetaApi(drawers: BetaDrawersProps, ariaLabels: AppLayoutProps['ariaLabels']) {
   return {
     drawers: drawers.items.map(
-      (betaDrawer): PublicDrawer => ({
+      (betaDrawer): AppLayoutProps.Drawer => ({
         ...betaDrawer,
         ariaLabels: { drawerName: betaDrawer.ariaLabels?.content ?? '', ...betaDrawer.ariaLabels },
         onResize: event => {
@@ -117,18 +117,20 @@ function applyToolsDrawer(toolsProps: ToolsProps, runtimeDrawers: DrawersLayout)
   return drawers;
 }
 
-export interface UseDrawersProps {
-  drawers: Array<PublicDrawer>;
+type UseDrawersProps = Pick<AppLayoutProps, 'drawers' | 'activeDrawerId' | 'onDrawerChange'> & {
   __disableRuntimeDrawers?: boolean;
-}
+};
 
 export function useDrawers(
-  { drawers, __disableRuntimeDrawers: disableRuntimeDrawers }: UseDrawersProps,
-  ariaLabels: PublicAriaLabelsWithDrawers | undefined,
+  {
+    drawers,
+    activeDrawerId: controlledActiveDrawerId,
+    onDrawerChange,
+    __disableRuntimeDrawers: disableRuntimeDrawers,
+  }: UseDrawersProps,
+  ariaLabels: AppLayoutProps['ariaLabels'],
   toolsProps: ToolsProps
 ) {
-  let controlledActiveDrawerId = undefined;
-  let onDrawerChange: NonCancelableEventHandler<{ activeDrawerId: string | null }> = () => {};
   if (isBetaDrawers(drawers)) {
     ({ drawers, controlledActiveDrawerId, onDrawerChange, ariaLabels } = convertBetaApi(drawers, ariaLabels));
   }

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -8,7 +8,7 @@ import ResizeHandler from '../../split-panel/icons/resize-handler';
 import { getLimitedValue } from '../../split-panel/utils/size-utils';
 import { usePointerEvents } from './use-pointer-events';
 import { useKeyboardEvents } from './use-keyboard-events';
-import { PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 
 import splitPanelStyles from '../../split-panel/styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -17,7 +17,7 @@ import { FocusControlRefs } from './use-focus-control';
 import { SizeControlProps } from './interfaces';
 
 export interface DrawerResizeProps {
-  activeDrawer: PublicDrawer | undefined;
+  activeDrawer: AppLayoutProps.Drawer | undefined;
   activeDrawerSize: number;
   onActiveDrawerResize: (detail: { id: string; size: number }) => void;
   drawersRefs: FocusControlRefs;

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -13,7 +13,7 @@ import React, {
 import { applyDefaults } from '../defaults';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
 import { DynamicOverlapContext } from '../../internal/context/dynamic-overlap-context';
-import { AppLayoutProps, PublicDrawer } from '../interfaces';
+import { AppLayoutProps } from '../interfaces';
 import { fireNonCancelableEvent } from '../../internal/events';
 import { FocusControlRefs, useFocusControl } from '../utils/use-focus-control';
 import { getSplitPanelDefaultSize } from '../../split-panel/utils/size-utils';
@@ -29,12 +29,12 @@ import useResize from '../utils/use-resize';
 import styles from './styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import useBackgroundOverlap from './use-background-overlap';
-import { useDrawers, UseDrawersProps } from '../utils/use-drawers';
+import { useDrawers } from '../utils/use-drawers';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
 interface AppLayoutInternals extends AppLayoutProps {
   activeDrawerId: string | null;
-  drawers: Array<PublicDrawer> | undefined;
+  drawers: Array<AppLayoutProps.Drawer> | undefined;
   drawersAriaLabel: string | undefined;
   drawersOverflowAriaLabel: string | undefined;
   drawersOverflowWithBadgeAriaLabel: string | undefined;
@@ -369,7 +369,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       onActiveDrawerResize,
       activeDrawerSize,
       ...drawersProps
-    } = useDrawers(props as UseDrawersProps, props.ariaLabels, {
+    } = useDrawers(props, props.ariaLabels, {
       ariaLabels: props.ariaLabels,
       toolsHide,
       toolsOpen: isToolsOpen,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Moving Drawers from beta to public. Beta API is still supported via `convertBetaApi` and `as any` type cast on consumers' end. Once the teams using the beta drawers fully migrate, we can delete that part of the code.

This also converts some tests for drawers to the public API whenever it was 1-line change, and adds several new tests, including breaking up `with-drawers` and `with-beta-drawers` test pages.


It adds 3 new AppLayout properties: 
```
  drawers?: Array<AppLayoutProps.Drawer>;
  activeDrawerId?: string | null;
  onDrawerChange?: NonCancelableEventHandler<{ activeDrawerId: string | null }>
```
And 3 new AppLayout ariaLabels:
```
    drawers?: string;
    drawersOverflow?: string;
    drawersOverflowWithBadge?: string;
```

In a separate PR (https://github.com/cloudscape-design/components/pull/1708), we are moving the internal `Drawer` component out to the general components folder to make that public.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
