### PR TITLE
fix: DateRangerPicker with hh timeInputFormat

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -239,6 +239,108 @@ describe('Date range picker', () => {
         expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/17');
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('23:59:59');
       });
+
+      (['hh:mm:ss', 'hh:mm', 'hh'] as DateRangePickerProps['timeInputFormat'][]).forEach(timeInputFormat => {
+        test(`sets start and end time to the beginning and end of day when only selecting a date with format ${timeInputFormat}`, () => {
+          const onChangeSpy = jest.fn();
+          const { wrapper } = renderDateRangePicker({
+            ...defaultProps,
+            timeInputFormat,
+            onChange: event => onChangeSpy(event.detail),
+          });
+
+          wrapper.findTrigger().click();
+          wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+          wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+          wrapper.findDropdown()!.findApplyButton().click();
+          expect(onChangeSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              value: {
+                type: 'absolute',
+                startDate: '2018-05-10T00:00:00+08:45',
+                endDate: '2018-05-12T23:59:59+08:45',
+              },
+            })
+          );
+        });
+      });
+    });
+
+    describe('time formats', () => {
+      test('hh:mm:ss format uses the provided string', () => {
+        const onChangeSpy = jest.fn();
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          timeInputFormat: 'hh:mm:ss',
+          onChange: event => onChangeSpy(event.detail),
+        });
+
+        wrapper.findTrigger().click();
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+        wrapper.findDropdown()!.findStartTimeInput()!.setInputValue('05:00:05');
+        wrapper.findDropdown()!.findEndTimeInput()!.setInputValue('23:00:05');
+        wrapper.findDropdown()!.findApplyButton().click();
+        expect(onChangeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            value: {
+              type: 'absolute',
+              startDate: '2018-05-10T05:00:05+08:45',
+              endDate: '2018-05-12T23:00:05+08:45',
+            },
+          })
+        );
+      });
+
+      test('hh:mm format gets padded with 00 for ss when provided via input', () => {
+        const onChangeSpy = jest.fn();
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          timeInputFormat: 'hh:mm',
+          onChange: event => onChangeSpy(event.detail),
+        });
+
+        wrapper.findTrigger().click();
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+        wrapper.findDropdown()!.findStartTimeInput()!.setInputValue('05:00');
+        wrapper.findDropdown()!.findEndTimeInput()!.setInputValue('23:00');
+        wrapper.findDropdown()!.findApplyButton().click();
+        expect(onChangeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            value: {
+              type: 'absolute',
+              startDate: '2018-05-10T05:00:00+08:45',
+              endDate: '2018-05-12T23:00:00+08:45',
+            },
+          })
+        );
+      });
+
+      test('hh format gets padded with 00:00 for mm:ss when provided via input', () => {
+        const onChangeSpy = jest.fn();
+        const { wrapper } = renderDateRangePicker({
+          ...defaultProps,
+          timeInputFormat: 'hh',
+          onChange: event => onChangeSpy(event.detail),
+        });
+
+        wrapper.findTrigger().click();
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+        wrapper.findDropdown()!.findStartTimeInput()!.setInputValue('05');
+        wrapper.findDropdown()!.findEndTimeInput()!.setInputValue('23');
+        wrapper.findDropdown()!.findApplyButton().click();
+        expect(onChangeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            value: {
+              type: 'absolute',
+              startDate: '2018-05-10T05:00:00+08:45',
+              endDate: '2018-05-12T23:00:00+08:45',
+            },
+          })
+        );
+      });
     });
 
     describe('time offset', () => {
@@ -251,10 +353,8 @@ describe('Date range picker', () => {
         });
 
         act(() => wrapper.findTrigger().click());
-
         act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10'));
         act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12'));
-
         act(() => wrapper.findDropdown()!.findApplyButton().click());
 
         expect(onChangeSpy).toHaveBeenCalledWith(

--- a/src/date-range-picker/utils.tsx
+++ b/src/date-range-picker/utils.tsx
@@ -3,6 +3,7 @@
 import { DateRangePickerProps } from './interfaces';
 import { setTimeOffset } from './time-offset';
 import { joinDateTime, splitDateTime } from '../internal/utils/date-time';
+import { normalizeTimeString } from '../internal/utils/date-time/join-date-time';
 
 export function formatValue(
   value: null | DateRangePickerProps.Value,
@@ -53,9 +54,12 @@ export function splitAbsoluteValue(
 export function joinAbsoluteValue(
   value: DateRangePickerProps.PendingAbsoluteValue
 ): DateRangePickerProps.AbsoluteValue {
+  const startTime = normalizeTimeString(value.start.time || '00:00:00');
+  const endTime = normalizeTimeString(value.end.time || '23:59:59');
+
   return {
     type: 'absolute',
-    startDate: joinDateTime(value.start.date, value.start.time || '00:00:00'),
-    endDate: joinDateTime(value.end.date, value.end.time || '23:59:59'),
+    startDate: joinDateTime(value.start.date, startTime),
+    endDate: joinDateTime(value.end.date, endTime),
   };
 }

--- a/src/internal/utils/date-time/join-date-time.ts
+++ b/src/internal/utils/date-time/join-date-time.ts
@@ -1,6 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+export function normalizeTimeString(timeString: string) {
+  const parts = timeString.split(':');
+  while (parts.length < 3) {
+    parts.push('00');
+  }
+  return parts.join(':');
+}
+
 export function joinDateTime(dateString: string, timeString: string) {
   return `${dateString}T${timeString}`;
 }


### PR DESCRIPTION
Normalizes returned value when timeInput is of the format hh

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
