### PR TITLE
fix: Export DrawerChangeDetail type from AppLayoutProps

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -401,7 +401,18 @@ Object {
     Object {
       "cancelable": false,
       "description": "Fired when the active drawer is toggled.",
-      "detailType": "unknown",
+      "detailInlineType": Object {
+        "name": "AppLayoutProps.DrawerChangeDetail",
+        "properties": Array [
+          Object {
+            "name": "activeDrawerId",
+            "optional": false,
+            "type": "null | string",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "AppLayoutProps.DrawerChangeDetail",
       "name": "onDrawerChange",
     },
     Object {

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -35,7 +35,7 @@ export interface AppLayoutProps extends BaseComponentProps {
   /**
    * Fired when the active drawer is toggled.
    */
-  onDrawerChange?: NonCancelableEventHandler<{ activeDrawerId: string | null }>;
+  onDrawerChange?: NonCancelableEventHandler<AppLayoutProps.DrawerChangeDetail>;
 
   /**
    * If `true`, disables outer paddings for the content slot.
@@ -313,4 +313,8 @@ export namespace AppLayoutProps {
   // Duplicated the positions because using this definition in SplitPanelPreferences would display
   // 'AppLayoutProps.SplitPanelPosition' on the API docs instead of the string values.
   export type SplitPanelPosition = 'side' | 'bottom';
+
+  export interface DrawerChangeDetail {
+    activeDrawerId: string | null;
+  }
 }

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -93,7 +93,7 @@ function convertBetaApi(drawers: BetaDrawersProps, ariaLabels: AppLayoutProps['a
       })
     ),
     controlledActiveDrawerId: drawers.activeDrawerId,
-    onDrawerChange: (event: NonCancelableCustomEvent<{ activeDrawerId: string | null }>) =>
+    onDrawerChange: (event: NonCancelableCustomEvent<AppLayoutProps.DrawerChangeDetail>) =>
       fireNonCancelableEvent(drawers.onChange, event.detail.activeDrawerId),
     ariaLabels: {
       ...ariaLabels,


### PR DESCRIPTION
### Description

Create and export `DrawerChangeDetail` type so users could import it from `AppLayoutProps`, also so the type could appear properly on the documentation website instead of `unknown` https://cloudscape.design/components/app-layout/#events 

### How has this been tested?

updated documentation snapshot

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
