### PR TITLE
chore: Improve documentation for contentDisplay and visibleColumns

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4731,6 +4731,7 @@ You must set the current value in the \`preferences.contentDensity\` property.",
     Object {
       "description": "Configures the built-in content display preference for order and visibility of columns in a table.
 Once set, the component displays this preference in the modal.
+Cannot be used together with \`visibleContentPreference\`.
 
 It contains the following:
 - \`title\` (string) - Specifies the text displayed at the top of the preference.
@@ -5004,6 +5005,7 @@ You must set the current value in the \`preferences.stripedRows\` property.",
     Object {
       "description": "Configures the built-in \\"visible content selection\\" preference (for example, visible columns in a table).
 If you set it, the component displays this preference in the modal.
+Cannot be used together with \`contentDisplayPreference\`.
 
 It contains the following:
 - \`title\` (string) - Specifies the text displayed at the top of the preference.
@@ -5017,6 +5019,8 @@ Each group of options contains the following:
   - \`editable\` (boolean) - (Optional) Determines whether the user is able to toggle its visibility. This is \`true\` by default.
 
 You must set the current list of visible content \`id\`s in the \`preferences.visibleContent\` property.
+
+**Deprecated** in table, replaced by \`contentDisplayPreference\`.
 ",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.VisibleContentPreference",
@@ -13204,6 +13208,7 @@ It's also used to connect \`items\` and \`selectedItems\` values when they refer
       "visualRefreshTag": "\`embedded\`, \`stacked\`, and \`full-page\` variants",
     },
     Object {
+      "deprecatedTag": "Replaced by \`columnDisplay\`.",
       "description": "Specifies an array containing the \`id\`s of visible columns. If not set, all columns are displayed.
 Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -5003,7 +5003,7 @@ You must set the current value in the \`preferences.stripedRows\` property.",
       "type": "string",
     },
     Object {
-      "description": "Configures the built-in \\"visible content selection\\" preference (for example, visible columns in a table).
+      "description": "Configures the built-in \\"visible content selection\\" preference (for example, visible sections in cards).
 If you set it, the component displays this preference in the modal.
 Cannot be used together with \`contentDisplayPreference\`.
 

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -94,6 +94,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Configures the built-in content display preference for order and visibility of columns in a table.
    *
    * Once set, the component displays this preference in the modal.
+   * Cannot be used together with `visibleContentPreference`.
    *
    * It contains the following:
    * - `title` (string) - Specifies the text displayed at the top of the preference.
@@ -119,6 +120,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * Configures the built-in "visible content selection" preference (for example, visible columns in a table).
    *
    * If you set it, the component displays this preference in the modal.
+   * Cannot be used together with `contentDisplayPreference`.
    *
    * It contains the following:
    * - `title` (string) - Specifies the text displayed at the top of the preference.
@@ -132,6 +134,8 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    *   - `editable` (boolean) - (Optional) Determines whether the user is able to toggle its visibility. This is `true` by default.
    *
    * You must set the current list of visible content `id`s in the `preferences.visibleContent` property.
+   *
+   * **Deprecated** in table, replaced by `contentDisplayPreference`.
    */
   visibleContentPreference?: CollectionPreferencesProps.VisibleContentPreference;
   /**

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -117,7 +117,7 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    */
   contentDisplayPreference?: CollectionPreferencesProps.ContentDisplayPreference;
   /**
-   * Configures the built-in "visible content selection" preference (for example, visible columns in a table).
+   * Configures the built-in "visible content selection" preference (for example, visible sections in cards).
    *
    * If you set it, the component displays this preference in the modal.
    * Cannot be used together with `contentDisplayPreference`.

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -223,7 +223,9 @@ export interface TableProps<T = any> extends BaseComponentProps {
    * Use it in conjunction with the visible content preference of the [collection preferences](/components/collection-preferences/) component.
    *
    * The order of ids doesn't influence the order in which columns are displayed - this is dictated by the `columnDefinitions` property.
-   * */
+   *
+   * @deprecated Replaced by `columnDisplay`.
+   */
   visibleColumns?: ReadonlyArray<string>;
 
   /**


### PR DESCRIPTION
### Description
The documentation in Table and Collection preferences don't talk much about how `contentDisplay` has replaced `visibleColumns` in table (not cards). To make this clear, we're adding a few more bits of documentation.

Next step: deprecate `visibleContentPreference` in Cards as well.

Related links, issue #, if available: AWSUI-22308

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
