### PR TITLE
fix: Remove unnecessary preventDefault in mouse event handlers

### DIFF
--- a/src/button-dropdown/category-elements/expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/expandable-category-element.tsx
@@ -45,8 +45,7 @@ const ExpandableCategoryElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
-    event.preventDefault();
+  const onHover = () => {
     highlightItem(item);
   };
 

--- a/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
+++ b/src/button-dropdown/category-elements/mobile-expandable-category-element.tsx
@@ -42,8 +42,7 @@ const MobileExpandableCategoryElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
-    event.preventDefault();
+  const onHover = () => {
     highlightItem(item);
   };
 

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -39,8 +39,7 @@ const ItemElement = ({
     }
   };
 
-  const onHover = (event: React.SyntheticEvent) => {
-    event.preventDefault();
+  const onHover = () => {
     highlightItem(item);
   };
 


### PR DESCRIPTION
### Description

Remove this code because it triggers an error message: "Unable to preventDefault inside passive event listener due to target being treated as passive"




Related links, issue #, if available: related code was added in CR-56013320

### How has this been tested?

Locally, no differences

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
