### PR TITLE
fix: Include substep number in subStepComplete event

### DIFF
--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -19,6 +19,9 @@ class MultiPageCreate extends BasePageObject {
     const actions = funnelLog.map(item => item.action);
     return { funnelLog, actions };
   }
+  getFunnelLogItem(index: number) {
+    return this.browser.execute(index => window.__awsuiFunnelMetrics__[index], index);
+  }
 }
 
 const setupTest = (testFn: (page: MultiPageCreate) => Promise<void>) => {
@@ -336,6 +339,23 @@ describe('Multi-page create', () => {
       expect(funnelErrorEvent.props).toEqual({
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
+    })
+  );
+
+  test(
+    'Correct substep number when the step is unmounted before blurring the substep',
+    setupTest(async page => {
+      await page.click(wrapper.findInput('[data-testid=field4]').findNativeInput().toSelector());
+      await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
+
+      const funnelSubStepCompleteEvent = await page.getFunnelLogItem(6);
+
+      expect(funnelSubStepCompleteEvent.action).toEqual('funnelSubStepComplete');
+      expect(funnelSubStepCompleteEvent.props).toEqual(
+        expect.objectContaining({
+          subStepNumber: 2,
+        })
+      );
     })
   );
 });

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -24,6 +24,7 @@ const setupTest = (testFn: (page: SinglePageCreate) => Promise<void>) => {
   return useBrowser(async browser => {
     const page = new SinglePageCreate(browser);
     await browser.url('#/light/funnel-analytics/static-single-page-flow');
+    await new Promise(r => setTimeout(r, 10));
     await testFn(page);
   });
 };
