### PR TITLE
fix: Exclude info link when double-clicking header for selection

### DIFF
--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -77,9 +77,13 @@ export default function InternalHeader({
             </span>
             {counter !== undefined && <span className={styles.counter}> {counter}</span>}
           </HeadingTag>
-          <InfoLinkLabelContext.Provider value={headingId}>
-            {info && <span className={styles.info}>{info}</span>}
-          </InfoLinkLabelContext.Provider>
+          {info && (
+            <InfoLinkLabelContext.Provider value={headingId}>
+              {/* Exists to create a space between heading text and info so that a double-click selection on the last word of the heading doesn't also include info */}
+              <span className={styles['virtual-space']}> &nbsp;</span>
+              <span className={styles.info}>{info}</span>
+            </InfoLinkLabelContext.Provider>
+          )}
         </div>
         {actions && (
           <div

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -166,6 +166,10 @@
   padding-bottom: awsui.$space-scaled-2x-xxs;
 }
 
+.virtual-space {
+  @include styles.awsui-util-hide;
+}
+
 .info {
   // Space 's' used as it's the smallest value that works in all browsers
   padding-right: awsui.$space-s;


### PR DESCRIPTION
### Description

The issue raised was that double-clicking on the last word of the heading also selects an adjacent info link. This happens because there's no text node space between the two words, only a margin. If we just "break" the inline flow with something like `inline-flex`, it's a quick hack to easily resolve this without visual differences or even worse hacks.

Related links, issue #, if available: AWSUI-22380

### How has this been tested?

Browser heuristic thing (sorta), so as long as it works once and doesn't affect screenshots, no JS tests are needed.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
