### PR TITLE
fix: Fix last item of collapsible flashbar not being dismissible

### DIFF
--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -45,7 +45,7 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
     setInitialAnimationState(rects);
   }, [getElementsToAnimate]);
 
-  const { animateFlash, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef, ref } = useFlashbar({
+  const { baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef, ref } = useFlashbar({
     items,
     ...restProps,
     onItemsAdded: newItems => {
@@ -76,6 +76,8 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
   if (items.length <= maxNonCollapsibleItems && isFlashbarStackExpanded) {
     setIsFlashbarStackExpanded(false);
   }
+
+  const animateFlash = !isReducedMotion;
 
   function toggleCollapseExpand() {
     sendToggleMetric(items.length, !isFlashbarStackExpanded);

--- a/src/flashbar/common.tsx
+++ b/src/flashbar/common.tsx
@@ -35,7 +35,6 @@ export function useFlashbar({
   const isVisualRefresh = useVisualRefresh();
   const [previousItems, setPreviousItems] = useState<ReadonlyArray<FlashbarProps.MessageDefinition>>(items);
   const [nextFocusId, setNextFocusId] = useState<string | null>(null);
-  const animateFlash = !isReducedMotion && isVisualRefresh;
 
   if (isDevelopment) {
     if (items?.some(item => item.ariaRole === 'alert' && !item.id)) {
@@ -72,7 +71,6 @@ export function useFlashbar({
 
   return {
     allItemsHaveId,
-    animateFlash,
     baseProps,
     breakpoint,
     isReducedMotion,

--- a/src/flashbar/non-collapsible-flashbar.tsx
+++ b/src/flashbar/non-collapsible-flashbar.tsx
@@ -15,11 +15,10 @@ import { useInternalI18n } from '../i18n/context';
 export { FlashbarProps };
 
 export default function NonCollapsibleFlashbar({ items, i18nStrings, ...restProps }: FlashbarProps) {
-  const { allItemsHaveId, animateFlash, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef } =
-    useFlashbar({
-      items,
-      ...restProps,
-    });
+  const { allItemsHaveId, baseProps, breakpoint, isReducedMotion, isVisualRefresh, mergedRef } = useFlashbar({
+    items,
+    ...restProps,
+  });
 
   const i18n = useInternalI18n('flashbar');
   const ariaLabel = i18n('i18nStrings.ariaLabel', i18nStrings?.ariaLabel);
@@ -38,6 +37,7 @@ export default function NonCollapsibleFlashbar({ items, i18nStrings, ...restProp
    */
   const motionDisabled = isReducedMotion || !isVisualRefresh || !allItemsHaveId;
 
+  const animateFlash = !isReducedMotion && isVisualRefresh;
   /**
    * If the flashbar is flat and motion is `enabled` then the adding and removing of items
    * from the flashbar will render with visual transitions.


### PR DESCRIPTION
### Description

The class `flash-with-motion` makes a flashbar flash enter or leave with animations, based on `.enter` and `.leave` suffixes that React Transition adds when the element enters or leaves: see https://github.com/cloudscape-design/components/blob/main/src/flashbar/motion.scss.

In #1656, I merged the logic to apply this class in the collapsible and non-collapsible versions of the flashbar but it turns out, there is a subtle difference:  in the non-collapsible flashbar these animations only play in Visual Refresh, but in the collapsible flashbar they are supposed to play not only in Visual Refresh but also in Classic, and it should stay like that.

Disabling React-Transition-based enter and leave animations for Classic had the following unintended consequences in Classic:

1. The enter animation did not look as intended
2. Even worse problem: dismissed items occasionally staying in the DOM. This is because our internal Transitions component [relies](https://github.com/cloudscape-design/components/blob/main/src/internal/components/transition/index.tsx#L46) on `transitionend` events, which are note emitted if the `.flashbar-with-motion` class, which [defines](https://github.com/cloudscape-design/components/blob/main/src/flashbar/motion.scss) the transition delays, is not present.

### How has this been tested?

In the `flashbar/interactive` page, followed these steps:
- Remove all initial flashes
- Enable "stack items"
- Add one flash
- Dismiss it and verify that it disappears

Ticket: AWSUI-23010

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
