### PR TITLE
chore: Remove unnecessary 'no-redundant-for' in a11y tests

### DIFF
--- a/src/__a11y__/to-validate-a11y.ts
+++ b/src/__a11y__/to-validate-a11y.ts
@@ -23,8 +23,6 @@ const htmlValidator = new HtmlValidate({
     'valid-id': ['error', { relaxed: true }],
     'no-inline-style': 'off',
     'prefer-native-element': ['error', { exclude: ['listbox', 'button', 'region'] }],
-    //TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
-    'no-redundant-for': 'off',
     // innerHTML normalizes attribute values
     // https://stackoverflow.com/questions/48092293/javascript-innerhtml-messing-with-html-attributes
     'attribute-boolean-style': 'off',

--- a/src/__tests__/test-a11y-validator.test.tsx
+++ b/src/__tests__/test-a11y-validator.test.tsx
@@ -41,7 +41,7 @@ describe('a11y validator', () => {
     );
     await expect(expect(container).toValidateA11y()).rejects.toThrow(
       new Error(
-        'Expected HTML to be valid but had the following errors:\nAxe checks\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
+        'Expected HTML to be valid but had the following errors:\nHTML validation\n1. Redundant "for" attribute [no-redundant-for]\nAxe checks\n1. Fix all of the following:\n  ARIA attribute element ID does not exist on the page: aria-labelledby="non-exist-id" [aria-valid-attr-value]'
       )
     );
   });


### PR DESCRIPTION
### Description
Resolving a pending "TODO" comment about `no-redundant-for` in a11y tests:

```
//TODO: revisit 'no-redundant-for' when fixing AWSUI-18968
```

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
