### PR TITLE
fix: Scroll child element makes table unexpectedly scroll

### DIFF
--- a/src/internal/hooks/use-scroll-sync/__tests__/use-scroll-sync.test.tsx
+++ b/src/internal/hooks/use-scroll-sync/__tests__/use-scroll-sync.test.tsx
@@ -15,7 +15,9 @@ function Demo() {
 
   return (
     <>
-      <div data-testid="element1" ref={ref1} onScroll={handleScroll} />
+      <div data-testid="element1" ref={ref1} onScroll={handleScroll}>
+        <div data-testid="element3" />
+      </div>
       <div data-testid="element2" ref={ref2} onScroll={handleScroll} />
     </>
   );
@@ -23,7 +25,7 @@ function Demo() {
 
 function scroll(panel: any, scrollLeft: number) {
   act(() => {
-    Object.defineProperty(panel, 'scrollLeft', { value: scrollLeft });
+    Object.defineProperty(panel, 'scrollLeft', { value: scrollLeft, writable: true });
     panel.dispatchEvent(new Event('scroll'));
   });
 }
@@ -49,5 +51,13 @@ describe('Sync scroll util', function () {
     scroll(getByTestId('element2'), 10);
     await timeout();
     expect(getByTestId('element1').scrollLeft).toEqual(10);
+  });
+  it('scroll child element should not affect synced element', async () => {
+    const { getByTestId } = render(<Demo />);
+    scroll(getByTestId('element1'), 30);
+    await timeout();
+    scroll(getByTestId('element3'), 10);
+    await timeout();
+    expect(getByTestId('element1').scrollLeft).toEqual(30);
   });
 });

--- a/src/internal/hooks/use-scroll-sync/index.ts
+++ b/src/internal/hooks/use-scroll-sync/index.ts
@@ -14,7 +14,7 @@ import { supportsStickyPosition } from '../../utils/dom';
 export function useScrollSync(refs: Array<RefObject<any>>, disabled = !supportsStickyPosition()) {
   const activeElement = useRef<HTMLElement | null>(null);
   const onScroll = (event: React.UIEvent) => {
-    const targetElement = event.target as HTMLElement;
+    const targetElement = event.currentTarget as HTMLElement;
     // remembers the first element that fires onscroll to align with other elements against it
     if (targetElement && (activeElement.current === null || activeElement.current === targetElement)) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
### Description

When render a Select in the horizontally scrollable Table, and the Select is vertically scrollable. When scrolling the Select, Table scroll to the left unexpectedly (see screen recording in the ticket). 
It is because the scroll event in the Select Portal is propagated to the Table. 
Using `event.target` takes the scrollLeft of the Dropdown in the Select(which is 0) and assign to Table scrollLeft. It causes the issue. 
The change uses `currentTarget`, which is the element where the event is attached to, in this case should be the Table itself, to calculate the scrollLeft.

Related links, issue #AWSUI-24387

### How has this been tested?

<!-- How did you test to verify your changes? --> Added unit test, also tested manually with the table. 

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
