### PR TITLE
fix: Fix table resizer issues with screen-reader

### DIFF
--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -295,18 +295,21 @@ test('should not trigger if the previous and the current widths are the same', (
 });
 
 describe('resize with keyboard', () => {
+  let mockWidth = 150;
+
   const originalBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
   beforeEach(() => {
     HTMLElement.prototype.getBoundingClientRect = function () {
       const rect = originalBoundingClientRect.apply(this);
       if (this.tagName === 'TH') {
-        rect.width = 150;
+        rect.width = mockWidth;
       }
       return rect;
     };
   });
 
   afterEach(() => {
+    mockWidth = 150;
     HTMLElement.prototype.getBoundingClientRect = originalBoundingClientRect;
   });
 
@@ -329,6 +332,19 @@ describe('resize with keyboard', () => {
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange).toHaveBeenCalledWith({ widths: [150 + 10, 300] });
     });
+  });
+
+  test('cannot resize below minsize', () => {
+    mockWidth = 80;
+    const onChange = jest.fn();
+    const { wrapper } = renderTable(<Table {...defaultProps} onColumnWidthsChange={event => onChange(event.detail)} />);
+    const columnResizerWrapper = wrapper.findColumnResizer(1)!;
+
+    columnResizerWrapper.focus();
+    columnResizerWrapper.keydown(KeyCode.left);
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(columnResizerWrapper.getElement()!).toHaveAttribute('aria-valuenow', '80');
   });
 });
 

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -28,8 +28,6 @@ interface TableHeaderCellProps<ItemType> {
   onResizeFinish: () => void;
   colIndex: number;
   updateColumn: (columnId: PropertyKey, newWidth: number) => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
   resizableColumns?: boolean;
   isEditable?: boolean;
   columnId: PropertyKey;
@@ -144,8 +142,8 @@ export function TableHeaderCell<ItemType>({
           tabIndex={tabIndex}
           focusId={`resize-control-${String(columnId)}`}
           showFocusRing={focusedComponent === `resize-control-${String(columnId)}`}
-          onDragMove={newWidth => updateColumn(columnId, newWidth)}
-          onFinish={onResizeFinish}
+          onWidthUpdate={newWidth => updateColumn(columnId, newWidth)}
+          onWidthUpdateCommit={onResizeFinish}
           ariaLabelledby={headerId}
           minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
         />

--- a/src/table/resizer/__tests__/resizer-lookup.test.tsx
+++ b/src/table/resizer/__tests__/resizer-lookup.test.tsx
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from '@testing-library/react';
+import { getResizerElements, getHeaderWidth } from '../../../../lib/components/table/resizer/resizer-lookup';
+import tableStyles from '../../../../lib/components/table/styles.css.js';
+import resizerStyles from '../../../../lib/components/table/resizer/styles.css.js';
+import React from 'react';
+
+jest.mock('../../../../lib/components/internal/utils/scrollable-containers', () => ({
+  getOverflowParents: jest.fn(() => {
+    const overflowParent = document.querySelector('[data-testid="scroll-parent"]')!;
+    return [overflowParent];
+  }),
+}));
+
+test('getHeaderWidth returns header bounding rect width', () => {
+  const header = document.createElement('th');
+  const originalGetBoundingClientRect = header.getBoundingClientRect;
+  header.getBoundingClientRect = () => ({ ...originalGetBoundingClientRect.apply(header), width: 100 });
+  const resizer = document.createElement('span');
+  header.append(resizer);
+
+  expect(getHeaderWidth(resizer)).toBe(100);
+});
+
+test('getHeaderWidth returns 0 when no header provided', () => {
+  expect(getHeaderWidth(null)).toBe(0);
+});
+
+test('getHeaderWidth returns 0 when no header found', () => {
+  const resizer = document.createElement('span');
+  expect(getHeaderWidth(resizer)).toBe(0);
+});
+
+test('getResizerElements returns elements required for resizer computations', () => {
+  const { container } = render(
+    <div className={tableStyles.root}>
+      <table>
+        <th>
+          <span data-testid="resizer" />
+        </th>
+      </table>
+      <div data-testid="tracker" className={resizerStyles.tracker} />
+      <div data-testid="scroll-parent" />
+    </div>
+  );
+
+  const elements = getResizerElements(container.querySelector('[data-testid="resizer"]')!);
+  expect(elements?.header).toBe(document.querySelector('th')!);
+  expect(elements?.table).toBe(document.querySelector('table')!);
+  expect(elements?.tracker).toBe(document.querySelector('[data-testid="tracker"]')!);
+  expect(elements?.scrollParent).toBe(document.querySelector('[data-testid="scroll-parent"]')!);
+});
+
+test('getResizerElements return null when no resizer', () => {
+  expect(getResizerElements(null)).toBe(null);
+});
+
+test('getResizerElements return null when no header', () => {
+  const { container } = render(
+    <div className={tableStyles.root}>
+      <table>
+        <td>
+          <span data-testid="resizer" />
+        </td>
+      </table>
+      <div data-testid="tracker" className={resizerStyles.tracker} />
+      <div data-testid="scroll-parent" />
+    </div>
+  );
+  expect(getResizerElements(container.querySelector('[data-testid="resizer"]')!)).toBe(null);
+});
+
+test('getResizerElements return null when no table root', () => {
+  const { container } = render(
+    <div>
+      <table>
+        <th>
+          <span data-testid="resizer" />
+        </th>
+      </table>
+      <div data-testid="tracker" className={resizerStyles.tracker} />
+      <div data-testid="scroll-parent" />
+    </div>
+  );
+  expect(getResizerElements(container.querySelector('[data-testid="resizer"]')!)).toBe(null);
+});
+
+test('getResizerElements return null when no table', () => {
+  const { container } = render(
+    <div className={tableStyles.root}>
+      <div>
+        <th>
+          <span data-testid="resizer" />
+        </th>
+      </div>
+      <div data-testid="tracker" className={resizerStyles.tracker} />
+      <div data-testid="scroll-parent" />
+    </div>
+  );
+  expect(getResizerElements(container.querySelector('[data-testid="resizer"]')!)).toBe(null);
+});
+
+test('getResizerElements return null when no tracker', () => {
+  const { container } = render(
+    <div className={tableStyles.root}>
+      <table>
+        <th>
+          <span data-testid="resizer" />
+        </th>
+      </table>
+      <div data-testid="scroll-parent" />
+    </div>
+  );
+  expect(getResizerElements(container.querySelector('[data-testid="resizer"]')!)).toBe(null);
+});
+
+test('getResizerElements return null when no overflow parent', () => {
+  const { container } = render(
+    <div className={tableStyles.root}>
+      <table>
+        <th>
+          <span data-testid="resizer" />
+        </th>
+      </table>
+      <div data-testid="tracker" className={resizerStyles.tracker} />
+    </div>
+  );
+  expect(getResizerElements(container.querySelector('[data-testid="resizer"]')!)).toBe(null);
+});

--- a/src/table/resizer/resizer-lookup.ts
+++ b/src/table/resizer/resizer-lookup.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
+import tableStyles from '../styles.css.js';
+import styles from './styles.css.js';
+import { getOverflowParents } from '../../internal/utils/scrollable-containers.js';
+
+export function getResizerElements(resizerElement: null | HTMLElement) {
+  if (!resizerElement) {
+    return null;
+  }
+
+  const header = findUpUntil(resizerElement, element => element.tagName.toLowerCase() === 'th');
+  if (!header) {
+    return null;
+  }
+
+  const tableRoot = findUpUntil(header, element => element.className.indexOf(tableStyles.root) > -1);
+  if (!tableRoot) {
+    return null;
+  }
+
+  const table = tableRoot.querySelector<HTMLElement>(`table`);
+  if (!table) {
+    return null;
+  }
+
+  // tracker is rendered inside table wrapper to align with its size
+  const tracker = tableRoot.querySelector<HTMLElement>(`.${styles.tracker}`);
+  if (!tracker) {
+    return null;
+  }
+
+  const scrollParent = getOverflowParents(header)[0];
+  if (!scrollParent) {
+    return null;
+  }
+
+  return { header, table, tracker, scrollParent };
+}
+
+export function getHeaderWidth(resizerElement: null | HTMLElement): number {
+  const header = resizerElement && findUpUntil(resizerElement, element => element.tagName.toLowerCase() === 'th');
+  return header?.getBoundingClientRect().width ?? 0;
+}

--- a/src/table/resizer/resizer-lookup.ts
+++ b/src/table/resizer/resizer-lookup.ts
@@ -3,7 +3,7 @@
 
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 import tableStyles from '../styles.css.js';
-import styles from './styles.css.js';
+import resizerStyles from './styles.css.js';
 import { getOverflowParents } from '../../internal/utils/scrollable-containers.js';
 
 export function getResizerElements(resizerElement: null | HTMLElement) {
@@ -27,7 +27,7 @@ export function getResizerElements(resizerElement: null | HTMLElement) {
   }
 
   // tracker is rendered inside table wrapper to align with its size
-  const tracker = tableRoot.querySelector<HTMLElement>(`.${styles.tracker}`);
+  const tracker = tableRoot.querySelector<HTMLElement>(`.${resizerStyles.tracker}`);
   if (!tracker) {
     return null;
   }


### PR DESCRIPTION
### Description

Fixed the following issues of the table column resizer:
* VO click (VO+Space) triggers is-dragging mode which is not ending as there is no follow-up mouse-up event.
* When resizing with keyboard the aria-valuenow of the separator can be set to below the min-width and become inconsistent with the actual column width value which is validated correctly. 

Besides, removed the non-null assertion operators from the queries done inside the resizer element. 

### How has this been tested?

Added a new unit test to cover the resize below min-size issue.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
