### PR TITLE
fix: Remove unnecessary <hr> in split panel

### DIFF
--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -68,7 +68,6 @@ export function SplitPanelContentSide({
         )}
         <div className={styles['content-side']} aria-hidden={!isOpen}>
           <div className={clsx(styles['pane-header-wrapper-side'])}>{header}</div>
-          <hr className={styles['header-divider']} />
           <div className={clsx(styles['pane-content-wrapper-side'])}>{children}</div>
         </div>
       </div>

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -243,6 +243,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   height: 100%;
   > .pane-header-wrapper-side {
     padding: 0 awsui.$space-m 0 awsui.$space-panel-side-left;
+    border-bottom: awsui.$border-panel-header-width solid awsui.$color-border-divider-default;
   }
   > .pane-content-wrapper-side {
     padding: 0 awsui.$space-panel-side-right 0 awsui.$space-panel-side-left;
@@ -263,12 +264,6 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
     padding: awsui.$space-xxs 0 awsui.$space-scaled-xxs 0;
     margin: 0;
   }
-}
-
-.header-divider {
-  border: none;
-  border-top: awsui.$border-panel-header-width solid awsui.$color-border-divider-default;
-  margin-top: calc(-1 * #{awsui.$border-panel-header-width});
 }
 
 .header-actions {


### PR DESCRIPTION
### Description

Replace an `hr` with borders for improved consistency across different split panel variants/positions.

Related links, issue #, if available: AWSUI-22580

### How has this been tested?

Visual regression tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
