### PR TITLE
refactor: Remove column widths sync from table sticky header

### DIFF
--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -212,11 +212,10 @@ describe('with stickyHeader=true', () => {
       { minWidth: '100px', width: '', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '300px' },
     ]);
-    // in JSDOM, there is no layout, so copied width is "0px" and no value is ""
     expect(extractSize(fakeHeader)).toEqual([
-      { minWidth: '', width: '0px', maxWidth: '' },
-      { minWidth: '', width: '0px', maxWidth: '' },
-      { minWidth: '', width: '0px', maxWidth: '' },
+      { minWidth: '', width: '200px', maxWidth: '' },
+      { minWidth: '', width: '', maxWidth: '' },
+      { minWidth: '', width: '', maxWidth: '' },
     ]);
   });
 });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -296,6 +296,7 @@ const InternalTable = React.forwardRef(
                     onScroll={handleScroll}
                     tableHasHeader={hasHeader}
                     contentDensity={contentDensity}
+                    resizableColumns={!!resizableColumns}
                     tableRole={tableRole}
                   />
                 )}

--- a/src/table/sticky-header.tsx
+++ b/src/table/sticky-header.tsx
@@ -26,6 +26,7 @@ interface StickyHeaderProps {
   onScroll?: React.UIEventHandler<HTMLDivElement>;
   contentDensity?: 'comfortable' | 'compact';
   tableHasHeader?: boolean;
+  resizableColumns: boolean;
   tableRole: TableRole;
 }
 
@@ -42,6 +43,7 @@ function StickyHeader(
     tableRef,
     tableHasHeader,
     contentDensity,
+    resizableColumns,
     tableRole,
   }: StickyHeaderProps,
   ref: React.Ref<StickyHeaderRef>
@@ -56,7 +58,8 @@ function StickyHeader(
     theadRef,
     secondaryTheadRef,
     secondaryTableRef,
-    wrapperRef
+    wrapperRef,
+    resizableColumns
   );
 
   useImperativeHandle(ref, () => ({

--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -5,19 +5,6 @@ import stickyScrolling, { calculateScrollingOffset, scrollUpBy } from './sticky-
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-function syncSizes(from: HTMLElement, to: HTMLElement) {
-  const fromCells = Array.prototype.slice.apply(from.children);
-  const toCells = Array.prototype.slice.apply(to.children);
-  for (let i = 0; i < fromCells.length; i++) {
-    let width = fromCells[i].style.width;
-    // use auto if it is set by resizable columns or real size otherwise
-    if (width !== 'auto') {
-      width = `${fromCells[i].offsetWidth}px`;
-    }
-    toCells[i].style.width = width;
-  }
-}
-
 export const useStickyHeader = (
   tableRef: RefObject<HTMLElement>,
   theadRef: RefObject<HTMLElement>,
@@ -35,8 +22,6 @@ export const useStickyHeader = (
       secondaryTableRef.current &&
       tableWrapperRef.current
     ) {
-      syncSizes(theadRef.current, secondaryTheadRef.current);
-
       // Using the tableRef offsetWidth instead of the theadRef because in VR
       // the tableRef adds extra padding to the table and by default the theadRef will have a width
       // without the padding and will make the sticky header width incorrect.

--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -5,12 +5,21 @@ import stickyScrolling, { calculateScrollingOffset, scrollUpBy } from './sticky-
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
+function syncSizes(from: HTMLElement, to: HTMLElement) {
+  const fromCells = Array.prototype.slice.apply(from.children);
+  const toCells = Array.prototype.slice.apply(to.children);
+  for (let i = 0; i < fromCells.length; i++) {
+    toCells[i].style.width = `${fromCells[i].offsetWidth}px`;
+  }
+}
+
 export const useStickyHeader = (
   tableRef: RefObject<HTMLElement>,
   theadRef: RefObject<HTMLElement>,
   secondaryTheadRef: RefObject<HTMLElement>,
   secondaryTableRef: RefObject<HTMLElement>,
-  tableWrapperRef: RefObject<HTMLElement>
+  tableWrapperRef: RefObject<HTMLElement>,
+  resizableColumns: boolean
 ) => {
   const isMobile = useMobile();
   // Sync the sizes of the column header copies in the sticky header with the originals
@@ -22,6 +31,11 @@ export const useStickyHeader = (
       secondaryTableRef.current &&
       tableWrapperRef.current
     ) {
+      // When resizable columns are used the column sizes are set explicitly in both headers and no sync is needed.
+      if (!resizableColumns) {
+        syncSizes(theadRef.current, secondaryTheadRef.current);
+      }
+
       // Using the tableRef offsetWidth instead of the theadRef because in VR
       // the tableRef adds extra padding to the table and by default the theadRef will have a width
       // without the padding and will make the sticky header width incorrect.
@@ -29,7 +43,7 @@ export const useStickyHeader = (
 
       tableWrapperRef.current.style.marginTop = `-${theadRef.current.offsetHeight}px`;
     }
-  }, [theadRef, secondaryTheadRef, secondaryTableRef, tableWrapperRef, tableRef]);
+  }, [theadRef, secondaryTheadRef, secondaryTableRef, tableWrapperRef, tableRef, resizableColumns]);
   useLayoutEffect(() => {
     syncColumnHeaderWidths();
   });


### PR DESCRIPTION
### Description

Table's header and sticky header render the same Thead component responsible for assigning column widths. When resizable columns feature is used there is no need to additionally sync the widths because there is no difference between them.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
