### PR TITLE
feat: Add `disableOuterPadding` property to Token group component

### DIFF
--- a/pages/token-group/index.page.tsx
+++ b/pages/token-group/index.page.tsx
@@ -29,6 +29,8 @@ export default function TokenGroupPage() {
       <h1>Token Group integration test page</h1>
       <input className="focus-element" aria-label="focus element" />
       <TokenGroup alignment="vertical" items={items} onDismiss={onDismiss} id="test" />
+      <h2>Token group without outer padding</h2>
+      <TokenGroup items={items} disableOuterPadding={true} onDismiss={() => {}} />
     </>
   );
 }

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14596,6 +14596,12 @@ Object {
       "type": "string",
     },
     Object {
+      "description": "Removes any outer padding from the component.",
+      "name": "disableOuterPadding",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": Object {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14596,7 +14596,8 @@ Object {
       "type": "string",
     },
     Object {
-      "description": "Removes any outer padding from the component.",
+      "description": "Removes any outer padding from the component.
+We recommend to always enable this property.",
       "name": "disableOuterPadding",
       "optional": true,
       "type": "boolean",

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -24,6 +24,7 @@ export interface TokenGroupProps extends BaseComponentProps {
 
   /**
    * Removes any outer padding from the component.
+   * We recommend to always enable this property.
    */
   disableOuterPadding?: boolean;
 

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -23,6 +23,11 @@ export interface TokenGroupProps extends BaseComponentProps {
   alignment?: TokenGroupProps.Alignment;
 
   /**
+   * Removes any outer padding from the component.
+   */
+  disableOuterPadding?: boolean;
+
+  /**
    *
    * An array of objects representing token items. Each token has the following properties:
    *

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -23,6 +23,7 @@ export default function InternalTokenGroup({
   onDismiss,
   limit,
   i18nStrings,
+  disableOuterPadding,
   __internalRootRef,
   ...props
 }: InternalTokenGroupProps) {
@@ -35,7 +36,12 @@ export default function InternalTokenGroup({
   return (
     <div
       {...baseProps}
-      className={clsx(baseProps.className, styles.root, hasItems && styles['has-items'])}
+      className={clsx(
+        baseProps.className,
+        styles.root,
+        hasItems && styles['has-items'],
+        disableOuterPadding && styles['no-padding']
+      )}
       ref={__internalRootRef}
     >
       <TokenList

--- a/src/token-group/styles.scss
+++ b/src/token-group/styles.scss
@@ -11,7 +11,7 @@
 .root {
   @include styles.styles-reset;
 
-  &.has-items {
+  &.has-items:not(.no-padding) {
     padding-top: awsui.$space-xs;
   }
 }


### PR DESCRIPTION
### Description
The token group component comes with some top padding by default, which is going against general expectations from components in the system. This was an oversight during the development of the component. However, simply removing the padding now would be a breaking change. Instead, we're adding a new property, `disableOuterPadding`, which removes the outer padding so that Token group becomes a more flexible building block.

Related links, issue #, if available: AWSUI-22994

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
