### PR TITLE
chore: Increase offset between link text and underline

### DIFF
--- a/src/attribute-editor/styles.scss
+++ b/src/attribute-editor/styles.scss
@@ -61,7 +61,7 @@
 
   /* stylelint-disable-next-line selector-max-type */
   > a {
-    @include styles.link-inline;
+    @include styles.link-inline('body-s');
   }
 }
 

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -20,7 +20,7 @@
   }
 
   > .anchor {
-    @include styles.link-inline;
+    @include styles.link-inline('body-m');
 
     @include focus-visible.when-visible {
       @include styles.link-focus;

--- a/src/internal/components/token-list/styles.scss
+++ b/src/internal/components/token-list/styles.scss
@@ -55,7 +55,7 @@
 
 .toggle {
   @include styles.styles-reset;
-  @include styles.link-default;
+  @include styles.link-default('body-m');
 
   display: flex;
   align-items: center;

--- a/src/internal/styles/links.scss
+++ b/src/internal/styles/links.scss
@@ -11,7 +11,7 @@
 @use '../hooks/focus-visible/' as focus-visible;
 @use '../../link/constants.scss' as constants;
 
-@mixin link-style($variant) {
+@mixin link-variant-style($variant) {
   color: map.get($variant, 'text-color-default');
   font-weight: map.get($variant, 'font-weight');
   letter-spacing: map.get($variant, 'letter-spacing');
@@ -44,18 +44,26 @@
   }
 }
 
-@mixin link-default {
-  @include link-style(map.get(constants.$link-variants, 'secondary'));
+@mixin link-font-size-style($font-size) {
+  text-underline-offset: map.get($font-size, 'text-underline-offset');
+  text-decoration-thickness: map.get($font-size, 'text-decoration-thickness');
+}
+
+@mixin link-default($font-size: 'inherit') {
+  @include link-variant-style(map.get(constants.$link-variants, 'secondary'));
+  @include link-font-size-style(map.get(constants.$link-font-sizes, $font-size));
 }
 
 /* Style used for links in slots/components that are text heavy, to help links stand out among 
 surrounding text. (WCAG F73) https://www.w3.org/WAI/WCAG21/Techniques/failures/F73#description */
-@mixin link-inline {
-  @include link-style(map.get(constants.$link-variants, 'primary'));
+@mixin link-inline($font-size: 'inherit') {
+  @include link-variant-style(map.get(constants.$link-variants, 'primary'));
+  @include link-font-size-style(map.get(constants.$link-font-sizes, $font-size));
 }
 
 // Need style as a mixin for tag editor only, because it needs special keyup/keydown behavior and thus cannot use the Link component
-@mixin link-recovery {
+@mixin link-recovery($font-size: 'inherit') {
   @include typography.font-smoothing;
-  @include link-style(map.get(constants.$link-variants, 'recovery'));
+  @include link-variant-style(map.get(constants.$link-variants, 'recovery'));
+  @include link-font-size-style(map.get(constants.$link-font-sizes, $font-size));
 }

--- a/src/internal/styles/links.scss
+++ b/src/internal/styles/links.scss
@@ -15,11 +15,8 @@
   color: map.get($variant, 'text-color-default');
   font-weight: map.get($variant, 'font-weight');
   letter-spacing: map.get($variant, 'letter-spacing');
-  // Fallback for browsers that do not support text-decoration-color, like IE11
-  text-decoration: map.get($variant, 'decoration');
-  /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+  text-decoration-line: map.get($variant, 'decoration-line');
   text-decoration-color: map.get($variant, 'decoration-color');
-  text-decoration-thickness: map.get($variant, 'decoration-thickness');
 
   @include styles.with-motion {
     transition-property: color, text-decoration;
@@ -42,10 +39,8 @@
   &:active,
   &:focus,
   &:hover {
-    text-decoration: underline;
-    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+    text-decoration-line: underline;
     text-decoration-color: map.get($variant, 'decoration-color-hover');
-    text-decoration-thickness: map.get($variant, 'decoration-thickness');
   }
 }
 

--- a/src/link/constants.scss
+++ b/src/link/constants.scss
@@ -9,7 +9,7 @@
 
 $link-font-sizes: (
   'body-s': (
-    'text-underline-offset': 0.25em,
+    'text-underline-offset': 0.3em,
     'text-decoration-thickness': 1px,
   ),
   'body-m': (

--- a/src/link/constants.scss
+++ b/src/link/constants.scss
@@ -7,13 +7,52 @@
 @use '../internal/styles/typography/constants.scss' as styles;
 @use '../internal/styles/tokens' as awsui;
 
+$link-font-sizes: (
+  'body-s': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'body-m': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'heading-xs': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'heading-s': (
+    'text-underline-offset': 0.3em,
+    'text-decoration-thickness': 1px,
+  ),
+  'heading-m': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'heading-l': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'heading-xl': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+  'display-l': (
+    'text-underline-offset': 0.23em,
+    'text-decoration-thickness': 2px,
+  ),
+  'inherit': (
+    'text-underline-offset': 0.25em,
+    'text-decoration-thickness': 1px,
+  ),
+);
+
 $link-variants: (
   'secondary': (
     'text-color-default': awsui.$color-text-link-default,
     'text-color-hover': awsui.$color-text-link-hover,
     'text-color-active': awsui.$color-text-link-hover,
     'font-weight': inherit,
-    'decoration': none,
+    'decoration-line': none,
     'decoration-color': transparent,
     'decoration-color-hover': currentColor,
     'letter-spacing': normal,
@@ -23,7 +62,7 @@ $link-variants: (
     'text-color-hover': awsui.$color-text-link-hover,
     'text-color-active': awsui.$color-text-link-hover,
     'font-weight': inherit,
-    'decoration': underline,
+    'decoration-line': underline,
     'decoration-color': currentColor,
     'decoration-color-hover': currentColor,
     'letter-spacing': normal,
@@ -33,7 +72,7 @@ $link-variants: (
     'text-color-hover': awsui.$color-text-link-hover,
     'text-color-active': awsui.$color-text-link-hover,
     'font-weight': awsui.$font-button-weight,
-    'decoration': none,
+    'decoration-line': none,
     'decoration-color': transparent,
     'decoration-color-hover': awsui.$color-text-link-button-underline-hover,
     'letter-spacing': styles.$letter-spacing-bold-link,
@@ -43,17 +82,16 @@ $link-variants: (
     'text-color-hover': awsui.$color-text-link-hover,
     'text-color-active': awsui.$color-text-link-hover,
     'font-weight': awsui.$font-box-value-large-weight,
-    'decoration': underline,
+    'decoration-line': underline,
     'decoration-color': currentColor,
     'decoration-color-hover': currentColor,
-    'decoration-thickness': 0.3rem,
   ),
   'top-navigation': (
     'text-color-default': awsui.$color-text-interactive-default,
     'text-color-hover': awsui.$color-text-interactive-hover,
     'text-color-active': awsui.$color-text-interactive-active,
     'font-weight': styles.$font-weight-bold,
-    'decoration': none,
+    'decoration-line': none,
     'decoration-color': transparent,
     'decoration-color-hover': transparent,
     'letter-spacing': styles.$letter-spacing-bold-link,
@@ -67,7 +105,7 @@ $link-variants: (
       'text-color-active': awsui.$color-text-link-hover,
       'font-weight': awsui.$font-link-button-weight,
       // Decoration fallback is for IE11, and IE11 does not support VR, so no variable needed
-      'decoration': underline,
+      'decoration-line': underline,
       'decoration-color': awsui.$color-text-link-button-underline,
       'decoration-color-hover': awsui.$color-text-link-button-underline-hover,
       'letter-spacing': awsui.$font-link-button-letter-spacing,
@@ -82,7 +120,7 @@ $link-styles: (
       'text-color-hover': awsui.$color-text-link-button-normal-hover,
       'text-color-active': awsui.$color-text-link-button-normal-active,
       'font-weight': awsui.$font-button-weight,
-      'decoration': none,
+      'decoration-line': none,
       'decoration-color': transparent,
       'decoration-color-hover': transparent,
       'letter-spacing': awsui.$font-button-letter-spacing,

--- a/src/link/constants.scss
+++ b/src/link/constants.scss
@@ -37,7 +37,7 @@ $link-font-sizes: (
     'text-decoration-thickness': 1px,
   ),
   'display-l': (
-    'text-underline-offset': 0.23em,
+    'text-underline-offset': 0.25em,
     'text-decoration-thickness': 2px,
   ),
   'inherit': (

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -9,18 +9,6 @@
 @use '../internal/hooks/focus-visible' as focus-visible;
 @use './constants' as constants;
 
-$font-sizes: (
-  'body-s',
-  'body-m',
-  'heading-xs',
-  'heading-s',
-  'heading-m',
-  'heading-l',
-  'heading-xl',
-  'display-l',
-  'inherit'
-);
-
 .link {
   @include styles.styles-reset;
   display: inline;
@@ -48,8 +36,7 @@ $font-sizes: (
   &.color-inverted {
     color: awsui.$color-text-notification-default;
     &:not(.button) {
-      text-decoration: underline;
-      /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+      text-decoration-line: underline;
       text-decoration-color: currentColor;
     }
     &:hover {
@@ -61,9 +48,11 @@ $font-sizes: (
     @include styles.link-focus;
   }
 
-  @each $variant in $font-sizes {
-    &.font-size-#{$variant} {
-      @include styles.font($variant);
+  @each $font-size, $properties in constants.$link-font-sizes {
+    &.font-size-#{$font-size} {
+      @include styles.font($font-size);
+      text-underline-offset: map.get($properties, 'text-underline-offset');
+      text-decoration-thickness: map.get($properties, 'text-decoration-thickness');
     }
   }
 }

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -24,13 +24,13 @@
         -webkit-font-smoothing: inherit;
         -moz-osx-font-smoothing: inherit;
       }
-      @include styles.link-style(map.get(constants.$link-variants, $variant));
+      @include styles.link-variant-style(map.get(constants.$link-variants, $variant));
     }
   }
 
   &.button {
     @include styles.font-smoothing;
-    @include styles.link-style(map.get(constants.$link-styles, 'button'));
+    @include styles.link-variant-style(map.get(constants.$link-styles, 'button'));
   }
 
   &.color-inverted {
@@ -51,8 +51,7 @@
   @each $font-size, $properties in constants.$link-font-sizes {
     &.font-size-#{$font-size} {
       @include styles.font($font-size);
-      text-underline-offset: map.get($properties, 'text-underline-offset');
-      text-decoration-thickness: map.get($properties, 'text-decoration-thickness');
+      @include styles.link-font-size-style(map.get(constants.$link-font-sizes, $font-size));
     }
   }
 }

--- a/src/tag-editor/styles.scss
+++ b/src/tag-editor/styles.scss
@@ -16,7 +16,7 @@
 }
 
 .undo-button {
-  @include styles.link-recovery;
+  @include styles.link-recovery('body-m');
 
   @include focus-visible.when-visible {
     @include styles.link-focus;


### PR DESCRIPTION
### Description

Check the internal research doc, the people love a heavy offset. This won't fit into the existing variant map, so I had to create a font-size map. And to prevent `text-decoration` from overriding all the little sub-properties, I switched to `text-decoration-line` which is supported by every browser in our support matrix.

Related links, issue #, if available: AWSUI-22009

### How has this been tested?

It's a styling change, and I expect the one big permutation page to collect all the differences.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
