### PR TITLE
fix: Removes jumping drawer caret by removing motion class

### DIFF
--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -335,9 +335,19 @@ describe('VR only features', () => {
     (useVisualRefresh as jest.Mock).mockReset();
   });
 
-  test('should add motion class', () => {
+  test('should add motion class when expected', () => {
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...resizableDrawer} />);
-    act(() => wrapper.findDrawersTriggers()![0].click());
+    act(() => wrapper.findDrawerTriggerById('security')!.click());
+
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveClass(styles['with-motion']);
+
+    // we want to remove the class on keypress to avoid jumping
+    act(() => wrapper.findActiveDrawerResizeHandle()!.keydown(KeyCode.left));
+    expect(wrapper.findActiveDrawer()!.getElement()).not.toHaveClass(styles['with-motion']);
+
+    // we expect the class to be back when the drawer is re-opened
+    act(() => wrapper.findActiveDrawerCloseButton()!.click());
+    act(() => wrapper.findDrawerTriggerById('security')!.click());
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveClass(styles['with-motion']);
   });
 

--- a/src/app-layout/utils/use-keyboard-events.ts
+++ b/src/app-layout/utils/use-keyboard-events.ts
@@ -3,6 +3,7 @@
 import React from 'react';
 import { KeyCode } from '../../internal/keycode';
 import { SizeControlProps } from './interfaces';
+import styles from '../styles.css.js';
 
 const KEYBOARD_SINGLE_STEP_SIZE = 10;
 const KEYBOARD_MULTIPLE_STEPS_SIZE = 60;
@@ -27,6 +28,8 @@ export const useKeyboardEvents = ({ position, onResize, panelRef }: SizeControlP
     let maxSize;
 
     const { panelHeight, panelWidth } = getCurrentSize(panelRef);
+
+    panelRef?.current?.classList.remove(styles['with-motion']);
 
     if (position === 'side') {
       currentSize = panelWidth;

--- a/src/app-layout/utils/use-keyboard-events.ts
+++ b/src/app-layout/utils/use-keyboard-events.ts
@@ -22,14 +22,16 @@ const getCurrentSize = (panelRef?: React.RefObject<HTMLDivElement>) => {
   };
 };
 
-export const useKeyboardEvents = ({ position, onResize, panelRef }: SizeControlProps) => {
+export const useKeyboardEvents = ({ position, onResize, panelRef, hasTransitions = false }: SizeControlProps) => {
   return (event: React.KeyboardEvent) => {
     let currentSize;
     let maxSize;
 
     const { panelHeight, panelWidth } = getCurrentSize(panelRef);
 
-    panelRef?.current?.classList.remove(styles['with-motion']);
+    if (hasTransitions) {
+      panelRef?.current?.classList.remove(styles['with-motion']);
+    }
 
     if (position === 'side') {
       currentSize = panelWidth;

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -91,6 +91,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   splitPanelRefs: SplitPanelFocusControlRefs;
   toolsControlId: string;
   toolsRefs: FocusControlRefs;
+  prevActiveDrawerId: string | undefined;
 }
 
 /**
@@ -381,6 +382,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     });
 
     const [drawersMaxWidth, setDrawersMaxWidth] = useState(toolsWidth);
+    const [prevActiveDrawerId, setPrevActiveDrawerId] = useState<string | undefined>(activeDrawerId);
 
     const {
       refs: drawersRefs,
@@ -399,7 +401,14 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       drawersMaxWidth,
     });
 
+    const previousActiveDrawerId = useRef(activeDrawerId);
+
+    useEffect(() => {
+      previousActiveDrawerId.current = activeDrawerId;
+    }, [activeDrawerId]);
+
     const handleDrawersClick = (id: string | undefined, skipFocusControl?: boolean) => {
+      setPrevActiveDrawerId(previousActiveDrawerId.current);
       const newActiveDrawerId = id !== activeDrawerId ? id : undefined;
 
       onActiveDrawerChange(newActiveDrawerId);
@@ -665,6 +674,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           toolsOpen: isToolsOpen,
           toolsWidth,
           toolsRefs,
+          prevActiveDrawerId,
         }}
       >
         <AppLayoutContext.Provider

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -72,6 +72,7 @@ function ActiveDrawer() {
     drawerSize,
     drawersMaxWidth,
     drawerRef,
+    prevActiveDrawerId,
   } = useAppLayoutInternals();
 
   const activeDrawer = drawers?.find(item => item.id === activeDrawerId) ?? null;
@@ -99,7 +100,7 @@ function ActiveDrawer() {
         [styles.unfocusable]: isUnfocusable,
         [testutilStyles['active-drawer']]: activeDrawerId,
         [testutilStyles.tools]: isToolsDrawer,
-        [sharedStyles['with-motion']]: activeDrawerId,
+        [sharedStyles['with-motion']]: activeDrawerId && !prevActiveDrawerId,
       })}
       style={{
         ...(!isMobile && drawerSize && { [customCssProps.drawerSize]: `${size}px` }),

--- a/src/split-panel/__tests__/utils.test.tsx
+++ b/src/split-panel/__tests__/utils.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { KeyCode } from '../../internal/keycode';
-import { useKeyboardEvents } from '../../app-layout/utils/use-keyboard-events';
+import { useKeyboardEvents } from '../../../lib/components/app-layout/utils/use-keyboard-events';
 
 const sizeControlProps: any = {
   position: 'bottom',


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
From Drawers Bug Bash.

In VR, the close caret was jumping when resizing via keyboard due to a motion class. This removes that class on keypress.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
