### PR TITLE
feat: Add ariaLabel and ariaLabelledby to progress bar

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10127,6 +10127,18 @@ Use the \`buttonText\` property and the \`onButtonClick\` event listener of the 
   "name": "ProgressBar",
   "properties": Array [
     Object {
+      "description": "Adds an \`aria-label\` to the progress bar.",
+      "name": "ariaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds \`aria-labelledby\` to the progress bar.",
+      "name": "ariaLabelledby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified classes to the root element of the component.",
       "name": "className",

--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -88,6 +88,26 @@ allVariants.forEach(variant => {
         expect(wrapper.find('[aria-live]')!.getElement()).toHaveTextContent('Result!');
       });
     });
+
+    describe('ARIA labels', () => {
+      test('attaches aria-label to the progress bar', () => {
+        const wrapper = renderProgressBar({ variant, value: 100, ariaLabel: 'aria label' });
+        expect(wrapper.find('progress')!.getElement()).toHaveAttribute('aria-label', 'aria label');
+      });
+
+      test('attaches aria-labelledby to the progress bar', () => {
+        const wrapper = renderProgressBar({ variant, value: 100, ariaLabelledby: 'testid' });
+        expect(wrapper.find('progress')!.getElement()).toHaveAttribute(
+          'aria-labelledby',
+          expect.stringContaining('testid')
+        );
+      });
+
+      test('ignores aria-labelledby if aria-label is provided', () => {
+        const wrapper = renderProgressBar({ variant, value: 100, ariaLabelledby: 'testid', ariaLabel: 'hello' });
+        expect(wrapper.find('progress')!.getElement()).not.toHaveAttribute('aria-labelledby');
+      });
+    });
   });
 });
 describe('Progress bar component flash variant - Result state', () => {

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -10,6 +10,7 @@ import { ProgressBarProps } from './interfaces';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { Progress, ResultState, SmallText } from './internal';
+import { joinStrings } from '../internal/utils/strings';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { throttle } from '../internal/utils/throttle';
@@ -25,6 +26,8 @@ export default function ProgressBar({
   variant = 'standalone',
   resultButtonText,
   label,
+  ariaLabel,
+  ariaLabelledby,
   description,
   additionalInfo,
   resultText,
@@ -71,7 +74,12 @@ export default function ProgressBar({
         <div>
           {isInProgressState ? (
             <>
-              <Progress value={value} labelId={labelId} isInFlash={isInFlash} />
+              <Progress
+                value={value}
+                ariaLabel={ariaLabel}
+                ariaLabelledby={joinStrings(labelId, ariaLabelledby)}
+                isInFlash={isInFlash}
+              />
               <LiveRegion delay={0}>
                 {label}
                 {label ? ': ' : null}

--- a/src/progress-bar/interfaces.ts
+++ b/src/progress-bar/interfaces.ts
@@ -39,6 +39,16 @@ export interface ProgressBarProps extends BaseComponentProps {
   resultButtonText?: string;
 
   /**
+   * Adds an `aria-label` to the progress bar.
+   */
+  ariaLabel?: string;
+
+  /**
+   * Adds `aria-labelledby` to the progress bar.
+   */
+  ariaLabelledby?: string;
+
+  /**
    * Short description of the operation that appears at the top of the component.
    *
    * Make sure that you always provide a label for accessibility.

--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -20,9 +20,10 @@ const clamp = (value: number, lowerLimit: number, upperLimit: number) => {
 interface ProgressProps {
   value: number;
   isInFlash: boolean;
-  labelId: string;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
 }
-export const Progress = ({ value, isInFlash, labelId }: ProgressProps) => {
+export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: ProgressProps) => {
   const roundedValue = Math.round(value);
   const progressValue = clamp(roundedValue, 0, MAX_VALUE);
 
@@ -36,7 +37,9 @@ export const Progress = ({ value, isInFlash, labelId }: ProgressProps) => {
         )}
         max={MAX_VALUE}
         value={progressValue}
-        aria-labelledby={labelId}
+        aria-label={ariaLabel}
+        // Ensures aria-label takes precedence over aria-labelledby
+        aria-labelledby={!ariaLabel ? ariaLabelledby : undefined}
       />
       <span aria-hidden="true" className={styles['percentage-container']}>
         <InternalBox className={styles.percentage} variant="small" color={isInFlash ? 'inherit' : undefined}>


### PR DESCRIPTION
### Description

Does what it says on the tin. People could provide visual labels through the `label` property, but it turns out in some contexts, like inside a table cell, the visual label itself doesn't provide enough context. So additional programmatic context needs to be added. This allows for that.

Related links, issue #, if available: AWSUI-22557

### How has this been tested?

Unit tests!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
