### PR TITLE
chore: Update drawers object shapes to public API

### DIFF
--- a/pages/app-layout/with-drawers.page.tsx
+++ b/pages/app-layout/with-drawers.page.tsx
@@ -15,7 +15,6 @@ import { AppLayoutProps } from '~components/app-layout';
 import appLayoutLabels from './utils/labels';
 import { Breadcrumbs, Containers } from './utils/content-blocks';
 import ScreenshotArea from '../utils/screenshot-area';
-import type { DrawerItem } from '~components/app-layout/drawer/interfaces';
 import AppContext, { AppContextType } from '../app/app-context';
 import styles from './styles.scss';
 
@@ -56,7 +55,7 @@ export default function WithDrawers() {
               content: <Security />,
               id: 'security',
               resizable: true,
-              onResize: ({ detail: { size } }) => {
+              onResize: ({ detail: { size } }: { detail: { size: number } }) => {
                 // A drawer implementer may choose to listen to THEIR drawer's
                 // resize event,should they want to persist, or otherwise respond
                 // to their drawer being resized.
@@ -144,7 +143,7 @@ export default function WithDrawers() {
                 iconName: 'call',
               },
             },
-          ] as DrawerItem[],
+          ],
           onChange: (event: NonCancelableCustomEvent<string>) => {
             setActiveDrawerId(event.detail);
           },

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -23,7 +23,7 @@ import drawerStyles from '../../../lib/components/app-layout/drawer/styles.css.j
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
 import { KeyCode } from '../../internal/keycode';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
