### PR TITLE
fix: Fix is-keyboard selector in multiselect dropdown

### DIFF
--- a/src/internal/components/selectable-item/__tests__/selectable-item.test.tsx
+++ b/src/internal/components/selectable-item/__tests__/selectable-item.test.tsx
@@ -42,6 +42,26 @@ it('highlighted option with screenReaderContent should have aria-hidden and scre
   expect(container.querySelector(`.${styles['screenreader-content']}`)).toContainHTML('announcement');
 });
 
+it('highlighted option with highlightType "mouse" should not add keyboard class to the item', () => {
+  const { container } = render(
+    <SelectableItem highlighted={true} highlightType="mouse">
+      Highlighted Option
+    </SelectableItem>
+  );
+  expect(container.querySelector(`.${styles.highlighted}`)).not.toBeNull();
+  expect(container.querySelector(`.${styles['is-keyboard']}`)).toBeNull();
+});
+
+it('highlighted option with highlightType "keyboard" should add keyboard class to the item', () => {
+  const { container } = render(
+    <SelectableItem highlighted={true} highlightType="keyboard">
+      Highlighted Option
+    </SelectableItem>
+  );
+  expect(container.querySelector(`.${styles.highlighted}`)).not.toBeNull();
+  expect(container.querySelector(`.${styles['is-keyboard']}`)).not.toBeNull();
+});
+
 it('assign aria-posinset and aria-setsize when set', () => {
   const { container } = render(
     <SelectableItem ariaPosinset={10} ariaSetsize={50}>

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -6,23 +6,11 @@ import styles from './styles.css.js';
 import Option from '../../internal/components/option';
 import SelectableItem from '../../internal/components/selectable-item';
 import { getBaseProps } from '../../internal/base-component';
-import { DropdownOption, OptionDefinition } from '../../internal/components/option/interfaces';
+import { OptionDefinition } from '../../internal/components/option/interfaces';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
-import { HighlightType } from '../../internal/components/options-list/utils/use-highlight-option.js';
-export interface ItemProps {
-  option: DropdownOption;
-  highlighted?: boolean;
-  selected?: boolean;
+import { ItemProps } from './item';
+interface MultiselectItemProps extends ItemProps {
   indeterminate?: boolean;
-  filteringValue?: string;
-  hasCheckbox?: boolean;
-  virtualPosition?: number;
-  padBottom?: boolean;
-  isNextSelected?: boolean;
-  screenReaderContent?: string;
-  ariaPosinset?: number;
-  ariaSetsize?: number;
-  highlightType?: HighlightType;
 }
 
 const MultiSelectItem = (
@@ -41,7 +29,7 @@ const MultiSelectItem = (
     ariaSetsize,
     highlightType,
     ...restProps
-  }: ItemProps,
+  }: MultiselectItemProps,
   ref: React.Ref<HTMLDivElement>
 ) => {
   const baseProps = getBaseProps(restProps);
@@ -63,7 +51,7 @@ const MultiSelectItem = (
       disabled={disabled}
       isParent={isParent}
       isChild={isChild}
-      highlightType={highlightType?.type}
+      highlightType={highlightType}
       ref={ref}
       virtualPosition={virtualPosition}
       padBottom={padBottom}


### PR DESCRIPTION
### Description

Before this change, when rendering the dropdown options in src/select/utils/render-options.tsx `highlightType` allowed to pass either `HighlightType` or `HighlightType['type']`. When rendering the Multiselect component, `HighlightType` was set while other components set the HighlightType['type'].

As part of this PR I de-duplicated the item prop interface of `ItemProps` and `MultiselectItem` to make the type checking more strict and highlight such issues.

Before:

https://github.com/cloudscape-design/components/assets/569011/961e882b-dbe2-42eb-8a80-37f113a4eba8

After:


https://github.com/cloudscape-design/components/assets/569011/91bbf8f8-d43b-4ec8-bb90-a4c2c82e443c


Related links, issue #, if available: AWSUI-24820

### How has this been tested?

- Manually tested in supported browsers.
 - Open the Select and Multiselect demo pages
  - Open the Dropdown of the elements and hover one of the options
  - Now use the arrow keys to move the selected option in the list - the border color of the expected option gets blue instead of gray.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
