### PR TITLE
fix: Property filter empty state visible when no properties

### DIFF
--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -90,6 +90,7 @@ export default function () {
                 countText={`${items.length} matches`}
                 i18nStrings={i18nStrings}
                 expandToViewport={true}
+                filteringEmpty="No properties"
               />
             }
             columnDefinitions={columnDefinitions.slice(0, 2)}

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -279,7 +279,7 @@ const AutosuggestInput = React.forwardRef(
             />
           }
           onMouseDown={handleDropdownMouseDown}
-          open={open && !!dropdownContent}
+          open={open && (!!dropdownContent || !!dropdownFooter)}
           footer={
             dropdownFooterRef && (
               <div ref={dropdownFooterRef} className={styles['dropdown-footer']}>

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -88,6 +88,7 @@ const filteringOptions: readonly FilteringOption[] = [
 ];
 
 const defaultProps: PropertyFilterProps = {
+  filteringEmpty: 'Empty',
   filteringProperties,
   filteringOptions,
   filteringPlaceholder: 'Search',
@@ -1002,17 +1003,41 @@ describe('property filter parts', () => {
   });
 
   describe('dropdown states', () => {
-    it('when free text filtering is allowed and no property is matched dropdown is visible but aria-expanded is false', () => {
-      const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering: false });
+    it('when free text filtering is allowed and no property is matched the dropdown is visible but aria-expanded is false', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: false,
+        filteringProperties: [],
+      });
       wrapper.setInputValue('free-text');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
       expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Use: "free-text"');
     });
-    it('when free text filtering is not allowed and no property is matched dropdown is not shown and aria-expanded is false', () => {
-      const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering: true });
+    it('when free text filtering is not allowed and no property is matched the dropdown is not shown and aria-expanded is false', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: true,
+        filteringProperties: [],
+      });
       wrapper.setInputValue('free-text');
       expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
       expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
+    });
+    it('when free text filtering is allowed and no properties available the filtering-empty is shown', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: false,
+        filteringProperties: [],
+      });
+      wrapper.focus();
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
+      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Empty');
+    });
+    it('when free text filtering is not allowed and no properties available the filtering-empty is shown', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        disableFreeTextFiltering: true,
+        filteringProperties: [],
+      });
+      wrapper.focus();
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'true');
+      expect(wrapper.findDropdown().findOpenDropdown()!.getElement()).toHaveTextContent('Empty');
     });
   });
 

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -210,7 +210,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
         dropdownContentKey={customForm ? 'custom' : 'options'}
         dropdownContent={content}
         dropdownFooter={
-          dropdownStatus.isSticky ? (
+          dropdownStatus.isSticky && dropdownStatus.content ? (
             <DropdownFooter
               content={dropdownStatus.content}
               hasItems={autosuggestItemsState.items.length >= 1}


### PR DESCRIPTION
### Description

The empty state of the property filter must be shown when no properties are available. The issue was in autosuggest-input not showing the dropdown when there is no content while the empty state is defined in a footer instead.

### How has this been tested?

New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
