### PR TITLE
chore: Use new disableOuterPadding property for Multiselect and update spacing

### DIFF
--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -350,11 +350,13 @@ const InternalMultiselect = React.forwardRef(
         </Dropdown>
         {showTokens && (
           <InternalTokenGroup
+            className={styles.tokens}
             alignment="horizontal"
             limit={tokenLimit}
             items={tokens}
             onDismiss={handleTokenDismiss}
             i18nStrings={tokenGroupI18nStrings}
+            disableOuterPadding={true}
           />
         )}
         <ScreenreaderOnly id={multiSelectAriaLabelId}>{ariaLabel}</ScreenreaderOnly>

--- a/src/multiselect/styles.scss
+++ b/src/multiselect/styles.scss
@@ -9,3 +9,7 @@
 .root {
   @include styles.styles-reset;
 }
+
+.tokens {
+  margin-top: awsui.$space-scaled-xs;
+}


### PR DESCRIPTION
### Description
Make sure multiselect uses new `disableOuterPadding` property now, as well as adjusting the spacing between multiselect and token group to use a scaled token.

Related links, issue #, if available: AWSUI-23613

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
