### PR TITLE
fix: Add currently selected value to date range picker's trigger label

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -70,7 +70,10 @@ describe('Date range picker', () => {
 
     test('aria-labelledby', () => {
       const { wrapper } = renderDateRangePicker({ ...defaultProps, ariaLabelledby: '#element' });
-      expect(wrapper.findTrigger().getElement()).toHaveAttribute('aria-labelledby', '#element');
+      expect(wrapper.findTrigger().getElement()).toHaveAttribute(
+        'aria-labelledby',
+        expect.stringContaining('#element')
+      );
 
       wrapper.openDropdown();
       expect(wrapper.findDropdown()!.getElement()).toHaveAttribute('aria-labelledby', '#element');
@@ -84,6 +87,19 @@ describe('Date range picker', () => {
     test('controlId', () => {
       const { wrapper } = renderDateRangePicker({ ...defaultProps, controlId: 'test' });
       expect(wrapper.findTrigger().getElement()).toHaveAttribute('id', 'test');
+    });
+
+    test('correctly labels the dropdown trigger with the selected value', () => {
+      const value = { type: 'relative', amount: 5, unit: 'day' } as const;
+      const { container } = render(
+        <FormField label="Label">
+          <DateRangePicker {...defaultProps} value={value} />
+        </FormField>
+      );
+      const wrapper = createWrapper(container).findDateRangePicker()!;
+      expect(wrapper.findTrigger().getElement()).toHaveAccessibleName(
+        'Label ' + i18nStrings.formatRelativeRange!(value)
+      );
     });
 
     test('does not pass through form field context to dropdown elements', () => {

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -21,14 +21,15 @@ import InternalIcon from '../icon/internal';
 import { normalizeTimeOffset, shiftTimeOffset } from './time-offset';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
-import { fireNonCancelableEvent } from '../internal/events/index.js';
+import { fireNonCancelableEvent } from '../internal/events';
 import { isDevelopment } from '../internal/is-development.js';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
-import { usePrevious } from '../internal/hooks/use-previous/index.js';
+import { usePrevious } from '../internal/hooks/use-previous';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { joinStrings } from '../internal/utils/strings/join-strings';
 import { formatDateRange, isIsoDateOnly } from '../internal/utils/date-time';
-import { formatValue } from './utils.js';
-import { useInternalI18n } from '../i18n/context.js';
+import { useInternalI18n } from '../i18n/context';
+import { formatValue } from './utils';
 
 export { DateRangePickerProps };
 
@@ -128,6 +129,7 @@ const DateRangePicker = React.forwardRef(
 
     const rootRef = useRef<HTMLDivElement>(null);
     const dropdownId = useUniqueId('date-range-picker-dropdown');
+    const triggerContentId = useUniqueId('date-range-picker-trigger');
 
     useFocusTracker({ rootRef, onBlur, onFocus });
 
@@ -229,9 +231,9 @@ const DateRangePicker = React.forwardRef(
           ref={triggerRef}
           id={controlId}
           invalid={invalid}
+          ariaLabelledby={joinStrings(ariaLabelledby, triggerContentId)}
           ariaLabel={i18nStrings?.ariaLabel}
           ariaDescribedby={ariaDescribedby}
-          ariaLabelledby={ariaLabelledby}
           className={clsx(styles.label, {
             [styles['label-enabled']]: !readOnly && !disabled,
           })}
@@ -249,7 +251,9 @@ const DateRangePicker = React.forwardRef(
             <span className={styles['icon-wrapper']}>
               <InternalIcon name="calendar" variant={disabled || readOnly ? 'disabled' : 'normal'} />
             </span>
-            {renderDateRange(value, placeholder ?? '', formatRelativeRange, normalizedTimeOffset)}
+            <span id={triggerContentId}>
+              {renderDateRange(value, placeholder ?? '', formatRelativeRange, normalizedTimeOffset)}
+            </span>
           </span>
         </ButtonTrigger>
       </div>


### PR DESCRIPTION
### Description

The trigger for the date range picker doesn't include the selected value. So screen reader users will be unable to tell what the selected date is. This is also something we do in other components like selects.

Related links, issue #, if available: AWSUI-22616

### How has this been tested?

Unit tests!

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
