### PR TITLE
fix: Do not dismiss modal on ESC if dropdown is opened

### DIFF
--- a/pages/modal/with-dropdowns.page.tsx
+++ b/pages/modal/with-dropdowns.page.tsx
@@ -1,0 +1,186 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import {
+  Modal,
+  Button,
+  SpaceBetween,
+  Autosuggest,
+  ButtonDropdown,
+  DatePicker,
+  DateRangePicker,
+  DateRangePickerProps,
+  Multiselect,
+  MultiselectProps,
+  Popover,
+} from '~components';
+
+export default function () {
+  const [visible, setVisible] = useState(false);
+  const [value, setValue] = useState('');
+  const [dateRangeValue, setDateRangeValue] = useState<DateRangePickerProps['value']>(null);
+  const [selectedOptions, setSelectedOptions] = useState<MultiselectProps['selectedOptions']>([
+    {
+      label: 'Option 1',
+      value: '1',
+      description: 'This is a description',
+    },
+  ]);
+
+  return (
+    <article>
+      <h1>Simple modal</h1>
+      <Button onClick={() => setVisible(true)}>Show modal</Button>
+      <Modal
+        header="Delete instance"
+        visible={visible}
+        onDismiss={() => setVisible(false)}
+        closeAriaLabel="Close modal"
+        footer={
+          <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button variant="link">Cancel</Button>
+            <Button variant="primary">Delete</Button>
+          </span>
+        }
+      >
+        <SpaceBetween size={'xs'}>
+          <Autosuggest
+            onChange={({ detail }) => setValue(detail.value)}
+            value={value}
+            options={[
+              { value: 'Suggestion 1' },
+              { value: 'Suggestion 2' },
+              { value: 'Suggestion 3' },
+              { value: 'Suggestion 4' },
+            ]}
+            ariaLabel="Autosuggest example with suggestions"
+            placeholder="Enter value"
+            empty="No matches found"
+          />
+
+          <ButtonDropdown
+            items={[
+              { text: 'Delete', id: 'rm', disabled: false },
+              { text: 'Move', id: 'mv', disabled: false },
+              { text: 'Rename', id: 'rn', disabled: true },
+              {
+                id: 'view',
+                text: 'View metrics',
+                href: 'https://example.com',
+                external: true,
+                externalIconAriaLabel: '(opens in new tab)',
+              },
+            ]}
+          >
+            Short
+          </ButtonDropdown>
+
+          <DatePicker
+            onChange={({ detail }) => setValue(detail.value)}
+            value={value}
+            openCalendarAriaLabel={selectedDate =>
+              'Choose certificate expiry date' + (selectedDate ? `, selected date is ${selectedDate}` : '')
+            }
+            placeholder="YYYY/MM/DD"
+          />
+
+          <DateRangePicker
+            onChange={({ detail }) => setDateRangeValue(detail.value)}
+            value={dateRangeValue}
+            relativeOptions={[
+              {
+                key: 'previous-5-minutes',
+                amount: 5,
+                unit: 'minute',
+                type: 'relative',
+              },
+              {
+                key: 'previous-30-minutes',
+                amount: 30,
+                unit: 'minute',
+                type: 'relative',
+              },
+              {
+                key: 'previous-1-hour',
+                amount: 1,
+                unit: 'hour',
+                type: 'relative',
+              },
+              {
+                key: 'previous-6-hours',
+                amount: 6,
+                unit: 'hour',
+                type: 'relative',
+              },
+            ]}
+            isValidRange={range => {
+              if (range?.type === 'absolute') {
+                const [startDateWithoutTime] = range.startDate.split('T');
+                const [endDateWithoutTime] = range.endDate.split('T');
+                if (!startDateWithoutTime || !endDateWithoutTime) {
+                  return {
+                    valid: false,
+                    errorMessage:
+                      'The selected date range is incomplete. Select a start and end date for the date range.',
+                  };
+                }
+              }
+              return { valid: true };
+            }}
+            i18nStrings={{}}
+            placeholder="Filter by a date and time range"
+          />
+
+          <Multiselect
+            selectedOptions={selectedOptions}
+            onChange={({ detail }) => setSelectedOptions(detail.selectedOptions)}
+            options={[
+              {
+                label: 'Option 1',
+                value: '1',
+                description: 'This is a description',
+              },
+              {
+                label: 'Option 2',
+                value: '2',
+                iconName: 'unlocked',
+                labelTag: 'This is a label tag',
+              },
+              {
+                label: 'Option 3 (disabled)',
+                value: '3',
+                iconName: 'share',
+                tags: ['Tags go here', 'Tag1', 'Tag2'],
+                disabled: true,
+              },
+              {
+                label: 'Option 4',
+                value: '4',
+                filteringTags: ['filtering', 'tags', 'these are filtering tags'],
+              },
+              { label: 'Option 5', value: '5' },
+            ]}
+            placeholder="Choose options"
+          />
+
+          <Popover
+            header="Memory Error"
+            content="This instance contains insufficient memory. Stop the instance, choose a different instance type with more memory, and restart it."
+          >
+            Error
+          </Popover>
+
+          <Popover
+            dismissButton={false}
+            position="top"
+            size="small"
+            triggerType="custom"
+            content={'Code snippet copied'}
+          >
+            <Button iconName="copy">Copy</Button>
+          </Popover>
+        </SpaceBetween>
+      </Modal>
+    </article>
+  );
+}

