### PR TITLE
chore: Make table and card content types span full width

### DIFF
--- a/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
@@ -53,7 +53,7 @@ describe('Default width per contentType', () => {
   ];
 
   testCases.forEach(({ viewPortWidth, navigationWidth, contentWidth, toolsWidth }) => {
-    for (const contentType of ['default', 'cards', 'form', 'table', 'wizard']) {
+    for (const contentType of ['default', 'form', 'wizard']) {
       test(
         `Browser viewPortWidth ${viewPortWidth}: contentType '${contentType}' has default width for content, navigation and tools slot.`,
         setupTest(viewPortWidth, async page => {
@@ -69,11 +69,21 @@ describe('Default width per contentType', () => {
     }
   });
 
+  for (const contentType of ['table', 'cards']) {
+    test(
+      `ContentType '${contentType}' uses the full available horizontal width.`,
+      setupTest(2000, async page => {
+        await page.setContentType(contentType);
+        await expect(page.getContentWidth()).resolves.toBeGreaterThan(1830);
+      })
+    );
+  }
+
   test(
     'Use the full available width when maxContentWidth is set to Number.MAX_VALUE',
     setupTest(3000, async page => {
       await page.setContentWidthToMaxValue();
-      await expect(page.getContentWidth()).resolves.toBe(2840);
+      await expect(page.getContentWidth()).resolves.toBeGreaterThan(2830);
     })
   );
 

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -98,6 +98,10 @@ explicitly set in script.
         }
       }
     }
+    &.content-type-table,
+    &.content-type-cards {
+      #{custom-props.$defaultMaxContentWidth}: 100%;
+    }
   }
 
   /*


### PR DESCRIPTION
### Description

This change makes pages that have contentType=“table” or “cards” set on the App Layout take up 100% of the available width. Previously, all pages in VR had a constrained max-width, however we are updating this in response to user feedback via the internal availability program. The change in behavior was also tested and confirmed in the info density usability study conducted this quarter.

#### Before
<img width="1789" alt="Screenshot 2023-11-30 at 4 54 31 PM" src="https://github.com/cloudscape-design/components/assets/15003460/6751e410-4915-41e4-ba32-35045ebc45ab">

#### After
<img width="1789" alt="Screenshot 2023-11-30 at 4 54 18 PM" src="https://github.com/cloudscape-design/components/assets/15003460/4365f3d0-2d2d-409c-9985-2979d8feabbe">

Related links, issue #, if available: AWSUI-19992

### How has this been tested?

Ran through my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
