### PR TITLE
fix: Render a hidden copy of tools drawer for compatibility when drawers are used

### DIFF
--- a/pages/app-layout/runtime-drawers-imperative.page.tsx
+++ b/pages/app-layout/runtime-drawers-imperative.page.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useRef } from 'react';
+import { AppLayout, ContentLayout, Header, HelpPanel, Link } from '~components';
+import appLayoutLabels from './utils/labels';
+import { AppLayoutProps } from '~components/app-layout';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import './utils/external-widget';
+
+export default function WithDrawers() {
+  const appLayoutRef = useRef<AppLayoutProps.Ref>(null);
+
+  return (
+    <AppLayout
+      ref={appLayoutRef}
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      content={
+        <ContentLayout
+          header={
+            <Header
+              variant="h1"
+              description="Sometimes you need custom drawers to get the job done."
+              info={<InfoLink />}
+            >
+              Testing Custom Drawers!
+            </Header>
+          }
+        >
+          <Containers />
+        </ContentLayout>
+      }
+      tools={<HelpPanelContent appLayoutRef={appLayoutRef} />}
+    />
+  );
+}
+
+function InfoLink() {
+  function notifyInfoLinkClick() {
+    document.body.dispatchEvent(new CustomEvent('info-link-click'));
+  }
+
+  return (
+    <Link variant="info" onFollow={notifyInfoLinkClick}>
+      Info
+    </Link>
+  );
+}
+
+function HelpPanelContent({ appLayoutRef }: { appLayoutRef: React.RefObject<AppLayoutProps.Ref> }) {
+  useEffect(() => {
+    function handleInfoLinkClick() {
+      appLayoutRef.current!.openTools();
+    }
+
+    document.body.addEventListener('info-link-click', handleInfoLinkClick);
+    return () => document.body.removeEventListener('info-link-click', handleInfoLinkClick);
+  }, [appLayoutRef]);
+
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+}

--- a/pages/app-layout/runtime-drawers-imperative.page.tsx
+++ b/pages/app-layout/runtime-drawers-imperative.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AppLayout, ContentLayout, Header, HelpPanel, Link } from '~components';
 import appLayoutLabels from './utils/labels';
 import { AppLayoutProps } from '~components/app-layout';
@@ -21,12 +21,14 @@ export default function WithDrawers() {
             <Header
               variant="h1"
               description="Sometimes you need custom drawers to get the job done."
-              info={<InfoLink />}
+              info={<InfoLink data-testid="info-link-header" pathSlug="header" />}
             >
               Testing Custom Drawers!
             </Header>
           }
+          disableOverlap={true}
         >
+          <Header info={<InfoLink data-testid="info-link-content" pathSlug="content" />}>Content</Header>
           <Containers />
         </ContentLayout>
       }
@@ -35,27 +37,29 @@ export default function WithDrawers() {
   );
 }
 