--- a/src/button-dropdown/utils/use-button-dropdown.ts
+++ b/src/button-dropdown/utils/use-button-dropdown.ts
@@ -161,6 +161,9 @@ export function useButtonDropdown({
         onReturnFocus();
         closeDropdown();
         event.preventDefault();
+        if (isOpen) {
+          event.stopPropagation();
+        }
         break;
       }
       case KeyCode.tab: {

--- a/src/date-picker/index.tsx
+++ b/src/date-picker/index.tsx
@@ -89,6 +89,7 @@ const DatePicker = React.forwardRef(
 
     const onWrapperKeyDownHandler = (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.keyCode === KeyCode.escape && isDropDownOpen) {
+        event.stopPropagation();
         buttonRef.current?.focus();
         setIsDropDownOpen(false);
       }

--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -146,6 +146,9 @@ const DateRangePicker = React.forwardRef(
 
     const onWrapperKeyDownHandler = (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.keyCode === KeyCode.escape) {
+        if (isDropDownOpen) {
+          event.stopPropagation();
+        }
         closeDropdown(true);
       }
     };

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -171,8 +171,10 @@ const AutosuggestInput = React.forwardRef(
         }
         case KeyCode.escape: {
           if (open) {
+            event.stopPropagation();
             closeDropdown();
           } else if (value) {
+            event.stopPropagation();
             fireNonCancelableEvent(onChange, { value: '' });
           }
           event.preventDefault();

--- a/src/internal/components/options-list/__tests__/use-keyboard.test.ts
+++ b/src/internal/components/options-list/__tests__/use-keyboard.test.ts
@@ -22,7 +22,7 @@ const menuKeys: any = [
   ['enter', KeyCode.enter],
   ['space', KeyCode.space],
 ].reduce<any>((acc, [name, keyCode]) => {
-  acc[name] = { detail: { keyCode }, preventDefault: jest.fn() };
+  acc[name] = { detail: { keyCode }, preventDefault: jest.fn(), stopPropagation: jest.fn() };
   return acc;
 }, {});
 

--- a/src/internal/components/options-list/utils/use-keyboard.ts
+++ b/src/internal/components/options-list/utils/use-keyboard.ts
@@ -44,6 +44,7 @@ export const useMenuKeyboard: UseMenuKeyboard = ({
           goEnd();
           break;
         case KeyCode.escape:
+          e.stopPropagation();
           closeDropdown();
           break;
         case KeyCode.enter:

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -4,6 +4,13 @@ import * as React from 'react';
 import { act, render, fireEvent } from '@testing-library/react';
 import Modal, { ModalProps } from '../../../lib/components/modal';
 import Select from '../../../lib/components/select';
+import Multiselect from '../../../lib/components/multiselect';
+import Autosuggest from '../../../lib/components/autosuggest';
+import DatePicker from '../../../lib/components/date-picker';
+import DateRangePicker from '../../../lib/components/date-range-picker';
+import ButtonDropdown from '../../../lib/components/button-dropdown';
+import Popover from '../../../lib/components/popover';
+import StatusIndicator from '../../../lib/components/status-indicator';
 import createWrapper, { ElementWrapper, ModalWrapper } from '../../../lib/components/test-utils/dom';
 
 import styles from '../../../lib/components/modal/styles.css.js';
@@ -185,7 +192,8 @@ describe('Modal component', () => {
 
       expect(onDismissSpy).toHaveBeenCalled();
     });
-    it('does not dismiss modal if ESC pressed with child dropdown element opened', () => {
+
+    it('does not dismiss modal if ESC pressed with child select opened', () => {
       const onDismissSpy = jest.fn();
       const select = (
         <Select
@@ -197,19 +205,163 @@ describe('Modal component', () => {
           options={[
             { label: 'Option 1', value: '1' },
             { label: 'Option 2', value: '2' },
-            { label: 'Option 3', value: '3' },
           ]}
         />
       );
       const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: select });
       const selectWrapper = wrapper.findContent().findSelect()!;
 
-      expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
       act(() => selectWrapper.findTrigger()!.keydown(KeyCode.space));
-      expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeTruthy();
 
       act(() => selectWrapper.findDropdown().findOptionByValue('1')!.keydown(KeyCode.escape));
       expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child multiselect opened', () => {
+      const onDismissSpy = jest.fn();
+      const multiselect = (
+        <Multiselect
+          selectedOptions={[]}
+          onChange={() => {}}
+          options={[
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+          ]}
+        />
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: multiselect });
+      const multiselectWrapper = wrapper.findContent().findMultiselect()!;
+
+      act(() => multiselectWrapper.findTrigger()!.keydown(KeyCode.space));
+
+      act(() => multiselectWrapper.findDropdown().findOptionByValue('1')!.keydown(KeyCode.escape));
+      expect(multiselectWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child autosuggest opened', () => {
+      const onDismissSpy = jest.fn();
+      const autosuggest = (
+        <Autosuggest
+          value={'opt'}
+          onChange={() => {}}
+          options={[
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+          ]}
+        />
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: autosuggest });
+      const autosuggestWrapper = wrapper.findContent().findAutosuggest()!;
+
+      act(() => autosuggestWrapper.focus());
+
+      act(() => autosuggestWrapper.findNativeInput().keydown(KeyCode.escape));
+      expect(autosuggestWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child button dropdown opened', () => {
+      const onDismissSpy = jest.fn();
+      const buttonDropdown = (
+        <ButtonDropdown
+          items={[
+            { text: 'Delete', id: 'rm', disabled: false },
+            { text: 'Move', id: 'mv', disabled: false },
+          ]}
+        >
+          Short
+        </ButtonDropdown>
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: buttonDropdown });
+      const btnDropdownWrapper = wrapper.findContent().findButtonDropdown()!;
+
+      act(() => btnDropdownWrapper.findNativeButton().keydown(KeyCode.enter));
+      expect(btnDropdownWrapper.findOpenDropdown()).toBeTruthy();
+
+      act(() => btnDropdownWrapper.findItemById('rm')!.keydown(KeyCode.escape));
+      expect(btnDropdownWrapper.findOpenDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child datepicker opened', () => {
+      const onDismissSpy = jest.fn();
+      const datePicker = <DatePicker onChange={() => {}} value={''} />;
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: datePicker });
+      const datePickerWrapper = wrapper.findContent().findDatePicker()!;
+
+      fireEvent.click(datePickerWrapper.findOpenCalendarButton().getElement());
+
+      act(() => datePickerWrapper.findCalendar()!.keydown(KeyCode.escape));
+      expect(datePickerWrapper.findCalendar()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child date range picker opened', () => {
+      const onDismissSpy = jest.fn();
+      const dateRangePicker = (
+        <DateRangePicker
+          onChange={() => {}}
+          value={null}
+          isValidRange={() => {
+            return { valid: true };
+          }}
+          relativeOptions={[
+            {
+              key: 'previous-5-minutes',
+              amount: 5,
+              unit: 'minute',
+              type: 'relative',
+            },
+          ]}
+        />
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: dateRangePicker });
+      const dateRangePickerWrapper = wrapper.findContent().findDateRangePicker()!;
+
+      dateRangePickerWrapper.openDropdown();
+
+      act(() => dateRangePickerWrapper.findDropdown()!.findCancelButton()!.keydown(KeyCode.escape));
+      expect(dateRangePickerWrapper.findDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+
+    it('does not dismiss modal if ESC pressed with child popover opened', () => {
+      const onDismissSpy = jest.fn();
+      const popover = (
+        <Popover
+          header="Memory Error"
+          content="This instance contains insufficient memory. Stop the instance, choose a different instance type with more memory, and restart it."
+        >
+          <StatusIndicator>Error</StatusIndicator>
+        </Popover>
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: popover });
+      const popoverWrapper = wrapper.findContent().findPopover()!;
+
+      fireEvent.click(popoverWrapper.findTrigger().getElement());
+
+      act(() => popoverWrapper.findDismissButton()!.keydown(KeyCode.escape));
+      expect(popoverWrapper.findContent()).toBeFalsy();
       expect(onDismissSpy).not.toHaveBeenCalled();
 
       act(() => wrapper.findContent()!.keydown(KeyCode.escape));

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { act, render, fireEvent } from '@testing-library/react';
 import Modal, { ModalProps } from '../../../lib/components/modal';
+import Select from '../../../lib/components/select';
 import createWrapper, { ElementWrapper, ModalWrapper } from '../../../lib/components/test-utils/dom';
 
 import styles from '../../../lib/components/modal/styles.css.js';
@@ -182,6 +183,36 @@ describe('Modal component', () => {
         createWrapper(textFieldRef!).keydown(KeyCode.escape);
       });
 
+      expect(onDismissSpy).toHaveBeenCalled();
+    });
+    it('does not dismiss modal if ESC pressed with child dropdown element opened', () => {
+      const onDismissSpy = jest.fn();
+      const select = (
+        <Select
+          selectedOption={{
+            label: 'Option 1',
+            value: '1',
+          }}
+          onChange={() => {}}
+          options={[
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+            { label: 'Option 3', value: '3' },
+          ]}
+        />
+      );
+      const wrapper = renderModal({ visible: true, onDismiss: onDismissSpy, children: select });
+      const selectWrapper = wrapper.findContent().findSelect()!;
+
+      expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
+      act(() => selectWrapper.findTrigger()!.keydown(KeyCode.space));
+      expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeTruthy();
+
+      act(() => selectWrapper.findDropdown().findOptionByValue('1')!.keydown(KeyCode.escape));
+      expect(selectWrapper.findDropdown()!.findOpenDropdown()).toBeFalsy();
+      expect(onDismissSpy).not.toHaveBeenCalled();
+
+      act(() => wrapper.findContent()!.keydown(KeyCode.escape));
       expect(onDismissSpy).toHaveBeenCalled();
     });
   });

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -45,6 +45,7 @@ export default function PopoverBody({
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.keyCode === KeyCode.escape) {
+        event.stopPropagation();
         onDismiss();
       }
     },

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -84,10 +84,12 @@ function InternalPopover(
 
   const onTriggerKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.keyCode === KeyCode.tab || event.keyCode === KeyCode.escape) {
-        if (event.keyCode === KeyCode.escape && visible) {
-          event.stopPropagation();
-        }
+      const isEscapeKey = event.keyCode === KeyCode.escape;
+      const isTabKey = event.keyCode === KeyCode.tab;
+      if (isEscapeKey && visible) {
+        event.stopPropagation();
+      }
+      if (isTabKey || isEscapeKey) {
         setVisible(false);
       }
     },

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -82,12 +82,17 @@ function InternalPopover(
     focusTrigger();
   }, [focusTrigger]);
 
-  const onTriggerKeyDown = useCallback((event: React.KeyboardEvent) => {
-    if (event.keyCode === KeyCode.tab || event.keyCode === KeyCode.escape) {
-      event.stopPropagation();
-      setVisible(false);
-    }
-  }, []);
+  const onTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.keyCode === KeyCode.tab || event.keyCode === KeyCode.escape) {
+        if (event.keyCode === KeyCode.escape && visible) {
+          event.stopPropagation();
+        }
+        setVisible(false);
+      }
+    },
+    [visible]
+  );
 
   useImperativeHandle(ref, () => ({
     dismissPopover: onDismiss,

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -84,6 +84,7 @@ function InternalPopover(
 
   const onTriggerKeyDown = useCallback((event: React.KeyboardEvent) => {
     if (event.keyCode === KeyCode.tab || event.keyCode === KeyCode.escape) {
+      event.stopPropagation();
       setVisible(false);
     }
   }, []);


### PR DESCRIPTION
### Description

Prevent Modal from closing on ESC, if there is a dropdown / popover opened inside the modal.

Related links, issue #, if available: AWSUI-22988

### How has this been tested?

New unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
