### PR TITLE
feat: Add accessible name to mode switcher in Date range picker

### DIFF
--- a/pages/date-range-picker/common.ts
+++ b/pages/date-range-picker/common.ts
@@ -21,6 +21,7 @@ export const i18nStrings: DateRangePickerProps['i18nStrings'] = {
   formatRelativeRange: formatRelativeRange,
   formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
   dateTimeConstraintText: 'Range must be between 6 and 30 days. Use 24 hour format.',
+  modeSelectionAriaLabel: 'Date range mode',
   relativeModeTitle: 'Relative range',
   absoluteModeTitle: 'Absolute range',
   relativeRangeSelectionHeading: 'Choose a range',

--- a/pages/date-range-picker/common.ts
+++ b/pages/date-range-picker/common.ts
@@ -21,7 +21,7 @@ export const i18nStrings: DateRangePickerProps['i18nStrings'] = {
   formatRelativeRange: formatRelativeRange,
   formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
   dateTimeConstraintText: 'Range must be between 6 and 30 days. Use 24 hour format.',
-  modeSelectionAriaLabel: 'Date range mode',
+  modeSelectionLabel: 'Date range mode',
   relativeModeTitle: 'Relative range',
   absoluteModeTitle: 'Absolute range',
   relativeRangeSelectionHeading: 'Choose a range',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5973,7 +5973,7 @@ Default: the user's current time offset as provided by the browser.
             "type": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
           },
           Object {
-            "name": "modeSelectionAriaLabel",
+            "name": "modeSelectionLabel",
             "optional": true,
             "type": "string",
           },

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5973,6 +5973,11 @@ Default: the user's current time offset as provided by the browser.
             "type": "(unit: DateRangePickerProps.TimeUnit, value: number) => string",
           },
           Object {
+            "name": "modeSelectionAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "nextMonthAriaLabel",
             "optional": true,
             "type": "string",

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -14,6 +14,7 @@ import { changeMode } from './change-mode';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import styles from '../../../lib/components/date-range-picker/styles.css.js';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
+import segmentedStyles from '../../../lib/components/segmented-control/styles.css.js';
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
@@ -120,6 +121,15 @@ describe('Date range picker', () => {
       );
       expect(dropdown.findEndTimeInput()!.findNativeInput()!.getElement()).toHaveAccessibleName(
         i18nStrings.endTimeLabel
+      );
+    });
+
+    test('toolbar accessible name', () => {
+      const { wrapper } = renderDateRangePicker();
+      wrapper.openDropdown();
+      const modeSelector = wrapper.findDropdown()!.findSelectionModeSwitch()!.findModesAsSegments();
+      expect(modeSelector.findByClassName(segmentedStyles['segment-part'])!.getElement()).toHaveAccessibleName(
+        i18nStrings.modeSelectionAriaLabel
       );
     });
   });

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -129,7 +129,7 @@ describe('Date range picker', () => {
       wrapper.openDropdown();
       const modeSelector = wrapper.findDropdown()!.findSelectionModeSwitch()!.findModesAsSegments();
       expect(modeSelector.findByClassName(segmentedStyles['segment-part'])!.getElement()).toHaveAccessibleName(
-        i18nStrings.modeSelectionAriaLabel
+        i18nStrings.modeSelectionLabel
       );
     });
   });

