### PR TITLE
refactor: Replace records having numeric keys with maps, part 2

### DIFF
--- a/src/internal/components/masked-input/__tests__/utils/mask-format.test.ts
+++ b/src/internal/components/masked-input/__tests__/utils/mask-format.test.ts
@@ -105,4 +105,13 @@ describe('MaskFormat', () => {
       expect(maskFormat.getSegmentValueWithAddition(3, '00:00', '1')).toBe(10);
     });
   });
+
+  describe('replaceDigitsWithZeroes', () => {
+    test('replaces selected digits with zeroes', () => {
+      expect(maskFormat.replaceDigitsWithZeroes('12:34', 0, 1)).toEqual({ position: 0, value: '02:34' });
+      expect(maskFormat.replaceDigitsWithZeroes('12:34', 1, 2)).toEqual({ position: 1, value: '10:34' });
+      expect(maskFormat.replaceDigitsWithZeroes('12:34', 1, 3)).toEqual({ position: 1, value: '10:34' });
+      expect(maskFormat.replaceDigitsWithZeroes('12:34', 1, 4)).toEqual({ position: 1, value: '10:04' });
+    });
+  });
 });

--- a/src/internal/components/masked-input/utils/mask-format.ts
+++ b/src/internal/components/masked-input/utils/mask-format.ts
@@ -148,6 +148,8 @@ class MaskFormat {
       cursorStart++;
     }
 
