### PR TITLE
fix: Improve space management logic in mixed line-bar chart

### DIFF
--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -99,6 +99,8 @@ interface YAxisProps extends BaseAxisProps {
   ticks: number[];
 }
 
+const fallbackContainerWidth = 500;
+
 export default function ChartContainer<T extends ChartDataTypes>({
   fitHeight,
   height: explicitPlotHeight,
@@ -133,9 +135,12 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
   const [leftLabelsWidth, setLeftLabelsWidth] = useState(0);
   const [verticalMarkerX, setVerticalMarkerX] = useState<VerticalMarkerX<T> | null>(null);
-  const [containerWidth, containerMeasureRef] = useContainerWidth(500);
+  const [containerWidth, containerMeasureRef] = useContainerWidth(fallbackContainerWidth);
   const maxLeftLabelsWidth = Math.round(containerWidth / 2);
-  const plotWidth = containerWidth ? containerWidth - leftLabelsWidth - LEFT_LABELS_MARGIN : 500;
+  const plotWidth = containerWidth
+    ? // Calculate the minimum between leftLabelsWidth and maxLeftLabelsWidth for extra safety because leftLabelsWidth could be out of date
+      Math.max(0, containerWidth - Math.min(leftLabelsWidth, maxLeftLabelsWidth) - LEFT_LABELS_MARGIN)
+    : fallbackContainerWidth;
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
   const popoverRef = useRef<HTMLElement | null>(null);


### PR DESCRIPTION
### Description

The mixed line-bar chart goes through a few render cycles in order to make some necessary calculations: only once it has rendered once it knows the container width, which is needed for calculating the maximum space available for the left labels. And after one more render we know the space that the left labels actually take.

Before the first render, the container width has a fallback assigned width of 500. If the actual size after render is smaller, this can lead to a situation where the calculated size for the plot (`plotWidth`) is negative until `leftLabelsSize` is updated in the next render. This does not produce visible artifacts but renders errors in the console for one render cycle.

This is fixed here by using the minimum of `leftLabelSize` and `maxLeftLabelSize`, as we already know the correct value of the latter at this point.

Also using `Math.max` to handle the extreme case of a viewport narrower than 16px.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

- Running through my pipeline
- Console errors are caught by internal pipeline integration tests. This was not caught by local integration tests because the local browser window does not become narrow enough to reproduce this.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
