### PR TITLE
test: Add recovery handler to fix screenshots

### DIFF
--- a/pages/autosuggest/permutations-async.page.tsx
+++ b/pages/autosuggest/permutations-async.page.tsx
@@ -41,6 +41,9 @@ export default function () {
                 onChange={() => {
                   /*empty handler to suppress react controlled property warning*/
                 }}
+                onLoadItems={() => {
+                  /* handler is required to render retry button */
+                }}
                 {...permutation}
               />
             </div>

--- a/pages/multiselect/screenshot.page.tsx
+++ b/pages/multiselect/screenshot.page.tsx
@@ -55,6 +55,7 @@ export default function () {
           finishedText="End of all results"
           errorText="verylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspacesverylongtextwithoutspaces"
           recoveryText="Retry"
+          onLoadItems={() => {}}
           statusType={showError ? 'error' : 'finished'}
           onChange={event => setSelected(event.detail.selectedOptions)}
           i18nStrings={i18nStrings}


### PR DESCRIPTION
### Description

We changed the logic of rendering retry button because of i18n fallback. Assuming that retry button should always have a callback, it should now be provided in order to render a button.
This PR adds missing callbacks to permutation pages

Related links, issue #, if available: -

### How has this been tested?


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
