### PR TITLE
feat: Allow Cards selection by clicking anywhere on the card with `entireCardClickable` property

### DIFF
--- a/pages/cards/selection.page.tsx
+++ b/pages/cards/selection.page.tsx
@@ -2,17 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import range from 'lodash/range';
-import Cards, { CardsProps } from '~components/cards/index';
-import Header from '~components/header/index';
+import Cards, { CardsProps } from '~components/cards';
+import Header from '~components/header';
 import Toggle from '~components/toggle';
+import { EmptyState } from '../table/shared-configs';
+import { useCollection } from '@cloudscape-design/collection-hooks';
+import Pagination from '~components/pagination';
+import TextFilter from '~components/text-filter';
 
 interface Item {
   number: number;
   text: string;
 }
 
+const renderAriaLive: CardsProps['renderAriaLive'] = ({ firstIndex, lastIndex, totalItemsCount }) =>
+  `Displaying items ${firstIndex} to ${lastIndex} of ${totalItemsCount}`;
+
+const getHeaderCounterText = (items: ReadonlyArray<unknown>, selectedItems: ReadonlyArray<unknown> | undefined) => {
+  return selectedItems && selectedItems?.length > 0 ? `(${selectedItems.length}/${items.length})` : `(${items.length})`;
+};
+
 const ariaLabels: CardsProps<Item>['ariaLabels'] = {
-  selectionGroupLabel: 'group label',
+  selectionGroupLabel: 'Resource selection',
   itemSelectionLabel: ({ selectedItems }, item) =>
     `${item.text} is ${!selectedItems.includes(item) ? 'not ' : ''}selected`,
 };
@@ -38,12 +49,23 @@ const cardDefinition: CardsProps.CardDefinition<Item> = {
   ],
 };
 