-function InfoLink() {
+function InfoLink({ pathSlug, ...rest }: { pathSlug: string }) {
   function notifyInfoLinkClick() {
-    document.body.dispatchEvent(new CustomEvent('info-link-click'));
+    document.body.dispatchEvent(new CustomEvent('info-link-click', { detail: { pathSlug } }));
   }
 
   return (
-    <Link variant="info" onFollow={notifyInfoLinkClick}>
+    <Link variant="info" onFollow={notifyInfoLinkClick} {...rest}>
       Info
     </Link>
   );
 }
 
 function HelpPanelContent({ appLayoutRef }: { appLayoutRef: React.RefObject<AppLayoutProps.Ref> }) {
+  const [helpPathSlug, setHelpPathSlug] = useState('default');
   useEffect(() => {
-    function handleInfoLinkClick() {
+    function handleInfoLinkClick(event: Event) {
       appLayoutRef.current!.openTools();
+      setHelpPathSlug((event as CustomEvent).detail.pathSlug);
     }
 
     document.body.addEventListener('info-link-click', handleInfoLinkClick);
     return () => document.body.removeEventListener('info-link-click', handleInfoLinkClick);
   }, [appLayoutRef]);
 
-  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you: {helpPathSlug}</HelpPanel>;
 }

--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -28,6 +28,7 @@ type DemoContext = React.Context<
 
 export default function WithDrawers() {
   const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
+  const [helpPathSlug, setHelpPathSlug] = useState<string>('default');
   const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
   const hasTools = urlParams.hasTools ?? false;
   const hasDrawers = urlParams.hasDrawers ?? true;
@@ -77,13 +78,21 @@ export default function WithDrawers() {
       breadcrumbs={<Breadcrumbs />}
       content={
         <ContentLayout
+          disableOverlap={true}
           header={
             <SpaceBetween size="m">
               <Header
                 variant="h1"
                 description="Sometimes you need custom drawers to get the job done."
                 info={
-                  <Link variant="info" onFollow={() => setIsToolsOpen(true)}>
+                  <Link
+                    data-testid="info-link-header"
+                    variant="info"
+                    onFollow={() => {
+                      setHelpPathSlug('header');
+                      setIsToolsOpen(true);
+                    }}
+                  >
                     Info
                   </Link>
                 }
@@ -103,6 +112,22 @@ export default function WithDrawers() {
             </SpaceBetween>
           }
         >
+          <Header
+            info={
+              <Link
+                data-testid="info-link-content"
+                variant="info"
+                onFollow={() => {
+                  setHelpPathSlug('content');
+                  setIsToolsOpen(true);
+                }}
+              >
+                Info
+              </Link>
+            }
+          >
+            Content
+          </Header>
           <Containers />
         </ContentLayout>
       }
@@ -135,7 +160,7 @@ export default function WithDrawers() {
       onToolsChange={event => {
         setIsToolsOpen(event.detail.open);
       }}
-      tools={<Info />}
+      tools={<Info helpPathSlug={helpPathSlug} />}
       toolsOpen={isToolsOpen}
       toolsHide={!hasTools}
       {...drawers}
@@ -143,8 +168,8 @@ export default function WithDrawers() {
   );
 }
 
-function Info() {
-  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you!</HelpPanel>;
+function Info({ helpPathSlug }: { helpPathSlug: string }) {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you: {helpPathSlug}</HelpPanel>;
 }
 
 function ProHelp() {

--- a/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper().findAppLayout();
+
+for (const visualRefresh of [true, false]) {
+  for (const pageName of ['runtime-drawers', 'runtime-drawers-imperative']) {
+    describe(`page=${pageName} visualRefresh=${visualRefresh}`, () => {
+      function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+        return useBrowser(async browser => {
+          const page = new BasePageObject(browser);
+
+          await browser.url(
+            `#/light/app-layout/${pageName}?${new URLSearchParams({
+              hasDrawers: 'false',
+              hasTools: 'true',
+              visualRefresh: `${visualRefresh}`,
+            }).toString()}`
+          );
+          await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
+          await testFn(page);
+        });
+      }
+
+      test(
+        'should switch between tools panel and runtime drawers',
+        setupTest(async page => {
+          await page.click(wrapper.findToolsToggle().toSelector());
+          await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain(
+            'Here is some info for you: default'
+          );
+
+          await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain('I am runtime drawer');
+
+          await page.click(wrapper.findDrawerTriggerById('awsui-internal-tools').toSelector());
+          await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain(
+            'Here is some info for you: default'
+          );
+        })
+      );
+
+      test(
+        'should allow switching to a drawer after clicking an info link',
+        setupTest(async page => {
+          await page.click('[data-testid="info-link-header"]');
+          await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBeTruthy();
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
+            'Here is some info for you: header'
+          );
+          await page.click(wrapper.findDrawerTriggerById('circle').toSelector());
+          await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBeFalsy();
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain('Nothing to see here');
+        })
+      );
+
+      test(
+        'should open and close tools via controlled mode',
+        setupTest(async page => {
+          const toolsContentSelector = wrapper.findTools().getElement();
+          await page.click(createWrapper().findHeader().findInfo().findLink().toSelector());
+          await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(true);
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
+            'Here is some info for you: header'
+          );
+
+          await page.click(wrapper.findToolsClose().toSelector());
+          await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(false);
+        })
+      );
+
+      test(
+        'should switch help panel content and close the panel afterwards',
+        setupTest(async page => {
+          await page.click('[data-testid="info-link-header"]');
+          await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBeTruthy();
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
+            'Here is some info for you: header'
+          );
+          await page.click('[data-testid="info-link-content"]');
+          await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
+            'Here is some info for you: content'
+          );
+          await page.click(wrapper.findToolsClose().toSelector());
+          await expect(page.isDisplayed(wrapper.findToolsClose().toSelector())).resolves.toBeFalsy();
+        })
+      );
+    });
+  }
+}

--- a/src/app-layout/__integ__/runtime-drawers.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers.test.ts
@@ -27,20 +27,6 @@ for (const visualRefresh of [true, false]) {
     }
 
     test(
-      'should switch between tools panel and runtime drawers',
-      setupTest(async page => {
-        await page.click(wrapper.findToolsToggle().toSelector());
-        await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain('Here is some info for you!');
-
-        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
-        await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain('I am runtime drawer');
-
-        await page.click(wrapper.findDrawerTriggerById('awsui-internal-tools').toSelector());
-        await expect(page.getText(wrapper.findTools().getElement())).resolves.toContain('Here is some info for you!');
-      })
-    );
-
-    test(
       'should resize equally with tools or drawers',
       setupTest(async page => {
         await page.setWindowSize({ ...viewports.desktop, width: 1800 });
@@ -53,21 +39,6 @@ for (const visualRefresh of [true, false]) {
         const { width: splitPanelWidthWithDrawer } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
 
         expect(splitPanelWidthWithTools).toEqual(splitPanelWidthWithDrawer);
-      })
-    );
-
-    test(
-      'should open and close tools via controlled mode',
-      setupTest(async page => {
-        const toolsContentSelector = wrapper.findTools().getElement();
-        await page.click(createWrapper().findHeader().findInfo().findLink().toSelector());
-        await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(true);
-        await expect(page.getText(wrapper.findActiveDrawer().getElement())).resolves.toContain(
-          'Here is some info for you!'
-        );
-
-        await page.click(wrapper.findToolsClose().toSelector());
-        await expect(page.isDisplayed(toolsContentSelector)).resolves.toBe(false);
       })
     );
 

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -169,29 +169,3 @@ test('a11y', async () => {
   );
   await expect(container).toValidateA11y();
 });
-
-test('drawers a11y', async () => {
-  const { container } = renderComponent(
-    <AppLayout
-      navigationOpen={true}
-      toolsOpen={true}
-      splitPanelOpen={true}
-      navigation={<div></div>}
-      content={<div></div>}
-      notifications={<div></div>}
-      breadcrumbs={<div></div>}
-      splitPanel={<div></div>}
-      {...singleDrawer}
-      ariaLabels={{
-        // notifications?: string;
-        // navigation?: string;
-        navigationToggle: 'Open navigation',
-        navigationClose: 'Close navigation',
-        // tools?: string;
-        toolsToggle: 'Open tools',
-        toolsClose: 'Close tools',
-      }}
-    />
-  );
-  await expect(container).toValidateA11y();
-});

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -44,6 +44,7 @@ export const Drawer = React.forwardRef(
       drawersAriaLabels,
       children,
       isOpen,
+      isHidden,
       isMobile,
       onToggle,
       onClick,
@@ -77,6 +78,7 @@ export const Drawer = React.forwardRef(
         id={drawers?.activeDrawerId}
         ref={ref}
         className={clsx(styles.drawer, {
+          [styles.hide]: isHidden,
           [styles['drawer-closed']]: !isOpen,
           [testutilStyles['drawer-closed']]: !isOpen,
           [styles['drawer-mobile']]: isMobile,

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -25,6 +25,7 @@ export interface DesktopDrawerProps {
   type: keyof typeof togglesConfig;
   isMobile: boolean;
   isOpen: boolean;
+  isHidden?: boolean;
   onToggle: (isOpen: boolean) => void;
   onClick?: (event: React.MouseEvent) => void;
   onLoseFocus?: (event: React.FocusEvent) => void;
@@ -42,6 +43,7 @@ export interface ResizableDrawerProps extends DesktopDrawerProps {
   size: number;
   getMaxWidth: () => number;
   refs: DrawerFocusControlRefs;
+  toolsContent?: React.ReactNode;
 }
 
 export interface DrawerTriggersBarProps {

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -12,7 +12,9 @@ import testutilStyles from '../test-classes/styles.css.js';
 
 import ResizeHandler from '../../split-panel/icons/resize-handler';
 import splitPanelStyles from '../../split-panel/styles.css.js';
+import styles from './styles.css.js';
 import { ResizableDrawerProps } from './interfaces';
+import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
 
 export const ResizableDrawer = ({
   onResize,
@@ -20,6 +22,7 @@ export const ResizableDrawer = ({
   getMaxWidth,
   refs,
   activeDrawer,
+  toolsContent,
   ...props
 }: ResizableDrawerProps) => {
   const { isOpen, children, isMobile } = props;
@@ -80,6 +83,7 @@ export const ResizableDrawer = ({
     <Drawer
       {...props}
       ref={drawerRefObject}
+      isHidden={!activeDrawer}
       resizeHandle={
         !isMobile &&
         activeDrawer?.resizable && <div className={splitPanelStyles['slider-wrapper-side']}>{resizeHandle}</div>
@@ -90,7 +94,8 @@ export const ResizableDrawer = ({
         closeLabel: activeDrawer?.ariaLabels?.closeButton,
       }}
     >
-      {children}
+      {toolsContent && <div className={clsx(activeDrawer?.id !== TOOLS_DRAWER_ID && styles.hide)}>{toolsContent}</div>}
+      {activeDrawer?.id !== TOOLS_DRAWER_ID ? children : null}
     </Drawer>
   );
 };

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -141,6 +141,11 @@ const OldAppLayout = React.forwardRef(
       isMobile ? false : defaults.toolsOpen,
       { componentName: 'AppLayout', controlledProp: 'toolsOpen', changeHandler: 'onToolsChange' }
     );
+    const onToolsToggle = (open: boolean) => {
+      setToolsOpen(open);
+      focusToolsButtons();
+      fireNonCancelableEvent(onToolsChange, { open });
+    };
 
     const {
       drawers,
@@ -156,7 +161,7 @@ const OldAppLayout = React.forwardRef(
       toolsOpen,
       toolsHide,
       toolsWidth,
-      onToolsChange,
+      onToolsToggle,
     });
     const hasDrawers = !!drawers;
 
@@ -178,14 +183,6 @@ const OldAppLayout = React.forwardRef(
       focusNavButtons();
       fireNonCancelableEvent(onNavigationChange, { open });
     });
-    const onToolsToggle = useCallback(
-      (open: boolean) => {
-        setToolsOpen(open);
-        focusToolsButtons();
-        fireNonCancelableEvent(onToolsChange, { open });
-      },
-      [setToolsOpen, onToolsChange, focusToolsButtons]
-    );
 
     const onNavigationClick = (event: React.MouseEvent) => {
       const hasLink = findUpUntil(
@@ -469,20 +466,16 @@ const OldAppLayout = React.forwardRef(
       isMobile,
     };
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        openTools: () => onToolsToggle(true),
-        closeNavigationIfNecessary: () => {
-          if (isMobile) {
-            onNavigationToggle(false);
-          }
-        },
-        focusToolsClose: () => focusToolsButtons(true),
-        focusSplitPanel: () => splitPanelRefs.slider.current?.focus(),
-      }),
-      [onToolsToggle, isMobile, onNavigationToggle, focusToolsButtons, splitPanelRefs.slider]
-    );
+    useImperativeHandle(ref, () => ({
+      openTools: () => onToolsToggle(true),
+      closeNavigationIfNecessary: () => {
+        if (isMobile) {
+          onNavigationToggle(false);
+        }
+      },
+      focusToolsClose: () => focusToolsButtons(true),
+      focusSplitPanel: () => splitPanelRefs.slider.current?.focus(),
+    }));
 
     const splitPanelBottomOffset =
       (!splitPanelDisplayed || finalSplitPanePosition !== 'bottom'

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -638,7 +638,7 @@ const OldAppLayout = React.forwardRef(
             {hasDrawers ? (
               <ResizableDrawer
                 contentClassName={clsx(
-                  testutilStyles['active-drawer'],
+                  activeDrawerId && testutilStyles['active-drawer'],
                   activeDrawerId === TOOLS_DRAWER_ID && testutilStyles.tools
                 )}
                 toggleClassName={testutilStyles['tools-toggle']}
@@ -672,7 +672,7 @@ const OldAppLayout = React.forwardRef(
                 onResize={changeDetail => onActiveDrawerResize(changeDetail)}
                 refs={drawerRefs}
                 getMaxWidth={getDrawerMaxWidth}
-                toolsContent={!toolsHide && tools}
+                toolsContent={drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content}
               >
                 {activeDrawer?.content}
               </ResizableDrawer>

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -635,67 +635,68 @@ const OldAppLayout = React.forwardRef(
 
             {finalSplitPanePosition === 'side' && splitPanelWrapped}
 
-            {hasDrawers
-              ? activeDrawerId && (
-                  <ResizableDrawer
-                    contentClassName={clsx(
-                      testutilStyles['active-drawer'],
-                      activeDrawerId === TOOLS_DRAWER_ID && testutilStyles.tools
-                    )}
-                    toggleClassName={testutilStyles['tools-toggle']}
-                    closeClassName={clsx(
-                      testutilStyles['active-drawer-close-button'],
-                      activeDrawerId === TOOLS_DRAWER_ID && testutilStyles['tools-close']
-                    )}
-                    ariaLabels={ariaLabels}
-                    width={!isResizeInvalid ? activeDrawerSize : toolsWidth}
-                    bottomOffset={footerHeight}
-                    topOffset={headerHeight}
-                    isMobile={isMobile}
-                    onToggle={() => {
-                      /*noop in this mode*/
-                    }}
-                    isOpen={true}
-                    toggleRefs={toolsRefs}
-                    type="tools"
-                    onLoseFocus={loseDrawersFocus}
-                    activeDrawer={activeDrawer}
-                    drawers={{
-                      items: drawers,
-                      activeDrawerId: activeDrawerId,
-                      onChange: changeDetail => {
-                        focusToolsButtons();
-                        setDrawerLastInteraction({ type: 'close' });
-                        onActiveDrawerChange(changeDetail.activeDrawerId);
-                      },
-                    }}
-                    size={!isResizeInvalid ? activeDrawerSize : toolsWidth}
-                    onResize={changeDetail => onActiveDrawerResize(changeDetail)}
-                    refs={drawerRefs}
-                    getMaxWidth={getDrawerMaxWidth}
-                  >
-                    {activeDrawer?.content}
-                  </ResizableDrawer>
-                )
-              : !toolsHide && (
-                  <Drawer
-                    contentClassName={testutilStyles.tools}
-                    toggleClassName={testutilStyles['tools-toggle']}
-                    closeClassName={testutilStyles['tools-close']}
-                    ariaLabels={ariaLabels}
-                    width={effectiveToolsWidth}
-                    bottomOffset={footerHeight}
-                    topOffset={headerHeight}
-                    isMobile={isMobile}
-                    onToggle={onToolsToggle}
-                    isOpen={toolsOpen}
-                    toggleRefs={toolsRefs}
-                    type="tools"
-                    onLoseFocus={loseToolsFocus}
-                  >
-                    {tools}
-                  </Drawer>
+            {hasDrawers ? (
+              <ResizableDrawer
+                contentClassName={clsx(
+                  testutilStyles['active-drawer'],
+                  activeDrawerId === TOOLS_DRAWER_ID && testutilStyles.tools
                 )}
+                toggleClassName={testutilStyles['tools-toggle']}
+                closeClassName={clsx(
+                  testutilStyles['active-drawer-close-button'],
+                  activeDrawerId === TOOLS_DRAWER_ID && testutilStyles['tools-close']
+                )}
+                ariaLabels={ariaLabels}
+                width={!isResizeInvalid ? activeDrawerSize : toolsWidth}
+                bottomOffset={footerHeight}
+                topOffset={headerHeight}
+                isMobile={isMobile}
+                onToggle={() => {
+                  /*noop in this mode*/
+                }}
+                isOpen={true}
+                toggleRefs={toolsRefs}
+                type="tools"
+                onLoseFocus={loseDrawersFocus}
+                activeDrawer={activeDrawer}
+                drawers={{
+                  items: drawers,
+                  activeDrawerId: activeDrawerId,
+                  onChange: changeDetail => {
+                    focusToolsButtons();
+                    setDrawerLastInteraction({ type: 'close' });
+                    onActiveDrawerChange(changeDetail.activeDrawerId);
+                  },
+                }}
+                size={!isResizeInvalid ? activeDrawerSize : toolsWidth}
+                onResize={changeDetail => onActiveDrawerResize(changeDetail)}
+                refs={drawerRefs}
+                getMaxWidth={getDrawerMaxWidth}
+                toolsContent={!toolsHide && tools}
+              >
+                {activeDrawer?.content}
+              </ResizableDrawer>
+            ) : (
+              !toolsHide && (
+                <Drawer
+                  contentClassName={testutilStyles.tools}
+                  toggleClassName={testutilStyles['tools-toggle']}
+                  closeClassName={testutilStyles['tools-close']}
+                  ariaLabels={ariaLabels}
+                  width={effectiveToolsWidth}
+                  bottomOffset={footerHeight}
+                  topOffset={headerHeight}
+                  isMobile={isMobile}
+                  onToggle={onToolsToggle}
+                  isOpen={toolsOpen}
+                  toggleRefs={toolsRefs}
+                  type="tools"
+                  onLoseFocus={loseToolsFocus}
+                >
+                  {tools}
+                </Drawer>
+              )
+            )}
             {hasDrawers && drawers.length > 0 && (
               <DrawerTriggersBar
                 bottomOffset={footerHeight}

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -18,7 +18,7 @@ interface ToolsProps {
   toolsOpen: boolean | undefined;
   toolsWidth: number;
   tools: React.ReactNode | undefined;
-  onToolsChange: AppLayoutProps['onToolsChange'];
+  onToolsToggle: (newOpen: boolean) => void;
   ariaLabels: AppLayoutProps.Labels | undefined;
 }
 
@@ -121,7 +121,7 @@ export function useDrawers(
     if (hasOwnDrawers) {
       fireNonCancelableEvent(ownDrawers?.onChange, newDrawerId);
     } else if (!toolsProps.toolsHide) {
-      fireNonCancelableEvent(toolsProps.onToolsChange, { open: newDrawerId === TOOLS_DRAWER_ID });
+      toolsProps.onToolsToggle(newDrawerId === TOOLS_DRAWER_ID);
     }
   }
 

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -377,7 +377,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       toolsOpen: isToolsOpen,
       tools: props.tools,
       toolsWidth,
-      onToolsChange: props.onToolsChange,
+      onToolsToggle: handleToolsClick,
     });
 
     const [drawersMaxWidth, setDrawersMaxWidth] = useState(toolsWidth);

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -159,6 +159,9 @@
 
     > .drawer-content {
       grid-column: 1 / span 4;
+      &.drawer-content-hidden {
+        display: none;
+      }
     }
   }
 

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -63,8 +63,6 @@ function ActiveDrawer() {
     drawersRefs,
     handleDrawersClick,
     handleToolsClick,
-    tools,
-    toolsHide,
     hasDrawerViewportOverlay,
     isMobile,
     isNavigationOpen,
@@ -87,6 +85,7 @@ function ActiveDrawer() {
   const isHidden = !activeDrawerId;
   const isUnfocusable = isHidden || (hasDrawerViewportOverlay && isNavigationOpen && !navigationHide);
   const isToolsDrawer = activeDrawerId === TOOLS_DRAWER_ID;
+  const toolsContent = drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content;
 
   const size = Math.max(Math.min(drawersMaxWidth, drawerSize), MIN_WIDTH);
 
@@ -131,14 +130,14 @@ function ActiveDrawer() {
             variant="icon"
           />
         </div>
-        {!toolsHide && (
+        {toolsContent && (
           <div
             className={clsx(
               styles['drawer-content'],
               activeDrawerId !== TOOLS_DRAWER_ID && styles['drawer-content-hidden']
             )}
           >
-            {tools}
+            {toolsContent}
           </div>
         )}
         {activeDrawerId !== TOOLS_DRAWER_ID && (

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -63,6 +63,8 @@ function ActiveDrawer() {
     drawersRefs,
     handleDrawersClick,
     handleToolsClick,
+    tools,
+    toolsHide,
     hasDrawerViewportOverlay,
     isMobile,
     isNavigationOpen,
@@ -129,7 +131,19 @@ function ActiveDrawer() {
             variant="icon"
           />
         </div>
-        <div className={styles['drawer-content']}>{activeDrawerId && activeDrawer?.content}</div>
+        {!toolsHide && (
+          <div
+            className={clsx(
+              styles['drawer-content'],
+              activeDrawerId !== TOOLS_DRAWER_ID && styles['drawer-content-hidden']
+            )}
+          >
+            {tools}
+          </div>
+        )}
+        {activeDrawerId !== TOOLS_DRAWER_ID && (
+          <div className={styles['drawer-content']}>{activeDrawerId && activeDrawer?.content}</div>
+        )}
       </div>
     </aside>
   );


### PR DESCRIPTION
### Description



In a single-drawer (tools only) mode, app layout renders `tools` slot content even when it is closed. Some teams are relying on this. When rendering multiple drawers we tried to render only the active one, but this broke compatibility.

This PR restores compatibility, we now always keep the tools content in the DOM, only hide it when it is closed
 
Related links, issue #, if available: n/a

### How has this been tested?

Added a dev page `pages/app-layout/runtime-drawers-imperative.page.tsx` to reproduce this case and added several unit tests to capture this behavior

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
