### PR TITLE
fix: Fixes overflow focus and adds test

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -163,6 +163,24 @@ function setupTest(
           )
         );
 
+        test(
+          'moves focus back to overflow button if drawer opens from overflow menu',
+          setupTest(
+            async page => {
+              await page.setWindowSize({ ...viewports.desktop, height: 350 });
+              const triggerSelector = wrapper
+                .find('[aria-label="Overflow drawers (Unread notifications)"]')
+                .toSelector();
+              await page.click(triggerSelector);
+              await page.keys('Enter');
+              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+              await page.keys('Enter');
+              await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', visualRefresh, mobile }
+          )
+        );
+
         describe('focus interaction with info links', () => {
           test(
             'moves focus to close button when panel is opened from info link',

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -177,6 +177,7 @@ function DesktopTriggers() {
 
   const hasMultipleTriggers = drawersTriggerCount > 1;
   const hasSplitPanel = splitPanel && splitPanelDisplayed && splitPanelPosition === 'side';
+  const [openedFromOverflow, setOpenedFromOverflow] = React.useState(false);
 
   const previousActiveDrawerId = useRef(activeDrawerId);
   const [containerHeight, triggersContainerRef] = useContainerQuery(rect => rect.contentBoxHeight);
@@ -243,8 +244,11 @@ function DesktopTriggers() {
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
               key={item.id}
-              onClick={() => handleDrawersClick(item.id)}
-              ref={item.id === previousActiveDrawerId.current ? drawersRefs.toggle : undefined}
+              onClick={() => {
+                handleDrawersClick(item.id);
+                setOpenedFromOverflow(false);
+              }}
+              ref={item.id === previousActiveDrawerId.current && !openedFromOverflow ? drawersRefs.toggle : undefined}
               selected={item.id === activeDrawerId}
               badge={item.badge}
               testId={`awsui-app-layout-trigger-${item.id}`}
@@ -258,7 +262,7 @@ function DesktopTriggers() {
             ariaLabel={overflowMenuHasBadge ? drawersOverflowWithBadgeAriaLabel : drawersOverflowAriaLabel}
             customTriggerBuilder={({ onClick, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => (
               <TriggerButton
-                ref={triggerRef}
+                ref={openedFromOverflow ? drawersRefs.toggle : triggerRef}
                 ariaLabel={ariaLabel}
                 ariaExpanded={ariaExpanded}
                 badge={overflowMenuHasBadge}
@@ -269,6 +273,7 @@ function DesktopTriggers() {
             )}
             onItemClick={({ detail }) => {
               handleDrawersClick(detail.id);
+              setOpenedFromOverflow(true);
             }}
           />
         )}
@@ -308,6 +313,7 @@ export function MobileTriggers() {
   } = useAppLayoutInternals();
 
   const previousActiveDrawerId = useRef(activeDrawerId);
+  const [openedFromOverflow, setOpenedFromOverflow] = React.useState(false);
 
   if (!drawers) {
     return null;
@@ -340,13 +346,16 @@ export function MobileTriggers() {
               item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
             )}
             disabled={hasDrawerViewportOverlay}
-            ref={item.id === previousActiveDrawerId.current ? drawersRefs.toggle : undefined}
+            ref={item.id === previousActiveDrawerId.current && !openedFromOverflow ? drawersRefs.toggle : undefined}
             formAction="none"
             iconName={item.trigger.iconName}
             iconSvg={item.trigger.iconSvg}
             badge={item.badge}
             key={item.id}
-            onClick={() => handleDrawersClick(item.id)}
+            onClick={() => {
+              handleDrawersClick(item.id);
+              setOpenedFromOverflow(false);
+            }}
             variant="icon"
             __nativeAttributes={{ 'aria-haspopup': true, 'data-testid': `awsui-app-layout-trigger-${item.id}` }}
           />
@@ -355,7 +364,24 @@ export function MobileTriggers() {
           <OverflowMenu
             items={overflowItems}
             ariaLabel={overflowMenuHasBadge ? drawersOverflowWithBadgeAriaLabel : drawersOverflowAriaLabel}
-            onItemClick={({ detail }) => handleDrawersClick(detail.id)}
+            onItemClick={({ detail }) => {
+              handleDrawersClick(detail.id);
+              setOpenedFromOverflow(true);
+            }}
+            customTriggerBuilder={({ onClick, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => {
+              return (
+                <InternalButton
+                  ref={openedFromOverflow ? drawersRefs.toggle : triggerRef}
+                  className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'], testUtilsClass)}
+                  ariaLabel={ariaLabel}
+                  ariaExpanded={ariaExpanded}
+                  variant="icon"
+                  iconName="ellipsis"
+                  badge={overflowMenuHasBadge}
+                  onClick={onClick}
+                />
+              );
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
From Drawers Bug Bash.

Focus was lost when opening a drawer from the overflow menu, and then closing it again. This adds openedFromOverflow logic to update the focus ref to the overflow button if a drawer was opened from the overflow menu.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