--- a/src/date-range-picker/__tests__/i18n-strings.ts
+++ b/src/date-range-picker/__tests__/i18n-strings.ts
@@ -15,6 +15,7 @@ export const i18nStrings: DateRangePickerProps.I18nStrings = {
   formatRelativeRange: range => `${range.unit}${range.amount}`,
   formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
   dateTimeConstraintText: 'Range must be between 6 and 30 days. Use 24 hour format.',
+  modeSelectionAriaLabel: 'Date range mode',
   relativeModeTitle: 'Relative range',
   absoluteModeTitle: 'Absolute range',
   relativeRangeSelectionHeading: 'Choose a range',

--- a/src/date-range-picker/__tests__/i18n-strings.ts
+++ b/src/date-range-picker/__tests__/i18n-strings.ts
@@ -15,7 +15,7 @@ export const i18nStrings: DateRangePickerProps.I18nStrings = {
   formatRelativeRange: range => `${range.unit}${range.amount}`,
   formatUnit: (unit, value) => (value === 1 ? unit : `${unit}s`),
   dateTimeConstraintText: 'Range must be between 6 and 30 days. Use 24 hour format.',
-  modeSelectionAriaLabel: 'Date range mode',
+  modeSelectionLabel: 'Date range mode',
   relativeModeTitle: 'Relative range',
   absoluteModeTitle: 'Absolute range',
   relativeRangeSelectionHeading: 'Choose a range',

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -265,6 +265,11 @@ export namespace DateRangePickerProps {
     ariaDescribedby?: string;
 
     /**
+     * Adds an `aria-label` to the mode selection group.
+     */
+    modeSelectionAriaLabel?: string;
+
+    /**
      * Segment title of the relative range selection mode
      */
     relativeModeTitle?: string;

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -265,9 +265,10 @@ export namespace DateRangePickerProps {
     ariaDescribedby?: string;
 
     /**
-     * Adds an `aria-label` to the mode selection group.
+     * Label of the mode selection group. In the standard view it adds `aria-label` on the group of segments.
+     * In a narrow container the label is visible and attached to the select component.
      */
-    modeSelectionAriaLabel?: string;
+    modeSelectionLabel?: string;
 
     /**
      * Segment title of the relative range selection mode

--- a/src/date-range-picker/interfaces.ts
+++ b/src/date-range-picker/interfaces.ts
@@ -265,7 +265,7 @@ export namespace DateRangePickerProps {
     ariaDescribedby?: string;
 
     /**
-     * Label of the mode selection group. In the standard view it adds `aria-label` on the group of segments.
+     * Label of the mode selection group. In the standard view, it adds 'aria-label' to the group of segments.
      * In a narrow container the label is visible and attached to the select component.
      */
     modeSelectionLabel?: string;

--- a/src/date-range-picker/mode-switcher.tsx
+++ b/src/date-range-picker/mode-switcher.tsx
@@ -19,6 +19,7 @@ export default function ModeSwitcher({ i18nStrings, mode, onChange }: ModeSwitch
     <InternalSegmentedControl
       className={styles['mode-switch']}
       selectedId={mode}
+      label={i18nStrings?.modeSelectionAriaLabel}
       options={[
         { id: 'relative', text: i18n('i18nStrings.relativeModeTitle', i18nStrings?.relativeModeTitle) },
         { id: 'absolute', text: i18n('i18nStrings.absoluteModeTitle', i18nStrings?.absoluteModeTitle) },

--- a/src/date-range-picker/mode-switcher.tsx
+++ b/src/date-range-picker/mode-switcher.tsx
@@ -19,7 +19,7 @@ export default function ModeSwitcher({ i18nStrings, mode, onChange }: ModeSwitch
     <InternalSegmentedControl
       className={styles['mode-switch']}
       selectedId={mode}
-      label={i18nStrings?.modeSelectionAriaLabel}
+      label={i18nStrings?.modeSelectionLabel}
       options={[
         { id: 'relative', text: i18n('i18nStrings.relativeModeTitle', i18nStrings?.relativeModeTitle) },
         { id: 'absolute', text: i18n('i18nStrings.absoluteModeTitle', i18nStrings?.absoluteModeTitle) },


### PR DESCRIPTION
### Description

Mode switcher in Date range picker is a toolbar and, therefore, should have an accessible name that describes it. We need to pass a string to `label` property of the segmented control used for the mode switcher

Related links, issue #, if available: AWSUI-22536

### How has this been tested?

new unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
