### PR TITLE
fix: Do not render autosuggest dropdown footer when it is empty

### DIFF
--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -234,7 +234,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
         )
       }
       dropdownFooter={
-        dropdownStatus.isSticky ? (
+        dropdownStatus.isSticky && dropdownStatus.content ? (
           <DropdownFooter
             id={footerControlId}
             content={dropdownStatus.content}


### PR DESCRIPTION
### Description

Fixes a merge issue between https://github.com/cloudscape-design/components/pull/1574 and https://github.com/cloudscape-design/components/pull/1567 changes.

The dropdown footer must not render when its content is null. This is used by the autosuggest-input internal component to not show the dropdown.

### How has this been tested?

Existing unit tests capture the change

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
