### PR TITLE
feat: New operator 'starts-with' in property filter

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10624,6 +10624,11 @@ operations are communicated to the user in another way.",
             "type": "string",
           },
           Object {
+            "name": "operatorStartsWithText",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "operatorText",
             "optional": true,
             "type": "string",
@@ -10683,7 +10688,7 @@ operations are communicated to the user in another way.",
 Each token has the following properties:
 * value [string]: The string value of the token to be used as a filter.
 * propertyKey [string]: The key of the corresponding property in filteringProperties.
-* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=']: The operator which indicates how to filter the dataset using this token.
+* operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^']: The operator which indicates how to filter the dataset using this token.
 
 \`operation\` has two valid values [and, or] and controls the join operation to be applied between tokens when filtering the items.
 ",

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -34,7 +34,7 @@ const filteringProperties: readonly FilteringProperty[] = [
   {
     key: 'string',
     propertyLabel: 'string',
-    operators: ['!:', ':', '=', '!=', '^'],
+    operators: ['!:', ':', '=', '!='],
     groupValuesLabel: 'String values',
   },
   // property label has the a prefix equal to another property's label
@@ -1388,6 +1388,7 @@ describe('i18n', () => {
       'i18nStrings.operatorGreaterText': 'Custom Greater than',
       'i18nStrings.operatorLessOrEqualText': 'Custom Less than or equal',
       'i18nStrings.operatorLessText': 'Custom Less than',
+      'i18nStrings.operatorStartsWithText': 'Custom Starts with',
       'i18nStrings.operatorText': 'Custom Operator',
       'i18nStrings.operatorsText': 'Custom Operators',
       'i18nStrings.propertyText': 'Custom Property',
@@ -1399,6 +1400,14 @@ describe('i18n', () => {
       <TestI18nProvider messages={providerMessages}>
         <PropertyFilter
           {...defaultProps}
+          filteringProperties={[
+            {
+              key: 'string',
+              propertyLabel: 'string',
+              operators: ['!:', ':', '=', '!=', '^'],
+              groupValuesLabel: 'String values',
+            },
+          ]}
           i18nStrings={{ filteringAriaLabel: 'your choice', filteringPlaceholder: 'Search' }}
         />
       </TestI18nProvider>
@@ -1413,7 +1422,13 @@ describe('i18n', () => {
     expect(dropdown.find('li:nth-child(2)')!.getElement()).toHaveTextContent('Custom Operators');
     expect(
       dropdown.findOptions().map(optionWrapper => optionWrapper.findDescription()?.getElement().textContent)
-    ).toEqual(['Custom Equals', 'Custom Does not equal', 'Custom Contains', 'Custom Does not contain']);
+    ).toEqual([
+      'Custom Equals',
+      'Custom Does not equal',
+      'Custom Contains',
+      'Custom Does not contain',
+      'Custom Starts with',
+    ]);
   });
 
   it('uses dropdown labels from i18n provider for a numeric property', () => {
@@ -1510,11 +1525,11 @@ describe('i18n', () => {
     expect(getRemoveButton(1)).toHaveAccessibleName('Remove filter, string Custom does not equal value2');
     expect(getRemoveButton(2)).toHaveAccessibleName('Remove filter, string Custom contains value3');
     expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, string Custom does not contain value4');
-    expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, string Custom starts with value5');
-    expect(getRemoveButton(4)).toHaveAccessibleName('Remove filter, range Custom greater than 1');
-    expect(getRemoveButton(5)).toHaveAccessibleName('Remove filter, range Custom less than 2');
-    expect(getRemoveButton(6)).toHaveAccessibleName('Remove filter, range Custom greater than or equals 3');
-    expect(getRemoveButton(7)).toHaveAccessibleName('Remove filter, range Custom less than or equals 4');
+    expect(getRemoveButton(4)).toHaveAccessibleName('Remove filter, string Custom starts with value5');
+    expect(getRemoveButton(5)).toHaveAccessibleName('Remove filter, range Custom greater than 1');
+    expect(getRemoveButton(6)).toHaveAccessibleName('Remove filter, range Custom less than 2');
+    expect(getRemoveButton(7)).toHaveAccessibleName('Remove filter, range Custom greater than or equals 3');
+    expect(getRemoveButton(8)).toHaveAccessibleName('Remove filter, range Custom less than or equals 4');
 
     const tokenOperation = wrapper.findTokens()[1].findTokenOperation()!;
     tokenOperation.openDropdown();

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -34,7 +34,7 @@ const filteringProperties: readonly FilteringProperty[] = [
   {
     key: 'string',
     propertyLabel: 'string',
-    operators: ['!:', ':', '=', '!='],
+    operators: ['!:', ':', '=', '!=', '^'],
     groupValuesLabel: 'String values',
   },
   // property label has the a prefix equal to another property's label
@@ -1473,6 +1473,7 @@ describe('i18n', () => {
               less_than_equal {Remove filter, {token__propertyKey} Custom less than or equals {token__value}}
               contains {Remove filter, {token__propertyKey} Custom contains {token__value}}
               not_contains {Remove filter, {token__propertyKey} Custom does not contain {token__value}}
+              starts_with {Remove filter, {token__propertyKey} Custom starts with {token__value}}
               other {}}`,
           },
         }}
