### PR TITLE
fix: Update built-in s3 resource selector i18n strings

### DIFF
--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID-Version",
     "i18nStrings.columnVersionLastModified": "Zuletzt geändert",
     "i18nStrings.columnVersionSize": "Größe",
-    "i18nStrings.validationPathMustBegin": "Der Pfad muss mit s3:// beginnen",
+    "i18nStrings.validationPathMustBegin": "Der Pfad muss mit s3:// beginnen, um gültig zu sein.",
     "i18nStrings.validationBucketLowerCase": "Der Bucket-Name muss mit einem Kleinbuchstaben oder einer Zahl beginnen.",
     "i18nStrings.validationBucketMustNotContain": "Der Bucket-Name darf keine Großbuchstaben enthalten.",
     "i18nStrings.validationBucketLength": "Der Bucket-Name muss aus 3 bis 63 Zeichen bestehen.",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "Version ID",
     "i18nStrings.columnVersionLastModified": "Last modified",
     "i18nStrings.columnVersionSize": "Size",
-    "i18nStrings.validationPathMustBegin": "The path must begin with s3://",
+    "i18nStrings.validationPathMustBegin": "The path must begin with s3:// to be valid.",
     "i18nStrings.validationBucketLowerCase": "The bucket name must start with a lowercase character or number.",
     "i18nStrings.validationBucketMustNotContain": "The bucket name must not contain uppercase characters.",
     "i18nStrings.validationBucketLength": "The bucket name must be from 3 to 63 characters.",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "Version ID",
     "i18nStrings.columnVersionLastModified": "Last modified",
     "i18nStrings.columnVersionSize": "Size",
-    "i18nStrings.validationPathMustBegin": "The path must begin with s3://",
+    "i18nStrings.validationPathMustBegin": "The path must begin with s3:// to be valid.",
     "i18nStrings.validationBucketLowerCase": "The bucket name must start with a lowercase character or number.",
     "i18nStrings.validationBucketMustNotContain": "The bucket name must not contain uppercase characters.",
     "i18nStrings.validationBucketLength": "The bucket name must be from 3 to 63 characters.",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID de la versión",
     "i18nStrings.columnVersionLastModified": "Modificado por última vez",
     "i18nStrings.columnVersionSize": "Tamaño",
-    "i18nStrings.validationPathMustBegin": "La ruta debe empezar por s3://",
+    "i18nStrings.validationPathMustBegin": "La ruta debe empezar por s3://para que sea válida.",
     "i18nStrings.validationBucketLowerCase": "El nombre del bucket debe empezar por un carácter o número en minúscula.",
     "i18nStrings.validationBucketMustNotContain": "El nombre del bucket no debe contener caracteres en mayúscula.",
     "i18nStrings.validationBucketLength": "El nombre del bucket debe tener entre 3 y 63 caracteres.",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID de version",
     "i18nStrings.columnVersionLastModified": "Dernière modification",
     "i18nStrings.columnVersionSize": "Taille",
-    "i18nStrings.validationPathMustBegin": "Le chemin doit commencer par s3 ://",
+    "i18nStrings.validationPathMustBegin": "Le chemin doit commencer par s3:// pour être valide.",
     "i18nStrings.validationBucketLowerCase": "Le nom du compartiment doit commencer par une minuscule ou un chiffre.",
     "i18nStrings.validationBucketMustNotContain": "Le nom du compartiment ne doit pas contenir de majuscules.",
     "i18nStrings.validationBucketLength": "Le nom du compartiment doit comporter entre 3 et 63 caractères.",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID Versi",
     "i18nStrings.columnVersionLastModified": "Terakhir diubah",
     "i18nStrings.columnVersionSize": "Ukuran",
-    "i18nStrings.validationPathMustBegin": "Jalur harus dimulai dengan s3://",
+    "i18nStrings.validationPathMustBegin": "Jalur harus dimulai dengan s3:// agar valid.",
     "i18nStrings.validationBucketLowerCase": "Nama bucket harus diawali dengan karakter huruf kecil atau angka.",
     "i18nStrings.validationBucketMustNotContain": "Nama bucket tidak boleh berisi karakter huruf besar.",
     "i18nStrings.validationBucketLength": "Nama bucket harus terdiri dari 3 hingga 63 karakter.",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID Versione",
     "i18nStrings.columnVersionLastModified": "Ultima modifica",
     "i18nStrings.columnVersionSize": "Dimensione",
