### PR TITLE
fix: Consider container paddings in table calculations

### DIFF
--- a/pages/table/resizable-columns-rounding.page.tsx
+++ b/pages/table/resizable-columns-rounding.page.tsx
@@ -39,11 +39,11 @@ const items: Array<Item> = [
 ];
 
 export default function () {
-  const [width, setWidth] = useState(609);
+  const [width, setWidth] = useState(649);
   return (
     <>
       <h1>Table in container with special size </h1>
-      <button id="shrink-container" onClick={() => setWidth(595)}>
+      <button id="shrink-container" onClick={() => setWidth(635)}>
         Resize container
       </button>
       <div style={{ width }}>

--- a/pages/table/resizable-columns.page.tsx
+++ b/pages/table/resizable-columns.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import range from 'lodash/range';
 import zipObject from 'lodash/zipObject';
 import Button from '~components/button';
@@ -13,6 +13,7 @@ import SpaceBetween from '~components/space-between';
 import Table, { TableProps } from '~components/table';
 import { NonCancelableCustomEvent } from '~components/interfaces';
 import ScreenshotArea from '../utils/screenshot-area';
+import AppContext, { AppContextType } from '../app/app-context';
 
 declare global {
   interface Window {
@@ -90,7 +91,22 @@ const items: Item[] = [
   })),
 ];
 
+type PageContext = React.Context<
+  AppContextType<{
+    wrapLines: boolean;
+    stickyHeader: boolean;
+    resizableColumns: boolean;
+    fullPage: boolean;
+  }>
+>;
+
 export default function App() {
+  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const wrapLines = urlParams.wrapLines ?? false;
+  const stickyHeader = urlParams.stickyHeader ?? false;
+  const resizableColumns = urlParams.resizableColumns ?? true;
+  const fullPage = urlParams.fullPage ?? false;
+
   const [renderKey, setRenderKey] = useState(0);
   const [columns, setColumns] = useState(columnsConfig);
   const [columnDisplay, setColumnDisplay] = useState([
@@ -100,9 +116,7 @@ export default function App() {
     { id: 'state', visible: true },
     { id: 'extra', visible: false },
   ]);
-  const [wrapLines, setWrapLines] = useState(false);
-  const [stickyHeader, setStickyHeader] = useState(false);
-  const [resizableColumns, setResizableColumns] = useState(true);
+
   const [sorting, setSorting] = useState<TableProps.SortingState<any>>();
 
   function handleWidthChange(event: NonCancelableCustomEvent<TableProps.ColumnWidthsChangeDetail>) {
@@ -127,22 +141,25 @@ export default function App() {
       <Container header={<Header>Preferences</Header>}>
         <ColumnLayout columns={3} borders="vertical">
           <div>
-            <Checkbox checked={wrapLines} onChange={event => setWrapLines(event.detail.checked)}>
+            <Checkbox checked={wrapLines} onChange={event => setUrlParams({ wrapLines: event.detail.checked })}>
               Wrap lines
             </Checkbox>
             <Checkbox
               id="sticky-header-toggle"
               checked={stickyHeader}
-              onChange={event => setStickyHeader(event.detail.checked)}
+              onChange={event => setUrlParams({ stickyHeader: event.detail.checked })}
             >
               Sticky header
             </Checkbox>
             <Checkbox
               id="resizable-columns-toggle"
               checked={resizableColumns}
-              onChange={event => setResizableColumns(event.detail.checked)}
+              onChange={event => setUrlParams({ resizableColumns: event.detail.checked })}
             >
               Resizable columns
+            </Checkbox>
+            <Checkbox checked={fullPage} onChange={event => setUrlParams({ fullPage: event.detail.checked })}>
+              Full page table
             </Checkbox>
           </div>
           <div>
@@ -182,6 +199,7 @@ export default function App() {
           sortingDescending={sorting?.isDescending}
           onSortingChange={event => setSorting(event.detail)}
           onColumnWidthsChange={handleWidthChange}
+          variant={fullPage ? 'full-page' : undefined}
         />
       </ScreenshotArea>
     </SpaceBetween>

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -186,6 +186,9 @@ describe.each([true, false])('StickyHeader=%s', sticky => {
     })
   );
 
+  // The page width of 620px is an empirical value defined for the respective test page in VR
+  // so that the container width is slightly less than the table width (a sum of the column widths).
+  // In that case we expect the container to be scrollable and no auto-width set for the last column.
   test(
     'should set explicit width for the last column when table width exceeds container width',
     useBrowser({ width: 620, height: 1000 }, async browser => {

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -201,6 +201,17 @@ describe.each([true, false])('StickyHeader=%s', sticky => {
   );
 
   test(
+    'should set explicit width for the last column when full-page table width exceeds container width',
+    useBrowser({ width: 600, height: 1000 }, async browser => {
+      const page = new TablePage(browser);
+      await browser.url('#/light/table/resizable-columns?visualRefresh=true&fullPage=true');
+      await page.waitForVisible(tableWrapper.findBodyCell(2, 1).toSelector());
+
+      await expect(page.getColumnStyle(4)).resolves.toContain('width: 120px;');
+    })
+  );
+
+  test(
     'should shrink the last column after revealing a column',
     setupStickyTest(async page => {
       const nameColumnWidth = await page.getColumnWidth(1);

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -187,6 +187,17 @@ describe.each([true, false])('StickyHeader=%s', sticky => {
   );
 
   test(
+    'should set explicit width for the last column when table width exceeds container width',
+    useBrowser({ width: 620, height: 1000 }, async browser => {
+      const page = new TablePage(browser);
+      await browser.url('#/light/table/resizable-columns?visualRefresh=true');
+      await page.waitForVisible(tableWrapper.findBodyCell(2, 1).toSelector());
+
+      await expect(page.getColumnStyle(4)).resolves.toContain('width: 120px;');
+    })
+  );
+
+  test(
     'should shrink the last column after revealing a column',
     setupStickyTest(async page => {
       const nameColumnWidth = await page.getColumnWidth(1);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useCallback, useImperativeHandle, useMemo, useRef } from 'react';
+import React, { useCallback, useImperativeHandle, useRef } from 'react';
 import { TableForwardRefType, TableProps } from './interfaces';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import InternalContainer, { InternalContainerProps } from '../container/internal';
@@ -119,14 +119,6 @@ const InternalTable = React.forwardRef(
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
 
-    const containerContentWidth = useMemo(() => {
-      if (!containerWidth || !tableRefObject.current) {
-        return null;
-      }
-      const tableStyle = getComputedStyle(tableRefObject.current);
-      return containerWidth - (parseFloat(tableStyle.paddingLeft) || 0) - (parseFloat(tableStyle.paddingRight) || 0);
-    }, [containerWidth]);
-
     const secondaryWrapperRef = React.useRef<HTMLDivElement>(null);
     const theadRef = useRef<HTMLTableRowElement>(null);
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
@@ -213,7 +205,7 @@ const InternalTable = React.forwardRef(
     const tableRole = hasEditableCells ? 'grid-default' : 'table';
 
     const theadProps: TheadProps = {
-      containerWidth: containerContentWidth,
+      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions: visibleColumnDefinitions,
@@ -241,12 +233,12 @@ const InternalTable = React.forwardRef(
       tableRole,
     };
 
-    const wrapperRef = useMergeRefs(wrapperMeasureRef, wrapperRefObject, stickyState.refs.wrapper);
+    const wrapperRef = useMergeRefs(wrapperRefObject, stickyState.refs.wrapper);
     const tableRef = useMergeRefs(tableMeasureRef, tableRefObject, stickyState.refs.table);
 
     const wrapperProps = getTableWrapperRoleProps({
       tableRole,
-      isScrollable: !!(tableWidth && containerContentWidth && tableWidth > containerContentWidth),
+      isScrollable: !!(tableWidth && containerWidth && tableWidth > containerWidth),
       ariaLabel: ariaLabels?.tableLabel,
     });
 
@@ -340,6 +332,7 @@ const InternalTable = React.forwardRef(
               onScroll={handleScroll}
               {...wrapperProps}
             >
+              <div className={styles['wrapper-content-measure']} ref={wrapperMeasureRef}></div>
               {!!renderAriaLive && !!firstIndex && (
                 <LiveRegion>
                   <span>

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -119,6 +119,8 @@ const InternalTable = React.forwardRef(
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
 
+    console.log(containerWidth, tableWidth);
+
     const secondaryWrapperRef = React.useRef<HTMLDivElement>(null);
     const theadRef = useRef<HTMLTableRowElement>(null);
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useCallback, useImperativeHandle, useRef } from 'react';
+import React, { useCallback, useImperativeHandle, useMemo, useRef } from 'react';
 import { TableForwardRefType, TableProps } from './interfaces';
 import { getVisualContextClassname } from '../internal/components/visual-context';
 import InternalContainer, { InternalContainerProps } from '../container/internal';
@@ -119,6 +119,14 @@ const InternalTable = React.forwardRef(
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
 
+    const containerContentWidth = useMemo(() => {
+      if (!containerWidth || !tableRefObject.current) {
+        return null;
+      }
+      const tableStyle = getComputedStyle(tableRefObject.current);
+      return containerWidth - (parseFloat(tableStyle.paddingLeft) || 0) - (parseFloat(tableStyle.paddingRight) || 0);
+    }, [containerWidth]);
+
     const secondaryWrapperRef = React.useRef<HTMLDivElement>(null);
     const theadRef = useRef<HTMLTableRowElement>(null);
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
@@ -205,7 +213,6 @@ const InternalTable = React.forwardRef(
     const tableRole = hasEditableCells ? 'grid-default' : 'table';
 
     const theadProps: TheadProps = {
-      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions: visibleColumnDefinitions,
@@ -238,7 +245,7 @@ const InternalTable = React.forwardRef(
 
     const wrapperProps = getTableWrapperRoleProps({
       tableRole,
-      isScrollable: !!(tableWidth && containerWidth && tableWidth > containerWidth),
+      isScrollable: !!(tableWidth && containerContentWidth && tableWidth > containerContentWidth),
       ariaLabel: ariaLabels?.tableLabel,
     });
 
@@ -259,7 +266,7 @@ const InternalTable = React.forwardRef(
         <ColumnWidthsProvider
           visibleColumns={visibleColumnWidthsWithSelection}
           resizableColumns={resizableColumns}
-          containerWidth={containerWidth ?? 0}
+          containerWidth={containerContentWidth ?? 0}
         >
           <InternalContainer
             {...baseProps}

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -68,7 +68,8 @@
   scrollbar-width: none; /* Hide scrollbar in Firefox */
   &.variant-stacked,
   &.variant-container {
-    & > .table {
+    & > .table,
+    & > .wrapper-content-measure {
       padding-left: awsui.$space-table-horizontal;
       padding-right: awsui.$space-table-horizontal;
     }
@@ -107,8 +108,6 @@
     @supports (position: sticky) {
       position: sticky;
       left: 0;
-      // Offset table paddings to position centered when sticky
-      margin: 0 calc(-2 * #{awsui.$space-table-horizontal});
     }
     /* stylelint-enable plugin/no-unsupported-browser-features */
   }

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -18,7 +18,6 @@ import { TableThElement } from './header-cell/th-element';
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 export interface TheadProps {
-  containerWidth: number | null;
   selectionType: TableProps.SelectionType | undefined;
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<any>>;
   sortingColumn: TableProps.SortingColumn<any> | undefined;


### PR DESCRIPTION
### Description

In VR styles container can have paddings (those are actually applied to the table element). The paddings must be considered when compared container width against table width - otherwise the isScrollable state is applied 40px later. It also causes the last column resizer to not auto-scroll the container.

Before fix (see how the last column is getting smaller than its min-width before container scroll applies):

https://github.com/cloudscape-design/components/assets/20790937/d7808de6-1a73-478a-bf50-fbcf7380ebbf

After fix:

https://github.com/cloudscape-design/components/assets/20790937/3e08a81d-6412-46d4-b995-0ba10e684a53

### How has this been tested?

Added an integration test for regression.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
