### PR TITLE
revert: Last table resizable column stable width in React 18

### DIFF
--- a/src/anchor-navigation/use-scroll-spy.tsx
+++ b/src/anchor-navigation/use-scroll-spy.tsx
@@ -37,7 +37,7 @@ export default function useScrollSpy({
   }, [hrefs]);
 
   // Get the bounding rectangle of an element by href
-  const getRectByHref = useCallback((href: string) => {
+  const getRectByHref = useCallback(href => {
     return document.getElementById(href.slice(1))?.getBoundingClientRect();
   }, []);
 

--- a/src/table/__integ__/resizable-columns.test.ts
+++ b/src/table/__integ__/resizable-columns.test.ts
@@ -60,20 +60,6 @@ class TablePage extends BasePageObject {
     return element.getAttribute('style');
   }
 
-  getFirstTableHeaderWidths() {
-    return this.browser.execute(() => {
-      const tables = document.querySelectorAll('table');
-      return Array.from(tables[0].querySelectorAll('th')).map(el => el.offsetWidth);
-    });
-  }
-
-  getLastTableHeaderWidths() {
-    return this.browser.execute(() => {
-      const tables = document.querySelectorAll('table');
-      return Array.from(tables[tables.length - 1].querySelectorAll('th')).map(el => el.offsetWidth);
-    });
-  }
-
   async getColumnMinWidth(columnIndex: number) {
     const columnSelector = tableWrapper
       // use internal CSS-selector to always receive the real table header and not a sticky copy
@@ -191,13 +177,13 @@ describe.each([true, false])('StickyHeader=%s', sticky => {
     })
   );
 
-  test.each([1680, 620])('sticky and real column headers must have identical widths for screen width %s', width =>
+  test(
+    'should render "width: auto" for the last on big screens and explicit value on small',
     setupStickyTest(async page => {
-      await page.setWindowSize({ ...defaultScreen, width });
-      const stickyHeaderWidths = await page.getFirstTableHeaderWidths();
-      const realHeaderWidths = await page.getLastTableHeaderWidths();
-      expect(stickyHeaderWidths).toEqual(realHeaderWidths);
-    })()
+      await expect(page.getColumnStyle(4)).resolves.toContain('width: auto;');
+      await page.setWindowSize({ ...defaultScreen, width: 620 });
+      await expect(page.getColumnStyle(4)).resolves.toContain('width: 120px;');
+    })
   );
 
   // The page width of 620px is an empirical value defined for the respective test page in VR

--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -212,10 +212,11 @@ describe('with stickyHeader=true', () => {
       { minWidth: '100px', width: '', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '300px' },
     ]);
+    // in JSDOM, there is no layout, so copied width is "0px" and no value is ""
     expect(extractSize(fakeHeader)).toEqual([
-      { minWidth: '', width: '200px', maxWidth: '' },
-      { minWidth: '', width: '', maxWidth: '' },
-      { minWidth: '', width: '', maxWidth: '' },
+      { minWidth: '', width: '0px', maxWidth: '' },
+      { minWidth: '', width: '0px', maxWidth: '' },
+      { minWidth: '', width: '0px', maxWidth: '' },
     ]);
   });
 });

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import times from 'lodash/times';
-import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 import { render, screen } from '@testing-library/react';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
@@ -18,11 +17,6 @@ jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => 
     overflowParent.getBoundingClientRect = fakeBoundingClientRect;
     return [overflowParent];
   }),
-}));
-
-jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
-  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
-  useResizeObserver: jest.fn().mockImplementation((_target, cb) => cb({ contentBoxWidth: 0 })),
 }));
 
 interface Item {
@@ -436,15 +430,4 @@ describe('column header content', () => {
     expect(getResizeHandle(0)).toHaveAttribute('aria-roledescription', 'resize button');
     expect(getResizeHandle(1)).toHaveAttribute('aria-roledescription', 'resize button');
   });
-});
-
-test('should set last column width to "auto" when container width exceeds total column width', () => {
-  const totalColumnsWidth = 150 + 300;
-  jest
-    .mocked(useResizeObserver)
-    .mockImplementation((_target, cb) => cb({ contentBoxWidth: totalColumnsWidth + 1 } as any));
-
-  const { wrapper } = renderTable(<Table {...defaultProps} />);
-
-  expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
 });

--- a/src/table/column-widths-utils.ts
+++ b/src/table/column-widths-utils.ts
@@ -11,25 +11,6 @@ export function checkColumnWidths(columnDefinitions: ReadonlyArray<TableProps.Co
   }
 }
 