@@ -1487,6 +1488,7 @@ describe('i18n', () => {
               { propertyKey: 'string', operator: '!=', value: 'value2' },
               { propertyKey: 'string', operator: ':', value: 'value3' },
               { propertyKey: 'string', operator: '!:', value: 'value4' },
+              { propertyKey: 'string', operator: '^', value: 'value5' },
               { propertyKey: 'range', operator: '>', value: '1' },
               { propertyKey: 'range', operator: '<', value: '2' },
               { propertyKey: 'range', operator: '>=', value: '3' },
@@ -1508,6 +1510,7 @@ describe('i18n', () => {
     expect(getRemoveButton(1)).toHaveAccessibleName('Remove filter, string Custom does not equal value2');
     expect(getRemoveButton(2)).toHaveAccessibleName('Remove filter, string Custom contains value3');
     expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, string Custom does not contain value4');
+    expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, string Custom starts with value5');
     expect(getRemoveButton(4)).toHaveAccessibleName('Remove filter, range Custom greater than 1');
     expect(getRemoveButton(5)).toHaveAccessibleName('Remove filter, range Custom less than 2');
     expect(getRemoveButton(6)).toHaveAccessibleName('Remove filter, range Custom greater than or equals 3');

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -68,7 +68,7 @@ export const getQueryActions = (
 
 export const getAllowedOperators = (property: InternalFilteringProperty): ComparisonOperator[] => {
   const { operators = [], defaultOperator } = property;
-  const operatorOrder = ['=', '!=', ':', '!:', '>=', '<=', '<', '>'] as const;
+  const operatorOrder = ['=', '!=', ':', '!:', '^', '>=', '<=', '<', '>'] as const;
   const operatorSet = new Set([defaultOperator, ...operators]);
   return operatorOrder.filter(op => operatorSet.has(op));
 };
@@ -342,6 +342,8 @@ export const operatorToDescription = (operator: ComparisonOperator, i18nStrings:
       return i18nStrings.operatorEqualsText;
     case '!=':
       return i18nStrings.operatorDoesNotEqualText;
+    case '^':
+      return i18nStrings.operatorStartsWithText;
     // The line is ignored from coverage because it is not reachable.
     // The purpose of it is to prevent TS errors if ComparisonOperator type gets extended.
     /* istanbul ignore next */

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -56,6 +56,8 @@ function getOperatorI18nString(operator: ComparisonOperator): string {
       return 'contains';
     case '!:':
       return 'not_contains';
+    case '^':
+      return 'starts_with';
     // The line is ignored from coverage because it is not reachable.
     // The purpose of it is to prevent TS errors if ComparisonOperator type gets extended.
     /* istanbul ignore next */

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -132,6 +132,7 @@ const PropertyFilter = React.forwardRef(
       operatorGreaterText: i18n('i18nStrings.operatorGreaterText', rest.i18nStrings?.operatorGreaterText),
       operatorLessOrEqualText: i18n('i18nStrings.operatorLessOrEqualText', rest.i18nStrings?.operatorLessOrEqualText),
       operatorLessText: i18n('i18nStrings.operatorLessText', rest.i18nStrings?.operatorLessText),
+      operatorStartsWithText: i18n('i18nStrings.operatorStartsWithText', rest.i18nStrings?.operatorStartsWithText),
       operatorText: i18n('i18nStrings.operatorText', rest.i18nStrings?.operatorText),
       operatorsText: i18n('i18nStrings.operatorsText', rest.i18nStrings?.operatorsText),
       propertyText: i18n('i18nStrings.propertyText', rest.i18nStrings?.propertyText),

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -47,7 +47,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    *
    * * value [string]: The string value of the token to be used as a filter.
    * * propertyKey [string]: The key of the corresponding property in filteringProperties.
-   * * operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=']: The operator which indicates how to filter the dataset using this token.
+   * * operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^']: The operator which indicates how to filter the dataset using this token.
    *
    * `operation` has two valid values [and, or] and controls the join operation to be applied between tokens when filtering the items.
    */
@@ -238,6 +238,7 @@ export namespace PropertyFilterProps {
     operatorDoesNotContainText?: string;
     operatorEqualsText?: string;
     operatorDoesNotEqualText?: string;
+    operatorStartsWithText?: string;
 
     editTokenHeader?: string;
     propertyText?: string;


### PR DESCRIPTION
### Description

Added new operator "^" (starts with) to the list of supported operators. Added a new translation label for it.

Related links: AWSUI-20384

### How has this been tested?

New tests for applied translations. The actual filtering is performed by the collection-hooks.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
