### PR TITLE
revert: migrate "A/B/C/D/E/F" components to logical properties

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -51,12 +51,9 @@
   },
   "overrides": [
     {
-      "files": [
-        "./src/a*/*.scss",
-        "./src/button/*.scss"
-      ],
+      "files": ["./src/button/*.scss"],
       "rules": {
-        "property-disallowed-list": ["border-radius", "border-style", "border-width", "margin", "padding"],
+        "property-disallowed-list": ["border", "border-radius", "border-style", "margin", "padding"],
         "csstools/use-logical": "always"
       }
     }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -53,12 +53,7 @@
     {
       "files": [
         "./src/a*/*.scss",
-        "./src/b*/*.scss",
-        "./src/c*/*.scss",
-        "./src/d*/*.scss",
-        "./src/e*/*.scss",
-        "./src/f*/*.scss"
-
+        "./src/button/*.scss"
       ],
       "rules": {
         "property-disallowed-list": ["border-radius", "border-style", "border-width", "margin", "padding"],

--- a/src/alert/styles.scss
+++ b/src/alert/styles.scss
@@ -25,13 +25,9 @@
   position: relative;
   display: grid;
   grid-template-columns: 1fr;
+  border-radius: awsui.$border-radius-alert;
   border: awsui.$border-field-width solid;
-  border-start-start-radius: awsui.$border-radius-alert;
-  border-start-end-radius: awsui.$border-radius-alert;
-  border-end-start-radius: awsui.$border-radius-alert;
-  border-end-end-radius: awsui.$border-radius-alert;
-  padding-block: awsui.$space-alert-vertical;
-  padding-inline: awsui.$space-alert-horizontal;
+  padding: awsui.$space-alert-vertical awsui.$space-alert-horizontal;
   background-color: awsui.$color-background-container-content;
 
   &.with-dismiss,
@@ -56,7 +52,7 @@
 
 .action {
   white-space: nowrap;
-  margin-inline-start: awsui.$space-alert-action-left;
+  margin-left: awsui.$space-alert-action-left;
 }
 
 .action-slot,
@@ -77,17 +73,14 @@
 }
 
 .text {
-  min-inline-size: 0;
-  // To account for vertical misalignment due to button borders
-  padding-block: awsui.$border-field-width;
-  padding-inline: 0;
-  margin-block: awsui.$space-scaled-xxs;
-  margin-inline: awsui.$space-xxs;
+  min-width: 0;
+  padding: awsui.$border-field-width 0; // To account for vertical misalignment due to button borders
+  margin: awsui.$space-scaled-xxs awsui.$space-xxs;
   &.icon {
-    margin-inline-start: 0;
+    margin-left: 0;
   }
   &.message {
-    margin-inline-end: awsui.$space-alert-message-right;
+    margin-right: awsui.$space-alert-message-right;
   }
 }
 
@@ -95,18 +88,18 @@
   // Below the breakpoint, arrange actions below the content
   > .action {
     grid-row: 2;
-    margin-block-end: awsui.$space-xxs;
+    margin-bottom: awsui.$space-xxs;
   }
 
   // Indent actions according to the size of the alert icon
   &.icon-size-medium > .action {
-    margin-inline-start: calc(#{awsui.$size-icon-medium} + #{awsui.$space-xs});
+    margin-left: calc(#{awsui.$size-icon-medium} + #{awsui.$space-xs});
   }
   &.icon-size-big > .action {
-    margin-inline-start: calc(#{awsui.$size-icon-big} + #{awsui.$space-xs});
+    margin-left: calc(#{awsui.$size-icon-big} + #{awsui.$space-xs});
   }
   &.icon-size-normal > .action {
-    margin-inline-start: calc(#{awsui.$size-icon-normal} + #{awsui.$space-xs});
+    margin-left: calc(#{awsui.$size-icon-normal} + #{awsui.$space-xs});
   }
 }
 
@@ -115,8 +108,8 @@
 }
 
 .dismiss {
-  margin-inline-end: calc(-1 * #{awsui.$space-xxs});
-  margin-inline-start: awsui.$space-s;
+  margin-right: calc(-1 * #{awsui.$space-xxs});
+  margin-left: awsui.$space-s;
 }
 
 .dismiss-button {

--- a/src/anchor-navigation/styles.scss
+++ b/src/anchor-navigation/styles.scss
@@ -16,25 +16,20 @@ $guide-line-offset: -2px; // Negative to expand 2px beyond the element
 
 .anchor-list {
   list-style: none;
-  margin-block: 0;
-  margin-inline: 0;
-  padding-block: 0;
-  padding-inline: 0;
+  margin: 0;
+  padding: 0;
   position: relative;
   text-indent: 0;
 
   &::before {
     content: '';
     background-color: awsui.$color-border-divider-default;
-    border-start-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-start-end-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-end-radius: awsui.$border-radius-tabs-focus-ring;
-    inset-block-end: $guide-line-offset;
+    border-radius: awsui.$border-radius-tabs-focus-ring;
+    bottom: $guide-line-offset;
     pointer-events: none;
     position: absolute;
-    inset-block-start: $guide-line-offset;
-    inline-size: $guide-line-width;
+    top: $guide-line-offset;
+    width: $guide-line-width;
   }
 }
 
@@ -47,8 +42,7 @@ $guide-line-offset: -2px; // Negative to expand 2px beyond the element
 
   color: awsui.$color-text-body-secondary;
   font-weight: styles.$font-weight-normal;
-  margin-block: awsui.$space-scaled-xxs;
-  margin-inline: 0;
+  margin: awsui.$space-scaled-xxs 0;
 
   &--active {
     position: relative;
@@ -56,15 +50,12 @@ $guide-line-offset: -2px; // Negative to expand 2px beyond the element
     &::before {
       content: '';
       background-color: awsui.$color-text-accent;
-      border-start-start-radius: awsui.$border-radius-tabs-focus-ring;
-      border-start-end-radius: awsui.$border-radius-tabs-focus-ring;
-      border-end-start-radius: awsui.$border-radius-tabs-focus-ring;
-      border-end-end-radius: awsui.$border-radius-tabs-focus-ring;
-      inset-block-end: $guide-line-offset;
+      border-radius: awsui.$border-radius-tabs-focus-ring;
+      bottom: $guide-line-offset;
       pointer-events: none;
       position: absolute;
-      inset-block-start: $guide-line-offset;
-      inline-size: $guide-line-width;
+      top: $guide-line-offset;
+      width: $guide-line-width;
     }
   }
 }
@@ -113,7 +104,7 @@ $guide-line-offset: -2px; // Negative to expand 2px beyond the element
 }
 
 .anchor-link-info {
-  margin-inline-start: awsui.$space-xs;
+  margin-left: awsui.$space-xs;
   @include styles.font-body-s;
   @include styles.font-smoothing;
   font-weight: awsui.$font-button-weight;

--- a/src/annotation-context/annotation/arrow.scss
+++ b/src/annotation-context/annotation/arrow.scss
@@ -26,33 +26,31 @@
   $arrow-width: 2 * styles.$base-size;
   $arrow-height: $arrow-width * 0.5;
 
-  inline-size: $arrow-width;
-  block-size: $arrow-height;
+  width: $arrow-width;
+  height: $arrow-height;
 
   &-outer,
   &-inner {
     position: absolute;
     overflow: hidden;
-    inline-size: $arrow-width;
-    block-size: $arrow-height;
+    width: $arrow-width;
+    height: $arrow-height;
 
-    inset-block-start: 0;
-    inset-inline-start: 0;
+    top: 0;
+    left: 0;
 
     &::after {
       content: '';
       box-sizing: border-box;
       display: inline-block;
       position: absolute;
-      border-start-start-radius: 2px;
-      border-start-end-radius: 0;
-      border-end-start-radius: 0;
-      border-end-end-radius: 0;
-      inset-block-end: 0;
-      inset-inline-start: 0;
+      border-radius: 2px 0 0 0;
 
-      inline-size: $arrow-edge-length;
-      block-size: $arrow-edge-length;
+      bottom: 0;
+      left: 0;
+
+      width: $arrow-edge-length;
+      height: $arrow-edge-length;
       transform: rotate(45deg);
       transform-origin: 0 100%;
     }
@@ -65,13 +63,10 @@
   }
 
   &-inner {
-    inset-block-start: 2px;
+    top: 2px;
 
     &::after {
-      border-start-start-radius: 1px;
-      border-start-end-radius: 0;
-      border-end-start-radius: 0;
-      border-end-end-radius: 0;
+      border-radius: 1px 0 0 0;
       background-color: awsui.$color-background-status-info;
     }
   }

--- a/src/annotation-context/annotation/styles.scss
+++ b/src/annotation-context/annotation/styles.scss
@@ -22,7 +22,7 @@
 
 .description {
   overflow: hidden;
-  margin-block-start: awsui.$space-xxs;
+  margin-top: awsui.$space-xxs;
 }
 
 .actionBar {
@@ -33,25 +33,24 @@
 }
 
 .stepCounter {
-  margin-inline-end: 2 * styles.$base-size;
+  margin-right: 2 * styles.$base-size;
 }
 
 .divider {
-  border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }
 
 .hotspot {
   @include styles.styles-reset;
   background: transparent;
   border: none;
-  padding-block: 0;
-  padding-inline: 0;
+  padding: 0;
   cursor: pointer;
   scroll-margin: var(#{custom-props.$contentScrollMargin}, 40px 0 0 0);
 
   // These dimensions match the dimensions of the contained SVG icon.
-  inline-size: 16px;
-  block-size: 16px;
+  width: 16px;
+  height: 16px;
 
   &:focus {
     outline: none;

--- a/src/app-layout/constants.scss
+++ b/src/app-layout/constants.scss
@@ -8,8 +8,9 @@
 
 // Toggle should have 40px width, whereas button is 26px wide.
 // 40 - 26 = 14px in total or 7px on each side
-$toggle-padding-horizontal: 0.7 * styles.$base-size;
-$toggle-padding-vertical: awsui.$space-xxs;
+$_toggle-padding-horizontal: 0.7 * styles.$base-size;
+$_toggle-padding-vertical: awsui.$space-xxs;
+$toggle-padding: $_toggle-padding-vertical $_toggle-padding-horizontal;
 
 $sidebar-size-closed: 4 * styles.$base-size;
 

--- a/src/app-layout/content-wrapper/styles.scss
+++ b/src/app-layout/content-wrapper/styles.scss
@@ -8,20 +8,20 @@
 @use '../constants' as constants;
 
 .content-wrapper {
-  padding-inline-start: awsui.$space-layout-content-horizontal;
-  padding-inline-end: awsui.$space-layout-content-horizontal;
+  padding-left: awsui.$space-layout-content-horizontal;
+  padding-right: awsui.$space-layout-content-horizontal;
   &-mobile {
-    padding-inline-start: awsui.$space-l;
-    padding-inline-end: awsui.$space-l;
+    padding-left: awsui.$space-l;
+    padding-right: awsui.$space-l;
   }
 }
 
 .content-type-dashboard {
-  margin-inline-start: auto;
-  margin-inline-end: auto;
+  margin-left: auto;
+  margin-right: auto;
   @each $breakpoint, $width in constants.$dashboard-content-widths {
     @include styles.media-breakpoint-up($breakpoint) {
-      max-inline-size: $width;
+      max-width: $width;
     }
   }
 }

--- a/src/app-layout/drawer/styles.scss
+++ b/src/app-layout/drawer/styles.scss
@@ -14,8 +14,7 @@ $drawer-z-index-mobile: 1001;
 
 .toggle {
   box-sizing: border-box;
-  padding-block: constants.$toggle-padding-vertical;
-  padding-inline: constants.$toggle-padding-horizontal;
+  padding: constants.$toggle-padding;
 }
 
 .drawer-triggers {
@@ -31,7 +30,7 @@ $drawer-z-index-mobile: 1001;
     z-index: $drawer-z-index;
   }
   &-closed {
-    min-inline-size: constants.$sidebar-size-closed;
+    min-width: constants.$sidebar-size-closed;
     &.drawer-mobile {
       display: none;
     }
@@ -43,10 +42,13 @@ $drawer-z-index-mobile: 1001;
   background-color: awsui.$color-background-layout-panel-content;
   .drawer-mobile > & {
     z-index: $drawer-z-index-mobile;
-    inset: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
   }
   .drawer-closed > & {
-    inline-size: constants.$sidebar-size-closed;
+    width: constants.$sidebar-size-closed;
     &.drawer-content-clickable {
       cursor: pointer;
       color: awsui.$color-text-interactive-default;
@@ -60,7 +62,7 @@ $drawer-z-index-mobile: 1001;
   }
   > .drawer-resize-content {
     overflow: auto;
-    block-size: 100%;
+    height: 100%;
     position: relative;
   }
 }
@@ -73,12 +75,11 @@ $drawer-z-index-mobile: 1001;
 }
 
 .drawer-trigger {
-  padding-block: constants.$toggle-padding-vertical;
-  padding-inline: constants.$toggle-padding-horizontal;
+  padding: constants.$toggle-padding;
   cursor: pointer;
   color: awsui.$color-text-interactive-default;
   &:not(:first-child) {
-    border-block-start: 1px solid awsui.$color-border-layout;
+    border-top: 1px solid awsui.$color-border-layout;
   }
   &:hover {
     color: awsui.$color-text-layout-toggle-hover;

--- a/src/app-layout/mobile-toolbar/styles.scss
+++ b/src/app-layout/mobile-toolbar/styles.scss
@@ -17,34 +17,33 @@
   align-items: center;
   flex-shrink: 0;
   z-index: 1000;
-  inline-size: 100%;
+  width: 100%;
   box-sizing: border-box;
   background-color: awsui.$color-background-layout-mobile-panel;
   box-shadow: awsui.$shadow-panel;
-  block-size: calc(2 * #{awsui.$space-m} + #{awsui.$space-scaled-xs});
+  height: calc(2 * #{awsui.$space-m} + #{awsui.$space-scaled-xs});
 }
 
 .mobile-bar-breadcrumbs {
-  min-inline-size: 0;
+  min-width: 0;
   flex: 1;
-  margin-inline-start: awsui.$space-m;
-  margin-inline-end: awsui.$space-m;
+  margin-left: awsui.$space-m;
+  margin-right: awsui.$space-m;
 }
 
 .mobile-toggle {
   box-sizing: border-box;
   cursor: pointer;
   z-index: 1;
-  padding-block: constants.$toggle-padding-vertical;
-  padding-inline: constants.$toggle-padding-horizontal;
-  inline-size: constants.$sidebar-size-closed;
+  padding: constants.$toggle-padding;
+  width: constants.$sidebar-size-closed;
   color: awsui.$color-text-interactive-default;
   &-type-navigation {
-    border-inline-end: 1px solid awsui.$color-border-layout;
+    border-right: 1px solid awsui.$color-border-layout;
   }
   &-type-tools,
   &-type-drawer {
-    border-inline-start: 1px solid awsui.$color-border-layout;
+    border-left: 1px solid awsui.$color-border-layout;
   }
   &:hover {
     background: awsui.$color-background-layout-panel-hover;

--- a/src/app-layout/notifications/styles.scss
+++ b/src/app-layout/notifications/styles.scss
@@ -17,7 +17,7 @@
 }
 
 .notifications-sticky {
-  inset-block-start: 0;
+  top: 0;
   position: sticky;
   #{custom-props.$flashbarStickyBottomMargin}: #{awsui.$space-xxl};
 }

--- a/src/app-layout/split-panel/styles.scss
+++ b/src/app-layout/split-panel/styles.scss
@@ -5,7 +5,7 @@
 @use '../constants' as constants;
 
 .drawer-displayed {
-  min-inline-size: constants.$sidebar-size-closed;
+  min-width: constants.$sidebar-size-closed;
 }
 
 .drawer-content {

--- a/src/app-layout/styles.scss
+++ b/src/app-layout/styles.scss
@@ -58,7 +58,7 @@
 
 .layout-main {
   flex: 1;
-  min-inline-size: 0;
+  min-width: 0;
   background-color: awsui.$color-background-layout-main;
   position: relative;
   &-scrollable {
@@ -73,24 +73,24 @@
 }
 
 .breadcrumbs-desktop {
-  padding-block-start: awsui.$space-scaled-m;
-  padding-block-end: awsui.$space-scaled-s;
+  padding-top: awsui.$space-scaled-m;
+  padding-bottom: awsui.$space-scaled-s;
 }
 
 .content-header-wrapper {
-  padding-block-end: awsui.$space-content-header-padding-bottom;
+  padding-bottom: awsui.$space-content-header-padding-bottom;
 }
 
 .content-wrapper {
-  padding-block-end: awsui.$space-layout-content-bottom;
+  padding-bottom: awsui.$space-layout-content-bottom;
 }
 
 .content-overlapped {
-  margin-block-start: calc(-1 * #{awsui.$space-dark-header-overlap-distance});
+  margin-top: calc(-1 * #{awsui.$space-dark-header-overlap-distance});
 }
 
 .content-extra-top-padding {
   // extra top padding when there are no breadcrumbs above,
   // applied to content or content header, whatever comes first
-  padding-block-start: awsui.$space-scaled-m;
+  padding-top: awsui.$space-scaled-m;
 }

--- a/src/app-layout/toggles/styles.scss
+++ b/src/app-layout/toggles/styles.scss
@@ -13,8 +13,7 @@
   // resemble button styles with an extra 1px offset for non-existing here border width
   $padding-vertical: calc(#{awsui.$space-scaled-xxs} + 1px);
   $padding-horizontal: calc(#{awsui.$space-xxs} + 1px);
-  padding-block: $padding-vertical;
-  padding-inline: $padding-horizontal;
+  padding: $padding-vertical $padding-horizontal;
   background: transparent;
   color: currentColor;
   &:focus {
@@ -29,7 +28,7 @@
 .close-button {
   position: absolute;
   outline: none;
-  inset-inline-end: awsui.$space-m;
-  inset-block-start: awsui.$size-vertical-panel-icon-offset;
+  right: awsui.$space-m;
+  top: awsui.$size-vertical-panel-icon-offset;
   z-index: 1;
 }

--- a/src/app-layout/visual-refresh/background.scss
+++ b/src/app-layout/visual-refresh/background.scss
@@ -21,15 +21,15 @@ div.background {
     grid-column: 1 / span 5;
     grid-row: 1 / 10;
     position: sticky;
-    inset-block-start: var(#{custom-props.$headerHeight});
+    top: var(#{custom-props.$headerHeight});
     z-index: 799;
 
     &:not(.has-sticky-notifications) {
-      block-size: calc(#{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight}));
+      height: calc(#{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight}));
     }
 
     &.has-sticky-notifications {
-      block-size: calc(
+      height: calc(
         var(#{custom-props.$notificationsGap}) + var(#{custom-props.$notificationsHeight}) + #{awsui.$space-scaled-s} + var(#{custom-props.$overlapHeight})
       );
     }

--- a/src/app-layout/visual-refresh/drawers.scss
+++ b/src/app-layout/visual-refresh/drawers.scss
@@ -12,10 +12,10 @@
   display: flex;
   grid-column: 5;
   grid-row: 1 / span 10;
-  block-size: var(#{custom-props.$contentHeight});
+  height: var(#{custom-props.$contentHeight});
   pointer-events: none;
   position: sticky;
-  inset-block-start: var(#{custom-props.$offsetTop});
+  top: var(#{custom-props.$offsetTop});
   z-index: 830;
 
   &.has-open-drawer {
@@ -25,7 +25,7 @@
 
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     /* stylelint-disable scss/operator-no-newline-after */
-    max-inline-size: calc(
+    max-width: calc(
       var(#{custom-props.$layoutWidth}) - var(#{custom-props.$mainOffsetLeft}) -
         var(#{custom-props.$defaultMinContentWidth}) - var(#{custom-props.$contentGapRight})
     );
@@ -34,7 +34,7 @@
 
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     position: fixed;
-    inset-inline-end: 0;
+    right: 0;
     z-index: 1001;
 
     /*
@@ -45,7 +45,7 @@
     relative to the body.
     */
     &.disable-body-scroll {
-      inset-block-start: var(#{custom-props.$headerHeight});
+      top: var(#{custom-props.$headerHeight});
     }
   }
 }
@@ -54,14 +54,14 @@
   @include styles.styles-reset;
   background-color: transparent;
   box-sizing: border-box;
-  block-size: 100%;
+  height: 100%;
   overflow-y: hidden;
   overflow-x: hidden;
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
   overscroll-behavior-y: contain;
 
   &:not(.has-multiple-triggers).has-open-drawer {
-    inline-size: 0;
+    width: 0;
   }
 
   &.has-multiple-triggers.has-open-drawer {
@@ -69,7 +69,7 @@
   }
 
   &:not(.has-multiple-triggers):not(.has-open-drawer) {
-    inline-size: calc((awsui.$space-layout-toggle-padding * 2) + awsui.$space-layout-toggle-diameter);
+    width: calc((awsui.$space-layout-toggle-padding * 2) + awsui.$space-layout-toggle-diameter);
   }
 }
 
@@ -82,8 +82,8 @@
   display: flex;
   flex-direction: column;
   gap: awsui.$space-xs;
-  padding-block-start: awsui.$space-scaled-s;
-  inline-size: calc((awsui.$space-layout-toggle-padding * 2) + awsui.$space-layout-toggle-diameter);
+  padding-top: awsui.$space-scaled-s;
+  width: calc((awsui.$space-layout-toggle-padding * 2) + awsui.$space-layout-toggle-diameter);
 
   &:not(.has-multiple-triggers).has-open-drawer {
     opacity: 0;
@@ -94,8 +94,7 @@
   }
 
   > .drawers-trigger-overflow {
-    padding-block: 0;
-    padding-inline: 1px;
+    padding: 0 1px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -104,7 +103,7 @@
 
 .drawers-trigger {
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
-    inline-size: constants.$sidebar-size-closed;
+    width: constants.$sidebar-size-closed;
     display: flex;
     justify-content: center;
   }
@@ -118,7 +117,7 @@
   grid-template-columns: awsui.$space-m 1fr;
   flex-shrink: 0;
 
-  block-size: 100%;
+  height: 100%;
   overflow-y: hidden;
   overflow-x: hidden;
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
@@ -129,7 +128,7 @@
   > .drawer-content-container {
     grid-column: 1 / span 2;
     grid-row: 1;
-    inline-size: var(#{custom-props.$drawerSize});
+    width: var(#{custom-props.$drawerSize});
     display: grid;
     grid-template-columns: awsui.$space-m 1fr auto awsui.$space-m;
     grid-template-rows: awsui.$size-vertical-panel-icon-offset auto 1fr;
@@ -152,20 +151,20 @@
   > .drawer-slider {
     grid-column: 1;
     grid-row: 1;
-    block-size: 100%;
+    height: 100%;
     display: flex;
     align-items: center;
   }
 
   &:not(.is-drawer-open) {
     opacity: 0;
-    inline-size: 0;
+    width: 0;
   }
 
   &.is-drawer-open {
-    border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+    border-right: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
     opacity: 1;
-    inline-size: var(#{custom-props.$drawerSize});
+    width: var(#{custom-props.$drawerSize});
   }
 
   @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
@@ -177,7 +176,7 @@
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     &.is-drawer-open {
       #{custom-props.$drawerSize}: 100vw;
-      inline-size: 100vw;
+      width: 100vw;
     }
   }
 }

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -76,7 +76,7 @@ explicitly set in script.
     var(#{custom-props.$mainGap})
     var(#{custom-props.$overlapHeight}) // main template area with overlap
     var(#{custom-props.$mainTemplateRows}); // main template area
-  min-block-size: var(#{custom-props.$contentHeight});
+  min-height: var(#{custom-props.$contentHeight});
   position: relative;
 
   /*
@@ -302,7 +302,7 @@ notifications top margin and some additional vertical space for aesthetics.
 .layout.disable-body-scroll {
   #{custom-props.$mainTemplateRows}: 1fr auto;
   #{custom-props.$offsetTop}: 0px;
-  block-size: var(#{custom-props.$contentHeight});
+  height: var(#{custom-props.$contentHeight});
   overflow-y: scroll;
 
   &.has-split-panel.split-panel-position-bottom {

--- a/src/app-layout/visual-refresh/main.scss
+++ b/src/app-layout/visual-refresh/main.scss
@@ -9,7 +9,7 @@
 
 .container {
   grid-area: main;
-  padding-block-end: awsui.$space-layout-content-bottom;
+  padding-bottom: awsui.$space-layout-content-bottom;
 
   /*
   If the split panel is in the bottom position additional padding will need to be
@@ -18,7 +18,7 @@
   sticky position of the split panel.
   */
   &.has-split-panel.split-panel-position-bottom {
-    padding-block-end: calc(var(#{custom-props.$splitPanelHeight}) + #{awsui.$space-layout-content-bottom});
+    padding-bottom: calc(var(#{custom-props.$splitPanelHeight}) + #{awsui.$space-layout-content-bottom});
   }
 
   /*
@@ -30,8 +30,7 @@
   */
   &.disable-content-paddings {
     grid-column: 1 / 6;
-    padding-block: 0;
-    padding-inline: 0;
+    padding: 0;
 
     @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
       &.is-navigation-open {

--- a/src/app-layout/visual-refresh/mobile-toolbar.scss
+++ b/src/app-layout/visual-refresh/mobile-toolbar.scss
@@ -10,23 +10,22 @@
 section.mobile-toolbar {
   align-items: center;
   background-color: awsui.$color-background-home-header;
-  border-block-end: 1px solid awsui.$color-border-divider-default;
+  border-bottom: 1px solid awsui.$color-border-divider-default;
   box-shadow: awsui.$shadow-panel-toggle;
   box-sizing: border-box;
-  block-size: var(#{custom-props.$mobileBarHeight});
+  height: var(#{custom-props.$mobileBarHeight});
   display: grid;
   grid-area: mobileToolbar;
   grid-column: 1 / span 5;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  padding-block: 0;
-  padding-inline: awsui.$space-m;
+  padding: 0 awsui.$space-m;
   position: sticky;
-  inset-block-start: var(#{custom-props.$offsetTop});
+  top: var(#{custom-props.$offsetTop});
   z-index: 1000;
 
   > .mobile-toolbar-nav {
     grid-column: 1;
-    margin-inline-end: awsui.$space-m;
+    margin-right: awsui.$space-m;
   }
 
   > .mobile-toolbar-breadcrumbs {
@@ -36,6 +35,6 @@ section.mobile-toolbar {
 
   > .mobile-toolbar-tools {
     grid-column: 3;
-    margin-inline-start: awsui.$space-m;
+    margin-left: awsui.$space-m;
   }
 }

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -12,9 +12,9 @@
   display: flex;
   grid-column: 1;
   grid-row: 1 / span 10;
-  block-size: var(#{custom-props.$contentHeight});
+  height: var(#{custom-props.$contentHeight});
   position: sticky;
-  inset-block-start: var(#{custom-props.$offsetTop});
+  top: var(#{custom-props.$offsetTop});
   z-index: 830;
 
   /*
@@ -34,7 +34,7 @@
   }
 
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
-    inset-inline-start: 0;
+    left: 0;
     position: fixed;
     z-index: 1001;
 
@@ -46,14 +46,13 @@
     relative to the body.
     */
     &.disable-body-scroll {
-      inset-block-start: var(#{custom-props.$headerHeight});
+      top: var(#{custom-props.$headerHeight});
     }
   }
 }
 
 nav.show-navigation {
-  padding-block: awsui.$space-scaled-s;
-  padding-inline: awsui.$space-layout-toggle-padding;
+  padding: awsui.$space-scaled-s awsui.$space-layout-toggle-padding;
 
   // Animation for the buttons when they are added to the DOM
   @keyframes showButtons {
@@ -89,8 +88,8 @@ nav.show-navigation {
 nav.navigation {
   background-color: awsui.$color-background-container-content;
   box-shadow: awsui.$shadow-panel;
-  inset-block-end: 0;
-  block-size: 100%;
+  bottom: 0;
+  height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
@@ -103,18 +102,18 @@ nav.navigation {
   @keyframes openNavigation {
     from {
       opacity: 0;
-      inline-size: calc(#{awsui.$space-layout-toggle-padding} * 2 + #{awsui.$space-layout-toggle-diameter});
+      width: calc(#{awsui.$space-layout-toggle-padding} * 2 + #{awsui.$space-layout-toggle-diameter});
     }
 
     to {
       opacity: 1;
-      inline-size: var(#{custom-props.$navigationWidth});
+      width: var(#{custom-props.$navigationWidth});
     }
   }
 
   // All content is hidden by the overflow-x property
   &:not(.is-navigation-open) {
-    inline-size: 0;
+    width: 0;
     // We need to hide the closed panel to make containing focusable elements not focusable anymore.
     display: none;
   }
@@ -134,7 +133,7 @@ nav.navigation {
   prevent unwanted text wrapping.
   */
   > .animated-content {
-    inline-size: var(#{custom-props.$navigationWidth});
+    width: var(#{custom-props.$navigationWidth});
   }
 
   // The Navigation drawer will take up the entire viewport on mobile
@@ -145,6 +144,6 @@ nav.navigation {
 
 .hide-navigation {
   position: absolute;
-  inset-inline-end: awsui.$space-m;
-  inset-block-start: awsui.$size-vertical-panel-icon-offset;
+  right: awsui.$space-m;
+  top: awsui.$size-vertical-panel-icon-offset;
 }

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -16,7 +16,7 @@
     &.sticky-notifications {
       #{custom-props.$flashbarStickyBottomMargin}: #{awsui.$space-xxl};
       position: sticky;
-      inset-block-start: calc(var(#{custom-props.$offsetTop}) + #{awsui.$space-xs});
+      top: calc(var(#{custom-props.$offsetTop}) + #{awsui.$space-xs});
     }
   }
 }

--- a/src/app-layout/visual-refresh/split-panel.scss
+++ b/src/app-layout/visual-refresh/split-panel.scss
@@ -19,11 +19,11 @@ section.split-panel-bottom {
   This could be off the viewport if the content area has enough content to be scrollable.
   */
   align-self: end;
-  inset-block-end: var(#{custom-props.$footerHeight});
+  bottom: var(#{custom-props.$footerHeight});
   display: none;
   grid-column: 1 / 6;
   grid-row: 10;
-  block-size: auto;
+  height: auto;
   overflow-y: hidden;
 
   /*
@@ -37,17 +37,17 @@ section.split-panel-bottom {
   // Animation for the height when opening the split panel
   @keyframes openSplitPanelBottom {
     from {
-      block-size: var(#{custom-props.$splitPanelReportedHeaderSize}, 0);
+      height: var(#{custom-props.$splitPanelReportedHeaderSize}, 0);
     }
 
     to {
-      block-size: var(#{custom-props.$splitPanelReportedSize});
+      height: var(#{custom-props.$splitPanelReportedSize});
     }
   }
 
   // If the Layout is the scrollable element then the footer height is not relevant
   &.disable-body-scroll {
-    inset-block-end: 0;
+    bottom: 0;
   }
 
   &.is-navigation-open.position-bottom {
@@ -93,13 +93,13 @@ section.split-panel-bottom {
 }
 
 section.split-panel-side {
-  block-size: 100%;
+  height: 100%;
   overflow-x: hidden;
   pointer-events: auto;
 
   &:not(.is-split-panel-open),
   &.position-bottom {
-    inline-size: 0;
+    width: 0;
   }
 
   /*
@@ -109,7 +109,7 @@ section.split-panel-side {
   */
   &.is-split-panel-open.position-side {
     box-shadow: awsui.$shadow-panel;
-    max-inline-size: var(#{custom-props.$splitPanelMaxWidth}, 280px);
-    min-inline-size: var(#{custom-props.$splitPanelMinWidth}, 280px);
+    max-width: var(#{custom-props.$splitPanelMaxWidth}, 280px);
+    min-width: var(#{custom-props.$splitPanelMinWidth}, 280px);
   }
 }

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -27,10 +27,10 @@ viewport size and state of the Tools drawer.
   display: flex;
   grid-column: 5;
   grid-row: 1 / span 10;
-  block-size: var(#{custom-props.$contentHeight});
-  max-inline-size: var(#{custom-props.$toolsMaxWidth});
+  height: var(#{custom-props.$contentHeight});
+  max-width: var(#{custom-props.$toolsMaxWidth});
   position: sticky;
-  inset-block-start: var(#{custom-props.$offsetTop});
+  top: var(#{custom-props.$offsetTop});
   z-index: 830;
 
   pointer-events: none;
@@ -43,7 +43,7 @@ viewport size and state of the Tools drawer.
     #{custom-props.$toolsMaxWidth}: none;
     #{custom-props.$toolsWidth}: auto;
     position: fixed;
-    inset-inline-end: 0;
+    right: 0;
     z-index: 1001;
 
     /*
@@ -54,7 +54,7 @@ viewport size and state of the Tools drawer.
     relative to the body.
     */
     &.disable-body-scroll {
-      inset-block-start: var(#{custom-props.$headerHeight});
+      top: var(#{custom-props.$headerHeight});
     }
   }
 }
@@ -63,7 +63,7 @@ viewport size and state of the Tools drawer.
   background-color: awsui.$color-background-container-content;
   box-shadow: awsui.$shadow-panel;
   flex-shrink: 0;
-  block-size: 100%;
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
@@ -76,17 +76,17 @@ viewport size and state of the Tools drawer.
   @keyframes openTools {
     from {
       opacity: var(#{custom-props.$toolsAnimationStartingOpacity}, 0);
-      inline-size: calc(#{awsui.$space-layout-toggle-padding} * 2 + #{awsui.$space-layout-toggle-diameter});
+      width: calc(#{awsui.$space-layout-toggle-padding} * 2 + #{awsui.$space-layout-toggle-diameter});
     }
 
     to {
       opacity: 1;
-      inline-size: var(#{custom-props.$toolsWidth});
+      width: var(#{custom-props.$toolsWidth});
     }
   }
 
   &:not(.is-tools-open) {
-    inline-size: 0;
+    width: 0;
     // We need to hide the closed panel to make containing focusable elements not focusable anymore.
     display: none;
   }
@@ -106,7 +106,7 @@ viewport size and state of the Tools drawer.
   prevent unwanted text wrapping.
   */
   > .animated-content {
-    inline-size: var(#{custom-props.$toolsWidth});
+    width: var(#{custom-props.$toolsWidth});
   }
 
   /*
@@ -117,7 +117,7 @@ viewport size and state of the Tools drawer.
   */
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     &.is-tools-open.has-tools-form-persistence {
-      border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+      border-right: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
     }
   }
 
@@ -129,8 +129,8 @@ viewport size and state of the Tools drawer.
 
 .hide-tools {
   position: absolute;
-  inset-inline-end: awsui.$space-m;
-  inset-block-start: awsui.$size-vertical-panel-icon-offset;
+  right: awsui.$space-m;
+  top: awsui.$size-vertical-panel-icon-offset;
   z-index: 1;
 }
 
@@ -142,8 +142,7 @@ handleSplitPanelMaxWidth function in the context.
 .show-tools {
   @include styles.styles-reset;
   box-sizing: border-box;
-  padding-block: awsui.$space-scaled-s;
-  padding-inline: awsui.$space-layout-toggle-padding;
+  padding: awsui.$space-scaled-s awsui.$space-layout-toggle-padding;
 
   // Animation for the buttons when they are added to the DOM
   @keyframes showButtons {

--- a/src/app-layout/visual-refresh/trigger-button.scss
+++ b/src/app-layout/visual-refresh/trigger-button.scss
@@ -21,12 +21,9 @@
 
 @mixin trigger-button-styles {
   background: awsui.$color-background-layout-toggle-default;
-  border-start-start-radius: 50%;
-  border-start-end-radius: 50%;
-  border-end-start-radius: 50%;
-  border-end-end-radius: 50%;
-  block-size: awsui.$space-layout-toggle-diameter;
-  inline-size: awsui.$space-layout-toggle-diameter;
+  border-radius: 50%;
+  height: awsui.$space-layout-toggle-diameter;
+  width: awsui.$space-layout-toggle-diameter;
 
   &:hover {
     background: awsui.$color-background-layout-toggle-hover;
@@ -41,8 +38,8 @@
   @include trigger-button-styles();
 
   position: absolute;
-  inset-block-start: 0;
-  inset-inline-start: 0;
+  top: 0;
+  left: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -59,6 +56,7 @@ handleSplitPanelMaxWidth function in the context.
 */
 .trigger {
   @include trigger-button-styles();
+
   border: none;
   color: awsui.$color-text-layout-toggle;
   cursor: pointer;
@@ -91,21 +89,15 @@ handleSplitPanelMaxWidth function in the context.
 .trigger-wrapper {
   position: relative;
   box-shadow: awsui.$shadow-panel-toggle;
-  border-start-start-radius: 50%;
-  border-start-end-radius: 50%;
-  border-end-start-radius: 50%;
-  border-end-end-radius: 50%;
+  border-radius: 50%;
 }
 
 .dot {
   position: absolute;
-  inline-size: 9px;
-  block-size: 9px;
-  border-start-start-radius: 8px;
-  border-start-end-radius: 8px;
-  border-end-start-radius: 8px;
-  border-end-end-radius: 8px;
+  width: 9px;
+  height: 9px;
+  border-radius: 8px;
   background-color: awsui.$color-background-badge-icon;
-  inset-block-start: 0;
-  inset-inline-end: 0;
+  top: 0;
+  right: 0;
 }

--- a/src/area-chart/styles.scss
+++ b/src/area-chart/styles.scss
@@ -32,7 +32,6 @@
 }
 
 .popover-divider {
-  margin-block: awsui.$space-xs;
-  margin-inline: 0;
-  border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  margin: awsui.$space-xs 0;
+  border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }

--- a/src/attribute-editor/styles.scss
+++ b/src/attribute-editor/styles.scss
@@ -42,22 +42,22 @@
   // The value is calculated as follows:
   // padding-top = awsui-form-field-controls: 4px +
   // line height (also applies to icon size) awsui-form-field-label: 22px
-  padding-block-start: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
+  padding-top: calc(#{awsui.$space-xxs} + #{awsui.$line-height-body-m});
 }
 
 .button-container-nolabel {
-  padding-block-start: #{awsui.$space-xxs};
+  padding-top: #{awsui.$space-xxs};
 }
 
 .divider {
-  border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }
 
 .additional-info {
   @include styles.form-control-description;
   display: block;
   word-wrap: break-word;
-  margin-block-start: awsui.$space-xxs;
+  margin-top: awsui.$space-xxs;
 
   /* stylelint-disable-next-line selector-max-type */
   > a {
@@ -66,6 +66,5 @@
 }
 
 .right-align {
-  display: flex;
-  justify-content: flex-end;
+  float: right;
 }

--- a/src/autosuggest/styles.scss
+++ b/src/autosuggest/styles.scss
@@ -4,11 +4,11 @@
 */
 
 .root {
-  inline-size: 100%;
+  width: 100%;
 }
 
 .layout-strut {
-  inline-size: 100%;
+  width: 100%;
   position: relative;
   // Prevent incorrect layer ordering in Safari by making sure
   // this element is also offloaded to the GPU along with the virtual items

--- a/src/badge/styles.scss
+++ b/src/badge/styles.scss
@@ -12,12 +12,8 @@
   @include styles.font-body-s;
   line-height: awsui.$line-height-body-m;
   display: inline-block;
-  border-start-start-radius: awsui.$border-radius-badge;
-  border-start-end-radius: awsui.$border-radius-badge;
-  border-end-start-radius: awsui.$border-radius-badge;
-  border-end-end-radius: awsui.$border-radius-badge;
-  padding-block: 0;
-  padding-inline: awsui.$space-xs;
+  border-radius: awsui.$border-radius-badge;
+  padding: 0 awsui.$space-xs;
   color: awsui.$color-text-notification-default;
 
   &.badge-color-grey {

--- a/src/box/base-styles.scss
+++ b/src/box/base-styles.scss
@@ -129,11 +129,9 @@ $font-styles: (
 }
 
 @mixin headings-paragraphs-extra-defaults {
-  margin-block: 0;
-  margin-inline: 0;
+  margin: 0;
   text-decoration: none;
-  padding-block: awsui.$space-xxs;
-  padding-inline: 0;
+  padding: awsui.$space-xxs 0;
 }
 
 @mixin code-extra-defaults {

--- a/src/box/layout.scss
+++ b/src/box/layout.scss
@@ -24,11 +24,9 @@
   }
 }
 
-/* stylelint-disable csstools/use-logical */
 .f-left {
   float: left;
 }
 .f-right {
   float: right;
 }
-/* stylelint-enable csstools/use-logical */

--- a/src/box/text.scss
+++ b/src/box/text.scss
@@ -41,7 +41,7 @@
     &.key-label-variant {
       @include styles.font-label;
       color: awsui.$color-text-label;
-      margin-block-end: awsui.$space-key-value-gap;
+      margin-bottom: awsui.$space-key-value-gap;
     }
     &.value-large-variant {
       @include styles.font-display-l;
@@ -90,10 +90,10 @@
 }
 
 .t-left {
-  text-align: start;
+  text-align: left;
 }
 .t-right {
-  text-align: end;
+  text-align: right;
 }
 .t-center {
   text-align: center;

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -15,8 +15,7 @@
   display: flex;
 
   > .icon {
-    margin-block: 0;
-    margin-inline: awsui.$space-xs;
+    margin: 0 awsui.$space-xs;
     color: awsui.$color-text-breadcrumb-icon;
   }
 
@@ -41,7 +40,7 @@
   }
 }
 .compressed {
-  min-inline-size: 0;
+  min-width: 0;
   overflow: hidden;
   > .text {
     overflow: hidden;

--- a/src/breadcrumb-group/styles.scss
+++ b/src/breadcrumb-group/styles.scss
@@ -8,10 +8,8 @@
 
 .breadcrumb-group {
   @include styles.styles-reset;
-  margin-block: 0;
-  margin-inline: 0;
-  padding-block: awsui.$space-xxs;
-  padding-inline: 0;
+  margin: 0;
+  padding: awsui.$space-xxs 0;
 
   > .item {
     @include styles.styles-reset;
@@ -21,29 +19,24 @@
   > .breadcrumb-group-list {
     display: flex;
     align-items: center;
-    padding-block: 0;
-    padding-inline: 0;
-    margin-block: 0;
-    margin-inline: 0;
+    padding: 0;
+    margin: 0;
     list-style: none;
-    inline-size: 100%;
+    width: 100%;
     flex-wrap: wrap;
 
     > .item,
     > .ellipsis {
       display: inline-block;
-      padding-block: 0;
-      padding-inline: 0;
-      margin-block: 0;
-      margin-inline: 0;
+      padding: 0;
+      margin: 0;
     }
 
     > .ellipsis {
       display: none;
 
       > .icon {
-        margin-block: 0;
-        margin-inline: styles.$base-size;
+        margin: 0 styles.$base-size;
         color: awsui.$color-text-breadcrumb-icon;
       }
     }
@@ -61,7 +54,7 @@
         flex-shrink: 0;
       }
       > .item {
-        min-inline-size: 0;
+        min-width: 0;
         &:not(:first-child):not(:last-child) {
           display: none;
         }

--- a/src/button-dropdown/category-elements/styles.scss
+++ b/src/button-dropdown/category-elements/styles.scss
@@ -8,20 +8,19 @@
 
 .header {
   position: relative;
-  margin-block: 0;
-  margin-inline: 0;
+  margin: 0;
   color: awsui.$color-text-dropdown-group-label;
-  border-block: awsui.$border-divider-list-width solid transparent;
-  border-inline: awsui.$border-divider-list-width solid transparent;
+  border: awsui.$border-divider-list-width solid transparent;
   // remove the borders completely to avoid the slating effect at the border ends (AWSUI-10545)
-  border-inline-width: 0;
+  border-left: 0;
+  border-right: 0;
   font-weight: bold;
   display: flex;
   justify-content: space-between;
   // to compensate for the loss of padding due to the removal of the left and right borders
   // and differences in default divider + selected border widths (visual refresh)
-  padding-block: styles.$option-padding-with-border-placeholder-vertical;
-  padding-inline: calc(#{awsui.$space-button-horizontal} + #{awsui.$border-item-width});
+  padding: styles.$option-padding-with-border-placeholder-vertical
+    calc(#{awsui.$space-button-horizontal} + #{awsui.$border-item-width});
   z-index: 1;
 
   &.disabled {
@@ -30,8 +29,8 @@
   }
 
   &.expandable-header {
-    border-block-start-color: awsui.$color-border-dropdown-group;
-    border-block-end-color: awsui.$color-border-dropdown-group;
+    border-top-color: awsui.$color-border-dropdown-group;
+    border-bottom-color: awsui.$color-border-dropdown-group;
     cursor: pointer;
     &.disabled {
       cursor: default;
@@ -40,22 +39,16 @@
       outline: none;
     }
     &.rolled-down {
-      border-block-end-color: transparent;
+      border-bottom-color: transparent;
     }
     &.highlighted {
       background-color: awsui.$color-background-dropdown-item-hover;
       color: awsui.$color-text-dropdown-item-highlighted;
       // reset padding when adding border back in
-      padding-block: styles.$option-padding-vertical;
-      padding-inline: awsui.$space-button-horizontal;
-      border-block: awsui.$border-item-width solid awsui.$color-border-dropdown-item-hover;
-      border-inline: awsui.$border-item-width solid awsui.$color-border-dropdown-item-hover;
-      border-start-start-radius: awsui.$border-radius-item;
-      border-start-end-radius: awsui.$border-radius-item;
-      border-end-start-radius: awsui.$border-radius-item;
-      border-end-end-radius: awsui.$border-radius-item;
+      padding: styles.$option-padding-vertical awsui.$space-button-horizontal;
+      border: awsui.$border-item-width solid awsui.$color-border-dropdown-item-hover;
+      border-radius: awsui.$border-radius-item;
       z-index: 2;
-
       &.disabled {
         background-color: awsui.$color-background-dropdown-item-dimmed;
         border-color: awsui.$color-border-dropdown-item-dimmed-hover;
@@ -68,12 +61,14 @@
     }
 
     &.variant-navigation {
-      padding-block: awsui.$space-xs;
+      padding-top: awsui.$space-xs;
+      padding-bottom: awsui.$space-xs;
 
       &.highlighted {
         border-color: transparent;
-        border-block-start-color: awsui.$color-border-dropdown-group;
-        border-block-end-color: awsui.$color-border-dropdown-group;
+        border-top-color: awsui.$color-border-dropdown-group;
+        border-bottom-color: awsui.$color-border-dropdown-group;
+
         background-color: transparent;
         color: awsui.$color-text-accent;
       }
@@ -83,34 +78,33 @@
 
 .category {
   list-style: none;
-  margin-block-start: calc(-1 * #{awsui.$border-divider-list-width});
-  padding-block: 0;
-  padding-inline: 0;
+  margin-top: calc(-1 * #{awsui.$border-divider-list-width});
+  padding: 0;
   &:first-child {
-    margin-block-start: 0;
+    margin-top: 0;
   }
 
   &.expandable {
-    border-block-start: 0;
+    border-top: 0;
   }
 
   &:last-child {
-    border-block-end: none;
+    border-bottom: none;
   }
 
   &.variant-navigation {
-    padding-block-start: awsui.$space-xxs;
+    padding-top: awsui.$space-xxs;
 
     &.expandable {
-      padding-block-start: 0;
+      padding-top: 0;
     }
   }
 }
 
 .expand-icon {
   position: relative;
-  inset-inline-start: awsui.$space-s;
-  inline-size: awsui.$space-m;
+  left: awsui.$space-s;
+  width: awsui.$space-m;
   display: inline-block;
 
   &-up {
@@ -126,10 +120,7 @@
 }
 
 .items-list-container {
-  padding-block: 0;
-  padding-inline: 0;
-  margin-block-start: -1px;
-  margin-block-end: 0;
-  margin-inline: 0;
+  padding: 0;
+  margin: -1px 0 0 0;
   overflow-y: auto;
 }

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -9,13 +9,11 @@
 .item-element {
   position: relative;
   z-index: 1;
-  border-block: awsui.$border-item-width solid transparent;
-  border-inline: awsui.$border-item-width solid transparent;
+  border: awsui.$border-item-width solid transparent;
   list-style: none;
-  padding-block: 0;
-  padding-inline: 0;
+  padding: 0;
   color: awsui.$color-text-dropdown-item-default;
-  margin-block-start: calc(-1 * #{styles.$control-border-width});
+  margin-top: calc(-1 * #{styles.$control-border-width});
   cursor: pointer;
 
   &.disabled {
@@ -23,10 +21,10 @@
     color: awsui.$color-text-dropdown-item-disabled;
   }
   &:first-child {
-    margin-block-start: 0;
+    margin-top: 0;
   }
   &.last {
-    border-block-end: awsui.$border-item-width solid awsui.$color-border-dropdown-group;
+    border-bottom: awsui.$border-item-width solid awsui.$color-border-dropdown-group;
   }
   &.highlighted {
     color: awsui.$color-text-dropdown-item-highlighted;
@@ -38,10 +36,7 @@
     &.variant-primary {
       background-color: awsui.$color-background-dropdown-item-hover;
       border-color: awsui.$color-border-dropdown-item-hover;
-      border-start-start-radius: awsui.$border-radius-item;
-      border-start-end-radius: awsui.$border-radius-item;
-      border-end-start-radius: awsui.$border-radius-item;
-      border-end-end-radius: awsui.$border-radius-item;
+      border-radius: awsui.$border-radius-item;
 
       &.disabled {
         color: awsui.$color-text-dropdown-item-dimmed;
@@ -63,17 +58,18 @@
 
     // Additional spacing for groups of items
     &.first:not(.has-category-header) {
-      padding-block-start: styles.$option-padding-vertical;
+      padding-top: styles.$option-padding-vertical;
     }
     &.last {
-      padding-block-end: styles.$option-padding-vertical;
+      padding-bottom: styles.$option-padding-vertical;
     }
     &.first.last {
-      padding-block: styles.$option-padding-vertical;
+      padding-bottom: styles.$option-padding-vertical;
+      padding-top: styles.$option-padding-vertical;
     }
     // Additional spacing for the very last item in the list
     &.last:last-child {
-      padding-block-end: styles.$option-padding-vertical;
+      padding-bottom: styles.$option-padding-vertical;
     }
   }
 }
@@ -82,8 +78,7 @@
   @include styles.text-wrapping;
   display: flex;
   align-items: flex-start;
-  padding-block: styles.$option-padding-vertical;
-  padding-inline: awsui.$space-button-horizontal;
+  padding: styles.$option-padding-vertical awsui.$space-button-horizontal;
   color: inherit;
   text-decoration: none;
 
@@ -94,15 +89,15 @@
   /* stylelint-disable-next-line selector-max-type */
   .has-category-header > &,
   .has-category-header > span > & {
-    padding-inline-start: calc(#{awsui.$space-s} + #{awsui.$space-button-horizontal});
+    padding-left: calc(#{awsui.$space-s} + #{awsui.$space-button-horizontal});
   }
 }
 
 .icon {
-  padding-inline-end: awsui.$space-xs;
+  padding-right: awsui.$space-xs;
   flex-shrink: 0;
 }
 
 .external-icon {
-  margin-inline-start: awsui.$space-xxs;
+  margin-left: awsui.$space-xxs;
 }

--- a/src/button-dropdown/mobile-expandable-group/styles.scss
+++ b/src/button-dropdown/mobile-expandable-group/styles.scss
@@ -20,12 +20,12 @@
     user-select: none;
     background-color: awsui.$color-background-dropdown-item-default;
     outline: none;
-    border-block-start: none;
-    border-block-end: none;
+    border-top: none;
+    border-bottom: none;
 
     display: flex;
     flex-direction: column;
-    inline-size: 100%;
+    width: 100%;
 
     &.nowrap {
       white-space: nowrap;

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -13,10 +13,8 @@ $dropdown-trigger-icon-offset: 2px;
 }
 
 .items-list-container {
-  padding-block: 0;
-  padding-inline: 0;
-  margin-block: 0;
-  margin-inline: 0;
+  padding: 0;
+  margin: 0;
 
   @include styles.with-motion {
     animation: awsui-motion-fade-in-0 500ms awsui.$motion-easing-show-quick;
@@ -42,11 +40,9 @@ $dropdown-trigger-icon-offset: 2px;
   display: flex;
   flex-direction: column;
   list-style: none;
-  padding-block: awsui.$space-s;
-  padding-inline: awsui.$space-l;
-  border-block-start: styles.$control-border-width solid transparent;
-  border-block-end: styles.$control-border-width solid awsui.$color-border-dropdown-group;
-  border-inline: styles.$control-border-width solid transparent;
+  padding: awsui.$space-s awsui.$space-l;
+  border: styles.$control-border-width solid transparent;
+  border-bottom: styles.$control-border-width solid awsui.$color-border-dropdown-group;
 }
 
 .title,
@@ -65,23 +61,24 @@ $dropdown-trigger-icon-offset: 2px;
 
   & > .trigger-item:not(:last-child) {
     & > .trigger-button {
-      border-start-end-radius: 0;
-      border-end-end-radius: 0;
-      padding-inline-end: awsui.$space-m;
-      margin-inline-end: awsui.$space-xxxs;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      padding-right: awsui.$space-m;
+      margin-right: awsui.$space-xxxs;
     }
   }
 
   & > .trigger-item:not(:first-child) {
     & > .trigger-button {
-      border-start-start-radius: 0;
-      border-end-start-radius: 0;
-      padding-inline: calc(#{awsui.$space-xs} - #{$dropdown-trigger-icon-offset});
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      padding-left: calc(#{awsui.$space-xs} - #{$dropdown-trigger-icon-offset});
+      padding-right: calc(#{awsui.$space-xs} - #{$dropdown-trigger-icon-offset});
     }
 
     &.visual-refresh {
       & > .trigger-button {
-        padding-inline-end: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
+        padding-right: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
       }
     }
   }

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -13,8 +13,7 @@
   background: map.get($variant, 'default-background');
   color: map.get($variant, 'default-color');
   border-color: map.get($variant, 'default-border-color');
-  border-block-width: map.get($variant, 'border-width');
-  border-inline-width: map.get($variant, 'border-width');
+  border-width: map.get($variant, 'border-width');
   position: relative;
   text-decoration: none;
   padding-block: map.get($variant, 'padding');

--- a/src/calendar/styles.scss
+++ b/src/calendar/styles.scss
@@ -18,12 +18,11 @@
 .calendar {
   display: block;
   // IE11 does not calculate the height correctly when in nested flex containers (@see https://github.com/philipwalton/flexbugs#flexbug-3)
-  inline-size: awsui.$size-calendar-grid-width;
+  width: awsui.$size-calendar-grid-width;
   overflow: auto;
 
   &-inner {
-    margin-block: awsui.$space-xs;
-    margin-inline: awsui.$space-xs;
+    margin: awsui.$space-xs;
   }
 
   &-header {
@@ -36,8 +35,7 @@
     @include styles.font-body-m;
     font-weight: typographyConstants.$font-weight-bold;
     color: calendar.$header-color;
-    margin-block: 0;
-    margin-inline: 0;
+    margin: 0;
   }
 
   &-next-month-btn {
@@ -49,45 +47,39 @@
   }
 
   &-grid {
-    inline-size: 100%;
+    width: 100%;
     border-spacing: 0;
   }
 
   &-grid-cell {
-    inline-size: calc(100% / 7);
+    width: calc(100% / 7);
     word-break: break-word;
     text-align: center;
     font-weight: unset;
   }
 
   &-day-header {
-    padding-block-start: awsui.$space-s;
-    padding-block-end: awsui.$space-xxs;
-    padding-inline: 0;
+    padding: awsui.$space-s 0 awsui.$space-xxs;
     color: calendar.$grid-day-name-color;
     @include styles.font-body-s;
   }
 
   &-day {
-    border-block-end: calendar.$grid-border;
-    border-inline-end: calendar.$grid-border;
-    padding-block: awsui.$space-xxs;
-    padding-inline: 0;
+    border-bottom: calendar.$grid-border;
+    border-right: calendar.$grid-border;
+    padding: awsui.$space-xxs 0;
     color: calendar.$grid-disabled-day-color;
     position: relative;
 
     &:first-child {
-      border-inline-start: calendar.$grid-border;
+      border-left: calendar.$grid-border;
     }
 
     &-enabled {
       cursor: pointer;
       color: calendar.$grid-nonmonth-day-color;
       &::after {
-        border-start-start-radius: awsui.$border-radius-item;
-        border-start-end-radius: awsui.$border-radius-item;
-        border-end-start-radius: awsui.$border-radius-item;
-        border-end-end-radius: awsui.$border-radius-item;
+        border-radius: awsui.$border-radius-item;
       }
       &.calendar-day-current-month {
         color: calendar.$grid-day-color;
@@ -96,8 +88,7 @@
           background-color: calendar.$grid-hover-background-color;
           &:not(.calendar-day-selected) {
             &::after {
-              border-block: awsui.$border-item-width solid calendar.$grid-hover-border-color;
-              border-inline: awsui.$border-item-width solid calendar.$grid-hover-border-color;
+              border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
             }
           }
         }
@@ -106,10 +97,7 @@
 
     &-today {
       background-color: calendar.$grid-today-background-color;
-      border-start-start-radius: awsui.$border-radius-item;
-      border-start-end-radius: awsui.$border-radius-item;
-      border-end-start-radius: awsui.$border-radius-item;
-      border-end-end-radius: awsui.$border-radius-item;
+      border-radius: awsui.$border-radius-item;
       font-weight: styles.$font-weight-bold;
     }
 
@@ -117,10 +105,10 @@
       content: '';
       position: absolute;
       z-index: 1;
-      inset-block-start: calc(-1 * #{awsui.$border-item-width});
-      inset-block-end: -1px;
-      inset-inline-start: -1px;
-      inset-inline-end: calc(-1 * #{awsui.$border-item-width});
+      top: calc(-1 * #{awsui.$border-item-width});
+      left: -1px;
+      bottom: -1px;
+      right: calc(-1 * #{awsui.$border-item-width});
       background-color: transparent;
     }
     > .day-inner {
@@ -160,12 +148,8 @@
       }
       &::after {
         background-color: calendar.$grid-selected-background-color;
-        border-block: awsui.$border-item-width solid calendar.$grid-selected-border-color;
-        border-inline: awsui.$border-item-width solid calendar.$grid-selected-border-color;
-        border-start-start-radius: awsui.$border-radius-item;
-        border-start-end-radius: awsui.$border-radius-item;
-        border-end-start-radius: awsui.$border-radius-item;
-        border-end-end-radius: awsui.$border-radius-item;
+        border: awsui.$border-item-width solid calendar.$grid-selected-border-color;
+        border-radius: awsui.$border-radius-item;
       }
       > .day-inner {
         z-index: 2;
@@ -178,7 +162,7 @@
   &-week {
     &:first-child {
       > .calendar-day {
-        border-block-start: calendar.$grid-border;
+        border-top: calendar.$grid-border;
       }
     }
   }

--- a/src/cards/styles.scss
+++ b/src/cards/styles.scss
@@ -18,11 +18,10 @@
 .header {
   &-variant-full-page.header-refresh {
     @include container.borders-and-shadows;
-    padding-block-start: 0;
-    padding-block-end: calc(
-      #{awsui.$space-container-header-bottom} + #{awsui.$space-table-header-tools-full-page-bottom}
-    );
-    padding-inline: 0;
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: calc(#{awsui.$space-container-header-bottom} + #{awsui.$space-table-header-tools-full-page-bottom});
   }
 }
 
@@ -31,17 +30,14 @@
   flex-wrap: wrap;
   box-sizing: border-box;
   // reset styles from OL
-  padding-block: 0;
-  padding-inline: 0;
+  padding: 0;
   list-style: none;
-  margin-block: 0;
-  margin-inline-start: calc(#{awsui.$space-grid-gutter} * -1);
-  margin-inline-end: 0;
+  margin: 0 0 0 calc(#{awsui.$space-grid-gutter} * -1);
 
   @for $i from 1 through 20 {
     &.list-grid-#{$i} {
       > .card {
-        inline-size: math.div(100%, $i);
+        width: math.div(100%, $i);
       }
     }
   }
@@ -50,11 +46,10 @@
 .selection-control {
   position: absolute;
   box-sizing: border-box;
-  inline-size: calc(#{awsui.$size-control} + (2 * #{awsui.$space-card-horizontal}));
-  inset-block-start: 0;
-  inset-inline-end: 0;
-  padding-block: awsui.$space-card-vertical;
-  padding-inline: awsui.$space-card-horizontal;
+  width: calc(#{awsui.$size-control} + (2 * #{awsui.$space-card-horizontal}));
+  top: 0;
+  right: 0;
+  padding: awsui.$space-card-vertical awsui.$space-card-horizontal;
 }
 
 .loading,
@@ -62,55 +57,48 @@
   overflow: hidden;
   text-align: center;
   color: awsui.$color-text-empty;
-  margin-block-end: awsui.$space-scaled-l;
+  margin-bottom: awsui.$space-scaled-l;
 }
 
 .has-header {
   // Unfortunately, we don't have access to the header of InternalContainer
   // in order to use margin-bottom instead.
-  margin-block-start: awsui.$space-grid-gutter;
+  margin-top: awsui.$space-grid-gutter;
 }
 
 .card {
   display: flex;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  margin-block: 0;
-  margin-inline: 0;
-  padding-block: 0;
-  padding-inline: 0;
+  margin: 0;
+  padding: 0;
   list-style: none;
   &-inner {
     position: relative;
     background-color: awsui.$color-background-container-content;
-    margin-block-start: 0;
-    margin-block-end: awsui.$space-grid-gutter;
-    margin-inline-start: awsui.$space-grid-gutter;
-    margin-inline-end: 0;
-    padding-block: awsui.$space-card-vertical;
-    padding-inline: awsui.$space-card-horizontal;
+    margin: 0 0 awsui.$space-grid-gutter awsui.$space-grid-gutter;
+    padding: awsui.$space-card-vertical awsui.$space-card-horizontal;
     @include styles.container-shadow;
-    inline-size: 100%;
-    min-inline-size: 0;
+    width: 100%;
+    min-width: 0;
   }
   &-header {
     @include styles.font-heading-m;
     &-inner {
-      inline-size: 100%;
+      width: 100%;
       display: inline-block;
     }
   }
   &-selectable {
     > .card-inner > .card-header {
-      inline-size: 90%;
+      width: 90%;
     }
   }
   &-selected {
     > .card-inner {
       background-color: awsui.$color-background-item-selected;
       &::before {
-        border-block: awsui.$border-item-width solid awsui.$color-border-item-selected;
-        border-inline: awsui.$border-item-width solid awsui.$color-border-item-selected;
+        border: awsui.$border-item-width solid awsui.$color-border-item-selected;
       }
     }
   }
@@ -120,9 +108,7 @@
   display: inline-block;
   box-sizing: border-box;
   // only scale bottom padding to reduce padding between sections and after the last section.
-  padding-block-start: awsui.$space-xs;
-  padding-block-end: awsui.$space-scaled-xs;
-  padding-inline: 0;
+  padding: awsui.$space-xs 0 awsui.$space-scaled-xs 0;
   vertical-align: top;
   &-header {
     @include styles.font-label;
@@ -133,9 +119,7 @@
   }
 }
 .section:last-child {
-  padding-block-start: awsui.$space-xs;
-  padding-block-end: 0;
-  padding-inline: 0;
+  padding: awsui.$space-xs 0 0 0;
 }
 
 .footer-pagination {

--- a/src/code-editor/ace-editor.scss
+++ b/src/code-editor/ace-editor.scss
@@ -12,10 +12,10 @@
 
 .code-editor-refresh :global .ace_editor {
   .ace_gutter {
-    border-start-start-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+    border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
   }
   .ace_scroller {
-    border-start-end-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+    border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
   }
 }
 
@@ -50,7 +50,8 @@
   }
 
   .ace_gutter-cell {
-    padding-inline: $gutter-padding-left $gutter-padding-right;
+    padding-left: $gutter-padding-left;
+    padding-right: $gutter-padding-right;
   }
 
   .ace_fold-widget {
@@ -58,17 +59,16 @@
        <<html<<<<
        </html>
     */
-    inline-size: $gutter-padding-right - 2 * 1px; // gutter padding - 1px margin each side
-    margin-inline-end: -$gutter-padding-right + 1px; // leave 1px margin on each side
+    width: $gutter-padding-right - 2 * 1px; // gutter padding - 1px margin each side
+    margin-right: -$gutter-padding-right + 1px; // leave 1px margin on each side
     background-color: transparent;
-    border-block: none;
-    border-inline: none;
+    border: none;
   }
 
   .ace_gutter_annotation {
     // To align our custom icon with the annotation clickable/focus area.
     // Based on -19px in ace's default stylesheet.
-    margin-inline-start: -21px;
+    margin-left: -21px;
   }
 
   .ace_fold-widget,
@@ -85,13 +85,13 @@
   .ace_marker-layer > .ace_active-line {
     background: transparent;
     box-sizing: border-box;
-    border-block-start: 1px solid $active-line-border-color-light;
-    border-block-end: 1px solid $active-line-border-color-light;
+    border-top: 1px solid $active-line-border-color-light;
+    border-bottom: 1px solid $active-line-border-color-light;
   }
 
   &.ace_dark .ace_marker-layer > .ace_active-line {
-    border-block-start: 1px solid $active-line-border-color-dark;
-    border-block-end: 1px solid $active-line-border-color-dark;
+    border-top: 1px solid $active-line-border-color-dark;
+    border-bottom: 1px solid $active-line-border-color-dark;
   }
 
   .ace_gutter {

--- a/src/code-editor/pane.scss
+++ b/src/code-editor/pane.scss
@@ -11,17 +11,17 @@
   $border: awsui.$border-item-width solid $border-color;
   $radius: awsui.$border-radius-item;
   > .pane__cell {
-    border-block-start: $border;
-    border-block-end: $border;
+    border-top: $border;
+    border-bottom: $border;
     &:first-child {
-      border-inline-start: $border;
-      border-start-start-radius: $radius;
-      border-end-start-radius: $radius;
+      border-left: $border;
+      border-top-left-radius: $radius;
+      border-bottom-left-radius: $radius;
     }
     &:last-child {
-      border-inline-end: $border;
-      border-start-end-radius: $radius;
-      border-end-end-radius: $radius;
+      border-right: $border;
+      border-top-right-radius: $radius;
+      border-bottom-right-radius: $radius;
     }
   }
 }
@@ -32,31 +32,30 @@
   flex-direction: row;
   flex: 1;
 
-  border-block-start: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
-  border-end-start-radius: awsui.$border-radius-code-editor;
-  border-end-end-radius: awsui.$border-radius-code-editor;
+  border-top: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
+  border-bottom-left-radius: awsui.$border-radius-code-editor;
+  border-bottom-right-radius: awsui.$border-radius-code-editor;
   background: awsui.$color-background-code-editor-status-bar;
   color: awsui.$color-text-body-default;
 
   &__close-container {
     position: absolute;
-    inset-block-start: 0;
-    inset-inline-end: calc(#{awsui.$space-s} / 2);
+    top: 0;
+    right: calc(#{awsui.$space-s} / 2);
   }
 
   &__list {
     flex: 1;
     overflow: auto;
-    max-block-size: 100%;
+    max-height: 100%;
     box-sizing: border-box;
-    margin-inline-end: calc(#{awsui.$line-height-body-m} + 2 * #{awsui.$space-xs});
+    margin-right: calc(#{awsui.$line-height-body-m} + 2 * #{awsui.$space-xs});
   }
 
   &__table {
-    inline-size: 100%;
+    width: 100%;
     border-spacing: 0;
-    margin-block: awsui.$space-s;
-    margin-inline: 0;
+    margin: awsui.$space-s 0;
   }
 
   &__item {
@@ -76,22 +75,21 @@
 
   &__location,
   &__description {
-    padding-block: awsui.$space-xxs;
-    padding-inline: awsui.$space-s;
+    padding: awsui.$space-xxs awsui.$space-s;
   }
 
   &__location {
     vertical-align: baseline;
     white-space: nowrap;
-    padding-inline-start: calc(#{awsui.$space-l} + #{awsui.$space-s});
+    padding-left: calc(#{awsui.$space-l} + #{awsui.$space-s});
   }
 
   &__description {
-    padding-inline-end: 0;
+    padding-right: 0;
     @include styles.text-wrapping;
   }
 }
 
 .focus-lock {
-  block-size: 100%;
+  height: 100%;
 }

--- a/src/code-editor/resizable-box/styles.scss
+++ b/src/code-editor/resizable-box/styles.scss
@@ -7,17 +7,17 @@
 
 .resizable-box {
   position: relative;
-  inline-size: 100%;
+  width: 100%;
 }
 
 .resizable-box-handle {
   position: absolute;
-  inset-inline-end: 0;
-  inset-block-end: 0;
+  right: 0;
+  bottom: 0;
   z-index: 10; // above editor, when editor is overflowing
 
-  inline-size: awsui.$space-l;
-  block-size: awsui.$space-l;
+  width: awsui.$space-l;
+  height: awsui.$space-l;
 
   background-repeat: no-repeat;
   background-origin: content-box;

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -13,18 +13,17 @@
 .code-editor {
   @include styles.styles-reset;
   display: inline-block;
-  border-block: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
-  border-inline: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
-  border-start-start-radius: awsui.$border-radius-code-editor;
-  border-start-end-radius: awsui.$border-radius-code-editor;
-  border-end-start-radius: awsui.$border-radius-code-editor;
-  border-end-end-radius: awsui.$border-radius-code-editor;
-  inline-size: 100%;
+  border: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
+  border-radius: awsui.$border-radius-code-editor;
+  width: 100%;
 }
 
 .editor {
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 
   &:focus {
     @include styles.focus-highlight(3px);
@@ -34,19 +33,19 @@
 }
 
 .editor-refresh {
-  border-start-start-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
-  border-start-end-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  border-top-left-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
+  border-top-right-radius: calc(awsui.$border-radius-code-editor - awsui.$border-item-width);
 }
 
 .status-bar {
   display: flex;
   vertical-align: middle;
 
-  border-block-start: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
+  border-top: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   background-color: awsui.$color-background-code-editor-status-bar;
   &-with-hidden-pane {
-    border-end-start-radius: awsui.$border-radius-code-editor;
-    border-end-end-radius: awsui.$border-radius-code-editor;
+    border-bottom-left-radius: awsui.$border-radius-code-editor;
+    border-bottom-right-radius: awsui.$border-radius-code-editor;
   }
 
   @include styles.text-wrapping;
@@ -55,8 +54,8 @@
     flex: 1;
     display: flex;
     flex-wrap: wrap;
-    padding-inline-start: awsui.$space-l;
-    border-inline-end: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
+    padding-left: awsui.$space-l;
+    border-right: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   }
 
   &__left-virtual {
@@ -73,13 +72,11 @@
   &__cursor-position {
     display: inline-block;
     color: awsui.$color-text-body-default;
-    padding-block: awsui.$space-scaled-xs;
-    padding-inline: awsui.$space-s;
+    padding: awsui.$space-scaled-xs awsui.$space-s;
   }
 
   &__cog-button {
-    padding-block: calc(#{awsui.$space-scaled-xxs} - 1px);
-    padding-inline: calc(#{awsui.$space-xs} - 2px);
+    padding: calc(#{awsui.$space-scaled-xxs} - 1px) calc(#{awsui.$space-xs} - 2px);
   }
 }
 
@@ -90,13 +87,11 @@
 .tab-button {
   position: relative;
   display: inline-block;
-  padding-block: awsui.$space-scaled-xs;
-  padding-inline: awsui.$space-s;
+  padding: awsui.$space-scaled-xs awsui.$space-s;
   line-height: inherit;
   color: awsui.$color-text-status-error;
   background: none;
-  border-block: none;
-  border-inline: none;
+  border: none;
   font-weight: bold;
   outline: none;
   cursor: pointer;
@@ -110,19 +105,17 @@
   &::after {
     content: '';
     position: absolute;
-    inset-inline: 0;
-    inset-block-end: 0;
-    block-size: awsui.$border-active-width;
-    border-start-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-start-end-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-end-radius: awsui.$border-radius-tabs-focus-ring;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: awsui.$border-active-width;
+    border-radius: awsui.$border-radius-tabs-focus-ring;
     background: awsui.$color-text-status-error;
     opacity: 0;
   }
 
   &--refresh {
-    padding-block-end: calc(#{awsui.$space-scaled-xs} + #{awsui.$border-active-width} - 2px);
+    padding-bottom: calc(#{awsui.$space-scaled-xs} + #{awsui.$border-active-width} - 2px);
   }
 
   &--warnings {
@@ -168,8 +161,8 @@
 
   &--divider {
     display: inline-block;
-    block-size: awsui.$line-height-body-m;
-    inline-size: awsui.$border-code-editor-status-divider-width;
+    height: awsui.$line-height-body-m;
+    width: awsui.$border-code-editor-status-divider-width;
     background: awsui.$color-border-tabs-divider;
     vertical-align: middle;
   }
@@ -185,13 +178,12 @@ $default-height: 480px;
   display: flex;
   align-items: center;
   justify-content: center;
-  block-size: $default-height;
+
+  height: $default-height;
+
   color: awsui.$color-text-body-secondary;
   background: awsui.$color-background-code-editor-loading;
-  border-start-start-radius: awsui.$border-radius-code-editor;
-  border-start-end-radius: awsui.$border-radius-code-editor;
-  border-end-start-radius: awsui.$border-radius-code-editor;
-  border-end-end-radius: awsui.$border-radius-code-editor;
+  border-radius: awsui.$border-radius-code-editor;
 }
 
 .error-screen {

--- a/src/collection-preferences/content-display/content-display-option.scss
+++ b/src/collection-preferences/content-display/content-display-option.scss
@@ -29,20 +29,15 @@ $border-radius: awsui.$border-radius-item;
   @include styles.styles-reset;
   display: flex;
   align-items: flex-start;
-  padding-block: awsui.$space-xs;
-  padding-inline-start: 0;
-  padding-inline-end: awsui.$space-scaled-xs;
+  padding: awsui.$space-xs awsui.$space-scaled-xs awsui.$space-xs 0;
   background-color: awsui.$color-background-container-content;
-  border-start-start-radius: $border-radius;
-  border-start-end-radius: $border-radius;
-  border-end-start-radius: $border-radius;
-  border-end-end-radius: $border-radius;
+  border-radius: $border-radius;
 }
 
 .content-display-option {
   list-style: none;
   position: relative;
-  border-block-start: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
+  border-top: awsui.$border-divider-list-width solid awsui.$color-border-divider-default;
   &:not(.placeholder).sorting {
     @include animated;
   }
@@ -52,12 +47,12 @@ $border-radius: awsui.$border-radius-item;
       &:after {
         content: ' ';
         position: absolute;
-        inset: 0;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
         background: awsui.$color-drag-placeholder-hover;
-        border-start-start-radius: $border-radius;
-        border-start-end-radius: $border-radius;
-        border-end-start-radius: $border-radius;
-        border-end-end-radius: $border-radius;
+        border-radius: $border-radius;
       }
     }
   }
@@ -66,15 +61,12 @@ $border-radius: awsui.$border-radius-item;
 .content-display-option-label {
   flex-grow: 1;
   @include styles.text-wrapping;
-  padding-inline-end: awsui.$space-l;
+  padding-right: awsui.$space-l;
 }
 
 .drag-overlay {
   box-shadow: awsui.$shadow-container-active;
-  border-start-start-radius: $border-radius;
-  border-start-end-radius: $border-radius;
-  border-end-start-radius: $border-radius;
-  border-end-end-radius: $border-radius;
+  border-radius: $border-radius;
   @include focus-visible {
     @include styles.focus-highlight(0px, $border-radius);
   }

--- a/src/collection-preferences/content-display/styles.scss
+++ b/src/collection-preferences/content-display/styles.scss
@@ -15,18 +15,16 @@
 .content-display-title {
   @include styles.font-label;
   color: awsui.$color-text-form-label;
-  margin-block: 0;
-  margin-inline: 0;
+  margin: 0;
 }
 
 .content-display-description {
   @include styles.form-control-description;
-  margin-block-start: awsui.$space-scaled-xxxs;
+  margin-top: awsui.$space-scaled-xxxs;
 }
 
 .content-display-option-list {
   position: relative;
   list-style: none;
-  padding-block: 0;
-  padding-inline: 0;
+  padding: 0;
 }

--- a/src/collection-preferences/styles.scss
+++ b/src/collection-preferences/styles.scss
@@ -18,7 +18,7 @@
 }
 
 .second-column-small {
-  padding-block-start: calc(2 * #{awsui.$space-scaled-l});
+  padding-top: calc(2 * #{awsui.$space-scaled-l});
 }
 
 .wrap-lines,

--- a/src/collection-preferences/visible-content.scss
+++ b/src/collection-preferences/visible-content.scss
@@ -18,33 +18,30 @@ $border: awsui.$border-divider-list-width solid awsui.$color-border-divider-defa
 .visible-content-title {
   @include styles.font-label;
   color: awsui.$color-text-form-label;
-  margin-block-start: 0;
-  margin-block-end: awsui.$space-scaled-l;
-  margin-inline: 0;
+  margin: 0;
+  margin-bottom: awsui.$space-scaled-l;
 }
 
 .visible-content-group-label {
   color: awsui.$color-text-group-label;
-  padding-block-end: awsui.$space-xs;
-  border-block-end: $border;
+  padding-bottom: awsui.$space-xs;
+  border-bottom: $border;
 }
 
 .visible-content-option {
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  padding-block: awsui.$space-xs;
-  padding-inline-start: awsui.$space-scaled-l;
-  padding-inline-end: 0px;
-  border-block-end: $border;
+  padding: awsui.$space-xs 0px awsui.$space-xs awsui.$space-scaled-l;
+  border-bottom: $border;
   &:last-child {
-    border-block-end: none;
+    border-bottom: none;
   }
 }
 
 .visible-content-option-label {
   overflow: hidden;
   text-overflow: ellipsis;
-  padding-inline-end: awsui.$space-l;
+  padding-right: awsui.$space-l;
   flex-grow: 1;
 }

--- a/src/column-layout/flexible-column-layout/styles.scss
+++ b/src/column-layout/flexible-column-layout/styles.scss
@@ -14,12 +14,13 @@
 
   &.grid-variant-text-grid {
     > .item {
-      border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
-      padding-inline: awsui.$space-grid-gutter;
+      border-left: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+      padding-left: awsui.$space-grid-gutter;
+      padding-right: awsui.$space-grid-gutter;
 
       &.first-column {
-        border-inline-start: 0;
-        padding-inline-start: 0;
+        border-left: 0;
+        padding-left: 0;
       }
     }
   }

--- a/src/column-layout/styles.scss
+++ b/src/column-layout/styles.scss
@@ -63,10 +63,10 @@ $column-breakpoint-spans: (
 @mixin make-horizontal-borders() {
   /* stylelint-disable selector-max-universal */
   > * {
-    border-block-end: $column-layout-border;
+    border-bottom: $column-layout-border;
 
     &:last-child {
-      border-block-end-width: 0;
+      border-bottom-width: 0;
     }
   }
   /* stylelint-enable selector-max-universal */
@@ -89,7 +89,7 @@ $column-breakpoint-spans: (
       @for $h from 1 through $items-per-row - $m + 1 {
         @if $h > 0 {
           > *:nth-last-child(#{$m}):nth-child(#{$items-per-row}n + #{$h}) {
-            border-block-end-width: 0;
+            border-bottom-width: 0;
           }
         }
       }
@@ -103,31 +103,25 @@ div.column-layout {
   word-wrap: break-word;
 
   > .grid {
-    margin-block: calc(#{$grid-gutter-width} / -2);
-    margin-inline: calc(#{$grid-gutter-width} / -2);
+    margin: calc(#{$grid-gutter-width} / -2);
 
     &.grid-no-gutters {
-      margin-block: 0;
-      margin-inline: 0;
+      margin: 0;
     }
 
     &.grid-variant-text-grid {
       @include make-vertical-borders('left');
-      margin-block: calc(-1 * #{$grid-gutter-width} / 2);
-      margin-inline: calc(-1 * #{$grid-gutter-width});
+      margin: calc(-1 * #{$grid-gutter-width} / 2) calc(-1 * #{$grid-gutter-width});
     }
     /* stylelint-disable-next-line selector-max-universal */
     &:not(.grid-no-gutters) > * {
-      padding-block: calc(#{$grid-gutter-width} / 2);
-      padding-inline: calc(#{$grid-gutter-width} / 2);
+      padding: calc(#{$grid-gutter-width} / 2);
     }
 
     /* stylelint-disable-next-line selector-max-universal */
     &:not(.grid-no-gutters).grid-variant-text-grid > * {
-      padding-block: 0;
-      padding-inline: $grid-gutter-width;
-      margin-block: calc(#{$grid-gutter-width} / 2);
-      margin-inline: 0;
+      padding: 0 $grid-gutter-width;
+      margin: calc(#{$grid-gutter-width} / 2) 0;
     }
 
     &.grid-vertical-borders {

--- a/src/container/shared.scss
+++ b/src/container/shared.scss
@@ -7,6 +7,8 @@
 @use '../internal/styles/tokens' as awsui;
 
 $header-padding-horizontal: awsui.$space-container-horizontal;
+$header-padding: awsui.$space-container-header-top awsui.$space-container-horizontal
+  awsui.$space-container-header-bottom;
 $footer-padding: awsui.$space-scaled-s awsui.$space-container-horizontal;
 
 // HACK: Remediate focus border for expandable section
@@ -18,5 +20,5 @@ $header-focus-visible-padding: calc(#{awsui.$space-scaled-s} - #{awsui.$border-d
 }
 
 @mixin divider {
-  border-block-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  border-top: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -15,7 +15,7 @@
   &.fit-height {
     display: flex;
     flex-direction: column;
-    block-size: 100%;
+    height: 100%;
     &.with-side-media {
       flex-direction: row;
     }
@@ -33,15 +33,15 @@
     &-stacked:not(:last-child),
     &-stacked:not(:last-child)::before,
     &-stacked:not(:last-child)::after {
-      border-end-end-radius: 0;
-      border-end-start-radius: 0;
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
     }
     // Meld container top corners into preceding container
     &-stacked + &-stacked,
     &-stacked + &-stacked::before,
     &-stacked + &-stacked::after {
-      border-start-start-radius: 0;
-      border-start-end-radius: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
     // Replace container border with a divider
     &-stacked + &-stacked::before {
@@ -56,10 +56,10 @@
   // To ensure the top border/divider is visible on sticky elements which have a higher z-index
   &.sticky-enabled {
     &::before {
-      inset-block-start: calc(-1 * #{awsui.$border-container-top-width});
+      top: calc(-1 * #{awsui.$border-container-top-width});
     }
     &.variant-stacked::before {
-      inset-block-start: calc(-1 * #{awsui.$border-divider-section-width});
+      top: calc(-1 * #{awsui.$border-divider-section-width});
     }
   }
 }
@@ -77,9 +77,9 @@
 .content-wrapper {
   display: flex;
   flex-direction: column;
-  inline-size: 100%;
+  width: 100%;
   &-fit-height {
-    block-size: 100%;
+    height: 100%;
     overflow: hidden;
   }
 }
@@ -92,42 +92,41 @@
   img,
   video,
   picture {
-    inline-size: 100%;
-    block-size: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
     object-position: center;
   }
 
   // stylelint-disable-next-line @cloudscape-design/no-implicit-descendant, selector-max-type
   iframe {
-    inline-size: 100%;
-    block-size: 100%;
-    border-block: 0;
-    border-inline: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
   }
 
   &-top {
-    max-block-size: 66%;
-    border-start-start-radius: awsui.$border-radius-container;
-    border-start-end-radius: awsui.$border-radius-container;
+    max-height: 66%;
+    border-top-left-radius: awsui.$border-radius-container;
+    border-top-right-radius: awsui.$border-radius-container;
   }
 
   &-side {
-    max-inline-size: 66%;
-    border-start-start-radius: awsui.$border-radius-container;
-    border-end-start-radius: awsui.$border-radius-container;
+    max-width: 66%;
+    border-top-left-radius: awsui.$border-radius-container;
+    border-bottom-left-radius: awsui.$border-radius-container;
   }
 }
 
 .header {
   background-color: awsui.$color-background-container-header;
-  border-start-start-radius: awsui.$border-radius-container;
-  border-start-end-radius: awsui.$border-radius-container;
+  border-top-left-radius: awsui.$border-radius-container;
+  border-top-right-radius: awsui.$border-radius-container;
 
   &.header-with-media {
     background: none;
     &:not(:empty) {
-      border-block-end: none;
+      border-bottom: none;
     }
   }
 
@@ -139,21 +138,16 @@
   }
 
   &-sticky-enabled {
-    inset-block-start: 0;
+    top: 0;
     /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     position: sticky;
     z-index: 800;
   }
 
   &-stuck {
-    border-start-start-radius: 0;
-    border-start-end-radius: 0;
-    border-end-start-radius: 0;
-    border-end-end-radius: 0;
-
+    border-radius: 0;
     &::before {
-      border-block: 0;
-      border-inline: 0;
+      border: 0;
     }
     &:not(.header-variant-cards) {
       box-shadow: awsui.$shadow-sticky-embedded;
@@ -162,27 +156,23 @@
 
   &-dynamic-height.header-stuck {
     // to prevent the block from changing its height when variant dynamically changes
-    margin-block-end: calc(#{awsui.$line-height-heading-xl} - #{awsui.$line-height-heading-l});
+    margin-bottom: calc(#{awsui.$line-height-heading-xl} - #{awsui.$line-height-heading-l});
   }
 
   &:not(:empty) {
-    border-block-end: awsui.$border-container-sticky-width solid awsui.$color-border-container-divider;
+    border-bottom: awsui.$border-container-sticky-width solid awsui.$color-border-container-divider;
   }
 
   &.with-paddings {
-    padding-block-start: awsui.$space-container-header-top;
-    padding-block-end: awsui.$space-container-header-bottom;
-    padding-inline: awsui.$space-container-horizontal;
-
+    padding: shared.$header-padding;
     &.header-variant-cards {
-      padding-block: awsui.$space-container-header-top;
-      padding-inline: awsui.$space-container-horizontal;
+      padding: awsui.$space-container-header-top awsui.$space-container-horizontal;
     }
   }
 
   &.with-hidden-content {
-    border-end-start-radius: awsui.$border-radius-container;
-    border-end-end-radius: awsui.$border-radius-container;
+    border-bottom-left-radius: awsui.$border-radius-container;
+    border-bottom-right-radius: awsui.$border-radius-container;
   }
 
   &-variant-cards {
@@ -193,10 +183,9 @@
 
     &.header-stuck::after,
     &.header-stuck::before {
-      border-block: 0;
-      border-inline: 0;
-      border-start-start-radius: 0;
-      border-start-end-radius: 0;
+      border: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
     }
   }
 
@@ -207,7 +196,10 @@
       content: '';
 
       position: absolute;
-      inset: 0;
+      right: 0;
+      left: 0;
+      bottom: 0;
+      top: 0;
 
       box-shadow: awsui.$shadow-sticky;
       // This polygon only shows the part of the shadow that is lower than the element itself.
@@ -231,13 +223,12 @@ the default white background of the container component.
     overflow: auto;
   }
   &.with-paddings {
-    padding-block: awsui.$space-scaled-l;
-    padding-inline: awsui.$space-container-horizontal;
+    padding: awsui.$space-scaled-l awsui.$space-container-horizontal;
 
     .header + & {
-      padding-block-start: awsui.$space-container-content-top;
+      padding-top: awsui.$space-container-content-top;
       &.content-with-media {
-        padding-block-start: 0;
+        padding-top: 0;
       }
     }
   }
@@ -245,8 +236,7 @@ the default white background of the container component.
 
 .footer {
   &.with-paddings {
-    padding-block: awsui.$space-scaled-s;
-    padding-inline: awsui.$space-container-horizontal;
+    padding: shared.$footer-padding;
   }
 
   &.with-divider {

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -20,7 +20,7 @@ nodes will directly touch with no gap between them.
   }
 
   > .header {
-    padding-block-end: awsui.$space-content-header-padding-bottom;
+    padding-bottom: awsui.$space-content-header-padding-bottom;
   }
 }
 
@@ -28,7 +28,7 @@ nodes will directly touch with no gap between them.
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto #{awsui.$space-dark-header-overlap-distance} 1fr;
-  min-block-size: 100%;
+  min-height: 100%;
 
   > .background {
     background-color: awsui.$color-background-layout-main;
@@ -44,7 +44,7 @@ nodes will directly touch with no gap between them.
   > .header {
     grid-column: 1;
     grid-row: 1;
-    padding-block-end: awsui.$space-content-header-padding-bottom;
+    padding-bottom: awsui.$space-content-header-padding-bottom;
   }
 
   > .content {
@@ -60,7 +60,7 @@ nodes will directly touch with no gap between them.
       1fr;
 
     > .content {
-      padding-block-start: var(#{custom-props.$containerFirstGap}, 0px);
+      padding-top: var(#{custom-props.$containerFirstGap}, 0px);
     }
   }
 

--- a/src/date-picker/styles.scss
+++ b/src/date-picker/styles.scss
@@ -29,7 +29,7 @@
 
 .date-picker-container {
   position: relative;
-  max-inline-size: 234px;
+  max-width: 234px;
 }
 
 .date-picker-trigger {
@@ -37,8 +37,8 @@
 }
 
 .date-picker-input {
-  padding-inline-end: awsui.$space-xs;
-  inline-size: 100%;
+  padding-right: awsui.$space-xs;
+  width: 100%;
 }
 
 .open-calendar-button {

--- a/src/date-range-picker/calendar/grids/styles.scss
+++ b/src/date-range-picker/calendar/grids/styles.scss
@@ -31,19 +31,17 @@
 }
 
 .grid {
-  inline-size: awsui.$size-calendar-grid-width;
+  width: awsui.$size-calendar-grid-width;
   border-spacing: 0;
 }
 .grid-cell {
-  inline-size: calc(100% / 7);
+  width: calc(100% / 7);
   word-break: break-word;
   text-align: center;
   font-weight: unset;
 }
 .day-header {
-  padding-block-start: awsui.$space-s;
-  padding-block-end: awsui.$space-xxs;
-  padding-inline: 0;
+  padding: awsui.$space-s 0 awsui.$space-xxs;
   color: calendar.$grid-day-name-color;
   @include styles.font-body-s;
 }
@@ -53,10 +51,9 @@
 }
 
 .day {
-  border-block-end: calendar.$grid-border;
-  border-inline-end: calendar.$grid-border;
-  padding-block: awsui.$space-xxs;
-  padding-inline: 0;
+  border-bottom: calendar.$grid-border;
+  border-right: calendar.$grid-border;
+  padding: awsui.$space-xxs 0;
   color: calendar.$grid-disabled-day-color;
   position: relative;
 
@@ -68,10 +65,10 @@
     content: '';
     position: absolute;
     z-index: 1;
-    inset-block-start: calc(-1 * #{awsui.$border-item-width});
-    inset-block-end: -1px;
-    inset-inline-start: -1px;
-    inset-inline-end: calc(-1 * #{awsui.$border-item-width});
+    top: calc(-1 * #{awsui.$border-item-width});
+    left: -1px;
+    bottom: -1px;
+    right: calc(-1 * #{awsui.$border-item-width});
     background-color: transparent;
   }
 
@@ -90,11 +87,11 @@
 }
 
 .in-first-row:not(.in-previous-month) {
-  border-block-start: calendar.$grid-border;
+  border-top: calendar.$grid-border;
 }
 
 .in-previous-month:not(.last-day-of-month) {
-  border-inline-end-color: transparent;
+  border-right-color: transparent;
 }
 
 .in-next-month {
@@ -102,10 +99,10 @@
 }
 
 .in-first-column {
-  border-inline-start: 1px solid transparent;
+  border-left: 1px solid transparent;
 
   &.in-current-month {
-    border-inline-start: calendar.$grid-border;
+    border-left: calendar.$grid-border;
   }
 }
 
@@ -119,10 +116,7 @@
     &.no-range {
       &,
       &::after {
-        border-start-start-radius: awsui.$border-radius-item;
-        border-start-end-radius: awsui.$border-radius-item;
-        border-end-start-radius: awsui.$border-radius-item;
-        border-end-end-radius: awsui.$border-radius-item;
+        border-radius: awsui.$border-radius-item;
       }
     }
     &:hover {
@@ -130,8 +124,7 @@
       background-color: calendar.$grid-hover-background-color;
       &:not(.selected) {
         &::after {
-          border-block: awsui.$border-item-width solid calendar.$grid-hover-border-color;
-          border-inline: awsui.$border-item-width solid calendar.$grid-hover-border-color;
+          border: awsui.$border-item-width solid calendar.$grid-hover-border-color;
         }
       }
     }
@@ -140,10 +133,7 @@
 
 .today:not(.in-range) {
   background-color: calendar.$grid-today-background-color;
-  border-start-start-radius: awsui.$border-radius-item;
-  border-start-end-radius: awsui.$border-radius-item;
-  border-end-start-radius: awsui.$border-radius-item;
-  border-end-end-radius: awsui.$border-radius-item;
+  border-radius: awsui.$border-radius-item;
   font-weight: styles.$font-weight-bold;
 }
 
@@ -165,8 +155,7 @@
 
   &::after {
     background-color: calendar.$grid-selected-background-color;
-    border-block: awsui.$border-item-width solid calendar.$grid-selected-border-color;
-    border-inline: awsui.$border-item-width solid calendar.$grid-selected-border-color;
+    border: awsui.$border-item-width solid calendar.$grid-selected-border-color;
     z-index: 0;
   }
 

--- a/src/date-range-picker/relative-range/styles.scss
+++ b/src/date-range-picker/relative-range/styles.scss
@@ -9,26 +9,26 @@
 
 .custom-range {
   // This padding aligns the custom range selection with the radio labels
-  padding-inline-start: calc(#{1.4 * styles.$base-size} + #{awsui.$space-xs});
+  padding-left: calc(#{1.4 * styles.$base-size} + #{awsui.$space-xs});
 
   display: flex;
-  inline-size: 80%;
+  width: 80%;
 }
 .custom-range--no-padding {
-  padding-inline-start: 0;
+  padding-left: 0;
 }
 
 .custom-range-form-controls {
   display: flex;
-  inline-size: 100%;
+  width: 100%;
 
   > .custom-range-duration,
   > .custom-range-unit {
-    inline-size: 50%;
+    width: 50%;
   }
 
   > .custom-range-duration {
-    margin-inline-end: awsui.$space-xs;
+    margin-right: awsui.$space-xs;
   }
 
   &.vertical {
@@ -36,11 +36,11 @@
 
     > .custom-range-duration,
     > .custom-range-unit {
-      inline-size: 100%;
+      width: 100%;
     }
 
     > .custom-range-unit {
-      margin-block-start: awsui.$space-s;
+      margin-top: awsui.$space-s;
     }
   }
 }

--- a/src/date-range-picker/styles.scss
+++ b/src/date-range-picker/styles.scss
@@ -14,7 +14,7 @@ $calendar-header-color: awsui.$color-text-body-default;
 
 .root {
   @include styles.styles-reset;
-  max-inline-size: 32em;
+  max-width: 32em;
 }
 
 .focus-lock {
@@ -22,7 +22,7 @@ $calendar-header-color: awsui.$color-text-body-default;
 }
 
 .trigger-wrapper {
-  min-inline-size: calc(#{$calendar-grid-width} + 2 * #{awsui.$space-l});
+  min-width: calc(#{$calendar-grid-width} + 2 * #{awsui.$space-l});
 }
 
 .trigger-flexbox {
@@ -30,10 +30,10 @@ $calendar-header-color: awsui.$color-text-body-default;
 }
 
 .calendar-container {
-  inline-size: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs});
+  width: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs});
 
   &.one-grid {
-    inline-size: $calendar-grid-width;
+    width: $calendar-grid-width;
   }
 }
 
@@ -47,10 +47,12 @@ $calendar-header-color: awsui.$color-text-body-default;
 
   &-header-months-wrapper {
     position: absolute;
-    inset: 0;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
 
-    margin-block: 0;
-    margin-inline: 0;
+    margin: 0;
 
     display: flex;
     justify-content: space-around;
@@ -90,7 +92,7 @@ $calendar-header-color: awsui.$color-text-body-default;
   gap: awsui.$space-xs;
 }
 .date-and-time-wrapper {
-  inline-size: $calendar-grid-width;
+  width: $calendar-grid-width;
   display: grid;
   gap: awsui.$space-xs;
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
@@ -100,33 +102,29 @@ $calendar-header-color: awsui.$color-text-body-default;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  border-block-start: 1px solid #{awsui.$color-border-dropdown-item-default};
-  padding-block-start: 0;
-  padding-block-end: awsui.$space-s;
-  padding-inline: awsui.$space-l;
+  border-top: 1px solid #{awsui.$color-border-dropdown-item-default};
+  padding: 0 awsui.$space-l awsui.$space-s;
 
   &.has-clear-button {
     justify-content: space-between;
   }
 
   &.one-grid {
-    padding-block-start: 0;
-    padding-block-end: awsui.$space-s;
-    padding-inline: awsui.$space-xs;
+    padding: 0 awsui.$space-xs awsui.$space-s;
   }
 }
 
 .footer-button-wrapper {
-  padding-block-start: awsui.$space-s;
+  padding-top: awsui.$space-s;
 
   &:last-child {
-    margin-inline-start: auto;
+    margin-left: auto;
   }
 }
 
 .icon-wrapper {
   color: awsui.$color-text-interactive-default;
-  margin-inline-end: awsui.$space-xs;
+  margin-right: awsui.$space-xs;
 }
 
 .label {
@@ -156,12 +154,9 @@ $calendar-header-color: awsui.$color-text-body-default;
   // widths.
   overflow: auto;
 
-  border-block-start: 1px solid #{awsui.$color-border-container-top};
-  border-block-end: 1px solid #{awsui.$color-border-container-top};
-  border-start-start-radius: awsui.$border-radius-dropdown;
-  border-start-end-radius: awsui.$border-radius-dropdown;
-  border-end-start-radius: awsui.$border-radius-dropdown;
-  border-end-end-radius: awsui.$border-radius-dropdown;
+  border-top: 1px solid #{awsui.$color-border-container-top};
+  border-bottom: 1px solid #{awsui.$color-border-container-top};
+  border-radius: awsui.$border-radius-dropdown;
 
   &:focus {
     outline: none;
@@ -174,10 +169,10 @@ $calendar-header-color: awsui.$color-text-body-default;
 .dropdown-content {
   user-select: text;
   background-color: awsui.$color-background-container-content;
-  inline-size: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs} + 2 * #{awsui.$space-l});
+  width: calc(2 * #{$calendar-grid-width} + #{awsui.$space-xs} + 2 * #{awsui.$space-l});
 
   &.one-grid {
-    inline-size: calc(#{$calendar-grid-width} + 2 * #{awsui.$space-l});
+    width: calc(#{$calendar-grid-width} + 2 * #{awsui.$space-l});
   }
 }
 

--- a/src/drawer/styles.scss
+++ b/src/drawer/styles.scss
@@ -10,23 +10,18 @@
 .drawer {
   @include styles.styles-reset;
   word-wrap: break-word;
-  padding-block-start: awsui.$space-scaled-l;
-  padding-block-end: awsui.$space-scaled-xxxl;
-  padding-inline-start: awsui.$space-panel-side-left;
-  padding-inline-end: awsui.$space-panel-side-right;
+  padding: awsui.$space-scaled-l awsui.$space-panel-side-right awsui.$space-scaled-xxxl awsui.$space-panel-side-left;
 }
 
 .header {
   @include styles.font-panel-header;
   color: awsui.$color-text-heading-default;
-  padding-block-end: awsui.$space-scaled-l;
-  padding-inline: awsui.$space-panel-side-left calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
+  padding-bottom: awsui.$space-scaled-l;
+  padding-left: awsui.$space-panel-side-left;
   // padding to make sure the header doesn't overlap with the close icon
-  border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
-  margin-block-start: 0;
-  margin-block-end: awsui.$space-scaled-l;
-  margin-inline-end: calc(-1 * #{awsui.$space-panel-side-right});
-  margin-inline-start: calc(-1 * #{awsui.$space-panel-side-left});
+  padding-right: calc(#{awsui.$space-xl} + #{awsui.$space-scaled-xxl});
+  border-bottom: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  margin: 0 calc(-1 * #{awsui.$space-panel-side-right}) awsui.$space-scaled-l calc(-1 * #{awsui.$space-panel-side-left});
 
   h2,
   h3,
@@ -34,8 +29,10 @@
   h5,
   h6 {
     @include styles.font-panel-header;
-    padding-block: 0;
-    margin-block: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-top: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -40,29 +40,28 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 
 .icon-container {
   position: relative;
-  margin-inline: calc(#{$icon-margin-left}) calc(#{$icon-margin-right-normal});
+  margin-left: calc(#{$icon-margin-left});
   // For vertical alignment of text in side navigation items
+  margin-right: calc(#{$icon-margin-right-normal});
   &-container {
-    margin-inline-end: $icon-margin-right-medium;
+    margin-right: $icon-margin-right-medium;
   }
 }
 
 .wrapper {
   box-sizing: border-box;
-  border-block: none;
-  border-inline: none;
-  inline-size: 100%;
+  border: none;
+  width: 100%;
   line-height: awsui.$line-height-body-m;
-  text-align: start;
+  text-align: left;
 
   &-default,
   &-footer {
-    border-block: awsui.$border-divider-section-width solid transparent;
-    border-inline: awsui.$border-divider-section-width solid transparent;
+    border: awsui.$border-divider-section-width solid transparent;
   }
   &-navigation {
     // not needed for focus ring compensation, but to keep this variant vertically aligned with other variants when used together
-    border-inline-start: awsui.$border-divider-section-width solid transparent;
+    border-left: awsui.$border-divider-section-width solid transparent;
   }
 
   &-navigation,
@@ -87,55 +86,57 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   }
 
   &-default {
-    padding-block: awsui.$space-scaled-xxs;
-    padding-inline-end: awsui.$space-xxs;
+    padding-top: awsui.$space-scaled-xxs;
+    padding-bottom: awsui.$space-scaled-xxs;
+    padding-right: awsui.$space-xxs;
     &.header-deprecated {
-      padding-inline-start: awsui.$space-xxs;
+      padding-left: awsui.$space-xxs;
     }
     &:not(.header-deprecated) {
-      padding-inline-start: calc(#{awsui.$space-xxs} + #{$icon-total-space-normal});
+      padding-left: calc(#{awsui.$space-xxs} + #{$icon-total-space-normal});
     }
   }
 
   &-footer {
-    padding-block: awsui.$space-scaled-xxs;
+    padding-top: awsui.$space-scaled-xxs;
+    padding-bottom: awsui.$space-scaled-xxs;
   }
 
   &-footer,
   &-compact {
-    padding-inline-end: 0;
+    padding-right: 0;
     &.header-deprecated {
-      padding-inline-start: 0;
+      padding-left: 0;
     }
     &:not(.header-deprecated) {
-      padding-inline-start: $icon-total-space-normal;
+      padding-left: $icon-total-space-normal;
     }
   }
 
   &-container {
-    padding-block: awsui.$space-container-header-top awsui.$space-container-header-bottom;
-    padding-inline-end: container.$header-padding-horizontal;
+    padding-top: awsui.$space-container-header-top;
+    padding-bottom: awsui.$space-container-header-bottom;
+    padding-right: container.$header-padding-horizontal;
 
     &:not(.wrapper-expanded) {
       // Equal top and bottom padding so standalone header has vertical symmetry.
-      padding-block-end: awsui.$space-container-header-top;
+      padding-bottom: awsui.$space-container-header-top;
     }
     &.header-deprecated {
-      padding-inline-start: container.$header-padding-horizontal;
+      padding-left: container.$header-padding-horizontal;
     }
     &:not(.header-deprecated) {
-      padding-inline-start: calc(#{container.$header-padding-horizontal} + #{$icon-total-space-medium});
+      padding-left: calc(#{container.$header-padding-horizontal} + #{$icon-total-space-medium});
     }
 
     @include focus-visible.when-visible {
       // HACK: Remediate focus border
-      padding-block: calc(#{awsui.$space-scaled-s} - #{awsui.$border-divider-section-width});
-      padding-inline: calc(#{awsui.$space-l} - #{awsui.$border-divider-section-width});
+      padding: container.$header-focus-visible-padding;
     }
   }
 
   &-default.wrapper-expanded {
-    border-block-end-color: awsui.$color-border-divider-default;
+    border-bottom-color: awsui.$color-border-divider-default;
   }
 }
 
@@ -151,10 +152,8 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   &-wrapper {
     font-size: inherit;
     letter-spacing: inherit;
-    margin-block: 0;
-    margin-inline: 0;
-    padding-block: 0;
-    padding-inline: 0;
+    margin: 0;
+    padding: 0;
   }
 
   &-actions-wrapper {
@@ -173,18 +172,18 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   &-button {
     box-sizing: border-box;
     display: flex;
-    margin-inline-start: calc(-1 * #{$icon-total-space-normal});
+    margin-left: calc(-1 * #{$icon-total-space-normal});
   }
 
   &-container-button {
-    margin-inline-start: calc(-1 * #{$icon-total-space-medium});
+    margin-left: calc(-1 * #{$icon-total-space-medium});
   }
 
   &-container {
-    inline-size: 100%;
+    width: 100%;
     // The icon-container style is kept for variant='container' and header
     > .icon-container {
-      margin-block-start: awsui.$space-expandable-section-icon-offset-top;
+      margin-top: awsui.$space-expandable-section-icon-offset-top;
     }
   }
 
@@ -193,10 +192,8 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
       display: inline-flex;
       cursor: pointer;
       color: awsui.$color-text-expandable-section-navigation-icon-default;
-      border-block: 0;
-      border-inline: 0;
-      padding-block: 0;
-      padding-inline: 0;
+      border: 0;
+      padding: 0;
       background: transparent;
       outline: none;
       text-decoration: none;
@@ -221,13 +218,11 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
   display: none;
 
   &-default {
-    padding-block: awsui.$space-scaled-xs;
-    padding-inline: 0;
+    padding: awsui.$space-scaled-xs 0;
   }
 
   &-footer {
-    padding-block: awsui.$space-xs;
-    padding-inline: 0;
+    padding: awsui.$space-xs 0;
   }
 
   &-expanded {

--- a/src/file-upload/dropzone/styles.scss
+++ b/src/file-upload/dropzone/styles.scss
@@ -12,12 +12,8 @@
   align-items: center;
   justify-content: center;
   gap: awsui.$space-static-xxs;
-  padding-block: awsui.$space-static-l;
-  padding-inline: awsui.$space-static-l;
-  border-start-start-radius: awsui.$border-radius-dropzone;
-  border-start-end-radius: awsui.$border-radius-dropzone;
-  border-end-start-radius: awsui.$border-radius-dropzone;
-  border-end-end-radius: awsui.$border-radius-dropzone;
+  padding: awsui.$space-static-l;
+  border-radius: awsui.$border-radius-dropzone;
   color: awsui.$color-dropzone-text-active;
   background-color: awsui.$color-dropzone-background-active;
   font-weight: styles.$font-weight-bold;

--- a/src/file-upload/file-option/styles.scss
+++ b/src/file-upload/file-option/styles.scss
@@ -13,22 +13,22 @@
 }
 
 .file-option {
-  inline-size: 100%;
-  min-inline-size: 0;
+  width: 100%;
+  min-width: 0;
   display: flex;
   gap: awsui.$space-scaled-xs;
 }
 
 .file-option-thumbnail {
-  margin-block-start: awsui.$space-static-xxs;
-  max-inline-size: 60px;
+  margin-top: awsui.$space-static-xxs;
+  max-width: 60px;
 }
 
 .file-option-thumbnail-image {
-  inline-size: 100%;
-  block-size: auto;
+  width: 100%;
+  height: auto;
 }
 
 .file-option-metadata {
-  inline-size: 100%;
+  width: 100%;
 }

--- a/src/file-upload/styles.scss
+++ b/src/file-upload/styles.scss
@@ -11,5 +11,5 @@
 }
 
 .hints {
-  margin-block-start: awsui.$space-static-xxs;
+  margin-top: awsui.$space-static-xxs;
 }

--- a/src/flashbar/collapsible.scss
+++ b/src/flashbar/collapsible.scss
@@ -83,7 +83,7 @@ the grid layout will be:
        with one single line of text.
        This makes them look better during the collapse animation, in which they are already empty.
      */
-    min-block-size: calc(
+    min-height: calc(
       #{awsui.$line-height-body-m} + (
           #{awsui.$space-scaled-xs} + #{awsui.$border-field-width} + #{awsui.$space-scaled-xxs}
         ) * 2
@@ -114,7 +114,7 @@ the grid layout will be:
   #{custom-props.$stackedNotificationsDefaultBottomMargin}: calc(
     #{$notification-bar-line-height} + 2 * #{$notification-bar-padding-vertical} + 2 * #{$border-width} - #{$top-overlap}
   );
-  margin-block-end: calc(
+  margin-bottom: calc(
     var(
         #{custom-props.$stackedNotificationsBottomMargin},
         var(#{custom-props.$stackedNotificationsDefaultBottomMargin})
@@ -122,15 +122,16 @@ the grid layout will be:
   );
 
   > .notification-bar {
-    margin-block-start: calc(-1 * #{$top-overlap} + #{$offset-bottom});
+    margin-top: calc(-1 * #{$top-overlap} + #{$offset-bottom});
     /* $notification-bar-line-height + 2 * $notification-bar-padding-vertical + 2 * $border-width
     is the full height of the notification bar */
     /* stylelint-disable scss/operator-no-newline-after */
-    margin-block-end: calc(
+    margin-bottom: calc(
       #{$top-overlap} - #{$notification-bar-line-height} - 2 * #{$notification-bar-padding-vertical} - 2 * #{$border-width} -
         #{$offset-bottom}
     );
-    padding-block: $notification-bar-padding-vertical;
+    padding-top: $notification-bar-padding-vertical;
+    padding-bottom: $notification-bar-padding-vertical;
   }
 }
 
@@ -200,12 +201,8 @@ the grid layout will be:
   @include styles.text-wrapping;
   background: awsui.$color-background-notification-stack-bar;
   border-color: awsui.$color-border-notification-stack-bar;
-  border-start-start-radius: awsui.$border-radius-button;
-  border-start-end-radius: awsui.$border-radius-button;
-  border-end-start-radius: awsui.$border-radius-button;
-  border-end-end-radius: awsui.$border-radius-button;
-  border-block-style: solid;
-  border-inline-style: solid;
+  border-radius: awsui.$border-radius-button;
+  border-style: solid;
   box-shadow: awsui.$shadow-panel-toggle;
   color: awsui.$color-text-notification-stack-bar;
   cursor: pointer;
@@ -217,7 +214,8 @@ the grid layout will be:
   column-gap: calc(#{awsui.$space-m} + #{awsui.$space-xxs});
   justify-content: center;
   letter-spacing: awsui.$font-button-letter-spacing;
-  margin-inline: auto;
+  margin-left: auto;
+  margin-right: auto;
   row-gap: 0;
   text-align: center;
   text-decoration: none;
@@ -229,8 +227,10 @@ the grid layout will be:
     @include typography.default-text-style;
     color: awsui.$color-text-notification-stack-bar;
     cursor: pointer;
-    margin-block: 0;
-    padding-block: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   > .status {
@@ -255,7 +255,7 @@ the grid layout will be:
       row-gap: 0;
 
       > .type-count > .count-number {
-        margin-inline-start: awsui.$space-xxs;
+        margin-left: awsui.$space-xxs;
       }
     }
   }
@@ -271,16 +271,16 @@ the grid layout will be:
 
   &.visual-refresh {
     $border-width: map.get($notification-bar-border-width, 'visual-refresh');
-    border-block-width: $border-width;
-    border-inline-width: $border-width;
-    padding-inline: awsui.$space-l;
+    border-width: $border-width;
+    padding-left: awsui.$space-l;
+    padding-right: awsui.$space-l;
   }
 
   &:not(.visual-refresh) {
     $border-width: map.get($notification-bar-border-width, 'classic');
-    border-block-width: $border-width;
-    border-inline-width: $border-width;
-    padding-inline: awsui.$space-s;
+    border-width: $border-width;
+    padding-left: awsui.$space-s;
+    padding-right: awsui.$space-s;
 
     &:focus {
       text-decoration: none;
@@ -295,9 +295,9 @@ the grid layout will be:
     display: inline-block;
     flex-grow: 1;
     background: none;
-    border-block: 0;
-    border-inline: none;
-    padding-block: 0;
+    border: 0 none;
+    padding-top: 0;
+    padding-bottom: 0;
 
     > .icon {
       @include styles.with-motion {
@@ -321,5 +321,5 @@ the grid layout will be:
 // Prevent the sticky Flashbar from reaching the end of the window by leaving some space below.
 .stack.expanded:not(.floating) {
   // Default to 0 so that this does not apply to non-sticky Flashbar.
-  padding-block-end: var(#{custom-props.$flashbarStickyBottomMargin}, 0);
+  padding-bottom: var(#{custom-props.$flashbarStickyBottomMargin}, 0);
 }

--- a/src/flashbar/styles.scss
+++ b/src/flashbar/styles.scss
@@ -15,7 +15,7 @@
   /* stylelint-disable-next-line selector-max-type */
   > li + li {
     // Avoid Flashbar list gets additional padding to fix issue AWSUI-20382
-    padding-block-start: 0;
+    padding-top: 0;
   }
 }
 
@@ -29,22 +29,15 @@
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
-  padding-block: awsui.$space-scaled-xs;
-  padding-inline: awsui.$space-flashbar-horizontal;
-  border-start-start-radius: awsui.$border-radius-flashbar;
-  border-start-end-radius: awsui.$border-radius-flashbar;
-  border-end-start-radius: awsui.$border-radius-flashbar;
-  border-end-end-radius: awsui.$border-radius-flashbar;
+  padding: awsui.$space-scaled-xs awsui.$space-flashbar-horizontal;
+  border-radius: awsui.$border-radius-flashbar;
   color: awsui.$color-text-notification-default;
   overflow-wrap: break-word;
   word-wrap: break-word;
 
   &::before {
     @include styles.base-pseudo-element;
-    border-start-start-radius: awsui.$border-radius-flashbar;
-    border-start-end-radius: awsui.$border-radius-flashbar;
-    border-end-start-radius: awsui.$border-radius-flashbar;
-    border-end-end-radius: awsui.$border-radius-flashbar;
+    border-radius: awsui.$border-radius-flashbar;
     box-shadow: awsui.$shadow-flash-sticky;
   }
   &-refresh::before {
@@ -54,14 +47,12 @@
 
 .flash-list {
   list-style: none;
-  padding-block: 0;
-  padding-inline: 0;
-  margin-block: 0;
-  margin-inline: 0;
+  padding: 0;
+  margin: 0;
 
   &:not(.collapsed) {
     > li:not(:last-child) {
-      margin-block-end: awsui.$space-xxxs;
+      margin-bottom: awsui.$space-xxxs;
     }
   }
 }
@@ -69,13 +60,13 @@
 .flash-body {
   display: flex;
   flex-grow: 1;
-  min-inline-size: 0;
+  min-width: 0;
 }
 
 .flash-focus-container {
   display: flex;
   flex: 1;
-  min-inline-size: 0;
+  min-width: 0;
 
   &:focus {
     outline: none;
@@ -86,15 +77,13 @@
 }
 
 .flash-text {
-  margin-block: awsui.$border-field-width;
-  margin-inline: 0;
-  padding-block: awsui.$space-scaled-xxs;
-  padding-inline: awsui.$space-xxs;
+  margin: awsui.$border-field-width 0;
+  padding: awsui.$space-scaled-xxs awsui.$space-xxs;
 }
 
 .flash-icon {
   flex: 0 0 auto;
-  padding-inline-start: 0;
+  padding-left: 0;
 }
 
 .flash-message {
@@ -112,8 +101,9 @@
 
 .dismiss-button-wrapper {
   flex: 0 0 auto;
-  margin-inline: awsui.$space-s calc(-1 * #{awsui.$space-xxs});
-  padding-inline-end: awsui.$space-flashbar-dismiss-right;
+  margin-left: awsui.$space-s;
+  margin-right: calc(-1 * #{awsui.$space-xxs});
+  padding-right: awsui.$space-flashbar-dismiss-right;
 }
 
 .dismiss-button {
@@ -122,15 +112,15 @@
 
 .action-button-wrapper {
   white-space: nowrap;
-  margin-inline-start: awsui.$space-flashbar-action-left;
+  margin-left: awsui.$space-flashbar-action-left;
 }
 
 .flashbar.breakpoint-default > .flash-list > .flash-list-item > .flash > .flash-body {
   display: block;
   & > .action-button-wrapper {
-    margin-inline-start: awsui.$space-l;
-    padding-inline-start: awsui.$space-xxs;
-    margin-block-end: awsui.$space-xxs;
+    margin-left: awsui.$space-l;
+    padding-left: awsui.$space-xxs;
+    margin-bottom: awsui.$space-xxs;
   }
 }
 

--- a/src/form-field/styles.scss
+++ b/src/form-field/styles.scss
@@ -24,8 +24,8 @@
 }
 
 .info {
-  padding-inline-start: awsui.$space-xs;
-  border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
+  padding-left: awsui.$space-xs;
+  border-left: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
 }
 
 .description,
@@ -35,7 +35,7 @@
 
 .hints,
 .constraint-has-error {
-  padding-block-start: awsui.$space-xxs;
+  padding-top: awsui.$space-xxs;
 }
 
 .secondary-control {
@@ -44,7 +44,7 @@
 
 .controls {
   &:not(.label-hidden) {
-    padding-block-start: awsui.$space-xxs;
+    padding-top: awsui.$space-xxs;
   }
 }
 
@@ -61,7 +61,7 @@
 }
 
 .error__message {
-  margin-inline-start: awsui.$space-xxs;
+  margin-left: awsui.$space-xxs;
 }
 
 .visually-hidden {

--- a/src/form/styles.scss
+++ b/src/form/styles.scss
@@ -11,7 +11,7 @@
 }
 
 .header:not(.full-page) {
-  margin-block-end: awsui.$space-scaled-m;
+  margin-bottom: awsui.$space-scaled-m;
 }
 
 .content {
@@ -23,23 +23,23 @@
 }
 
 .footer {
-  margin-block-start: awsui.$space-scaled-l;
+  margin-top: awsui.$space-scaled-l;
 }
 .actions-section {
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
   flex-wrap: wrap;
-  margin-inline-start: calc(-1 * #{awsui.$space-scaled-m});
-  margin-block-end: calc(-1 * #{awsui.$space-scaled-m});
+  margin-left: calc(-1 * #{awsui.$space-scaled-m});
+  margin-bottom: calc(-1 * #{awsui.$space-scaled-m});
 }
 .secondary-actions {
-  min-inline-size: 1px;
-  margin-inline-start: awsui.$space-scaled-m;
-  margin-block-end: awsui.$space-scaled-m;
+  min-width: 1px;
+  margin-left: awsui.$space-scaled-m;
+  margin-bottom: awsui.$space-scaled-m;
 }
 .actions {
-  min-inline-size: 1px;
-  margin-inline-start: awsui.$space-scaled-m;
-  margin-block-end: awsui.$space-scaled-m;
+  min-width: 1px;
+  margin-left: awsui.$space-scaled-m;
+  margin-bottom: awsui.$space-scaled-m;
 }


### PR DESCRIPTION
### Description

This reverts two commits

* e59a6505d34813321cb9806de196dea5d0a55b42
* 8400936648a425c75b87853ab546b2cf4435752e

There was found an issue with `postcss-preset-env` and we are undoing these changes for now
Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
