### PR TITLE
chore: Emit performance marks for button and table

### DIFF
--- a/pages/button/performance-marks.page.tsx
+++ b/pages/button/performance-marks.page.tsx
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Button from '~components/button';
+import Box from '~components/box';
+import { SpaceBetween, Tabs } from '~components';
+
+export default function ButtonsScenario() {
+  const [loading, setLoading] = useState(true);
+  const [disabled, setDisabled] = useState(false);
+  return (
+    <Box padding="xxl">
+      <SpaceBetween size="l">
+        <label>
+          <input type="checkbox" checked={loading} onChange={e => setLoading(e.target.checked)} id="loading" />
+          Loading
+        </label>
+        <label>
+          <input type="checkbox" checked={disabled} onChange={e => setDisabled(e.target.checked)} id="disabled" />
+          Disabled
+        </label>
+        <Button variant="primary" loading={loading} disabled={disabled}>
+          Primary button
+        </Button>
+        <Button>Non-primary button</Button>
+
+        <Tabs
+          tabs={[
+            {
+              label: 'An empty tab',
+              id: 'first',
+              content: "There is nothing in this tab, but there's a button in the other tab.",
+            },
+            {
+              label: 'A tab with a button',
+              id: 'second',
+              content: <Button variant="primary">This is the button in the tab</Button>,
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/pages/button/performance-marks.page.tsx
+++ b/pages/button/performance-marks.page.tsx
@@ -10,6 +10,7 @@ export default function ButtonsScenario() {
   const [disabled, setDisabled] = useState(false);
   return (
     <Box padding="xxl">
+      <h1>Performance marks in buttons</h1>
       <SpaceBetween size="l">
         <label>
           <input type="checkbox" checked={loading} onChange={e => setLoading(e.target.checked)} id="loading" />

--- a/pages/button/performance-marks.page.tsx
+++ b/pages/button/performance-marks.page.tsx
@@ -3,9 +3,9 @@
 import React, { useState } from 'react';
 import Button from '~components/button';
 import Box from '~components/box';
-import { SpaceBetween, Tabs } from '~components';
+import { Modal, SpaceBetween, Tabs } from '~components';
 
-export default function ButtonsScenario() {
+export default function ButtonsPerformanceMarkPage() {
   const [loading, setLoading] = useState(true);
   const [disabled, setDisabled] = useState(false);
   return (
@@ -24,6 +24,8 @@ export default function ButtonsScenario() {
           Primary button
         </Button>
         <Button>Non-primary button</Button>
+
+        <Modal visible={false} footer={<Button variant="primary">Submit modal</Button>}></Modal>
 
         <Tabs
           tabs={[

--- a/pages/table/performance-marks.page.tsx
+++ b/pages/table/performance-marks.page.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
 import Box from '~components/box';
-import { Header, Link, SpaceBetween, Table, Tabs } from '~components';
+import { Header, Link, Modal, SpaceBetween, Table, Tabs } from '~components';
 
-export default function ButtonsScenario() {
+export default function TablePerformanceMarkPage() {
   const [loading, setLoading] = useState(true);
   return (
     <Box padding="xxl">
@@ -23,6 +23,10 @@ export default function ButtonsScenario() {
         />
 
         <Table items={[]} columnDefinitions={[]} header="A table without the Header component" />
+
+        <Modal visible={false}>
+          <Table items={[]} columnDefinitions={[]} header="A table inside a Modal" />
+        </Modal>
 
         <Tabs
           tabs={[

--- a/pages/table/performance-marks.page.tsx
+++ b/pages/table/performance-marks.page.tsx
@@ -8,6 +8,7 @@ export default function ButtonsScenario() {
   const [loading, setLoading] = useState(true);
   return (
     <Box padding="xxl">
+      <h1>Performance marks in table</h1>
       <SpaceBetween size="xxl">
         <label>
           <input type="checkbox" checked={loading} onChange={e => setLoading(e.target.checked)} id="loading" />

--- a/pages/table/performance-marks.page.tsx
+++ b/pages/table/performance-marks.page.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Box from '~components/box';
+import { Header, Link, SpaceBetween, Table, Tabs } from '~components';
+
+export default function ButtonsScenario() {
+  const [loading, setLoading] = useState(true);
+  return (
+    <Box padding="xxl">
+      <SpaceBetween size="xxl">
+        <label>
+          <input type="checkbox" checked={loading} onChange={e => setLoading(e.target.checked)} id="loading" />
+          Loading
+        </label>
+
+        <Table
+          items={[]}
+          loading={loading}
+          columnDefinitions={[]}
+          header={<Header info={<Link variant="info">Info</Link>}>This is my table</Header>}
+        />
+
+        <Table items={[]} columnDefinitions={[]} header="A table without the Header component" />
+
+        <Tabs
+          tabs={[
+            {
+              label: 'An empty tab',
+              id: 'first',
+              content: "There is nothing in this tab, but there's a table in the other tab.",
+            },
+            {
+              label: 'A tab with a table',
+              id: 'second',
+              content: (
+                <Table
+                  items={[]}
+                  loading={loading}
+                  columnDefinitions={[]}
+                  header={<Header info={<Link variant="info">Info</Link>}>This is the table in the tab.</Header>}
+                />
+              ),
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </Box>
+  );
+}

--- a/src/button/__integ__/performance-marks.test.ts
+++ b/src/button/__integ__/performance-marks.test.ts
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+function setupTest(testFn: (page: BasePageObject, getMarks: () => Promise<PerformanceMark[]>) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/button/performance-marks');
+    const getMarks = async () => {
+      const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
+      return marks.filter(m => m.detail?.source === 'cloudscape');
+    };
+    await testFn(page, getMarks);
+  });
+}
+
+describe('Button', () => {
+  test(
+    'Emits a mark only for primary visible buttons',
+    setupTest(async (_, getMarks) => {
+      const marks = await getMarks();
+
+      expect(marks).toHaveLength(1);
+      expect(marks[0].name).toBe('primaryButtonRendered');
+      expect(marks[0].detail).toMatchObject({
+        source: 'cloudscape',
+        instanceId: expect.any(String),
+        loading: true,
+        disabled: false,
+        text: 'Primary button',
+      });
+    })
+  );
+
+  test(
+    'Emits a mark when properties change',
+    setupTest(async (page, getMarks) => {
+      await page.click('#disabled');
+      await page.click('#loading');
+      const marks = await getMarks();
+
+      expect(marks).toHaveLength(3);
+      expect(marks[1].name).toBe('primaryButtonUpdated');
+      expect(marks[1].detail).toMatchObject({
+        source: 'cloudscape',
+        instanceId: marks[0].detail.instanceId,
+        loading: true,
+        disabled: true,
+        text: 'Primary button',
+      });
+      expect(marks[2].name).toBe('primaryButtonUpdated');
+      expect(marks[2].detail).toMatchObject({
+        source: 'cloudscape',
+        instanceId: marks[1].detail.instanceId,
+        loading: false,
+        disabled: true,
+        text: 'Primary button',
+      });
+    })
+  );
+});

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -21,6 +21,7 @@ import {
 } from '../internal/analytics/selectors';
 import { FunnelMetrics } from '../internal/analytics';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { usePerformanceMarks } from '../internal/hooks/use-performance-marks';
 
 export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   variant?: ButtonProps['variant'] | 'flashbar-icon' | 'breadcrumb-group' | 'menu-trigger' | 'modal-dismiss';
@@ -79,6 +80,18 @@ export const InternalButton = React.forwardRef(
     const { funnelInteractionId } = useFunnel();
     const { stepNumber, stepNameSelector } = useFunnelStep();
     const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
+
+    usePerformanceMarks(
+      'primaryButton',
+      variant === 'primary',
+      buttonRef,
+      () => ({
+        loading,
+        disabled,
+        text: buttonRef.current?.innerText,
+      }),
+      [loading, disabled]
+    );
 
     const handleClick = (event: React.MouseEvent) => {
       if (isNotInteractive) {

--- a/src/internal/hooks/use-performance-marks.ts
+++ b/src/internal/hooks/use-performance-marks.ts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+import { useUniqueId } from './use-unique-id';
+import { useEffectOnUpdate } from './use-effect-on-update';
+
+export function usePerformanceMarks(
+  name: string,
+  enabled: boolean,
+  elementRef: React.RefObject<HTMLElement>,
+  getDetails: () => Record<string, string | boolean | number | undefined>,
+  dependencies: React.DependencyList
+) {
+  const id = useUniqueId();
+
+  useEffect(() => {
+    if (!enabled || !elementRef.current) {
+      return;
+    }
+
+    const elementVisible =
+      elementRef.current.offsetWidth > 0 &&
+      elementRef.current.offsetHeight > 0 &&
+      getComputedStyle(elementRef.current).visibility !== 'hidden';
+
+    if (!elementVisible) {
+      return;
+    }
+
+    const renderedMarkName = `${name}Rendered`;
+
+    performance.mark(renderedMarkName, {
+      detail: {
+        source: 'cloudscape',
+        instanceId: id,
+        ...getDetails(),
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffectOnUpdate(() => {
+    if (!enabled || !elementRef.current) {
+      return;
+    }
+    const elementVisible =
+      elementRef.current.offsetWidth > 0 &&
+      elementRef.current.offsetHeight > 0 &&
+      getComputedStyle(elementRef.current).visibility !== 'hidden';
+
+    if (!elementVisible) {
+      return;
+    }
+
+    const updatedMarkName = `${name}Updated`;
+
+    performance.mark(updatedMarkName, {
+      detail: {
+        source: 'cloudscape',
+        instanceId: id,
+        ...getDetails(),
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, dependencies);
+}

--- a/src/table/__integ__/performance-marks.test.ts
+++ b/src/table/__integ__/performance-marks.test.ts
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+function setupTest(testFn: (page: BasePageObject, getMarks: () => Promise<PerformanceMark[]>) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/table/performance-marks');
+    const getMarks = async () => {
+      const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
+      return marks.filter(m => m.detail?.source === 'cloudscape');
+    };
+    await testFn(page, getMarks);
+  });
+}
+
+describe('Table', () => {
+  test(
+    'Emits a mark only for visible tables',
+    setupTest(async (_, getMarks) => {
+      const marks = await getMarks();
+
+      expect(marks).toHaveLength(2);
+      expect(marks[0].name).toBe('tableRendered');
+      expect(marks[0].detail).toEqual({
+        source: 'cloudscape',
+        instanceId: expect.any(String),
+        loading: true,
+        header: 'This is my table',
+      });
+
+      expect(marks[1].name).toBe('tableRendered');
+      expect(marks[1].detail).toEqual({
+        source: 'cloudscape',
+        instanceId: expect.any(String),
+        loading: false,
+        header: 'A table without the Header component',
+      });
+
+      expect(marks[0].detail.instanceId).not.toEqual(marks[1].detail.instanceId);
+    })
+  );
+
+  test(
+    'Emits a mark when properties change',
+    setupTest(async (page, getMarks) => {
+      await page.click('#loading');
+      let marks = await getMarks();
+
+      expect(marks).toHaveLength(3);
+      expect(marks[2].name).toBe('tableUpdated');
+      expect(marks[2].detail).toMatchObject({
+        source: 'cloudscape',
+        instanceId: marks[0].detail.instanceId,
+        loading: false,
+        header: 'This is my table',
+      });
+
+      await page.click('#loading');
+
+      marks = await getMarks();
+
+      expect(marks[3].name).toBe('tableUpdated');
+      expect(marks[3].detail).toMatchObject({
+        source: 'cloudscape',
+        instanceId: marks[2].detail.instanceId,
+        loading: true,
+        header: 'This is my table',
+      });
+    })
+  );
+});

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -19,6 +19,7 @@ import { ColumnWidthDefinition, ColumnWidthsProvider, DEFAULT_COLUMN_WIDTH } fro
 import { useScrollSync } from '../internal/hooks/use-scroll-sync';
 import { ResizeTracker } from './resizer';
 import styles from './styles.css.js';
+import headerStyles from '../header/styles.css.js';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import StickyHeader, { StickyHeaderRef } from './sticky-header';
@@ -40,6 +41,7 @@ import { LinkDefaultVariantContext } from '../internal/context/link-default-vari
 import { CollectionLabelContext } from '../internal/context/collection-label-context';
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import { NoDataCell } from './node-data-cell';
+import { usePerformanceMarks } from '../internal/hooks/use-performance-marks';
 
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
@@ -124,6 +126,23 @@ const InternalTable = React.forwardRef(
     const stickyHeaderRef = React.useRef<StickyHeaderRef>(null);
     const scrollbarRef = React.useRef<HTMLDivElement>(null);
     const { cancelEdit, ...cellEditing } = useCellEditing({ onCancel: onEditCancel, onSubmit: submitEdit });
+
+    usePerformanceMarks(
+      'table',
+      true,
+      tableRefObject,
+      () => {
+        const headerText =
+          toolsHeaderWrapper.current?.querySelector<HTMLElement>(`.${headerStyles['heading-text']}`)?.innerText ??
+          toolsHeaderWrapper.current?.innerText;
+
+        return {
+          loading: loading ?? false,
+          header: headerText,
+        };
+      },
+      [loading]
+    );
 
     useImperativeHandle(
       ref,
@@ -248,7 +267,7 @@ const InternalTable = React.forwardRef(
     const hasDynamicHeight = computedVariant === 'full-page';
     const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
     useTableFocusNavigation(selectionType, tableRefObject, visibleColumnDefinitions, items?.length);
-    const toolsHeaderWrapper = useRef(null);
+    const toolsHeaderWrapper = useRef<HTMLDivElement>(null);
     // If is mobile, we take into consideration the AppLayout's mobile bar and we subtract the tools wrapper height so only the table header is sticky
     const toolsHeaderHeight =
       (toolsHeaderWrapper?.current as HTMLDivElement | null)?.getBoundingClientRect().height ?? 0;


### PR DESCRIPTION
### Description

This change adds performance marks to the Button and Table component. These marks are created when the component is first rendered, and when properties of the component (e.g. `loading` or `disabled`) change.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added integration tests. I did not add unit tests, since JSDOM does not support the necessary performance APIs.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
