### PR TITLE
fix: Close chart popover when focus moves away

### DIFF
--- a/src/area-chart/__integ__/area-chart.test.ts
+++ b/src/area-chart/__integ__/area-chart.test.ts
@@ -227,6 +227,22 @@ describe('Popover', () => {
       await expect(page.hasPopover()).resolves.toBe(false);
     })
   );
+
+  test(
+    'popover can be closed by moving focus away',
+    setupTest('#/light/area-chart/test', 'Controlled linear latency chart', async page => {
+      await page.focusPlot();
+      await expect(page.hasPopover()).resolves.toBe(true);
+      const popover = page.getPopover();
+      const buttonDropdown = popover.findContent().findButtonDropdown();
+      expect(page.getElementsCount(buttonDropdown.toSelector())).resolves.toBe(1);
+      await page.keys(['Tab']);
+      expect(await page.getFocusedElementText()).toBe('Actions');
+      await page.keys(['Tab']);
+      expect(await page.getFocusedElementText()).toBe('p50');
+      await expect(page.hasPopover()).resolves.toBe(false);
+    })
+  );
 });
 
 describe('Keyboard navigation', () => {

--- a/src/area-chart/__integ__/page-objects/area-chart-page.ts
+++ b/src/area-chart/__integ__/page-objects/area-chart-page.ts
@@ -112,4 +112,8 @@ export default class AreaChartPageObject extends BasePageObject {
     const distanceBetweenPoints = (chartWidth - labelsWidth) / totalPoints;
     return labelsWidth + distanceBetweenPoints * serialIndex;
   }
+
+  getPopover() {
+    return this.chart.findDetailPopover();
+  }
 }

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -199,6 +199,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
           dismissAriaLabel={detailPopoverDismissAriaLabel}
           size={detailPopoverSize}
           footer={detailPopoverFooterContent}
+          onBlur={model.handlers.onSVGBlur}
         />
       }
     />

--- a/src/area-chart/elements/chart-popover.tsx
+++ b/src/area-chart/elements/chart-popover.tsx
@@ -17,12 +17,14 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
   dismissAriaLabel,
   footer,
   size,
