### PR TITLE
fix: Adjust dropdown width only on resize

### DIFF
--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -23,6 +23,7 @@ import TabTrap from '../tab-trap/index.js';
 import { getFirstFocusable, getLastFocusable } from '../focus-lock/utils.js';
 import { useUniqueId } from '../../hooks/use-unique-id/index.js';
 import customCssProps from '../../generated/custom-css-properties';
+import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
 interface DropdownContainerProps {
   children?: React.ReactNode;
@@ -278,6 +279,32 @@ const Dropdown = ({
     }
   };
 
+  // Prevent the dropdown width from stretching beyond the trigger width
+  // if that is going to cause the dropdown to be cropped because of overflow
+  const fixStretching = () => {
+    const classNameToRemove = styles['stretch-beyond-trigger-width'];
+    if (
+      open &&
+      stretchBeyondTriggerWidth &&
+      dropdownRef.current &&
+      triggerRef.current &&
+      dropdownRef.current.classList.contains(classNameToRemove) &&
+      !hasEnoughSpaceToStretchBeyondTriggerWidth({
+        triggerElement: triggerRef.current,
+        dropdownElement: dropdownRef.current,
+        desiredMinWidth: minWidth,
+        expandToViewport,
+        stretchWidth,
+        stretchHeight,
+        isMobile,
+      })
+    ) {
+      dropdownRef.current.classList.remove(classNameToRemove);
+    }
+  };
+
+  useResizeObserver(() => dropdownRef.current, fixStretching);
+
   useLayoutEffect(() => {
     const onDropdownOpen = () => {
       if (open && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
@@ -326,26 +353,6 @@ const Dropdown = ({
     // See AWSUI-13040
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, dropdownRef, triggerRef, verticalContainerRef, interior, stretchWidth, isMobile, contentKey]);
-
-  // Prevent the dropdown width from stretching beyond the trigger width
-  // if that is going to cause the dropdown to be cropped because of overflow
-  useLayoutEffect(() => {
-    if (stretchBeyondTriggerWidth && dropdownRef.current && triggerRef.current && verticalContainerRef.current) {
-      if (
-        !hasEnoughSpaceToStretchBeyondTriggerWidth({
-          triggerElement: triggerRef.current,
-          dropdownElement: dropdownRef.current,
-          desiredMinWidth: minWidth,
-          expandToViewport,
-          stretchWidth,
-          stretchHeight,
-          isMobile,
-        })
-      ) {
-        dropdownRef.current.classList.remove(styles['stretch-beyond-trigger-width']);
-      }
-    }
-  });
 
   // subscribe to outside click
   useEffect(() => {


### PR DESCRIPTION
### Description

Alternative fix to https://github.com/cloudscape-design/components/pull/1669, without caching anything.

Ticket: AWSUI-22613

Note: dropdowns do not expand beyond the trigger width when virtual scroll is enabled. This is a known issue: AWSUI-22357

### How has this been tested?

- Successful dry-run build to same failing package as in https://github.com/cloudscape-design/components/pull/1669. The build time is similar (11m 47s then, 12m 35s now)
- Manually tested against existing page `dropdown/width` (which also has [integration tests](https://github.com/cloudscape-design/components/blob/main/src/internal/components/dropdown/__integ__/width.test.ts))

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
