### PR TITLE
chore: Use consistent aria label descriptions for API docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10202,7 +10202,7 @@ Note: Using popover rendered with portal within a Modal is not supported.
       "type": "string",
     },
     Object {
-      "description": "Adds an aria-label to the text trigger button. Use this to provide an accessible name for triggers
+      "description": "Adds \`aria-label\` to the text trigger button. Use this to provide an accessible name for triggers
 that don't have visible text, and to distinguish between multiple triggers with identical visible text.",
       "name": "triggerAriaLabel",
       "optional": true,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2967,8 +2967,9 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
       "type": "boolean",
     },
     Object {
-      "description": "Adds \`aria-label\` to the button element. It should be used in buttons that don't have text in order to make
-them accessible. The text will also be added to the \`title\` attribute of the button.",
+      "description": "Adds \`aria-label\` to the button element. Use this to provide an accessible name for buttons
+that don't have visible text, and to distinguish between multiple buttons with identical visible text.
+The text will also be added to the \`title\` attribute of the button.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -3350,7 +3351,7 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the item has an \`href\` se
   "properties": Array [
     Object {
       "description": "Adds \`aria-label\` to the button dropdown trigger.
-It should be used in buttons that don't have text in order to make them accessible.",
+Use this to provide an accessible name for buttons that don't have visible text.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -9150,7 +9151,8 @@ and set the property to a string of each ID separated by spaces (for example, \`
       "type": "string",
     },
     Object {
-      "description": "Adds \`aria-label\` to the select element.",
+      "description": "Adds \`aria-label\` to the select element.
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",
@@ -10200,7 +10202,8 @@ Note: Using popover rendered with portal within a Modal is not supported.
       "type": "string",
     },
     Object {
-      "description": "Adds an aria-label to the text trigger button.",
+      "description": "Adds an aria-label to the text trigger button. Use this to provide an accessible name for triggers
+that don't have visible text, and to distinguish between multiple triggers with identical visible text.",
       "name": "triggerAriaLabel",
       "optional": true,
       "type": "string",
@@ -11731,7 +11734,8 @@ and set the property to a string of each ID separated by spaces (for example, \`
       "type": "string",
     },
     Object {
-      "description": "Adds \`aria-label\` to the select element.",
+      "description": "Adds \`aria-label\` to the select element.
+Use this if you don't have a visible label for this control.",
       "name": "ariaLabel",
       "optional": true,
       "type": "string",

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -69,7 +69,7 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
   expandableGroups?: boolean;
   /**
    * Adds `aria-label` to the button dropdown trigger.
-   * It should be used in buttons that don't have text in order to make them accessible.
+   * Use this to provide an accessible name for buttons that don't have visible text.
    */
   ariaLabel?: string;
   /**

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -66,8 +66,9 @@ export interface ButtonProps extends BaseComponentProps {
   formAction?: ButtonProps.FormAction;
 
   /**
-   * Adds `aria-label` to the button element. It should be used in buttons that don't have text in order to make
-   * them accessible. The text will also be added to the `title` attribute of the button.
+   * Adds `aria-label` to the button element. Use this to provide an accessible name for buttons
+   * that don't have visible text, and to distinguish between multiple buttons with identical visible text.
+   * The text will also be added to the `title` attribute of the button.
    */
   ariaLabel?: string;
 

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -29,7 +29,8 @@ export interface PopoverProps extends BaseComponentProps {
   triggerType?: PopoverProps.TriggerType;
 
   /**
-   * Adds an aria-label to the text trigger button.
+   * Adds an aria-label to the text trigger button. Use this to provide an accessible name for triggers
+   * that don't have visible text, and to distinguish between multiple triggers with identical visible text.
    */
   triggerAriaLabel?: string;
 

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -29,7 +29,7 @@ export interface PopoverProps extends BaseComponentProps {
   triggerType?: PopoverProps.TriggerType;
 
   /**
-   * Adds an aria-label to the text trigger button. Use this to provide an accessible name for triggers
+   * Adds `aria-label` to the text trigger button. Use this to provide an accessible name for triggers
    * that don't have visible text, and to distinguish between multiple triggers with identical visible text.
    */
   triggerAriaLabel?: string;

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -107,6 +107,7 @@ export interface BaseSelectProps
   ariaRequired?: boolean;
   /**
    * Adds `aria-label` to the select element.
+   * Use this if you don't have a visible label for this control.
    */
   ariaLabel?: string;
   /**


### PR DESCRIPTION
### Description

Updated descriptions for aria label properties assigned to controls to be better consistent and better inline with our guidelines.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
