### PR TITLE
chore: Re-add margin for VR sticky-scrollbar when offset

### DIFF
--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -37,6 +37,11 @@
       margin-top: calc(-1 * awsui.$border-divider-section-width); // -1px to compensate for border width
       border-top: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
     }
+
+    &.is-visual-refresh {
+      // Needed to avoid sticky scrollbar overlapping with interactive elements in VR compact mode
+      margin-top: -5px;
+    }
   }
 }
 


### PR DESCRIPTION
### Description

Re-added the margin that was necessary for avoiding sticky scrollbar overlap with interactive elements on a VR compact mode table.
This regression was introduced here: https://github.com/cloudscape-design/components/pull/1554/files#diff-b75a1d7e7c07f45b0c5b02301c632dc0cd30bc15c824eb2d951d1f697cd22803L41-L43 and caught on visual regression tests.

### How has this been tested?

dev-v3-rucarva pipeline screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
