### PR TITLE
fix: Warn about missing `formatRelativeRange` only when relevant

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -215,7 +215,7 @@ const DateRangePicker = React.forwardRef(
     );
 
     if (isDevelopment) {
-      if (!formatRelativeRange) {
+      if (!formatRelativeRange && rangeSelectorMode !== 'absolute-only') {
         warnOnce(
           'DateRangePicker',
           'A function for i18nStrings.formatRelativeRange was not provided. Relative ranges will not be correctly rendered.'


### PR DESCRIPTION
### Description

Warn about this being missing only if relative ranges are actually enabled

Related links, issue #, if available: AWSUI-22546

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
