### PR TITLE
chore: Remove redundant motion disabled parameters

### DIFF
--- a/src/__integ__/themes.test.ts
+++ b/src/__integ__/themes.test.ts
@@ -40,6 +40,7 @@ describe('CSS Custom Properties', () => {
     ['light', `#light/?visualRefresh=false`],
     ['dark', '#dark/?visualRefresh=false'],
     ['compact', '#light/?visualRefresh=false&density=compact'],
+    // use motionDisabled to force design tokens into expected values
     ['reduced-motion', '#light/?visualRefresh=false&motionDisabled=true'],
     ['visual-refresh', '#light/?visualRefresh=true'],
     ['visual-refresh-dark', '#dark/?visualRefresh=true'],

--- a/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
@@ -39,7 +39,7 @@ function setupTest(viewportWidth: number, testFn: (page: AppLayoutRefreshNotofic
   return useBrowser(async browser => {
     const page = new AppLayoutRefreshNotoficationsPage(browser);
     await page.setWindowSize({ ...viewports.desktop, width: viewportWidth });
-    await browser.url('#/light/app-layout/refresh-content-width/?visualRefresh=true&motionDisabled=true');
+    await browser.url('#/light/app-layout/refresh-content-width/?visualRefresh=true');
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);
   });

--- a/src/app-layout/__integ__/app-layout-refresh-edge-controls.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-edge-controls.test.ts
@@ -18,7 +18,7 @@ function setupTest(testFn: (page: AppLayoutRefreshEdgeControlsPage) => Promise<v
   return useBrowser(async browser => {
     const page = new AppLayoutRefreshEdgeControlsPage(browser);
     await page.setWindowSize(viewports.desktop);
-    await browser.url(`#/light/app-layout/disable-paddings-edge-controls/?visualRefresh=true&motionDisabled=true`);
+    await browser.url(`#/light/app-layout/disable-paddings-edge-controls/?visualRefresh=true`);
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);
   });

--- a/src/app-layout/__integ__/app-layout-refresh-notifications.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-notifications.test.ts
@@ -46,9 +46,7 @@ function setupTest(
     const page = new AppLayoutRefreshNotoficationsPage(browser);
     await page.setWindowSize(viewport);
     await browser.url(
-      `#/light/app-layout/notifications-refresh/?visualRefresh=true&motionDisabled=true${
-        removeNotifications ? `&removeNotifications` : ''
-      }`
+      `#/light/app-layout/notifications-refresh/?visualRefresh=true${removeNotifications ? `&removeNotifications` : ''}`
     );
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);

--- a/src/tabs/__integ__/tabs-in-help-panel.test.ts
+++ b/src/tabs/__integ__/tabs-in-help-panel.test.ts
@@ -10,9 +10,7 @@ const tabsWrapper = createWrapper().findTabs();
 const setupTest = (visualRefresh = false, testFn: (page: BasePageObject) => Promise<void>) => {
   return useBrowser(async browser => {
     const page = new BasePageObject(browser);
-    await browser.url(
-      `#/light/tabs/in-app-layout-help-panel/?motionDisabled=true${visualRefresh ? '&visualRefresh=true' : ''}`
-    );
+    await browser.url(`#/light/tabs/in-app-layout-help-panel/?${visualRefresh ? 'visualRefresh=true' : ''}`);
     await page.waitForVisible(appLayoutWrapper.findContentRegion().toSelector());
     await testFn(page);
   });

--- a/src/tabs/__integ__/tabs.test.ts
+++ b/src/tabs/__integ__/tabs.test.ts
@@ -58,8 +58,7 @@ class TabsPage extends BasePageObject {
 const setupTest = (testFn: (page: TabsPage) => Promise<void>, smallViewport = false) => {
   return useBrowser(async browser => {
     const page = new TabsPage(browser);
-    // TODO: Remove VR flag once AWSUI-18703 is fixed
-    await browser.url('#/light/tabs/responsive-integ/?motionDisabled=true&visualRefresh=false');
+    await browser.url('#/light/tabs/responsive-integ');
     await page.waitForVisible(wrapper.findTabContent().toSelector());
     if (smallViewport) {
       await page.setWindowSize({ width: 400, height: 1000 });
@@ -188,7 +187,7 @@ test(
 test(
   'adds pagination buttons upon changing the tabs array',
   setupTest(async page => {
-    await page.setWindowSize({ width: 700, height: 1000 });
+    await page.setWindowSize({ width: 800, height: 1000 });
     await page.hasPaginationButtons(false);
     await page.click('#add-tab');
     await page.hasPaginationButtons(true);


### PR DESCRIPTION
### Description

We already force disabled motion in our browser setup: https://github.com/cloudscape-design/browser-test-tools/blob/cf77d3f913826dd0083eadeef0dd8df6ac6a3ab8/src/browsers/local.ts#L19-L23

No need for the extra query parameter, it does nothing.

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
