### PR TITLE
fix: Ensure split panel heading styling matches other drawers

### DIFF
--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -255,7 +255,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   display: flex;
   flex: auto;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   width: 100%;
   margin: awsui.$size-vertical-panel-icon-offset 0;
@@ -263,6 +263,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
     @include styles.font-panel-header;
     padding: 0;
     margin: 0;
+    margin-top: calc(#{awsui.$space-scaled-xxs} + 1px);
   }
 }
 

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -255,13 +255,13 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
   display: flex;
   flex: auto;
   flex-direction: row;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   width: 100%;
-  margin: awsui.$space-scaled-m 0 awsui.$space-m 0;
+  margin: awsui.$size-vertical-panel-icon-offset 0;
   &-text {
     @include styles.font-panel-header;
-    padding: awsui.$space-xxs 0 awsui.$space-scaled-xxs 0;
+    padding: 0;
     margin: 0;
   }
 }


### PR DESCRIPTION
### Description

Fix some small alignment issues between split panel and help panel/other drawers

Related links, issue #, if available: Follow-up to #1620

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
