### PR TITLE
chore: Add missing commas in documentation

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -556,7 +556,7 @@ Example:
   notifications: \\"Notifications\\",
   tools: \\"Help panel\\",
   toolsClose: \\"Close help panel\\",
-  toolsToggle: \\"Open help panel\\"
+  toolsToggle: \\"Open help panel\\",
   drawers: \\"Drawers\\",
   drawersOverflow: \\"Overflow drawers\\",
   drawersOverflowWithBadge: \\"Overflow drawers (Unread notifications)\\"
@@ -9612,7 +9612,7 @@ Example:
 \`\`\`
 {
   nextPageLabel: 'Next page',
-  paginationLabel: 'Table pagination'
+  paginationLabel: 'Table pagination',
   previousPageLabel: 'Previous page',
   pageLabel: pageNumber => \`Page \${pageNumber}\`
 }

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -131,7 +131,7 @@ export interface AppLayoutProps extends BaseComponentProps {
    *   notifications: "Notifications",
    *   tools: "Help panel",
    *   toolsClose: "Close help panel",
-   *   toolsToggle: "Open help panel"
+   *   toolsToggle: "Open help panel",
    *   drawers: "Drawers",
    *   drawersOverflow: "Overflow drawers",
    *   drawersOverflowWithBadge: "Overflow drawers (Unread notifications)"

--- a/src/pagination/interfaces.ts
+++ b/src/pagination/interfaces.ts
@@ -40,7 +40,7 @@ export interface PaginationProps {
    * ```
    * {
    *   nextPageLabel: 'Next page',
-   *   paginationLabel: 'Table pagination'
+   *   paginationLabel: 'Table pagination',
    *   previousPageLabel: 'Previous page',
    *   pageLabel: pageNumber => `Page ${pageNumber}`
    * }


### PR DESCRIPTION
### Description

In two of our examples in the inline code comments, the code examples were missing a comma.

Related links, issue #, if available: n/a

### How has this been tested?

n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
