### PR TITLE
fix: Make popover scrollable when needed also when not using a portal

### DIFF
--- a/pages/popover/scrollable.page.tsx
+++ b/pages/popover/scrollable.page.tsx
@@ -1,14 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import Popover from '~components/popover';
+import AppContext, { AppContextType } from '../app/app-context';
 
 const content =
   'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui.';
 
+type DemoContext = React.Context<
+  AppContextType<{
+    renderWithPortal: boolean;
+  }>
+>;
+
 export default function () {
   const [loading, setLoading] = useState(true);
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
 
   useEffect(() => {
     const interval = setInterval(() => setLoading(prev => !prev), 3000);
@@ -19,13 +27,22 @@ export default function () {
     <>
       <h1>Popover scrollable test</h1>
 
+      <label>
+        Render with portal{' '}
+        <input
+          type="checkbox"
+          checked={urlParams.renderWithPortal || false}
+          onChange={event => setUrlParams({ renderWithPortal: event.target.checked })}
+        />
+      </label>
+
       <div style={{ height: 600, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Popover
           size="medium"
           header="Lorem ipsum"
           content={<div>{loading ? content.slice(0, 200) + '...' : content}</div>}
           dismissAriaLabel="Close"
-          renderWithPortal={true}
+          renderWithPortal={urlParams.renderWithPortal}
         >
           Click!
         </Popover>

--- a/src/popover/__tests__/positions.test.ts
+++ b/src/popover/__tests__/positions.test.ts
@@ -107,24 +107,15 @@ describe('calculatePosition', () => {
       ],
     ] as const
   ).forEach(([trigger, body], index) => {
-    test(`index=${index} returns scrollable=true if can't fit popover into viewport`, () => {
-      const container = { ...viewport, height: viewport.height * 2 };
-      const position = calculatePosition('top', trigger, arrow, body, container, viewport, true);
-      expect(position.scrollable).toBe(true);
-      expect(position.boundingOffset.width).toBe(250);
-      expect(position.boundingOffset.height).toBeLessThan(900);
+    describe(`index=${index} returns scrollable=true if can't fit popover into viewport`, () => {
+      test.each([false, true])('renderWithPortal=%s', renderWithPortal => {
+        const container = { ...viewport, height: viewport.height * 2 };
+        const position = calculatePosition('top', trigger, arrow, body, container, viewport, renderWithPortal);
+        expect(position.scrollable).toBe(true);
+        expect(position.boundingOffset.width).toBe(250);
+        expect(position.boundingOffset.height).toBeLessThan(900);
+      });
     });
-  });
-
-  test('Prefers container over viewport when fitting the body if it is larger and renderWithPortal = false', () => {
-    const container = { ...viewport, height: viewport.height + 100 };
-    const trigger = { left: 200, top: 200, height: 25, width: 25 };
-    const body = { width: 250, height: 1000 };
-    const position = calculatePosition('top', trigger, arrow, body, container, viewport);
-    expect(position.scrollable).toBe(true);
-    expect(position.boundingOffset.width).toBe(250);
-    expect(position.boundingOffset.height).toBeGreaterThan(900);
-    expect(position.boundingOffset.height).toBeLessThan(1000);
   });
 });
 

--- a/src/popover/utils/positions.ts
+++ b/src/popover/utils/positions.ts
@@ -188,12 +188,6 @@ function fitIntoContainer(inner: BoundingOffset, outer: BoundingOffset): Boundin
   return { left, width, top, height };
 }
 
-function getLargestRect(rect1: BoundingOffset, rect2: BoundingOffset): BoundingOffset {
-  const area1 = rect1.height * rect1.width;
-  const area2 = rect2.height * rect2.width;
-  return area1 >= area2 ? rect1 : rect2;
-}
-
 /**
  * Returns the area of the intersection of passed in rectangles or a null, if there is no intersection
  */
@@ -262,10 +256,7 @@ export function calculatePosition(
   // Get default rect for that placement.
   const defaultOffset = RECTANGLE_CALCULATIONS[internalPosition]({ body, trigger, arrow });
   // Get largest possible rect that fits into viewport or container.
-  const optimisedOffset = fitIntoContainer(
-    defaultOffset,
-    renderWithPortal ? viewport : getLargestRect(container, viewport)
-  );
+  const optimisedOffset = fitIntoContainer(defaultOffset, viewport);
   // If largest possible rect is smaller than original - set body scroll.
   const scrollable = optimisedOffset.height < defaultOffset.height;
 


### PR DESCRIPTION
### Description

Popovers are not allowed to overflow the viewport and are made scrollable if necessary but only when the property `renderWithPortal` is `true` and not otherwise. This PR unifies the behavior and makes popovers scrollable if necessary regardless of whether using a portal or not.

Related links, issue #, if available: n/a

### How has this been tested?

- Unit tests
- Manually tested. Adapted existing page for manual testing
- Ran through my pipeline. One integration test catches the change and the result is expected (the popover is now cropped)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
