### PR TITLE
chore: Fix incorrect mock application in app layout tests

### DIFF
--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { render } from '@testing-library/react';
+import AppLayout from '../../../lib/components/app-layout';
 import { SplitPanelProps } from '../../../lib/components/split-panel';
 import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
@@ -34,30 +35,13 @@ export function renderComponent(jsx: React.ReactElement) {
   const wrapper = createWrapper(container).findAppLayout()!;
 
   const isUsingGridLayout = wrapper.getElement().classList.contains(visualRefreshStyles.layout);
+  const isUsingMobile = !!wrapper.findByClassName(testutilStyles['mobile-bar']);
 
   const contentElement = isUsingGridLayout
     ? wrapper.getElement()
     : wrapper.findByClassName(styles['layout-wrapper'])!.getElement();
 
-  return { wrapper, rerender, isUsingGridLayout, contentElement, container };
-}
-
-export function describeDesktopAppLayout(callback: () => void) {
-  describe('Desktop', () => {
-    beforeEach(() => {
-      (useMobile as jest.Mock).mockReturnValue(false);
-    });
-    callback();
-  });
-}
-
-export function describeMobileAppLayout(callback: () => void) {
-  describe('Mobile', () => {
-    beforeEach(() => {
-      (useMobile as jest.Mock).mockReturnValue(true);
-    });
-    callback();
-  });
+  return { wrapper, rerender, isUsingGridLayout, isUsingMobile, contentElement, container };
 }
 
 export function describeEachThemeAppLayout(isMobile: boolean, callback: (theme: string) => void) {
@@ -70,6 +54,11 @@ export function describeEachThemeAppLayout(isMobile: boolean, callback: (theme: 
       afterEach(() => {
         (useMobile as jest.Mock).mockReset();
         (useVisualRefresh as jest.Mock).mockReset();
+      });
+      test('mocks applied correctly', () => {
+        const { isUsingGridLayout, isUsingMobile } = renderComponent(<AppLayout />);
+        expect(isUsingGridLayout).toEqual(theme === 'refresh');
+        expect(isUsingMobile).toEqual(isMobile);
       });
       callback(theme);
     });
@@ -87,6 +76,11 @@ export function describeEachAppLayout(callback: (size: 'desktop' | 'mobile') => 
         afterEach(() => {
           (useMobile as jest.Mock).mockReset();
           (useVisualRefresh as jest.Mock).mockReset();
+        });
+        test('mocks applied correctly', () => {
+          const { isUsingGridLayout, isUsingMobile } = renderComponent(<AppLayout />);
+          expect(isUsingGridLayout).toEqual(theme === 'refresh');
+          expect(isUsingMobile).toEqual(size === 'mobile');
         });
         callback(size);
       });

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -99,7 +99,7 @@ export function MobileToolbar({
   return (
     <div
       ref={mobileBarRef}
-      className={clsx(styles['mobile-bar'], unfocusable && sharedStyles.unfocusable)}
+      className={clsx(styles['mobile-bar'], testutilStyles['mobile-bar'], unfocusable && sharedStyles.unfocusable)}
       style={{ top: topOffset }}
     >
       {!navigationHide && (


### PR DESCRIPTION
### Description

Fixing a bug where `jest.mock` did not mock `useMobile` and `useVisualRefresh` properly

Related links, issue #, if available: n/a

### How has this been tested?

Added an acid test to ensure that the mocks apply correctly

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
