### PR TITLE
fix: Positions drawer slider so that it does not scroll with content

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -17,6 +17,7 @@ import { Breadcrumbs, Containers } from './utils/content-blocks';
 import ScreenshotArea from '../utils/screenshot-area';
 import type { DrawerItem } from '~components/app-layout/drawer/interfaces';
 import AppContext, { AppContextType } from '../app/app-context';
+import styles from './styles.scss';
 
 type DemoContext = React.Context<
   AppContextType<{
@@ -213,7 +214,15 @@ export default function WithDrawers() {
 }
 
 function Security() {
-  return <HelpPanel header={<h2>Security</h2>}>Everyone needs it.</HelpPanel>;
+  return (
+    <HelpPanel header={<h2>Security</h2>}>
+      <SpaceBetween size="l">
+        <div className={styles.contentPlaceholder} />
+        <div className={styles.contentPlaceholder} />
+        <div className={styles.contentPlaceholder} />
+      </SpaceBetween>
+    </HelpPanel>
+  );
 }
 
 function ProHelp() {

--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -204,7 +204,11 @@ export default function WithDrawers() {
               resizeHandleAriaLabel: 'Slider',
             }}
           >
-            This is the Split Panel!
+            <SpaceBetween size="l">
+              <div className={styles.contentPlaceholder} />
+              <div className={styles.contentPlaceholder} />
+              <div className={styles.contentPlaceholder} />
+            </SpaceBetween>
           </SplitPanel>
         }
         {...drawers}

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -131,36 +131,43 @@
   background-color: awsui.$color-background-container-content;
   border-color: transparent;
   display: grid;
+  grid-template-columns: awsui.$space-m 1fr;
   flex-shrink: 0;
-  grid-template-columns: awsui.$space-m 1fr auto awsui.$space-m;
-  grid-template-rows: awsui.$size-vertical-panel-icon-offset auto 1fr;
+
   height: 100%;
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: hidden;
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
   overscroll-behavior-y: contain;
   pointer-events: auto;
   word-wrap: break-word;
 
-  > .drawer-close-button {
-    grid-column: 3;
-    grid-row: 2;
-    z-index: 1;
-  }
-
-  > .drawer-content {
-    grid-column: 1 / span 4;
-    grid-row: 1 / span 3;
+  > .drawer-content-container {
+    grid-column: 1 / span 2;
+    grid-row: 1;
     width: var(#{custom-props.$drawerSize});
+    display: grid;
+    grid-template-columns: awsui.$space-m 1fr auto awsui.$space-m;
+    grid-template-rows: awsui.$size-vertical-panel-icon-offset auto 1fr;
+    overflow-y: auto;
+
+    > .drawer-close-button {
+      grid-column: 3;
+      grid-row: 2;
+      z-index: 1;
+    }
+
+    > .drawer-content {
+      grid-column: 1 / span 4;
+    }
   }
 
   > .drawer-slider {
     grid-column: 1;
-    grid-row: 1 / span 3;
+    grid-row: 1;
     height: 100%;
     display: flex;
     align-items: center;
-    position: absolute;
   }
 
   &:not(.is-drawer-open) {

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -160,6 +160,7 @@
     height: 100%;
     display: flex;
     align-items: center;
+    position: absolute;
   }
 
   &:not(.is-drawer-open) {

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -111,25 +111,26 @@ function ActiveDrawer() {
       }}
     >
       {!isMobile && activeDrawer?.resizable && resizeHandle}
-      <div className={clsx(styles['drawer-close-button'])}>
-        <InternalButton
-          ariaLabel={computedAriaLabels.closeButton}
-          className={clsx({
-            [testutilStyles['active-drawer-close-button']]: activeDrawerId,
-            [testutilStyles['tools-close']]: isToolsDrawer,
-          })}
-          formAction="none"
-          iconName={isMobile ? 'close' : 'angle-right'}
-          onClick={() => {
-            handleDrawersClick(activeDrawerId ?? undefined);
-            handleToolsClick(false);
-          }}
-          ref={drawersRefs.close}
-          variant="icon"
-        />
+      <div className={styles['drawer-content-container']}>
+        <div className={clsx(styles['drawer-close-button'])}>
+          <InternalButton
+            ariaLabel={computedAriaLabels.closeButton}
+            className={clsx({
+              [testutilStyles['active-drawer-close-button']]: activeDrawerId,
+              [testutilStyles['tools-close']]: isToolsDrawer,
+            })}
+            formAction="none"
+            iconName={isMobile ? 'close' : 'angle-right'}
+            onClick={() => {
+              handleDrawersClick(activeDrawerId ?? undefined);
+              handleToolsClick(false);
+            }}
+            ref={drawersRefs.close}
+            variant="icon"
+          />
+        </div>
+        <div className={styles['drawer-content']}>{activeDrawerId && activeDrawer?.content}</div>
       </div>
-
-      <div className={styles['drawer-content']}>{activeDrawerId && activeDrawer?.content}</div>
     </aside>
   );
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
From Drawers Bug Bash.

The Drawers slider was scrolling up with long content, instead of being sticky like the split panel. This moves the slider out of the scrollable content area and reworks the grid.

This also adds scrolling content to the test page.
![image](https://github.com/cloudscape-design/components/assets/9701338/d936ab3a-fe40-4186-b7be-ad5fd17a195f)


<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