+    console.log('DEBUG', this.isSegmentStart(cursorStart));
+
     // first, insert zeros in a partial segment at beginning of selection
     if (!this.isSegmentStart(cursorStart)) {
       const segment = this.positionFormats.get(cursorStart)!;

--- a/src/internal/components/masked-input/utils/mask-format.ts
+++ b/src/internal/components/masked-input/utils/mask-format.ts
@@ -148,8 +148,6 @@ class MaskFormat {
       cursorStart++;
     }
 
-    console.log('DEBUG', this.isSegmentStart(cursorStart));
-
     // first, insert zeros in a partial segment at beginning of selection
     if (!this.isSegmentStart(cursorStart)) {
       const segment = this.positionFormats.get(cursorStart)!;

--- a/src/internal/components/masked-input/utils/mask-format.ts
+++ b/src/internal/components/masked-input/utils/mask-format.ts
@@ -133,7 +133,7 @@ class MaskFormat {
   }
 
   getSegmentValueWithAddition(position: number, value: string, enteredDigit: string) {
-    const segment = this.getPositionFormatOrThrow(position);
+    const segment = this.positionFormats.get(position)!;
     const segmentValue = value.substr(segment.start, segment.length);
     const segmentPosition = position - segment.start;
     const newValue = insertAt(segmentValue, enteredDigit, segmentPosition, segmentPosition + 1);
@@ -150,14 +150,14 @@ class MaskFormat {
 
     // first, insert zeros in a partial segment at beginning of selection
     if (!this.isSegmentStart(cursorStart)) {
-      const segment = this.getPositionFormatOrThrow(cursorStart);
+      const segment = this.positionFormats.get(cursorStart)!;
       value = insertAt(value, padLeftZeros('', segment.end - cursorStart), cursorStart, segment.end);
       cursorStart = segment.end + 1;
     }
 
     // then loop through remaining segments, filling with zeros
     let currentSegment: FormatSegmentFull;
-    while (cursorStart < cursorEnd && (currentSegment = this.getPositionFormatOrThrow(cursorStart + 1))) {
+    while (cursorStart < cursorEnd && (currentSegment = this.positionFormats.get(cursorStart + 1)!)) {
       const insertionEnd = Math.min(cursorEnd, currentSegment.end);
       value = insertAt(
         value,
@@ -178,7 +178,7 @@ class MaskFormat {
 
   handleSeparatorInput(value: string, position: number): ChangeResult | void {
     if (position === value.length && !this.isSegmentStart(position)) {
-      const segment = this.getPositionFormatOrThrow(position);
+      const segment = this.positionFormats.get(position)!;
       let segmentValue = value.substr(segment.start, segment.length);
       segmentValue = this.padWithDefaultValue(segmentValue, segment);
       value = insertAt(value, segmentValue, segment.start, segment.end);
@@ -199,11 +199,11 @@ class MaskFormat {
   }
 
   getSegmentMaxValue(value: string, position: number): number {
-    return this.getPositionFormatOrThrow(position).max(value);
+    return this.positionFormats.get(position)!.max(value);
   }
 
   getSegmentMinValue(value: string, position: number): number {
-    return this.getPositionFormatOrThrow(position).min;
+    return this.positionFormats.get(position)!.min;
   }
 
   getMaxLength() {
@@ -357,14 +357,6 @@ class MaskFormat {
       // skip a position for separator
       position++;
     }
-  }
-
-  private getPositionFormatOrThrow(position: number): FormatSegmentFull {
-    const format = this.positionFormats.get(position);
-    if (format === undefined) {
-      throw new Error('Invariant violation: undefined position format.');
-    }
-    return format;
   }
 }
 

--- a/src/internal/components/masked-input/utils/mask-format.ts
+++ b/src/internal/components/masked-input/utils/mask-format.ts
@@ -31,10 +31,9 @@ class MaskFormat {
   separator: string;
   private inputSeparators: Array<string>;
   private segments: Array<FormatSegmentFull>;
-  private positionFormats: { [x: number]: FormatSegmentFull };
+  private positionFormats = new Map<number, FormatSegmentFull>();
 
   constructor({ separator, inputSeparators = [], segments }: MaskArgs) {
-    this.positionFormats = {};
     this.segments = [];
     this.separator = separator;
 
@@ -134,7 +133,7 @@ class MaskFormat {
   }
 
   getSegmentValueWithAddition(position: number, value: string, enteredDigit: string) {
-    const segment = this.positionFormats[position];
+    const segment = this.getPositionFormatOrThrow(position);
     const segmentValue = value.substr(segment.start, segment.length);
     const segmentPosition = position - segment.start;
     const newValue = insertAt(segmentValue, enteredDigit, segmentPosition, segmentPosition + 1);
@@ -151,14 +150,14 @@ class MaskFormat {
 
     // first, insert zeros in a partial segment at beginning of selection
     if (!this.isSegmentStart(cursorStart)) {
-      const segment = this.positionFormats[cursorStart];
+      const segment = this.getPositionFormatOrThrow(cursorStart);
       value = insertAt(value, padLeftZeros('', segment.end - cursorStart), cursorStart, segment.end);
       cursorStart = segment.end + 1;
     }
 
     // then loop through remaining segments, filling with zeros
     let currentSegment: FormatSegmentFull;
-    while (cursorStart < cursorEnd && (currentSegment = this.positionFormats[cursorStart + 1])) {
+    while (cursorStart < cursorEnd && (currentSegment = this.getPositionFormatOrThrow(cursorStart + 1))) {
       const insertionEnd = Math.min(cursorEnd, currentSegment.end);
       value = insertAt(
         value,
@@ -179,7 +178,7 @@ class MaskFormat {
 
   handleSeparatorInput(value: string, position: number): ChangeResult | void {
     if (position === value.length && !this.isSegmentStart(position)) {
-      const segment = this.positionFormats[position];
+      const segment = this.getPositionFormatOrThrow(position);
       let segmentValue = value.substr(segment.start, segment.length);
       segmentValue = this.padWithDefaultValue(segmentValue, segment);
       value = insertAt(value, segmentValue, segment.start, segment.end);
@@ -192,7 +191,7 @@ class MaskFormat {
   }
 
   isCursorAtSeparator(position: number) {
-    return 0 < position && position < this.getMaxLength() && this.positionFormats[position] === undefined;
+    return 0 < position && position < this.getMaxLength() && this.positionFormats.get(position) === undefined;
   }
 
   isSegmentStart(position: number) {
@@ -200,11 +199,11 @@ class MaskFormat {
   }
 
   getSegmentMaxValue(value: string, position: number): number {
-    return this.positionFormats[position].max(value);
+    return this.getPositionFormatOrThrow(position).max(value);
   }
 
   getSegmentMinValue(value: string, position: number): number {
-    return this.positionFormats[position].min;
+    return this.getPositionFormatOrThrow(position).min;
   }
 
   getMaxLength() {
@@ -237,7 +236,7 @@ class MaskFormat {
   }
 
   correctMinMaxValues(value: string): string {
-    let segment = this.positionFormats[0];
+    let segment = this.positionFormats.get(0);
     while (segment && value.length >= segment.end) {
       const segmentValue = parseInt(value.substr(segment.start, segment.length), 10);
       const segmentMax = segment.max(value);
@@ -249,7 +248,7 @@ class MaskFormat {
       if (segmentValue > segmentMax) {
         value = insertAt(value, segmentMax.toFixed(), segment.start, segment.end);
       }
-      segment = this.positionFormats[segment.end + 1];
+      segment = this.positionFormats.get(segment.end + 1);
     }
     return value.substr(0, this.segments[this.segments.length - 1].end);
   }
@@ -339,7 +338,7 @@ class MaskFormat {
   }
 
   private enrichSegmentDefinitions(segments: FormatSegment[]) {
-    this.positionFormats = {};
+    this.positionFormats = new Map();
     this.segments = [];
     let position = 0;
     for (const segment of segments) {
@@ -353,11 +352,19 @@ class MaskFormat {
       this.segments.push(fullSegment);
       // insert this format segment for every char in the max value
       for (let j = 0; j < fullSegment.length; j++) {
-        this.positionFormats[position++] = fullSegment;
+        this.positionFormats.set(position++, fullSegment);
       }
       // skip a position for separator
       position++;
     }
+  }
+
+  private getPositionFormatOrThrow(position: number): FormatSegmentFull {
+    const format = this.positionFormats.get(position);
+    if (format === undefined) {
+      throw new Error('Invariant violation: undefined position format.');
+    }
+    return format;
   }
 }
 

--- a/src/internal/hooks/use-date-cache/index.ts
+++ b/src/internal/hooks/use-date-cache/index.ts
@@ -3,13 +3,14 @@
 import { useRef } from 'react';
 
 export function useDateCache(): (date: Date) => Date {
-  const cacheRef = useRef<{ [key: number]: Date }>({});
+  const cacheRef = useRef(new Map<number, Date>());
 
   return (date: Date) => {
-    if (cacheRef.current[date.getTime()]) {
-      return cacheRef.current[date.getTime()];
+    const current = cacheRef.current.get(date.getTime());
+    if (current) {
+      return current;
     }
-    cacheRef.current[date.getTime()] = date;
+    cacheRef.current.set(date.getTime(), date);
     return date;
   };
 }


### PR DESCRIPTION
### Description

The refactoring is made to prevent issues similar to one occurred recently in table resizable columns: https://github.com/cloudscape-design/components/pull/1745#discussion_r1398860225

The PR covers part of the codebase, related PRs: https://github.com/cloudscape-design/components/pull/1801, https://github.com/cloudscape-design/components/pull/1807, https://github.com/cloudscape-design/components/pull/1808.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
