### PR TITLE
chore: Add integ tests for multi page create funnel metrics

### DIFF
--- a/pages/funnel-analytics/mock-funnel.ts
+++ b/pages/funnel-analytics/mock-funnel.ts
@@ -8,7 +8,7 @@ const funnelMetricsLog: { action: string; resolvedProps?: any; props: any }[] = 
 
 export const MockedFunnelMetrics: IFunnelMetrics = {
   funnelStart(props): string {
-    const funnelName = document.querySelector(props.funnelNameSelector)!.innerHTML;
+    const funnelName = document.querySelector(props.funnelNameSelector)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStart', props, resolvedProps: { funnelName } });
     return 'mocked-funnel-id';
   },
@@ -34,35 +34,35 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   funnelStepStart(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepStart', props, resolvedProps: { stepName } });
   },
 
   funnelStepComplete(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepComplete', props, resolvedProps: { stepName } });
   },
 
   funnelStepNavigation(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
     // const subStepAllElements = document.querySelectorAll(props.subStepAllSelector); // TODO: Does not work
 
     funnelMetricsLog.push({ action: 'funnelStepNavigation', props, resolvedProps: { stepName } });
   },
 
   funnelStepError(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepError', props, resolvedProps: { stepName } });
   },
 
   funnelStepChange(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepChange', props, resolvedProps: { stepName } });
   },
 
   funnelSubStepStart(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
-    const subStepName = document.querySelector(props.subStepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
     const subStepElement = document.querySelector(props.subStepSelector);
 
@@ -87,10 +87,10 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   funnelSubStepError(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
-    const subStepName = document.querySelector(props.subStepNameSelector)!.innerHTML;
-    const fieldLabel = document.querySelector(props.fieldLabelSelector!)!.innerHTML;
-    const fieldError = document.querySelector(props.fieldErrorSelector!)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
+    const fieldLabel = document.querySelector(props.fieldLabelSelector!)?.innerHTML;
+    const fieldError = document.querySelector(props.fieldErrorSelector!)?.innerHTML;
 
     funnelMetricsLog.push({
       action: 'funnelSubStepError',
@@ -100,8 +100,8 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   helpPanelInteracted(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
-    const subStepName = document.querySelector(props.subStepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepElement = document.querySelectorAll(props.subStepSelector);
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
     const element = document.querySelector(props.elementSelector);
@@ -114,8 +114,8 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   externalLinkInteracted(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)!.innerHTML;
-    const subStepName = document.querySelector(props.subStepNameSelector)!.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepElement = document.querySelectorAll(props.subStepSelector);
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
     const element = document.querySelector(props.elementSelector);

--- a/pages/funnel-analytics/static-multi-page-flow.page.tsx
+++ b/pages/funnel-analytics/static-multi-page-flow.page.tsx
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  BreadcrumbGroup,
+  Container,
+  Input,
+  Link,
+  FormField,
+  SpaceBetween,
+  Wizard,
+  WizardProps,
+  Header,
+} from '~components';
+
+import { i18nStrings } from '../wizard/common';
+import styles from '../wizard/styles.scss';
+
+import { setFunnelMetrics } from '~components/internal/analytics';
+import { MockedFunnelMetrics } from './mock-funnel';
+
+setFunnelMetrics(MockedFunnelMetrics);
+
+export default function MultiPageCreate() {
+  const [mounted, setMounted] = useState(true);
+  const [value, setValue] = useState('');
+  const [value2, setValue2] = useState('');
+  const [value3, setValue3] = useState('');
+  const [value4, setValue4] = useState('');
+
+  const [errorText, setErrorText] = useState('');
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+
+  const steps: WizardProps.Step[] = [
+    {
+      title: 'Step 1',
+      errorText,
+      content: (
+        <SpaceBetween size="s">
+          <Container header={<Header>Container 1 - header</Header>}>
+            <SpaceBetween size="s">
+              <FormField
+                info={
+                  <Link data-testid="external-link" external={true} href="#">
+                    Learn more
+                  </Link>
+                }
+                errorText={value === 'error' ? 'Trigger error' : ''}
+                label="Field 1"
+              >
+                <Input
+                  data-testid="field1"
+                  value={value}
+                  onChange={event => {
+                    setValue(event.detail.value);
+                  }}
+                />
+              </FormField>
+              <FormField label="Field 2">
+                <Input
+                  data-testid="field2"
+                  value={value2}
+                  onChange={event => {
+                    setValue2(event.detail.value);
+                  }}
+                />
+              </FormField>
+            </SpaceBetween>
+          </Container>
+          <Container header={<Header>Container 2 - header</Header>}>
+            <SpaceBetween size="s">
+              <FormField label="Field 3">
+                <Input
+                  data-testid="field3"
+                  value={value3}
+                  onChange={event => {
+                    setValue3(event.detail.value);
+                  }}
+                />
+              </FormField>
+              <FormField label="Field 4">
+                <Input
+                  data-testid="field4"
+                  value={value4}
+                  onChange={event => {
+                    setValue4(event.detail.value);
+                  }}
+                />
+              </FormField>
+            </SpaceBetween>
+          </Container>
+        </SpaceBetween>
+      ),
+    },
+    {
+      title: 'Step 2',
+      isOptional: true,
+      errorText,
+      content: (
+        <div className={styles['step-content']}>
+          <div id="content-text">Content 2</div>
+        </div>
+      ),
+    },
+    {
+      title: 'Step 3',
+      info: <Link variant="info">Info</Link>,
+      errorText,
+      content: (
+        <div className={styles['step-content']}>
+          {Array.from(Array(15).keys()).map(key => (
+            <div key={key} className={styles['content-item']}>
+              Item {key}
+            </div>
+          ))}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <BreadcrumbGroup
+        items={[
+          { text: 'System', href: '#' },
+          { text: 'Components', href: '#components' },
+          {
+            text: 'Create Resource',
+            href: '#components/breadcrumb-group',
+          },
+        ]}
+        ariaLabel="Breadcrumbs"
+      />
+      <button data-testid="unmount" onClick={() => setMounted(false)}>
+        Unmount
+      </button>
+      {mounted && (
+        <Wizard
+          i18nStrings={i18nStrings}
+          steps={steps}
+          activeStepIndex={activeStepIndex}
+          onNavigate={e => {
+            if (value === 'error') {
+              setErrorText('There is an error');
+            } else {
+              setErrorText('');
+              setActiveStepIndex(e.detail.requestedStepIndex);
+            }
+          }}
+          onCancel={() => {
+            setMounted(false);
+          }}
+          onSubmit={() => {
+            setMounted(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -1,0 +1,341 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
+
+interface ExtendedWindow extends Window {
+  __awsuiFunnelMetrics__: Array<any>;
+}
+
+declare const window: ExtendedWindow;
+
+const wrapper = createWrapper();
+const FUNNEL_INTERACTION_ID = 'mocked-funnel-id';
+
+class MultiPageCreate extends BasePageObject {
+  async getFunnelLog() {
+    const funnelLog = await this.browser.execute(() => window.__awsuiFunnelMetrics__);
+    const actions = funnelLog.map(item => item.action);
+    return { funnelLog, actions };
+  }
+}
+
+const setupTest = (testFn: (page: MultiPageCreate) => Promise<void>) => {
+  return useBrowser(async browser => {
+    const page = new MultiPageCreate(browser);
+    await browser.url('#/light/funnel-analytics/static-multi-page-flow');
+    await testFn(page);
+  });
+};
+
+describe('Multi-page create', () => {
+  test(
+    'Starts funnel and funnel step and page is loaded',
+    setupTest(async page => {
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual(['funnelStart', 'funnelStepStart']);
+
+      const [funnelStartEvent, funnelStartStepEvent] = funnelLog;
+      expect(funnelStartEvent.props).toEqual({
+        componentVersion: expect.any(String),
+        funnelNameSelector: expect.any(String),
+        funnelVersion: expect.any(String),
+        funnelType: 'multi-page',
+        optionalStepNumbers: [2],
+        theme: 'vr',
+        totalFunnelSteps: 3,
+        stepConfiguration: [
+          {
+            name: 'Step 1',
+            number: 1,
+            isOptional: false,
+          },
+          {
+            name: 'Step 2',
+            number: 2,
+            isOptional: true,
+          },
+          {
+            name: 'Step 3',
+            number: 3,
+            isOptional: false,
+          },
+        ],
+      });
+
+      expect(funnelStartEvent.resolvedProps).toEqual({
+        funnelName: 'Create Resource',
+      });
+
+      expect(funnelStartStepEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        subStepConfiguration: [
+          {
+            name: 'Container 1 - header',
+            number: 1,
+          },
+          {
+            name: 'Container 2 - header',
+            number: 2,
+          },
+        ],
+        stepNumber: 1,
+        totalSubSteps: 2,
+      });
+    })
+  );
+
+  test(
+    'Starts and ends substep when navigating between containers',
+    setupTest(async page => {
+      await page.click('[data-testid=field1]');
+      await page.keys('Tab'); // Input 1 -> Input 2
+      await page.keys('Tab'); // Input 2 -> Form Field 3 External Link
+
+      const { funnelLog, actions } = await page.getFunnelLog();
+      const [, , funnelSubStep1StartEvent, funnelSubsteStep1CompleteEvent, funnelSubStep2StartEvent] = funnelLog;
+
+      expect(actions).toEqual([
+        'funnelStart',
+        'funnelStepStart',
+        'funnelSubStepStart',
+        'funnelSubStepComplete',
+        'funnelSubStepStart',
+      ]);
+
+      expect(funnelSubStep1StartEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+        subStepSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        subStepName: 'Container 1 - header',
+        stepNumber: 1,
+      });
+      expect(funnelSubStep1StartEvent.resolvedProps).toEqual({
+        subStepElement: expect.any(Object),
+        subStepAllElements: expect.any(Object),
+        stepName: 'Step 1',
+        subStepName: 'Container 1 - header',
+      });
+      expect(funnelSubStep1StartEvent.resolvedProps.subStepAllElements.length).toBe(2);
+
+      expect(funnelSubsteStep1CompleteEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+        subStepSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        subStepName: 'Container 1 - header',
+        stepNumber: 1,
+      });
+      expect(funnelSubsteStep1CompleteEvent.resolvedProps).toEqual({
+        subStepElement: expect.any(Object),
+        subStepAllElements: expect.any(Object),
+        stepName: 'Step 1',
+        subStepName: 'Container 1 - header',
+      });
+
+      expect(funnelSubStep2StartEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+        subStepSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        subStepName: 'Container 2 - header',
+        stepNumber: 1,
+      });
+      expect(funnelSubStep2StartEvent.resolvedProps).toEqual({
+        subStepElement: expect.any(Object),
+        subStepAllElements: expect.any(Object),
+        stepName: 'Step 1',
+        subStepName: 'Container 2 - header',
+      });
+      expect(funnelSubStep2StartEvent.resolvedProps.subStepAllElements.length).toBe(2);
+    })
+  );
+
+  test(
+    'wizard step navigation',
+    setupTest(async page => {
+      await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
+      await page.click(wrapper.findWizard().findPreviousButton().toSelector());
+      const { funnelLog, actions } = await page.getFunnelLog();
+      const [, , funnelStepNavigationEvent, , , funnelStepPreviousNavigationEvent] = funnelLog;
+
+      expect(actions).toEqual([
+        'funnelStart',
+        'funnelStepStart', // Step 1 - Start
+        'funnelStepNavigation', // Navigate to Step 2
+        'funnelStepComplete', // Step 1 - Complete
+        'funnelStepStart', // Step 2 - Start
+        'funnelStepNavigation', // Navigate back to Step 1
+        'funnelStepComplete', // Step 2 - Complete
+        'funnelStepStart', // Step 1 - Start
+      ]);
+
+      expect(funnelStepNavigationEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        navigationType: 'next',
+        destinationStepNumber: 2,
+        stepNumber: 1,
+      });
+
+      expect(funnelStepNavigationEvent.resolvedProps).toEqual({
+        stepName: 'Step 1',
+      });
+
+      expect(funnelStepPreviousNavigationEvent.props).toEqual({
+        stepNameSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 2',
+        navigationType: 'previous',
+        destinationStepNumber: 1,
+        stepNumber: 2,
+      });
+
+      expect(funnelStepPreviousNavigationEvent.resolvedProps).toEqual({
+        stepName: 'Step 2',
+      });
+    })
+  );
+
+  test(
+    'wizard submission',
+    setupTest(async page => {
+      const primaryButton = wrapper.findWizard().findPrimaryButton().toSelector();
+      await page.click(primaryButton);
+      await page.click(primaryButton);
+      await page.click(primaryButton); // Create
+
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual([
+        'funnelStart',
+        'funnelStepStart', // Step 1 - Start
+        'funnelStepNavigation', // Navigate to Step 2
+        'funnelStepComplete', // Step 1 - Complete
+        'funnelStepStart', // Step 2 - Start
+        'funnelStepNavigation', // Navigate to Step 3
+        'funnelStepComplete', // Step 2 - Complete
+        'funnelStepStart', // Step 3 - Start
+        'funnelComplete',
+        'funnelSuccessful',
+        'funnelStepComplete', // TODO: This is the current order, it needs work :(
+      ]);
+
+      const funnelCompleteEvent = funnelLog[8];
+      const funnelSuccessfulEvent = funnelLog[9];
+
+      expect(funnelCompleteEvent.props).toEqual({
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+      });
+
+      expect(funnelSuccessfulEvent.props).toEqual({
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+      });
+    })
+  );
+
+  test(
+    'wizard cancelled',
+    setupTest(async page => {
+      await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
+      await page.click(wrapper.findWizard().findCancelButton().toSelector());
+
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual([
+        'funnelStart',
+        'funnelStepStart', // Step 1 - Start
+        'funnelStepNavigation', // Navigate to Step 2
+        'funnelStepComplete', // Step 1 - Complete
+        'funnelStepStart', // Step 2 - Start
+        'funnelCancelled',
+      ]);
+      const funnelCancelledEvent = funnelLog[5];
+      expect(funnelCancelledEvent.props).toEqual({
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+      });
+    })
+  );
+
+  test(
+    'wizard abandoned',
+    setupTest(async page => {
+      await page.click('[data-testid=unmount]');
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelCancelled']);
+
+      const funnelCancelledEvent = funnelLog[2];
+      expect(funnelCancelledEvent.props).toEqual({
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+      });
+    })
+  );
+
+  test(
+    'Field error',
+    setupTest(async page => {
+      await page.click('[data-testid=field1]');
+      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual(['funnelStart', 'funnelStepStart', 'funnelSubStepStart', 'funnelSubStepError']);
+
+      const funnelSubStepErrorEvent = funnelLog[3];
+      expect(funnelSubStepErrorEvent.props).toEqual({
+        fieldErrorSelector: expect.any(String),
+        fieldLabelSelector: expect.any(String),
+        subStepNameSelector: expect.any(String),
+        stepNameSelector: expect.any(String),
+        subStepSelector: expect.any(String),
+        subStepAllSelector: expect.any(String),
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepName: 'Step 1',
+        stepNumber: 1,
+        subStepName: 'Container 1 - header',
+      });
+
+      expect(funnelSubStepErrorEvent.resolvedProps).toEqual({
+        fieldLabel: 'Field 1',
+        fieldError: 'Trigger error',
+        stepName: 'Step 1',
+        subStepName: 'Container 1 - header',
+      });
+    })
+  );
+
+  test(
+    'Wizard error',
+    setupTest(async page => {
+      await page.click('[data-testid=field1]');
+      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
+      await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
+
+      const { funnelLog, actions } = await page.getFunnelLog();
+      expect(actions).toEqual([
+        'funnelStart',
+        'funnelStepStart',
+        'funnelSubStepStart',
+        'funnelSubStepError',
+        'funnelStepNavigation', // Navigation "attempt"
+        'funnelSubStepError', // FIXME: Should be a funnelStepError with error message
+        'funnelError',
+        'funnelSubStepComplete',
+      ]);
+      const funnelErrorEvent = funnelLog[6];
+      expect(funnelErrorEvent.props).toEqual({
+        funnelInteractionId: FUNNEL_INTERACTION_ID,
+      });
+    })
+  );
+});

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -359,7 +359,7 @@ describe('Single-page create', () => {
 
 describe('Embedded Form', () => {
   test.skip(
-    'Forms embedded in Modal unrelataed to the main Form',
+    'Forms embedded in Modal unrelated to the main Form',
     setupTest(async page => {
       await page.click('[data-testid=embedded-form-modal]');
       const { funnelLog, actions } = await page.getFunnelLog();


### PR DESCRIPTION
### Description

Similar to this [PR](https://github.com/cloudscape-design/components/pull/1671) to add for integ tests for single page.

This adds tests for the existing behaviour. It includes some fix mes that were found while writing and is intended as a start to testing.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
