### PR TITLE
chore: Clean up date range picker unit tests

### DIFF
--- a/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-absolute.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
 import { i18nStrings } from './i18n-strings';
@@ -131,7 +131,7 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2020-03-02T05:00:00+08:45', endDate: '2020-03-12T13:05:21+08:45' },
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
         expect(wrapper.findDropdown()!.findHeader().getElement()).toHaveTextContent('March 2020');
       });
@@ -142,7 +142,7 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
         expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/02');
         expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('05:00:00');
@@ -159,9 +159,9 @@ describe('Date range picker', () => {
           ...defaultProps,
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
-        act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
+        wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
 
         expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('17');
         expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/17');
@@ -173,10 +173,10 @@ describe('Date range picker', () => {
           ...defaultProps,
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
-        act(() => wrapper.findDropdown()!.findDateAt('left', 2, 3).click());
-        act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
+        wrapper.findDropdown()!.findDateAt('left', 2, 3).click();
+        wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
 
         expect(wrapper.findDropdown()!.findSelectedEndDate()!.getElement()).toHaveTextContent('17');
         expect(wrapper.findDropdown()!.findEndDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/17');
@@ -188,10 +188,10 @@ describe('Date range picker', () => {
           ...defaultProps,
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
-        act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
-        act(() => wrapper.findDropdown()!.findDateAt('left', 2, 3).click());
+        wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
+        wrapper.findDropdown()!.findDateAt('left', 2, 3).click();
 
         expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('9');
         expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/09');
@@ -208,9 +208,9 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
         wrapper.findDropdown()!.findStartDateInput()!.setInputValue('');
-        act(() => wrapper.findDropdown()!.findDateAt('left', 2, 3).click());
+        wrapper.findDropdown()!.findDateAt('left', 2, 3).click();
 
         expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('9');
         expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/09');
@@ -227,9 +227,9 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2021-03-02T05:00:00+08:45', endDate: '2021-03-12T13:05:21+08:45' },
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
         wrapper.findDropdown()!.findStartDateInput()!.setInputValue('');
-        act(() => wrapper.findDropdown()!.findDateAt('left', 3, 4).click());
+        wrapper.findDropdown()!.findDateAt('left', 3, 4).click();
 
         expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('12');
         expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement()).toHaveValue('2021/03/12');
@@ -352,10 +352,10 @@ describe('Date range picker', () => {
           onChange: event => onChangeSpy(event.detail),
         });
 
-        act(() => wrapper.findTrigger().click());
-        act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10'));
-        act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12'));
-        act(() => wrapper.findDropdown()!.findApplyButton().click());
+        wrapper.findTrigger().click();
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+        wrapper.findDropdown()!.findApplyButton().click();
 
         expect(onChangeSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -375,12 +375,12 @@ describe('Date range picker', () => {
           onChange: event => onChangeSpy(event.detail),
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
-        act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10'));
-        act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12'));
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
 
-        act(() => wrapper.findDropdown()!.findApplyButton().click());
+        wrapper.findDropdown()!.findApplyButton().click();
 
         expect(onChangeSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -408,7 +408,7 @@ describe('Date range picker', () => {
           '2018-01-01T17:00:00-08:00 — 2018-01-05T01:00:00-08:00'
         );
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
         expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('17:00:00');
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('01:00:00');
@@ -429,7 +429,7 @@ describe('Date range picker', () => {
           '2018-01-01T21:00:00-08:00 — 2018-01-05T09:00:00-08:00'
         );
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
         expect(wrapper.findDropdown()!.findStartTimeInput()!.findNativeInput().getElement()).toHaveValue('21:00:00');
         expect(wrapper.findDropdown()!.findEndTimeInput()!.findNativeInput().getElement()).toHaveValue('09:00:00');
@@ -501,12 +501,12 @@ describe('Date range picker', () => {
           onChange: event => onChangeSpy(event.detail),
         });
 
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
 
-        act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/01/01'));
-        act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/06/01'));
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/01/01');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/06/01');
 
-        act(() => wrapper.findDropdown()!.findApplyButton().click());
+        wrapper.findDropdown()!.findApplyButton().click();
 
         expect(onChangeSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -560,10 +560,10 @@ describe('Date range picker', () => {
           onChange: event => onChangeSpy(event.detail),
         });
 
-        act(() => wrapper.findTrigger().click());
-        act(() => wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10'));
-        act(() => wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12'));
-        act(() => wrapper.findDropdown()!.findApplyButton().click());
+        wrapper.findTrigger().click();
+        wrapper.findDropdown()!.findStartDateInput()!.setInputValue('2018/05/10');
+        wrapper.findDropdown()!.findEndDateInput()!.setInputValue('2018/05/12');
+        wrapper.findDropdown()!.findApplyButton().click();
 
         expect(onChangeSpy).toHaveBeenCalledWith(
           expect.objectContaining({ value: { type: 'absolute', startDate: '2018-05-10', endDate: '2018-05-12' } })
@@ -596,7 +596,7 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2022-11-24T12:55:00', endDate: '2022-11-28T11:14:00' },
           customAbsoluteRangeControl: customControl,
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
         expect(getByTestId('display')).toHaveTextContent(
           '{"start":{"date":"2022-11-24","time":"12:55:00"},"end":{"date":"2022-11-28","time":"11:14:00"}}'
         );
@@ -607,7 +607,7 @@ describe('Date range picker', () => {
           ...defaultProps,
           customAbsoluteRangeControl: customControl,
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
         getByTestId('set-date').click();
         expect(getByTestId('display')).toHaveTextContent(
           '{"start":{"date":"2022-01-02","time":"00:00:00"},"end":{"date":"2022-02-06","time":"12:34:56"}}'
@@ -626,7 +626,7 @@ describe('Date range picker', () => {
           value: { type: 'absolute', startDate: '2022-11-24T12:55:00', endDate: '2022-11-28T11:14:00' },
           customAbsoluteRangeControl: customControl,
         });
-        act(() => wrapper.findTrigger().click());
+        wrapper.findTrigger().click();
         getByTestId('clear-date').click();
         expect(getByTestId('display')).toHaveTextContent('{"start":{"date":"","time":""},"end":{"date":"","time":""}}');
         expect(wrapper.findDropdown()!.findSelectedStartDate()).toBeNull();

--- a/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker-relative.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import Mockdate from 'mockdate';
 import createWrapper, { DateRangePickerWrapper } from '../../../lib/components/test-utils/dom';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
@@ -60,7 +60,7 @@ describe('Date range picker', () => {
       const { container, wrapper } = renderDateRangePicker({
         ...defaultProps,
       });
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
 
       await expect(container).toValidateA11y();
     });
@@ -72,10 +72,10 @@ describe('Date range picker', () => {
         onChange: event => onChangeSpy(event.detail),
       });
 
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
 
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('previous-5-minutes')!.click());
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('previous-5-minutes')!.click();
+      wrapper.findDropdown()!.findApplyButton().click();
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -96,14 +96,14 @@ describe('Date range picker', () => {
         onChange: event => onChangeSpy(event.detail),
       });
 
-      act(() => wrapper.findTrigger().click());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click());
+      wrapper.findTrigger().click();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click();
 
-      act(() => wrapper.findDropdown()!.findCustomRelativeRangeDuration()!.setInputValue('14'));
-      act(() => wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown());
-      act(() => wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.selectOption(5));
+      wrapper.findDropdown()!.findCustomRelativeRangeDuration()!.setInputValue('14');
+      wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
+      wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.selectOption(5);
 
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.findDropdown()!.findApplyButton().click();
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy).toHaveBeenCalledWith(
@@ -123,8 +123,8 @@ describe('Date range picker', () => {
         onChange: () => undefined,
       });
 
-      act(() => wrapper.findTrigger().click());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click());
+      wrapper.findTrigger().click();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[4].findLabel().click();
 
       const durationAriaLabelId = wrapper
         .findDropdown()!
@@ -154,8 +154,8 @@ describe('Date range picker', () => {
         ...defaultProps,
       });
 
-      act(() => wrapper.findTrigger().click());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[2].findLabel().click());
+      wrapper.findTrigger().click();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findButtons()[2].findLabel().click();
 
       changeMode(wrapper, 'absolute');
       expect(wrapper.findDropdown()!.findRelativeRangeRadioGroup()).toBeNull();
@@ -174,7 +174,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
 
       const modeSelector = wrapper.findDropdown()!.findSelectionModeSwitch().findModesAsSegments();
       expect(modeSelector.findSelectedSegment()!.getElement().textContent).toBe('Absolute range');
@@ -186,7 +186,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
       changeMode(wrapper, 'relative');
 
       expect(!!wrapper.findDropdown()!.findRelativeRangeRadioGroup()).toBe(false);
@@ -198,7 +198,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
       });
 
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
       changeMode(wrapper, 'relative');
 
       expect(wrapper.findDropdown()!.getElement().textContent).toContain('Set a custom range in the past');
@@ -210,7 +210,7 @@ describe('Date range picker', () => {
         rangeSelectorMode: 'relative-only',
         relativeOptions: [],
       });
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
 
       wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual([
@@ -231,7 +231,7 @@ describe('Date range picker', () => {
         relativeOptions: [],
         dateOnly: true,
       });
-      act(() => wrapper.findTrigger().click());
+      wrapper.findTrigger().click();
 
       wrapper.findDropdown()!.findCustomRelativeRangeUnit()!.openDropdown();
       expect(getCustomRelativeRangeUnits(wrapper)).toEqual(['days', 'weeks', 'months', 'years']);

--- a/src/date-range-picker/__tests__/date-range-picker.test.tsx
+++ b/src/date-range-picker/__tests__/date-range-picker.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import Mockdate from 'mockdate';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import DateRangePicker, { DateRangePickerProps } from '../../../lib/components/date-range-picker';
@@ -109,14 +109,14 @@ describe('Date range picker', () => {
         </FormField>
       );
       const wrapper = createWrapper(container).findDateRangePicker()!;
-      act(() => wrapper.openDropdown());
+      wrapper.openDropdown();
       const dropdown = wrapper.findDropdown()!;
 
       expect(dropdown.findRelativeRangeRadioGroup()!.getElement()).toHaveAccessibleName(
         i18nStrings.relativeRangeSelectionHeading
       );
 
-      dropdown.findRelativeRangeRadioGroup()?.findButtons().at(-1)!.findNativeInput().click();
+      dropdown.findRelativeRangeRadioGroup()!.findButtons().at(-1)!.findNativeInput().click();
       expect(dropdown.findCustomRelativeRangeDuration()!.findNativeInput().getElement()).toHaveAccessibleName(
         i18nStrings.customRelativeRangeDurationLabel
       );
@@ -152,25 +152,25 @@ describe('Date range picker', () => {
 
   test('opens relative range mode by default', () => {
     const { wrapper } = renderDateRangePicker();
-    act(() => wrapper.openDropdown());
+    wrapper.openDropdown();
     expect(wrapper.findDropdown()!.findRelativeRangeRadioGroup()).not.toBeNull();
   });
 
   test('opens absolute range mode by default if no relative ranges are provided', () => {
     const { wrapper } = renderDateRangePicker({ ...defaultProps, relativeOptions: [] });
-    act(() => wrapper.openDropdown());
+    wrapper.openDropdown();
     expect(wrapper.findDropdown()!.findRelativeRangeRadioGroup()).toBeNull();
   });
 
   test('shows the clear button by default', () => {
     const { wrapper } = renderDateRangePicker();
-    act(() => wrapper.openDropdown());
+    wrapper.openDropdown();
     expect(wrapper.findDropdown()!.findClearButton()).not.toBeNull();
   });
 
   test('hides the clear button if specified', () => {
     const { wrapper } = renderDateRangePicker({ ...defaultProps, showClearButton: false });
-    act(() => wrapper.openDropdown());
+    wrapper.openDropdown();
     expect(wrapper.findDropdown()!.findClearButton()).toBeNull();
   });
 
@@ -224,12 +224,12 @@ describe('Date range picker', () => {
     });
 
     test('produces the value even if validation does not catch an incomplete range', () => {
-      act(() => wrapper.openDropdown());
+      wrapper.openDropdown();
 
       changeMode(wrapper, 'absolute');
-      act(() => wrapper.findDropdown()!.findDateAt('right', 3, 4).click());
+      wrapper.findDropdown()!.findDateAt('right', 3, 4).click();
 
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.findDropdown()!.findApplyButton().click();
 
       expect(onChangeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -239,41 +239,41 @@ describe('Date range picker', () => {
     });
 
     test('should not fire onChange if the date is invalid', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click());
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click();
+      wrapper.findDropdown()!.findApplyButton().click();
 
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
     });
 
     test('does not display the error message until after the first submit', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click();
       expect(wrapper.findDropdown()!.findValidationError()).toBeNull();
 
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.findDropdown()!.findApplyButton().click();
       expect(wrapper.findDropdown()!.findValidationError()?.getElement()).toHaveTextContent('10 is not allowed.');
       expect(wrapper.findDropdown()!.findByClassName(styles['validation-section'])!.find('[aria-live]')).not.toBe(null);
     });
 
     test('after rendering the error once, displays subsequent errors in real time', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click());
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click();
+      wrapper.findDropdown()!.findApplyButton().click();
 
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('five-hours')!.click());
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('five-hours')!.click();
       expect(wrapper.findDropdown()!.findValidationError()).toBeNull();
 
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click());
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click();
       expect(wrapper.findDropdown()!.findValidationError()?.getElement()).toHaveTextContent('10 is not allowed.');
     });
 
     test('resets validation state when switching between modes', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findRelativeRangeRadioGroup()!.findInputByValue('ten-hours')!.click();
       expect(wrapper.findDropdown()!.findValidationError()).toBeNull();
 
-      act(() => wrapper.findDropdown()!.findApplyButton().click());
+      wrapper.findDropdown()!.findApplyButton().click();
       expect(wrapper.findDropdown()!.findValidationError()?.getElement()).toHaveTextContent('10 is not allowed.');
 
       changeMode(wrapper, 'absolute');
@@ -300,8 +300,8 @@ describe('Date range picker', () => {
     });
 
     test('should fire when clearing the selection', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findClearButton()!.click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findClearButton()!.click();
 
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
       expect(onChangeSpy).toHaveBeenCalledWith(
@@ -312,8 +312,8 @@ describe('Date range picker', () => {
     });
 
     test('should not fire when canceling the selection', () => {
-      act(() => wrapper.openDropdown());
-      act(() => wrapper.findDropdown()!.findCancelButton().click());
+      wrapper.openDropdown();
+      wrapper.findDropdown()!.findCancelButton().click();
 
       expect(onChangeSpy).toHaveBeenCalledTimes(0);
     });
@@ -323,7 +323,7 @@ describe('Date range picker', () => {
     (['absolute-only', 'relative-only'] as const).forEach(rangeSelectorMode =>
       test(`shows no mode switcher when mode = ${rangeSelectorMode} and value = null`, () => {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, rangeSelectorMode });
-        act(() => wrapper.openDropdown());
+        wrapper.openDropdown();
 
         expect(wrapper.findDropdown()!.findSelectionModeSwitch()).toBeNull();
       })
@@ -337,7 +337,7 @@ describe('Date range picker', () => {
     ).forEach(([rangeSelectorMode, value]) =>
       test(`uses null as value when mode = ${rangeSelectorMode} and value.type = ${value.type}`, () => {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, rangeSelectorMode, value });
-        act(() => wrapper.openDropdown());
+        wrapper.openDropdown();
 
         expect(wrapper.findTrigger().getElement()).toHaveTextContent('');
       })
@@ -345,7 +345,7 @@ describe('Date range picker', () => {
 
     test('focuses dropdown when opened', () => {
       const { wrapper } = renderDateRangePicker();
-      act(() => wrapper.openDropdown());
+      wrapper.openDropdown();
 
       expectToHaveFocus(wrapper.findDropdown()!.getElement());
     });

--- a/src/date-range-picker/calendar/__tests__/calendar.test.tsx
+++ b/src/date-range-picker/calendar/__tests__/calendar.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import Mockdate from 'mockdate';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import DateRangePickerWrapper from '../../../../lib/components/test-utils/dom/date-range-picker';
 import DateRangePicker, { DateRangePickerProps } from '../../../../lib/components/date-range-picker';
 import styles from '../../../../lib/components/date-range-picker/styles.selectors.js';
@@ -43,7 +43,7 @@ describe('Date range picker calendar', () => {
     );
 
     const wrapper = createWrapper(container).findDateRangePicker()!;
-    act(() => wrapper.findTrigger().click());
+    wrapper.findTrigger().click();
     return {
       wrapper,
       getByTestId,
@@ -197,22 +197,22 @@ describe('Date range picker calendar', () => {
       });
 
       test('should go to the next day', () => {
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
+        findFocusableDate(wrapper)!.keydown(KeyCode.right);
         expect(findFocusableDateText(wrapper)).toBe('23');
       });
 
       test('should go to the previous day', () => {
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
+        findFocusableDate(wrapper)!.keydown(KeyCode.left);
         expect(findFocusableDateText(wrapper)).toBe('21');
       });
 
       test('should go to the previous week', () => {
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.up));
+        findFocusableDate(wrapper)!.keydown(KeyCode.up);
         expect(findFocusableDateText(wrapper)).toBe('15');
       });
 
       test('should go to the next week', () => {
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.down));
+        findFocusableDate(wrapper)!.keydown(KeyCode.down);
         expect(findFocusableDateText(wrapper)).toBe('29');
       });
 
@@ -222,7 +222,7 @@ describe('Date range picker calendar', () => {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, value: null });
 
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.up));
+        findFocusableDate(wrapper)!.keydown(KeyCode.up);
         expect(findFocusableDateText(wrapper)).toBe('24');
         expect(findCalendarHeaderText(wrapper)).toBe('February 2018March 2018');
       });
@@ -233,21 +233,21 @@ describe('Date range picker calendar', () => {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, value: null });
 
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.down));
+        findFocusableDate(wrapper)!.keydown(KeyCode.down);
 
         expect(findFocusableDateText(wrapper)).toBe('5');
         expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
 
       test('should allow first date to be focused after moving dates then navigating between months', () => {
-        act(() => wrapper.findDropdown()!.findNextMonthButton().click());
-        act(() => wrapper.findDropdown()!.findNextMonthButton().click());
+        wrapper.findDropdown()!.findNextMonthButton().click();
+        wrapper.findDropdown()!.findNextMonthButton().click();
 
         // focus a new date
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
+        findFocusableDate(wrapper)!.keydown(KeyCode.right);
         // navigate to previous month
-        act(() => wrapper.findDropdown()!.findPreviousMonthButton()!.click());
-        act(() => wrapper.findDropdown()!.findPreviousMonthButton()!.click());
+        wrapper.findDropdown()!.findPreviousMonthButton()!.click();
+        wrapper.findDropdown()!.findPreviousMonthButton()!.click();
 
         expect(findFocusableDateText(wrapper)).toBe('1');
       });
@@ -257,8 +257,8 @@ describe('Date range picker calendar', () => {
         const { wrapper } = renderDateRangePicker({ ...defaultProps, isDateEnabled });
 
         changeMode(wrapper, 'absolute');
-        act(() => wrapper.findDropdown()!.findNextMonthButton()!.click());
-        act(() => wrapper.findDropdown()!.findNextMonthButton()!.click());
+        wrapper.findDropdown()!.findNextMonthButton()!.click();
+        wrapper.findDropdown()!.findNextMonthButton()!.click();
 
         expect(findFocusableDateText(wrapper)).toBe('2');
       });
@@ -272,7 +272,7 @@ describe('Date range picker calendar', () => {
         });
 
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
+        findFocusableDate(wrapper)!.keydown(KeyCode.right);
         expect(findFocusableDateText(wrapper)).toBe('23');
       });
 
@@ -284,7 +284,7 @@ describe('Date range picker calendar', () => {
           value: { type: 'absolute', startDate: '2018-03-21T00:00:00', endDate: '2018-03-21T00:00:00' },
         });
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
+        findFocusableDate(wrapper)!.keydown(KeyCode.left);
         expect(findFocusableDateText(wrapper)).toBe('19');
       });
 
@@ -296,7 +296,7 @@ describe('Date range picker calendar', () => {
           value: { type: 'absolute', startDate: '2018-03-21T00:00:00', endDate: '2018-03-21T00:00:00' },
         });
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
+        findFocusableDate(wrapper)!.keydown(KeyCode.right);
         expect(findFocusableDateText(wrapper)).toBe('1');
         expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
@@ -309,7 +309,7 @@ describe('Date range picker calendar', () => {
           value: { type: 'absolute', startDate: '2018-03-21T00:00:00', endDate: '2018-03-21T00:00:00' },
         });
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
+        findFocusableDate(wrapper)!.keydown(KeyCode.left);
         expect(findFocusableDateText(wrapper)).toBe('28');
         expect(findCalendarHeaderText(wrapper)).toBe('February 2018March 2018');
       });
@@ -323,7 +323,7 @@ describe('Date range picker calendar', () => {
           value: { type: 'absolute', startDate: '2018-03-21T00:00:00', endDate: '2018-03-21T00:00:00' },
         });
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.right));
+        findFocusableDate(wrapper)!.keydown(KeyCode.right);
         expect(findFocusableDateText(wrapper)).toBe('21');
         expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
@@ -337,7 +337,7 @@ describe('Date range picker calendar', () => {
           value: { type: 'absolute', startDate: '2018-03-21T00:00:00', endDate: '2018-03-21T00:00:00' },
         });
         changeMode(wrapper, 'absolute');
-        act(() => findFocusableDate(wrapper)!.keydown(KeyCode.left));
+        findFocusableDate(wrapper)!.keydown(KeyCode.left);
         expect(findFocusableDateText(wrapper)).toBe('21');
         expect(findCalendarHeaderText(wrapper)).toBe('March 2018April 2018');
       });
@@ -365,12 +365,12 @@ describe('Date range picker calendar', () => {
         isDateEnabled,
       });
       changeMode(wrapper, 'absolute');
-      act(() => {
-        wrapper
-          .findDropdown()!
-          .findDateAt('left', 2, 1) // March 4th
-          .click();
-      });
+
+      wrapper
+        .findDropdown()!
+        .findDateAt('left', 2, 1) // March 4th
+        .click();
+
       expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('4');
       expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement().value).toBe('2018/03/04');
     });
