### PR TITLE
feat: Make Input aria-label available when using FormField

### DIFF
--- a/src/input/__tests__/input.test.tsx
+++ b/src/input/__tests__/input.test.tsx
@@ -338,6 +338,19 @@ describe('Input', () => {
       expect(element).toHaveAttribute('aria-label', 'Input label');
       expect(element).not.toHaveAttribute('aria-labelledby');
     });
+
+    test('aria-labelled by from input takes precedence over aria-label', () => {
+      render(
+        <FormField label="Form label">
+          <Input value="" ariaLabel="Input label" ariaLabelledby="test" />
+        </FormField>
+      );
+
+      const element = createWrapper().find('input')!.getElement();
+
+      expect(element).toHaveAttribute('aria-label', 'Input label');
+      expect(element).toHaveAttribute('aria-labelledby', 'test');
+    });
   });
 
   describe('Ref', () => {

--- a/src/input/__tests__/input.test.tsx
+++ b/src/input/__tests__/input.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import Input, { InputProps } from '../../../lib/components/input';
+import FormField from '../../../lib/components/form-field';
 import styles from '../../../lib/components/input/styles.css.js';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
@@ -323,6 +324,19 @@ describe('Input', () => {
         const { input } = renderInput({ ariaRequired: false, ariaLabel: 'input' });
         expect(input).not.toHaveAttribute('aria-required');
       });
+    });
+
+    test('aria-label from input takes precedence over aria-labelledBy from form field', () => {
+      render(
+        <FormField label="Form label">
+          <Input value="" ariaLabel="Input label" />
+        </FormField>
+      );
+
+      const element = createWrapper().find('input')!.getElement();
+
+      expect(element).toHaveAttribute('aria-label', 'Input label');
+      expect(element).not.toHaveAttribute('aria-labelledby');
     });
   });
 

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -101,7 +101,7 @@ function InternalInput(
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledby,
+    'aria-labelledby': ariaLabel ? undefined : ariaLabelledby,
     'aria-describedby': ariaDescribedby,
     name,
     placeholder,

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -101,6 +101,9 @@ function InternalInput(
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
+    // aria-labelledby has precedence over aria-label in accessible name calculation.
+    // When aria-label is provided for Input, it should override aria-labelledBy from form-field context.
+    // If both aria-label and aria-labelledby come from Input props, aria-labelledby will be used in accessible name
     'aria-labelledby': ariaLabel && !rest.ariaLabelledby ? undefined : ariaLabelledby,
     'aria-describedby': ariaDescribedby,
     name,

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -101,7 +101,7 @@ function InternalInput(
 
   const attributes: React.InputHTMLAttributes<HTMLInputElement> = {
     'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabel ? undefined : ariaLabelledby,
+    'aria-labelledby': ariaLabel && !rest.ariaLabelledby ? undefined : ariaLabelledby,
     'aria-describedby': ariaDescribedby,
     name,
     placeholder,


### PR DESCRIPTION
### Description

Currently when using Input inside FormField, `aria-labelledby` is always being set from FormField context. Because `aria-labelledby` has precedence over `aria-label` in accessible name calculation, it's not possible to use `aria-label` on Input to add additional context.

Related links, issue #, if available: AWSUI-22502

### How has this been tested?

New tests added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
