### PR TITLE
revert: Column auto width is set in column widths utils (#1638)

### DIFF
--- a/src/anchor-navigation/use-scroll-spy.tsx
+++ b/src/anchor-navigation/use-scroll-spy.tsx
@@ -37,7 +37,7 @@ export default function useScrollSpy({
   }, [hrefs]);
 
   // Get the bounding rectangle of an element by href
-  const getRectByHref = useCallback((href: string) => {
+  const getRectByHref = useCallback(href => {
     return document.getElementById(href.slice(1))?.getBoundingClientRect();
   }, []);
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -256,11 +256,7 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <ColumnWidthsProvider
-          visibleColumns={visibleColumnWidthsWithSelection}
-          resizableColumns={resizableColumns}
-          containerWidth={containerWidth ?? 0}
-        >
+        <ColumnWidthsProvider visibleColumns={visibleColumnWidthsWithSelection} resizableColumns={resizableColumns}>
           <InternalContainer
             {...baseProps}
             __internalRootRef={__internalRootRef}

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -156,7 +156,7 @@ export function useStickyCellStyles({
 
   // refCallback updates the cell ref and sets up the store subscription
   const refCallback = useCallback(
-    (cellElement: null | HTMLElement) => {
+    cellElement => {
       if (unsubscribeRef.current) {
         // Unsubscribe before we do any updates to avoid leaving any subscriptions hanging
         unsubscribeRef.current();

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -46,6 +46,7 @@ export interface TheadProps {
 const Thead = React.forwardRef(
   (
     {
+      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions,
@@ -88,7 +89,7 @@ const Thead = React.forwardRef(
       isVisualRefresh && styles['is-visual-refresh']
     );
 
-    const { columnWidths, updateColumn, setCell } = useColumnWidths();
+    const { columnWidths, totalWidth, updateColumn, setCell } = useColumnWidths();
 
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
@@ -130,13 +131,24 @@ const Thead = React.forwardRef(
 
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
-            const columnWidth = resizableColumns ? columnWidths[columnId] ?? 'auto' : column.width;
+
+            let widthOverride;
+            if (resizableColumns) {
+              if (columnWidths) {
+                // use stateful value if available
+                widthOverride = columnWidths[columnId];
+              }
+              if (colIndex === columnDefinitions.length - 1 && containerWidth && containerWidth > totalWidth) {
+                // let the last column grow and fill the container width
+                widthOverride = 'auto';
+              }
+            }
             return (
               <TableHeaderCell
                 key={columnId}
                 className={headerCellClass}
                 style={{
-                  width: columnWidth,
+                  width: widthOverride || column.width,
                   minWidth: sticky ? undefined : column.minWidth,
                   maxWidth: resizableColumns || sticky ? undefined : column.maxWidth,
                 }}


### PR DESCRIPTION
This reverts commit 26a79cebae573b14e95fd6953aba60f63b4f52d7.

### Description

Reverting as causing regression in screenshot tests

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
