### PR TITLE
fix: Make useStickyScrollbar hook react to offset prop

### DIFF
--- a/src/table/sticky-scrollbar/sticky-scrollbar.tsx
+++ b/src/table/sticky-scrollbar/sticky-scrollbar.tsx
@@ -39,8 +39,7 @@ function StickyScrollbar(
    */
   const { stickyOffsetBottom } = useAppLayoutContext();
 
-  useStickyScrollbar(scrollbarRef, scrollbarContentRef, tableRef, wrapperRef, stickyOffsetBottom);
-
+  useStickyScrollbar(scrollbarRef, scrollbarContentRef, tableRef, wrapperRef, stickyOffsetBottom, offsetScrollbar);
   return (
     <div
       ref={mergedRef}

--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -37,10 +37,6 @@
       margin-top: calc(-1 * awsui.$border-divider-section-width); // -1px to compensate for border width
       border-top: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
     }
-
-    &.is-visual-refresh {
-      margin-top: -5px;
-    }
   }
 }
 

--- a/src/table/sticky-scrollbar/use-sticky-scrollbar.ts
+++ b/src/table/sticky-scrollbar/use-sticky-scrollbar.ts
@@ -66,7 +66,8 @@ export function useStickyScrollbar(
   scrollbarContentRef: RefObject<HTMLDivElement>,
   tableRef: RefObject<HTMLTableElement>,
   wrapperRef: RefObject<HTMLDivElement>,
-  footerHeight: number
+  footerHeight: number,
+  offsetScrollbar: boolean
 ) {
   // We don't take into account containing-block calculations because that would
   // unnecessarily overcomplicate the position logic. For now, we assume that a
@@ -109,7 +110,15 @@ export function useStickyScrollbar(
         observer.disconnect();
       };
     }
-  }, [scrollbarContentRef, scrollbarRef, tableRef, wrapperRef, consideredFooterHeight, hasContainingBlock]);
+  }, [
+    scrollbarContentRef,
+    scrollbarRef,
+    tableRef,
+    wrapperRef,
+    consideredFooterHeight,
+    hasContainingBlock,
+    offsetScrollbar,
+  ]);
 
   // Update scrollbar position when window resizes (vertically).
   useEffect(() => {


### PR DESCRIPTION
### Description

When toggling the sticky columns preference back and forth, the sticky scrollbar disappears. 
This fixes it.

Related issue: AWSUI-22340

### How has this been tested?

Existing tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
