### PR TITLE
chore: Change default Funnel Name selector for Forms and Modals

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -5,16 +5,18 @@ import { act, render } from '@testing-library/react';
 
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Button from '../../../lib/components/button';
+import Container from '../../../lib/components/container';
 import Form from '../../../lib/components/form';
+import Header from '../../../lib/components/header';
 import Modal from '../../../lib/components/modal';
-import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
 
 import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 import { useFunnel } from '../../../lib/components/internal/analytics/hooks/use-funnel';
 
 import { mockFunnelMetrics, mockInnerText } from '../../internal/analytics/__tests__/mocks';
-import Container from '../../../lib/components/container';
-import Header from '../../../lib/components/header';
+
+import formStyles from '../../../lib/components/form/styles.selectors.js';
+import modalStyles from '../../../lib/components/modal/styles.selectors.js';
 
 mockInnerText();
 
@@ -27,13 +29,10 @@ describe('Form Analytics', () => {
 
   test('sends funnelStart and funnelStepStart metrics when Form is mounted', () => {
     render(
-      <>
-        <BreadcrumbGroup items={[{ text: 'My funnel', href: '' }]} />
-        <Form>
-          <Container header={<Header>Substep one</Header>}></Container>
-          <Container header={<Header>Substep two</Header>}></Container>
-        </Form>
-      </>
+      <Form header="My funnel">
+        <Container header={<Header>Substep one</Header>}></Container>
+        <Container header={<Header>Substep two</Header>}></Container>
+      </Form>
     );
     act(() => void jest.runAllTimers());
 
@@ -43,7 +42,7 @@ describe('Form Analytics', () => {
         funnelType: 'single-page',
         totalFunnelSteps: 1,
         optionalStepNumbers: [],
-        funnelNameSelector: expect.any(String),
+        funnelNameSelector: `.${formStyles.header}`,
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
         theme: expect.any(String),
@@ -66,18 +65,8 @@ describe('Form Analytics', () => {
     );
   });
 
-  test('includes the current breadcrumb as the step name in the funnelStepStart event', () => {
-    render(
-      <>
-        <BreadcrumbGroup
-          items={[
-            { text: 'Resources', href: '' },
-            { text: 'My creation flow', href: '' },
-          ]}
-        />
-        <Form />
-      </>
-    );
+  test('includes the current Form Header as the step name in the funnelStepStart event', () => {
+    render(<Form header="My creation flow" />);
     act(() => void jest.runAllTimers());
 
     expect(FunnelMetrics.funnelStepStart).toHaveBeenCalledWith(
@@ -347,6 +336,27 @@ describe('Form Analytics', () => {
           { name: 'Substep 3', number: 4 },
           { name: 'Substep 4', number: 5 },
         ],
+      })
+    );
+  });
+
+  test('forms embedded inside a Modal use Modal header for the Funnel Name', () => {
+    render(
+      <Modal header="My Modal Funnel" visible={true}>
+        <Form>
+          <Container header={<Header>Substep one</Header>}></Container>
+          <Container header={<Header>Substep two</Header>}></Container>
+        </Form>
+      </Modal>
+    );
+
+    act(() => void jest.runAllTimers());
+
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledTimes(1);
+    expect(FunnelMetrics.funnelStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        funnelNameSelector: `.${modalStyles['header--text']}`,
+        stepConfiguration: [{ isOptional: false, name: 'My Modal Funnel', number: 1 }],
       })
     );
   });

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -7,9 +7,10 @@ import InternalForm from './internal';
 import useBaseComponent from '../internal/hooks/use-base-component';
 
 import { AnalyticsFunnel, AnalyticsFunnelStep } from '../internal/analytics/components/analytics-funnel';
-import { getFunnelNameSelector } from '../internal/analytics/selectors';
 import { ButtonContext, ButtonContextProps } from '../internal/context/button-context';
-import { useFunnel, useFunnelStep } from '../internal/analytics/hooks/use-funnel';
+import { useFunnel, useFunnelNameSelector, useFunnelStep } from '../internal/analytics/hooks/use-funnel';
+
+import styles from './styles.css.js';
 
 export { FormProps };
 
@@ -33,10 +34,17 @@ const FormWithAnalytics = ({ variant = 'full-page', actions, ...props }: FormPro
 
 export default function Form({ variant = 'full-page', ...props }: FormProps) {
   const baseComponentProps = useBaseComponent('Form');
+  const inheritedFunnelNameSelector = useFunnelNameSelector();
+  const funnelNameSelector = inheritedFunnelNameSelector || `.${styles.header}`;
 
   return (
-    <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1}>
-      <AnalyticsFunnelStep stepNumber={1} stepNameSelector={getFunnelNameSelector()}>
+    <AnalyticsFunnel
+      funnelType="single-page"
+      optionalStepNumbers={[]}
+      totalFunnelSteps={1}
+      funnelNameSelector={funnelNameSelector}
+    >
+      <AnalyticsFunnelStep stepNumber={1} stepNameSelector={funnelNameSelector}>
         <FormWithAnalytics variant={variant} {...props} {...baseComponentProps} />
       </AnalyticsFunnelStep>
     </AnalyticsFunnel>

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -11,7 +11,7 @@ import {
   FunnelState,
   FunnelSubStepContextValue,
 } from '../context/analytics-context';
-import { useFunnel, useFunnelStep } from '../hooks/use-funnel';
+import { useFunnel, useFunnelNameSelector, useFunnelStep } from '../hooks/use-funnel';
 import { useUniqueId } from '../../hooks/use-unique-id';
 import { useVisualRefresh } from '../../hooks/use-visual-mode';
 
@@ -31,11 +31,11 @@ import {
 import { useDebounceCallback } from '../../hooks/use-debounce-callback';
 import { nodeBelongs } from '../../utils/node-belongs';
 
-export const FUNNEL_VERSION = '1.2';
+export const FUNNEL_VERSION = '1.3';
 
 type AnalyticsFunnelProps = { children?: React.ReactNode; stepConfiguration?: StepConfiguration[] } & Pick<
   FunnelProps,
-  'funnelType' | 'optionalStepNumbers' | 'totalFunnelSteps'
+  'funnelNameSelector' | 'funnelType' | 'optionalStepNumbers' | 'totalFunnelSteps'
 >;
 
 export const AnalyticsFunnel = (props: AnalyticsFunnelProps) => {
@@ -68,6 +68,8 @@ const InnerAnalyticsFunnel = ({ children, stepConfiguration, ...props }: Analyti
   const [funnelInteractionId, setFunnelInteractionId] = useState<string>('');
   const [submissionAttempt, setSubmissionAttempt] = useState(0);
   const isVisualRefresh = useVisualRefresh();
+  const inheritedFunnelNameSelector = useFunnelNameSelector();
+  const funnelNameSelector = props.funnelNameSelector || inheritedFunnelNameSelector || getFunnelNameSelector();
   const funnelState = useRef<FunnelState>('default');
   const errorCount = useRef<number>(0);
   const loadingButtonCount = useRef<number>(0);
@@ -99,11 +101,11 @@ const InnerAnalyticsFunnel = ({ children, stepConfiguration, ...props }: Analyti
       funnelState.current = 'default';
 
       const singleStepFlowStepConfiguration = [
-        { number: 1, isOptional: false, name: getNameFromSelector(getFunnelNameSelector()) ?? '' },
+        { number: 1, isOptional: false, name: getNameFromSelector(funnelNameSelector) ?? '' },
       ];
 
       const funnelInteractionId = FunnelMetrics.funnelStart({
-        funnelNameSelector: getFunnelNameSelector(),
+        funnelNameSelector: funnelNameSelector,
         optionalStepNumbers: props.optionalStepNumbers,
         funnelType: props.funnelType,
         totalFunnelSteps: props.totalFunnelSteps,

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -94,3 +94,5 @@ export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({
   isFocusedSubStep: { current: false },
   focusCleanupFunction: { current: undefined },
 });
+
+export const FunnelNameSelectorContext = createContext<string | undefined>(undefined);

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useContext } from 'react';
-import { FunnelContext, FunnelStepContext, FunnelSubStepContext } from '../context/analytics-context';
+import {
+  FunnelContext,
+  FunnelNameSelectorContext,
+  FunnelStepContext,
+  FunnelSubStepContext,
+} from '../context/analytics-context';
 import {
   DATA_ATTR_FUNNEL_INTERACTION_ID,
   DATA_ATTR_FUNNEL_SUBSTEP,
@@ -175,4 +180,9 @@ export const useFunnel = () => {
     : {};
 
   return { funnelProps, ...context };
+};
+
+export const useFunnelNameSelector = () => {
+  const context = useContext(FunnelNameSelectorContext);
+  return context;
 };

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -12,6 +12,7 @@ export interface FunnelProps extends BaseFunnelProps {
   totalFunnelSteps: number;
   optionalStepNumbers: number[];
   funnelType: FunnelType;
+  funnelNameSelector?: string;
 }
 
 export interface FunnelStartProps {

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -25,6 +25,7 @@ import { useInternalI18n } from '../i18n/context';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { ButtonContext } from '../internal/context/button-context';
+import { FunnelNameSelectorContext } from '../internal/analytics/context/analytics-context';
 
 type InternalModalProps = SomeRequired<ModalProps, 'size'> & InternalBaseComponentProps;
 
@@ -121,65 +122,72 @@ function InnerModal({
   const [footerHeight, footerRef] = useContainerQuery(rect => rect.borderBoxHeight);
 
   return (
-    <ButtonContext.Provider value={{ onClick: () => {} }}>
-      <FormFieldContext.Provider value={{}}>
-        <div
-          {...baseProps}
-          className={clsx(styles.root, { [styles.hidden]: !visible }, baseProps.className, isRefresh && styles.refresh)}
-          role="dialog"
-          aria-modal={true}
-          aria-labelledby={headerId}
-          onMouseDown={onOverlayMouseDown}
-          onClick={onOverlayClick}
-          ref={mergedRef}
-          style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
-          data-awsui-referrer-id={referrerId}
-        >
-          <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
-            <div
-              className={clsx(
-                styles.dialog,
-                styles[size],
-                styles[`breakpoint-${breakpoint}`],
-                isRefresh && styles.refresh
-              )}
-              onKeyDown={escKeyHandler}
-            >
-              <div className={styles.container}>
-                <div className={styles.header}>
-                  <InternalHeader
-                    variant="h2"
-                    __disableActionsWrapping={true}
-                    actions={
-                      <InternalButton
-                        ariaLabel={closeAriaLabel}
-                        className={styles['dismiss-control']}
-                        variant="modal-dismiss"
-                        iconName="close"
-                        formAction="none"
-                        onClick={onCloseButtonClick}
-                      />
-                    }
-                  >
-                    <span id={headerId} className={styles['header--text']}>
-                      {header}
-                    </span>
-                  </InternalHeader>
-                </div>
-                <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
-                  {children}
-                  <div ref={stickySentinelRef} />
-                </div>
-                {footer && (
-                  <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
-                    {footer}
-                  </div>
+    <FunnelNameSelectorContext.Provider value={`.${styles['header--text']}`}>
+      <ButtonContext.Provider value={{ onClick: () => {} }}>
+        <FormFieldContext.Provider value={{}}>
+          <div
+            {...baseProps}
+            className={clsx(
+              styles.root,
+              { [styles.hidden]: !visible },
+              baseProps.className,
+              isRefresh && styles.refresh
+            )}
+            role="dialog"
+            aria-modal={true}
+            aria-labelledby={headerId}
+            onMouseDown={onOverlayMouseDown}
+            onClick={onOverlayClick}
+            ref={mergedRef}
+            style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
+            data-awsui-referrer-id={referrerId}
+          >
+            <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
+              <div
+                className={clsx(
+                  styles.dialog,
+                  styles[size],
+                  styles[`breakpoint-${breakpoint}`],
+                  isRefresh && styles.refresh
                 )}
+                onKeyDown={escKeyHandler}
+              >
+                <div className={styles.container}>
+                  <div className={styles.header}>
+                    <InternalHeader
+                      variant="h2"
+                      __disableActionsWrapping={true}
+                      actions={
+                        <InternalButton
+                          ariaLabel={closeAriaLabel}
+                          className={styles['dismiss-control']}
+                          variant="modal-dismiss"
+                          iconName="close"
+                          formAction="none"
+                          onClick={onCloseButtonClick}
+                        />
+                      }
+                    >
+                      <span id={headerId} className={styles['header--text']}>
+                        {header}
+                      </span>
+                    </InternalHeader>
+                  </div>
+                  <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
+                    {children}
+                    <div ref={stickySentinelRef} />
+                  </div>
+                  {footer && (
+                    <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
+                      {footer}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          </FocusLock>
-        </div>
-      </FormFieldContext.Provider>
-    </ButtonContext.Provider>
+            </FocusLock>
+          </div>
+        </FormFieldContext.Provider>
+      </ButtonContext.Provider>
+    </FunnelNameSelectorContext.Provider>
   );
 }


### PR DESCRIPTION
### Description

We saw two issues with the funnel names reported by some customers that were either 1. reporting incorrectly due to asynchronously render their breadcrumbs for various reasons or 2. using a modal with an embedded form would use the breadcrumb as its funnel name which might be unrelated to the modal contents (e.g. Feedback dialogs). 

This PR tries to improve this for Forms by allowing it to rather prefer using the Form Header slot instead of the breadcrumb and for Modals it introduces a new context where it can provide the preferred funnel name selector to the Funnel.

New behaviour:
- Forms will now default to the Form Header slot instead of Breadcrumb
- Forms inside a Modal will default to the Modal Header instead of Breadcrumb

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Updated unit tests

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
