### PR TITLE
fix: Flashbar renders invisible interactive content

### DIFF
--- a/pages/flashbar/interactive.page.tsx
+++ b/pages/flashbar/interactive.page.tsx
@@ -84,12 +84,17 @@ export default function InteractiveFlashbar() {
             Add To Bottom
           </Button>
           <Button onClick={() => removeAndAddToBottom('error')}>Add And Remove</Button>
+          <Button data-id="remove-all" onClick={() => setItems([])}>
+            Remove all
+          </Button>
         </SpaceBetween>
+        <input id="focus-before" />
         <ScreenshotArea>
           <Box padding="xxl">
             <Flashbar items={items} {...restProps} />
           </Box>
         </ScreenshotArea>
+        <input id="focus-after" />
       </SpaceBetween>
     </>
   );

--- a/pages/flashbar/interactive.page.tsx
+++ b/pages/flashbar/interactive.page.tsx
@@ -88,13 +88,13 @@ export default function InteractiveFlashbar() {
             Remove all
           </Button>
         </SpaceBetween>
-        <input id="focus-before" />
+        <input id="focus-before" aria-label="Focusable input before the flashbars" />
         <ScreenshotArea>
           <Box padding="xxl">
             <Flashbar items={items} {...restProps} />
           </Box>
         </ScreenshotArea>
-        <input id="focus-after" />
+        <input id="focus-after" aria-label="Focusable input after the flashbars" />
       </SpaceBetween>
     </>
   );

--- a/src/flashbar/__integ__/collapsible.test.ts
+++ b/src/flashbar/__integ__/collapsible.test.ts
@@ -12,7 +12,8 @@ describe('Collapsible Flashbar', () => {
         await page.toggleStackingFeature();
 
         // Navigate past all buttons to add and remove flashes
-        await page.keys(new Array(8).fill('Tab'));
+        await page.click('#focus-before');
+        await page.keys('Tab');
 
         await expect(page.countFlashes()).resolves.toBe(1);
         await page.keys('Space');

--- a/src/flashbar/__integ__/focus-interactions.test.ts
+++ b/src/flashbar/__integ__/focus-interactions.test.ts
@@ -4,6 +4,21 @@ import { setupTest } from './pages/interactive-page';
 import { FOCUS_THROTTLE_DELAY } from '../utils';
 
 test(
+  'a flash with ariaRole="status" produces no duplicate interactive content',
+  setupTest(async page => {
+    await page.removeAll();
+    await page.addInfoFlash();
+
+    await page.click('#focus-before');
+    await page.keys('Tab');
+    await page.keys('Tab');
+    await page.keys('Tab');
+
+    expect(await page.isFocused('#focus-after')).toBe(true);
+  })
+);
+
+test(
   'adding flash with ariaRole="status" does not move focus',
   setupTest(async page => {
     await page.addInfoFlash();

--- a/src/flashbar/__integ__/pages/interactive-page.ts
+++ b/src/flashbar/__integ__/pages/interactive-page.ts
@@ -23,6 +23,10 @@ export class FlashbarInteractivePage extends FlashbarBasePage {
   async toggleStackingFeature() {
     await this.click('[data-id="stack-items"]');
   }
+
+  async removeAll() {
+    await this.click('[data-id="remove-all"]');
+  }
 }
 
 export const setupTest = (testFn: (page: FlashbarInteractivePage) => Promise<void>) => {

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { render as reactRender } from '@testing-library/react';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
+import { defaultDelay } from '../../../lib/components/internal/components/live-region';
+import { mockInnerText } from '../../internal/analytics/__tests__/mocks';
 import Button from '../../../lib/components/button';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/flashbar/styles.css.js';
@@ -21,6 +23,8 @@ jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => {
     useVisualRefresh: (...args: any) => useVisualRefresh || originalVisualModeModule.useVisualRefresh(...args),
   };
 });
+
+mockInnerText();
 
 declare global {
   interface Window {
@@ -412,7 +416,7 @@ describe('Flashbar component', () => {
         expect(list.getElement().getAttribute('aria-label')).toEqual(customAriaLabel);
       });
 
-      test('renders the label, header, and content in an aria-live region for ariaRole="status"', () => {
+      test('renders the label, header, and content in an aria-live region for ariaRole="status"', async () => {
         const { rerender, container } = reactRender(<Flashbar items={[]} />);
         rerender(
           <Flashbar
@@ -428,8 +432,11 @@ describe('Flashbar component', () => {
             ]}
           />
         );
+
+        await new Promise(r => setTimeout(r, defaultDelay * 2));
+
         // Render area of the LiveRegion component.
-        expect(container.querySelector('span[aria-hidden]')).toHaveTextContent('Error The header The content');
+        expect(container.querySelector('span[aria-live]')).toHaveTextContent('Error The header The content');
       });
     });
   });

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render as reactRender } from '@testing-library/react';
+import { render as reactRender, waitFor } from '@testing-library/react';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
-import { defaultDelay } from '../../../lib/components/internal/components/live-region';
 import { mockInnerText } from '../../internal/analytics/__tests__/mocks';
 import Button from '../../../lib/components/button';
 import createWrapper from '../../../lib/components/test-utils/dom';
@@ -433,10 +432,9 @@ describe('Flashbar component', () => {
           />
         );
 
-        await new Promise(r => setTimeout(r, defaultDelay * 2));
-
-        // Render area of the LiveRegion component.
-        expect(container.querySelector('span[aria-live]')).toHaveTextContent('Error The header The content');
+        await waitFor(() => {
+          expect(container.querySelector('span[aria-live]')).toHaveTextContent('Error The header The content');
+        });
       });
     });
   });

