### PR TITLE
fix: Pie chart is better optimised for fit-height

### DIFF
--- a/pages/pie-chart/fit-height.page.tsx
+++ b/pages/pie-chart/fit-height.page.tsx
@@ -12,6 +12,8 @@ type DemoContext = React.Context<
     fitHeight: boolean;
     hideFilter: boolean;
     hideLegend: boolean;
+    hideTitles: boolean;
+    hideDescriptions: boolean;
     minSize: 'large' | 'medium' | 'small';
   }>
 >;
@@ -19,7 +21,7 @@ type DemoContext = React.Context<
 export default function () {
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const minSize = urlParams.minSize ?? 'small';
-  const heights = [800, 600, 400, 300, 200, 100];
+  const heights = [800, 600, 400, 300, 160, 100];
   const fitHeight = urlParams.fitHeight ?? true;
   return (
     <Box padding="m">
@@ -34,6 +36,15 @@ export default function () {
         </Checkbox>
         <Checkbox checked={urlParams.hideLegend} onChange={e => setUrlParams({ hideLegend: e.detail.checked })}>
           hide legend
+        </Checkbox>
+        <Checkbox checked={urlParams.hideTitles} onChange={e => setUrlParams({ hideTitles: e.detail.checked })}>
+          hide titles
+        </Checkbox>
+        <Checkbox
+          checked={urlParams.hideDescriptions}
+          onChange={e => setUrlParams({ hideDescriptions: e.detail.checked })}
+        >
+          hide descriptions
         </Checkbox>
         <SpaceBetween size="xs" direction="horizontal" alignItems="center">
           <SegmentedControl
@@ -64,6 +75,9 @@ export default function () {
                   fitHeight={fitHeight}
                   hideFilter={urlParams.hideFilter}
                   hideLegend={urlParams.hideLegend}
+                  hideTitles={urlParams.hideTitles}
+                  hideDescriptions={urlParams.hideDescriptions}
+                  segmentDescription={item => `${item.calories} calories`}
                   data={data1}
                   ariaLabel="Food facts"
                   size={minSize}

--- a/src/pie-chart/constants.scss
+++ b/src/pie-chart/constants.scss
@@ -23,3 +23,21 @@ $pie-chart-sizes: (
     'labelPadding': calc(2 * #{awsui.$line-height-body-m}),
   ),
 );
+
+$pie-chart-sizes-fit-height: (
+  'small': (
+    'radius': 30px,
+    'innerPadding': 0px,
+    'labelPadding': calc(2 * #{awsui.$line-height-body-m}),
+  ),
+  'medium': (
+    'radius': 100px,
+    'innerPadding': 0px,
+    'labelPadding': calc(2 * #{awsui.$line-height-body-m}),
+  ),
+  'large': (
+    'radius': 140px,
+    'innerPadding': 0px,
+    'labelPadding': calc(2 * #{awsui.$line-height-body-m}),
+  ),
+);

--- a/src/pie-chart/styles.scss
+++ b/src/pie-chart/styles.scss
@@ -17,14 +17,20 @@
   @each $size in map.keys(constants.$pie-chart-sizes) {
     &.content--#{$size} {
       $sizes: map.get(constants.$pie-chart-sizes, $size);
-      &.content--fit-height {
-        $sizes: map.get(constants.$pie-chart-sizes-fit-height, $size);
-      }
+      $fitSizes: map.get(constants.$pie-chart-sizes-fit-height, $size);
+
       min-height: calc(
         2 * (#{map.get($sizes, 'radius')} + #{map.get($sizes, 'innerPadding')} + #{map.get($sizes, 'labelPadding')})
       );
+      &.content--fit-height {
+        min-height: calc(2 * (#{map.get($fitSizes, 'radius')} + #{map.get($fitSizes, 'labelPadding')}));
+      }
+
       &.content--without-labels {
         min-height: calc(2 * (#{map.get($sizes, 'radius')} + #{map.get($sizes, 'innerPadding')}));
+        &.content--fit-height {
+          min-height: calc(2 * (#{map.get($fitSizes, 'radius')}));
+        }
       }
     }
   }

--- a/src/pie-chart/styles.scss
+++ b/src/pie-chart/styles.scss
@@ -17,6 +17,9 @@
   @each $size in map.keys(constants.$pie-chart-sizes) {
     &.content--#{$size} {
       $sizes: map.get(constants.$pie-chart-sizes, $size);
+      &.content--fit-height {
+        $sizes: map.get(constants.$pie-chart-sizes-fit-height, $size);
+      }
       min-height: calc(
         2 * (#{map.get($sizes, 'radius')} + #{map.get($sizes, 'innerPadding')} + #{map.get($sizes, 'labelPadding')})
       );

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -14,7 +14,7 @@ export interface Dimension {
 }
 
 const minRadius = 30;
-const paddingLabels = 40; // = 2 * (line-height-body-m)
+const paddingLabels = 44; // = 2 * (size-lineHeight-body-100)
 const defaultPadding = 12; // = space-s
 const smallPadding = 8; // = space-xs
 export const minLabelLineAngularPadding = Math.PI / 20;

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -13,7 +13,8 @@ export interface Dimension {
   cornerRadius?: number;
 }
 
-const paddingLabels = 44; // = 2 * (size-lineHeight-body-100)
+const minRadius = 30;
+const paddingLabels = 40; // = 2 * (line-height-body-m)
 const defaultPadding = 12; // = space-s
 const smallPadding = 8; // = space-xs
 export const minLabelLineAngularPadding = Math.PI / 20;
@@ -91,7 +92,7 @@ export function getDimensionsBySize({
   const padding = sizeSpec[matchedSize].padding;
   const paddingLabels = hasLabels ? sizeSpec[matchedSize].paddingLabels : 0;
   const radiiRatio = sizeSpec[matchedSize].outerRadius / sizeSpec[matchedSize].innerRadius;
-  const outerRadius = (size - 2 * paddingLabels - 2 * padding) / 2;
+  const outerRadius = Math.max(minRadius, (size - 2 * paddingLabels - 2 * padding) / 2);
   const innerRadius = outerRadius / radiiRatio;
 
   return { ...sizeSpec[matchedSize], outerRadius, innerRadius, size: matchedSize };


### PR DESCRIPTION
### Description

Adjusted the min size calculation for the pie chart when fit-height is used to achieve better responsiveness.

Currently, the min-height is set for the pie chart to give enough space for the labels to render. More often than not, the labels take much less space which results in lots of empty space around the chart and despite that empty space a scrollbar is added if the container content height is below 196px.

The adjusted values to calculate the min-height neglect the labels and allow for the radius to shrink but not below the hard limit of 30px. That allows to fit the charts much better (can now fit into 140px w/o adding a scrollbar while previously it couldn't fit into 180px).

### How has this been tested?

Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
