### PR TITLE
fix: Fixes scroll discrepencies between drawer and tools

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -13,11 +13,18 @@ import {
   Toggle,
 } from '~components';
 import appLayoutLabels from './utils/labels';
+import { AppLayoutProps } from '~components/app-layout';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
 import './utils/external-widget';
 import AppContext, { AppContextType } from '../app/app-context';
 
-type DemoContext = React.Context<AppContextType<{ hasTools: boolean | undefined; hasDrawers: boolean | undefined }>>;
+type DemoContext = React.Context<
+  AppContextType<{
+    hasTools: boolean | undefined;
+    hasDrawers: boolean | undefined;
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+  }>
+>;
 
 export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
@@ -118,6 +125,13 @@ export default function WithDrawers() {
           This is the Split Panel!
         </SplitPanel>
       }
+      splitPanelPreferences={{
+        position: urlParams.splitPanelPosition,
+      }}
+      onSplitPanelPreferencesChange={event => {
+        const { position } = event.detail;
+        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+      }}
       onToolsChange={event => {
         setIsToolsOpen(event.detail.open);
       }}

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -155,7 +155,6 @@ export default function WithDrawers() {
       <AppLayout
         ariaLabels={appLayoutLabels}
         breadcrumbs={<Breadcrumbs />}
-        tools={<Links />}
         content={
           <ContentLayout
             data-test-id="content"
@@ -222,44 +221,5 @@ function ProHelp() {
 }
 
 function Links() {
-  return (
-    <HelpPanel header={<h2>Links</h2>}>
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-      Here is a link. <br />
-    </HelpPanel>
-  );
+  return <HelpPanel header={<h2>Links</h2>}>Here is a link.</HelpPanel>;
 }

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -155,6 +155,7 @@ export default function WithDrawers() {
       <AppLayout
         ariaLabels={appLayoutLabels}
         breadcrumbs={<Breadcrumbs />}
+        tools={<Links />}
         content={
           <ContentLayout
             data-test-id="content"
@@ -221,5 +222,44 @@ function ProHelp() {
 }
 
 function Links() {
-  return <HelpPanel header={<h2>Links</h2>}>Here is a link.</HelpPanel>;
+  return (
+    <HelpPanel header={<h2>Links</h2>}>
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+      Here is a link. <br />
+    </HelpPanel>
+  );
 }

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -17,6 +17,7 @@ for (const visualRefresh of [true, false]) {
           `#/light/app-layout/runtime-drawers?${new URLSearchParams({
             hasDrawers: 'false',
             hasTools: 'true',
+            splitPanelPosition: 'side',
             visualRefresh: `${visualRefresh}`,
           }).toString()}`
         );
@@ -39,16 +40,12 @@ for (const visualRefresh of [true, false]) {
       })
     );
 
-    test.only(
+    test(
       'should resize equally with tools or drawers',
       setupTest(async page => {
         await page.setWindowSize({ ...viewports.desktop, width: 1800 });
         await page.click(wrapper.findToolsToggle().toSelector());
         await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-        await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-        const tile = createWrapper().findModal().findContent().findTiles().findItemByValue('side');
-        await page.click(tile.toSelector());
-        await page.click('button=Confirm');
 
         const { width: splitPanelWidthWithTools } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
 

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -3,6 +3,7 @@
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from './constants';
 
 const wrapper = createWrapper().findAppLayout();
 
@@ -35,6 +36,26 @@ for (const visualRefresh of [true, false]) {
 
         await page.click(wrapper.findDrawerTriggerById('awsui-internal-tools').toSelector());
         await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain('Here is some info for you!');
+      })
+    );
+
+    test.only(
+      'should resize equally with tools or drawers',
+      setupTest(async page => {
+        await page.setWindowSize({ ...viewports.desktop, width: 1800 });
+        await page.click(wrapper.findToolsToggle().toSelector());
+        await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+        await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
+        const tile = createWrapper().findModal().findContent().findTiles().findItemByValue('side');
+        await page.click(tile.toSelector());
+        await page.click('button=Confirm');
+
+        const { width: splitPanelWidthWithTools } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
+
+        await page.click(wrapper.findDrawerTriggerById('circle').toSelector());
+        const { width: splitPanelWidthWithDrawer } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
+
+        expect(splitPanelWidthWithTools).toEqual(splitPanelWidthWithDrawer);
       })
     );
 

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -541,10 +541,20 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       function handleSplitPanelMaxWidth() {
         const contentGapRight = 80; // Approximately 40px when rendered but doubled for safety
         const toolsFormOffsetWidth = 160; // Approximately 80px when rendered but doubled for safety
-        const panelOffsetWidth = isToolsOpen ? toolsWidth : activeDrawerId ? drawerSize : 0;
+        const getPanelOffsetWidth = () => {
+          if (drawers) {
+            return activeDrawerId ? drawerSize : 0;
+          }
+          return isToolsOpen ? toolsWidth : 0;
+        };
 
         setSplitPanelMaxWidth(
-          layoutWidth - mainOffsetLeft - minContentWidth - contentGapRight - toolsFormOffsetWidth - panelOffsetWidth
+          layoutWidth -
+            mainOffsetLeft -
+            minContentWidth -
+            contentGapRight -
+            toolsFormOffsetWidth -
+            getPanelOffsetWidth()
         );
 
         setDrawersMaxWidth(layoutWidth - mainOffsetLeft - minContentWidth - contentGapRight - toolsFormOffsetWidth);
@@ -552,6 +562,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       [
         activeDrawerId,
         drawerSize,
+        drawers,
         isNavigationOpen,
         isToolsOpen,
         layoutWidth,

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -541,17 +541,10 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       function handleSplitPanelMaxWidth() {
         const contentGapRight = 80; // Approximately 40px when rendered but doubled for safety
         const toolsFormOffsetWidth = 160; // Approximately 80px when rendered but doubled for safety
-        const toolsOffsetWidth = isToolsOpen ? toolsWidth : 0;
-        const activeDrawerOffsetWidth = activeDrawerId ? drawerSize : 0;
+        const panelOffsetWidth = isToolsOpen ? toolsWidth : activeDrawerId ? drawerSize : 0;
 
         setSplitPanelMaxWidth(
-          layoutWidth -
-            mainOffsetLeft -
-            minContentWidth -
-            contentGapRight -
-            toolsOffsetWidth -
-            toolsFormOffsetWidth -
-            activeDrawerOffsetWidth
+          layoutWidth - mainOffsetLeft - minContentWidth - contentGapRight - toolsFormOffsetWidth - panelOffsetWidth
         );
 
         setDrawersMaxWidth(layoutWidth - mainOffsetLeft - minContentWidth - contentGapRight - toolsFormOffsetWidth);


### PR DESCRIPTION
### Description
From Drawers Bug Bash.

With both tools and drawers, having both tools and a side split panel open simultaneously was not allowing for adequate resize of split panel.

This merges the variables into a single variable when calculating the max width of the split panel, so that the two function the same.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
