### PR TITLE
fix: Fixes drawer resize handle scrolling with content

### DIFF
--- a/src/app-layout/__integ__/app-layout-drawers.test.ts
+++ b/src/app-layout/__integ__/app-layout-drawers.test.ts
@@ -57,6 +57,11 @@ class AppLayoutDrawersPage extends BasePageObject {
     const { width } = await this.getBoundingBox(wrapper.find('[data-test-id="content"]').toSelector());
     return width;
   }
+
+  async getResizeHandlePosition() {
+    const position = await this.getBoundingBox(wrapper.findActiveDrawerResizeHandle().toSelector());
+    return position;
+  }
 }
 
 interface SetupTestOptions {
@@ -197,6 +202,17 @@ for (const visualRefresh of ['true', 'false']) {
           );
         }
       )
+    );
+
+    test(
+      'scrolling drawer does not affect resize handle position',
+      setupTest({}, async page => {
+        await page.openFirstDrawer();
+        const resizeHandleBefore = await page.getResizeHandlePosition();
+        await page.elementScrollTo(wrapper.findActiveDrawer().toSelector(), { top: 100 });
+        const resizeHandleAfter = await page.getResizeHandlePosition();
+        await expect(resizeHandleAfter).toEqual(resizeHandleBefore);
+      })
     );
   });
 }

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -115,7 +115,7 @@ export const Drawer = React.forwardRef(
         >
           {!isMobile && !hideOpenButton && regularOpenButton}
           {resizeHandle}
-          <TagName aria-label={mainLabel} aria-hidden={!isOpen}>
+          <TagName className={clsx(styles['drawer-children'])} aria-label={mainLabel} aria-hidden={!isOpen}>
             <CloseButton
               ref={toggleRefs.close}
               className={closeClassName}

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -115,7 +115,11 @@ export const Drawer = React.forwardRef(
         >
           {!isMobile && !hideOpenButton && regularOpenButton}
           {resizeHandle}
-          <TagName className={clsx(styles['drawer-children'])} aria-label={mainLabel} aria-hidden={!isOpen}>
+          <TagName
+            className={clsx(resizeHandle && styles['drawer-resize-content'])}
+            aria-label={mainLabel}
+            aria-hidden={!isOpen}
+          >
             <CloseButton
               ref={toggleRefs.close}
               className={closeClassName}

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -60,6 +60,11 @@ $drawer-z-index-mobile: 1001;
   & > [aria-hidden='true'] {
     display: none;
   }
+  > .drawer-resize-content {
+    overflow: auto;
+    height: 100%;
+    position: relative;
+  }
 }
 
 .drawer-triggers-wrapper {
@@ -67,12 +72,6 @@ $drawer-z-index-mobile: 1001;
   flex-direction: column;
   text-align: center;
   align-items: stretch;
-}
-
-.drawer-children {
-  overflow: auto;
-  height: 100%;
-  position: relative;
 }
 
 .drawer-trigger {

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -69,6 +69,12 @@ $drawer-z-index-mobile: 1001;
   align-items: stretch;
 }
 
+.drawer-children {
+  overflow: auto;
+  height: 100%;
+  position: relative;
+}
+
 .drawer-trigger {
   padding: constants.$toggle-padding;
   cursor: pointer;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
In classic, the drawer resize handle was scrolling up with the content. This fixes that, and adds a test to avoid regressions in the future.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
