### PR TITLE
fix: Improve heading double-click text selection UX

### DIFF
--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -202,6 +202,12 @@
   font-size: inherit;
   @include styles.info-link-spacing();
 
+  // Both children (.heading-text and .counter) override user-select to text.
+  // This provides a similar effect to `user-select: contain`, by restricting
+  // double-click selection to inside .heading-text without letting it spill
+  // out into .counter or .info
+  user-select: none;
+
   &-variant-h1 {
     @include styles.font(heading-xl);
   }
@@ -214,7 +220,8 @@
 }
 
 .heading-text {
-  /* used in test-utils */
+  user-select: text;
+
   &-variant-h1 {
     @include styles.font-heading-xl;
   }
@@ -227,6 +234,8 @@
 }
 
 .counter {
+  user-select: text;
+
   color: awsui.$color-text-counter;
   font-weight: styles.$font-weight-normal;
 }


### PR DESCRIPTION
### Description

I always love a fun delightful stupid little hack. The issue raised was that double-clicking on a header also selects other text (like the counter or the info link) on the same line. It's user agent behavior, so we don't really have control over it, but it's still a common enough case that this will make a lot of situations less frustrating.

Related links, issue #, if available: AWSUI-22380

### How has this been tested?

Maybe I can write an integration test for this. Hold tight. If I can't, oh well - it'll have to be "I manually tested this in Chrome, Firefox, and Safari".

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
