### PR TITLE
fix: Constrain dropdown width to viewport

### DIFF
--- a/pages/dropdown/min-width.page.tsx
+++ b/pages/dropdown/min-width.page.tsx
@@ -9,7 +9,7 @@ export default function DropdownScenario() {
   const [open, setOpen] = useState(false);
   return (
     <article>
-      <h1>Dropdown`s midWidth property test</h1>
+      <h1>Dropdown`s minWidth property test</h1>
       <ul>
         <li>
           Dropdown should have the width equal to <code>minWidth</code>, if the trigger is larger than it

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -107,10 +107,11 @@ interface CommonProps {
   expandToViewport: boolean;
   loading?: boolean;
   onOpen: () => void;
+  onClose: () => void;
   virtualScroll: boolean;
 }
 
-function CustomAutosuggest({ expandToViewport, loading, onOpen, virtualScroll }: CommonProps) {
+function CustomAutosuggest({ expandToViewport, loading, onOpen, onClose, virtualScroll }: CommonProps) {
   const [value, setValue] = useState('');
   return (
     <Autosuggest
@@ -136,11 +137,12 @@ function CustomAutosuggest({ expandToViewport, loading, onOpen, virtualScroll }:
       placeholder="Choose an option"
       statusType={loading ? 'loading' : undefined}
       onFocus={onOpen}
+      onBlur={onClose}
     />
   );
 }
 
-function CustomMultiSelect({ expandToViewport, loading, onOpen, virtualScroll }: CommonProps) {
+function CustomMultiSelect({ expandToViewport, loading, onOpen, onClose, virtualScroll }: CommonProps) {
   const [selectedOptions, setSelectedOptions] = useState<ReadonlyArray<MultiselectProps.Option>>([]);
   return (
     <Multiselect
@@ -163,11 +165,12 @@ function CustomMultiSelect({ expandToViewport, loading, onOpen, virtualScroll }:
       placeholder="Choose an option"
       statusType={loading ? 'loading' : undefined}
       onFocus={onOpen}
+      onBlur={onClose}
     />
   );
 }
 
-function CustomSelect({ expandToViewport, loading, onOpen, virtualScroll }: CommonProps) {
+function CustomSelect({ expandToViewport, loading, onOpen, onClose, virtualScroll }: CommonProps) {
   const [selectedOption, setSelectedOption] = useState<SelectProps['selectedOption']>(null);
 
   return (
@@ -195,6 +198,7 @@ function CustomSelect({ expandToViewport, loading, onOpen, virtualScroll }: Comm
       placeholder="Choose an option"
       statusType={loading ? 'loading' : undefined}
       onFocus={onOpen}
+      onBlur={onClose}
     />
   );
 }
@@ -204,11 +208,12 @@ export default function () {
   const { asyncLoading, component, triggerWidth, virtualScroll, expandToViewport, containerWidth } = urlParams;
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
-    setLoading(asyncLoading);
     if (asyncLoading) {
+      setLoading(true);
       setTimeout(() => setLoading(false), 500);
     }
   };
+  const onClose = () => setLoading(false);
   useEffect(onOpen, [asyncLoading]);
   return (
     <article>
@@ -223,6 +228,7 @@ export default function () {
                 expandToViewport={expandToViewport}
                 loading={loading}
                 onOpen={onOpen}
+                onClose={onClose}
               />
             )}
             {component === 'multiselect' && (
@@ -231,6 +237,7 @@ export default function () {
                 virtualScroll={virtualScroll}
                 loading={loading}
                 onOpen={onOpen}
+                onClose={onClose}
               />
             )}
             {component === 'select' && (
@@ -239,6 +246,7 @@ export default function () {
                 virtualScroll={virtualScroll}
                 loading={loading}
                 onOpen={onOpen}
+                onClose={onClose}
               />
             )}
           </div>

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -1,0 +1,240 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useState } from 'react';
+import Select, { SelectProps } from '~components/select';
+import Multiselect, { MultiselectProps } from '~components/multiselect';
+import Autosuggest from '~components/autosuggest';
+import ButtonDropdown from '~components/button-dropdown';
+import PropertyFilter, { PropertyFilterProps } from '~components/property-filter';
+import AppContext, { AppContextType } from '../app/app-context';
+import SpaceBetween from '~components/space-between';
+import ColumnLayout from '~components/column-layout';
+import FormField from '~components/form-field';
+import { range } from 'lodash';
+import { i18nStrings as propertyFilterI18n } from '../property-filter/common-props';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    component: string;
+    width: string;
+    virtualScroll: boolean;
+    expandToViewport: boolean;
+  }>
+>;
+
+const shortOptionText = 'Short text';
+const longOptionText =
+  'A very very very very very very very very very very very very very very very very very very very very very very very very very very long text';
+
+const componentOptions: ReadonlyArray<SelectProps.Option> = [
+  {
+    value: 'autosuggest',
+    label: 'Autosuggest',
+  },
+  {
+    value: 'button-dropdown',
+    label: 'Button dropdown',
+  },
+  {
+    value: 'multiselect',
+    label: 'Multiselect',
+  },
+  {
+    value: 'select',
+    label: 'Select',
+  },
+  {
+    value: 'property-filter',
+    label: 'Property filter',
+  },
+];
+
+function SettingsForm() {
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+
+  return (
+    <ColumnLayout columns={4}>
+      <FormField label="Component">
+        <select
+          value={componentOptions.find(option => option.value === urlParams.component)?.value}
+          onChange={event => setUrlParams({ component: event.target.value })}
+        >
+          {componentOptions.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </FormField>
+      <FormField label="Width">
+        <input
+          placeholder={'example: 300px'}
+          value={urlParams.width}
+          onChange={event => setUrlParams({ width: event.target.value })}
+        />
+      </FormField>
+      <FormField label="ExpandToViewport">
+        <input
+          type="checkbox"
+          checked={urlParams.expandToViewport}
+          onChange={event => setUrlParams({ expandToViewport: event.target.checked })}
+        />
+      </FormField>
+      {['autosuggest', 'multiselect', 'property-filter', 'select'].includes(urlParams.component) && (
+        <FormField label="virtualScroll">
+          <input
+            type="checkbox"
+            checked={urlParams.virtualScroll}
+            onChange={event => setUrlParams({ virtualScroll: event.target.checked })}
+          />
+        </FormField>
+      )}
+    </ColumnLayout>
+  );
+}
+
+function CustomAutosuggest({ expandToViewport, virtualScroll }: { expandToViewport: boolean; virtualScroll: boolean }) {
+  const [value, setValue] = useState('');
+  return (
+    <Autosuggest
+      value={value}
+      onChange={e => setValue(e.detail.value)}
+      options={[
+        { value: longOptionText, tags: ['tag1', 'tag2'], filteringTags: ['bla', 'opt'], description: 'description1' },
+        { value: shortOptionText, labelTag: 'This is a label tag' },
+      ]}
+      ariaLabel="simple autosuggest"
+      virtualScroll={virtualScroll}
+      expandToViewport={expandToViewport}
+    />
+  );
+}
+
+function CustomButtonDropdown({ expandToViewport }: { expandToViewport: boolean }) {
+  return (
+    <ButtonDropdown
+      expandToViewport={expandToViewport}
+      expandableGroups={true}
+      items={[
+        {
+          id: 'category1',
+          text: longOptionText,
+        },
+        {
+          id: 'category2',
+          text: shortOptionText,
+        },
+      ]}
+    >
+      Open dropdown
+    </ButtonDropdown>
+  );
+}
+
+function CustomMultiSelect({ expandToViewport, virtualScroll }: { expandToViewport: boolean; virtualScroll: boolean }) {
+  const [selectedOptions, setSelectedOptions] = useState<ReadonlyArray<MultiselectProps.Option>>([]);
+  return (
+    <Multiselect
+      expandToViewport={expandToViewport}
+      virtualScroll={virtualScroll}
+      options={[
+        { value: 'first', label: longOptionText },
+        {
+          value: 'second',
+          label: shortOptionText,
+        },
+      ]}
+      selectedOptions={selectedOptions}
+      onChange={({ detail }) => setSelectedOptions(detail.selectedOptions)}
+    />
+  );
+}
+
+function CustomSelect({ expandToViewport, virtualScroll }: { expandToViewport: boolean; virtualScroll: boolean }) {
+  const [selectedOption, setSelectedOption] = useState<SelectProps['selectedOption']>(null);
+  return (
+    <Select
+      selectedOption={selectedOption}
+      options={[
+        {
+          value: longOptionText,
+          tags: ['tag1', 'tag2'],
+          filteringTags: ['bla', 'opt'],
+          description: 'description1',
+        },
+        { value: shortOptionText },
+      ]}
+      onChange={event => setSelectedOption(event.detail.selectedOption)}
+      ariaLabel={'simple select'}
+      filteringType={'auto'}
+      virtualScroll={virtualScroll}
+      expandToViewport={expandToViewport}
+    />
+  );
+}
+
+function CustomPropertyFilter({
+  expandToViewport,
+  virtualScroll,
+}: {
+  expandToViewport: boolean;
+  virtualScroll: boolean;
+}) {
+  const [query, setQuery] = useState<PropertyFilterProps['query']>({
+    tokens: [{ operator: ':', value: '1' } as const],
+    operation: 'and',
+  });
+
+  return (
+    <PropertyFilter
+      query={query}
+      onChange={e => setQuery(e.detail)}
+      filteringProperties={[
+        {
+          key: 'property',
+          operators: ['=', '!=', '>', '<', '<=', '>='],
+          propertyLabel: longOptionText,
+          groupValuesLabel: `Label values`,
+        },
+      ]}
+      filteringOptions={range(100).map(value => ({
+        propertyKey: 'property',
+        value: value + '',
+      }))}
+      filteringLoadingText={'loading text'}
+      filteringErrorText={'error text'}
+      filteringRecoveryText={'recovery text'}
+      filteringFinishedText={'finished text'}
+      i18nStrings={propertyFilterI18n}
+      expandToViewport={expandToViewport}
+      virtualScroll={virtualScroll}
+    />
+  );
+}
+
+export default function () {
+  const { urlParams } = useContext(AppContext as DemoContext);
+
+  const { component, width, virtualScroll, expandToViewport } = urlParams;
+  return (
+    <article>
+      <h1>Dropdown width</h1>
+      <SpaceBetween size="l">
+        <SettingsForm />
+        <div style={{ width }}>
+          {component === 'autosuggest' && (
+            <CustomAutosuggest virtualScroll={virtualScroll} expandToViewport={expandToViewport} />
+          )}
+          {component === 'button-dropdown' && <CustomButtonDropdown expandToViewport={expandToViewport} />}
+          {component === 'multiselect' && (
+            <CustomMultiSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
+          )}
+          {component === 'property-filter' && (
+            <CustomPropertyFilter expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
+          )}
+          {component === 'select' && <CustomSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />}
+        </div>
+      </SpaceBetween>
+    </article>
+  );
+}

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -36,10 +36,6 @@ const componentOptions: ReadonlyArray<SelectProps.Option> = [
     value: 'select',
     label: 'Select',
   },
-  {
-    value: 'property-filter',
-    label: 'Property filter',
-  },
 ];
 
 function SettingsForm() {
@@ -95,16 +91,14 @@ function SettingsForm() {
         />{' '}
         expandToViewport
       </label>
-      {['autosuggest', 'multiselect', 'property-filter', 'select'].includes(urlParams.component) && (
-        <label>
-          <input
-            type="checkbox"
-            checked={urlParams.virtualScroll}
-            onChange={event => setUrlParams({ virtualScroll: event.target.checked })}
-          />{' '}
-          virtualScroll
-        </label>
-      )}
+      <label>
+        <input
+          type="checkbox"
+          checked={urlParams.virtualScroll}
+          onChange={event => setUrlParams({ virtualScroll: event.target.checked })}
+        />{' '}
+        virtualScroll
+      </label>
     </ColumnLayout>
   );
 }

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -9,16 +9,16 @@ import PropertyFilter, { PropertyFilterProps } from '~components/property-filter
 import AppContext, { AppContextType } from '../app/app-context';
 import SpaceBetween from '~components/space-between';
 import ColumnLayout from '~components/column-layout';
-import FormField from '~components/form-field';
 import { range } from 'lodash';
 import { i18nStrings as propertyFilterI18n } from '../property-filter/common-props';
 
 type DemoContext = React.Context<
   AppContextType<{
     component: string;
-    width: string;
+    triggerWidth: string;
     virtualScroll: boolean;
     expandToViewport: boolean;
+    containerWidth: string;
   }>
 >;
 
@@ -54,40 +54,55 @@ function SettingsForm() {
 
   return (
     <ColumnLayout columns={4}>
-      <FormField label="Component">
+      <label>
+        Component{' '}
         <select
-          value={componentOptions.find(option => option.value === urlParams.component)?.value}
+          value={componentOptions.find(option => option.value === urlParams.component)?.value || ''}
           onChange={event => setUrlParams({ component: event.target.value })}
         >
+          <option value="" disabled={true}>
+            Select a component
+          </option>
           {componentOptions.map(option => (
             <option key={option.value} value={option.value}>
               {option.label}
             </option>
           ))}
         </select>
-      </FormField>
-      <FormField label="Width">
+      </label>
+      <label>
+        Trigger width{' '}
         <input
           placeholder={'example: 300px'}
-          value={urlParams.width}
-          onChange={event => setUrlParams({ width: event.target.value })}
+          value={urlParams.triggerWidth || ''}
+          onChange={event => setUrlParams({ triggerWidth: event.target.value })}
         />
-      </FormField>
-      <FormField label="ExpandToViewport">
+      </label>
+      <label>
+        Container width{' '}
+        <input
+          placeholder={'example: 500px'}
+          value={urlParams.containerWidth || ''}
+          onChange={event => setUrlParams({ containerWidth: event.target.value })}
+        />
+      </label>
+      <label>
         <input
           type="checkbox"
           checked={urlParams.expandToViewport}
           onChange={event => setUrlParams({ expandToViewport: event.target.checked })}
-        />
-      </FormField>
+        />{' '}
+        expandToViewport
+      </label>
       {['autosuggest', 'multiselect', 'property-filter', 'select'].includes(urlParams.component) && (
-        <FormField label="virtualScroll">
+        <label>
           <input
             type="checkbox"
             checked={urlParams.virtualScroll}
             onChange={event => setUrlParams({ virtualScroll: event.target.checked })}
-          />
-        </FormField>
+          />{' '}
+          virtualScroll
+        </label>
       )}
     </ColumnLayout>
   );
@@ -215,24 +230,28 @@ function CustomPropertyFilter({
 export default function () {
   const { urlParams } = useContext(AppContext as DemoContext);
 
-  const { component, width, virtualScroll, expandToViewport } = urlParams;
+  const { component, triggerWidth, virtualScroll, expandToViewport, containerWidth } = urlParams;
   return (
     <article>
       <h1>Dropdown width</h1>
       <SpaceBetween size="l">
         <SettingsForm />
-        <div style={{ width }}>
-          {component === 'autosuggest' && (
-            <CustomAutosuggest virtualScroll={virtualScroll} expandToViewport={expandToViewport} />
-          )}
-          {component === 'button-dropdown' && <CustomButtonDropdown expandToViewport={expandToViewport} />}
-          {component === 'multiselect' && (
-            <CustomMultiSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
-          )}
-          {component === 'property-filter' && (
-            <CustomPropertyFilter expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
-          )}
-          {component === 'select' && <CustomSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />}
+        <div style={{ width: containerWidth, height: '300px', overflow: 'hidden', border: `1px solid blue` }}>
+          <div style={{ width: triggerWidth }}>
+            {component === 'autosuggest' && (
+              <CustomAutosuggest virtualScroll={virtualScroll} expandToViewport={expandToViewport} />
+            )}
+            {component === 'button-dropdown' && <CustomButtonDropdown expandToViewport={expandToViewport} />}
+            {component === 'multiselect' && (
+              <CustomMultiSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
+            )}
+            {component === 'property-filter' && (
+              <CustomPropertyFilter expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
+            )}
+            {component === 'select' && (
+              <CustomSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
+            )}
+          </div>
         </div>
       </SpaceBetween>
     </article>

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -4,13 +4,9 @@ import React, { useContext, useState } from 'react';
 import Select, { SelectProps } from '~components/select';
 import Multiselect, { MultiselectProps } from '~components/multiselect';
 import Autosuggest from '~components/autosuggest';
-import ButtonDropdown from '~components/button-dropdown';
-import PropertyFilter, { PropertyFilterProps } from '~components/property-filter';
 import AppContext, { AppContextType } from '../app/app-context';
 import SpaceBetween from '~components/space-between';
 import ColumnLayout from '~components/column-layout';
-import { range } from 'lodash';
-import { i18nStrings as propertyFilterI18n } from '../property-filter/common-props';
 
 type DemoContext = React.Context<
   AppContextType<{
@@ -30,10 +26,6 @@ const componentOptions: ReadonlyArray<SelectProps.Option> = [
   {
     value: 'autosuggest',
     label: 'Autosuggest',
-  },
-  {
-    value: 'button-dropdown',
-    label: 'Button dropdown',
   },
   {
     value: 'multiselect',
@@ -125,27 +117,6 @@ function CustomAutosuggest({ expandToViewport, virtualScroll }: { expandToViewpo
   );
 }
 
-function CustomButtonDropdown({ expandToViewport }: { expandToViewport: boolean }) {
-  return (
-    <ButtonDropdown
-      expandToViewport={expandToViewport}
-      expandableGroups={true}
-      items={[
-        {
-          id: 'category1',
-          text: longOptionText,
-        },
-        {
-          id: 'category2',
-          text: shortOptionText,
-        },
-      ]}
-    >
-      Open dropdown
-    </ButtonDropdown>
-  );
-}
-
 function CustomMultiSelect({ expandToViewport, virtualScroll }: { expandToViewport: boolean; virtualScroll: boolean }) {
   const [selectedOptions, setSelectedOptions] = useState<ReadonlyArray<MultiselectProps.Option>>([]);
   return (
@@ -188,45 +159,6 @@ function CustomSelect({ expandToViewport, virtualScroll }: { expandToViewport: b
   );
 }
 
-function CustomPropertyFilter({
-  expandToViewport,
-  virtualScroll,
-}: {
-  expandToViewport: boolean;
-  virtualScroll: boolean;
-}) {
-  const [query, setQuery] = useState<PropertyFilterProps['query']>({
-    tokens: [{ operator: ':', value: '1' } as const],
-    operation: 'and',
-  });
-
-  return (
-    <PropertyFilter
-      query={query}
-      onChange={e => setQuery(e.detail)}
-      filteringProperties={[
-        {
-          key: 'property',
-          operators: ['=', '!=', '>', '<', '<=', '>='],
-          propertyLabel: longOptionText,
-          groupValuesLabel: `Label values`,
-        },
-      ]}
-      filteringOptions={range(100).map(value => ({
-        propertyKey: 'property',
-        value: value + '',
-      }))}
-      filteringLoadingText={'loading text'}
-      filteringErrorText={'error text'}
-      filteringRecoveryText={'recovery text'}
-      filteringFinishedText={'finished text'}
-      i18nStrings={propertyFilterI18n}
-      expandToViewport={expandToViewport}
-      virtualScroll={virtualScroll}
-    />
-  );
-}
-
 export default function () {
   const { urlParams } = useContext(AppContext as DemoContext);
 
@@ -241,12 +173,8 @@ export default function () {
             {component === 'autosuggest' && (
               <CustomAutosuggest virtualScroll={virtualScroll} expandToViewport={expandToViewport} />
             )}
-            {component === 'button-dropdown' && <CustomButtonDropdown expandToViewport={expandToViewport} />}
             {component === 'multiselect' && (
               <CustomMultiSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
-            )}
-            {component === 'property-filter' && (
-              <CustomPropertyFilter expandToViewport={expandToViewport} virtualScroll={virtualScroll} />
             )}
             {component === 'select' && (
               <CustomSelect expandToViewport={expandToViewport} virtualScroll={virtualScroll} />

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -42,21 +42,19 @@ function setupTest(
     componentId,
     triggerWidth,
     expandToViewport,
-    virtualScroll,
     asyncLoading = false,
   }: {
     pageWidth: number;
     componentId: ComponentId;
     triggerWidth: number;
     expandToViewport: boolean;
-    virtualScroll: boolean;
     asyncLoading?: boolean;
   },
   testFn: (page: DropdownPageObject) => Promise<void>
 ) {
   return useBrowser({ width: pageWidth, height: 1000 }, async browser => {
     await browser.url(
-      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&virtualScroll=${virtualScroll}&asyncLoading=${asyncLoading}`
+      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&asyncLoading=${asyncLoading}`
     );
     const page = new DropdownPageObject(browser);
     await page.waitForVisible(page.getWrapperAndTrigger(componentId).wrapper.toSelector());
@@ -105,7 +103,6 @@ function testForAllCases(
           expandToViewport,
           pageWidth,
           triggerWidth,
-          virtualScroll: false,
         },
         page => testFn({ page, componentId: componentId as ComponentId, expandToViewport })
       )()
@@ -138,7 +135,7 @@ describe('Dropdown width', () => {
       expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
     });
   });
-  describe('updates its width between re-renders', () => {
+  describe('updates between re-renders', () => {
     const pageWidth = 350;
     testForAllCases(
       { pageWidth, triggerWidth, asyncLoading: true },

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -6,28 +6,33 @@ import createWrapper from '../../../../../lib/components/test-utils/selectors';
 
 type ComponentId = 'autosuggest' | 'multiselect' | 'select';
 
-function getWrapperAndTrigger(componentId: ComponentId) {
-  const wrapper = createWrapper();
-  let componentWrapper;
-  switch (componentId) {
-    case 'autosuggest':
-      componentWrapper = wrapper.findAutosuggest();
-      return {
-        wrapper: componentWrapper,
-        trigger: componentWrapper.findNativeInput(),
-      };
-    case 'multiselect':
-      componentWrapper = wrapper.findMultiselect();
-      return {
-        wrapper: componentWrapper,
-        trigger: componentWrapper.findTrigger(),
-      };
-    case 'select':
-      componentWrapper = wrapper.findSelect();
-      return {
-        wrapper: componentWrapper,
-        trigger: componentWrapper.findTrigger(),
-      };
+export class DropdownPageObject extends BasePageObject {
+  getWrapperAndTrigger(componentId: ComponentId) {
+    const wrapper = createWrapper();
+    let componentWrapper;
+    switch (componentId) {
+      case 'autosuggest':
+        componentWrapper = wrapper.findAutosuggest();
+        return {
+          wrapper: componentWrapper,
+          trigger: componentWrapper.findNativeInput(),
+        };
+      case 'multiselect':
+        componentWrapper = wrapper.findMultiselect();
+        return {
+          wrapper: componentWrapper,
+          trigger: componentWrapper.findTrigger(),
+        };
+      case 'select':
+        componentWrapper = wrapper.findSelect();
+        return {
+          wrapper: componentWrapper,
+          trigger: componentWrapper.findTrigger(),
+        };
+    }
+  }
+  public waitUntil(fn: () => Promise<boolean>, options: { timeout: number }) {
+    return this.browser.waitUntil(fn, options);
   }
 }
 
@@ -38,21 +43,23 @@ function setupTest(
     triggerWidth,
     expandToViewport,
     virtualScroll,
+    asyncLoading = false,
   }: {
     pageWidth: number;
     componentId: ComponentId;
     triggerWidth: number;
     expandToViewport: boolean;
     virtualScroll: boolean;
+    asyncLoading?: boolean;
   },
-  testFn: (page: BasePageObject) => Promise<void>
+  testFn: (page: DropdownPageObject) => Promise<void>
 ) {
   return useBrowser({ width: pageWidth, height: 1000 }, async browser => {
     await browser.url(
-      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&virtualScroll=${virtualScroll}`
+      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&virtualScroll=${virtualScroll}&asyncLoading=${asyncLoading}`
     );
-    const page = new BasePageObject(browser);
-    await page.waitForVisible(getWrapperAndTrigger(componentId).wrapper.toSelector());
+    const page = new DropdownPageObject(browser);
+    await page.waitForVisible(page.getWrapperAndTrigger(componentId).wrapper.toSelector());
     await testFn(page);
   });
 }
@@ -63,45 +70,91 @@ async function openDropdown({
   expandToViewport,
 }: {
   componentId: ComponentId;
-  page: BasePageObject;
+  page: DropdownPageObject;
   expandToViewport: boolean;
 }) {
-  const { wrapper, trigger } = getWrapperAndTrigger(componentId);
+  const { wrapper, trigger } = page.getWrapperAndTrigger(componentId);
   await page.click(trigger.toSelector());
   const openDropdownSelector = wrapper.findDropdown({ expandToViewport }).findOpenDropdown().toSelector();
   await expect(openDropdownSelector).toBeTruthy();
-  return page.getBoundingBox(openDropdownSelector);
+  return { selector: openDropdownSelector, box: await page.getBoundingBox(openDropdownSelector) };
+}
+
+function testForAllCases(
+  {
+    pageWidth,
+    triggerWidth,
+    asyncLoading = false,
+  }: { pageWidth: number; triggerWidth: number; asyncLoading?: boolean },
+  testFn: ({
+    page,
+    componentId,
+    expandToViewport,
+  }: {
+    page: DropdownPageObject;
+    componentId: ComponentId;
+    expandToViewport: boolean;
+  }) => Promise<void>
+) {
+  describe.each([false, true])('expandToViewport: %s', expandToViewport => {
+    test.each(['autosuggest', 'multiselect', 'select'])('with %s', componentId =>
+      setupTest(
+        {
+          asyncLoading,
+          componentId: componentId as ComponentId,
+          expandToViewport,
+          pageWidth,
+          triggerWidth,
+          virtualScroll: false,
+        },
+        page => testFn({ page, componentId: componentId as ComponentId, expandToViewport })
+      )()
+    );
+  });
 }
 
 describe('Dropdown width', () => {
   const triggerWidth = 200;
   describe('stretches beyond the trigger width if there is enough space', () => {
     const pageWidth = 500;
-    describe.each([false, true])('expandToViewport: %s', expandToViewport => {
-      test.each(['autosuggest', 'multiselect', 'select'])('with %s', componentId =>
-        setupTest(
-          { componentId: componentId as ComponentId, triggerWidth, pageWidth, expandToViewport, virtualScroll: false },
-          async page => {
-            const dropdownBox = await openDropdown({ componentId: componentId as ComponentId, page, expandToViewport });
-            expect(dropdownBox.width).toBeGreaterThan(triggerWidth);
-            expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
-          }
-        )()
-      );
+    testForAllCases({ pageWidth, triggerWidth }, async ({ page, componentId, expandToViewport }) => {
+      const { box: dropdownBox } = await openDropdown({
+        componentId: componentId as ComponentId,
+        page,
+        expandToViewport,
+      });
+      expect(dropdownBox.width).toBeGreaterThan(triggerWidth);
+      expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
     });
   });
   describe('does not overflow the viewport', () => {
     const pageWidth = 350;
-    describe.each([false, true])('expandToViewport: %s', expandToViewport => {
-      test.each(['autosuggest', 'multiselect', 'select'])('with %s', componentId =>
-        setupTest(
-          { componentId: componentId as ComponentId, triggerWidth, pageWidth, expandToViewport, virtualScroll: false },
-          async page => {
-            const dropdownBox = await openDropdown({ componentId: componentId as ComponentId, page, expandToViewport });
-            expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
-          }
-        )()
-      );
+    testForAllCases({ pageWidth, triggerWidth }, async ({ page, componentId, expandToViewport }) => {
+      const { box: dropdownBox } = await openDropdown({
+        componentId: componentId as ComponentId,
+        page,
+        expandToViewport,
+      });
+      expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
     });
+  });
+  describe('updates its width between re-renders', () => {
+    const pageWidth = 350;
+    testForAllCases(
+      { pageWidth, triggerWidth, asyncLoading: true },
+      async ({ page, componentId, expandToViewport }) => {
+        const { box: dropdownBox, selector: dropdownSelector } = await openDropdown({
+          componentId: componentId as ComponentId,
+          page,
+          expandToViewport,
+        });
+        expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+        await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
+        await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
+          timeout: 1000,
+        });
+        expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+      }
+    );
   });
 });

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper from '../../../../../lib/components/test-utils/selectors';
+
+function getWrapper(componentId: string) {
+  return componentId === 'multiselect' ? createWrapper().findMultiselect() : createWrapper().findSelect();
+}
+
+function setupTest(
+  {
+    pageWidth,
+    componentId,
+    triggerWidth,
+    expandToViewport,
+    virtualScroll,
+  }: {
+    pageWidth: number;
+    componentId: string;
+    triggerWidth: number;
+    expandToViewport: boolean;
+    virtualScroll: boolean;
+  },
+  testFn: (page: BasePageObject) => Promise<void>
+) {
+  return useBrowser({ width: pageWidth, height: 1000 }, async browser => {
+    await browser.url(
+      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&virtualScroll=${virtualScroll}`
+    );
+    const page = new BasePageObject(browser);
+    await page.waitForVisible(getWrapper(componentId).toSelector());
+    await testFn(page);
+  });
+}
+
+async function openDropdown({
+  componentId,
+  page,
+  expandToViewport,
+}: {
+  componentId: string;
+  page: BasePageObject;
+  expandToViewport: boolean;
+}) {
+  const wrapper = getWrapper(componentId);
+  await page.click(wrapper.findTrigger().toSelector());
+  const openDropdownSelector = wrapper.findDropdown({ expandToViewport }).findOpenDropdown().toSelector();
+  await expect(openDropdownSelector).toBeTruthy();
+  return page.getBoundingBox(openDropdownSelector);
+}
+
+describe('Dropdown width', () => {
+  const triggerWidth = 200;
+  describe('overflows the trigger width if there is enough space', () => {
+    const pageWidth = 500;
+    describe.each([false, true])('expandToViewport: %s', expandToViewport => {
+      test.each(['multiselect', 'select'])('%s', componentId =>
+        setupTest({ componentId, triggerWidth, pageWidth, expandToViewport, virtualScroll: false }, async page => {
+          const dropdownBox = await openDropdown({ componentId, page, expandToViewport });
+          expect(dropdownBox.width).toBeGreaterThan(triggerWidth);
+          expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+        })()
+      );
+    });
+  });
+  describe('does not overflow the viewport', () => {
+    const pageWidth = 350;
+    describe.each([false, true])('expandToViewport: %s', expandToViewport => {
+      test.each(['multiselect', 'select'])('%s', componentId =>
+        setupTest({ componentId, triggerWidth, pageWidth, expandToViewport, virtualScroll: false }, async page => {
+          const dropdownBox = await openDropdown({ componentId, page, expandToViewport });
+          expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+        })()
+      );
+    });
+  });
+});

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -135,7 +135,7 @@ describe('Dropdown width', () => {
       expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
     });
   });
-  describe('updates between re-renders', () => {
+  describe('keeps not overflowing the viewport after re-rendering wider', () => {
     const pageWidth = 500;
     testForAllCases(
       { pageWidth, triggerWidth, asyncLoading: true },
@@ -145,13 +145,13 @@ describe('Dropdown width', () => {
           page,
           expandToViewport,
         });
-        const oldWidth = dropdownBox.width;
+        expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
         await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
         await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
           timeout: 1000,
         });
-        const newWidth = (await page.getBoundingBox(dropdownSelector)).width;
-        expect(newWidth).toBeGreaterThan(oldWidth);
+        const newBox = await page.getBoundingBox(dropdownSelector);
+        expect(newBox.left + newBox.width).toBeLessThanOrEqual(pageWidth);
       }
     );
   });

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -54,7 +54,7 @@ function setupTest(
 ) {
   return useBrowser({ width: pageWidth, height: 1000 }, async browser => {
     await browser.url(
-      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&width=${triggerWidth}px&asyncLoading=${asyncLoading}`
+      `#/light/dropdown/width?component=${componentId}&expandToViewport=${expandToViewport}&triggerWidth=${triggerWidth}px&asyncLoading=${asyncLoading}`
     );
     const page = new DropdownPageObject(browser);
     await page.waitForVisible(page.getWrapperAndTrigger(componentId).wrapper.toSelector());
@@ -136,7 +136,7 @@ describe('Dropdown width', () => {
     });
   });
   describe('updates between re-renders', () => {
-    const pageWidth = 350;
+    const pageWidth = 500;
     testForAllCases(
       { pageWidth, triggerWidth, asyncLoading: true },
       async ({ page, componentId, expandToViewport }) => {
@@ -145,12 +145,13 @@ describe('Dropdown width', () => {
           page,
           expandToViewport,
         });
-        expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+        const oldWidth = dropdownBox.width;
         await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
         await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
           timeout: 1000,
         });
-        expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
+        const newWidth = (await page.getBoundingBox(dropdownSelector)).width;
+        expect(newWidth).toBeGreaterThan(oldWidth);
       }
     );
   });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -14,7 +14,6 @@ const defaults = {
   height: '605px',
   left: 'auto',
   width: '100px',
-  overflows: false,
 };
 
 function getSizedElement(width: number, height: number, top = 0, left = 0) {
@@ -54,7 +53,6 @@ describe('getDropdownPosition', () => {
       getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
     ).toEqual({
       ...defaults,
-      overflows: true,
       dropLeft: true,
       width: '550px',
     });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -28,17 +28,19 @@ function getSizedElement(width: number, height: number, top = 0, left = 0) {
 
 describe('getDropdownPosition', () => {
   test('prefers dropping down by default', () => {
-    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual(
-      defaults
-    );
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual(defaults);
   });
 
   test('drops up if space above is not enough', () => {
-    const triggerBox = getSizedElement(100, 50, 900, 100).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 900, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       dropUp: true,
       height: '853px',
@@ -46,9 +48,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('drops left if dropdown is too wide', () => {
-    const triggerBox = getSizedElement(100, 50, 300, 500).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, 500);
     const dropdown = getSizedElement(600, 400);
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       overflows: true,
       dropLeft: true,
@@ -57,20 +61,22 @@ describe('getDropdownPosition', () => {
   });
 
   test('falls back to central position when there is not enough space from both sides', () => {
-    const triggerBox = getSizedElement(900, 50, 300, 50).getBoundingClientRect();
+    const trigger = getSizedElement(900, 50, 300, 50);
     const dropdown = getSizedElement(900, 400);
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       width: '900px',
     });
   });
 
   test('supports dropdown minWidth override', () => {
-    const triggerBox = getSizedElement(500, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(500, 50, 300, 100);
     const dropdown = getSizedElement(200, 400);
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -82,11 +88,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('dropdown can grow beyond the minWidth', () => {
-    const triggerBox = getSizedElement(500, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(500, 50, 300, 100);
     const dropdown = getSizedElement(600, 400);
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -98,11 +104,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('minWidth cannot be more than trigger width', () => {
-    const triggerBox = getSizedElement(200, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(200, 50, 300, 100);
     const dropdown = getSizedElement(100, 400);
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -114,25 +120,27 @@ describe('getDropdownPosition', () => {
   });
 
   test('dropdown matches trigger width when trigger sticks to the right screen edge', () => {
-    const triggerBox = getSizedElement(100, 50, 300, windowSize.width - 110).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, windowSize.width - 110);
     const dropdown = getSizedElement(100, 400);
 
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual({
       ...defaults,
       dropLeft: true, // TODO: this value is incorrect, should be fixed, see AWSUI-16369 for details
     });
   });
 
   test('takes parent overflow elements when they are found', () => {
-    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(100, 300);
-    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual(
-      defaults
-    );
+    expect(
+      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
+    ).toEqual(defaults);
     const scrollableContainer = { top: 100, left: 0, height: 400, width: 400 };
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize, scrollableContainer],
       })
@@ -144,11 +152,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('adjusts left offset if preferCenter=true', () => {
-    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, 100);
     const dropdown = getSizedElement(200, 300);
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         preferCenter: true,
@@ -161,11 +169,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('does not change offset if preferCenter=true, but it does not fit', () => {
-    const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
+    const trigger = getSizedElement(100, 50, 300, 15);
     const dropdown = getSizedElement(200, 300);
     expect(
       getDropdownPosition({
-        triggerBox,
+        triggerElement: trigger,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         preferCenter: true,
@@ -178,12 +186,12 @@ describe('getDropdownPosition', () => {
 
   describe('with stretchBeyondTriggerWidth=true', () => {
     test('can expand beyond trigger width', () => {
-      const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
+      const triggerElement = getSizedElement(100, 50, 300, 15);
       const dropdownElement = getSizedElement(200, 300);
 
       expect(
         getDropdownPosition({
-          triggerBox,
+          triggerElement,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,
@@ -195,12 +203,12 @@ describe('getDropdownPosition', () => {
     });
 
     test('cannot expand beyond the XXS breakpoint', () => {
-      const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
+      const triggerElement = getSizedElement(100, 50, 300, 15);
       const dropdownElement = getSizedElement(1000, 300);
 
       expect(
         getDropdownPosition({
-          triggerBox,
+          triggerElement,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,
@@ -212,12 +220,12 @@ describe('getDropdownPosition', () => {
     });
 
     test('will always grow to the width of the trigger if possible', () => {
-      const triggerBox = getSizedElement(700, 50, 300, 15).getBoundingClientRect();
+      const triggerElement = getSizedElement(700, 50, 300, 15);
       const dropdownElement = getSizedElement(400, 300);
 
       expect(
         getDropdownPosition({
-          triggerBox,
+          triggerElement,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -14,6 +14,7 @@ const defaults = {
   height: '605px',
   left: 'auto',
   width: '100px',
+  overflows: false,
 };
 
 function getSizedElement(width: number, height: number, top = 0, left = 0) {
@@ -49,6 +50,7 @@ describe('getDropdownPosition', () => {
     const dropdown = getSizedElement(600, 400);
     expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
       ...defaults,
+      overflows: true,
       dropLeft: true,
       width: '550px',
     });

--- a/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
+++ b/src/internal/components/dropdown/__tests__/dropdown-fit-handler.test.ts
@@ -27,19 +27,17 @@ function getSizedElement(width: number, height: number, top = 0, left = 0) {
 
 describe('getDropdownPosition', () => {
   test('prefers dropping down by default', () => {
-    const trigger = getSizedElement(100, 50, 300, 100);
+    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(100, 300);
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual(defaults);
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual(
+      defaults
+    );
   });
 
   test('drops up if space above is not enough', () => {
-    const trigger = getSizedElement(100, 50, 900, 100);
+    const triggerBox = getSizedElement(100, 50, 900, 100).getBoundingClientRect();
     const dropdown = getSizedElement(100, 300);
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual({
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
       ...defaults,
       dropUp: true,
       height: '853px',
@@ -47,11 +45,9 @@ describe('getDropdownPosition', () => {
   });
 
   test('drops left if dropdown is too wide', () => {
-    const trigger = getSizedElement(100, 50, 300, 500);
+    const triggerBox = getSizedElement(100, 50, 300, 500).getBoundingClientRect();
     const dropdown = getSizedElement(600, 400);
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual({
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
       ...defaults,
       dropLeft: true,
       width: '550px',
@@ -59,22 +55,20 @@ describe('getDropdownPosition', () => {
   });
 
   test('falls back to central position when there is not enough space from both sides', () => {
-    const trigger = getSizedElement(900, 50, 300, 50);
+    const triggerBox = getSizedElement(900, 50, 300, 50).getBoundingClientRect();
     const dropdown = getSizedElement(900, 400);
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual({
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
       ...defaults,
       width: '900px',
     });
   });
 
   test('supports dropdown minWidth override', () => {
-    const trigger = getSizedElement(500, 50, 300, 100);
+    const triggerBox = getSizedElement(500, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(200, 400);
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -86,11 +80,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('dropdown can grow beyond the minWidth', () => {
-    const trigger = getSizedElement(500, 50, 300, 100);
+    const triggerBox = getSizedElement(500, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(600, 400);
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -102,11 +96,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('minWidth cannot be more than trigger width', () => {
-    const trigger = getSizedElement(200, 50, 300, 100);
+    const triggerBox = getSizedElement(200, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(100, 400);
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         minWidth: 300,
@@ -118,27 +112,25 @@ describe('getDropdownPosition', () => {
   });
 
   test('dropdown matches trigger width when trigger sticks to the right screen edge', () => {
-    const trigger = getSizedElement(100, 50, 300, windowSize.width - 110);
+    const triggerBox = getSizedElement(100, 50, 300, windowSize.width - 110).getBoundingClientRect();
     const dropdown = getSizedElement(100, 400);
 
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual({
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual({
       ...defaults,
       dropLeft: true, // TODO: this value is incorrect, should be fixed, see AWSUI-16369 for details
     });
   });
 
   test('takes parent overflow elements when they are found', () => {
-    const trigger = getSizedElement(100, 50, 300, 100);
+    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(100, 300);
-    expect(
-      getDropdownPosition({ triggerElement: trigger, dropdownElement: dropdown, overflowParents: [windowSize] })
-    ).toEqual(defaults);
+    expect(getDropdownPosition({ triggerBox, dropdownElement: dropdown, overflowParents: [windowSize] })).toEqual(
+      defaults
+    );
     const scrollableContainer = { top: 100, left: 0, height: 400, width: 400 };
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize, scrollableContainer],
       })
@@ -150,11 +142,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('adjusts left offset if preferCenter=true', () => {
-    const trigger = getSizedElement(100, 50, 300, 100);
+    const triggerBox = getSizedElement(100, 50, 300, 100).getBoundingClientRect();
     const dropdown = getSizedElement(200, 300);
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         preferCenter: true,
@@ -167,11 +159,11 @@ describe('getDropdownPosition', () => {
   });
 
   test('does not change offset if preferCenter=true, but it does not fit', () => {
-    const trigger = getSizedElement(100, 50, 300, 15);
+    const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
     const dropdown = getSizedElement(200, 300);
     expect(
       getDropdownPosition({
-        triggerElement: trigger,
+        triggerBox,
         dropdownElement: dropdown,
         overflowParents: [windowSize],
         preferCenter: true,
@@ -184,12 +176,12 @@ describe('getDropdownPosition', () => {
 
   describe('with stretchBeyondTriggerWidth=true', () => {
     test('can expand beyond trigger width', () => {
-      const triggerElement = getSizedElement(100, 50, 300, 15);
+      const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
       const dropdownElement = getSizedElement(200, 300);
 
       expect(
         getDropdownPosition({
-          triggerElement,
+          triggerBox,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,
@@ -201,12 +193,12 @@ describe('getDropdownPosition', () => {
     });
 
     test('cannot expand beyond the XXS breakpoint', () => {
-      const triggerElement = getSizedElement(100, 50, 300, 15);
+      const triggerBox = getSizedElement(100, 50, 300, 15).getBoundingClientRect();
       const dropdownElement = getSizedElement(1000, 300);
 
       expect(
         getDropdownPosition({
-          triggerElement,
+          triggerBox,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,
@@ -218,12 +210,12 @@ describe('getDropdownPosition', () => {
     });
 
     test('will always grow to the width of the trigger if possible', () => {
-      const triggerElement = getSizedElement(700, 50, 300, 15);
+      const triggerBox = getSizedElement(700, 50, 300, 15).getBoundingClientRect();
       const dropdownElement = getSizedElement(400, 300);
 
       expect(
         getDropdownPosition({
-          triggerElement,
+          triggerBox,
           dropdownElement,
           overflowParents: [windowSize],
           stretchBeyondTriggerWidth: true,

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -45,7 +45,7 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
 export const defaultMaxDropdownWidth = getBreakpointValue('xxs');
 
 export const getAvailableSpace = (
-  trigger: HTMLElement,
+  trigger: DOMRect,
   dropdown: HTMLElement,
   overflowParents: ReadonlyArray<Dimensions>,
   stretchWidth = false,
@@ -62,12 +62,12 @@ export const getAvailableSpace = (
     : isMobile
     ? AVAILABLE_SPACE_RESERVE_MOBILE_HORIZONTAL
     : AVAILABLE_SPACE_RESERVE_DEFAULT;
-  const { bottom: triggerBottom, left: triggerLeft, right: triggerRight } = trigger.getBoundingClientRect();
+  const { bottom: triggerBottom, left: triggerLeft, right: triggerRight } = trigger;
 
   return overflowParents.reduce(
     ({ above, below, left, right }, overflowParent) => {
       const offsetTop = triggerBottom - overflowParent.top;
-      const currentAbove = offsetTop - trigger.offsetHeight - availableSpaceReserveVertical;
+      const currentAbove = offsetTop - trigger.height - availableSpaceReserveVertical;
       const currentBelow = overflowParent.height - offsetTop - availableSpaceReserveVertical;
       const currentLeft = triggerRight - overflowParent.left - availableSpaceReserveHorizontal;
       const currentRight = overflowParent.left + overflowParent.width - triggerLeft - availableSpaceReserveHorizontal;
@@ -122,7 +122,7 @@ export const getInteriorAvailableSpace = (
 };
 
 export const getDropdownPosition = ({
-  triggerElement,
+  triggerBox,
   dropdownElement,
   overflowParents,
   minWidth: desiredMinWidth,
@@ -132,7 +132,7 @@ export const getDropdownPosition = ({
   isMobile = false,
   stretchBeyondTriggerWidth = false,
 }: {
-  triggerElement: HTMLElement;
+  triggerBox: DOMRect;
   dropdownElement: HTMLElement;
   overflowParents: ReadonlyArray<Dimensions>;
   minWidth?: number;
@@ -144,7 +144,7 @@ export const getDropdownPosition = ({
 }): DropdownPosition => {
   // Determine the space available around the dropdown that it can grow in
   const availableSpace = getAvailableSpace(
-    triggerElement,
+    triggerBox,
     dropdownElement,
     overflowParents,
     stretchWidth,
@@ -152,7 +152,7 @@ export const getDropdownPosition = ({
     isMobile
   );
   // Determine the width of the trigger
-  const triggerWidth = triggerElement.getBoundingClientRect().width;
+  const triggerWidth = triggerBox.width;
   // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
   // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
@@ -273,10 +273,11 @@ export const calculatePosition = (
   dropdownElement.classList.remove(styles['dropdown-drop-up']);
 
   const overflowParents = getOverflowParentDimensions(dropdownElement, interior, expandToViewport, stretchHeight);
+  const triggerBox = triggerElement.getBoundingClientRect();
   const position = interior
     ? getInteriorDropdownPosition(triggerElement, dropdownElement, overflowParents, isMobile)
     : getDropdownPosition({
-        triggerElement,
+        triggerBox,
         dropdownElement,
         overflowParents,
         minWidth,
@@ -286,6 +287,5 @@ export const calculatePosition = (
         isMobile,
         stretchBeyondTriggerWidth,
       });
-  const triggerBox = triggerElement.getBoundingClientRect();
   return [position, triggerBox];
 };

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -20,6 +20,7 @@ export interface DropdownPosition {
   dropUp: boolean;
   dropLeft: boolean;
   left: string;
+  overflows: boolean;
 }
 export interface InteriorDropdownPosition extends DropdownPosition {
   bottom: string;
@@ -165,6 +166,7 @@ export const getDropdownPosition = ({
   let dropLeft: boolean;
   let left: number | null = null;
   let width = idealWidth;
+  let overflows = false;
 
   //1. Can it be positioned with ideal width to the right?
   if (idealWidth <= availableSpace.right) {
@@ -176,6 +178,7 @@ export const getDropdownPosition = ({
   } else {
     dropLeft = availableSpace.left > availableSpace.right;
     width = Math.max(availableSpace.left, availableSpace.right, minWidth);
+    overflows = true;
   }
 
   if (preferCenter) {
@@ -202,6 +205,7 @@ export const getDropdownPosition = ({
     left: left === null ? 'auto' : `${left}px`,
     height: `${croppedHeight}px`,
     width: `${width}px`,
+    overflows,
   };
 };
 
@@ -216,6 +220,7 @@ export const getInteriorDropdownPosition = (
   const { top: parentDropdownTop, height: parentDropdownHeight } = getClosestParentDimensions(trigger);
 
   let dropLeft;
+  let overflows = false;
 
   let width = dropdown.getBoundingClientRect().width;
   const top = triggerTop - parentDropdownTop;
@@ -226,6 +231,7 @@ export const getInteriorDropdownPosition = (
   } else {
     dropLeft = availableSpace.left > availableSpace.right;
     width = Math.max(availableSpace.left, availableSpace.right);
+    overflows = true;
   }
 
   const left = dropLeft ? 0 - width : triggerWidth;
@@ -244,6 +250,7 @@ export const getInteriorDropdownPosition = (
     top: `${top}px`,
     bottom: `${bottom}px`,
     left: `${left}px`,
+    overflows,
   };
 };
 

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -189,7 +189,7 @@ export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
     stretchHeight,
     isMobile,
   });
-  return idealWidth <= availableSpace.left && idealWidth <= availableSpace.right;
+  return idealWidth <= availableSpace.left || idealWidth <= availableSpace.right;
 };
 
 export const getDropdownPosition = ({

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -46,7 +46,7 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
 export const defaultMaxDropdownWidth = getBreakpointValue('xxs');
 
 export const getAvailableSpace = (
-  trigger: DOMRect,
+  trigger: HTMLElement,
   dropdown: HTMLElement,
   overflowParents: ReadonlyArray<Dimensions>,
   stretchWidth = false,
@@ -63,12 +63,12 @@ export const getAvailableSpace = (
     : isMobile
     ? AVAILABLE_SPACE_RESERVE_MOBILE_HORIZONTAL
     : AVAILABLE_SPACE_RESERVE_DEFAULT;
-  const { bottom: triggerBottom, left: triggerLeft, right: triggerRight } = trigger;
+  const { bottom: triggerBottom, left: triggerLeft, right: triggerRight } = trigger.getBoundingClientRect();
 
   return overflowParents.reduce(
     ({ above, below, left, right }, overflowParent) => {
       const offsetTop = triggerBottom - overflowParent.top;
-      const currentAbove = offsetTop - trigger.height - availableSpaceReserveVertical;
+      const currentAbove = offsetTop - trigger.offsetHeight - availableSpaceReserveVertical;
       const currentBelow = overflowParent.height - offsetTop - availableSpaceReserveVertical;
       const currentLeft = triggerRight - overflowParent.left - availableSpaceReserveHorizontal;
       const currentRight = overflowParent.left + overflowParent.width - triggerLeft - availableSpaceReserveHorizontal;
@@ -123,7 +123,7 @@ export const getInteriorAvailableSpace = (
 };
 
 export const getDropdownPosition = ({
-  triggerBox,
+  triggerElement,
   dropdownElement,
   overflowParents,
   minWidth: desiredMinWidth,
@@ -133,7 +133,7 @@ export const getDropdownPosition = ({
   isMobile = false,
   stretchBeyondTriggerWidth = false,
 }: {
-  triggerBox: DOMRect;
+  triggerElement: HTMLElement;
   dropdownElement: HTMLElement;
   overflowParents: ReadonlyArray<Dimensions>;
   minWidth?: number;
@@ -145,7 +145,7 @@ export const getDropdownPosition = ({
 }): DropdownPosition => {
   // Determine the space available around the dropdown that it can grow in
   const availableSpace = getAvailableSpace(
-    triggerBox,
+    triggerElement,
     dropdownElement,
     overflowParents,
     stretchWidth,
@@ -153,7 +153,7 @@ export const getDropdownPosition = ({
     isMobile
   );
   // Determine the width of the trigger
-  const triggerWidth = triggerBox.width;
+  const triggerWidth = triggerElement.getBoundingClientRect().width;
   // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
   const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
   // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
@@ -280,11 +280,10 @@ export const calculatePosition = (
   dropdownElement.classList.remove(styles['dropdown-drop-up']);
 
   const overflowParents = getOverflowParentDimensions(dropdownElement, interior, expandToViewport, stretchHeight);
-  const triggerBox = triggerElement.getBoundingClientRect();
   const position = interior
     ? getInteriorDropdownPosition(triggerElement, dropdownElement, overflowParents, isMobile)
     : getDropdownPosition({
-        triggerBox,
+        triggerElement,
         dropdownElement,
         overflowParents,
         minWidth,
@@ -294,5 +293,6 @@ export const calculatePosition = (
         isMobile,
         stretchBeyondTriggerWidth,
       });
+  const triggerBox = triggerElement.getBoundingClientRect();
   return [position, triggerBox];
 };

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -20,7 +20,6 @@ export interface DropdownPosition {
   dropUp: boolean;
   dropLeft: boolean;
   left: string;
-  overflows: boolean;
 }
 export interface InteriorDropdownPosition extends DropdownPosition {
   bottom: string;
@@ -45,14 +44,19 @@ const getClosestParentDimensions = (element: HTMLElement): any => {
 // This value was determined by UX but may be subject to change in the future, depending on the feedback.
 export const defaultMaxDropdownWidth = getBreakpointValue('xxs');
 
-export const getAvailableSpace = (
-  trigger: HTMLElement,
-  dropdown: HTMLElement,
-  overflowParents: ReadonlyArray<Dimensions>,
+export const getAvailableSpace = ({
+  trigger,
+  overflowParents,
   stretchWidth = false,
   stretchHeight = false,
-  isMobile?: boolean
-): AvailableSpace => {
+  isMobile,
+}: {
+  trigger: HTMLElement;
+  overflowParents: ReadonlyArray<Dimensions>;
+  stretchWidth?: boolean;
+  stretchHeight?: boolean;
+  isMobile?: boolean;
+}): AvailableSpace => {
   const availableSpaceReserveVertical = stretchHeight
     ? 0
     : isMobile
@@ -84,12 +88,15 @@ export const getAvailableSpace = (
   );
 };
 
-export const getInteriorAvailableSpace = (
-  trigger: HTMLElement,
-  dropdown: HTMLElement,
-  overflowParents: ReadonlyArray<Dimensions>,
-  isMobile?: boolean
-): AvailableSpace => {
+export const getInteriorAvailableSpace = ({
+  trigger,
+  overflowParents,
+  isMobile,
+}: {
+  trigger: HTMLElement;
+  overflowParents: ReadonlyArray<Dimensions>;
+  isMobile?: boolean;
+}): AvailableSpace => {
   const AVAILABLE_SPACE_RESERVE_VERTICAL = isMobile
     ? AVAILABLE_SPACE_RESERVE_MOBILE_VERTICAL
     : AVAILABLE_SPACE_RESERVE_DEFAULT;
@@ -122,6 +129,69 @@ export const getInteriorAvailableSpace = (
   );
 };
 
+export const getWidths = ({
+  triggerElement,
+  dropdownElement,
+  desiredMinWidth,
+  stretchBeyondTriggerWidth = false,
+}: {
+  triggerElement: HTMLElement;
+  dropdownElement: HTMLElement;
+  desiredMinWidth?: number;
+  stretchBeyondTriggerWidth?: boolean;
+}) => {
+  // Determine the width of the trigger
+  const triggerWidth = triggerElement.getBoundingClientRect().width;
+  // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
+  const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
+  // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
+  const maxWidth = stretchBeyondTriggerWidth ? Math.max(defaultMaxDropdownWidth, triggerWidth) : Number.MAX_VALUE;
+  // Determine the actual dropdown width, the size that it "wants" to be
+  const requiredWidth = dropdownElement.getBoundingClientRect().width;
+  // Try to achieve the required/desired width within the given parameters
+  const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
+  return { idealWidth, minWidth, triggerWidth };
+};
+
+export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
+  triggerElement,
+  dropdownElement,
+  desiredMinWidth,
+  expandToViewport,
+  stretchWidth,
+  stretchHeight,
+  isMobile,
+}: {
+  triggerElement: HTMLElement;
+  dropdownElement: HTMLElement;
+  desiredMinWidth?: number;
+  expandToViewport: boolean;
+  stretchWidth: boolean;
+  stretchHeight: boolean;
+  isMobile: boolean;
+}) => {
+  const overflowParents = getOverflowParentDimensions({
+    element: dropdownElement,
+    excludeClosestParent: false,
+    expandToViewport,
+    canExpandOutsideViewport: stretchHeight,
+  });
+  const { idealWidth } = getWidths({
+    triggerElement: triggerElement,
+    dropdownElement,
+    desiredMinWidth,
+    stretchBeyondTriggerWidth: true,
+  });
+  const availableSpace = getAvailableSpace({
+    trigger: triggerElement,
+    overflowParents,
+    stretchWidth,
+    stretchHeight,
+    isMobile,
+  });
+  return idealWidth <= availableSpace.left && idealWidth <= availableSpace.right;
+};
+
 export const getDropdownPosition = ({
   triggerElement,
   dropdownElement,
@@ -144,29 +214,23 @@ export const getDropdownPosition = ({
   stretchBeyondTriggerWidth?: boolean;
 }): DropdownPosition => {
   // Determine the space available around the dropdown that it can grow in
-  const availableSpace = getAvailableSpace(
-    triggerElement,
-    dropdownElement,
+  const availableSpace = getAvailableSpace({
+    trigger: triggerElement,
     overflowParents,
     stretchWidth,
     stretchHeight,
-    isMobile
-  );
-  // Determine the width of the trigger
-  const triggerWidth = triggerElement.getBoundingClientRect().width;
-  // Minimum width is determined by either an explicit number (desiredMinWidth) or the trigger width
-  const minWidth = desiredMinWidth ? Math.min(triggerWidth, desiredMinWidth) : triggerWidth;
-  // If stretchBeyondTriggerWidth is true, the maximum width is the XS breakpoint (465px) or the trigger width (if bigger).
-  const maxWidth = stretchBeyondTriggerWidth ? Math.max(defaultMaxDropdownWidth, triggerWidth) : Number.MAX_VALUE;
-  // Determine the actual dropdown width, the size that it "wants" to be
-  const requiredWidth = dropdownElement.getBoundingClientRect().width;
-  // Try to achieve the required/desired width within the given parameters
-  const idealWidth = Math.min(Math.max(requiredWidth, minWidth), maxWidth);
+    isMobile,
+  });
+  const { idealWidth, minWidth, triggerWidth } = getWidths({
+    triggerElement,
+    dropdownElement,
+    desiredMinWidth,
+    stretchBeyondTriggerWidth,
+  });
 
   let dropLeft: boolean;
   let left: number | null = null;
   let width = idealWidth;
-  let overflows = false;
 
   //1. Can it be positioned with ideal width to the right?
   if (idealWidth <= availableSpace.right) {
@@ -178,7 +242,6 @@ export const getDropdownPosition = ({
   } else {
     dropLeft = availableSpace.left > availableSpace.right;
     width = Math.max(availableSpace.left, availableSpace.right, minWidth);
-    overflows = true;
   }
 
   if (preferCenter) {
@@ -205,7 +268,6 @@ export const getDropdownPosition = ({
     left: left === null ? 'auto' : `${left}px`,
     height: `${croppedHeight}px`,
     width: `${width}px`,
-    overflows,
   };
 };
 
@@ -215,12 +277,11 @@ export const getInteriorDropdownPosition = (
   overflowParents: ReadonlyArray<Dimensions>,
   isMobile?: boolean
 ): InteriorDropdownPosition => {
-  const availableSpace = getInteriorAvailableSpace(trigger, dropdown, overflowParents, isMobile);
+  const availableSpace = getInteriorAvailableSpace({ trigger, overflowParents, isMobile });
   const { bottom: triggerBottom, top: triggerTop, width: triggerWidth } = trigger.getBoundingClientRect();
   const { top: parentDropdownTop, height: parentDropdownHeight } = getClosestParentDimensions(trigger);
 
   let dropLeft;
-  let overflows = false;
 
   let width = dropdown.getBoundingClientRect().width;
   const top = triggerTop - parentDropdownTop;
@@ -231,7 +292,6 @@ export const getInteriorDropdownPosition = (
   } else {
     dropLeft = availableSpace.left > availableSpace.right;
     width = Math.max(availableSpace.left, availableSpace.right);
-    overflows = true;
   }
 
   const left = dropLeft ? 0 - width : triggerWidth;
@@ -250,7 +310,6 @@ export const getInteriorDropdownPosition = (
     top: `${top}px`,
     bottom: `${bottom}px`,
     left: `${left}px`,
-    overflows,
   };
 };
 
@@ -279,7 +338,12 @@ export const calculatePosition = (
   dropdownElement.classList.remove(styles['dropdown-drop-right']);
   dropdownElement.classList.remove(styles['dropdown-drop-up']);
 
-  const overflowParents = getOverflowParentDimensions(dropdownElement, interior, expandToViewport, stretchHeight);
+  const overflowParents = getOverflowParentDimensions({
+    element: dropdownElement,
+    excludeClosestParent: interior,
+    expandToViewport,
+    canExpandOutsideViewport: stretchHeight,
+  });
   const position = interior
     ? getInteriorDropdownPosition(triggerElement, dropdownElement, overflowParents, isMobile)
     : getDropdownPosition({

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -190,17 +190,19 @@ const Dropdown = ({
       verticalContainer.style.maxHeight = position.height;
     }
 
+    if (entireWidth && !expandToViewport) {
+      if (stretchToTriggerWidth) {
+        target.classList.add(styles['occupy-entire-width']);
+      }
+    } else {
+      target.style.width = position.width;
+    }
+
+    // Prevent the dropdown width from stretching beyond the trigger width
+    // if that is going to cause the dropdown to be cropped because of overflow
     if (position.overflows) {
       target.classList.remove(styles['stretch-beyond-trigger-width']);
       target.style.removeProperty('maxWidth');
-    } else {
-      if (entireWidth && !expandToViewport) {
-        if (stretchToTriggerWidth) {
-          target.classList.add(styles['occupy-entire-width']);
-        }
-      } else {
-        target.style.width = position.width;
-      }
     }
 
     // Using styles for main dropdown to adjust its position as preferred alternative

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -190,13 +190,18 @@ const Dropdown = ({
       verticalContainer.style.maxHeight = position.height;
     }
 
-    if (entireWidth && !expandToViewport) {
-      if (stretchToTriggerWidth) {
-        target.classList.add(styles['occupy-entire-width']);
+    if (position.overflows) {
+      target.classList.remove(styles['stretch-beyond-trigger-width']);
+      target.style.removeProperty('maxWidth');
+    } else {
+      if (entireWidth && !expandToViewport) {
+        if (stretchToTriggerWidth) {
+          target.classList.add(styles['occupy-entire-width']);
+        }
+      } else {
+        target.style.width = position.width;
       }
     }
-
-    target.style.width = position.width;
 
     // Using styles for main dropdown to adjust its position as preferred alternative
     if (position.dropUp && !interior) {

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -22,6 +22,7 @@ import { useMobile } from '../../hooks/use-mobile';
 import TabTrap from '../tab-trap/index.js';
 import { getFirstFocusable, getLastFocusable } from '../focus-lock/utils.js';
 import { useUniqueId } from '../../hooks/use-unique-id/index.js';
+import customCssProps from '../../generated/custom-css-properties';
 
 interface DropdownContainerProps {
   children?: React.ReactNode;
@@ -114,7 +115,9 @@ const TransitionContent = ({
       data-open={open}
       data-animating={state !== 'exited'}
       aria-hidden={!open}
-      style={stretchBeyondTriggerWidth ? { maxWidth: defaultMaxDropdownWidth } : {}}
+      style={
+        stretchBeyondTriggerWidth ? { [customCssProps.dropdownDefaultMaxWidth]: `${defaultMaxDropdownWidth}px` } : {}
+      }
       onMouseDown={onMouseDown}
     >
       <div className={clsx(styles['dropdown-content-wrapper'], isRefresh && styles.refresh)}>
@@ -337,7 +340,6 @@ const Dropdown = ({
         })
       ) {
         dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
-        dropdownRef.current.style.removeProperty('maxWidth');
       }
     }
   });

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -12,8 +12,7 @@ import {
   InteriorDropdownPosition,
   calculatePosition,
   defaultMaxDropdownWidth,
-  getDropdownPosition,
-  getInteriorDropdownPosition,
+  hasEnoughSpaceToStretchBeyondTriggerWidth,
 } from './dropdown-fit-handler';
 import { Transition, TransitionStatus } from '../transition';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
@@ -23,7 +22,6 @@ import { useMobile } from '../../hooks/use-mobile';
 import TabTrap from '../tab-trap/index.js';
 import { getFirstFocusable, getLastFocusable } from '../focus-lock/utils.js';
 import { useUniqueId } from '../../hooks/use-unique-id/index.js';
-import { getOverflowParentDimensions } from '../../utils/scrollable-containers';
 
 interface DropdownContainerProps {
   children?: React.ReactNode;
@@ -327,26 +325,17 @@ const Dropdown = ({
   // if that is going to cause the dropdown to be cropped because of overflow
   useLayoutEffect(() => {
     if (stretchBeyondTriggerWidth && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
-      const overflowParents = getOverflowParentDimensions(
-        dropdownRef.current,
-        interior,
-        expandToViewport,
-        stretchHeight
-      );
-      const { overflows } = interior
-        ? getInteriorDropdownPosition(triggerRef.current, dropdownRef.current, overflowParents, isMobile)
-        : getDropdownPosition({
-            triggerElement: triggerRef.current,
-            dropdownElement: dropdownRef.current,
-            overflowParents,
-            minWidth,
-            preferCenter,
-            stretchWidth,
-            stretchHeight,
-            isMobile,
-            stretchBeyondTriggerWidth,
-          });
-      if (overflows) {
+      if (
+        !hasEnoughSpaceToStretchBeyondTriggerWidth({
+          triggerElement: triggerRef.current,
+          dropdownElement: dropdownRef.current,
+          desiredMinWidth: minWidth,
+          expandToViewport,
+          stretchWidth,
+          stretchHeight,
+          isMobile,
+        })
+      ) {
         dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
         dropdownRef.current.style.removeProperty('maxWidth');
       }

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -12,6 +12,8 @@ import {
   InteriorDropdownPosition,
   calculatePosition,
   defaultMaxDropdownWidth,
+  getDropdownPosition,
+  getInteriorDropdownPosition,
 } from './dropdown-fit-handler';
 import { Transition, TransitionStatus } from '../transition';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
@@ -21,6 +23,7 @@ import { useMobile } from '../../hooks/use-mobile';
 import TabTrap from '../tab-trap/index.js';
 import { getFirstFocusable, getLastFocusable } from '../focus-lock/utils.js';
 import { useUniqueId } from '../../hooks/use-unique-id/index.js';
+import { getOverflowParentDimensions } from '../../utils/scrollable-containers';
 
 interface DropdownContainerProps {
   children?: React.ReactNode;
@@ -198,13 +201,6 @@ const Dropdown = ({
       target.style.width = position.width;
     }
 
-    // Prevent the dropdown width from stretching beyond the trigger width
-    // if that is going to cause the dropdown to be cropped because of overflow
-    if (position.overflows) {
-      target.classList.remove(styles['stretch-beyond-trigger-width']);
-      target.style.removeProperty('maxWidth');
-    }
-
     // Using styles for main dropdown to adjust its position as preferred alternative
     if (position.dropUp && !interior) {
       target.classList.add(styles['dropdown-drop-up']);
@@ -326,6 +322,36 @@ const Dropdown = ({
     // See AWSUI-13040
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, dropdownRef, triggerRef, verticalContainerRef, interior, stretchWidth, isMobile, contentKey]);
+
+  // Prevent the dropdown width from stretching beyond the trigger width
+  // if that is going to cause the dropdown to be cropped because of overflow
+  useLayoutEffect(() => {
+    if (stretchBeyondTriggerWidth && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
+      const overflowParents = getOverflowParentDimensions(
+        dropdownRef.current,
+        interior,
+        expandToViewport,
+        stretchHeight
+      );
+      const { overflows } = interior
+        ? getInteriorDropdownPosition(triggerRef.current, dropdownRef.current, overflowParents, isMobile)
+        : getDropdownPosition({
+            triggerElement: triggerRef.current,
+            dropdownElement: dropdownRef.current,
+            overflowParents,
+            minWidth,
+            preferCenter,
+            stretchWidth,
+            stretchHeight,
+            isMobile,
+            stretchBeyondTriggerWidth,
+          });
+      if (overflows) {
+        dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
+        dropdownRef.current.style.removeProperty('maxWidth');
+      }
+    }
+  });
 
   // subscribe to outside click
   useEffect(() => {

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -194,9 +194,10 @@ const Dropdown = ({
       if (stretchToTriggerWidth) {
         target.classList.add(styles['occupy-entire-width']);
       }
-    } else {
-      target.style.width = position.width;
     }
+
+    target.style.width = position.width;
+
     // Using styles for main dropdown to adjust its position as preferred alternative
     if (position.dropUp && !interior) {
       target.classList.add(styles['dropdown-drop-up']);

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -6,6 +6,7 @@
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
 @use './motion';
+@use '../../generated/custom-css-properties/index' as custom-props;
 
 .root {
   @include styles.styles-reset;
@@ -72,6 +73,7 @@
   }
   &.stretch-beyond-trigger-width {
     width: max-content;
+    max-width: var(#{custom-props.$dropdownDefaultMaxWidth}, 100%);
   }
   &.hide-upper-border > .dropdown-content-wrapper {
     border-top: none;

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -47,5 +47,7 @@ const customCssPropertiesList = [
   'flashbarStickyBottomMargin',
   'stackedNotificationsBottomMargin',
   'stackedNotificationsDefaultBottomMargin',
+  // Dropdown
+  'dropdownDefaultMaxWidth',
 ];
 module.exports = customCssPropertiesList;

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -17,12 +17,17 @@ export const getOverflowParents = (element: HTMLElement): HTMLElement[] => {
   return parents;
 };
 
-export const getOverflowParentDimensions = (
-  element: HTMLElement,
+export const getOverflowParentDimensions = ({
+  element,
   excludeClosestParent = false,
   expandToViewport = false,
-  canExpandOutsideViewport = false
-): Dimensions[] => {
+  canExpandOutsideViewport = false,
+}: {
+  element: HTMLElement;
+  excludeClosestParent: boolean;
+  expandToViewport: boolean;
+  canExpandOutsideViewport: boolean;
+}): Dimensions[] => {
   const parents = expandToViewport
     ? []
     : getOverflowParents(element).map(el => {


### PR DESCRIPTION
### Description

After #1423, dropdowns of the autosuggest, select and multiselect components expand beyond the trigger width, like this:

![localhost_8080_ (29)](https://github.com/cloudscape-design/components/assets/1257272/f5c688a5-7340-4b3e-9d67-458c69e7b735)

The problem is, that doesn't account for the available space, so in a narrow viewport or in a narrow container with hidden overflow the dropdown will be cut off:

![localhost_8080_ (28)](https://github.com/cloudscape-design/components/assets/1257272/737e8d73-ebee-4c68-a271-f63ddfc173cd)

This is fixed here by opting out of that behavior if it was detected that the the dropdown overflows. So if that would happen, it will _not_ stretch beyond the trigger:

![localhost_8080_ (30)](https://github.com/cloudscape-design/components/assets/1257272/a25089cb-9726-42f9-8539-2666a1c1d135)

Issue: AWSUI-22328

### How has this been tested?

Added new test page, which I used for both running manual testing and for writing new integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
