### PR TITLE
feat: Optimize space occupation of pie charts titles

### DIFF
--- a/src/pie-chart/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/src/pie-chart/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`balanceLabelNodes changes xOffset if vertical overlap 1`] = `
+NodeList [
+  <g
+    data-x="20"
+    data-y="-50"
+    transform=""
+  >
+    <text
+      x="20"
+      y="-50"
+    >
+      Segment 1
+    </text>
+  </g>,
+  <g
+    data-x="20"
+    data-y="-49"
+    transform="translate(79.67948635501689 25)"
+  >
+    <text
+      x="20"
+      y="-49"
+    >
+      Segment 2
+    </text>
+  </g>,
+  <g
+    data-x="-20"
+    data-y="21"
+    transform="translate(-68.79189152169245 25)"
+  >
+    <text
+      x="-20"
+      y="21"
+    >
+      Segment 3
+    </text>
+  </g>,
+  <g
+    data-x="-20"
+    data-y="20"
+    transform=""
+  >
+    <text
+      x="-20"
+      y="20"
+    >
+      Segment 4
+    </text>
+  </g>,
+]
+`;
+
+exports[`balanceLabelNodes does not change xOffset if no vertical overlap 1`] = `
+NodeList [
+  <g
+    data-x="20"
+    data-y="-50"
+    transform=""
+  >
+    <text
+      x="20"
+      y="-50"
+    >
+      Segment 1
+    </text>
+  </g>,
+  <g
+    data-x="20"
+    data-y="-20"
+    transform=""
+  >
+    <text
+      x="20"
+      y="-20"
+    >
+      Segment 2
+    </text>
+  </g>,
+  <g
+    data-x="-20"
+    data-y="50"
+    transform=""
+  >
+    <text
+      x="-20"
+      y="50"
+    >
+      Segment 3
+    </text>
+  </g>,
+  <g
+    data-x="-20"
+    data-y="20"
+    transform=""
+  >
+    <text
+      x="-20"
+      y="20"
+    >
+      Segment 4
+    </text>
+  </g>,
+]
+`;
+
 exports[`balanceLabelNodes empty 1`] = `NodeList []`;
 
 exports[`balanceLabelNodes heavy overlap on both sides 1`] = `

--- a/src/pie-chart/__tests__/utils.test.tsx
+++ b/src/pie-chart/__tests__/utils.test.tsx
@@ -8,6 +8,7 @@ import {
   computeSmartAngle,
   getDimensionsBySize,
   dimensionsBySize,
+  minLabelLineAngularPadding,
   refreshDimensionsBySize,
 } from '../../../lib/components/pie-chart/utils';
 
@@ -408,9 +409,9 @@ describe('computeSmartAngle', () => {
     expect(computeSmartAngle(0, pi / 2)).toEqual(pi / 4);
   });
   test('returns mid angle if segment is too small', () => {
-    const startAngle = 0;
-    const endAngle = pi / 100;
-    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi / 200);
+    expect(computeSmartAngle(0, pi / 100, true)).toEqual(pi / 200);
+    expect(computeSmartAngle(0, 2 * minLabelLineAngularPadding, true)).toEqual(minLabelLineAngularPadding);
+    expect(computeSmartAngle(1, 1, true)).toEqual(1);
   });
   test('returns 0 if segment contains 0 angle', () => {
     const startAngle = -1.5;
@@ -425,21 +426,21 @@ describe('computeSmartAngle', () => {
   test('returns padded start angle if closest to 0', () => {
     const startAngle = 0;
     const endAngle = pi / 2;
-    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi / 40);
+    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(minLabelLineAngularPadding);
   });
   test('returns padded start angle if closest to PI', () => {
     const startAngle = pi;
     const endAngle = (3 * pi) / 2;
-    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi + pi / 40);
+    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi + minLabelLineAngularPadding);
   });
   test('returns padded end angle if closest to 2*PI', () => {
     const startAngle = (3 * pi) / 2;
     const endAngle = 2 * pi;
-    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(2 * pi - pi / 40);
+    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(2 * pi - minLabelLineAngularPadding);
   });
   test('returns padded end angle if closest to PI', () => {
     const startAngle = pi / 2;
     const endAngle = pi;
-    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi - pi / 40);
+    expect(computeSmartAngle(startAngle, endAngle, true)).toEqual(pi - minLabelLineAngularPadding);
   });
 });

--- a/src/pie-chart/labels.tsx
+++ b/src/pie-chart/labels.tsx
@@ -78,7 +78,7 @@ export default <T extends PieChartProps.Datum>({
   containerRef,
 }: LabelsProps<T>) => {
   const containerBoundaries = useElementBoundaries(containerRef);
-  const optimizeLabels =
+  const shouldOptimizeLabels =
     containerBoundaries.right - containerBoundaries.left - (dimensions.outerRadius + dimensions.innerLabelPadding) * 2 <
     300;
   const markers = useMemo(() => {
@@ -95,16 +95,17 @@ export default <T extends PieChartProps.Datum>({
 
     return pieData.map((datum, i) => {
       const labelDatum = pieData[i];
-      const smartAngle = computeSmartAngle(labelDatum.startAngle, labelDatum.endAngle, optimizeLabels);
+      const smartAngle = computeSmartAngle(labelDatum.startAngle, labelDatum.endAngle, shouldOptimizeLabels);
 
       // Make the marker line longer if the segment is closer to the top or bottom of the chart
-      arcMarkerBreak.outerRadius(radius + 20 * (0.5 * Math.cos(2 * smartAngle) + 0.5));
-      arcMarkerBreak.innerRadius(radius + 20 * (0.5 * Math.cos(2 * smartAngle) + 0.5));
+      const lineExtension = 0.5 * Math.cos(2 * smartAngle) + 0.5;
+      arcMarkerBreak.outerRadius(radius + 20 * lineExtension);
+      arcMarkerBreak.innerRadius(radius + 20 * lineExtension);
       const [startX, startY] = arcMarkerStart.centroid({ ...datum, startAngle: smartAngle, endAngle: smartAngle });
       const [breakX, breakY] = arcMarkerBreak.centroid({ ...datum, startAngle: smartAngle, endAngle: smartAngle });
 
       const rightSide = smartAngle < Math.PI;
-      const endX = optimizeLabels ? breakX + 20 * (rightSide ? 1 : -1) : (radius + 20) * (rightSide ? 1 : -1);
+      const endX = shouldOptimizeLabels ? breakX + 20 * (rightSide ? 1 : -1) : (radius + 20) * (rightSide ? 1 : -1);
       const textX = endX + 5 * (rightSide ? 1 : -1);
 
       return {
@@ -120,7 +121,7 @@ export default <T extends PieChartProps.Datum>({
         datum,
       };
     });
-  }, [pieData, dimensions, optimizeLabels]);
+  }, [pieData, dimensions, shouldOptimizeLabels]);
 
   const rootRef = useRef<SVGGElement>(null);
 

--- a/src/pie-chart/labels.tsx
+++ b/src/pie-chart/labels.tsx
@@ -7,7 +7,7 @@ import { arc, PieArcDatum } from 'd3-shape';
 import { PieChartProps } from './interfaces';
 import styles from './styles.css.js';
 import { InternalChartDatum } from './pie-chart';
-import { Dimension, balanceLabelNodes } from './utils';
+import { Dimension, balanceLabelNodes, computeSmartAngle } from './utils';
 import ResponsiveText from './responsive-text';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
@@ -78,7 +78,9 @@ export default <T extends PieChartProps.Datum>({
   containerRef,
 }: LabelsProps<T>) => {
   const containerBoundaries = useElementBoundaries(containerRef);
-
+  const optimizeLabels =
+    containerBoundaries.right - containerBoundaries.left - (dimensions.outerRadius + dimensions.innerLabelPadding) * 2 <
+    300;
   const markers = useMemo(() => {
     const { outerRadius: radius, innerLabelPadding } = dimensions;
 
@@ -93,16 +95,16 @@ export default <T extends PieChartProps.Datum>({
 
     return pieData.map((datum, i) => {
       const labelDatum = pieData[i];
-      const midAngle = labelDatum.startAngle + (labelDatum.endAngle - labelDatum.startAngle) / 2;
+      const smartAngle = computeSmartAngle(labelDatum.startAngle, labelDatum.endAngle, optimizeLabels);
 
       // Make the marker line longer if the segment is closer to the top or bottom of the chart
-      arcMarkerBreak.outerRadius(radius + 20 * (0.5 * Math.cos(2 * midAngle) + 0.5));
-      arcMarkerBreak.innerRadius(radius + 20 * (0.5 * Math.cos(2 * midAngle) + 0.5));
-      const [startX, startY] = arcMarkerStart.centroid(datum);
-      const [breakX, breakY] = arcMarkerBreak.centroid(datum);
+      arcMarkerBreak.outerRadius(radius + 20 * (0.5 * Math.cos(2 * smartAngle) + 0.5));
+      arcMarkerBreak.innerRadius(radius + 20 * (0.5 * Math.cos(2 * smartAngle) + 0.5));
+      const [startX, startY] = arcMarkerStart.centroid({ ...datum, startAngle: smartAngle, endAngle: smartAngle });
+      const [breakX, breakY] = arcMarkerBreak.centroid({ ...datum, startAngle: smartAngle, endAngle: smartAngle });
 
-      const rightSide = midAngle < Math.PI;
-      const endX = (radius + 20) * (rightSide ? 1 : -1);
+      const rightSide = smartAngle < Math.PI;
+      const endX = optimizeLabels ? breakX + 20 * (rightSide ? 1 : -1) : (radius + 20) * (rightSide ? 1 : -1);
       const textX = endX + 5 * (rightSide ? 1 : -1);
 
       return {
@@ -118,7 +120,7 @@ export default <T extends PieChartProps.Datum>({
         datum,
       };
     });
-  }, [pieData, dimensions]);
+  }, [pieData, dimensions, optimizeLabels]);
 
   const rootRef = useRef<SVGGElement>(null);
 
@@ -129,9 +131,9 @@ export default <T extends PieChartProps.Datum>({
 
     // Relax labels that are overlapping
     const labelNodes = rootRef.current.querySelectorAll<SVGGElement>(`.${styles['label-text']}`);
-    balanceLabelNodes(labelNodes, markers, false);
-    balanceLabelNodes(labelNodes, markers, true);
-  }, [markers, pieData]);
+    balanceLabelNodes(labelNodes, markers, false, dimensions.outerRadius + dimensions.innerLabelPadding);
+    balanceLabelNodes(labelNodes, markers, true, dimensions.outerRadius + dimensions.innerLabelPadding);
+  }, [markers, pieData, dimensions]);
 
   return (
     <g className={styles.markers} aria-hidden="true" ref={rootRef}>

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -16,7 +16,7 @@ export interface Dimension {
 const paddingLabels = 44; // = 2 * (size-lineHeight-body-100)
 const defaultPadding = 12; // = space-s
 const smallPadding = 8; // = space-xs
-export const minLabelLineAngularPadding = Math.PI / 10;
+export const minLabelLineAngularPadding = Math.PI / 20;
 
 export const dimensionsBySize: Record<NonNullable<PieChartProps['size']>, Dimension> = {
   small: {

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -16,6 +16,7 @@ export interface Dimension {
 const paddingLabels = 44; // = 2 * (size-lineHeight-body-100)
 const defaultPadding = 12; // = space-s
 const smallPadding = 8; // = space-xs
+export const minLabelLineAngularPadding = Math.PI / 10;
 
 export const dimensionsBySize: Record<NonNullable<PieChartProps['size']>, Dimension> = {
   small: {
@@ -188,14 +189,12 @@ export const balanceLabelNodes = (
   }
 };
 
-const squareDistance = (edge: Array<number>): number => Math.pow(edge[0], 2) + Math.pow(edge[1], 2);
+const squareDistance = (edge: [number, number]): number => Math.pow(edge[0], 2) + Math.pow(edge[1], 2);
 
 const computeXOffset = (box: { x: number; y: number; height: number }, yOffset: number, radius: number): number => {
-  const edges = [
-    [box.x, box.y + yOffset],
-    [box.x, box.y + box.height + yOffset],
-  ];
-  const closestEdge = squareDistance(edges[0]) < squareDistance(edges[1]) ? edges[0] : edges[1];
+  const upperEdge: [number, number] = [box.x, box.y + yOffset];
+  const lowerEdge: [number, number] = [box.x, box.y + box.height + yOffset];
+  const closestEdge = squareDistance(upperEdge) < squareDistance(lowerEdge) ? upperEdge : lowerEdge;
 
   if (squareDistance(closestEdge) < Math.pow(radius, 2)) {
     return Math.sqrt(Math.pow(radius, 2) - Math.pow(closestEdge[1], 2)) - Math.abs(closestEdge[0]);
@@ -204,11 +203,11 @@ const computeXOffset = (box: { x: number; y: number; height: number }, yOffset: 
 };
 
 export const computeSmartAngle = (startAngle: number, endAngle: number, optimize = false): number => {
-  if (!optimize || endAngle - startAngle < Math.PI / 20) {
-    return startAngle + (endAngle - startAngle) / 2;
+  if (!optimize || endAngle - startAngle < 2 * minLabelLineAngularPadding) {
+    return (endAngle + startAngle) / 2;
   }
-  const paddedStartAngle = startAngle + Math.PI / 40;
-  const paddedEndAngle = endAngle - Math.PI / 40;
+  const paddedStartAngle = startAngle + minLabelLineAngularPadding;
+  const paddedEndAngle = endAngle - minLabelLineAngularPadding;
   if (paddedStartAngle < 0 && paddedEndAngle > 0) {
     return 0;
   }


### PR DESCRIPTION
### Description

Distributes pie charts labels to better occupy available space by:
- Positioning them in a circle around the chart, as opposed to aligning them on the right/left
- Pushing them as much as possible to the top or bottom of the chart, were there is more horizontal space to display the labels

### How has this been tested?

<!-- How did you test to verify your changes? -->
Locally and through internal pipeline

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
