### PR TITLE
chore: Add dev warning if recovery text provided without function

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -9,6 +9,7 @@ import itemStyles from '../../../lib/components/internal/components/selectable-i
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 const defaultOptions: AutosuggestProps.Options = [
   { value: '1', label: 'One' },
@@ -26,6 +27,20 @@ function renderAutosuggest(jsx: React.ReactElement) {
   const wrapper = createWrapper(container).findAutosuggest()!;
   return { container, wrapper, rerender };
 }
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => {
+  const originalModule = jest.requireActual('@cloudscape-design/component-toolkit/internal');
+
+  //just mock the `warnOnce` export
+  return {
+    __esModule: true,
+    ...originalModule,
+    warnOnce: jest.fn(),
+  };
+});
+beforeEach(() => {
+  (warnOnce as any).mockClear();
+});
 
 test('renders correct labels when focused', () => {
   const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
@@ -223,6 +238,17 @@ describe('Dropdown states', () => {
     wrapper.setInputValue('free-text');
     expect(wrapper.findNativeInput().getElement()).toHaveAttribute('aria-expanded', 'false');
     expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+  });
+
+  it('should warn if recoveryText is provided without associated handler', () => {
+    renderAutosuggest(
+      <Autosuggest {...defaultProps} statusType="error" errorText="Test error text" recoveryText="Retry" />
+    );
+    expect(warnOnce).toHaveBeenCalledTimes(1);
+    expect(warnOnce).toHaveBeenCalledWith(
+      'Autosuggest',
+      '`onLoadItems` must be provided for `recoveryText` to be displayed.'
+    );
   });
 });
 

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -82,6 +82,10 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const selectedAriaLabel = i18n('selectedAriaLabel', restProps.selectedAriaLabel);
   const recoveryText = i18n('recoveryText', restProps.recoveryText);
 
+  if (restProps.recoveryText && !onLoadItems) {
+    warnOnce('Autosuggest', '`onLoadItems` must be provided for `recoveryText` to be displayed.');
+  }
+
   if (!enteredTextLabel) {
     warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
   }

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -36,6 +36,7 @@ import styles from './styles.css.js';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { joinStrings } from '../internal/utils/strings';
 import { useInternalI18n } from '../i18n/context';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 type InternalMultiselectProps = MultiselectProps & InternalBaseComponentProps & { inlineTokens?: boolean };
 
@@ -88,6 +89,10 @@ const InternalMultiselect = React.forwardRef(
     const recoveryText = i18nCommon('recoveryText', restProps.recoveryText);
     const errorIconAriaLabel = i18nCommon('errorIconAriaLabel', restProps.errorIconAriaLabel);
     const selectedAriaLabel = i18nCommon('selectedAriaLabel', restProps.selectedAriaLabel);
+
+    if (restProps.recoveryText && !onLoadItems) {
+      warnOnce('Multiselect', '`onLoadItems` must be provided for `recoveryText` to be displayed.');
+    }
 
     const { handleLoadMore, handleRecoveryClick, fireLoadItems } = useLoadItems({
       onLoadItems,

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -8,6 +8,21 @@ import Select, { SelectProps } from '../../../lib/components/select';
 import selectPartsStyles from '../../../lib/components/select/parts/styles.css.js';
 import '../../__a11y__/to-validate-a11y';
 import statusIconStyles from '../../../lib/components/status-indicator/styles.selectors.js';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => {
+  const originalModule = jest.requireActual('@cloudscape-design/component-toolkit/internal');
+
+  //just mock the `warnOnce` export
+  return {
+    __esModule: true,
+    ...originalModule,
+    warnOnce: jest.fn(),
+  };
+});
+beforeEach(() => {
+  (warnOnce as any).mockClear();
+});
 
 const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
 const defaultOptions: SelectProps.Options = [
@@ -202,6 +217,19 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
       onLoadItems.mockClear();
       wrapper.findErrorRecoveryButton({ expandToViewport })!.click();
       expect(onLoadItems).toHaveBeenCalledWith({ filteringText: '', firstPage: false, samePage: true });
+    });
+
+    it('should warn if recoveryText is provided without associated handler', () => {
+      renderSelect({
+        options: defaultOptions,
+        recoveryText: 'Retry',
+        statusType: 'error',
+      });
+      expect(warnOnce).toHaveBeenCalledTimes(1);
+      expect(warnOnce).toHaveBeenCalledWith(
+        'Select',
+        '`onLoadItems` must be provided for `recoveryText` to be displayed.'
+      );
     });
 
     test('applies automatic client-side filtering when it is enabled', () => {

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -31,6 +31,7 @@ import { SomeRequired } from '../internal/types';
 import ScreenreaderOnly from '../internal/components/screenreader-only/index.js';
 import { joinStrings } from '../internal/utils/strings/join-strings.js';
 import { useInternalI18n } from '../i18n/context.js';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 export interface InternalSelectProps extends SomeRequired<SelectProps, 'options'>, InternalBaseComponentProps {
   __inFilteringToken?: boolean;
@@ -78,6 +79,10 @@ const InternalSelect = React.forwardRef(
     const errorIconAriaLabel = i18n('errorIconAriaLabel', restProps.errorIconAriaLabel);
     const selectedAriaLabel = i18n('selectedAriaLabel', restProps.selectedAriaLabel);
     const recoveryText = i18n('recoveryText', restProps.recoveryText);
+
+    if (restProps.recoveryText && !onLoadItems) {
+      warnOnce('Select', '`onLoadItems` must be provided for `recoveryText` to be displayed.');
+    }
 
     const { handleLoadMore, handleRecoveryClick, fireLoadItems } = useLoadItems({
       onLoadItems,


### PR DESCRIPTION
### Description

Include warning to make it clearer that `recoveryText` is only displayed if an `onLoadItems` function is provided

Related links, issue #, if available: n/a

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