-const items = createSimpleItems(8);
+const getTextFilterCounterText = (count: number) => `${count} ${count === 1 ? 'match' : 'matches'}`;
+
+const allItems = createSimpleItems(50);
 
 export default function () {
-  const [selectedItems, setSelectedItems] = useState<Item[]>([]);
+  const [selectionType, setSelectionType] = useState<CardsProps.SelectionType>('multi');
   const [entireCard, setEntireCard] = useState(false);
   const [someDisabled, setSomeDisabled] = useState(false);
+
+  const { items, filteredItemsCount, collectionProps, filterProps, paginationProps } = useCollection(allItems, {
+    filtering: {
+      empty: <EmptyState title="No resources" subtitle="No resources to display." action={null} />,
+      noMatch: <EmptyState title="No matches" subtitle="We can’t find a match." action={null} />,
+    },
+    pagination: { pageSize: 10 },
+    selection: {},
+  });
 
   return (
     <>
@@ -54,16 +76,32 @@ export default function () {
       <Toggle checked={someDisabled} onChange={event => setSomeDisabled(event.detail.checked)}>
         Make some card elements inactive
       </Toggle>
+      <Toggle
+        checked={selectionType === 'multi'}
+        onChange={event => setSelectionType(event.detail.checked ? 'multi' : 'single')}
+      >
+        Use multi selection
+      </Toggle>
       <Cards<Item>
+        {...collectionProps}
         items={items}
         cardDefinition={cardDefinition}
-        header={<Header>Cards header</Header>}
-        selectionType="multi"
-        selectedItems={selectedItems}
-        onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+        header={<Header counter={getHeaderCounterText(allItems, collectionProps.selectedItems)}>Resources</Header>}
+        selectionType={selectionType}
         ariaLabels={ariaLabels}
+        renderAriaLive={renderAriaLive}
         entireCardClickable={entireCard}
         isItemDisabled={item => someDisabled && !item.text.includes('o')}
+        pagination={<Pagination {...paginationProps} />}
+        filter={
+          <TextFilter
+            {...filterProps}
+            filteringAriaLabel="Filter resources"
+            filteringPlaceholder="Find resources"
+            filteringClearAriaLabel="Clear"
+            countText={getTextFilterCounterText(filteredItemsCount ?? 0)}
+          />
+        }
       />
     </>
   );

--- a/pages/cards/selection.page.tsx
+++ b/pages/cards/selection.page.tsx
@@ -5,7 +5,7 @@ import range from 'lodash/range';
 import Cards, { CardsProps } from '~components/cards';
 import Header from '~components/header';
 import Toggle from '~components/toggle';
-import { EmptyState } from '../table/shared-configs';
+import { EmptyState, getMatchesCountText, paginationLabels } from '../table/shared-configs';
 import { useCollection } from '@cloudscape-design/collection-hooks';
 import Pagination from '~components/pagination';
 import TextFilter from '~components/text-filter';
@@ -49,8 +49,6 @@ const cardDefinition: CardsProps.CardDefinition<Item> = {
   ],
 };
 
-const getTextFilterCounterText = (count: number) => `${count} ${count === 1 ? 'match' : 'matches'}`;
-
 const allItems = createSimpleItems(50);
 
 export default function () {
@@ -92,14 +90,14 @@ export default function () {
         renderAriaLive={renderAriaLive}
         entireCardClickable={entireCard}
         isItemDisabled={item => someDisabled && !item.text.includes('o')}
-        pagination={<Pagination {...paginationProps} />}
+        pagination={<Pagination {...paginationProps} ariaLabels={paginationLabels} />}
         filter={
           <TextFilter
             {...filterProps}
             filteringAriaLabel="Filter resources"
             filteringPlaceholder="Find resources"
             filteringClearAriaLabel="Clear"
-            countText={getTextFilterCounterText(filteredItemsCount ?? 0)}
+            countText={getMatchesCountText(filteredItemsCount ?? 0)}
           />
         }
       />

--- a/pages/cards/selection.page.tsx
+++ b/pages/cards/selection.page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import range from 'lodash/range';
 import Cards, { CardsProps } from '~components/cards/index';
 import Header from '~components/header/index';
+import Toggle from '~components/toggle';
 
 interface Item {
   number: number;
@@ -37,13 +38,22 @@ const cardDefinition: CardsProps.CardDefinition<Item> = {
   ],
 };
 
-const items = createSimpleItems(4);
+const items = createSimpleItems(8);
 
 export default function () {
   const [selectedItems, setSelectedItems] = useState<Item[]>([]);
+  const [entireCard, setEntireCard] = useState(false);
+  const [someDisabled, setSomeDisabled] = useState(false);
+
   return (
     <>
       <h1>Cards selection</h1>
+      <Toggle checked={entireCard} onChange={event => setEntireCard(event.detail.checked)}>
+        Allow clicking entire card to select
+      </Toggle>
+      <Toggle checked={someDisabled} onChange={event => setSomeDisabled(event.detail.checked)}>
+        Make some card elements inactive
+      </Toggle>
       <Cards<Item>
         items={items}
         cardDefinition={cardDefinition}
@@ -52,6 +62,8 @@ export default function () {
         selectedItems={selectedItems}
         onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
         ariaLabels={ariaLabels}
+        entireCardClickable={entireCard}
+        isItemDisabled={item => someDisabled && !item.text.includes('o')}
       />
     </>
   );

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3829,7 +3829,7 @@ Default value:
     },
     Object {
       "description": "Activating this property makes the entire card clickable to select it.
-Do not use this if there are any other interactive elements in the card.",
+Don't use this property if the card has any other interactive elements.",
       "name": "entireCardClickable",
       "optional": true,
       "type": "boolean",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3828,6 +3828,13 @@ Default value:
       "type": "string",
     },
     Object {
+      "description": "Activating this property makes the entire card clickable to select it.
+Do not use this if there are any other interactive elements in the card.",
+      "name": "entireCardClickable",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "description": " Use this property to inform screen readers which range of cards is currently displayed.
  It specifies the index (1-based) of the first card.
  If the cards list has no pagination, leave this property undefined.",

--- a/src/cards/__tests__/selection.test.tsx
+++ b/src/cards/__tests__/selection.test.tsx
@@ -66,6 +66,20 @@ describe('Cards selection', () => {
       ).wrapper;
       expect(getSelectedCardsText()).toEqual(['0']);
     });
+
+    it('cannot select items by clicking anywhere on the card by default', () => {
+      wrapper = renderCards(<Cards<Item> {...props} selectionType={selectionType} />).wrapper;
+      getCard(1).findCardHeader()?.click();
+      expect(handleSelectionChange).not.toHaveBeenCalled();
+    });
+
+    it('can select items by clicking anywhere on the card when entireCardClickable is enabled', () => {
+      wrapper = renderCards(
+        <Cards<Item> {...props} selectionType={selectionType} entireCardClickable={true} />
+      ).wrapper;
+      getCard(1).findCardHeader()?.click();
+      expectSelected([{ description: '1' }]);
+    });
   });
 
   describe('Single selection', () => {

--- a/src/cards/__tests__/selection.test.tsx
+++ b/src/cards/__tests__/selection.test.tsx
@@ -79,6 +79,7 @@ describe('Cards selection', () => {
       ).wrapper;
       getCard(1).findCardHeader()?.click();
       expectSelected([{ description: '1' }]);
+      expect(getCardSelectionArea(1)?.find('input')?.getElement()).toHaveFocus();
     });
   });
 

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -269,7 +269,15 @@ const CardsList = <T,>({
         >
           <div
             className={styles['card-inner']}
-            onClick={canClickEntireCard ? getItemSelectionProps(item).onChange : undefined}
+            onClick={
+              canClickEntireCard
+                ? event => {
+                    getItemSelectionProps(item).onChange();
+                    // Manually move focus to the native input (checkbox or radio button)
+                    event.currentTarget.querySelector('input')?.focus();
+                  }
+                : undefined
+            }
           >
             <div className={styles['card-header']}>
               <div className={styles['card-header-inner']}>

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -59,6 +59,7 @@ const Cards = React.forwardRef(function <T = any>(
     renderAriaLive,
     firstIndex,
     totalItemsCount,
+    entireCardClickable,
     ...rest
   }: CardsProps<T>,
   ref: React.Ref<CardsProps.Ref>
@@ -187,6 +188,7 @@ const Cards = React.forwardRef(function <T = any>(
                   onFocus={onCardFocus}
                   ariaLabel={ariaLabels?.cardsLabel}
                   ariaLabelledby={isLabelledByHeader && headerIdRef.current ? headerIdRef.current : undefined}
+                  entireCardClickable={entireCardClickable}
                 />
               )}
             </div>
@@ -212,7 +214,11 @@ const CardsList = <T,>({
   onFocus,
   ariaLabelledby,
   ariaLabel,
-}: Pick<CardsProps<T>, 'items' | 'cardDefinition' | 'trackBy' | 'selectionType' | 'visibleSections'> & {
+  entireCardClickable,
+}: Pick<
+  CardsProps<T>,
+  'items' | 'cardDefinition' | 'trackBy' | 'selectionType' | 'visibleSections' | 'entireCardClickable'
+> & {
   columns: number | null;
   isItemSelected: (item: T) => boolean;
   getItemSelectionProps: (item: T) => SelectionControlProps;
@@ -223,6 +229,7 @@ const CardsList = <T,>({
   ariaDescribedby?: string;
 }) => {
   const selectable = !!selectionType;
+  const canClickEntireCard = selectable && entireCardClickable;
 
   const { moveFocusDown, moveFocusUp } = useSelectionFocusMove(selectionType, items.length);
 
@@ -260,7 +267,10 @@ const CardsList = <T,>({
           {...(focusMarkers && focusMarkers.item)}
           role={listItemRole}
         >
-          <div className={styles['card-inner']}>
+          <div
+            className={styles['card-inner']}
+            onClick={canClickEntireCard ? getItemSelectionProps(item).onChange : undefined}
+          >
             <div className={styles['card-header']}>
               <div className={styles['card-header-inner']}>
                 {cardDefinition.header ? cardDefinition.header(item) : ''}

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -210,7 +210,7 @@ export interface CardsProps<T = any> extends BaseComponentProps {
 
   /**
    * Activating this property makes the entire card clickable to select it.
-   * Do not use this if there are any other interactive elements in the card.
+   * Don't use this property if the card has any other interactive elements.
    */
   entireCardClickable?: boolean;
 }

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -207,6 +207,12 @@ export interface CardsProps<T = any> extends BaseComponentProps {
    * @visualrefresh `full-page` variant
    */
   variant?: 'container' | 'full-page';
+
+  /**
+   * Activating this property makes the entire card clickable to select it.
+   * Do not use this if there are any other interactive elements in the card.
+   */
+  entireCardClickable?: boolean;
 }
 
 export namespace CardsProps {


### PR DESCRIPTION
### Description

This change introduces a new property for Cards that allows the entire card to be clickable to make a selection. This is helpful when selection is a main use-case for this instance of Cards, and there are no other interactive elements in the cards sections.

Related links, issue #, if available: AWSUI-14894, `InohAwVWe3aI`

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
