### PR TITLE
chore: Fix Form step context not adding step data attribute

### DIFF
--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -374,4 +374,10 @@ describe('Form Analytics', () => {
       })
     );
   });
+
+  test('adds a data-analytics-funnel-step attribute to the root of form', () => {
+    const { container } = render(<Form></Form>);
+    const form = createWrapper(container).findForm()!.getElement();
+    expect(form).toHaveAttribute('data-analytics-funnel-step', '1');
+  });
 });

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -27,11 +27,9 @@ const FormWithAnalytics = ({ variant = 'full-page', actions, ...props }: FormPro
   };
 
   return (
-    <AnalyticsFunnelStep stepNumber={1}>
-      <ButtonContext.Provider value={{ onClick: handleActionButtonClick }}>
-        <InternalForm variant={variant} actions={actions} {...props} {...funnelProps} {...funnelStepProps} />
-      </ButtonContext.Provider>
-    </AnalyticsFunnelStep>
+    <ButtonContext.Provider value={{ onClick: handleActionButtonClick }}>
+      <InternalForm variant={variant} actions={actions} {...props} {...funnelProps} {...funnelStepProps} />
+    </ButtonContext.Provider>
   );
 };
 
@@ -47,7 +45,9 @@ export default function Form({ variant = 'full-page', ...props }: FormProps) {
       totalFunnelSteps={1}
       funnelNameSelectors={[funnelNameSelector, `.${formStyles.header}`]}
     >
-      <FormWithAnalytics variant={variant} {...props} {...baseComponentProps} />
+      <AnalyticsFunnelStep stepNumber={1}>
+        <FormWithAnalytics variant={variant} {...props} {...baseComponentProps} />
+      </AnalyticsFunnelStep>
     </AnalyticsFunnel>
   );
 }

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -13,6 +13,10 @@ const wrapper = createWrapper();
 const FUNNEL_INTERACTION_ID = 'mocked-funnel-id';
 
 class SinglePageCreate extends BasePageObject {
+  getFormAttribute(attribute: string) {
+    return this.getElementAttribute(wrapper.findForm().toSelector(), attribute);
+  }
+
   async getFunnelLog() {
     const funnelLog = await this.browser.execute(() => window.__awsuiFunnelMetrics__);
     const actions = funnelLog.map(item => item.action);
@@ -33,6 +37,9 @@ describe('Single-page create', () => {
   test(
     'Starts funnel and funnel step as page is loaded',
     setupTest(async page => {
+      expect(page.getFormAttribute('data-analytics-funnel-step')).resolves.toBe('1');
+      expect(page.getFormAttribute('data-analytics-funnel-interaction-id')).resolves.toBe(FUNNEL_INTERACTION_ID);
+
       const { funnelLog, actions } = await page.getFunnelLog();
       expect(actions).toEqual(['funnelStart', 'funnelStepStart']);
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
A regression was introduced in this [PR](https://github.com/cloudscape-design/components/commit/7fa1db81e78164671003df2c78c02d1b865e7011#diff-cf319f69cf00076c2f61b37cf74d218c8925885695b31a060421fa9cc79c7e13) where I moved the context provider 1 level down. This was a mistake and I don't know why I did it :( 

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
