### PR TITLE
fix: Table column resizer to have expected cursor

### DIFF
--- a/src/table/resizer/styles.scss
+++ b/src/table/resizer/styles.scss
@@ -16,9 +16,9 @@ $handle-width: awsui.$space-l;
 $active-separator-width: 2px;
 
 .resizer {
+  @include styles.styles-reset;
   border: none;
   background: none;
-
   bottom: 0;
   cursor: col-resize;
   position: absolute;
@@ -65,7 +65,6 @@ $active-separator-width: 2px;
       box-shadow: inset 0 0 0 2px awsui.$color-border-item-focused;
     }
   }
-  @include styles.styles-reset;
 }
 
 .tracker {


### PR DESCRIPTION
### Description

The `styles.styles-reset` added after the cursor declaration overrode it with "auto". Moving the mixin on top fixes the issue.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
