### PR TITLE
chore: Switch to new actions repo for workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,14 +20,14 @@ permissions:
 
 jobs:
   build:
-    uses: cloudscape-design/.github/.github/workflows/build-lint-test.yml@main
+    uses: cloudscape-design/actions/.github/workflows/build-lint-test.yml@main
     secrets: inherit
     with:
       artifact-path: lib/static-default
       artifact-name: dev-pages
   deploy:
     needs: build
-    uses: cloudscape-design/.github/.github/workflows/deploy.yml@main
+    uses: cloudscape-design/actions/.github/workflows/deploy.yml@main
     secrets: inherit
     with:
       artifact-name: dev-pages

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -27,7 +27,7 @@ jobs:
             })
 
       - name: Checkout the PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'components'
 
@@ -64,7 +64,7 @@ jobs:
       # ------- Base branch size measurement ------------------------------
 
       - name: Checkout the base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: 'components'
@@ -102,7 +102,7 @@ jobs:
       # ------- Pull request size measurement -----------------------------
 
       - name: Checkout the PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'components'
 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   dry-run:
-    uses: cloudscape-design/.github/.github/workflows/dry-run.yml@main
+    uses: cloudscape-design/actions/.github/workflows/dry-run.yml@main

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   dry-run:
-    uses: cloudscape-design/.github/.github/workflows/lint-pr.yml@main
+    uses: cloudscape-design/actions/.github/workflows/lint-pr.yml@main

--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    uses: cloudscape-design/.github/.github/workflows/release-gh-notes.yml@main
+    uses: cloudscape-design/actions/.github/workflows/release-gh-notes.yml@main
     secrets: inherit
     with:
       npm_package: ${{ github.event.inputs.npm_package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Components unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -30,7 +30,7 @@ jobs:
     name: Components integ tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -46,7 +46,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -63,7 +63,7 @@ jobs:
       - integTest
       - a11yTest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,6 @@ jobs:
           aws codeartifact login --tool npm --repository $CODE_ARTIFACT_REPO --domain awsui --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region us-west-2 --namespace @cloudscape-design
 
       - name: Release package to private CodeArtifact
-        uses: cloudscape-design/.github/.github/actions/release-package@main
+        uses: cloudscape-design/actions/.github/actions/release-package@main
         with:
           publish-packages: lib/components,lib/design-tokens,lib/style-dictionary,lib/components-themeable,lib/dev-pages,lib/components-definitions

--- a/.github/workflows/visuals.yml
+++ b/.github/workflows/visuals.yml
@@ -17,7 +17,7 @@ jobs:
     name: Generate reference images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
       - name: Setup Node.js
@@ -47,7 +47,7 @@ jobs:
     needs:
       - buildReference
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### Description
This PR switches to the new shared repository for GitHub workflows and actions: https://github.com/cloudscape-design/actions.

For the most recent changes to the shared workflows, see https://github.com/cloudscape-design/actions/pull/1. The new configuration was successfully tested in this Draft PR: https://github.com/cloudscape-design/components/pull/1672.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
