### PR TITLE
fix: Don't display dropdown border when there is no content on autosuggest in VR

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -372,6 +372,52 @@ describe('keyboard interactions', () => {
   });
 });
 
+describe('Check if should render dropdown', () => {
+  test('should render dropdown content when not empty and dropdown content is not null', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest
+        {...defaultProps}
+        value="1"
+        options={[{ value: '1', label: 'One' }]}
+        statusType="error"
+        errorText="Test error text"
+      />
+    );
+
+    wrapper.focus();
+
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('should not render dropdown content when empty and dropdown content is null', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} value="" options={[]} />);
+
+    wrapper.focus();
+
+    expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+  });
+
+  test('should render dropdown content when not empty', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest {...defaultProps} value="1" options={[{ value: '1', label: 'One' }]} />
+    );
+
+    wrapper.focus();
+
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  test('should render dropdown content when dropdown content is not null', () => {
+    const { wrapper } = renderAutosuggest(
+      <Autosuggest {...defaultProps} value="" options={[]} statusType="error" errorText="Test error text" />
+    );
+
+    wrapper.focus();
+
+    expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+});
+
 describe('Ref', () => {
   test('can be used to focus the component', () => {
     const ref = React.createRef<AutosuggestProps.Ref>();

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -181,6 +181,8 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     filteringResultsText: filteredText,
   });
 
+  const shouldRenderDropdownContent = !isEmpty || dropdownStatus.content;
+
   return (
     <AutosuggestInput
       {...restProps}
@@ -208,25 +210,27 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
       ariaActivedescendant={highlightedOptionId}
       dropdownExpanded={autosuggestItemsState.items.length > 1 || dropdownStatus.content !== null}
       dropdownContent={
-        <AutosuggestOptionsList
-          statusType={statusType}
-          autosuggestItemsState={autosuggestItemsState}
-          autosuggestItemsHandlers={autosuggestItemsHandlers}
-          highlightedOptionId={highlightedOptionId}
-          highlightText={value}
-          listId={listId}
-          controlId={controlId}
-          enteredTextLabel={enteredTextLabel}
-          handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
-          hasDropdownStatus={dropdownStatus.content !== null}
-          virtualScroll={virtualScroll}
-          selectedAriaLabel={selectedAriaLabel}
-          renderHighlightedAriaLive={renderHighlightedAriaLive}
-          listBottom={
-            !dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} id={footerControlId} /> : null
-          }
-          ariaDescribedby={dropdownStatus.content ? footerControlId : undefined}
-        />
+        shouldRenderDropdownContent && (
+          <AutosuggestOptionsList
+            statusType={statusType}
+            autosuggestItemsState={autosuggestItemsState}
+            autosuggestItemsHandlers={autosuggestItemsHandlers}
+            highlightedOptionId={highlightedOptionId}
+            highlightText={value}
+            listId={listId}
+            controlId={controlId}
+            enteredTextLabel={enteredTextLabel}
+            handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
+            hasDropdownStatus={dropdownStatus.content !== null}
+            virtualScroll={virtualScroll}
+            selectedAriaLabel={selectedAriaLabel}
+            renderHighlightedAriaLive={renderHighlightedAriaLive}
+            listBottom={
+              !dropdownStatus.isSticky ? <DropdownFooter content={dropdownStatus.content} id={footerControlId} /> : null
+            }
+            ariaDescribedby={dropdownStatus.content ? footerControlId : undefined}
+          />
+        )
       }
       dropdownFooter={
         dropdownStatus.isSticky ? (

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -102,7 +102,6 @@ const TransitionContent = ({
         [styles['with-limited-width']]: !stretchWidth,
         [styles['hide-upper-border']]: stretchWidth,
         [styles.interior]: interior,
-        [styles['is-empty']]: !header && !children,
         [styles.refresh]: isRefresh,
         [styles['use-portal']]: expandToViewport && !interior,
         [styles['stretch-beyond-trigger-width']]: stretchBeyondTriggerWidth,
@@ -120,15 +119,19 @@ const TransitionContent = ({
       }
       onMouseDown={onMouseDown}
     >
-      <div className={clsx(styles['dropdown-content-wrapper'], isRefresh && styles.refresh)}>
-        <div className={styles['ie11-wrapper']}>
-          <div ref={verticalContainerRef} className={styles['dropdown-content']}>
-            <DropdownContextProvider position={position}>
-              {header}
-              {children}
-              {footer}
-            </DropdownContextProvider>
-          </div>
+      <div
+        className={clsx(
+          styles['dropdown-content-wrapper'],
+          !header && !children && styles['is-empty'],
+          isRefresh && styles.refresh
+        )}
+      >
+        <div ref={verticalContainerRef} className={styles['dropdown-content']}>
+          <DropdownContextProvider position={position}>
+            {header}
+            {children}
+            {footer}
+          </DropdownContextProvider>
         </div>
       </div>
     </div>

--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -50,6 +50,11 @@
     }
 
     border-bottom: none;
+
+    // Don't show dropdown border when there's no dropdown content
+    &.is-empty::after {
+      display: none;
+    }
   }
 
   &-drop-up {
@@ -98,23 +103,12 @@
       overflow: scroll;
     }
   }
-  // Don't show dropdown border when there's no dropdown content
-  &.is-empty::after {
-    display: none;
-  }
 }
 
 .dropdown-content {
   display: flex;
   flex-direction: column;
   width: 100%;
-}
-
-// Child flex wrapper used because when combining an absolute position
-// and flexbox, IE11 will incorrectly size the container according to its parent
-// and not its content.
-.ie11-wrapper {
-  display: flex;
 }
 
 .stretch-trigger-height {


### PR DESCRIPTION
### Description


When focusing the autosuggest input field on the ["No suggestions" example](https://cloudscape.design/components/autosuggest/?tabId=playground&example=no-suggestions) without an `empty` text, you can see the undesired collapsed border. This is because even when there is no suggestions and no empty text, we still render the dropdown content. This is a regression from Classic.

Customers need this to use Autosuggest to build a search experience. We want to support this use case, extending the component's guidelines to reflect it.

This PR adds an `shouldRenderDropdownContent` condition to the autosuggest component. This was needed because there were empty wrapper nodes passed on to the dropdown, even though there was no actual content inside of them.
This allows us to apply the correct styling to hide the borders in this case.



Related issue: AWSUI-22344

### How has this been tested?

Existing tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
