### PR TITLE
chore: Fix missing drawer resize handler

### DIFF
--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -1,19 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React, { useEffect, useImperativeHandle, useState } from 'react';
 import ReactDOM, { unmountComponentAtNode } from 'react-dom';
 import HelpPanel from '~components/help-panel';
 import awsuiPlugins from '~components/internal/plugins';
 
 const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
 
-function Content() {
+const Content = React.forwardRef((props, ref) => {
+  const [resized, setResized] = useState(false);
+
+  useImperativeHandle(ref, () => setResized);
+
   useEffect(() => {
     console.log('mounted');
     return () => console.log('unmounted');
   }, []);
-  return <HelpPanel header={<h2>Security</h2>}>I am runtime drawer</HelpPanel>;
-}
+  return (
+    <HelpPanel header={<h2>Security</h2>}>
+      I am runtime drawer, <span data-testid="current-size">resized: {`${resized}`}</span>
+    </HelpPanel>
+  );
+});
+
+const setSizeRef = React.createRef<(resized: boolean) => void>();
 
 awsuiPlugins.appLayout.registerDrawer({
   id: 'security',
@@ -37,12 +47,13 @@ awsuiPlugins.appLayout.registerDrawer({
   resizable: true,
   defaultSize: 320,
 
-  onResize: newSize => {
-    console.log('resize', newSize);
+  onResize: event => {
+    setSizeRef.current?.(true);
+    console.log('resize', event.detail);
   },
 
   mountContent: container => {
-    ReactDOM.render(<Content />, container);
+    ReactDOM.render(<Content ref={setSizeRef} />, container);
   },
   unmountContent: container => unmountComponentAtNode(container),
 });

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -52,5 +52,29 @@ for (const visualRefresh of [true, false]) {
         await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(false);
       })
     );
+
+    test(
+      'renders according to defaultSize property',
+      setupTest(async page => {
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+        // using `clientWidth` to neglect possible border width set on this element
+        const width = await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth');
+        expect(width).toEqual(320);
+      })
+    );
+
+    test(
+      'should call resize handler',
+      setupTest(async page => {
+        // close navigation panel to give drawer more room to resize
+        await page.click(wrapper.findNavigationClose().toSelector());
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: false');
+
+        await page.dragAndDrop(wrapper.findDrawersSlider().toSelector(), -200);
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
+      })
+    );
   });
 }

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -212,11 +212,17 @@ describeEachThemeAppLayout(false, () => {
 
   test('should change size via mouse pointer on slider handle', () => {
     const onResize = jest.fn();
+    const onDrawerItemResize = jest.fn();
     const drawersOpen: Required<InternalDrawerProps> = {
       drawers: {
         onResize: ({ detail }) => onResize(detail),
         activeDrawerId: 'security',
-        items: resizableDrawer.drawers.items,
+        items: [
+          {
+            ...resizableDrawer.drawers.items[0],
+            onResize: event => onDrawerItemResize(event.detail),
+          },
+        ],
       },
     };
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawersOpen} />);
@@ -226,6 +232,7 @@ describeEachThemeAppLayout(false, () => {
     wrapper.findDrawersSlider()!.fireEvent(new MouseEvent('pointerup', { bubbles: true }));
 
     expect(onResize).toHaveBeenCalledWith({ size: expect.any(Number), id: 'security' });
+    expect(onDrawerItemResize).toHaveBeenCalledWith({ size: expect.any(Number), id: 'security' });
   });
 
   test('should read relative size on resize handle', () => {

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { describeEachAppLayout, renderComponent, singleDrawer, manyDrawers } from './utils';
+import { describeEachAppLayout, renderComponent, singleDrawer, manyDrawers, findActiveDrawerLandmark } from './utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import { render } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
+import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   useMobile: jest.fn().mockReturnValue(true),
@@ -16,7 +17,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout(() => {
+describeEachAppLayout(size => {
   test(`should not render drawer when it is not defined`, () => {
     const { wrapper, rerender } = renderComponent(<AppLayout contentType="form" toolsHide={true} {...singleDrawer} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
@@ -53,5 +54,43 @@ describeEachAppLayout(() => {
     buttonDropdown!.openDropdown();
     buttonDropdown!.findItemById('5')!.click();
     expect(wrapper.findActiveDrawer()).toBeTruthy();
+  });
+
+  test('renders aria-labels', async () => {
+    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...singleDrawer} />);
+    expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
+      'aria-label',
+      'Security trigger button'
+    );
+    wrapper.findDrawerTriggerById('security')!.click();
+    expect(findActiveDrawerLandmark(wrapper)!.getElement()).toHaveAttribute('aria-label', 'Security drawer content');
+    expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveAttribute('aria-label', 'Security close button');
+  });
+
+  test('renders resize only on resizable drawer', async () => {
+    const drawers: Required<InternalDrawerProps> = {
+      drawers: {
+        items: [
+          singleDrawer.drawers.items[0],
+          {
+            ...singleDrawer.drawers.items[0],
+            id: 'security-resizable',
+            resizable: true,
+          },
+        ],
+      },
+    };
+    const { wrapper } = await renderComponent(<AppLayout contentType="form" {...drawers} />);
+
+    wrapper.findDrawerTriggerById('security')!.click();
+    expect(wrapper.findDrawersSlider()).toBeFalsy();
+
+    wrapper.findDrawerTriggerById('security-resizable')!.click();
+    if (size === 'desktop') {
+      expect(wrapper.findDrawersSlider()).toBeTruthy();
+      expect(wrapper.findDrawersSlider()!.getElement()).toHaveAttribute('aria-label', 'Security resize handle');
+    } else {
+      expect(wrapper.findDrawersSlider()).toBeFalsy();
+    }
   });
 });

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
 import { SplitPanelProps } from '../../../lib/components/split-panel';
-import createWrapper, { ElementWrapper } from '../../../lib/components/test-utils/dom';
+import createWrapper, { AppLayoutWrapper, ElementWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import { findUpUntil } from '../../../lib/components/internal/utils/dom';
@@ -92,6 +92,18 @@ export function isDrawerClosed(drawer: ElementWrapper) {
   // The visibility class name we are attaching to the wrapping element,
   // however the test-util points to the inner element, which has the scrollbar
   return !!findUpUntil(drawer.getElement(), element => element.classList.contains(testutilStyles['drawer-closed']));
+}
+
+export function findActiveDrawerLandmark(wrapper: AppLayoutWrapper) {
+  const drawer = wrapper.findActiveDrawer();
+  if (!drawer) {
+    return null;
+  }
+  // <aside> tag is rendered differently in classic and refresh designs
+  if (drawer.getElement().tagName === 'ASIDE') {
+    return drawer;
+  }
+  return drawer.find('aside');
 }
 
 export const splitPanelI18nStrings: SplitPanelProps.I18nStrings = {

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -112,6 +112,7 @@ export function useDrawers(
 
   function onActiveDrawerResize({ id, size }: { id: string; size: number }) {
     setDrawerSizes(oldSizes => ({ ...oldSizes, [id]: size }));
+    fireNonCancelableEvent(activeDrawer?.onResize, { id, size });
     fireNonCancelableEvent(ownDrawers?.onResize, { id, size });
   }
 


### PR DESCRIPTION
### Description

Fixing a bug where `drawerItem.onResize` was not called

Related links, issue #, if available: n/a

### How has this been tested?

Added extra tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
