### PR TITLE
chore: Updates test pages to use drawer instead of help panel

### DIFF
--- a/pages/app-layout/runtime-drawers.page.tsx
+++ b/pages/app-layout/runtime-drawers.page.tsx
@@ -6,6 +6,7 @@ import {
   ContentLayout,
   Header,
   HelpPanel,
+  Drawer,
   Link,
   NonCancelableCustomEvent,
   SpaceBetween,
@@ -173,5 +174,5 @@ function Info({ helpPathSlug }: { helpPathSlug: string }) {
 }
 
 function ProHelp() {
-  return <HelpPanel header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</HelpPanel>;
+  return <Drawer header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</Drawer>;
 }

--- a/pages/app-layout/utils/drawers.tsx
+++ b/pages/app-layout/utils/drawers.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { AppLayoutProps, HelpPanel, SpaceBetween } from '~components';
+import { AppLayoutProps, Drawer, SpaceBetween } from '~components';
 import styles from '../styles.scss';
 
 const getAriaLabels = (title: string, badge: boolean) => {
@@ -15,13 +15,13 @@ const getAriaLabels = (title: string, badge: boolean) => {
 
 function Security() {
   return (
-    <HelpPanel header={<h2>Security</h2>}>
+    <Drawer header={<h2>Security</h2>}>
       <SpaceBetween size="l">
         <div className={styles.contentPlaceholder} />
         <div className={styles.contentPlaceholder} />
         <div className={styles.contentPlaceholder} />
       </SpaceBetween>
-    </HelpPanel>
+    </Drawer>
   );
 }
 
@@ -43,7 +43,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
   },
   {
     ariaLabels: getAriaLabels('Pro help', true),
-    content: <HelpPanel header={<h2>Pro help</h2>}>Pro help.</HelpPanel>,
+    content: <Drawer header={<h2>Pro help</h2>}>Pro help.</Drawer>,
     badge: true,
     defaultSize: 600,
     id: 'pro-help',
@@ -55,7 +55,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
     ariaLabels: getAriaLabels('Links', false),
     resizable: true,
     defaultSize: 500,
-    content: <HelpPanel header={<h2>Links</h2>}>Links.</HelpPanel>,
+    content: <Drawer header={<h2>Links</h2>}>Links.</Drawer>,
     id: 'links',
     trigger: {
       iconName: 'share',
@@ -63,7 +63,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
   },
   {
     ariaLabels: getAriaLabels('Test 1', true),
-    content: <HelpPanel header={<h2>Test 1</h2>}>Test 1.</HelpPanel>,
+    content: <Drawer header={<h2>Test 1</h2>}>Test 1.</Drawer>,
     badge: true,
     id: 'test-1',
     trigger: {
@@ -74,7 +74,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
     ariaLabels: getAriaLabels('Test 2', false),
     resizable: true,
     defaultSize: 500,
-    content: <HelpPanel header={<h2>Test 2</h2>}>Test 2.</HelpPanel>,
+    content: <Drawer header={<h2>Test 2</h2>}>Test 2.</Drawer>,
     id: 'test-2',
     trigger: {
       iconName: 'share',
@@ -82,7 +82,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
   },
   {
     ariaLabels: getAriaLabels('Test 3', true),
-    content: <HelpPanel header={<h2>Test 3</h2>}>Test 3.</HelpPanel>,
+    content: <Drawer header={<h2>Test 3</h2>}>Test 3.</Drawer>,
     badge: true,
     id: 'test-3',
     trigger: {
@@ -93,7 +93,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
     ariaLabels: getAriaLabels('Test 4', false),
     resizable: true,
     defaultSize: 500,
-    content: <HelpPanel header={<h2>Test 4</h2>}>Test 4.</HelpPanel>,
+    content: <Drawer header={<h2>Test 4</h2>}>Test 4.</Drawer>,
     id: 'test-4',
     trigger: {
       iconName: 'edit',
@@ -103,7 +103,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
     ariaLabels: getAriaLabels('Test 5', false),
     resizable: true,
     defaultSize: 500,
-    content: <HelpPanel header={<h2>Test 5</h2>}>Test 5.</HelpPanel>,
+    content: <Drawer header={<h2>Test 5</h2>}>Test 5.</Drawer>,
     id: 'test-5',
     trigger: {
       iconName: 'add-plus',
@@ -113,7 +113,7 @@ export const drawerItems: Array<AppLayoutProps.Drawer> = [
     ariaLabels: getAriaLabels('Test 6', false),
     resizable: true,
     defaultSize: 500,
-    content: <HelpPanel header={<h2>Test 6</h2>}>Test 6.</HelpPanel>,
+    content: <Drawer header={<h2>Test 6</h2>}>Test 6.</Drawer>,
     id: 'test-6',
     trigger: {
       iconName: 'call',

--- a/pages/app-layout/utils/external-widget.tsx
+++ b/pages/app-layout/utils/external-widget.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useImperativeHandle, useState } from 'react';
 import ReactDOM, { unmountComponentAtNode } from 'react-dom';
-import HelpPanel from '~components/help-panel';
+import Drawer from '~components/drawer';
 import awsuiPlugins from '~components/internal/plugins';
 
 const searchParams = new URL(location.hash.substring(1), location.href).searchParams;
@@ -17,9 +17,9 @@ const Content = React.forwardRef((props, ref) => {
     return () => console.log('unmounted');
   }, []);
   return (
-    <HelpPanel header={<h2>Security</h2>}>
+    <Drawer header={<h2>Security</h2>}>
       I am runtime drawer, <span data-testid="current-size">resized: {`${resized}`}</span>
-    </HelpPanel>
+    </Drawer>
   );
 });
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
Now that Drawer is released, we can update the test pages to use the correct component.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
