### PR TITLE
fix: Aligns drawers slider to split panel and matches side nav animation

### DIFF
--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -21,10 +21,10 @@
   &.has-open-drawer {
     background-color: awsui.$color-background-container-content;
     box-shadow: awsui.$shadow-panel;
-  }
 
-  @include styles.with-motion {
-    transition: background-color awsui.$motion-duration-refresh-only-fast;
+    @include styles.with-motion {
+      transition: background-color awsui.$motion-duration-refresh-only-fast;
+    }
   }
 
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
@@ -156,7 +156,7 @@
 
   > .drawer-slider {
     grid-column: 1;
-    grid-row: 3;
+    grid-row: 1 / span 3;
     height: 100%;
     display: flex;
     align-items: center;

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -92,11 +92,12 @@ function ActiveDrawer() {
       id={activeDrawerId}
       aria-hidden={isHidden}
       aria-label={computedAriaLabels.content}
-      className={clsx(styles.drawer, sharedStyles['with-motion'], {
+      className={clsx(styles.drawer, {
         [styles['is-drawer-open']]: activeDrawerId,
         [styles.unfocusable]: isUnfocusable,
         [testutilStyles['active-drawer']]: activeDrawerId,
         [testutilStyles.tools]: isToolsDrawer,
+        [sharedStyles['with-motion']]: activeDrawerId,
       })}
       style={{
         ...(!isMobile && drawerSize && { [customCssProps.drawerSize]: `${size}px` }),


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
The slider of drawers didn't line up vertically with the slider of split panel.

Before:
![image](https://github.com/cloudscape-design/components/assets/9701338/6a89ecd3-0364-4823-92b7-d19db75af246)

After:
<img width="1174" alt="image" src="https://github.com/cloudscape-design/components/assets/9701338/935d3f16-5cab-426c-82ce-5bf6ee287963">

Also, the drawer was animated both in and out, which didn't match the navigation on the other side. This removes the animation out so that the two match. There is a separate issue with the animation that creates lag in certain scenarios, but since that is a more complex fix, this is a holdover for the launch of drawers until that bug can be fixed.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