--- a/src/flashbar/flash.tsx
+++ b/src/flashbar/flash.tsx
@@ -73,7 +73,6 @@ export const Flash = React.forwardRef(
       content,
       dismissible,
       dismissLabel,
-      statusIconAriaLabel,
       loading,
       action,
       buttonText,
@@ -84,6 +83,7 @@ export const Flash = React.forwardRef(
       ariaRole,
       i18nStrings,
       type = 'info',
+      ...props
     }: FlashProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
@@ -120,6 +120,10 @@ export const Flash = React.forwardRef(
       [DATA_ATTR_ANALYTICS_FLASHBAR]: effectiveType,
     };
 
+    const statusIconAriaLabel =
+      props.statusIconAriaLabel ||
+      i18nStrings?.[`${loading || type === 'in-progress' ? 'inProgress' : type}IconAriaLabel`];
+
     return (
       // We're not using "polite" or "assertive" here, just turning default behavior off.
       // eslint-disable-next-line @cloudscape-design/prefer-live-region
@@ -149,10 +153,7 @@ export const Flash = React.forwardRef(
             <div
               className={clsx(styles['flash-icon'], styles['flash-text'])}
               role="img"
-              aria-label={
-                statusIconAriaLabel ||
-                i18nStrings?.[`${loading || type === 'in-progress' ? 'inProgress' : type}IconAriaLabel`]
-              }
+              aria-label={statusIconAriaLabel}
             >
               {icon}
             </div>
@@ -178,11 +179,7 @@ export const Flash = React.forwardRef(
           />
         </div>
         {dismissible && dismissButton(dismissLabel, handleDismiss)}
-        {ariaRole === 'status' && (
-          <LiveRegion>
-            {statusIconAriaLabel} {header} {content}
-          </LiveRegion>
-        )}
+        {ariaRole === 'status' && <LiveRegion source={[statusIconAriaLabel, headerRef, contentRef]} />}
       </div>
     );
   }

--- a/src/internal/components/live-region/__tests__/live-region.test.tsx
+++ b/src/internal/components/live-region/__tests__/live-region.test.tsx
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
-import LiveRegion, { defaultDelay } from '../../../../../lib/components/internal/components/live-region';
+import LiveRegion from '../../../../../lib/components/internal/components/live-region';
 import { mockInnerText } from '../../../../internal/analytics/__tests__/mocks';
 
 mockInnerText();
@@ -12,14 +12,14 @@ const renderLiveRegion = async (jsx: React.ReactElement) => {
   const { container } = render(jsx);
   const wrapper = createWrapper(container);
 
-  await new Promise(r => setTimeout(r, defaultDelay));
+  await waitFor(() => expect(wrapper.find('[aria-live]')!.getElement()).toBeInTheDocument());
 
   return {
     wrapper,
     container,
     visibleSource: wrapper.find(':first-child')?.getElement(),
     hiddenSource: wrapper.find('[aria-hidden=true]')?.getElement(),
-    liveRegion: wrapper.find('[aria-live]')?.getElement(),
+    liveRegion: wrapper.find('[aria-live]')!.getElement(),
   };
 };
 

--- a/src/internal/components/live-region/__tests__/live-region.test.tsx
+++ b/src/internal/components/live-region/__tests__/live-region.test.tsx
@@ -12,7 +12,7 @@ const renderLiveRegion = async (jsx: React.ReactElement) => {
   const { container } = render(jsx);
   const wrapper = createWrapper(container);
 
-  await waitFor(() => expect(wrapper.find('[aria-live]')!.getElement()).toBeInTheDocument());
+  await waitFor(() => expect(wrapper.find('[aria-live]')!.getElement()).not.toBeEmptyDOMElement());
 
   return {
     wrapper,

--- a/src/internal/components/live-region/__tests__/live-region.test.tsx
+++ b/src/internal/components/live-region/__tests__/live-region.test.tsx
@@ -3,58 +3,81 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import createWrapper from '../../../../../lib/components/test-utils/dom';
-import LiveRegion from '../../../../../lib/components/internal/components/live-region';
+import LiveRegion, { defaultDelay } from '../../../../../lib/components/internal/components/live-region';
+import { mockInnerText } from '../../../../internal/analytics/__tests__/mocks';
 
-const renderLiveRegion = (jsx: React.ReactElement) => {
+mockInnerText();
+
+const renderLiveRegion = async (jsx: React.ReactElement) => {
   const { container } = render(jsx);
-  return { wrapper: createWrapper(container), container };
+  const wrapper = createWrapper(container);
+
+  await new Promise(r => setTimeout(r, defaultDelay));
+
+  return {
+    wrapper,
+    container,
+    visibleSource: wrapper.find(':first-child')?.getElement(),
+    hiddenSource: wrapper.find('[aria-hidden=true]')?.getElement(),
+    liveRegion: wrapper.find('[aria-live]')?.getElement(),
+  };
 };
 
 describe('LiveRegion', () => {
-  it('renders', () => {
-    const { wrapper } = renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
-    const source = wrapper.find('[aria-hidden=true]')?.getElement();
-    const liveRegion = wrapper.find('[aria-live]')?.getElement();
+  it('renders', async () => {
+    const { hiddenSource, liveRegion } = await renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
 
-    expect(source).toHaveTextContent('Announcement');
+    expect(hiddenSource).toHaveTextContent('Announcement');
     expect(liveRegion).toHaveAttribute('aria-live', 'polite');
     expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+    expect(liveRegion).toHaveTextContent('Announcement');
   });
 
-  it('renders with a span by default', () => {
-    const { wrapper } = renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
-    const source = wrapper.find('[aria-hidden=true]')?.getElement();
+  it('renders with a span by default', async () => {
+    const { hiddenSource, liveRegion } = await renderLiveRegion(<LiveRegion>Announcement</LiveRegion>);
 
-    expect(source?.tagName).toBe('SPAN');
+    expect(hiddenSource!.tagName).toBe('SPAN');
+    expect(liveRegion).toHaveTextContent('Announcement');
   });
 
-  it('wraps visible content in a span by default', () => {
-    const { wrapper } = renderLiveRegion(<LiveRegion visible={true}>Announcement</LiveRegion>);
-    const visibleSource = wrapper.find(':first-child')?.getElement();
+  it('wraps visible content in a span by default', async () => {
+    const { visibleSource } = await renderLiveRegion(<LiveRegion visible={true}>Announcement</LiveRegion>);
 
-    expect(visibleSource?.tagName).toBe('SPAN');
+    expect(visibleSource!.tagName).toBe('SPAN');
+    expect(visibleSource).toHaveTextContent('Announcement');
   });
 
-  it('can render with a div', () => {
-    const { wrapper } = renderLiveRegion(<LiveRegion tagName="div">Announcement</LiveRegion>);
-    const source = wrapper.find('[aria-hidden=true]')?.getElement();
+  it('can render with a div', async () => {
+    const { hiddenSource } = await renderLiveRegion(<LiveRegion tagName="div">Announcement</LiveRegion>);
 
-    expect(source?.tagName).toBe('DIV');
+    expect(hiddenSource!.tagName).toBe('DIV');
+    expect(hiddenSource).toHaveTextContent('Announcement');
   });
 
-  it('can wrap visible content in a div', () => {
-    const { wrapper } = renderLiveRegion(
+  it('can wrap visible content in a div', async () => {
+    const { visibleSource } = await renderLiveRegion(
       <LiveRegion tagName="div" visible={true}>
         Announcement
       </LiveRegion>
     );
-    const visibleSource = wrapper.find(':first-child')?.getElement();
 
-    expect(visibleSource?.tagName).toBe('DIV');
+    expect(visibleSource!.tagName).toBe('DIV');
   });
 
-  it('can render assertive live region', () => {
-    const { wrapper } = renderLiveRegion(<LiveRegion assertive={true}>Announcement</LiveRegion>);
-    expect(wrapper.find('[aria-live="assertive"]')?.getElement()).toBeInTheDocument();
+  it('can render assertive live region', async () => {
+    const { liveRegion } = await renderLiveRegion(<LiveRegion assertive={true}>Announcement</LiveRegion>);
+    expect(liveRegion).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('uses the `source` parameter if provided', async () => {
+    const ref = { current: null };
+    const { liveRegion } = await renderLiveRegion(
+      <>
+        <LiveRegion source={['static text', ref, undefined, 'more static text']}>Announcement</LiveRegion>
+        <span ref={ref}>Element text</span>
+      </>
+    );
+    expect(liveRegion).toHaveTextContent('static text Element text more static text');
+    expect(liveRegion).not.toHaveTextContent('Announcement');
   });
 });

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -100,15 +100,15 @@ function LiveRegion({
     function getSourceContent() {
       if (source) {
         return source
-          .map(source => {
-            if (!source) {
+          .map(item => {
+            if (!item) {
               return undefined;
             }
-            if (typeof source === 'string') {
-              return source;
+            if (typeof item === 'string') {
+              return item;
             }
-            if (source.current) {
-              return extractInnerText(source.current);
+            if (item.current) {
+              return extractInnerText(item.current);
             }
           })
           .filter(Boolean)

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -70,11 +70,9 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
  */
 export default memo(LiveRegion);
 
-export const defaultDelay = 10;
-
 function LiveRegion({
   assertive = false,
-  delay = defaultDelay,
+  delay = 10,
   visible = false,
   tagName: TagName = 'span',
   children,

--- a/src/internal/components/live-region/index.tsx
+++ b/src/internal/components/live-region/index.tsx
@@ -70,9 +70,11 @@ export interface LiveRegionProps extends ScreenreaderOnlyProps {
  */
 export default memo(LiveRegion);
 
+export const defaultDelay = 10;
+
 function LiveRegion({
   assertive = false,
-  delay = 10,
+  delay = defaultDelay,
   visible = false,
   tagName: TagName = 'span',
   children,

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -8,7 +8,7 @@ import styles from './styles.css.js';
 export interface ScreenreaderOnlyProps {
   id?: string;
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
### Description

This fixes a bug where interactive content of the flashbar would be rendered twice, which leads to duplicated tab stops if the content contains interactive elements like links.

Instead of duplicating the content into the LiveRegion, the flashbar now provides references to the existing content.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-24287

### How has this been tested?
Tested in a dev page, with VoiceOver

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
