### PR TITLE
fix: Improve alignment for popover in extreme right/left positions

### DIFF
--- a/src/popover/__integ__/popover-placement.test.ts
+++ b/src/popover/__integ__/popover-placement.test.ts
@@ -79,22 +79,22 @@ const leftTop: Expectation = (trigger, container, arrow) => {
 
 const bottomRight: Expectation = (trigger, container) => {
   expect(trigger.bottom).toBeLessThan(container.top);
-  expect(Math.round(trigger.left)).toEqual(Math.round(container.left));
+  expect(trigger.left).toBeLessThan(container.left);
 };
 
 const bottomLeft: Expectation = (trigger, container) => {
   expect(trigger.bottom).toBeLessThan(container.top);
-  expect(Math.abs(trigger.right - container.right)).toBeLessThan(1);
+  expect(trigger.right).toBeGreaterThan(container.right);
 };
 
 const topRight: Expectation = (trigger, container) => {
   expect(trigger.top).toBeGreaterThan(container.bottom);
-  expect(Math.round(trigger.left)).toEqual(Math.round(container.left));
+  expect(trigger.left).toBeLessThan(container.left);
 };
 
 const topLeft: Expectation = (trigger, container) => {
   expect(trigger.top).toBeGreaterThan(container.bottom);
-  expect(Math.abs(trigger.right - container.right)).toBeLessThan(1);
+  expect(trigger.right).toBeGreaterThan(container.right);
 };
 
 const setupTest = (

--- a/src/popover/utils/positions.ts
+++ b/src/popover/utils/positions.ts
@@ -80,7 +80,7 @@ const RECTANGLE_CALCULATIONS: Record<InternalPosition, (r: ElementGroup) => Boun
   'top-right': ({ body, trigger, arrow }) => {
     return {
       top: trigger.top - body.height - arrow.height,
-      left: trigger.left,
+      left: trigger.left + trigger.width / 2 - ARROW_OFFSET - arrow.width / 2,
       width: body.width,
       height: body.height,
     };
@@ -88,7 +88,7 @@ const RECTANGLE_CALCULATIONS: Record<InternalPosition, (r: ElementGroup) => Boun
   'top-left': ({ body, trigger, arrow }) => {
     return {
       top: trigger.top - body.height - arrow.height,
-      left: trigger.left + trigger.width - body.width,
+      left: trigger.left + trigger.width / 2 + ARROW_OFFSET + arrow.width / 2 - body.width,
       width: body.width,
       height: body.height,
     };
@@ -104,7 +104,7 @@ const RECTANGLE_CALCULATIONS: Record<InternalPosition, (r: ElementGroup) => Boun
   'bottom-right': ({ body, trigger, arrow }) => {
     return {
       top: trigger.top + trigger.height + arrow.height,
-      left: trigger.left,
+      left: trigger.left + trigger.width / 2 - ARROW_OFFSET - arrow.width / 2,
       width: body.width,
       height: body.height,
     };
@@ -112,7 +112,7 @@ const RECTANGLE_CALCULATIONS: Record<InternalPosition, (r: ElementGroup) => Boun
   'bottom-left': ({ body, trigger, arrow }) => {
     return {
       top: trigger.top + trigger.height + arrow.height,
-      left: trigger.left + trigger.width - body.width,
+      left: trigger.left + trigger.width / 2 + ARROW_OFFSET + arrow.width / 2 - body.width,
       width: body.width,
       height: body.height,
     };


### PR DESCRIPTION


### Description

closes #1719

Related links, issue #, if available: n/a

### How has this been tested?

* Locally
* Screenshot tests in my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
