### PR TITLE
chore: Update sticky-scrollbar z-index to avoid conflict with sticky header

### DIFF
--- a/pages/table/sticky-header-with-actions.page.tsx
+++ b/pages/table/sticky-header-with-actions.page.tsx
@@ -5,7 +5,7 @@ import Header from '~components/header';
 import ButtonDropdown, { ButtonDropdownProps } from '~components/button-dropdown';
 import Table from '~components/table';
 import { Instance, generateItems } from '../table/generate-data';
-import { columnsConfig, ARIA_LABELS } from '../table/shared-configs';
+import { columnsConfig, selectionLabels } from '../table/shared-configs';
 
 const dropdownItems: Array<ButtonDropdownProps.Item> = [
   { id: '1', text: 'Item 1' },
@@ -23,11 +23,18 @@ export default function () {
       <div style={{ height: '400px', width: '500px', overflow: 'auto', padding: '0px 1px' }} id="scroll-container">
         <div style={{ height: '100px' }} />
         <Table<Instance>
-          ariaLabels={ARIA_LABELS}
+          ariaLabels={selectionLabels}
           selectionType="multi"
           stickyColumns={{ last: 1 }}
           header={
-            <Header actions={<ButtonDropdown items={dropdownItems}>Actions</ButtonDropdown>} headingTagOverride="h1">
+            <Header
+              actions={
+                <ButtonDropdown data-test-id="actions-button" items={dropdownItems}>
+                  Actions
+                </ButtonDropdown>
+              }
+              headingTagOverride="h1"
+            >
               Instances
             </Header>
           }

--- a/pages/table/sticky-header-with-actions.page.tsx
+++ b/pages/table/sticky-header-with-actions.page.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import Header from '~components/header';
+import ButtonDropdown, { ButtonDropdownProps } from '~components/button-dropdown';
+import Table from '~components/table';
+import { Instance, generateItems } from '../table/generate-data';
+import { columnsConfig, ARIA_LABELS } from '../table/shared-configs';
+
+const dropdownItems: Array<ButtonDropdownProps.Item> = [
+  { id: '1', text: 'Item 1' },
+  { id: '2', text: 'Item 2' },
+  { id: '3', text: 'Item 3' },
+  { id: '4', text: 'Item 4' },
+  { id: '5', text: 'Item 5' },
+  { id: '6', text: 'Item 6' },
+];
+
+export default function () {
+  return (
+    <>
+      <h1>Table with a sticky header and actions</h1>
+      <div style={{ height: '400px', width: '500px', overflow: 'auto', padding: '0px 1px' }} id="scroll-container">
+        <div style={{ height: '100px' }} />
+        <Table<Instance>
+          ariaLabels={ARIA_LABELS}
+          selectionType="multi"
+          stickyColumns={{ last: 1 }}
+          header={
+            <Header actions={<ButtonDropdown items={dropdownItems}>Actions</ButtonDropdown>} headingTagOverride="h1">
+              Instances
+            </Header>
+          }
+          columnDefinitions={columnsConfig}
+          items={generateItems(1)}
+          stickyHeader={true}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/table/sticky-scrollbar/styles.scss
+++ b/src/table/sticky-scrollbar/styles.scss
@@ -30,7 +30,7 @@
     // "offset" styles are needed for when sticky columns are enabled.
     // We move the scrollbar lower, so it doesn't overlap interactive elements (such as checkboxes or links)
 
-    z-index: 800; // Higher than sticky columns
+    z-index: 799; // Higher than sticky columns (798) and lower than table sticky header (800)
     &:not(.is-visual-refresh) {
       background-color: awsui.$color-background-container-content;
       height: 15px;


### PR DESCRIPTION
### Description

The table's sticky header, which houses elements with a dropdown (e.g.: Select or ButtonDropdown), has a `position: sticky` and a `z-index: 800`. This conflicts with the horizontal scrollbar's z-index (also 800), causing the dropdown options to hide behind the scrollbar.

Related links, issue #, if available: AWSUI-22618

### Testing 

Added screenshot tests: CR-103247561

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
