### PR TITLE
fix: Property filter token editor match by key

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -1213,6 +1213,41 @@ describe('property filter parts', () => {
         })
       );
     });
+
+    test('token editor has matched property options', () => {
+      function AsyncPropertyFilter(props: PropertyFilterProps) {
+        const [loadedFilteringOptions, setFilteringOptions] = useState<readonly FilteringOption[]>([]);
+        return (
+          <PropertyFilter
+            {...props}
+            filteringOptions={loadedFilteringOptions}
+            onLoadItems={(...args) => {
+              props.onLoadItems?.(...args);
+              setFilteringOptions(filteringOptions);
+            }}
+          />
+        );
+      }
+
+      const renderComponent = (props?: Partial<PropertyFilterProps>) => {
+        const { container } = render(<AsyncPropertyFilter {...defaultProps} {...props} />);
+        return createWrapper(container).findPropertyFilter()!;
+      };
+
+      const wrapper = renderComponent({
+        query: { tokens: [{ propertyKey: 'state', value: '0', operator: '=' }], operation: 'or' },
+      });
+
+      const [contentWrapper] = openTokenEditor(wrapper);
+      const valueSelectWrapper = findValueSelector(contentWrapper);
+      act(() => valueSelectWrapper.focus());
+      expect(
+        valueSelectWrapper
+          .findDropdown()
+          .findOptions()!
+          .map(optionWrapper => optionWrapper.getElement().textContent)
+      ).toEqual(['Stopped', 'Stopping', 'Running']);
+    });
   });
 
   describe('labelled values', () => {

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -157,12 +157,10 @@ function ValueInput({
 }: ValueInputProps) {
   const valueOptions = property
     ? filteringOptions
-        .filter(option => option.property === property)
-        .map(({ label, value }) => ({
-          label,
-          value,
-        }))
+        .filter(option => option.property?.propertyKey === property.propertyKey)
+        .map(({ label, value }) => ({ label, value }))
     : [];
+
   const valueAutosuggestHandlers = useLoadItems(onLoadItems, '', property?.externalProperty);
   const asyncValueAutosuggestProps = property?.propertyKey
     ? { ...valueAutosuggestHandlers, ...asyncProps }


### PR DESCRIPTION
### Description

In a recent change to the property filter component the matching logic was updated to compare filtering properties by reference. That does not work though for the token editor with async options because in the editor the property is cached in React state. Then, if the properties are updated as result of the onLoadItems call - the options can no longer be matched.

ref: AWSUI-24057

### How has this been tested?

The issue is reproducible in the existing `async-loading.integ.page.tsx`.  Without the fix there are no suggestions in the token editor. With the fix all suggestions are available.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
