### PR TITLE
chore: Apply no-focus and no-scroll classes when drawer opens on mobile

### DIFF
--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -122,6 +122,14 @@ describeEachThemeAppLayout(true, theme => {
     expect(wrapper.findToolsToggle().getElement()).toBeDisabled();
   });
 
+  test('renders open drawer state', () => {
+    const { wrapper } = renderComponent(<AppLayout contentType="form" {...singleDrawerOpen} />);
+    expect(document.body).toHaveClass(blockBodyScrollClassName);
+    expect(wrapper.findNavigation()).toBeTruthy();
+    expect(wrapper.findTools()).toBeFalsy(); // no tools rendered in drawers mode
+    expect(wrapper.findActiveDrawer()).toBeTruthy();
+  });
+
   test('Renders mobile toolbar when at least one of it features is defined', function () {
     const findMobileToolbar = () => wrapper.findByClassName(mobileBarClassName);
     const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} />);
@@ -383,6 +391,23 @@ describeEachThemeAppLayout(true, theme => {
         expect(wrapper.findAllByClassName(styles.unfocusable)).toHaveLength(2);
         expect(wrapper.findByClassName(toolbarStyles['mobile-bar'])?.getElement()).toHaveClass(unfocusableClassName);
         expect(wrapper.findByClassName(styles['layout-main'])?.getElement()).toHaveClass(unfocusableClassName);
+      }
+    });
+
+    test('content and toolbar is unfocusable when a drawer is open', () => {
+      const { wrapper, isUsingGridLayout } = renderComponent(<AppLayout {...props} {...singleDrawerOpen} />);
+
+      if (isUsingGridLayout) {
+        expect(wrapper.findAllByClassName(unfocusableClassName)).toHaveLength(6);
+        expect(wrapper.findByClassName(testUtilsStyles['mobile-bar'])!.getElement()).toHaveClass(unfocusableClassName);
+        expect(wrapper.findByClassName(testUtilsStyles.content)!.getElement()).toHaveClass(unfocusableClassName);
+        expect(
+          wrapper.findByClassName(visualRefreshRefactoredStyles['navigation-container'])!.getElement()
+        ).toHaveClass(unfocusableClassName);
+      } else {
+        expect(wrapper.findAllByClassName(styles.unfocusable)).toHaveLength(2);
+        expect(wrapper.findByClassName(toolbarStyles['mobile-bar'])!.getElement()).toHaveClass(unfocusableClassName);
+        expect(wrapper.findByClassName(styles['layout-main'])!.getElement()).toHaveClass(unfocusableClassName);
       }
     });
 

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -215,7 +215,7 @@ const OldAppLayout = React.forwardRef(
     const [isSplitpanelForcedPosition, setIsSplitpanelForcedPosition] = useState(false);
 
     const [notificationsHeight, notificationsRef] = useContainerQuery(rect => rect.contentBoxHeight);
-    const anyPanelOpen = navigationVisible || toolsVisible;
+    const anyPanelOpen = navigationVisible || toolsVisible || !!activeDrawer;
     const hasRenderedNotifications = notificationsHeight ? notificationsHeight > 0 : false;
     const stickyNotificationsHeight = stickyNotifications ? notificationsHeight : null;
 

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -233,28 +233,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     );
 
     /**
-     * On mobile viewports the navigation and tools drawers are adjusted to a fixed position
-     * that consumes 100% of the viewport height and width. The body content could potentially
-     * be scrollable underneath the drawer. In order to prevent this a CSS class needs to be
-     * added to the document body that sets overflow to hidden.
-     */
-    useEffect(
-      function handleBodyScroll() {
-        if (isMobile && (isNavigationOpen || isToolsOpen)) {
-          document.body.classList.add(styles['block-body-scroll']);
-        } else {
-          document.body.classList.remove(styles['block-body-scroll']);
-        }
-
-        // Ensure the CSS class is removed from the body on side effect cleanup
-        return function cleanup() {
-          document.body.classList.remove(styles['block-body-scroll']);
-        };
-      },
-      [isMobile, isNavigationOpen, isToolsOpen]
-    );
-
-    /**
      * Query the DOM for the header and footer elements based on the selectors provided
      * by the properties and pass the heights to the custom property definitions.
      */
@@ -473,6 +451,28 @@ export const AppLayoutInternalsProvider = React.forwardRef(
         setMainOffsetLeft(mainElement?.current?.offsetLeft ?? 0);
       },
       [layoutWidth, isNavigationOpen, isToolsOpen, splitPanelReportedSize]
+    );
+
+    /**
+     * On mobile viewports the navigation and tools drawers are adjusted to a fixed position
+     * that consumes 100% of the viewport height and width. The body content could potentially
+     * be scrollable underneath the drawer. In order to prevent this a CSS class needs to be
+     * added to the document body that sets overflow to hidden.
+     */
+    useEffect(
+      function handleBodyScroll() {
+        if (isMobile && (isNavigationOpen || isToolsOpen || !!activeDrawer)) {
+          document.body.classList.add(styles['block-body-scroll']);
+        } else {
+          document.body.classList.remove(styles['block-body-scroll']);
+        }
+
+        // Ensure the CSS class is removed from the body on side effect cleanup
+        return function cleanup() {
+          document.body.classList.remove(styles['block-body-scroll']);
+        };
+      },
+      [isMobile, isNavigationOpen, isToolsOpen, activeDrawer]
     );
 
     /**


### PR DESCRIPTION
### Description

Fixed a bug where open drawer allowed to focus and scroll the main page content rendered underneath 

Related links, issue #, if available: n/a

### How has this been tested?

Replicated existing tests we had for the same feature in tools 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
