### PR TITLE
chore: Add ScreenshotArea to table sticky-header test page

### DIFF
--- a/pages/table/sticky-header-with-actions.page.tsx
+++ b/pages/table/sticky-header-with-actions.page.tsx
@@ -6,6 +6,7 @@ import ButtonDropdown, { ButtonDropdownProps } from '~components/button-dropdown
 import Table from '~components/table';
 import { Instance, generateItems } from '../table/generate-data';
 import { columnsConfig, selectionLabels } from '../table/shared-configs';
+import ScreenshotArea from '../utils/screenshot-area';
 
 const dropdownItems: Array<ButtonDropdownProps.Item> = [
   { id: '1', text: 'Item 1' },
@@ -20,29 +21,31 @@ export default function () {
   return (
     <>
       <h1>Table with a sticky header and actions</h1>
-      <div style={{ height: '400px', width: '500px', overflow: 'auto', padding: '0px 1px' }} id="scroll-container">
-        <div style={{ height: '100px' }} />
-        <Table<Instance>
-          ariaLabels={selectionLabels}
-          selectionType="multi"
-          stickyColumns={{ last: 1 }}
-          header={
-            <Header
-              actions={
-                <ButtonDropdown data-test-id="actions-button" items={dropdownItems}>
-                  Actions
-                </ButtonDropdown>
-              }
-              headingTagOverride="h1"
-            >
-              Instances
-            </Header>
-          }
-          columnDefinitions={columnsConfig}
-          items={generateItems(1)}
-          stickyHeader={true}
-        />
-      </div>
+      <ScreenshotArea>
+        <div style={{ height: '400px', width: '500px', overflow: 'auto', padding: '0px 1px' }} id="scroll-container">
+          <div style={{ height: '100px' }} />
+          <Table<Instance>
+            ariaLabels={selectionLabels}
+            selectionType="multi"
+            stickyColumns={{ last: 1 }}
+            header={
+              <Header
+                actions={
+                  <ButtonDropdown data-test-gid="actions-button" items={dropdownItems}>
+                    Actions
+                  </ButtonDropdown>
+                }
+                headingTagOverride="h1"
+              >
+                Instances
+              </Header>
+            }
+            columnDefinitions={columnsConfig}
+            items={generateItems(1)}
+            stickyHeader={true}
+          />
+        </div>
+      </ScreenshotArea>
     </>
   );
 }

--- a/pages/table/sticky-header-with-actions.page.tsx
+++ b/pages/table/sticky-header-with-actions.page.tsx
@@ -31,7 +31,7 @@ export default function () {
             header={
               <Header
                 actions={
-                  <ButtonDropdown data-test-gid="actions-button" items={dropdownItems}>
+                  <ButtonDropdown data-test-id="actions-button" items={dropdownItems}>
                     Actions
                   </ButtonDropdown>
                 }


### PR DESCRIPTION
### Description

There was a missing `.screnshot-area` on the test page.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
