### PR TITLE
feat: Add yellow value to status indicator colorOverride prop

### DIFF
--- a/pages/status-indicator/permutations.page.tsx
+++ b/pages/status-indicator/permutations.page.tsx
@@ -12,7 +12,7 @@ const permutations = createPermutations<InternalStatusIndicatorProps>([
   },
   {
     type: ['pending'],
-    colorOverride: ['blue', 'grey', 'green', 'red'],
+    colorOverride: ['blue', 'grey', 'green', 'red', 'yellow'],
   },
   {
     type: ['info'],

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12455,6 +12455,7 @@ Object {
           "grey",
           "green",
           "red",
+          "yellow",
         ],
       },
       "name": "colorOverride",

--- a/src/status-indicator/internal.tsx
+++ b/src/status-indicator/internal.tsx
@@ -69,7 +69,7 @@ export namespace StatusIndicatorProps {
   // Why not enums? Explained there
   // https://stackoverflow.com/questions/52393730/typescript-string-literal-union-type-from-enum
   export type Type = 'error' | 'warning' | 'success' | 'info' | 'stopped' | 'pending' | 'in-progress' | 'loading';
-  export type Color = 'blue' | 'grey' | 'green' | 'red';
+  export type Color = 'blue' | 'grey' | 'green' | 'red' | 'yellow';
 }
 
 export default function StatusIndicator({

--- a/src/status-indicator/styles.scss
+++ b/src/status-indicator/styles.scss
@@ -25,6 +25,7 @@ $_color-overrides: (
   'grey': awsui.$color-text-status-inactive,
   'blue': awsui.$color-text-status-info,
   'green': awsui.$color-text-status-success,
+  'yellow': awsui.$color-text-status-warning,
 );
 
 .root {


### PR DESCRIPTION
### Description

Fixes #1643.

Since warning yellow was added to the system in #1340, it only makes sense that this color can be used as color override for status indicators.

### How has this been tested?

- Added permutation to existing permutations page, verified the result visually
- Verified that the BackstopJS failures are as expected

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
