### PR TITLE
fix: Remove bottom offset when there is no SplitPanel in AppLayout and splitPanelOpen is true

### DIFF
--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -338,7 +338,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       displayed: false,
       ariaLabel: undefined,
     });
-    const splitPanelDisplayed = !!(splitPanelToggle.displayed || isSplitPanelOpen);
+    const splitPanelDisplayed = !!(splitPanelToggle.displayed || (isSplitPanelOpen && !!splitPanel));
     const splitPanelControlId = useUniqueId('split-panel-');
     const toolsControlId = useUniqueId('tools-');
 


### PR DESCRIPTION
### Description

in `AppLayout` when `splitPanel` slot is `null` and `splitPanelOpen` is `true` bottom offset is added to the page, ideally users should provide the component with the proper state however this used to work in the old version of `AppLayout` so for backward compatibility we'll need to support this case in the new `AppLayout`

Related links, issue #, if available: AWSUI-24603

### How has this been tested?

[in this example](https://github.com/cloudscape-design/components/blob/main/pages/app-layout/with-split-panel.page.tsx#L77) set `splitPanel` to `null` and `splitPanelOpen` to `true`

I'm not sure if there is a proper way to test this, it doesn't seem like a case worth adding a screenshot test for

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