+  onBlur,
 }: {
   model: ChartModel<T>;
   highlightDetails: null | HighlightDetails;
   dismissAriaLabel?: string;
   footer?: React.ReactNode;
   size?: 'small' | 'medium' | 'large';
+  onBlur?: (event: React.FocusEvent) => void;
 }) {
   if (!highlightDetails) {
     return null;
@@ -44,6 +46,7 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
       container={model.refs.container.current}
       dismissAriaLabel={dismissAriaLabel}
       size={size}
+      onBlur={onBlur}
     >
       <ChartSeriesDetails details={highlightDetails.seriesDetails} />
       <div className={styles['popover-divider']} />

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -16,6 +16,7 @@ import { throttle } from '../../internal/utils/throttle';
 import { useReaction } from '../async-store';
 import { useHeightMeasure } from '../../internal/hooks/container-queries/use-height-measure';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
+import { nodeBelongs } from '../../internal/utils/node-belongs';
 
 const MAX_HOVER_MARGIN = 6;
 const SVG_HOVER_THROTTLE = 25;
@@ -273,10 +274,10 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     // A callback for svg blur to clear all highlights unless the popover is pinned.
-    const onSVGBlur = () => {
+    const onSVGBlur = (event: React.FocusEvent<Element>) => {
       // Pinned popover stays pinned even if the focus is lost.
       // If blur is not caused by the popover, forget the previously highlighted point.
-      if (!interactions.get().isPopoverPinned) {
+      if (!nodeBelongs(containerRef.current, event.relatedTarget) && !interactions.get().isPopoverPinned) {
         interactions.clearHighlight();
       }
     };

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -44,6 +44,8 @@ export interface ChartPopoverProps extends PopoverProps {
   /** Fired when the pointer leaves the hoverable area around the popover */
   onMouseLeave?: (event: React.MouseEvent) => void;
 
+  onBlur?: (event: React.FocusEvent) => void;
+
   /** Popover content */
   children?: React.ReactNode;
 }
@@ -68,6 +70,7 @@ function ChartPopover(
 
     onMouseEnter,
     onMouseLeave,
+    onBlur,
 
     ...restProps
   }: ChartPopoverProps,
@@ -102,6 +105,7 @@ function ChartPopover(
       ref={popoverRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onBlur={onBlur}
     >
       <PopoverContainer
         size={size}

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -384,6 +384,19 @@ describe('Details popover', () => {
     })
   );
 
+  test('can be hidden by moving focus away', () => {
+    setupTest('#/light/mixed-line-bar-chart/test', async page => {
+      await page.click('#focus-target');
+      await page.keys(['Tab', 'Tab', 'ArrowRight']);
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
+      await page.keys(['Tab']);
+      expect(await page.getFocusedElementText()).toBe('Filter by Apples');
+      await page.keys(['Tab']);
+      expect(await page.getFocusedElementText()).toBe('Happiness');
+      await expect(page.isDisplayed(popoverContentSelector())).resolves.toBe(false);
+    });
+  });
+
   test(
     'can be pinned by clicking on chart background and dismissed by clicking outside chart area in line chart',
     setupTest('#/light/line-chart/test', async page => {

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -637,6 +637,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
           footer={detailPopoverFooterContent}
           dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
           onMouseLeave={onPopoverLeave}
+          onBlur={onSVGBlur}
         />
       }
     />

--- a/src/mixed-line-bar-chart/chart-popover.tsx
+++ b/src/mixed-line-bar-chart/chart-popover.tsx
@@ -24,6 +24,7 @@ export interface MixedChartPopoverProps<T extends ChartDataTypes> {
   dismissAriaLabel?: string;
   onMouseEnter?: (event: React.MouseEvent) => void;
   onMouseLeave?: (event: React.MouseEvent) => void;
+  onBlur?: (event: React.FocusEvent) => void;
 }
 
 export default React.forwardRef(MixedChartPopover);
@@ -41,6 +42,7 @@ function MixedChartPopover<T extends ChartDataTypes>(
     dismissAriaLabel,
     onMouseEnter,
     onMouseLeave,
+    onBlur,
   }: MixedChartPopoverProps<T>,
   popoverRef: React.Ref<HTMLElement>
 ) {
@@ -61,6 +63,7 @@ function MixedChartPopover<T extends ChartDataTypes>(
               size={size}
               onMouseEnter={onMouseEnter}
               onMouseLeave={onMouseLeave}
+              onBlur={onBlur}
             >
               <ChartSeriesDetails details={highlightDetails.details} />
               {footer && <InternalBox margin={{ top: 's' }}>{footer}</InternalBox>}

--- a/src/pie-chart/__integ__/pie-chart.test.ts
+++ b/src/pie-chart/__integ__/pie-chart.test.ts
@@ -335,6 +335,20 @@ describe('Detail popover', () => {
   );
 
   test(
+    'can be dismissed by moving focus away',
+    setupTest(async page => {
+      await page.click('#focus-target');
+      await page.keys(['Tab', 'Tab', 'Enter']);
+      await page.waitForVisible(detailsPopoverSelector);
+      await expect(page.getText(detailsPopoverSelector)).resolves.toContain('Potatoes');
+      await page.keys(['Tab']);
+      await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(true);
+      await page.keys(['Tab']);
+      await expect(page.isDisplayed(detailsPopoverSelector)).resolves.toBe(false);
+    })
+  );
+
+  test(
     'allow mouse to enter popover on hover',
     setupTest(async page => {
       await page.hoverElement(pieWrapper.findSegments().get(3).toSelector());

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -381,6 +381,7 @@ export default <T extends PieChartProps.Datum>({
           container={plotRef.current?.svg || null}
           size={detailPopoverSize}
           onMouseLeave={checkMouseLeave}
+          onBlur={onBlur}
         >
           {tooltipContent}
           {detailPopoverFooterContent && <InternalBox margin={{ top: 's' }}>{detailPopoverFooterContent}</InternalBox>}


### PR DESCRIPTION
### Description

Since custom content is supported in chart popovers via `detailPopoverFooter`, it is possible to insert interactive elements, such as links and buttons, in a chart popover. In such a case, it is possible to navigate into a chart popover with the keyboard, even without necessarily pinning it. However, there were a couple issues when navigating inside the popover without pinning it:

- In bar, line, mixed line-bar and pie charts, the popover would stay open when navigating away. This can be especially problematic if the popover is tall, since it could be covering focused legend items below.
- In area charts, it was not possible to navigate inside the popover by tabbing. When doing so, the popover would close.

This PR fixes these two issues and establishes one single behavior for all graphs as required by a11y: allow to navigate in and close when navigating out. This behavior mimics the mouse behavior.

Doc: `GVf7Asm4sCUs/Initial-a11y-review-for-Chart-drill-down-features#temp:C:EVOe4154480d00441e78e4cdb80e`

### How has this been tested?

- Added integration tests
- Manually tested

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
