### PR TITLE
fix: Adds min-width to drawer

### DIFF
--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -128,9 +128,7 @@ for (const visualRefresh of [true, false]) {
 
     test(
       `should not shrink drawer beyond min width`,
-      setupTest({}, async page => {
-        // this width is small enough that it would hit the min-width of a drawer
-        await page.setWindowSize({ ...viewports.desktop, width: 700 });
+      setupTest({ screenSize: { ...viewports.desktop, width: 700 } }, async page => {
         await page.openThirdDrawer();
         // there are different layouts between these two designs
         // the min-width of the drawer is 290

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -127,6 +127,18 @@ for (const visualRefresh of [true, false]) {
     );
 
     test(
+      `should not shrink drawer beyond min width`,
+      setupTest({}, async page => {
+        // this width is small enough that it would hit the min-width of a drawer
+        await page.setWindowSize({ ...viewports.desktop, width: 700 });
+        await page.openThirdDrawer();
+        // there are different layouts between these two designs
+        // the min-width of the drawer is 290
+        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh ? 292 : 290);
+      })
+    );
+
+    test(
       'split panel and drawer can resize independently',
       setupTest({ splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1800 } }, async page => {
         await page.openFirstDrawer();

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -75,6 +75,7 @@ function ActiveDrawer() {
   } = useAppLayoutInternals();
 
   const activeDrawer = drawers?.find(item => item.id === activeDrawerId) ?? null;
+  const MIN_WIDTH = 290;
 
   const computedAriaLabels = {
     closeButton: activeDrawerId ? activeDrawer?.ariaLabels?.closeButton : ariaLabels?.toolsClose,
@@ -85,7 +86,7 @@ function ActiveDrawer() {
   const isUnfocusable = isHidden || (hasDrawerViewportOverlay && isNavigationOpen && !navigationHide);
   const isToolsDrawer = activeDrawerId === TOOLS_DRAWER_ID;
 
-  const size = Math.min(drawersMaxWidth, drawerSize);
+  const size = Math.max(Math.min(drawersMaxWidth, drawerSize), MIN_WIDTH);
 
   return (
     <aside


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
From Drawers Bug Bash.

No min-width on drawers caused situations like this on small screens:
![image](https://github.com/cloudscape-design/components/assets/9701338/31e96e14-5a90-44d0-b892-eb00c32a3157)

Added a min-width of 290 for feature parity with tools.

It should be noted that situations like this can still happen, which isn't ideal, but should be handled holistically:
![image](https://github.com/cloudscape-design/components/assets/9701338/ad71abeb-ea10-4e1f-b858-4f8c92e93c0f)


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
