### PR TITLE
feat: Mimics tools behavior when there is only one drawer

### DIFF
--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -293,6 +293,20 @@ describe('Classic only features', () => {
 
     expect(wrapper.findByClassName(iconStyles.badge)!.getElement()).toBeInTheDocument();
   });
+
+  test(`should toggle single drawer on click of container`, () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
+    act(() => wrapper.findDrawersDesktopTriggersContainer()!.click());
+    expect(wrapper.findActiveDrawer()).toBeTruthy();
+    act(() => wrapper.findDrawersDesktopTriggersContainer()!.click());
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+  });
+
+  test(`should not toggle many drawers on click of container`, () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...manyDrawers} />);
+    act(() => wrapper.findDrawersDesktopTriggersContainer()!.click());
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+  });
 });
 
 describe('VR only features', () => {

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -196,15 +196,24 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
     <div
       className={clsx(styles.drawer, styles['drawer-closed'], testutilStyles['drawer-closed'], {
         [styles['drawer-mobile']]: isMobile,
+        [styles.hide]: drawers?.items.length === 1 && drawers.activeDrawerId !== undefined,
       })}
       ref={containerRef}
     >
       <div
         ref={triggersContainerRef}
         style={{ top: topOffset, bottom: bottomOffset }}
-        className={clsx(styles['drawer-content'])}
+        className={clsx(styles['drawer-content'], {
+          [styles['drawer-content-clickable']]: drawers?.items.length === 1,
+        })}
         role="toolbar"
         aria-orientation="vertical"
+        onClick={() => {
+          drawers?.items.length === 1 &&
+            drawers?.onChange({
+              activeDrawerId: drawers.items[0].id !== drawers.activeDrawerId ? drawers.items[0].id : undefined,
+            });
+        }}
       >
         {!isMobile && (
           <aside
@@ -229,9 +238,10 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                     itemId={item.id}
                     isActive={drawers?.activeDrawerId === item.id}
                     onClick={() => {
-                      drawers?.onChange({
-                        activeDrawerId: item.id !== drawers.activeDrawerId ? item.id : undefined,
-                      });
+                      drawers?.items.length !== 1 &&
+                        drawers?.onChange({
+                          activeDrawerId: item.id !== drawers.activeDrawerId ? item.id : undefined,
+                        });
                     }}
                   />
                 );

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -84,4 +84,15 @@ $drawer-z-index-mobile: 1001;
     background-color: awsui.$color-background-layout-toggle-selected-default;
     color: awsui.$color-text-layout-toggle-active;
   }
+  .drawer-triggers-wrapper > & {
+    .drawer-content-clickable > & {
+      &:hover {
+        color: awsui.$color-text-interactive-default;
+      }
+    }
+  }
+}
+
+.hide {
+  display: none;
 }

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -394,6 +394,9 @@ const OldAppLayout = React.forwardRef(
 
       if (hasDrawers) {
         if (activeDrawer) {
+          if (drawers.length === 1) {
+            return activeDrawerSize;
+          }
           if (!isResizeInvalid && activeDrawerSize) {
             return activeDrawerSize + closedDrawerWidth;
           }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
A single drawer acted slightly different than tools - the entire bar was not clickable (only the icon), and it would keep the trigger bar visible when opened. This PR adjusts those two features so that a single drawer now acts the same as tools. 

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
