### PR TITLE
chore: Cascade postcss version upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10445,11 +10445,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/icss-utils": {
       "version": "5.1.0",
       "dev": true,
@@ -15144,32 +15139,12 @@
       }
     },
     "node_modules/postcss-initial": {
-      "version": "3.0.4",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^7.0.2"
-      }
-    },
-    "node_modules/postcss-initial/node_modules/picocolors": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/postcss-initial/node_modules/postcss": {
-      "version": "7.0.39",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-inline-svg": {
@@ -15326,12 +15301,13 @@
       }
     },
     "node_modules/postcss-modules": {
-      "version": "4.3.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
+      "integrity": "sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "generic-names": "^4.0.0",
-        "icss-replace-symbols": "^1.1.0",
+        "icss-utils": "^5.1.0",
         "lodash.camelcase": "^4.3.0",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
@@ -27395,10 +27371,6 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
-    "icss-replace-symbols": {
-      "version": "1.1.0",
-      "dev": true
-    },
     "icss-utils": {
       "version": "5.1.0",
       "dev": true,
@@ -30451,25 +30423,11 @@
       "requires": {}
     },
     "postcss-initial": {
-      "version": "3.0.4",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
       "dev": true,
-      "requires": {
-        "postcss": "^7.0.2"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "0.2.1",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        }
-      }
+      "requires": {}
     },
     "postcss-inline-svg": {
       "version": "6.0.0",
@@ -30566,11 +30524,13 @@
       }
     },
     "postcss-modules": {
-      "version": "4.3.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
+      "integrity": "sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==",
       "dev": true,
       "requires": {
         "generic-names": "^4.0.0",
-        "icss-replace-symbols": "^1.1.0",
+        "icss-utils": "^5.1.0",
         "lodash.camelcase": "^4.3.0",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",


### PR DESCRIPTION
### Description

Pull in this upgrade: https://github.com/cloudscape-design/theming-core/pull/62

Should resolve https://github.com/cloudscape-design/components/security/dependabot/36

Related links, issue #, if available: n/a

### How has this been tested?

Checked package-lock.json

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