-export function setElementWidths(element: undefined | HTMLElement, styles: React.CSSProperties) {
-  function setProperty(property: 'width' | 'minWidth' | 'maxWidth') {
-    const value = styles[property];
-    let widthCssValue = '';
-    if (typeof value === 'number') {
-      widthCssValue = value + 'px';
-    }
-    if (typeof value === 'string') {
-      widthCssValue = value;
-    }
-    if (element && element.style[property] !== widthCssValue) {
-      element.style[property] = widthCssValue;
-    }
-  }
-  setProperty('width');
-  setProperty('minWidth');
-  setProperty('maxWidth');
-}
-
 function checkProperty(column: TableProps.ColumnDefinition<any>, name: 'width' | 'minWidth') {
   const value = column[name];
   if (typeof value !== 'number' && typeof value !== 'undefined') {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -114,8 +114,7 @@ const InternalTable = React.forwardRef(
     const isMobile = useMobile();
 
     const [containerWidth, wrapperMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
-    const wrapperMeasureRefObject = useRef(null);
-    const wrapperMeasureMergedRef = useMergeRefs(wrapperMeasureRef, wrapperMeasureRefObject);
+    const wrapperRefObject = useRef(null);
 
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
@@ -135,7 +134,6 @@ const InternalTable = React.forwardRef(
       [cancelEdit]
     );
 
-    const wrapperRefObject = useRef(null);
     const handleScroll = useScrollSync([wrapperRefObject, scrollbarRef, secondaryWrapperRef]);
 
     const { moveFocusDown, moveFocusUp, moveFocus } = useSelectionFocusMove(selectionType, items.length);
@@ -207,6 +205,7 @@ const InternalTable = React.forwardRef(
     const tableRole = hasEditableCells ? 'grid-default' : 'table';
 
     const theadProps: TheadProps = {
+      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions: visibleColumnDefinitions,
@@ -258,11 +257,7 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <ColumnWidthsProvider
-          visibleColumns={visibleColumnWidthsWithSelection}
-          resizableColumns={resizableColumns}
-          containerRef={wrapperMeasureRefObject}
-        >
+        <ColumnWidthsProvider visibleColumns={visibleColumnWidthsWithSelection} resizableColumns={resizableColumns}>
           <InternalContainer
             {...baseProps}
             __internalRootRef={__internalRootRef}
@@ -338,7 +333,7 @@ const InternalTable = React.forwardRef(
               onScroll={handleScroll}
               {...wrapperProps}
             >
-              <div className={styles['wrapper-content-measure']} ref={wrapperMeasureMergedRef}></div>
+              <div className={styles['wrapper-content-measure']} ref={wrapperMeasureRef}></div>
               {!!renderAriaLive && !!firstIndex && (
                 <LiveRegion>
                   <span>

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -156,7 +156,7 @@ export function useStickyCellStyles({
 
   // refCallback updates the cell ref and sets up the store subscription
   const refCallback = useCallback(
-    (cellElement: null | HTMLElement) => {
+    cellElement => {
       if (unsubscribeRef.current) {
         // Unsubscribe before we do any updates to avoid leaving any subscriptions hanging
         unsubscribeRef.current();

--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -5,6 +5,19 @@ import stickyScrolling, { calculateScrollingOffset, scrollUpBy } from './sticky-
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
+function syncSizes(from: HTMLElement, to: HTMLElement) {
+  const fromCells = Array.prototype.slice.apply(from.children);
+  const toCells = Array.prototype.slice.apply(to.children);
+  for (let i = 0; i < fromCells.length; i++) {
+    let width = fromCells[i].style.width;
+    // use auto if it is set by resizable columns or real size otherwise
+    if (width !== 'auto') {
+      width = `${fromCells[i].offsetWidth}px`;
+    }
+    toCells[i].style.width = width;
+  }
+}
+
 export const useStickyHeader = (
   tableRef: RefObject<HTMLElement>,
   theadRef: RefObject<HTMLElement>,
@@ -22,6 +35,8 @@ export const useStickyHeader = (
       secondaryTableRef.current &&
       tableWrapperRef.current
     ) {
+      syncSizes(theadRef.current, secondaryTheadRef.current);
+
       // Using the tableRef offsetWidth instead of the theadRef because in VR
       // the tableRef adds extra padding to the table and by default the theadRef will have a width
       // without the padding and will make the sticky header width incorrect.


### PR DESCRIPTION
Revert because of the issue: AWSUI-24456


Reverts cloudscape-design/components#1718