### PR TITLE
fix: Adds aria label for badge on overflow drawers

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -45,6 +45,7 @@ export default function WithDrawers() {
         drawers: {
           ariaLabel: 'Drawers',
           overflowAriaLabel: 'Overflow drawers',
+          overflowWithBadgeAriaLabel: 'Overflow drawers (Unread notifications)',
           activeDrawerId: activeDrawerId,
           items: [
             {

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -1,7 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { describeEachAppLayout, renderComponent, singleDrawer, manyDrawers, findActiveDrawerLandmark } from './utils';
+import {
+  describeEachAppLayout,
+  renderComponent,
+  singleDrawer,
+  manyDrawers,
+  manyDrawersWithBadges,
+  findActiveDrawerLandmark,
+} from './utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 import { render } from '@testing-library/react';
@@ -54,6 +61,19 @@ describeEachAppLayout(size => {
     buttonDropdown!.openDropdown();
     buttonDropdown!.findItemById('5')!.click();
     expect(wrapper.findActiveDrawer()).toBeTruthy();
+  });
+
+  test('renders correct aria-label on overflow menu', () => {
+    const { container, rerender } = render(<AppLayout contentType="form" {...manyDrawers} />);
+    const buttonDropdown = createWrapper(container).findButtonDropdown();
+
+    expect(buttonDropdown!.findNativeButton().getElement()).toHaveAttribute('aria-label', 'Overflow drawers');
+
+    rerender(<AppLayout contentType="form" {...manyDrawersWithBadges} />);
+    expect(buttonDropdown!.findNativeButton().getElement()).toHaveAttribute(
+      'aria-label',
+      'Overflow drawers (Unread notifications)'
+    );
   });
 
   test('renders aria-labels', async () => {

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -163,7 +163,7 @@ export const singleDrawer: Required<InternalDrawerProps> = {
   },
 };
 
-const getDrawerItem = (id: string, iconName: IconProps.Name) => {
+const getDrawerItem = (id: string, iconName: IconProps.Name, badge: boolean) => {
   return {
     ariaLabels: {
       closeButton: `${id} close button`,
@@ -172,6 +172,7 @@ const getDrawerItem = (id: string, iconName: IconProps.Name) => {
       resizeHandle: `${id} resize handle`,
     },
     content: <span>{id}</span>,
+    badge,
     id,
     trigger: {
       iconName,
@@ -184,6 +185,8 @@ const manyDrawersArray = [...Array(100).keys()].map(item => item.toString());
 export const manyDrawers: Required<InternalDrawerProps> = {
   drawers: {
     ariaLabel: 'Drawers',
+    overflowAriaLabel: 'Overflow drawers',
+    overflowWithBadgeAriaLabel: 'Overflow drawers (Unread notifications)',
     items: [
       {
         ariaLabels: {
@@ -199,8 +202,17 @@ export const manyDrawers: Required<InternalDrawerProps> = {
           iconName: 'security',
         },
       },
-      ...manyDrawersArray.map(item => getDrawerItem(item, 'security')),
+      ...manyDrawersArray.map(item => getDrawerItem(item, 'security', false)),
     ],
+  },
+};
+
+export const manyDrawersWithBadges: Required<InternalDrawerProps> = {
+  drawers: {
+    ariaLabel: 'Drawers',
+    overflowAriaLabel: 'Overflow drawers',
+    overflowWithBadgeAriaLabel: 'Overflow drawers (Unread notifications)',
+    items: [...manyDrawersArray.map(item => getDrawerItem(item, 'security', true))],
   },
 };
 

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -191,6 +191,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
   };
 
   const { visibleItems, overflowItems } = splitItems(drawers?.items, getIndexOfOverflowItem(), drawers?.activeDrawerId);
+  const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
   return (
     <div
@@ -245,7 +246,7 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
               {overflowItems.length > 0 && (
                 <div className={clsx(styles['drawer-trigger'])}>
                   <OverflowMenu
-                    ariaLabel={drawers?.overflowAriaLabel}
+                    ariaLabel={overflowMenuHasBadge ? drawers?.overflowWithBadgeAriaLabel : drawers?.overflowAriaLabel}
                     items={overflowItems}
                     onItemClick={({ detail }) => {
                       drawers?.onChange({

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -54,6 +54,7 @@ export interface DrawerTriggersBarProps {
     onChange: (changeDetail: { activeDrawerId: string | undefined }) => void;
     ariaLabel?: string;
     overflowAriaLabel?: string;
+    overflowWithBadgeAriaLabel?: string;
   };
 }
 
@@ -86,5 +87,6 @@ export interface InternalDrawerProps {
     onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
     ariaLabel?: string;
     overflowAriaLabel?: string;
+    overflowWithBadgeAriaLabel?: string;
   };
 }

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -525,6 +525,7 @@ const OldAppLayout = React.forwardRef(
                       },
                       ariaLabel: drawersProps.ariaLabel,
                       overflowAriaLabel: drawersProps.overflowAriaLabel,
+                      overflowWithBadgeAriaLabel: drawersProps.overflowWithBadgeAriaLabel,
                     }
                   : undefined
               }
@@ -728,6 +729,7 @@ const OldAppLayout = React.forwardRef(
                   },
                   ariaLabel: drawersProps.ariaLabel,
                   overflowAriaLabel: drawersProps.overflowAriaLabel,
+                  overflowWithBadgeAriaLabel: drawersProps.overflowWithBadgeAriaLabel,
                 }}
               />
             )}

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -66,6 +66,7 @@ interface MobileToolbarProps {
     onChange: (changeDetail: { activeDrawerId: string | undefined }) => void;
     ariaLabel?: string;
     overflowAriaLabel?: string;
+    overflowWithBadgeAriaLabel?: string;
   };
 }
 
@@ -95,6 +96,7 @@ export function MobileToolbar({
   }, [anyPanelOpen]);
 
   const { overflowItems, visibleItems } = splitItems(drawers?.items, 2, drawers?.activeDrawerId);
+  const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
   return (
     <div
@@ -150,7 +152,7 @@ export function MobileToolbar({
           {overflowItems.length > 0 && (
             <div className={clsx(styles['mobile-toggle'], styles['mobile-toggle-type-drawer'])}>
               <OverflowMenu
-                ariaLabel={drawers.overflowAriaLabel}
+                ariaLabel={overflowMenuHasBadge ? drawers.overflowWithBadgeAriaLabel : drawers.overflowAriaLabel}
                 items={overflowItems}
                 onItemClick={({ detail }) => {
                   drawers.onChange({

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -139,6 +139,7 @@ export function useDrawers(
   return {
     ariaLabel: ownDrawers?.ariaLabel,
     overflowAriaLabel: ownDrawers?.overflowAriaLabel,
+    overflowWithBadgeAriaLabel: ownDrawers?.overflowWithBadgeAriaLabel,
     drawers: combinedDrawers,
     activeDrawer,
     activeDrawerId: activeDrawerIdResolved,

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -39,6 +39,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   drawers: Array<DrawerItem> | null;
   drawersAriaLabel: string | undefined;
   drawersOverflowAriaLabel: string | undefined;
+  drawersOverflowWithBadgeAriaLabel: string | undefined;
   drawersRefs: DrawerFocusControlRefs;
   drawerSize: number;
   drawersMaxWidth: number;
@@ -599,6 +600,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           drawers,
           drawersAriaLabel: drawersProps.ariaLabel,
           drawersOverflowAriaLabel: drawersProps.overflowAriaLabel,
+          drawersOverflowWithBadgeAriaLabel: drawersProps.overflowWithBadgeAriaLabel,
           drawersRefs,
           drawersMaxWidth,
           drawerSize,

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -145,6 +145,7 @@ function DesktopTriggers() {
     drawers,
     drawersAriaLabel,
     drawersOverflowAriaLabel,
+    drawersOverflowWithBadgeAriaLabel,
     drawersRefs,
     drawersTriggerCount,
     handleDrawersClick,
@@ -240,7 +241,7 @@ function DesktopTriggers() {
         {overflowItems.length > 0 && (
           <OverflowMenu
             items={overflowItems}
-            ariaLabel={drawersOverflowAriaLabel}
+            ariaLabel={overflowMenuHasBadge ? drawersOverflowWithBadgeAriaLabel : drawersOverflowAriaLabel}
             customTriggerBuilder={({ onClick, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => (
               <TriggerButton
                 ref={triggerRef}
@@ -286,6 +287,7 @@ export function MobileTriggers() {
     drawers,
     drawersAriaLabel,
     drawersOverflowAriaLabel,
+    drawersOverflowWithBadgeAriaLabel,
     drawersRefs,
     handleDrawersClick,
     hasDrawerViewportOverlay,
@@ -302,6 +304,7 @@ export function MobileTriggers() {
   }
 
   const { visibleItems, overflowItems } = splitItems(drawers, 2, activeDrawerId);
+  const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
   return (
     <aside
@@ -335,7 +338,7 @@ export function MobileTriggers() {
       {overflowItems.length > 0 && (
         <OverflowMenu
           items={overflowItems}
-          ariaLabel={drawersOverflowAriaLabel}
+          ariaLabel={overflowMenuHasBadge ? drawersOverflowWithBadgeAriaLabel : drawersOverflowAriaLabel}
           onItemClick={({ detail }) => handleDrawersClick(detail.id)}
         />
       )}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
During the Drawers Bug Bash, it was discovered that the overflow drawer button does not communicate it's badged state. In order to communicate this, a small API change was required to add an additional aria label in this case.
<img width="95" alt="image" src="https://github.com/cloudscape-design/components/assets/9701338/627b3714-33c3-4929-ab56-6e94d1feec37">


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