-    "i18nStrings.validationPathMustBegin": "Il percorso deve iniziare con s3://",
+    "i18nStrings.validationPathMustBegin": "Il percorso deve iniziare con s3:// per essere valido.",
     "i18nStrings.validationBucketLowerCase": "Il nome del bucket deve iniziare con un carattere minuscolo o un numero.",
     "i18nStrings.validationBucketMustNotContain": "Il nome del bucket non deve contenere caratteri maiuscoli.",
     "i18nStrings.validationBucketLength": "Il nome del bucket deve contenere da 3 a 63 caratteri.",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "バージョン ID",
     "i18nStrings.columnVersionLastModified": "最終更新日",
     "i18nStrings.columnVersionSize": "サイズ",
-    "i18nStrings.validationPathMustBegin": "パスの先頭は s3:// である必要があります",
+    "i18nStrings.validationPathMustBegin": "パスが有効であるためには、s3:// で始まる必要があります。",
     "i18nStrings.validationBucketLowerCase": "バケット名の先頭は小文字または数字である必要があります。",
     "i18nStrings.validationBucketMustNotContain": "バケット名には大文字を使用できません。",
     "i18nStrings.validationBucketLength": "バケット名は 3～63 文字である必要があります。",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "버전 ID",
     "i18nStrings.columnVersionLastModified": "최종 수정 날짜",
     "i18nStrings.columnVersionSize": "크기",
-    "i18nStrings.validationPathMustBegin": "경로는 s3://로 시작해야 합니다.",
+    "i18nStrings.validationPathMustBegin": "유효한 경로는 s3://로 시작해야 합니다.",
     "i18nStrings.validationBucketLowerCase": "버킷 이름은 소문자나 숫자로 시작해야 합니다.",
     "i18nStrings.validationBucketMustNotContain": "버킷 이름에 대문자를 포함할 수 없습니다.",
     "i18nStrings.validationBucketLength": "버킷 이름은 3~63자여야 합니다.",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "ID da versão",
     "i18nStrings.columnVersionLastModified": "Última modificação",
     "i18nStrings.columnVersionSize": "Tamanho",
-    "i18nStrings.validationPathMustBegin": "O caminho precisa começar com s3://",
+    "i18nStrings.validationPathMustBegin": "O caminho deve começar com s3:// para ser válido.",
     "i18nStrings.validationBucketLowerCase": "O nome do bucket deve começar com um caractere minúsculo ou com um número.",
     "i18nStrings.validationBucketMustNotContain": "O nome do bucket não deve conter caracteres maiúsculos.",
     "i18nStrings.validationBucketLength": "O nome do bucket deve ter de 3 a 63 caracteres.",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "Sürüm kimliği",
     "i18nStrings.columnVersionLastModified": "Son değiştirme",
     "i18nStrings.columnVersionSize": "Boyut",
-    "i18nStrings.validationPathMustBegin": "Yol s3:// ile başlamalıdır",
+    "i18nStrings.validationPathMustBegin": "Yolun geçerli olması için s3:// ile başlaması gerekir.",
     "i18nStrings.validationBucketLowerCase": "Bucket adı, küçük harfli bir karakter veya sayı ile başlamalıdır.",
     "i18nStrings.validationBucketMustNotContain": "Bucket adı, büyük harfli karakterler içermemelidir.",
     "i18nStrings.validationBucketLength": "Bucket adı, 3 ile 63 karakter arasında olmalıdır.",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "版本 ID",
     "i18nStrings.columnVersionLastModified": "上次修改时间",
     "i18nStrings.columnVersionSize": "大小",
-    "i18nStrings.validationPathMustBegin": "路径必须以 s3:// 开头",
+    "i18nStrings.validationPathMustBegin": "路径必须以 s3:// 开头才有效。",
     "i18nStrings.validationBucketLowerCase": "存储桶名称必须以小写字符或数字开头。",
     "i18nStrings.validationBucketMustNotContain": "存储桶名称不得包含大写字符。",
     "i18nStrings.validationBucketLength": "存储桶名称必须介于 3 到 63 个字符之间。",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -230,7 +230,7 @@
     "i18nStrings.columnVersionID": "版本 ID",
     "i18nStrings.columnVersionLastModified": "上次修改",
     "i18nStrings.columnVersionSize": "尺寸",
-    "i18nStrings.validationPathMustBegin": "路徑必須以 s3:// 開頭",
+    "i18nStrings.validationPathMustBegin": "路徑必須以 s3:// 開頭才有效。",
     "i18nStrings.validationBucketLowerCase": "儲存貯體名稱必須以小寫字元或數字開頭。",
     "i18nStrings.validationBucketMustNotContain": "儲存貯體名稱不得包含大寫字元。",
     "i18nStrings.validationBucketLength": "儲存貯體名稱必須介於 3 到 63 個字元之間。",


### PR DESCRIPTION
### Description

Fixing the text according to our writing guidelines

Related links, issue #, if available: AWSUI-24340

### How has this been tested?

Locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