@@ -99,6 +100,7 @@ describe('Single-page create', () => {
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
+        subStepNumber: 1,
       });
 
       expect(funnelLog[2].resolvedProps).toEqual({
@@ -118,6 +120,7 @@ describe('Single-page create', () => {
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
+        subStepNumber: 1,
       });
 
       expect(funnelLog[3].resolvedProps).toEqual({
@@ -137,6 +140,7 @@ describe('Single-page create', () => {
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 2 - header',
+        subStepNumber: 2,
       });
 
       expect(funnelLog[4].resolvedProps).toEqual({
@@ -156,6 +160,7 @@ describe('Single-page create', () => {
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 2 - header',
+        subStepNumber: 2,
       });
 
       expect(funnelLog[5].resolvedProps).toEqual({

--- a/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
+++ b/src/internal/analytics/__tests__/hooks/use-funnel-step.test.tsx
@@ -27,6 +27,7 @@ describe('useFunnelStep hook', () => {
           isInStep: true,
           funnelInteractionId: 'a placeholder funnel interaction ID',
           onStepChange: jest.fn(),
+          subStepConfiguration: { current: [] },
         }}
       >
         <ChildComponent />

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -254,7 +254,7 @@ function getSubStepConfiguration(): SubStepConfiguration[] {
 }
 
 function useStepChangeListener(stepNumber: number, handler: (stepConfiguration: SubStepConfiguration[]) => void) {
-  const subStepConfiguration = useRef<Record<number, SubStepConfiguration[]>>({});
+  const subStepConfiguration = useRef<Record<number, SubStepConfiguration[] | undefined>>({});
   /*
    Chosen so that it's hopefully shorter than a user interaction, but gives enough time for the
    amount of containers to stabilise.
@@ -282,7 +282,7 @@ function useStepChangeListener(stepNumber: number, handler: (stepConfiguration: 
       return;
     }
 
-    handler(subStepConfiguration.current[stepNumber]);
+    handler(subStepConfiguration.current[stepNumber]!);
   }, SUBSTEP_CHANGE_DEBOUNCE);
 
   return { onStepChange: stepChangeCallback, subStepConfiguration };

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -34,7 +34,7 @@ export interface FunnelStepContextValue {
   funnelInteractionId: string | undefined;
   /** This function is called when the list of substeps in this step changes.  */
   onStepChange: () => void;
-  subStepConfiguration: MutableRefObject<SubStepConfiguration[] | undefined>;
+  subStepConfiguration: MutableRefObject<Record<number, SubStepConfiguration[]> | undefined>;
 }
 
 export interface FunnelSubStepContextValue {

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -34,7 +34,7 @@ export interface FunnelStepContextValue {
   funnelInteractionId: string | undefined;
   /** This function is called when the list of substeps in this step changes.  */
   onStepChange: () => void;
-  subStepConfiguration: MutableRefObject<Record<number, SubStepConfiguration[]> | undefined>;
+  subStepConfiguration: MutableRefObject<Record<number, SubStepConfiguration[] | undefined> | undefined>;
 }
 
 export interface FunnelSubStepContextValue {

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { MutableRefObject, RefObject, createContext } from 'react';
-import { FunnelType } from '../interfaces';
+import { FunnelType, SubStepConfiguration } from '../interfaces';
 import { getFunnelNameSelector } from '../selectors';
 
 export type FunnelState = 'default' | 'validating' | 'complete' | 'cancelled';
@@ -34,6 +34,7 @@ export interface FunnelStepContextValue {
   funnelInteractionId: string | undefined;
   /** This function is called when the list of substeps in this step changes.  */
   onStepChange: () => void;
+  subStepConfiguration: MutableRefObject<SubStepConfiguration[] | undefined>;
 }
 
 export interface FunnelSubStepContextValue {
@@ -85,6 +86,7 @@ export const FunnelStepContext = createContext<FunnelStepContextValue>({
   isInStep: false,
   funnelInteractionId: undefined,
   onStepChange: () => {},
+  subStepConfiguration: { current: [] },
 });
 
 export const FunnelSubStepContext = createContext<FunnelSubStepContextValue>({

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -30,7 +30,7 @@ import { nodeBelongs } from '../../utils/node-belongs';
 export const useFunnelSubStep = () => {
   const context = useContext(FunnelSubStepContext);
   const { funnelInteractionId, funnelState, latestFocusCleanupFunction } = useFunnel();
-  const { stepNumber, stepNameSelector } = useFunnelStep();
+  const { stepNumber, stepNameSelector, subStepConfiguration } = useFunnelStep();
 
   const {
     subStepId,
@@ -70,11 +70,14 @@ export const useFunnelSubStep = () => {
       const subStepName = getNameFromSelector(subStepNameSelector);
       const stepName = getNameFromSelector(stepNameSelector);
 
+      const subStepNumber = subStepConfiguration.current?.find(element => element.name === subStepName)?.number;
+
       FunnelMetrics.funnelSubStepStart({
         funnelInteractionId,
         subStepSelector,
         subStepNameSelector,
         subStepName,
+        subStepNumber,
         stepNumber,
         stepName,
         stepNameSelector,
@@ -98,12 +101,15 @@ export const useFunnelSubStep = () => {
         }
         cleanupFunctionHasBeenRun = true;
 
+        const subStepNumber = subStepConfiguration.current?.find(element => element.name === subStepName)?.number;
+
         if (funnelState.current !== 'cancelled') {
           FunnelMetrics.funnelSubStepComplete({
             funnelInteractionId,
             subStepSelector,
             subStepNameSelector,
             subStepName,
+            subStepNumber,
             stepNumber,
             stepName,
             stepNameSelector,

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -69,9 +69,7 @@ export const useFunnelSubStep = () => {
 
       const subStepName = getNameFromSelector(subStepNameSelector);
       const stepName = getNameFromSelector(stepNameSelector);
-
-      const subStepNumber = subStepConfiguration.current?.find(element => element.name === subStepName)?.number;
-
+      const subStepNumber = subStepConfiguration.current?.[stepNumber].find(step => step.name === subStepName)?.number;
       FunnelMetrics.funnelSubStepStart({
         funnelInteractionId,
         subStepSelector,
@@ -101,7 +99,9 @@ export const useFunnelSubStep = () => {
         }
         cleanupFunctionHasBeenRun = true;
 
-        const subStepNumber = subStepConfiguration.current?.find(element => element.name === subStepName)?.number;
+        const subStepNumber = subStepConfiguration.current?.[stepNumber].find(
+          step => step.name === subStepName
+        )?.number;
 
         if (funnelState.current !== 'cancelled') {
           FunnelMetrics.funnelSubStepComplete({

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -69,7 +69,7 @@ export const useFunnelSubStep = () => {
 
       const subStepName = getNameFromSelector(subStepNameSelector);
       const stepName = getNameFromSelector(stepNameSelector);
-      const subStepNumber = subStepConfiguration.current?.[stepNumber].find(step => step.name === subStepName)?.number;
+      const subStepNumber = subStepConfiguration.current?.[stepNumber]?.find(step => step.name === subStepName)?.number;
       FunnelMetrics.funnelSubStepStart({
         funnelInteractionId,
         subStepSelector,
@@ -99,9 +99,7 @@ export const useFunnelSubStep = () => {
         }
         cleanupFunctionHasBeenRun = true;
 
-        const subStepNumber = subStepConfiguration.current?.[stepNumber].find(
-          step => step.name === subStepName
-        )?.number;
+        const subStepNumber = subStepConfiguration.current?.[stepNumber]?.find(s => s.name === subStepName)?.number;
 
         if (funnelState.current !== 'cancelled') {
           FunnelMetrics.funnelSubStepComplete({

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -62,6 +62,7 @@ export interface FunnelSubStepProps extends FunnelStepProps {
   subStepSelector: string;
   subStepName?: string | undefined;
   subStepNameSelector: string;
+  subStepNumber?: number;
 }
 
 export interface FunnelSubStepErrorProps extends FunnelSubStepProps {


### PR DESCRIPTION
### Description

This PR fixes a bug that occurs in some usages of funnel events.

When the user has the browser focus on an input element in a Wizard and then clicks on the "Next" button, the Wizard proceeds to the next step before emitting the `subStepComplete` event. At that point, the CSS selector that was used to identify the substep's index does not point to valid/useful elements anymore.
With this change, instead of the CSS selectors we use the `subStepConfiguration` for determining the correct substep number, and include that number in the event data. The `subStepConfiguration` is updated every time a substep is mounted or unmounted.

Related links, issue #, if available: n/a

### How has this been tested?

Added an integration test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