@@ -382,12 +382,12 @@ describe('Date range picker calendar', () => {
         isDateEnabled,
       });
       changeMode(wrapper, 'absolute');
-      act(() => {
-        wrapper
-          .findDropdown()!
-          .findDateAt('left', 4, 1) // March, 18th
-          .click();
-      });
+
+      wrapper
+        .findDropdown()!
+        .findDateAt('left', 4, 1) // March, 18th
+        .click();
+
       expect(wrapper.findDropdown()!.findSelectedStartDate()!.getElement()).toHaveTextContent('1');
       expect(wrapper.findDropdown()!.findStartDateInput()!.findNativeInput().getElement().value).toBe('2018/03/01');
     });
@@ -458,24 +458,20 @@ describe('Date range picker calendar', () => {
         value: null,
       });
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent('');
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
-      });
+      wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
+
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
-      });
+      wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
+
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings!.renderSelectedAbsoluteRangeAriaLive!('', ''))
       );
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 3, 2).click();
-      });
+
+      wrapper.findDropdown()!.findDateAt('left', 3, 2).click();
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 3, 1).click();
-      });
+
+      wrapper.findDropdown()!.findDateAt('left', 3, 1).click();
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.startDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(
         new RegExp(i18nStrings.renderSelectedAbsoluteRangeAriaLive!('', ''))
@@ -490,13 +486,9 @@ describe('Date range picker calendar', () => {
         value: null,
       });
       // select start
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
-      });
+      wrapper.findDropdown()!.findDateAt('left', 2, 1).click();
       // select end
-      act(() => {
-        wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
-      });
+      wrapper.findDropdown()!.findDateAt('left', 2, 2).click();
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent(new RegExp(i18nStrings.endDateLabel!));
       expect(findLiveAnnouncement(wrapper)).toHaveTextContent('Sunday, September 6, 2020 – Monday, September 7, 2020');
     });


### PR DESCRIPTION
### Description

Remove usage of act as test utils now wrap with act by default.
Related links, issue #, if available: n/a

### How has this been tested?
All tests still pasing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
