### PR TITLE
fix: Cache dropdown's overflow parents for better jsdom performance

### DIFF
--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -156,6 +156,7 @@ export const getWidths = ({
 export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
   triggerElement,
   dropdownElement,
+  dropdownOverflowParents,
   desiredMinWidth,
   expandToViewport,
   stretchWidth,
@@ -164,14 +165,16 @@ export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
 }: {
   triggerElement: HTMLElement;
   dropdownElement: HTMLElement;
+  dropdownOverflowParents: HTMLElement[];
   desiredMinWidth?: number;
   expandToViewport: boolean;
   stretchWidth: boolean;
   stretchHeight: boolean;
   isMobile: boolean;
 }) => {
-  const overflowParents = getOverflowParentDimensions({
+  const overflowParentDimensions = getOverflowParentDimensions({
     element: dropdownElement,
+    overflowParents: dropdownOverflowParents,
     excludeClosestParent: false,
     expandToViewport,
     canExpandOutsideViewport: stretchHeight,
@@ -184,7 +187,7 @@ export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
   });
   const availableSpace = getAvailableSpace({
     trigger: triggerElement,
-    overflowParents,
+    overflowParents: overflowParentDimensions,
     stretchWidth,
     stretchHeight,
     isMobile,
@@ -313,19 +316,33 @@ export const getInteriorDropdownPosition = (
   };
 };
 
-export const calculatePosition = (
-  dropdownElement: HTMLDivElement,
-  triggerElement: HTMLDivElement,
-  verticalContainerElement: HTMLDivElement,
-  interior: boolean,
-  expandToViewport: boolean,
-  preferCenter: boolean,
-  stretchWidth: boolean,
-  stretchHeight: boolean,
-  isMobile: boolean,
-  minWidth?: number,
-  stretchBeyondTriggerWidth?: boolean
-): [DropdownPosition, DOMRect] => {
+export const calculatePosition = ({
+  dropdownElement,
+  dropdownOverflowParents,
+  triggerElement,
+  verticalContainerElement,
+  interior,
+  expandToViewport,
+  preferCenter,
+  stretchWidth,
+  stretchHeight,
+  isMobile,
+  minWidth,
+  stretchBeyondTriggerWidth,
+}: {
+  dropdownElement: HTMLDivElement;
+  dropdownOverflowParents: HTMLElement[];
+  triggerElement: HTMLDivElement;
+  verticalContainerElement: HTMLDivElement;
+  interior: boolean;
+  expandToViewport: boolean;
+  preferCenter: boolean;
+  stretchWidth: boolean;
+  stretchHeight: boolean;
+  isMobile: boolean;
+  minWidth?: number;
+  stretchBeyondTriggerWidth?: boolean;
+}): [DropdownPosition, DOMRect] => {
   // cleaning previously assigned values,
   // so that they are not reused in case of screen resize and similar events
   verticalContainerElement.style.maxHeight = '';
@@ -343,6 +360,7 @@ export const calculatePosition = (
     excludeClosestParent: interior,
     expandToViewport,
     canExpandOutsideViewport: stretchHeight,
+    overflowParents: dropdownOverflowParents,
   });
   const position = interior
     ? getInteriorDropdownPosition(triggerElement, dropdownElement, overflowParents, isMobile)

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -173,7 +173,6 @@ export const hasEnoughSpaceToStretchBeyondTriggerWidth = ({
   isMobile: boolean;
 }) => {
   const overflowParentDimensions = getOverflowParentDimensions({
-    element: dropdownElement,
     overflowParents: dropdownOverflowParents,
     excludeClosestParent: false,
     expandToViewport,
@@ -356,7 +355,6 @@ export const calculatePosition = ({
   dropdownElement.classList.remove(styles['dropdown-drop-up']);
 
   const overflowParents = getOverflowParentDimensions({
-    element: dropdownElement,
     excludeClosestParent: interior,
     expandToViewport,
     canExpandOutsideViewport: stretchHeight,

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -344,21 +344,23 @@ const Dropdown = ({
   // Prevent the dropdown width from stretching beyond the trigger width
   // if that is going to cause the dropdown to be cropped because of overflow
   useLayoutEffect(() => {
-    if (stretchBeyondTriggerWidth && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
-      if (
-        !hasEnoughSpaceToStretchBeyondTriggerWidth({
-          triggerElement: triggerRef.current,
-          dropdownElement: dropdownRef.current,
-          dropdownOverflowParents: getDropdownOverflowParents(),
-          desiredMinWidth: minWidth,
-          expandToViewport,
-          stretchWidth,
-          stretchHeight,
-          isMobile,
-        })
-      ) {
-        dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
-      }
+    if (
+      stretchBeyondTriggerWidth &&
+      dropdownRef.current &&
+      triggerRef.current &&
+      verticalContainerRef.current &&
+      !hasEnoughSpaceToStretchBeyondTriggerWidth({
+        triggerElement: triggerRef.current,
+        dropdownElement: dropdownRef.current,
+        dropdownOverflowParents: getDropdownOverflowParents(),
+        desiredMinWidth: minWidth,
+        expandToViewport,
+        stretchWidth,
+        stretchHeight,
+        isMobile,
+      })
+    ) {
+      dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
     }
   });
 

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -18,31 +18,27 @@ export const getOverflowParents = (element: HTMLElement): HTMLElement[] => {
 };
 
 export const getOverflowParentDimensions = ({
-  element,
   excludeClosestParent = false,
   expandToViewport = false,
   canExpandOutsideViewport = false,
-  overflowParents = getOverflowParents(element),
+  overflowParents,
 }: {
-  element: HTMLElement;
   excludeClosestParent: boolean;
   expandToViewport: boolean;
   canExpandOutsideViewport: boolean;
-  overflowParents?: HTMLElement[];
+  overflowParents: HTMLElement[];
 }): Dimensions[] => {
-  const parents = expandToViewport
-    ? []
-    : overflowParents.map(el => {
-        const { height, width, top, left } = el.getBoundingClientRect();
-        return {
-          // Treat the whole scrollable area as the available height
-          // if we're allowed to expand past the viewport.
-          height: canExpandOutsideViewport ? el.scrollHeight : height,
-          width,
-          top,
-          left,
-        };
-      });
+  const parents = overflowParents.map(el => {
+    const { height, width, top, left } = el.getBoundingClientRect();
+    return {
+      // Treat the whole scrollable area as the available height
+      // if we're allowed to expand past the viewport.
+      height: canExpandOutsideViewport ? el.scrollHeight : height,
+      width,
+      top,
+      left,
+    };
+  });
 
   if (canExpandOutsideViewport && !expandToViewport) {
     const documentDimensions = document.documentElement.getBoundingClientRect();

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -22,15 +22,17 @@ export const getOverflowParentDimensions = ({
   excludeClosestParent = false,
   expandToViewport = false,
   canExpandOutsideViewport = false,
+  overflowParents = getOverflowParents(element),
 }: {
   element: HTMLElement;
   excludeClosestParent: boolean;
   expandToViewport: boolean;
   canExpandOutsideViewport: boolean;
+  overflowParents?: HTMLElement[];
 }): Dimensions[] => {
   const parents = expandToViewport
     ? []
-    : getOverflowParents(element).map(el => {
+    : overflowParents.map(el => {
         const { height, width, top, left } = el.getBoundingClientRect();
         return {
           // Treat the whole scrollable area as the available height


### PR DESCRIPTION
### Description

`getOverflowParents` is expensive on testing environments because we are calling `getComputedStyle` on every element in the parent chain and Jest does not yet incorporate a version of jsdom that includes [this fix](https://github.com/jsdom/jsdom/pull/3482). This causes some packages to have test timeouts after #1555.

This PR handles this by caching the result of `getOverflowParents` in the dropdown component. Note that it does not cache their dimensions, which will still be recalculated as necessary.

Ticket: AWSUI-22613

### How has this been tested?

- Successful dry-run build to previously failing package
- Successfully ran tests in previously failing package, and observed that the run time is reduced significantly (~3x).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
