### PR TITLE
fix: Last table resizable columns stable with React 18 (#2)

### DIFF
--- a/pages/table/resizable-columns.page.tsx
+++ b/pages/table/resizable-columns.page.tsx
@@ -104,12 +104,14 @@ type PageContext = React.Context<
 
 export default function App() {
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
-  const wrapLines = urlParams.wrapLines ?? false;
-  const stickyHeader = urlParams.stickyHeader ?? false;
-  const resizableColumns = urlParams.resizableColumns ?? true;
-  const fullPage = urlParams.fullPage ?? false;
-  const withColumnIds = urlParams.withColumnIds ?? true;
-  const withSelection = urlParams.withSelection ?? false;
+  const {
+    wrapLines = false,
+    stickyHeader = false,
+    resizableColumns = true,
+    fullPage = false,
+    withColumnIds = true,
+    withSelection = false,
+  } = urlParams;
 
   const [renderKey, setRenderKey] = useState(0);
   const [columns, setColumns] = useState(columnsConfig);

--- a/pages/table/resizable-columns.page.tsx
+++ b/pages/table/resizable-columns.page.tsx
@@ -97,6 +97,8 @@ type PageContext = React.Context<
     stickyHeader: boolean;
     resizableColumns: boolean;
     fullPage: boolean;
+    withColumnIds?: boolean;
+    withSelection?: boolean;
   }>
 >;
 
@@ -106,6 +108,8 @@ export default function App() {
   const stickyHeader = urlParams.stickyHeader ?? false;
   const resizableColumns = urlParams.resizableColumns ?? true;
   const fullPage = urlParams.fullPage ?? false;
+  const withColumnIds = urlParams.withColumnIds ?? true;
+  const withSelection = urlParams.withSelection ?? false;
 
   const [renderKey, setRenderKey] = useState(0);
   const [columns, setColumns] = useState(columnsConfig);
@@ -161,6 +165,12 @@ export default function App() {
             <Checkbox checked={fullPage} onChange={event => setUrlParams({ fullPage: event.detail.checked })}>
               Full page table
             </Checkbox>
+            <Checkbox checked={withColumnIds} onChange={event => setUrlParams({ withColumnIds: event.detail.checked })}>
+              Columns have IDs
+            </Checkbox>
+            <Checkbox checked={withSelection} onChange={event => setUrlParams({ withSelection: event.detail.checked })}>
+              With row selection
+            </Checkbox>
           </div>
           <div>
             {columnsConfig.map(column => (
@@ -190,9 +200,10 @@ export default function App() {
           key={renderKey}
           header={<Header>Simple table</Header>}
           stickyHeader={stickyHeader}
-          columnDefinitions={columns}
+          columnDefinitions={columns.map(col => (withColumnIds ? col : { ...col, id: undefined }))}
           resizableColumns={resizableColumns}
-          columnDisplay={columnDisplay}
+          columnDisplay={withColumnIds ? columnDisplay : undefined}
+          selectionType={withSelection ? 'single' : undefined}
           items={items}
           wrapLines={wrapLines}
           sortingColumn={sorting?.sortingColumn}

--- a/src/anchor-navigation/use-scroll-spy.tsx
+++ b/src/anchor-navigation/use-scroll-spy.tsx
@@ -37,7 +37,7 @@ export default function useScrollSpy({
   }, [hrefs]);
 
   // Get the bounding rectangle of an element by href
-  const getRectByHref = useCallback(href => {
+  const getRectByHref = useCallback((href: string) => {
     return document.getElementById(href.slice(1))?.getBoundingClientRect();
   }, []);
 

--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -202,6 +202,7 @@ describe('with stickyHeader=true', () => {
       });
     const columns: TableProps.ColumnDefinition<Item>[] = [
       { id: 'id', header: 'id', cell: () => '-', width: 200 },
+      { id: undefined, header: 'unknown', cell: () => '-', width: 300 },
       { id: 'name', header: 'name', cell: () => '-', minWidth: 100 },
       { id: 'description', header: '', cell: () => '-', maxWidth: 300 },
     ];
@@ -209,11 +210,13 @@ describe('with stickyHeader=true', () => {
     const [fakeHeader, realHeader] = wrapper.findAll('thead');
     expect(extractSize(realHeader)).toEqual([
       { minWidth: '', width: '200px', maxWidth: '' },
+      { minWidth: '', width: '300px', maxWidth: '' },
       { minWidth: '100px', width: '', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '300px' },
     ]);
     expect(extractSize(fakeHeader)).toEqual([
       { minWidth: '', width: '200px', maxWidth: '' },
+      { minWidth: '', width: '300px', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '' },
     ]);

--- a/src/table/__tests__/columns-width.test.tsx
+++ b/src/table/__tests__/columns-width.test.tsx
@@ -212,11 +212,10 @@ describe('with stickyHeader=true', () => {
       { minWidth: '100px', width: '', maxWidth: '' },
       { minWidth: '', width: '', maxWidth: '300px' },
     ]);
-    // in JSDOM, there is no layout, so copied width is "0px" and no value is ""
     expect(extractSize(fakeHeader)).toEqual([
-      { minWidth: '', width: '0px', maxWidth: '' },
-      { minWidth: '', width: '0px', maxWidth: '' },
-      { minWidth: '', width: '0px', maxWidth: '' },
+      { minWidth: '', width: '200px', maxWidth: '' },
+      { minWidth: '', width: '', maxWidth: '' },
+      { minWidth: '', width: '', maxWidth: '' },
     ]);
   });
 });

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useLayoutEffect, useEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import times from 'lodash/times';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 import { render, screen } from '@testing-library/react';
@@ -453,11 +453,6 @@ test('should set last column width to "auto" when container width exceeds total 
     };
 
     useLayoutEffect(() => {
-      cb({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    useEffect(() => {
       cb({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -23,7 +23,7 @@ jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => 
 
 jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
-  useResizeObserver: jest.fn().mockImplementation((_target, cb) => cb({ contentBoxWidth: 0 })),
+  useResizeObserver: jest.fn(),
 }));
 
 interface Item {

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import times from 'lodash/times';
+import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 import { render, screen } from '@testing-library/react';
 import createWrapper, { TableWrapper } from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
@@ -17,6 +18,11 @@ jest.mock('../../../lib/components/internal/utils/scrollable-containers', () => 
     overflowParent.getBoundingClientRect = fakeBoundingClientRect;
     return [overflowParent];
   }),
+}));
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  useResizeObserver: jest.fn().mockImplementation((_target, cb) => cb({ contentBoxWidth: 0 })),
 }));
 
 interface Item {
@@ -430,4 +436,15 @@ describe('column header content', () => {
     expect(getResizeHandle(0)).toHaveAttribute('aria-roledescription', 'resize button');
     expect(getResizeHandle(1)).toHaveAttribute('aria-roledescription', 'resize button');
   });
+});
+
+test('should set last column width to "auto" when container width exceeds total column width', () => {
+  const totalColumnsWidth = 150 + 300;
+  jest
+    .mocked(useResizeObserver)
+    .mockImplementation((_target, cb) => cb({ contentBoxWidth: totalColumnsWidth + 1 } as any));
+
+  const { wrapper } = renderTable(<Table {...defaultProps} />);
+
+  expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
 });

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -442,15 +442,12 @@ describe('column header content', () => {
 test('should set last column width to "auto" when container width exceeds total column width', () => {
   const totalColumnsWidth = 150 + 300;
 
-  let outsideCb: (entry: ContainerQueryEntry) => void = () => {};
+  const callbacks: ((entry: ContainerQueryEntry) => void)[] = [];
+  const fireCallbacks = (entry: ContainerQueryEntry) => callbacks.forEach(cb => cb(entry));
   jest.mocked(useResizeObserver).mockImplementation((_target, cb) => {
     // The table uses more than one resize observer.
     // The callback must be triggered for all to ensure the expected one is targeted as well.
-    const prev = outsideCb;
-    outsideCb = entry => {
-      prev(entry);
-      cb(entry);
-    };
+    callbacks.push(cb);
 
     useLayoutEffect(() => {
       cb({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
@@ -461,9 +458,9 @@ test('should set last column width to "auto" when container width exceeds total 
   const { wrapper } = renderTable(<Table {...defaultProps} />);
   expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
 
-  outsideCb({ contentBoxWidth: totalColumnsWidth } as unknown as ContainerQueryEntry);
+  fireCallbacks({ contentBoxWidth: totalColumnsWidth } as unknown as ContainerQueryEntry);
   expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', '300px']);
 
-  outsideCb({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
+  fireCallbacks({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
   expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
 });

--- a/src/table/column-widths-utils.ts
+++ b/src/table/column-widths-utils.ts
@@ -11,6 +11,25 @@ export function checkColumnWidths(columnDefinitions: ReadonlyArray<TableProps.Co
   }
 }
 
+export function setElementWidths(element: undefined | HTMLElement, styles: React.CSSProperties) {
+  function setProperty(property: 'width' | 'minWidth' | 'maxWidth') {
+    const value = styles[property];
+    let widthCssValue = '';
+    if (typeof value === 'number') {
+      widthCssValue = value + 'px';
+    }
+    if (typeof value === 'string') {
+      widthCssValue = value;
+    }
+    if (element && element.style[property] !== widthCssValue) {
+      element.style[property] = widthCssValue;
+    }
+  }
+  setProperty('width');
+  setProperty('minWidth');
+  setProperty('maxWidth');
+}
+
 function checkProperty(column: TableProps.ColumnDefinition<any>, name: 'width' | 'minWidth') {
   const value = column[name];
   if (typeof value !== 'number' && typeof value !== 'undefined') {

--- a/src/table/column-widths-utils.ts
+++ b/src/table/column-widths-utils.ts
@@ -11,7 +11,7 @@ export function checkColumnWidths(columnDefinitions: ReadonlyArray<TableProps.Co
   }
 }
 
-export function setElementWidths(element: undefined | HTMLElement, styles: React.CSSProperties) {
+export function setElementWidths(element: HTMLElement, styles: React.CSSProperties) {
   function setProperty(property: 'width' | 'minWidth' | 'maxWidth') {
     const value = styles[property];
     let widthCssValue = '';
@@ -21,7 +21,7 @@ export function setElementWidths(element: undefined | HTMLElement, styles: React
     if (typeof value === 'string') {
       widthCssValue = value;
     }
-    if (element && element.style[property] !== widthCssValue) {
+    if (element.style[property] !== widthCssValue) {
       element.style[property] = widthCssValue;
     }
   }

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -114,7 +114,8 @@ const InternalTable = React.forwardRef(
     const isMobile = useMobile();
 
     const [containerWidth, wrapperMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
-    const wrapperRefObject = useRef(null);
+    const wrapperMeasureRefObject = useRef(null);
+    const wrapperMeasureMergedRef = useMergeRefs(wrapperMeasureRef, wrapperMeasureRefObject);
 
     const [tableWidth, tableMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
     const tableRefObject = useRef(null);
@@ -134,6 +135,7 @@ const InternalTable = React.forwardRef(
       [cancelEdit]
     );
 
+    const wrapperRefObject = useRef(null);
     const handleScroll = useScrollSync([wrapperRefObject, scrollbarRef, secondaryWrapperRef]);
 
     const { moveFocusDown, moveFocusUp, moveFocus } = useSelectionFocusMove(selectionType, items.length);
@@ -205,7 +207,6 @@ const InternalTable = React.forwardRef(
     const tableRole = hasEditableCells ? 'grid-default' : 'table';
 
     const theadProps: TheadProps = {
-      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions: visibleColumnDefinitions,
@@ -257,7 +258,11 @@ const InternalTable = React.forwardRef(
 
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
-        <ColumnWidthsProvider visibleColumns={visibleColumnWidthsWithSelection} resizableColumns={resizableColumns}>
+        <ColumnWidthsProvider
+          visibleColumns={visibleColumnWidthsWithSelection}
+          resizableColumns={resizableColumns}
+          containerRef={wrapperMeasureRefObject}
+        >
           <InternalContainer
             {...baseProps}
             __internalRootRef={__internalRootRef}
@@ -333,7 +338,7 @@ const InternalTable = React.forwardRef(
               onScroll={handleScroll}
               {...wrapperProps}
             >
-              <div className={styles['wrapper-content-measure']} ref={wrapperMeasureRef}></div>
+              <div className={styles['wrapper-content-measure']} ref={wrapperMeasureMergedRef}></div>
               {!!renderAriaLive && !!firstIndex && (
                 <LiveRegion>
                   <span>

--- a/src/table/sticky-columns/use-sticky-columns.ts
+++ b/src/table/sticky-columns/use-sticky-columns.ts
@@ -156,7 +156,7 @@ export function useStickyCellStyles({
 
   // refCallback updates the cell ref and sets up the store subscription
   const refCallback = useCallback(
-    cellElement => {
+    (cellElement: null | HTMLElement) => {
       if (unsubscribeRef.current) {
         // Unsubscribe before we do any updates to avoid leaving any subscriptions hanging
         unsubscribeRef.current();

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -18,7 +18,6 @@ import { TableThElement } from './header-cell/th-element';
 import { findUpUntil } from '@cloudscape-design/component-toolkit/dom';
 
 export interface TheadProps {
-  containerWidth: null | number;
   selectionType: TableProps.SelectionType | undefined;
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<any>>;
   sortingColumn: TableProps.SortingColumn<any> | undefined;
@@ -47,7 +46,6 @@ export interface TheadProps {
 const Thead = React.forwardRef(
   (
     {
-      containerWidth,
       selectionType,
       getSelectAllProps,
       columnDefinitions,
@@ -91,7 +89,7 @@ const Thead = React.forwardRef(
       isVisualRefresh && styles['is-visual-refresh']
     );
 
-    const { columnWidths, totalWidth, updateColumn, setCell } = useColumnWidths();
+    const { getColumnStyles, columnWidths, updateColumn, setCell } = useColumnWidths();
 
     return (
       <thead className={clsx(!hidden && styles['thead-active'])}>
@@ -133,27 +131,11 @@ const Thead = React.forwardRef(
 
           {columnDefinitions.map((column, colIndex) => {
             const columnId = getColumnKey(column, colIndex);
-
-            let widthOverride;
-            if (resizableColumns) {
-              if (columnWidths) {
-                // use stateful value if available
-                widthOverride = columnWidths[columnId];
-              }
-              if (colIndex === columnDefinitions.length - 1 && containerWidth && containerWidth > totalWidth) {
-                // let the last column grow and fill the container width
-                widthOverride = 'auto';
-              }
-            }
             return (
               <TableHeaderCell
                 key={columnId}
+                style={getColumnStyles(sticky, columnId)}
                 className={headerCellClass}
-                style={{
-                  width: widthOverride || column.width,
-                  minWidth: sticky ? undefined : column.minWidth,
-                  maxWidth: resizableColumns || sticky ? undefined : column.maxWidth,
-                }}
                 tabIndex={sticky ? -1 : 0}
                 focusedComponent={focusedComponent}
                 column={column}
@@ -170,7 +152,7 @@ const Thead = React.forwardRef(
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 isEditable={!!column.editConfig}
                 stickyState={stickyState}
-                cellRef={node => setCell(columnId, node)}
+                cellRef={node => setCell(sticky, columnId, node)}
                 tableRole={tableRole}
                 resizerRoleDescription={resizerRoleDescription}
               />

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -116,12 +116,14 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   // Imperatively sets width style for a cell avoiding React state.
   // This allows setting the style as soon container's size change is observed.
   const updateColumnWidths = useStableCallback(() => {
-    for (const column of visibleColumns) {
-      setElementWidths(cellsRef.current[column.id], getColumnStyles(false, column.id));
+    for (const { id } of visibleColumns) {
+      if (cellsRef.current[id]) {
+        setElementWidths(cellsRef.current[id], getColumnStyles(false, id));
+      }
     }
     // Sticky column widths must be synchronized once all real column widths are assigned.
-    if (Object.keys(stickyCellsRef.current).length > 0) {
-      for (const { id } of visibleColumns) {
+    for (const { id } of visibleColumns) {
+      if (stickyCellsRef.current[id]) {
         setElementWidths(stickyCellsRef.current[id], getColumnStyles(true, id));
       }
     }

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -1,12 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useResizeObserver, useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import React, { useEffect, useRef, useState, createContext, useContext } from 'react';
+import { setElementWidths } from './column-widths-utils';
 
 export const DEFAULT_COLUMN_WIDTH = 120;
 
 export interface ColumnWidthDefinition {
   id: PropertyKey;
   minWidth?: string | number;
+  maxWidth?: string | number;
   width?: string | number;
 }
 
@@ -47,14 +50,14 @@ function updateWidths(
 }
 
 interface WidthsContext {
-  totalWidth: number;
+  getColumnStyles(sticky: boolean, columnId: PropertyKey): React.CSSProperties;
   columnWidths: Record<PropertyKey, number>;
   updateColumn: (columnId: PropertyKey, newWidth: number) => void;
-  setCell: (columnId: PropertyKey, node: null | HTMLElement) => void;
+  setCell: (sticky: boolean, columnId: PropertyKey, node: null | HTMLElement) => void;
 }
 
 const WidthsContext = createContext<WidthsContext>({
-  totalWidth: 0,
+  getColumnStyles: () => ({}),
   columnWidths: {},
   updateColumn: () => {},
   setCell: () => {},
@@ -63,26 +66,76 @@ const WidthsContext = createContext<WidthsContext>({
 interface WidthProviderProps {
   visibleColumns: readonly ColumnWidthDefinition[];
   resizableColumns: boolean | undefined;
+  containerRef: React.RefObject<HTMLElement>;
   children: React.ReactNode;
 }
 
-export function ColumnWidthsProvider({ visibleColumns, resizableColumns, children }: WidthProviderProps) {
-  const visibleColumnsRef = useRef<(PropertyKey | undefined)[] | null>(null);
-  const [columnWidths, setColumnWidths] = useState<Record<PropertyKey, number>>({});
+export function ColumnWidthsProvider({ visibleColumns, resizableColumns, containerRef, children }: WidthProviderProps) {
+  const visibleColumnsRef = useRef<PropertyKey[] | null>(null);
+  const containerWidthRef = useRef(0);
+  const [columnWidths, setColumnWidths] = useState<null | Record<PropertyKey, number>>(null);
 
   const cellsRef = useRef<Record<PropertyKey, HTMLElement>>({});
+  const stickyCellsRef = useRef<Record<PropertyKey, HTMLElement>>({});
   const getCell = (columnId: PropertyKey): null | HTMLElement => cellsRef.current[columnId] ?? null;
-  const setCell = (columnId: PropertyKey, node: null | HTMLElement) => {
+  const setCell = (sticky: boolean, columnId: PropertyKey, node: null | HTMLElement) => {
+    const ref = sticky ? stickyCellsRef : cellsRef;
     if (node) {
-      cellsRef.current[columnId] = node;
+      ref.current[columnId] = node;
     } else {
-      delete cellsRef.current[columnId];
+      delete ref.current[columnId];
     }
   };
+
+  const getColumnStyles = (sticky: boolean, columnId: PropertyKey): React.CSSProperties => {
+    const column = visibleColumns.find(column => column.id === columnId);
+    if (!column) {
+      return {};
+    }
+
+    if (sticky) {
+      return { width: cellsRef.current[column.id]?.offsetWidth || (columnWidths?.[column.id] ?? column.width) };
+    }
+
+    if (resizableColumns && columnWidths) {
+      const isLastColumn = column.id === visibleColumns[visibleColumns.length - 1]?.id;
+      const totalWidth = visibleColumns.reduce((sum, { id }) => sum + (columnWidths[id] || DEFAULT_COLUMN_WIDTH), 0);
+      if (isLastColumn && containerWidthRef.current > totalWidth) {
+        return { width: 'auto', minWidth: column?.minWidth };
+      } else {
+        return { width: columnWidths[column.id], minWidth: column?.minWidth };
+      }
+    }
+    return {
+      width: column.width,
+      minWidth: column.minWidth,
+      maxWidth: !resizableColumns ? column.maxWidth : undefined,
+    };
+  };
+
+  // Imperatively sets width style for a cell avoiding React state.
+  // This allows setting the style as soon container's size change is observed.
+  const updateColumnWidths = useStableCallback(() => {
+    for (const column of visibleColumns) {
+      setElementWidths(cellsRef.current[column.id], getColumnStyles(false, column.id));
+    }
+    // Sticky column widths must be synchronized once all real column widths are assigned.
+    for (const id of Object.keys(stickyCellsRef.current)) {
+      setElementWidths(stickyCellsRef.current[id], getColumnStyles(true, id));
+    }
+  });
+
+  // Observes container size and requests an update to the last cell width as it depends on the container's width.
+  useResizeObserver(containerRef, ({ contentBoxWidth: containerWidth }) => {
+    containerWidthRef.current = containerWidth;
+    updateColumnWidths();
+  });
 
   // The widths of the dynamically added columns (after the first render) if not set explicitly
   // will default to the DEFAULT_COLUMN_WIDTH.
   useEffect(() => {
+    updateColumnWidths();
+
     if (!resizableColumns) {
       return;
     }
@@ -91,7 +144,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, childre
     if (lastVisible) {
       for (let index = 0; index < visibleColumns.length; index++) {
         const column = visibleColumns[index];
-        if (!columnWidths[column.id] && lastVisible.indexOf(column.id) === -1) {
+        if (!columnWidths?.[column.id] && lastVisible.indexOf(column.id) === -1) {
           updates[column.id] = (column.width as number) || DEFAULT_COLUMN_WIDTH;
         }
       }
@@ -100,7 +153,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, childre
       }
     }
     visibleColumnsRef.current = visibleColumns.map(column => column.id);
-  }, [columnWidths, resizableColumns, visibleColumns]);
+  }, [columnWidths, resizableColumns, visibleColumns, updateColumnWidths]);
 
   // Read the actual column widths after the first render to employ the browser defaults for
   // those columns without explicit width.
@@ -114,16 +167,11 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, childre
   }, []);
 
   function updateColumn(columnId: PropertyKey, newWidth: number) {
-    setColumnWidths(columnWidths => updateWidths(visibleColumns, columnWidths, newWidth, columnId));
+    setColumnWidths(columnWidths => updateWidths(visibleColumns, columnWidths ?? {}, newWidth, columnId));
   }
 
-  const totalWidth = visibleColumns.reduce(
-    (total, column) => total + (columnWidths[column.id] || DEFAULT_COLUMN_WIDTH),
-    0
-  );
-
   return (
-    <WidthsContext.Provider value={{ columnWidths, totalWidth, updateColumn, setCell }}>
+    <WidthsContext.Provider value={{ getColumnStyles, columnWidths: columnWidths ?? {}, updateColumn, setCell }}>
       {children}
     </WidthsContext.Provider>
   );

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -120,8 +120,10 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
       setElementWidths(cellsRef.current[column.id], getColumnStyles(false, column.id));
     }
     // Sticky column widths must be synchronized once all real column widths are assigned.
-    for (const id of Object.keys(stickyCellsRef.current)) {
-      setElementWidths(stickyCellsRef.current[id], getColumnStyles(true, id));
+    if (Object.keys(stickyCellsRef.current).length > 0) {
+      for (const { id } of visibleColumns) {
+        setElementWidths(stickyCellsRef.current[id], getColumnStyles(true, id));
+      }
     }
   });
 

--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -5,19 +5,6 @@ import stickyScrolling, { calculateScrollingOffset, scrollUpBy } from './sticky-
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-function syncSizes(from: HTMLElement, to: HTMLElement) {
-  const fromCells = Array.prototype.slice.apply(from.children);
-  const toCells = Array.prototype.slice.apply(to.children);
-  for (let i = 0; i < fromCells.length; i++) {
-    let width = fromCells[i].style.width;
-    // use auto if it is set by resizable columns or real size otherwise
-    if (width !== 'auto') {
-      width = `${fromCells[i].offsetWidth}px`;
-    }
-    toCells[i].style.width = width;
-  }
-}
-
 export const useStickyHeader = (
   tableRef: RefObject<HTMLElement>,
   theadRef: RefObject<HTMLElement>,
@@ -35,8 +22,6 @@ export const useStickyHeader = (
       secondaryTableRef.current &&
       tableWrapperRef.current
     ) {
-      syncSizes(theadRef.current, secondaryTheadRef.current);
-
       // Using the tableRef offsetWidth instead of the theadRef because in VR
       // the tableRef adds extra padding to the table and by default the theadRef will have a width
       // without the padding and will make the sticky header width incorrect.


### PR DESCRIPTION
### Description

Re-introduction of https://github.com/cloudscape-design/components/pull/1718 but with a fix to default column IDs.

### How has this been tested?

New integration tests to secure regression.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
