### PR TITLE
fix: Pushes content over when drawer opens, and adds test

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -22,6 +22,7 @@ type DemoContext = React.Context<
   AppContextType<{
     hasDrawers: boolean | undefined;
     splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+    disableContentPaddings: boolean | undefined;
   }>
 >;
 
@@ -38,6 +39,7 @@ export default function WithDrawers() {
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
   const hasDrawers = urlParams.hasDrawers ?? true;
+  const disableContentPaddings = urlParams.disableContentPaddings ?? false;
 
   const drawers = !hasDrawers
     ? null
@@ -155,6 +157,7 @@ export default function WithDrawers() {
         breadcrumbs={<Breadcrumbs />}
         content={
           <ContentLayout
+            data-test-id="content"
             header={
               <SpaceBetween size="m">
                 <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
@@ -183,6 +186,7 @@ export default function WithDrawers() {
           const { position } = event.detail;
           setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
         }}
+        disableContentPaddings={disableContentPaddings}
         splitPanel={
           <SplitPanel
             header="Split panel header"

--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -52,30 +52,46 @@ class AppLayoutDrawersPage extends BasePageObject {
     const { width } = await this.getBoundingBox(wrapper.findSplitPanel().toSelector());
     return width;
   }
+
+  async getMainContentWidth() {
+    const { width } = await this.getBoundingBox(wrapper.find('[data-test-id="content"]').toSelector());
+    return width;
+  }
 }
 
 interface SetupTestOptions {
   splitPanelPosition?: string;
   screenSize?: typeof viewports['desktop' | 'mobile'];
+  disableContentPaddings?: string;
+  visualRefresh?: string;
 }
 
-for (const visualRefresh of [true, false]) {
-  const setupTest = (
-    { splitPanelPosition = 'bottom', screenSize = viewports.desktop }: SetupTestOptions,
-    testFn: (page: AppLayoutDrawersPage) => Promise<void>
-  ) =>
-    useBrowser(screenSize, async browser => {
-      const page = new AppLayoutDrawersPage(browser);
-      const params = new URLSearchParams({ visualRefresh: `${visualRefresh}`, splitPanelPosition }).toString();
-      await browser.url(`#/light/app-layout/with-drawers?${params}`);
-      await page.waitForVisible(wrapper.findContentRegion().toSelector());
-      await testFn(page);
-    });
+const setupTest = (
+  {
+    splitPanelPosition = 'bottom',
+    screenSize = viewports.desktop,
+    disableContentPaddings = 'false',
+    visualRefresh = 'false',
+  }: SetupTestOptions,
+  testFn: (page: AppLayoutDrawersPage) => Promise<void>
+) =>
+  useBrowser(screenSize, async browser => {
+    const page = new AppLayoutDrawersPage(browser);
+    const params = new URLSearchParams({
+      visualRefresh,
+      splitPanelPosition,
+      disableContentPaddings,
+    }).toString();
+    await browser.url(`#/light/app-layout/with-drawers?${params}`);
+    await page.waitForVisible(wrapper.findContentRegion().toSelector());
+    await testFn(page);
+  });
 
+for (const visualRefresh of ['true', 'false']) {
   describe(`visualRefresh=${visualRefresh}`, () => {
     test(
       'slider is accessible by keyboard in side position',
-      setupTest({}, async page => {
+      setupTest({ visualRefresh }, async page => {
         await page.openFirstDrawer();
         await page.keys(['Enter']);
         await expect(page.isFocused(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(true);
@@ -89,7 +105,7 @@ for (const visualRefresh of [true, false]) {
 
     test(
       'hides the resize handle on mobile',
-      setupTest({}, async page => {
+      setupTest({ visualRefresh }, async page => {
         await page.openFirstDrawer();
         await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(true);
 
@@ -100,20 +116,20 @@ for (const visualRefresh of [true, false]) {
 
     test(
       `should not allow resize drawer beyond min and max limits`,
-      setupTest({}, async page => {
+      setupTest({ visualRefresh }, async page => {
         await page.openFirstDrawer();
         const { width } = await page.getWindowSize();
         await page.dragResizerTo({ x: width, y: 0 });
         // there are different layouts between these two designs
-        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh ? 292 : 280);
+        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh === 'true' ? 292 : 280);
         await page.dragResizerTo({ x: 0, y: 0 });
-        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh ? 362 : 520);
+        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh === 'true' ? 362 : 520);
       })
     );
 
     test(
       'automatically shrinks drawer when screen resizes',
-      setupTest({}, async page => {
+      setupTest({ visualRefresh }, async page => {
         const largeWindowWidth = 1400;
         const smallWindowWidth = 900;
         await page.setWindowSize({ ...viewports.desktop, width: largeWindowWidth });
@@ -128,49 +144,71 @@ for (const visualRefresh of [true, false]) {
 
     test(
       `should not shrink drawer beyond min width`,
-      setupTest({ screenSize: { ...viewports.desktop, width: 700 } }, async page => {
+      setupTest({ visualRefresh, screenSize: { ...viewports.desktop, width: 700 } }, async page => {
         await page.openThirdDrawer();
         // there are different layouts between these two designs
         // the min-width of the drawer is 290
-        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh ? 292 : 290);
+        await expect(page.getActiveDrawerWidth()).resolves.toEqual(visualRefresh === 'true' ? 292 : 290);
       })
     );
 
     test(
       'split panel and drawer can resize independently',
-      setupTest({ splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1800 } }, async page => {
-        await page.openFirstDrawer();
-        await page.openSplitPanel();
+      setupTest(
+        { visualRefresh, splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1800 } },
+        async page => {
+          await page.openFirstDrawer();
+          await page.openSplitPanel();
 
-        const originalSplitPanelWidth = await page.getSplitPanelWidth();
-        const originalDrawerWidth = await page.getActiveDrawerWidth();
-        await page.dragAndDrop(wrapper.findSplitPanel().findSlider().toSelector(), 100);
+          const originalSplitPanelWidth = await page.getSplitPanelWidth();
+          const originalDrawerWidth = await page.getActiveDrawerWidth();
+          await page.dragAndDrop(wrapper.findSplitPanel().findSlider().toSelector(), 100);
 
-        const newSplitPanelWidth = await page.getSplitPanelWidth();
-        expect(newSplitPanelWidth).toBeLessThan(originalSplitPanelWidth);
-        await expect(page.getActiveDrawerWidth()).resolves.toEqual(originalDrawerWidth);
+          const newSplitPanelWidth = await page.getSplitPanelWidth();
+          expect(newSplitPanelWidth).toBeLessThan(originalSplitPanelWidth);
+          await expect(page.getActiveDrawerWidth()).resolves.toEqual(originalDrawerWidth);
 
-        await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -100);
-        await expect(page.getSplitPanelWidth()).resolves.toEqual(newSplitPanelWidth);
-        await expect(page.getActiveDrawerWidth()).resolves.toBeGreaterThan(originalDrawerWidth);
-      })
+          await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -100);
+          await expect(page.getSplitPanelWidth()).resolves.toEqual(newSplitPanelWidth);
+          await expect(page.getActiveDrawerWidth()).resolves.toBeGreaterThan(originalDrawerWidth);
+        }
+      )
     );
 
     test(
       'updates side split panel position when using different width drawers',
-      setupTest({ splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1500 } }, async page => {
-        await page.openFirstDrawer();
-        await page.openSplitPanel();
-        await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toEqual(true);
+      setupTest(
+        { visualRefresh, splitPanelPosition: 'side', screenSize: { ...viewports.desktop, width: 1500 } },
+        async page => {
+          await page.openFirstDrawer();
+          await page.openSplitPanel();
+          await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toEqual(
+            true
+          );
 
-        await page.openThirdDrawer();
-        await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelBottom().toSelector())).resolves.toEqual(
-          true
-        );
+          await page.openThirdDrawer();
+          await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelBottom().toSelector())).resolves.toEqual(
+            true
+          );
 
-        await page.openFirstDrawer();
-        await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toEqual(true);
-      })
+          await page.openFirstDrawer();
+          await expect(page.isExisting(wrapper.findSplitPanel().findOpenPanelSide().toSelector())).resolves.toEqual(
+            true
+          );
+        }
+      )
     );
   });
 }
+
+describe('Visual refresh only', () => {
+  test(
+    'pushes content over with disableContentPaddings',
+    setupTest({ disableContentPaddings: 'true', visualRefresh: 'true' }, async page => {
+      const width = await page.getMainContentWidth();
+      await page.openFirstDrawer();
+      const newWidth = await page.getMainContentWidth();
+      await expect(width).toBeGreaterThan(newWidth);
+    })
+  );
+});

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -38,7 +38,8 @@
       }
 
       &.is-tools-open,
-      &.is-split-panel-open.split-panel-position-side {
+      &.is-split-panel-open.split-panel-position-side,
+      &.has-active-drawer {
         grid-column-end: 5;
       }
     }

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -20,6 +20,7 @@ export default function Main() {
     offsetBottom,
     splitPanelDisplayed,
     splitPanelPosition,
+    activeDrawerId,
   } = useAppLayoutInternals();
 
   const splitPanelHeight = offsetBottom - footerHeight;
@@ -34,6 +35,7 @@ export default function Main() {
           [styles['has-split-panel']]: splitPanelDisplayed,
           [styles['is-navigation-open']]: isNavigationOpen,
           [styles['is-tools-open']]: isToolsOpen,
+          [styles['has-active-drawer']]: !!activeDrawerId,
           [styles['is-split-panel-open']]: isSplitPanelOpen,
           [styles.unfocusable]: hasDrawerViewportOverlay,
         },


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
From Drawers Bug Bash.

An open drawer wasn't pushing over the content when `disableContentPaddings` was true. This updates the logic in the main file and adds an appropriate integration test.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
