### PR TITLE
chore: Remove tools from drawers page

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -20,7 +20,6 @@ import AppContext, { AppContextType } from '../app/app-context';
 
 type DemoContext = React.Context<
   AppContextType<{
-    hasTools: boolean | undefined;
     hasDrawers: boolean | undefined;
     splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
   }>
@@ -38,7 +37,6 @@ const getAriaLabels = (title: string, badge: boolean) => {
 export default function WithDrawers() {
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
-  const hasTools = urlParams.hasTools ?? false;
   const hasDrawers = urlParams.hasDrawers ?? true;
 
   const drawers = !hasDrawers
@@ -164,15 +162,6 @@ export default function WithDrawers() {
 
                 <SpaceBetween size="xs">
                   <Toggle
-                    checked={hasTools}
-                    onChange={e => {
-                      setUrlParams({ hasTools: e.detail.checked });
-                    }}
-                  >
-                    Has Tools
-                  </Toggle>
-
-                  <Toggle
                     checked={hasDrawers}
                     onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}
                     data-id="toggle-drawers"
@@ -212,16 +201,10 @@ export default function WithDrawers() {
             This is the Split Panel!
           </SplitPanel>
         }
-        tools={<Info />}
-        toolsHide={!hasTools}
         {...drawers}
       />
     </ScreenshotArea>
   );
-}
-
-function Info() {
-  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
 }
 
 function Security() {


### PR DESCRIPTION
### Description

Follow up for #1581. With that change, tools are now ignored on this page.

Related links, issue #, if available: n/a

### How has this been tested?

Opened the page locally, it works

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
