### PR TITLE
refactor: Column auto width is set in column widths utils

### DIFF
--- a/src/anchor-navigation/use-scroll-spy.tsx
+++ b/src/anchor-navigation/use-scroll-spy.tsx
@@ -37,7 +37,7 @@ export default function useScrollSpy({
   }, [hrefs]);
 
   // Get the bounding rectangle of an element by href
-  const getRectByHref = useCallback(href => {
+  const getRectByHref = useCallback((href: string) => {
     return document.getElementById(href.slice(1))?.getBoundingClientRect();
   }, []);
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -259,7 +259,11 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <ColumnWidthsProvider visibleColumns={visibleColumnWidthsWithSelection} resizableColumns={resizableColumns}>
+        <ColumnWidthsProvider
+          visibleColumns={visibleColumnWidthsWithSelection}
+          resizableColumns={resizableColumns}
+          containerWidth={containerWidth ?? 0}
+        >
           <InternalContainer
             {...baseProps}
             __internalRootRef={__internalRootRef}

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -156,7 +156,7 @@ export function useStickyCellStyles({
 
   // refCallback updates the cell ref and sets up the store subscription
   const refCallback = useCallback(
-    cellElement => {
+    (cellElement: null | HTMLElement) => {
       if (unsubscribeRef.current) {
         // Unsubscribe before we do any updates to avoid leaving any subscriptions hanging
         unsubscribeRef.current();

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -130,7 +130,7 @@ const Thead = React.forwardRef(
 
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
-            const columnWidth = resizableColumns && columnWidths ? columnWidths[columnId] : column.width;
+            const columnWidth = resizableColumns ? columnWidths[columnId] ?? 'auto' : column.width;
             return (
               <TableHeaderCell
                 key={columnId}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -46,7 +46,6 @@ export interface TheadProps {
 const Thead = React.forwardRef(
   (
     {
-      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions,
@@ -89,7 +88,7 @@ const Thead = React.forwardRef(
       isVisualRefresh && styles['is-visual-refresh']
     );
 
-    const { columnWidths, totalWidth, updateColumn, setCell } = useColumnWidths();
+    const { columnWidths, updateColumn, setCell } = useColumnWidths();
 
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
@@ -131,18 +130,7 @@ const Thead = React.forwardRef(
 
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
-
-            let columnWidth = column.width;
-            if (resizableColumns) {
-              if (columnWidths) {
-                // use stateful value if available
-                columnWidth = columnWidths[columnId];
-              }
-              if (colIndex === columnDefinitions.length - 1 && containerWidth && containerWidth > totalWidth) {
-                // let the last column grow and fill the container width
-                columnWidth = undefined;
-              }
-            }
+            const columnWidth = resizableColumns && columnWidths ? columnWidths[columnId] : column.width;
             return (
               <TableHeaderCell
                 key={columnId}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -132,15 +132,15 @@ const Thead = React.forwardRef(
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
 
-            let widthOverride;
+            let columnWidth = column.width;
             if (resizableColumns) {
               if (columnWidths) {
                 // use stateful value if available
-                widthOverride = columnWidths[columnId];
+                columnWidth = columnWidths[columnId];
               }
               if (colIndex === columnDefinitions.length - 1 && containerWidth && containerWidth > totalWidth) {
                 // let the last column grow and fill the container width
-                widthOverride = 'auto';
+                columnWidth = undefined;
               }
             }
             return (
@@ -148,7 +148,7 @@ const Thead = React.forwardRef(
                 key={columnId}
                 className={headerCellClass}
                 style={{
-                  width: widthOverride || column.width,
+                  width: columnWidth,
                   minWidth: sticky ? undefined : column.minWidth,
                   maxWidth: resizableColumns || sticky ? undefined : column.maxWidth,
                 }}

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState, createContext, useContext } from 'react';
+import React, { useEffect, useRef, useState, createContext, useContext, useMemo } from 'react';
 
 export const DEFAULT_COLUMN_WIDTH = 120;
 
@@ -47,14 +47,12 @@ function updateWidths(
 }
 
 interface WidthsContext {
-  totalWidth: number;
   columnWidths: Record<PropertyKey, number>;
   updateColumn: (columnId: PropertyKey, newWidth: number) => void;
   setCell: (columnId: PropertyKey, node: null | HTMLElement) => void;
 }
 
 const WidthsContext = createContext<WidthsContext>({
-  totalWidth: 0,
   columnWidths: {},
   updateColumn: () => {},
   setCell: () => {},
@@ -63,10 +61,16 @@ const WidthsContext = createContext<WidthsContext>({
 interface WidthProviderProps {
   visibleColumns: readonly ColumnWidthDefinition[];
   resizableColumns: boolean | undefined;
+  containerWidth: number;
   children: React.ReactNode;
 }
 
-export function ColumnWidthsProvider({ visibleColumns, resizableColumns, children }: WidthProviderProps) {
+export function ColumnWidthsProvider({
+  visibleColumns,
+  resizableColumns,
+  containerWidth,
+  children,
+}: WidthProviderProps) {
   const visibleColumnsRef = useRef<(PropertyKey | undefined)[] | null>(null);
   const [columnWidths, setColumnWidths] = useState<Record<PropertyKey, number>>({});
 
@@ -100,7 +104,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, childre
       }
     }
     visibleColumnsRef.current = visibleColumns.map(column => column.id);
-  }, [columnWidths, resizableColumns, visibleColumns]);
+  }, [columnWidths, resizableColumns, visibleColumns, setColumnWidths]);
 
   // Read the actual column widths after the first render to employ the browser defaults for
   // those columns without explicit width.
@@ -117,13 +121,19 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, childre
     setColumnWidths(columnWidths => updateWidths(visibleColumns, columnWidths, newWidth, columnId));
   }
 
-  const totalWidth = visibleColumns.reduce(
-    (total, column) => total + (columnWidths[column.id] || DEFAULT_COLUMN_WIDTH),
-    0
-  );
+  const columnWidthsWithAuto = useMemo(() => {
+    const nextWidths = { ...columnWidths };
+    const totalWidth = visibleColumns.reduce((total, { id }) => total + (nextWidths[id] || DEFAULT_COLUMN_WIDTH), 0);
+
+    // The width of the last column is not set when there is enough space to allow the column to grow.
+    if (visibleColumns.length > 0 && containerWidth > totalWidth) {
+      delete nextWidths[visibleColumns[visibleColumns.length - 1].id];
+    }
+    return nextWidths;
+  }, [columnWidths, visibleColumns, containerWidth]);
 
   return (
-    <WidthsContext.Provider value={{ columnWidths, totalWidth, updateColumn, setCell }}>
+    <WidthsContext.Provider value={{ columnWidths: columnWidthsWithAuto, updateColumn, setCell }}>
       {children}
     </WidthsContext.Provider>
   );


### PR DESCRIPTION
### Description

Moving column width related logic loser together. It is a step towards resolving the issue visible with React 18 when containerWidth changes in an effect causing the auto width to be calculated one render too late. As result the last column can be resized below its min width for a short while.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
