### PR TITLE
chore: Added missing FollowDetail to TopNavigationProps.Identity.onFo…

### DIFF
--- a/src/top-navigation/1.0-beta/interfaces.ts
+++ b/src/top-navigation/1.0-beta/interfaces.ts
@@ -66,7 +66,7 @@ export namespace TopNavigationProps {
     title?: string;
     logo?: Logo;
     href: string;
-    onFollow?: CancelableEventHandler;
+    onFollow?: CancelableEventHandler<FollowDetail>;
   }
 
   export interface Logo {
@@ -110,5 +110,9 @@ export namespace TopNavigationProps {
     searchIconAriaLabel?: string;
     searchDismissIconAriaLabel?: string;
     overflowMenuTriggerText: string;
+  }
+
+  export interface FollowDetail extends BaseNavigationDetail {
+      href: string;
   }
 }

--- a/src/top-navigation/interfaces.ts
+++ b/src/top-navigation/interfaces.ts
@@ -72,7 +72,7 @@ export namespace TopNavigationProps {
     title?: string;
     logo?: Logo;
     href: string;
-    onFollow?: CancelableEventHandler;
+    onFollow?: CancelableEventHandler<FollowDetail>;
   }
 
   export interface Logo {
@@ -123,5 +123,9 @@ export namespace TopNavigationProps {
     overflowMenuBackIconAriaLabel?: string;
     overflowMenuTriggerText?: string;
     overflowMenuTitleText?: string;
+  }
+  
+  export interface FollowDetail extends BaseNavigationDetail {
+      href: string;
   }
 }


### PR DESCRIPTION
### Description

The typing was incomplete for the `TopNavigationProps.Identity.onFollow`, which caused my IDE to complain that the `href` in the following is invalid:

    <TopNavigation
            identity={{
                onFollow: (event) => {
                    event.preventDefault();
                    navigate(event.detail.href);
                },
                href: '/',
                title: 'title',
                logo: { src: logo, alt: 'ogo' }
            }}
    />

Related links, issue #, if available: n/a

### How has this been tested?

1. Include this branch in your workspace.
2. Copy the above code into your project
3. The `href` now has a type.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
