### PR TITLE
fix: Dispatch create edit flow event to top window

### DIFF
--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -57,15 +57,22 @@ export const AnalyticsFunnel = (props: AnalyticsFunnelProps) => {
   return <InnerAnalyticsFunnel {...props} />;
 };
 export const CREATION_EDIT_FLOW_DONE_EVENT_NAME = 'awsui-creation-edit-flow-done';
+const dispatchCreateEditFlowDoneEvent = () => {
+  try {
+    window.top?.document.dispatchEvent(new Event(CREATION_EDIT_FLOW_DONE_EVENT_NAME));
+  } catch {
+    // probably because of cross-origin error, then do not dispatch the event
+  }
+};
 
 const onFunnelCancelled = ({ funnelInteractionId }: { funnelInteractionId: string }) => {
   FunnelMetrics.funnelCancelled({ funnelInteractionId });
-  document.dispatchEvent(new Event(CREATION_EDIT_FLOW_DONE_EVENT_NAME));
+  dispatchCreateEditFlowDoneEvent();
 };
 
 const onFunnelComplete = ({ funnelInteractionId }: { funnelInteractionId: string }) => {
   FunnelMetrics.funnelComplete({ funnelInteractionId });
-  document.dispatchEvent(new Event(CREATION_EDIT_FLOW_DONE_EVENT_NAME));
+  dispatchCreateEditFlowDoneEvent();
 };
 
 function evaluateSelectors(selectors: string[], defaultSelector: string) {


### PR DESCRIPTION
### Description

dispatch the event to the top window, because the listener is attached to top window. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
