### PR TITLE
fix: Fix alignment for header with non-interactive elements in actions

### DIFF
--- a/pages/expandable-section/common.tsx
+++ b/pages/expandable-section/common.tsx
@@ -3,6 +3,7 @@
 import Link from '~components/link';
 import React from 'react';
 import Button from '~components/button';
+import StatusIndicator from '~components/status-indicator';
 import SpaceBetween from '~components/space-between';
 
 export const headerInfo = <Link variant="info">info</Link>;
@@ -13,3 +14,5 @@ export const headerActions = (
     <Button>Another action</Button>
   </SpaceBetween>
 );
+
+export const headerTextActions = <StatusIndicator>Information</StatusIndicator>;

--- a/pages/expandable-section/container-variant.permutations.page.tsx
+++ b/pages/expandable-section/container-variant.permutations.page.tsx
@@ -6,7 +6,7 @@ import ExpandableSection, { ExpandableSectionProps } from '~components/expandabl
 import ScreenshotArea from '../utils/screenshot-area';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
-import { headerActions, headerInfo } from './common';
+import { headerActions, headerInfo, headerTextActions } from './common';
 
 const permutations = createPermutations<ExpandableSectionProps>([
   {
@@ -18,6 +18,10 @@ const permutations = createPermutations<ExpandableSectionProps>([
     ],
     headerInfo: [undefined, headerInfo],
     headerActions: [undefined, headerActions],
+  },
+  {
+    headerCounter: ['(5)'],
+    headerActions: [headerTextActions],
   },
 ]);
 export default function ExpandableSectionContainerVariantPermutations({

--- a/pages/expandable-section/simple.page.tsx
+++ b/pages/expandable-section/simple.page.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import ExpandableSection from '~components/expandable-section';
 import SpaceBetween from '~components/space-between';
+import Button from '~components/button';
+import StatusIndicator from '~components/status-indicator';
 
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -53,6 +55,25 @@ export default function SimpleContainers() {
             headerCounter={'(5)'}
             variant="container"
             defaultExpanded={true}
+          >
+            Verify or edit the settings below.
+          </ExpandableSection>
+
+          <ExpandableSection
+            headerText={'Header component'}
+            headerCounter={'(5)'}
+            variant="container"
+            defaultExpanded={false}
+            headerActions={<StatusIndicator>Warning</StatusIndicator>}
+          >
+            Verify or edit the settings below.
+          </ExpandableSection>
+          <ExpandableSection
+            headerText={'Header component'}
+            headerCounter={'(5)'}
+            variant="container"
+            defaultExpanded={false}
+            headerActions={<Button>Action</Button>}
           >
             Verify or edit the settings below.
           </ExpandableSection>

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -87,7 +87,12 @@ export default function InternalHeader({
         </div>
         {actions && (
           <div
-            className={clsx(styles.actions, styles[`actions-variant-${variantOverride}`], isRefresh && styles.refresh)}
+            className={clsx(
+              styles.actions,
+              styles[`actions-variant-${variantOverride}`],
+              isRefresh && styles.refresh,
+              !__disableActionsWrapping && [styles['actions-centered']]
+            )}
           >
             {actions}
           </div>

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -92,6 +92,13 @@
   // https://github.com/philipwalton/flexbugs/issues/170
   display: flex;
   align-items: flex-start;
+  min-height: awsui.$size-vertical-input;
+
+  // we can align actions to center in most cases, cause if the header is too long, actions will wrap the first.
+  // exception is Modal header, where __disableActionsWrapping makes header text wrap to multiple lines, shifting the close button
+  &-centered {
+    align-items: center;
+  }
 
   // Calculate padding so the heading text is better aligned with the buttons.
   // Can't align-items: middle because we want buttons to stay at the top of the container when text wraps to multiple lines.


### PR DESCRIPTION
### Description

When an element with a height smaller than button's height is provided to `headerActions` slot, it makes header vertical padding asymmetric.
![image](https://github.com/cloudscape-design/components/assets/29692746/8821ad57-b829-40c8-98b9-93fa93c51f00)

Related links, issue #, if available: AWSUI-22377

### How has this been tested?

New permutation added, waiting for screenshots in dev pipeline 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
