### PR TITLE
chore: Fix test page and flaky test

### DIFF
--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -209,11 +209,10 @@ export default function () {
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
     if (asyncLoading) {
-      setLoading(true);
       setTimeout(() => setLoading(false), 500);
     }
   };
-  const onClose = () => setLoading(false);
+  const onClose = () => setLoading(asyncLoading);
   useEffect(onOpen, [asyncLoading]);
   return (
     <article>

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -209,7 +209,7 @@ export default function () {
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
     if (asyncLoading) {
-      setTimeout(() => setLoading(false), 1000);
+      setTimeout(() => setLoading(false), 500);
     }
   };
   const onClose = () => setLoading(asyncLoading);

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import Select, { SelectProps } from '~components/select';
 import Multiselect, { MultiselectProps } from '~components/multiselect';
 import Autosuggest from '~components/autosuggest';
@@ -214,7 +214,6 @@ export default function () {
     }
   };
   const onClose = () => setLoading(asyncLoading);
-  useEffect(onOpen, [asyncLoading]);
   return (
     <article>
       <h1>Dropdown width</h1>

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -209,6 +209,7 @@ export default function () {
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
     if (asyncLoading) {
+      setLoading(true);
       setTimeout(() => setLoading(false), 500);
     }
   };

--- a/pages/dropdown/width.page.tsx
+++ b/pages/dropdown/width.page.tsx
@@ -209,7 +209,7 @@ export default function () {
   const [loading, setLoading] = useState(asyncLoading);
   const onOpen = () => {
     if (asyncLoading) {
-      setTimeout(() => setLoading(false), 500);
+      setTimeout(() => setLoading(false), 1000);
     }
   };
   const onClose = () => setLoading(asyncLoading);

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -148,7 +148,7 @@ describe('Dropdown width', () => {
         expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
         await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
         await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
-          timeout: 2000,
+          timeout: 1000,
         });
         const newBox = await page.getBoundingBox(dropdownSelector);
         expect(newBox.left + newBox.width).toBeLessThanOrEqual(pageWidth);

--- a/src/internal/components/dropdown/__integ__/width.test.ts
+++ b/src/internal/components/dropdown/__integ__/width.test.ts
@@ -148,7 +148,7 @@ describe('Dropdown width', () => {
         expect(dropdownBox.left + dropdownBox.width).toBeLessThanOrEqual(pageWidth);
         await expect(page.getText(dropdownSelector)).resolves.toContain('Loading');
         await page.waitUntil(async () => (await page.getText(dropdownSelector)).includes('A very'), {
-          timeout: 1000,
+          timeout: 2000,
         });
         const newBox = await page.getBoundingBox(dropdownSelector);
         expect(newBox.left + newBox.width).toBeLessThanOrEqual(pageWidth);


### PR DESCRIPTION
### Description

A leftover `useEffect` was interfering with tests, causing flakiness.

Also, correctly set `loading` back to `asyncLoading` instead of `false` when closing the dropdown, so that it the page state is correctly reset to its initial state also when `asyncLoading` is `true`.

### How has this been tested?

- Ran the integration tests 3 times, all successfully
- Manually tested the page to make sure it keeps behaving as expected.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