-import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
+import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 
 jest.mock('@cloudscape-design/component-toolkit', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit'),
@@ -174,24 +174,31 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test('should change size via keyboard events on slider handle', () => {
+    const onDrawerItemResize = jest.fn();
     const onResize = jest.fn();
-    const drawers: Required<InternalDrawerProps> = {
+    const drawers: { drawers: BetaDrawersProps } = {
       drawers: {
-        onResize: ({ detail }) => onResize(detail),
         activeDrawerId: 'security',
-        items: resizableDrawer.drawers.items,
+        onResize: ({ detail }) => onResize(detail),
+        items: [
+          {
+            ...resizableDrawer.drawers.items[0],
+            onResize: event => onDrawerItemResize(event.detail),
+          },
+        ],
       },
     };
     const { wrapper } = renderComponent(<AppLayout contentType="form" {...drawers} />);
     wrapper.findActiveDrawerResizeHandle()!.keydown(KeyCode.left);
 
     expect(onResize).toHaveBeenCalledWith({ size: expect.any(Number), id: 'security' });
+    expect(onDrawerItemResize).toHaveBeenCalledWith({ size: expect.any(Number), id: 'security' });
   });
 
   test('should change size via mouse pointer on slider handle', () => {
     const onResize = jest.fn();
     const onDrawerItemResize = jest.fn();
-    const drawersOpen: Required<InternalDrawerProps> = {
+    const drawersOpen: { drawers: BetaDrawersProps } = {
       drawers: {
         onResize: ({ detail }) => onResize(detail),
         activeDrawerId: 'security',
@@ -241,7 +248,7 @@ describeEachThemeAppLayout(false, () => {
   });
 
   test('should have width equal to the size declaration', () => {
-    const resizableDrawer = {
+    const resizableDrawer: { drawers: BetaDrawersProps } = {
       drawers: {
         ariaLabel: 'Drawers',
         activeDrawerId: 'security',

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -13,7 +13,7 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 
 import { render } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';
-import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
+import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   useMobile: jest.fn().mockReturnValue(true),
@@ -88,7 +88,7 @@ describeEachAppLayout(size => {
   });
 
   test('renders resize only on resizable drawer', async () => {
-    const drawers: Required<InternalDrawerProps> = {
+    const drawers: { drawers: BetaDrawersProps } = {
       drawers: {
         items: [
           singleDrawer.drawers.items[0],

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -10,7 +10,7 @@ import {
   singleDrawer,
 } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
-import { InternalDrawerProps } from '../../../lib/components/app-layout/drawer/interfaces';
+import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 import { TOOLS_DRAWER_ID } from '../../../lib/components/app-layout/utils/use-drawers';
 import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
@@ -126,6 +126,24 @@ describeEachAppLayout(size => {
     } else {
       expect(wrapper.findActiveDrawerResizeHandle()).toBeFalsy();
     }
+  });
+
+  (size === 'desktop' ? test : test.skip)('calls onResize handler', async () => {
+    const onResize = jest.fn();
+    awsuiPlugins.appLayout.registerDrawer({
+      ...drawerDefaults,
+      resizable: true,
+      onResize: event => onResize(event.detail),
+    });
+    const { wrapper } = await renderComponent(<AppLayout />);
+
+    wrapper.findDrawerTriggerById(drawerDefaults.id)!.click();
+    const handle = wrapper.findActiveDrawerResizeHandle()!;
+    handle.fireEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    handle.fireEvent(new MouseEvent('pointermove', { bubbles: true }));
+    handle.fireEvent(new MouseEvent('pointerup', { bubbles: true }));
+
+    expect(onResize).toHaveBeenCalledWith({ size: expect.any(Number), id: drawerDefaults.id });
   });
 
   test('supports badge property', async () => {
@@ -394,7 +412,7 @@ describeEachAppLayout(size => {
   test('updates active drawer id in controlled mode', async () => {
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, defaultActive: true });
     const onChange = jest.fn();
-    const drawers: Required<InternalDrawerProps> = {
+    const drawers: { drawers: BetaDrawersProps } = {
       drawers: {
         ...singleDrawer.drawers,
         onChange: event => onChange(event.detail),
@@ -523,7 +541,7 @@ describeEachAppLayout(size => {
         ariaLabels: { triggerButton: 'ccc' },
         orderPriority: -1,
       });
-      const drawers: InternalDrawerProps = {
+      const drawers: { drawers: BetaDrawersProps } = {
         drawers: {
           items: [{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd' } }],
         },

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -10,7 +10,7 @@ import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-vis
 import { findUpUntil } from '../../../lib/components/internal/utils/dom';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
 import testutilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
-import { InternalDrawerProps, DrawerItem } from '../../../lib/components/app-layout/drawer/interfaces';
+import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 import { IconProps } from '../../../lib/components/icon/interfaces';
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
 import iconStyles from '../../../lib/components/icon/styles.css.js';
@@ -137,7 +137,7 @@ export const splitPanelI18nStrings: SplitPanelProps.I18nStrings = {
   resizeHandleAriaLabel: 'Resize panel',
 };
 
-export const singleDrawer: Required<InternalDrawerProps> = {
+export const singleDrawer: { drawers: BetaDrawersProps } = {
   drawers: {
     ariaLabel: 'Drawers',
     items: [
@@ -177,7 +177,7 @@ const getDrawerItem = (id: string, iconName: IconProps.Name, badge: boolean) => 
 
 const manyDrawersArray = [...Array(100).keys()].map(item => item.toString());
 
-export const manyDrawers: Required<InternalDrawerProps> = {
+export const manyDrawers: { drawers: BetaDrawersProps } = {
   drawers: {
     ariaLabel: 'Drawers',
     overflowAriaLabel: 'Overflow drawers',
@@ -202,7 +202,7 @@ export const manyDrawers: Required<InternalDrawerProps> = {
   },
 };
 
-export const manyDrawersWithBadges: Required<InternalDrawerProps> = {
+export const manyDrawersWithBadges: { drawers: BetaDrawersProps } = {
   drawers: {
     ariaLabel: 'Drawers',
     overflowAriaLabel: 'Overflow drawers',
@@ -211,7 +211,7 @@ export const manyDrawersWithBadges: Required<InternalDrawerProps> = {
   },
 };
 
-export const singleDrawerOpen: Required<InternalDrawerProps> = {
+export const singleDrawerOpen: { drawers: BetaDrawersProps } = {
   drawers: {
     ariaLabel: 'Drawers',
     activeDrawerId: 'security',
@@ -233,7 +233,7 @@ export const singleDrawerOpen: Required<InternalDrawerProps> = {
   },
 };
 
-export const resizableDrawer: Required<InternalDrawerProps> = {
+export const resizableDrawer: { drawers: BetaDrawersProps } = {
   drawers: {
     ariaLabel: 'Drawers',
     items: [
@@ -255,7 +255,7 @@ export const resizableDrawer: Required<InternalDrawerProps> = {
   },
 };
 
-export const drawerWithoutLabels: Required<InternalDrawerProps> = {
+export const drawerWithoutLabels: { drawers: BetaDrawersProps } = {
   drawers: {
     items: [
       {
@@ -264,7 +264,7 @@ export const drawerWithoutLabels: Required<InternalDrawerProps> = {
         trigger: {
           iconName: 'security',
         },
-      } as DrawerItem,
+      } as BetaDrawersProps['items'][number],
     ],
   },
 };

--- a/src/app-layout/drawer/__tests__/drawers-helpers.test.ts
+++ b/src/app-layout/drawer/__tests__/drawers-helpers.test.ts
@@ -4,11 +4,11 @@
 import { splitItems } from '../../../../lib/components/app-layout/drawer/drawers-helpers';
 
 test('handles empty values', () => {
-  expect(splitItems(undefined, 2, undefined)).toEqual({ visibleItems: [], overflowItems: [] });
+  expect(splitItems(undefined, 2, null)).toEqual({ visibleItems: [], overflowItems: [] });
 });
 
 test('splits items by index', () => {
-  expect(splitItems([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }], 2, undefined)).toEqual({
+  expect(splitItems([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }], 2, null)).toEqual({
     visibleItems: [{ id: '1' }, { id: '2' }],
     overflowItems: [{ id: '3' }, { id: '4' }],
   });
@@ -36,7 +36,7 @@ test('does not fail when active id resolves to a non-existing item', () => {
 });
 
 test('moves single overflow item into visible items', () => {
-  expect(splitItems([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }], 3, undefined)).toEqual({
+  expect(splitItems([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }], 3, null)).toEqual({
     visibleItems: [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }],
     overflowItems: [],
   });

--- a/src/app-layout/drawer/drawers-helpers.ts
+++ b/src/app-layout/drawer/drawers-helpers.ts
@@ -4,7 +4,7 @@
 export function splitItems<T extends { id: string }>(
   maybeItems: Array<T> | undefined,
   splitIndex: number,
-  activeId: string | undefined
+  activeId: string | null
 ) {
   const items = maybeItems ?? [];
   const visibleItems = items.slice(0, splitIndex);

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -6,12 +6,13 @@ import { ToggleButton, CloseButton, togglesConfig } from '../toggles';
 
 import testutilStyles from '../test-classes/styles.css.js';
 import styles from './styles.css.js';
-import { DesktopDrawerProps, DrawerTriggersBarProps, DrawerItem } from './interfaces';
+import { DesktopDrawerProps, DrawerTriggersBarProps } from './interfaces';
 import OverflowMenu from './overflow-menu';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 import { splitItems } from './drawers-helpers';
 import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
+import { PublicDrawer } from '../interfaces';
 
 // We are using two landmarks per drawer, i.e. two NAVs and two ASIDEs, because of several
 // known bugs in NVDA that cause focus changes within a container to sometimes not be
@@ -32,6 +33,7 @@ import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
 export const Drawer = React.forwardRef(
   (
     {
+      id,
       contentClassName,
       toggleClassName,
       closeClassName,
@@ -41,22 +43,21 @@ export const Drawer = React.forwardRef(
       topOffset,
       bottomOffset,
       ariaLabels,
-      drawersAriaLabels,
       children,
+      hideOpenButton,
       isOpen,
       isHidden,
       isMobile,
       onToggle,
       onClick,
       onLoseFocus,
-      drawers,
       resizeHandle,
     }: DesktopDrawerProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
     const openButtonWrapperRef = useRef<HTMLElement | null>(null);
-    const { TagName, iconName, getLabels } = togglesConfig[type];
-    const { mainLabel, closeLabel, openLabel } = drawersAriaLabels ?? getLabels(ariaLabels);
+    const { TagName, iconName } = togglesConfig[type];
+    const { mainLabel, closeLabel, openLabel } = ariaLabels;
     const drawerContentWidthOpen = isMobile ? undefined : width;
     const drawerContentWidth = isOpen ? drawerContentWidthOpen : undefined;
 
@@ -75,7 +76,7 @@ export const Drawer = React.forwardRef(
 
     return (
       <div
-        id={drawers?.activeDrawerId}
+        id={id}
         ref={ref}
         className={clsx(styles.drawer, {
           [styles.hide]: isHidden,
@@ -112,7 +113,7 @@ export const Drawer = React.forwardRef(
           style={{ width: drawerContentWidth, top: topOffset, bottom: bottomOffset }}
           className={clsx(styles['drawer-content'], styles['drawer-content-clickable'], contentClassName)}
         >
-          {!isMobile && !drawers && regularOpenButton}
+          {!isMobile && !hideOpenButton && regularOpenButton}
           {resizeHandle}
           <TagName aria-label={mainLabel} aria-hidden={!isOpen}>
             <CloseButton
@@ -121,7 +122,6 @@ export const Drawer = React.forwardRef(
               ariaLabel={closeLabel}
               onClick={() => {
                 onToggle(false);
-                drawers?.onChange({ activeDrawerId: undefined });
               }}
             />
             {children}
@@ -140,8 +140,8 @@ interface DrawerTriggerProps {
   badge: boolean | undefined;
   itemId?: string;
   isActive: boolean;
-  trigger: DrawerItem['trigger'];
-  onClick: () => void;
+  trigger: PublicDrawer['trigger'];
+  onClick: (() => void) | undefined;
 }
 
 const DrawerTrigger = React.forwardRef(
@@ -175,7 +175,15 @@ const DrawerTrigger = React.forwardRef(
   )
 );
 
-export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }: DrawerTriggersBarProps) => {
+export const DrawerTriggersBar = ({
+  isMobile,
+  topOffset,
+  bottomOffset,
+  activeDrawerId,
+  ariaLabels,
+  drawers,
+  onDrawerChange,
+}: DrawerTriggersBarProps) => {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [containerHeight, triggersContainerRef] = useContainerQuery(rect => rect.contentBoxHeight);
   const isCompactMode = useDensityMode(containerRef) === 'compact';
@@ -192,14 +200,14 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
     return 0;
   };
 
-  const { visibleItems, overflowItems } = splitItems(drawers?.items, getIndexOfOverflowItem(), drawers?.activeDrawerId);
+  const { visibleItems, overflowItems } = splitItems(drawers, getIndexOfOverflowItem(), activeDrawerId);
   const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
   return (
     <div
       className={clsx(styles.drawer, styles['drawer-closed'], testutilStyles['drawer-closed'], {
         [styles['drawer-mobile']]: isMobile,
-        [styles.hide]: drawers?.items.length === 1 && drawers.activeDrawerId !== undefined,
+        [styles.hide]: drawers.length === 1 && !!activeDrawerId,
       })}
       ref={containerRef}
     >
@@ -207,17 +215,16 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
         ref={triggersContainerRef}
         style={{ top: topOffset, bottom: bottomOffset }}
         className={clsx(styles['drawer-content'], {
-          [styles['drawer-content-clickable']]: drawers?.items.length === 1,
+          [styles['drawer-content-clickable']]: drawers.length === 1,
         })}
-        onClick={() => {
-          drawers?.items.length === 1 &&
-            drawers?.onChange({
-              activeDrawerId: drawers.items[0].id !== drawers.activeDrawerId ? drawers.items[0].id : undefined,
-            });
-        }}
+        onClick={
+          drawers.length === 1
+            ? () => onDrawerChange(drawers[0].id !== activeDrawerId ? drawers[0].id : null)
+            : undefined
+        }
       >
         {!isMobile && (
-          <aside aria-label={drawers?.ariaLabel} role="region">
+          <aside aria-label={ariaLabels?.drawers} role="region">
             <div className={clsx(styles['drawer-triggers-wrapper'])} role="toolbar" aria-orientation="vertical">
               {visibleItems.map((item, index) => {
                 return (
@@ -227,32 +234,29 @@ export const DrawerTriggersBar = ({ isMobile, topOffset, bottomOffset, drawers }
                       testutilStyles['drawers-trigger'],
                       item.id === TOOLS_DRAWER_ID && testutilStyles['tools-toggle']
                     )}
-                    ariaExpanded={drawers?.activeDrawerId === item.id}
+                    ariaExpanded={activeDrawerId === item.id}
                     ariaLabel={item.ariaLabels?.triggerButton}
-                    ariaControls={drawers?.activeDrawerId === item.id ? item.id : undefined}
+                    ariaControls={activeDrawerId === item.id ? item.id : undefined}
                     trigger={item.trigger}
                     badge={item.badge}
                     itemId={item.id}
-                    isActive={drawers?.activeDrawerId === item.id}
-                    onClick={() => {
-                      drawers?.items.length !== 1 &&
-                        drawers?.onChange({
-                          activeDrawerId: item.id !== drawers.activeDrawerId ? item.id : undefined,
-                        });
-                    }}
+                    isActive={activeDrawerId === item.id}
+                    onClick={
+                      drawers.length !== 1
+                        ? () => onDrawerChange(item.id !== activeDrawerId ? item.id : null)
+                        : undefined
+                    }
                   />
                 );
               })}
               {overflowItems.length > 0 && (
                 <div className={clsx(styles['drawer-trigger'])}>
                   <OverflowMenu
-                    ariaLabel={overflowMenuHasBadge ? drawers?.overflowWithBadgeAriaLabel : drawers?.overflowAriaLabel}
+                    ariaLabel={
+                      overflowMenuHasBadge ? ariaLabels?.drawersOverflowWithBadge : ariaLabels?.drawersOverflow
+                    }
                     items={overflowItems}
-                    onItemClick={({ detail }) => {
-                      drawers?.onChange({
-                        activeDrawerId: detail.id !== drawers.activeDrawerId ? detail.id : undefined,
-                      });
-                    }}
+                    onItemClick={({ detail }) => onDrawerChange(detail.id)}
                   />
                 </div>
               )}

--- a/src/app-layout/drawer/interfaces.ts
+++ b/src/app-layout/drawer/interfaces.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { togglesConfig } from '../toggles';
-import { AppLayoutProps } from '../interfaces';
+import { PublicAriaLabelsWithDrawers, PublicDrawer } from '../interfaces';
 import { IconProps } from '../../icon/interfaces';
 import { NonCancelableEventHandler } from '../../internal/events';
 
 import { DrawerFocusControlRefs } from '../utils/use-drawer-focus-control';
 
 export interface DesktopDrawerProps {
+  id?: string;
   contentClassName: string;
   toggleClassName: string;
   closeClassName: string;
@@ -19,9 +20,14 @@ export interface DesktopDrawerProps {
   width: number;
   topOffset: number | undefined;
   bottomOffset: number | undefined;
-  ariaLabels: AppLayoutProps.Labels | undefined;
-  drawersAriaLabels?: { mainLabel: string | undefined; closeLabel: string | undefined; openLabel: string | undefined };
+  ariaLabels: {
+    mainLabel: string | undefined;
+    closeLabel: string | undefined;
+    openLabel: string | undefined;
+    resizeHandle?: string;
+  };
   children: React.ReactNode;
+  hideOpenButton?: boolean;
   type: keyof typeof togglesConfig;
   isMobile: boolean;
   isOpen: boolean;
@@ -29,16 +35,11 @@ export interface DesktopDrawerProps {
   onToggle: (isOpen: boolean) => void;
   onClick?: (event: React.MouseEvent) => void;
   onLoseFocus?: (event: React.FocusEvent) => void;
-  drawers?: {
-    items: Array<DrawerItem>;
-    activeDrawerId: string | undefined;
-    onChange: (changeDetail: { activeDrawerId: string | undefined }) => void;
-  };
   resizeHandle?: React.ReactNode;
 }
 
 export interface ResizableDrawerProps extends DesktopDrawerProps {
-  activeDrawer?: DrawerItem;
+  activeDrawer?: PublicDrawer;
   onResize: (resizeDetail: { size: number; id: string }) => void;
   size: number;
   getMaxWidth: () => number;
@@ -50,45 +51,42 @@ export interface DrawerTriggersBarProps {
   topOffset: number | undefined;
   bottomOffset: number | undefined;
   isMobile: boolean;
-  drawers?: {
-    items: Array<DrawerItem>;
-    activeDrawerId?: string;
-    onChange: (changeDetail: { activeDrawerId: string | undefined }) => void;
-    ariaLabel?: string;
-    overflowAriaLabel?: string;
-    overflowWithBadgeAriaLabel?: string;
-  };
+  drawers: Array<PublicDrawer>;
+  activeDrawerId: string | null;
+  onDrawerChange: (newDrawerId: string | null) => void;
+  ariaLabels: PublicAriaLabelsWithDrawers | undefined;
 }
 
-export interface DrawerItemAriaLabels {
+// Beta interfaces
+// TODO: remove after beta consumers migrate to prod API
+interface BetaDrawerItemAriaLabels {
   content?: string;
   closeButton?: string;
   triggerButton?: string;
   resizeHandle?: string;
 }
 
-export interface DrawerItem {
+interface BetaDrawerItem {
   id: string;
   content: React.ReactNode;
   trigger: {
     iconName?: IconProps.Name;
     iconSvg?: React.ReactNode;
   };
-  ariaLabels: DrawerItemAriaLabels;
+  ariaLabels: BetaDrawerItemAriaLabels;
   resizable?: boolean;
   defaultSize?: number;
   onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
   badge?: boolean;
 }
 
-export interface InternalDrawerProps {
-  drawers?: {
-    items: Array<DrawerItem>;
-    activeDrawerId?: string;
-    onChange?: NonCancelableEventHandler<string>;
-    onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
-    ariaLabel?: string;
-    overflowAriaLabel?: string;
-    overflowWithBadgeAriaLabel?: string;
-  };
+export interface BetaDrawersProps {
+  items: Array<BetaDrawerItem>;
+  activeDrawerId?: string | null;
+  onChange?: NonCancelableEventHandler<string | null>;
+  onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
+  ariaLabel?: string;
+  overflowAriaLabel?: string;
+  overflowWithBadgeAriaLabel?: string;
 }
+// Beta interfaces end

--- a/src/app-layout/drawer/overflow-menu.tsx
+++ b/src/app-layout/drawer/overflow-menu.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import InternalButtonDropdown from '../../button-dropdown/internal';
 import { ButtonDropdownProps, InternalButtonDropdownProps } from '../../button-dropdown/interfaces';
 import { CancelableEventHandler } from '../../internal/events';
-import { DrawerItem } from './interfaces';
+import { PublicDrawer } from '../interfaces';
 
 interface OverflowMenuProps {
-  items: DrawerItem[];
+  items: Array<PublicDrawer>;
   onItemClick: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails>;
   customTriggerBuilder?: InternalButtonDropdownProps['customTriggerBuilder'];
   ariaLabel?: string;
@@ -18,7 +18,7 @@ export default function OverflowMenu({ items, onItemClick, customTriggerBuilder,
     <InternalButtonDropdown
       items={items.map(item => ({
         id: item.id,
-        text: item.ariaLabels?.content || 'Content',
+        text: item.ariaLabels.drawerName,
         iconName: item.trigger.iconName,
         iconSvg: item.trigger.iconSvg,
         badge: item.badge,

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -88,9 +88,9 @@ export const ResizableDrawer = ({
         !isMobile &&
         activeDrawer?.resizable && <div className={splitPanelStyles['slider-wrapper-side']}>{resizeHandle}</div>
       }
-      drawersAriaLabels={{
+      ariaLabels={{
         openLabel: activeDrawer?.ariaLabels?.triggerButton,
-        mainLabel: activeDrawer?.ariaLabels?.content,
+        mainLabel: activeDrawer?.ariaLabels?.drawerName,
         closeLabel: activeDrawer?.ariaLabels?.closeButton,
       }}
     >

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -3,6 +3,7 @@
 import React from 'react';
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { IconProps } from '../icon/interfaces';
 
 export interface AppLayoutProps extends BaseComponentProps {
   /**
@@ -251,4 +252,31 @@ export namespace AppLayoutProps {
   // Duplicated the positions because using this definition in SplitPanelPreferences would display
   // 'AppLayoutProps.SplitPanelPosition' on the API docs instead of the string values.
   export type SplitPanelPosition = 'side' | 'bottom';
+}
+
+export interface PublicDrawer {
+  id: string;
+  content: React.ReactNode;
+  trigger: {
+    iconName?: IconProps.Name;
+    iconSvg?: React.ReactNode;
+  };
+  ariaLabels: PublicDrawerAriaLabels;
+  badge?: boolean;
+  resizable?: boolean;
+  defaultSize?: number;
+  onResize?: NonCancelableEventHandler<{ size: number }>;
+}
+
+export interface PublicAriaLabelsWithDrawers extends AppLayoutProps.Labels {
+  drawers?: string;
+  drawersOverflow?: string;
+  drawersOverflowWithBadge?: string;
+}
+
+export interface PublicDrawerAriaLabels {
+  drawerName: string;
+  closeButton?: string;
+  triggerButton?: string;
+  resizeHandle?: string;
 }

--- a/src/app-layout/mobile-toolbar/index.tsx
+++ b/src/app-layout/mobile-toolbar/index.tsx
@@ -3,8 +3,7 @@
 import clsx from 'clsx';
 import React, { useEffect } from 'react';
 import { ButtonProps } from '../../button/interfaces';
-import { AppLayoutProps } from '../interfaces';
-import { DrawerItem } from '../drawer/interfaces';
+import { AppLayoutProps, PublicAriaLabelsWithDrawers, PublicDrawer } from '../interfaces';
 import { ToggleButton, togglesConfig } from '../toggles';
 import OverflowMenu from '../drawer/overflow-menu';
 import styles from './styles.css.js';
@@ -55,19 +54,14 @@ interface MobileToolbarProps {
   navigationHide: boolean | undefined;
   toolsHide: boolean | undefined;
   topOffset?: number;
-  ariaLabels: AppLayoutProps.Labels | undefined;
+  ariaLabels: PublicAriaLabelsWithDrawers | undefined;
   mobileBarRef: React.Ref<HTMLDivElement>;
   children: React.ReactNode;
   onNavigationOpen: () => void;
   onToolsOpen: () => void;
-  drawers?: {
-    items: Array<DrawerItem>;
-    activeDrawerId: string | undefined;
-    onChange: (changeDetail: { activeDrawerId: string | undefined }) => void;
-    ariaLabel?: string;
-    overflowAriaLabel?: string;
-    overflowWithBadgeAriaLabel?: string;
-  };
+  drawers: Array<PublicDrawer> | undefined;
+  activeDrawerId: string | null;
+  onDrawerChange: (newDrawerId: string | null) => void;
 }
 
 export function MobileToolbar({
@@ -78,10 +72,12 @@ export function MobileToolbar({
   toolsHide,
   anyPanelOpen,
   unfocusable,
+  drawers,
+  activeDrawerId,
   children,
   onNavigationOpen,
   onToolsOpen,
-  drawers,
+  onDrawerChange,
   mobileBarRef,
 }: MobileToolbarProps) {
   useEffect(() => {
@@ -95,7 +91,7 @@ export function MobileToolbar({
     }
   }, [anyPanelOpen]);
 
-  const { overflowItems, visibleItems } = splitItems(drawers?.items, 2, drawers?.activeDrawerId);
+  const { overflowItems, visibleItems } = splitItems(drawers, 2, activeDrawerId);
   const overflowMenuHasBadge = !!overflowItems.find(item => item.badge);
 
   return (
@@ -128,13 +124,13 @@ export function MobileToolbar({
         />
       )}
       {drawers && (
-        <aside aria-label={drawers.ariaLabel} role="region">
+        <aside aria-label={ariaLabels?.drawers} role="region">
           <div className={clsx(styles['drawers-container'])} role="toolbar" aria-orientation="horizontal">
             {visibleItems.map((item, index) => (
               <div
                 className={clsx(styles['mobile-toggle'], styles['mobile-toggle-type-drawer'])}
                 key={index}
-                onClick={() => drawers.onChange({ activeDrawerId: item.id })}
+                onClick={() => onDrawerChange(item.id)}
               >
                 <ToggleButton
                   className={clsx(
@@ -145,7 +141,7 @@ export function MobileToolbar({
                   iconSvg={item.trigger.iconSvg}
                   badge={item.badge}
                   ariaLabel={item.ariaLabels?.triggerButton}
-                  ariaExpanded={drawers.activeDrawerId === item.id}
+                  ariaExpanded={activeDrawerId === item.id}
                   testId={`awsui-app-layout-trigger-${item.id}`}
                 />
               </div>
@@ -153,13 +149,9 @@ export function MobileToolbar({
             {overflowItems.length > 0 && (
               <div className={clsx(styles['mobile-toggle'], styles['mobile-toggle-type-drawer'])}>
                 <OverflowMenu
-                  ariaLabel={overflowMenuHasBadge ? drawers.overflowWithBadgeAriaLabel : drawers.overflowAriaLabel}
+                  ariaLabel={overflowMenuHasBadge ? ariaLabels?.drawersOverflowWithBadge : ariaLabels?.drawersOverflow}
                   items={overflowItems}
-                  onItemClick={({ detail }) => {
-                    drawers.onChange({
-                      activeDrawerId: detail.id !== drawers.activeDrawerId ? detail.id : undefined,
-                    });
-                  }}
+                  onItemClick={({ detail }) => onDrawerChange(detail.id)}
                 />
               </div>
             )}

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -8,7 +8,7 @@ import ResizeHandler from '../../split-panel/icons/resize-handler';
 import { getLimitedValue } from '../../split-panel/utils/size-utils';
 import { usePointerEvents } from './use-pointer-events';
 import { useKeyboardEvents } from './use-keyboard-events';
-import { DrawerItem } from '../drawer/interfaces';
+import { PublicDrawer } from '../interfaces';
 
 import splitPanelStyles from '../../split-panel/styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -17,7 +17,7 @@ import { DrawerFocusControlRefs } from './use-drawer-focus-control';
 import { SizeControlProps } from './interfaces';
 
 export interface DrawerResizeProps {
-  activeDrawer: DrawerItem | undefined;
+  activeDrawer: PublicDrawer | undefined;
   activeDrawerSize: number;
   onActiveDrawerResize: (detail: { id: string; size: number }) => void;
   drawersRefs: DrawerFocusControlRefs;

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -13,7 +13,7 @@ import React, {
 import { applyDefaults } from '../defaults';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
 import { DynamicOverlapContext } from '../../internal/context/dynamic-overlap-context';
-import { AppLayoutProps } from '../interfaces';
+import { AppLayoutProps, PublicDrawer } from '../interfaces';
 import { fireNonCancelableEvent } from '../../internal/events';
 import { FocusControlRefs, useFocusControl } from '../utils/use-focus-control';
 import { DrawerFocusControlRefs, useDrawerFocusControl } from '../utils/use-drawer-focus-control';
@@ -25,18 +25,17 @@ import { SplitPanelFocusControlRefs, useSplitPanelFocusControl } from '../utils/
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
 import { useObservedElement } from '../utils/use-observed-element';
 import { useMobile } from '../../internal/hooks/use-mobile';
-import { DrawerItem, InternalDrawerProps } from '../drawer/interfaces';
 import { useStableCallback, warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import useResize from '../utils/use-resize';
 import styles from './styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import useBackgroundOverlap from './use-background-overlap';
-import { useDrawers } from '../utils/use-drawers';
+import { useDrawers, UseDrawersProps } from '../utils/use-drawers';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 
 interface AppLayoutInternals extends AppLayoutProps {
-  activeDrawerId: string | undefined;
-  drawers: Array<DrawerItem> | null;
+  activeDrawerId: string | null;
+  drawers: Array<PublicDrawer> | undefined;
   drawersAriaLabel: string | undefined;
   drawersOverflowAriaLabel: string | undefined;
   drawersOverflowWithBadgeAriaLabel: string | undefined;
@@ -46,7 +45,7 @@ interface AppLayoutInternals extends AppLayoutProps {
   drawerRef: React.Ref<HTMLElement>;
   resizeHandle: React.ReactElement;
   drawersTriggerCount: number;
-  handleDrawersClick: (activeDrawerId: string | undefined, skipFocusControl?: boolean) => void;
+  handleDrawersClick: (activeDrawerId: string | null, skipFocusControl?: boolean) => void;
   handleSplitPanelClick: () => void;
   handleNavigationClick: (isOpen: boolean) => void;
   handleSplitPanelPreferencesChange: (detail: AppLayoutProps.SplitPanelPreferences) => void;
@@ -371,7 +370,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       onActiveDrawerResize,
       activeDrawerSize,
       ...drawersProps
-    } = useDrawers(props as InternalDrawerProps, {
+    } = useDrawers(props as UseDrawersProps, props.ariaLabels, {
       ariaLabels: props.ariaLabels,
       toolsHide,
       toolsOpen: isToolsOpen,
@@ -399,8 +398,8 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       drawersMaxWidth,
     });
 
-    const handleDrawersClick = (id: string | undefined, skipFocusControl?: boolean) => {
-      const newActiveDrawerId = id !== activeDrawerId ? id : undefined;
+    const handleDrawersClick = (id: string | null, skipFocusControl?: boolean) => {
+      const newActiveDrawerId = id !== activeDrawerId ? id : null;
 
       onActiveDrawerChange(newActiveDrawerId);
 
@@ -413,7 +412,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       drawersTriggerCount++;
     }
     const hasOpenDrawer =
-      activeDrawerId !== undefined ||
+      !!activeDrawerId ||
       (!toolsHide && isToolsOpen) ||
       (splitPanelDisplayed && splitPanelPosition === 'side' && isSplitPanelOpen);
     const hasDrawerViewportOverlay =
@@ -602,9 +601,9 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           activeDrawerId,
           contentType,
           drawers,
-          drawersAriaLabel: drawersProps.ariaLabel,
-          drawersOverflowAriaLabel: drawersProps.overflowAriaLabel,
-          drawersOverflowWithBadgeAriaLabel: drawersProps.overflowWithBadgeAriaLabel,
+          drawersAriaLabel: drawersProps.ariaLabelsWithDrawers?.drawers,
+          drawersOverflowAriaLabel: drawersProps.ariaLabelsWithDrawers?.drawersOverflow,
+          drawersOverflowWithBadgeAriaLabel: drawersProps.ariaLabelsWithDrawers?.drawersOverflowWithBadge,
           drawersRefs,
           drawersMaxWidth,
           drawerSize,

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -78,7 +78,7 @@ function ActiveDrawer() {
 
   const computedAriaLabels = {
     closeButton: activeDrawerId ? activeDrawer?.ariaLabels?.closeButton : ariaLabels?.toolsClose,
-    content: activeDrawerId ? activeDrawer?.ariaLabels?.content : ariaLabels?.tools,
+    content: activeDrawerId ? activeDrawer?.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
   const isHidden = !activeDrawerId;
@@ -90,7 +90,7 @@ function ActiveDrawer() {
 
   return (
     <aside
-      id={activeDrawerId}
+      id={activeDrawerId ?? undefined}
       aria-hidden={isHidden}
       aria-label={computedAriaLabels.content}
       className={clsx(styles.drawer, {
@@ -121,7 +121,7 @@ function ActiveDrawer() {
             formAction="none"
             iconName={isMobile ? 'close' : 'angle-right'}
             onClick={() => {
-              handleDrawersClick(activeDrawerId ?? undefined);
+              handleDrawersClick(activeDrawerId);
               handleToolsClick(false);
             }}
             ref={drawersRefs.close}

--- a/src/internal/plugins/controllers/drawers.ts
+++ b/src/internal/plugins/controllers/drawers.ts
@@ -1,9 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DrawerItem } from '../../../app-layout/drawer/interfaces';
 import debounce from '../../debounce';
+import { NonCancelableEventHandler } from '../../events';
 
-export type DrawerConfig = Omit<DrawerItem, 'content' | 'trigger'> & {
+export interface DrawerConfig {
+  id: string;
+  ariaLabels: {
+    content?: string;
+    closeButton?: string;
+    triggerButton?: string;
+    resizeHandle?: string;
+  };
+  badge?: boolean;
+  resizable?: boolean;
+  defaultSize?: number;
+  onResize?: NonCancelableEventHandler<{ size: number; id: string }>;
   orderPriority?: number;
   defaultActive?: boolean;
   trigger: {
@@ -11,7 +22,8 @@ export type DrawerConfig = Omit<DrawerItem, 'content' | 'trigger'> & {
   };
   mountContent: (container: HTMLElement) => void;
   unmountContent: (container: HTMLElement) => void;
-};
+}
+
 export type DrawersRegistrationListener = (drawers: Array<DrawerConfig>) => void;
 
 export interface DrawersApiPublic {


### PR DESCRIPTION
### Description

Preparing to make `<AppLayout drawers={[...]}>` API public. The final api shape is different than our beta version, so this PR updates all internal usage of this object and adds a converter step to support two APIs same time to give beta consumers some time to migrate

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Preview deployment for manual testing
* Screenshot tests in my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
