### PR TITLE
fix: Table has same height when last row is selected

### DIFF
--- a/src/table/__integ__/selection.test.ts
+++ b/src/table/__integ__/selection.test.ts
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const tableWrapper = createWrapper().findTable();
+
+class TablePage extends BasePageObject {
+  async selectFirstRow() {
+    await this.click(tableWrapper.findRowSelectionArea(1).toSelector());
+  }
+
+  async selectLastRow() {
+    const rowCount = await this.getElementsCount(tableWrapper.findRows().toSelector());
+    await this.click(tableWrapper.findRowSelectionArea(rowCount).toSelector());
+  }
+
+  async selectAll() {
+    await this.click(tableWrapper.findSelectAllTrigger().toSelector());
+  }
+
+  async getTableHeight() {
+    const { height } = await this.getBoundingBox(tableWrapper.toSelector());
+    return height;
+  }
+}
+
+describe('Selection has no effect on table height', () => {
+  const setupTest = (testFn: (page: TablePage) => Promise<void>) => {
+    return useBrowser(async browser => {
+      const page = new TablePage(browser);
+      await browser.url('#/light/table/shift-selection');
+      await page.waitForVisible(tableWrapper.findBodyCell(2, 1).toSelector());
+      await testFn(page);
+    });
+  };
+
+  test(
+    'select last row does not change table height',
+    setupTest(async page => {
+      const heightNoSelection = await page.getTableHeight();
+      await page.selectLastRow();
+      const heightWithLastRowSelected = await page.getTableHeight();
+      await expect(heightWithLastRowSelected).toBe(heightNoSelection);
+    })
+  );
+
+  test(
+    'select first row does not change table height',
+    setupTest(async page => {
+      const heightNoSelection = await page.getTableHeight();
+      await page.selectFirstRow();
+      const heightWithLastRowSelected = await page.getTableHeight();
+      await expect(heightWithLastRowSelected).toBe(heightNoSelection);
+    })
+  );
+
+  test(
+    'select first and last row does not change table height',
+    setupTest(async page => {
+      const heightNoSelection = await page.getTableHeight();
+      await page.selectFirstRow();
+      await page.selectLastRow();
+      const heightWithLastRowSelected = await page.getTableHeight();
+      await expect(heightWithLastRowSelected).toBe(heightNoSelection);
+    })
+  );
+
+  test(
+    'select all rows not change table height',
+    setupTest(async page => {
+      const heightNoSelection = await page.getTableHeight();
+      await page.selectAll();
+      const heightWithLastRowSelected = await page.getTableHeight();
+      await expect(heightWithLastRowSelected).toBe(heightNoSelection);
+    })
+  );
+});

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -101,6 +101,13 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     border-top: $selected-border;
     border-bottom: $selected-border;
     padding-bottom: $cell-vertical-padding;
+
+    // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
+    // Adjust padding-bottom prevents a slight jump in the table height.
+    &.body-cell-last-row.is-visual-refresh {
+      padding-bottom: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
+    }
+
     &:first-child {
       border-left: $selected-border;
       border-radius: awsui.$border-radius-item 0 0 awsui.$border-radius-item;


### PR DESCRIPTION
### Description

Before this change, when selecting the last row on a table in VR
there has been a 1px jump. Caused by the last row which had the same
default border-bottom-height of 2px as all remaining rows.
So when selecting the last row, the padding-bottom got reduced (as for all remaining rows) when selecting to make the available space for increasing the border-bottom-width from 1px to 2px. This caused the jump.

With this change, when selecting the last row it does not adjust the padding-bottom as it’d be needed for all remaining rows. This keeps the table at the same height in VR.

_⚠️ Failing Table permutation tests are expected: Previous state includes the 1px jump when the last row is selected._

**Recording of the changes (focus on the changes in the computed box model when interacting with the table)**

_Before:_

https://github.com/cloudscape-design/components/assets/569011/f3b8959c-d70b-4df4-91bb-0362ee0cdc32

_After:_


https://github.com/cloudscape-design/components/assets/569011/40899d75-956e-40e9-8820-1db93b2b767d




Related links, issue #, if available: AWSUI-22872

### How has this been tested?

- manually tested the changes local
- verified VR and Classic in my pipeline
- verified screenshot tests in my pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
