### PR TITLE
feat: Resized column detail in table's onColumnWidthsChange

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12493,7 +12493,7 @@ Object {
     Object {
       "cancelable": false,
       "description": "Fired when the user resizes a table column.
-The event detail include:
+The event detail includes:
 * \`widths\` - an array of column widths in pixels including the hidden via preferences columns.
 * \`resizedColumn\` - the id and the width of the column resized by the user.
 Use this event to persist the column widths.

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12492,11 +12492,20 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
-      "description": "Fired when the user resizes a table column. The event detail contains an array of column widths in pixels,
-including the hidden via preferences columns. Use this event to persist the column widths.",
+      "description": "Fired when the user resizes a table column.
+The event detail include:
+* \`widths\` - an array of column widths in pixels including the hidden via preferences columns.
+* \`resizedColumn\` - the id and the width of the column resized by the user.
+Use this event to persist the column widths.
+",
       "detailInlineType": Object {
         "name": "TableProps.ColumnWidthsChangeDetail",
         "properties": Array [
+          Object {
+            "name": "resizedColumn",
+            "optional": false,
+            "type": "unknown",
+          },
           Object {
             "name": "widths",
             "optional": false,

--- a/src/table/__tests__/columns-auto-resize.test.tsx
+++ b/src/table/__tests__/columns-auto-resize.test.tsx
@@ -76,7 +76,7 @@ test('should auto-grow the column width when the cursor moves out of table bound
   tick();
   expect(wrapper.findColumnHeaders()[0].getElement()).toHaveStyle({ width: '160px' });
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [160, 300] });
+  expect(onChange).toHaveBeenCalledWith({ widths: [160, 300], resizedColumn: { id: 'id', width: 160 } });
 });
 
 test('should cancel auto-grow when the cursor returns back into the container', () => {

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -231,7 +231,7 @@ test('should trigger the columnWidthsChange event after a column is resized', ()
   fireMouseup(100);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300] });
+  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300], resizedColumn: { id: 'id', width: 100 } });
 });
 
 test('should provide the value for the last column when it was not defined', () => {
@@ -247,7 +247,7 @@ test('should provide the value for the last column when it was not defined', () 
   fireMouseup(100);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300, 120] });
+  expect(onChange).toHaveBeenCalledWith({ widths: [100, 300, 120], resizedColumn: { id: 'id', width: 100 } });
 });
 
 test('should include hidden columns into the event detail', () => {
@@ -268,7 +268,7 @@ test('should include hidden columns into the event detail', () => {
   fireMouseup(140);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [150, 300, 120, 140] });
+  expect(onChange).toHaveBeenCalledWith({ widths: [150, 300, 120, 140], resizedColumn: { id: 'last', width: 140 } });
 });
 
 test('should update the value for the last column when it is resized', () => {
@@ -280,7 +280,7 @@ test('should update the value for the last column when it is resized', () => {
   fireMouseup(400);
 
   expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith({ widths: [150, 400] });
+  expect(onChange).toHaveBeenCalledWith({ widths: [150, 400], resizedColumn: { id: 'description', width: 400 } });
 });
 
 test('should not trigger if the previous and the current widths are the same', () => {
@@ -323,14 +323,14 @@ describe('resize with keyboard', () => {
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({ widths: [150 - 10, 300] });
+      expect(onChange).toHaveBeenCalledWith({ widths: [150 - 10, 300], resizedColumn: { id: 'id', width: 150 - 10 } });
     });
 
     columnResizerWrapper.keydown(KeyCode.right);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(2);
-      expect(onChange).toHaveBeenCalledWith({ widths: [150 + 10, 300] });
+      expect(onChange).toHaveBeenCalledWith({ widths: [150 + 10, 300], resizedColumn: { id: 'id', width: 150 + 10 } });
     });
   });
 

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -5,6 +5,7 @@ import times from 'lodash/times';
 import { render, screen, waitFor } from '@testing-library/react';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
+import { KEYBOARD_RESIZE_STEP } from '../../../lib/components/table/resizer';
 import resizerStyles from '../../../lib/components/table/resizer/styles.css.js';
 import { fireMousedown, fireMouseup, fireMouseMove, fakeBoundingClientRect } from './utils/resize-actions';
 import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils';
@@ -323,14 +324,20 @@ describe('resize with keyboard', () => {
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({ widths: [150 - 10, 300], resizedColumn: { id: 'id', width: 150 - 10 } });
+      expect(onChange).toHaveBeenCalledWith({
+        widths: [150 - KEYBOARD_RESIZE_STEP, 300],
+        resizedColumn: { id: 'id', width: 150 - KEYBOARD_RESIZE_STEP },
+      });
     });
 
     columnResizerWrapper.keydown(KeyCode.right);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(2);
-      expect(onChange).toHaveBeenCalledWith({ widths: [150 + 10, 300], resizedColumn: { id: 'id', width: 150 + 10 } });
+      expect(onChange).toHaveBeenCalledWith({
+        widths: [150 + KEYBOARD_RESIZE_STEP, 300],
+        resizedColumn: { id: 'id', width: 150 + KEYBOARD_RESIZE_STEP },
+      });
     });
   });
 

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -25,7 +25,7 @@ interface TableHeaderCellProps<ItemType> {
   wrapLines?: boolean;
   hidden?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
-  onResizeFinish: () => void;
+  onResizeFinish: (columnId: PropertyKey) => void;
   colIndex: number;
   updateColumn: (columnId: PropertyKey, newWidth: number) => void;
   resizableColumns?: boolean;
@@ -143,7 +143,7 @@ export function TableHeaderCell<ItemType>({
           focusId={`resize-control-${String(columnId)}`}
           showFocusRing={focusedComponent === `resize-control-${String(columnId)}`}
           onWidthUpdate={newWidth => updateColumn(columnId, newWidth)}
-          onWidthUpdateCommit={onResizeFinish}
+          onWidthUpdateCommit={() => onResizeFinish(columnId)}
           ariaLabelledby={headerId}
           minWidth={typeof column.minWidth === 'string' ? parseInt(column.minWidth) : column.minWidth}
         />

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -227,7 +227,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
 
   /**
    * Fired when the user resizes a table column.
-   * The event detail include:
+   * The event detail includes:
    * * `widths` - an array of column widths in pixels including the hidden via preferences columns.
    * * `resizedColumn` - the id and the width of the column resized by the user.
    *

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -226,8 +226,12 @@ export interface TableProps<T = any> extends BaseComponentProps {
   visibleColumns?: ReadonlyArray<string>;
 
   /**
-   * Fired when the user resizes a table column. The event detail contains an array of column widths in pixels,
-   * including the hidden via preferences columns. Use this event to persist the column widths.
+   * Fired when the user resizes a table column.
+   * The event detail include:
+   * * `widths` - an array of column widths in pixels including the hidden via preferences columns.
+   * * `resizedColumn` - the id and the width of the column resized by the user.
+   *
+   * Use this event to persist the column widths.
    */
   onColumnWidthsChange?: NonCancelableEventHandler<TableProps.ColumnWidthsChangeDetail>;
 
@@ -424,6 +428,7 @@ export namespace TableProps {
 
   export interface ColumnWidthsChangeDetail {
     widths: ReadonlyArray<number>;
+    resizedColumn: { id: string; width: number };
   }
 
   export interface LiveAnnouncement {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -220,13 +220,16 @@ const InternalTable = React.forwardRef(
       sortingDescending,
       onSortingChange,
       onFocusMove: moveFocus,
-      onResizeFinish(newWidth) {
+      onResizeFinish(columnId, newWidth) {
         const widthsDetail = columnDefinitions.map(
           (column, index) => newWidth[getColumnKey(column, index)] || (column.width as number) || DEFAULT_COLUMN_WIDTH
         );
         const widthsChanged = widthsDetail.some((width, index) => columnDefinitions[index].width !== width);
         if (widthsChanged) {
-          fireNonCancelableEvent(onColumnWidthsChange, { widths: widthsDetail });
+          fireNonCancelableEvent(onColumnWidthsChange, {
+            widths: widthsDetail,
+            resizedColumn: { id: columnId, width: newWidth[columnId] },
+          });
         }
       },
       singleSelectionHeaderAriaLabel: ariaLabels?.selectionGroupLabel,

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -22,6 +22,8 @@ const AUTO_GROW_START_TIME = 10;
 const AUTO_GROW_INTERVAL = 10;
 const AUTO_GROW_INCREMENT = 5;
 
+export const KEYBOARD_RESIZE_STEP = 10;
+
 export function Resizer({
   onWidthUpdate,
   onWidthUpdateCommit,
@@ -108,12 +110,12 @@ export function Resizer({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.keyCode === KeyCode.left) {
         event.preventDefault();
-        updateColumnWidth(elements.header.getBoundingClientRect().width - 10);
+        updateColumnWidth(elements.header.getBoundingClientRect().width - KEYBOARD_RESIZE_STEP);
         setTimeout(() => onWidthUpdateCommit(), 0);
       }
       if (event.keyCode === KeyCode.right) {
         event.preventDefault();
-        updateColumnWidth(elements.header.getBoundingClientRect().width + 10);
+        updateColumnWidth(elements.header.getBoundingClientRect().width + KEYBOARD_RESIZE_STEP);
         setTimeout(() => onWidthUpdateCommit(), 0);
       }
     };

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -29,7 +29,7 @@ export interface TheadProps {
   resizableColumns: boolean | undefined;
   getSelectAllProps: () => SelectionProps;
   onFocusMove: ((sourceElement: HTMLElement, fromIndex: number, direction: -1 | 1) => void) | undefined;
-  onResizeFinish: (newWidths: Record<string, number>) => void;
+  onResizeFinish: (columnId: string, newWidths: Record<string, number>) => void;
   onSortingChange: NonCancelableEventHandler<TableProps.SortingState<any>> | undefined;
   sticky?: boolean;
   hidden?: boolean;
@@ -163,7 +163,7 @@ const Thead = React.forwardRef(
                 colIndex={selectionType ? colIndex + 1 : colIndex}
                 columnId={columnId}
                 updateColumn={updateColumn}
-                onResizeFinish={() => onResizeFinish(columnWidths)}
+                onResizeFinish={columnId => onResizeFinish(columnId.toString(), columnWidths)}
                 resizableColumns={resizableColumns}
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 isEditable={!!column.editConfig}


### PR DESCRIPTION
### Description

Extended table's onColumnWidthsChange detail with column ID and width resized by the user so that it is possible to only store those widths that were explicitly altered.

ref: AWSUI-22345

### How has this been tested?

Updated existing tests to include the added detail

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
