### PR TITLE
refactor: Replace records having numeric keys with maps, part 1

### DIFF
--- a/src/column-layout/grid-column-layout.tsx
+++ b/src/column-layout/grid-column-layout.tsx
@@ -11,12 +11,12 @@ import { InternalColumnLayoutProps } from './interfaces';
 import { COLUMN_TRIGGERS, ColumnLayoutBreakpoint } from './internal';
 import styles from './styles.css.js';
 
-const COLUMN_DEFS: Record<number, GridProps.ElementDefinition | undefined> = {
-  1: { colspan: { default: 12, xxs: 12, xs: 12 } },
-  2: { colspan: { default: 12, xxs: 6, xs: 6 } },
-  3: { colspan: { default: 12, xxs: 6, xs: 4 } },
-  4: { colspan: { default: 12, xxs: 6, xs: 3 } },
-};
+const COLUMN_DEFS = new Map<number, GridProps.ElementDefinition>([
+  [1, { colspan: { default: 12, xxs: 12, xs: 12 } }],
+  [2, { colspan: { default: 12, xxs: 6, xs: 6 } }],
+  [3, { colspan: { default: 12, xxs: 6, xs: 4 } }],
+  [4, { colspan: { default: 12, xxs: 6, xs: 3 } }],
+]);
 
 interface GridColumnLayoutProps
   extends Required<Pick<InternalColumnLayoutProps, 'columns' | 'variant' | 'borders' | 'disableGutters'>> {
@@ -46,7 +46,7 @@ export default function GridColumnLayout({
     <InternalGrid
       ref={ref}
       disableGutters={true}
-      gridDefinition={repeat(COLUMN_DEFS[columns] ?? {}, flattenedChildren.length)}
+      gridDefinition={repeat(COLUMN_DEFS.get(columns) ?? {}, flattenedChildren.length)}
       className={clsx(styles.grid, styles[`grid-columns-${columns}`], styles[`grid-variant-${variant}`], {
         [styles['grid-horizontal-borders']]: shouldHaveHorizontalBorders,
         [styles['grid-vertical-borders']]: shouldHaveVerticalBorders,

--- a/src/flashbar/collapsible-flashbar.tsx
+++ b/src/flashbar/collapsible-flashbar.tsx
@@ -64,9 +64,9 @@ export default function CollapsibleFlashbar({ items, ...restProps }: FlashbarPro
     },
   });
 
-  const collapsedItemRefs = useRef<Record<string | number, HTMLElement | null>>({});
-  const expandedItemRefs = useRef<Record<string | number, HTMLElement | null>>({});
-  const [initialAnimationState, setInitialAnimationState] = useState<Record<string | number, DOMRect> | null>(null);
+  const collapsedItemRefs = useRef<Record<string, HTMLElement | null>>({});
+  const expandedItemRefs = useRef<Record<string, HTMLElement | null>>({});
+  const [initialAnimationState, setInitialAnimationState] = useState<Record<string, DOMRect> | null>(null);
   const listElementRef = useRef<HTMLUListElement | null>(null);
   const notificationBarRef = useRef<HTMLDivElement | null>(null);
   const [transitioning, setTransitioning] = useState(false);

--- a/src/internal/animate.ts
+++ b/src/internal/animate.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export function getDOMRects(elements: Record<string | number, HTMLElement | null>) {
+export function getDOMRects(elements: Record<string, HTMLElement | null>) {
   const rects: Record<string, DOMRect> = {};
   for (const id in elements) {
     const element = elements[id];
@@ -29,8 +29,8 @@ export function animate({
   onTransitionsEnd,
   newElementInitialState,
 }: {
-  elements: Record<string | number, HTMLElement | null>;
-  oldState: Record<string | number, DOMRect>;
+  elements: Record<string, HTMLElement | null>;
+  oldState: Record<string, DOMRect>;
   onTransitionsEnd?: () => void;
   newElementInitialState?: (newRect: DOMRect) => { scale?: number; y?: number };
 }) {

--- a/src/mixed-line-bar-chart/__tests__/utils.test.ts
+++ b/src/mixed-line-bar-chart/__tests__/utils.test.ts
@@ -52,9 +52,25 @@ describe('calculateOffsetMaps', () => {
     const actual = calculateOffsetMaps(data);
 
     expect(actual).toEqual([
-      { positiveOffsets: {}, negativeOffsets: {} },
-      { positiveOffsets: { Potatoes: 77, Chocolate: 546, Apples: 52, Oranges: 47 }, negativeOffsets: {} },
-      { positiveOffsets: { Potatoes: 87, Chocolate: 566, Apples: 52, Oranges: 97 }, negativeOffsets: {} },
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
+      {
+        positiveOffsets: new Map([
+          ['Potatoes', 77],
+          ['Chocolate', 546],
+          ['Apples', 52],
+          ['Oranges', 47],
+        ]),
+        negativeOffsets: new Map(),
+      },
+      {
+        positiveOffsets: new Map([
+          ['Potatoes', 87],
+          ['Chocolate', 566],
+          ['Apples', 52],
+          ['Oranges', 97],
+        ]),
+        negativeOffsets: new Map(),
+      },
     ]);
   });
 
@@ -65,14 +81,14 @@ describe('calculateOffsetMaps', () => {
     const actual = calculateOffsetMaps(data);
 
     expect(actual).toEqual([
-      { positiveOffsets: {}, negativeOffsets: {} },
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
       {
-        positiveOffsets: { [date.getTime()]: 1 },
-        negativeOffsets: {},
+        positiveOffsets: new Map([[date.getTime(), 1]]),
+        negativeOffsets: new Map(),
       },
       {
-        positiveOffsets: { [date.getTime()]: 3 },
-        negativeOffsets: {},
+        positiveOffsets: new Map([[date.getTime(), 3]]),
+        negativeOffsets: new Map(),
       },
     ]);
   });
@@ -83,14 +99,14 @@ describe('calculateOffsetMaps', () => {
     const actual = calculateOffsetMaps(data);
 
     expect(actual).toEqual([
-      { positiveOffsets: {}, negativeOffsets: {} },
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
       {
-        positiveOffsets: { 1: 1 },
-        negativeOffsets: {},
+        positiveOffsets: new Map([[1, 1]]),
+        negativeOffsets: new Map(),
       },
       {
-        positiveOffsets: { 1: 3 },
-        negativeOffsets: {},
+        positiveOffsets: new Map([[1, 3]]),
+        negativeOffsets: new Map(),
       },
     ]);
   });
@@ -117,14 +133,24 @@ describe('calculateOffsetMaps', () => {
     const actual = calculateOffsetMaps(data);
 
     expect(actual).toEqual([
-      { positiveOffsets: {}, negativeOffsets: {} },
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
       {
-        positiveOffsets: { 2: 3 },
-        negativeOffsets: { 1: -1, 3: -4 },
+        positiveOffsets: new Map([[2, 3]]),
+        negativeOffsets: new Map([
+          [1, -1],
+          [3, -4],
+        ]),
       },
       {
-        positiveOffsets: { 1: 2, 2: 3 },
-        negativeOffsets: { 1: -1, 2: -3, 3: -8 },
+        positiveOffsets: new Map([
+          [1, 2],
+          [2, 3],
+        ]),
+        negativeOffsets: new Map([
+          [1, -1],
+          [2, -3],
+          [3, -8],
+        ]),
       },
     ]);
   });

--- a/src/mixed-line-bar-chart/bar-series.tsx
+++ b/src/mixed-line-bar-chart/bar-series.tsx
@@ -81,7 +81,7 @@ export default function BarSeries<T extends ChartDataTypes>({
       if (stackedBarOffsets) {
         // Stacked bars
         const offsetMap = d.y < 0 ? stackedBarOffsets.negativeOffsets : stackedBarOffsets.positiveOffsets;
-        yValue = d.y + (offsetMap[getKeyValue(d.x)] || 0);
+        yValue = d.y + (offsetMap.get(getKeyValue(d.x)) || 0);
       } else if (totalSeriesCount > 1) {
         // Regular grouped bars
         barX += seriesIndex * (barWidth + PADDING);

--- a/src/mixed-line-bar-chart/utils.ts
+++ b/src/mixed-line-bar-chart/utils.ts
@@ -67,7 +67,7 @@ export const matchesX = <T>(x1: T, x2: T) => {
   return x1 === x2;
 };
 
-export type OffsetMap = Record<string | number, number>;
+export type OffsetMap = Map<string | number, number>;
 
 export interface StackedOffsets {
   positiveOffsets: OffsetMap;
@@ -83,21 +83,21 @@ export function calculateOffsetMaps(
   return data.reduce((acc, curr, idx) => {
     // First series receives empty offsets map
     if (idx === 0) {
-      acc.push({ positiveOffsets: {}, negativeOffsets: {} });
+      acc.push({ positiveOffsets: new Map(), negativeOffsets: new Map() });
     }
     const lastMap = acc[idx];
     const map: StackedOffsets = lastMap
-      ? { positiveOffsets: { ...lastMap.positiveOffsets }, negativeOffsets: { ...lastMap.negativeOffsets } }
-      : { positiveOffsets: {}, negativeOffsets: {} };
+      ? { positiveOffsets: new Map(lastMap.positiveOffsets), negativeOffsets: new Map(lastMap.negativeOffsets) }
+      : { positiveOffsets: new Map(), negativeOffsets: new Map() };
 
     curr.forEach(({ x, y }) => {
       const key = getKeyValue(x);
       if (y < 0) {
-        const lastValue = lastMap?.negativeOffsets[key] || 0;
-        map.negativeOffsets[key] = lastValue + y;
+        const lastValue = lastMap?.negativeOffsets.get(key) || 0;
+        map.negativeOffsets.set(key, lastValue + y);
       } else {
-        const lastValue = lastMap?.positiveOffsets[key] || 0;
-        map.positiveOffsets[key] = lastValue + y;
+        const lastValue = lastMap?.positiveOffsets.get(key) || 0;
+        map.positiveOffsets.set(key, lastValue + y);
       }
     });
 

--- a/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
+++ b/src/table/sticky-columns/__tests__/use-sticky-columns.test.tsx
@@ -58,8 +58,8 @@ test('wrapper styles is not empty and wrapper listener is attached when feature 
 });
 
 test('styles update when sticky column properties change', () => {
-  const emptyVisibleColumns = new Array<string>();
-  const allVisibleColumns = ['1', '2', '3'];
+  const emptyVisibleColumns = new Array<PropertyKey>();
+  const allVisibleColumns = [1, 2, 3];
   const { result, rerender } = renderHook(useStickyColumns, {
     initialProps: { visibleColumns: emptyVisibleColumns, stickyColumnsFirst: 0, stickyColumnsLast: 0 },
   });
@@ -100,7 +100,7 @@ test('styles update when wrapper scrolls', () => {
 
 test('generates non-empty sticky cell state', () => {
   const { result, rerender } = renderHook(() =>
-    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+    useStickyColumns({ visibleColumns: [1, 2, 3], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
   );
   createMockTable(result.current, 300, 500, 100, 200, 300);
 
@@ -108,23 +108,24 @@ test('generates non-empty sticky cell state', () => {
   rerender({});
 
   expect(result.current.store.get()).toEqual({
-    cellState: {
-      1: {
-        lastLeft: false,
-        lastRight: false,
-        padLeft: false,
-        offset: { left: 0 },
-      },
-      2: null,
-      3: null,
-    },
+    cellState: new Map([
+      [
+        1,
+        {
+          lastLeft: false,
+          lastRight: false,
+          padLeft: false,
+          offset: { left: 0 },
+        },
+      ],
+    ]),
     wrapperState: { scrollPaddingLeft: 100, scrollPaddingRight: 0 },
   });
 });
 
 test('generates empty cell state if wrapper is not scrollable', () => {
   const { result, rerender } = renderHook(() =>
-    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+    useStickyColumns({ visibleColumns: [1, 2, 3], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
   );
   createMockTable(result.current, 500, 500, 100, 200, 300);
 
@@ -132,18 +133,14 @@ test('generates empty cell state if wrapper is not scrollable', () => {
   rerender({});
 
   expect(result.current.store.get()).toEqual({
-    cellState: {
-      1: null,
-      2: null,
-      3: null,
-    },
+    cellState: new Map(),
     wrapperState: { scrollPaddingLeft: 100, scrollPaddingRight: 0 },
   });
 });
 
 test('generates empty sticky cell state if not enough scrollable space', () => {
   const { result, rerender } = renderHook(() =>
-    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+    useStickyColumns({ visibleColumns: [1, 2, 3], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
   );
   createMockTable(result.current, 300, 500, 200, 300, 100);
 
@@ -151,24 +148,20 @@ test('generates empty sticky cell state if not enough scrollable space', () => {
   rerender({});
 
   expect(result.current.store.get()).toEqual({
-    cellState: {
-      1: null,
-      2: null,
-      3: null,
-    },
+    cellState: new Map(),
     wrapperState: { scrollPaddingLeft: 200, scrollPaddingRight: 0 },
   });
 });
 
 test('generates non-empty styles for sticky cells', () => {
   const { result, rerender } = renderHook(() =>
-    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 0, stickyColumnsLast: 1 })
+    useStickyColumns({ visibleColumns: [1, 2, 3], stickyColumnsFirst: 0, stickyColumnsLast: 1 })
   );
   createMockTable(result.current, 300, 500, 300, 200, 100);
 
   const getClassName = jest.fn().mockImplementation(() => ({ 'sticky-cell': true }));
   const { result: cellStylesResult, rerender: rerenderCellStyles } = renderHook(() =>
-    useStickyCellStyles({ stickyColumns: result.current, columnId: '3', getClassName })
+    useStickyCellStyles({ stickyColumns: result.current, columnId: 3, getClassName })
   );
 
   // Wait for effect
@@ -187,13 +180,13 @@ test('generates non-empty styles for sticky cells', () => {
 
 test('updates sticky cell styles', () => {
   const { result, rerender } = renderHook(() =>
-    useStickyColumns({ visibleColumns: ['1', '2', '3'], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
+    useStickyColumns({ visibleColumns: [1, 2, 3], stickyColumnsFirst: 1, stickyColumnsLast: 0 })
   );
   const elements = createMockTable(result.current, 300, 500, 100, 200, 300);
 
   const getClassName = jest.fn().mockImplementation(() => ({ 'sticky-cell': true }));
   const { result: cellStylesResult, rerender: rerenderCellStyles } = renderHook(() =>
-    useStickyCellStyles({ stickyColumns: result.current, columnId: '1', getClassName })
+    useStickyCellStyles({ stickyColumns: result.current, columnId: 1, getClassName })
   );
   cellStylesResult.current.ref(elements.cells[0]);
 
@@ -220,7 +213,7 @@ test('updates sticky cell styles', () => {
 });
 
 test('performs styles cleanup', () => {
-  const visibleColumns = ['1', '2', '3'];
+  const visibleColumns = [1, 2, 3];
   const { result, rerender } = renderHook(useStickyColumns, {
     initialProps: { visibleColumns, stickyColumnsFirst: 1, stickyColumnsLast: 0 },
   });
@@ -228,7 +221,7 @@ test('performs styles cleanup', () => {
 
   const getClassName = jest.fn().mockImplementation(state => ({ 'sticky-cell': !!state }));
   const { result: cellStylesResult } = renderHook(() =>
-    useStickyCellStyles({ stickyColumns: result.current, columnId: '1', getClassName })
+    useStickyCellStyles({ stickyColumns: result.current, columnId: 1, getClassName })
   );
   cellStylesResult.current.ref(elements.cells[0]);
 
@@ -247,14 +240,14 @@ test('cell subscriptions are cleaned up on ref change', () => {
   const subscribe = jest.fn(() => unsubscribe);
   const stickyColumns = {
     store: {
-      get: () => ({ cellState: {}, wrapperState: { scrollPaddingLeft: 0, scrollPaddingRight: 0 } }),
+      get: () => ({ cellState: new Map(), wrapperState: { scrollPaddingLeft: 0, scrollPaddingRight: 0 } }),
       subscribe,
       unsubscribe: () => {},
     },
     style: { wrapper: {} },
     refs: { table: () => {}, wrapper: () => {}, cell: () => {} },
   };
-  const { result } = renderHook(() => useStickyCellStyles({ stickyColumns, columnId: '1', getClassName: () => ({}) }));
+  const { result } = renderHook(() => useStickyCellStyles({ stickyColumns, columnId: 1, getClassName: () => ({}) }));
 
   result.current.ref(document.createElement('td'));
 
@@ -324,10 +317,11 @@ describe('getStickyClassNames helper', () => {
 });
 
 test('updateCellOffsets element widths fallback to 0 when elements are missing', () => {
-  const { offsets } = updateCellOffsets(
-    {},
-    { stickyColumnsFirst: 1, stickyColumnsLast: 1, visibleColumns: ['a', 'b', 'c'] }
-  );
+  const { offsets } = updateCellOffsets(new Map(), {
+    stickyColumnsFirst: 1,
+    stickyColumnsLast: 1,
+    visibleColumns: ['a', 'b', 'c'],
+  });
   expect(offsets.get('a')).toEqual({ first: 0, last: 0 });
   expect(offsets.get('c')).toEqual({ first: 0, last: 0 });
 });

--- a/src/table/sticky-columns/interfaces.ts
+++ b/src/table/sticky-columns/interfaces.ts
@@ -8,7 +8,7 @@ export interface StickyColumnsProps {
 }
 
 export interface StickyColumnsState {
-  cellState: Record<PropertyKey, null | StickyColumnsCellState>;
+  cellState: Map<PropertyKey, StickyColumnsCellState>;
   wrapperState: StickyColumnsWrapperState;
 }
 

--- a/src/table/sticky-columns/utils.ts
+++ b/src/table/sticky-columns/utils.ts
@@ -20,19 +20,19 @@ export function isWrapperStatesEqual(s1: StickyColumnsWrapperState, s2: StickyCo
   return s1.scrollPaddingLeft === s2.scrollPaddingLeft && s1.scrollPaddingRight === s2.scrollPaddingRight;
 }
 
-export function updateCellOffsets(cells: Record<PropertyKey, HTMLElement>, props: StickyColumnsProps): CellOffsets {
+export function updateCellOffsets(cells: Map<PropertyKey, HTMLElement>, props: StickyColumnsProps): CellOffsets {
   const totalColumns = props.visibleColumns.length;
 
   const firstColumnsWidths: number[] = [];
   for (let i = 0; i < Math.min(totalColumns, props.stickyColumnsFirst); i++) {
-    const element = cells[props.visibleColumns[i]];
+    const element = cells.get(props.visibleColumns[i]);
     const cellWidth = element?.getBoundingClientRect().width ?? 0;
     firstColumnsWidths[i] = (firstColumnsWidths[i - 1] ?? 0) + cellWidth;
   }
 
   const lastColumnsWidths: number[] = [];
   for (let i = 0; i < Math.min(totalColumns, props.stickyColumnsLast); i++) {
-    const element = cells[props.visibleColumns[totalColumns - 1 - i]];
+    const element = cells.get(props.visibleColumns[totalColumns - 1 - i]);
     const cellWidth = element?.getBoundingClientRect().width ?? 0;
     lastColumnsWidths[i] = (lastColumnsWidths[i - 1] ?? 0) + cellWidth;
   }


### PR DESCRIPTION
### Description

The refactoring is made to prevent issues similar to one occurred recently in table resizable columns: https://github.com/cloudscape-design/components/pull/1745#discussion_r1398860225

The PR covers part of the codebase, related PRs: https://github.com/cloudscape-design/components/pull/1806, https://github.com/cloudscape-design/components/pull/1807, https://github.com/cloudscape-design/components/pull/1808.

### How has this been tested?

Existing tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
