### PR TITLE
chore: Remove additional div from Modal

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -13,6 +13,8 @@ import { useMobile } from '../internal/hooks/use-mobile';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import styles from './styles.css.js';
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
+import { useModalContext } from '../internal/context/modal-context';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>, InternalBaseComponentProps {
   __stickyHeader?: boolean;
@@ -38,7 +40,15 @@ export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>,
 
 export function InternalContainerAsSubstep(props: InternalContainerProps) {
   const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
-  return <InternalContainer {...props} __subStepRef={subStepRef} __funnelSubStepProps={funnelSubStepProps} />;
+  const modalContext = useModalContext();
+
+  return (
+    <InternalContainer
+      {...props}
+      __subStepRef={modalContext?.isInModal ? { current: null } : subStepRef}
+      __funnelSubStepProps={modalContext?.isInModal ? {} : funnelSubStepProps}
+    />
+  );
 }
 
 export default function InternalContainer({
@@ -76,13 +86,14 @@ export default function InternalContainer({
     __mobileStickyOffset,
     __disableStickyMobile
   );
+  const contentId = useUniqueId();
   const { setHasStickyBackground } = useAppLayoutContext();
   const isRefresh = useVisualRefresh();
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
   const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight || !__darkHeader });
 
-  const mergedRef = useMergeRefs(rootRef, __subStepRef, __internalRootRef);
+  const mergedRef = useMergeRefs(rootRef, __internalRootRef);
   const headerMergedRef = useMergeRefs(headerRef, overlapElement, __headerRef);
 
   /**
@@ -132,7 +143,11 @@ export default function InternalContainer({
           {media.content}
         </div>
       )}
-      <div className={clsx(styles['content-wrapper'], fitHeight && styles['content-wrapper-fit-height'])}>
+      <div
+        id={contentId}
+        ref={__subStepRef}
+        className={clsx(styles['content-wrapper'], fitHeight && styles['content-wrapper-fit-height'])}
+      >
         {header && (
           <StickyHeaderContext.Provider value={{ isStuck }}>
             <div

--- a/src/expandable-section/expandable-section-container.tsx
+++ b/src/expandable-section/expandable-section-container.tsx
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import InternalContainer, { InternalContainerProps } from '../container/internal';
+import { InternalContainerAsSubstep } from '../container/internal';
 import React from 'react';
 import { ExpandableSectionProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+
+import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 
 export interface ExpandableSectionContainerProps extends InternalBaseComponentProps {
   className?: string;
@@ -12,8 +14,6 @@ export interface ExpandableSectionContainerProps extends InternalBaseComponentPr
   variant: ExpandableSectionProps.Variant;
   expanded: boolean | undefined;
   disableContentPaddings: boolean | undefined;
-  __funnelSubStepProps?: InternalContainerProps['__funnelSubStepProps'];
-  __subStepRef?: InternalContainerProps['__subStepRef'];
 }
 
 export const ExpandableSectionContainer = ({
@@ -24,26 +24,24 @@ export const ExpandableSectionContainer = ({
   expanded,
   disableContentPaddings,
   __internalRootRef,
-  __funnelSubStepProps,
-  __subStepRef,
   ...rest
 }: ExpandableSectionContainerProps) => {
   if (variant === 'container' || variant === 'stacked') {
     return (
-      <InternalContainer
-        {...rest}
-        className={className}
-        header={header}
-        variant={variant === 'stacked' ? 'stacked' : 'default'}
-        disableContentPaddings={disableContentPaddings || !expanded}
-        disableHeaderPaddings={true}
-        __hiddenContent={!expanded}
-        __internalRootRef={__internalRootRef}
-        __funnelSubStepProps={__funnelSubStepProps}
-        __subStepRef={__subStepRef}
-      >
-        {children}
-      </InternalContainer>
+      <AnalyticsFunnelSubStep>
+        <InternalContainerAsSubstep
+          {...rest}
+          className={className}
+          header={header}
+          variant={variant === 'stacked' ? 'stacked' : 'default'}
+          disableContentPaddings={disableContentPaddings || !expanded}
+          disableHeaderPaddings={true}
+          __hiddenContent={!expanded}
+          __internalRootRef={__internalRootRef}
+        >
+          {children}
+        </InternalContainerAsSubstep>
+      </AnalyticsFunnelSubStep>
     );
   }
 

--- a/src/expandable-section/index.tsx
+++ b/src/expandable-section/index.tsx
@@ -4,31 +4,15 @@ import React from 'react';
 
 import { ExpandableSectionProps } from './interfaces';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
-import InternalExpandableSection, { InternalExpandableSectionProps } from './internal';
+import InternalExpandableSection from './internal';
 import useBaseComponent from '../internal/hooks/use-base-component';
-import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
-import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 
 export { ExpandableSectionProps };
 
 export default function ExpandableSection({ variant = 'default', ...props }: ExpandableSectionProps) {
   const baseComponentProps = useBaseComponent('ExpandableSection');
 
-  if (variant === 'container' || variant === 'stacked') {
-    return (
-      <AnalyticsFunnelSubStep>
-        <InternalExpandableSectionAsSubstep variant={variant} {...props} {...baseComponentProps} />
-      </AnalyticsFunnelSubStep>
-    );
-  } else {
-    return <InternalExpandableSection variant={variant} {...props} {...baseComponentProps} />;
-  }
-}
-
-function InternalExpandableSectionAsSubstep(props: InternalExpandableSectionProps) {
-  const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
-
-  return <InternalExpandableSection {...props} __subStepRef={subStepRef} __funnelSubStepProps={funnelSubStepProps} />;
+  return <InternalExpandableSection variant={variant} {...props} {...baseComponentProps} />;
 }
 
 applyDisplayName(ExpandableSection, 'ExpandableSection');

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -13,14 +13,12 @@ import { fireNonCancelableEvent } from '../internal/events';
 import { ExpandableSectionProps } from './interfaces';
 
 import styles from './styles.css.js';
-import { ExpandableSectionContainer, ExpandableSectionContainerProps } from './expandable-section-container';
+import { ExpandableSectionContainer } from './expandable-section-container';
 import { ExpandableSectionHeader } from './expandable-section-header';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { variantSupportsDescription } from './utils';
 
-export type InternalExpandableSectionProps = ExpandableSectionProps &
-  InternalBaseComponentProps &
-  Pick<ExpandableSectionContainerProps, '__funnelSubStepProps' | '__subStepRef'>;
+export type InternalExpandableSectionProps = ExpandableSectionProps & InternalBaseComponentProps;
 
 export default function InternalExpandableSection({
   expanded: controlledExpanded,
@@ -38,8 +36,6 @@ export default function InternalExpandableSection({
   disableContentPaddings,
   headerAriaLabel,
   __internalRootRef,
-  __funnelSubStepProps,
-  __subStepRef,
   ...props
 }: InternalExpandableSectionProps) {
   const ref = useRef<HTMLDivElement>(null);
@@ -102,8 +98,6 @@ export default function InternalExpandableSection({
       expanded={expanded}
       className={clsx(baseProps.className, styles.root)}
       variant={variant}
-      __funnelSubStepProps={__funnelSubStepProps}
-      __subStepRef={__subStepRef}
       disableContentPaddings={disableContentPaddings}
       header={
         <ExpandableSectionHeader

--- a/src/internal/context/modal-context.ts
+++ b/src/internal/context/modal-context.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext, useContext } from 'react';
+
+export const ModalContext = createContext<{ isInModal: boolean }>({ isInModal: false });
+
+export const useModalContext = () => {
+  const modalContext = useContext(ModalContext);
+  return modalContext;
+};

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -47,16 +47,14 @@ const selectionColumnId = Symbol('selection-column-id');
 type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps & {
     __funnelSubStepProps?: InternalContainerProps['__funnelSubStepProps'];
-    __subStepRef?: InternalContainerProps['__subStepRef'];
   };
 
 export const InternalTableAsSubstep = React.forwardRef(
   <T,>(props: InternalTableProps<T>, ref: React.Ref<TableProps.Ref>) => {
-    const { subStepRef, funnelSubStepProps } = useFunnelSubStep();
+    const { funnelSubStepProps } = useFunnelSubStep();
 
     const tableProps: InternalTableProps<T> = {
       ...props,
-      __subStepRef: subStepRef,
       __funnelSubStepProps: funnelSubStepProps,
     };
 
@@ -107,7 +105,6 @@ const InternalTable = React.forwardRef(
       stickyColumns,
       columnDisplay,
       __funnelSubStepProps,
-      __subStepRef,
       ...rest
     }: InternalTableProps<T>,
     ref: React.Ref<TableProps.Ref>
@@ -265,7 +262,6 @@ const InternalTable = React.forwardRef(
             __internalRootRef={__internalRootRef}
             className={clsx(baseProps.className, styles.root)}
             __funnelSubStepProps={__funnelSubStepProps}
-            __subStepRef={__subStepRef}
             header={
               <>
                 {hasHeader && (


### PR DESCRIPTION
### Description

Additional div around the modal was initially used to associate the HTML node used by the Portal which would later be used to check from funnel step focus by checking if a focussed element is a descendant of this node. This information is useful to understand if a user is still on the same step when opening a modal from a form element in that given step, e.g. an s3 resource selector. However the additional div caused a layout shift. 

We do not have a strong use case for embedded funnels inside a modal as they are primarily either a Form or Wizard and so we can ignore further interactions in this and change if new data is presented.

This change:
- Reverts/refactors some code made in [1494](https://github.com/cloudscape-design/components/pull/1494)
- Adds a modal context so that funnel components can ignore some of the funnel functions when they detect they are in Modal

Related links, issue #, if available: AWSUI-22535

### How has this been tested?

All existing unit tests passing which includes a test for if a funnel step state change happens when focus moves from an active step into a Modal inside a step.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
