### PR TITLE
refactor: Replace records having numeric keys with maps, part 3

### DIFF
--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -239,7 +239,8 @@ const InternalTable = React.forwardRef(
       onFocusMove: moveFocus,
       onResizeFinish(newWidth) {
         const widthsDetail = columnDefinitions.map(
-          (column, index) => newWidth[getColumnKey(column, index)] || (column.width as number) || DEFAULT_COLUMN_WIDTH
+          (column, index) =>
+            newWidth.get(getColumnKey(column, index)) || (column.width as number) || DEFAULT_COLUMN_WIDTH
         );
         const widthsChanged = widthsDetail.some((width, index) => columnDefinitions[index].width !== width);
         if (widthsChanged) {

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -29,7 +29,7 @@ export interface TheadProps {
   resizableColumns: boolean | undefined;
   getSelectAllProps: () => SelectionProps;
   onFocusMove: ((sourceElement: HTMLElement, fromIndex: number, direction: -1 | 1) => void) | undefined;
-  onResizeFinish: (newWidths: Record<string, number>) => void;
+  onResizeFinish: (newWidths: Map<PropertyKey, number>) => void;
   onSortingChange: NonCancelableEventHandler<TableProps.SortingState<any>> | undefined;
   sticky?: boolean;
   hidden?: boolean;

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -17,7 +17,7 @@ function readWidths(
   getCell: (columnId: PropertyKey) => null | HTMLElement,
   visibleColumns: readonly ColumnWidthDefinition[]
 ) {
-  const result: Record<PropertyKey, number> = {};
+  const result = new Map<PropertyKey, number>();
   for (let index = 0; index < visibleColumns.length; index++) {
     const column = visibleColumns[index];
     let width = (column.width as number) || 0;
@@ -29,9 +29,10 @@ function readWidths(
       const colEl = getCell(column.id);
       width = colEl?.getBoundingClientRect().width ?? DEFAULT_COLUMN_WIDTH;
     }
-    result[column.id] = Math.max(width, minWidth);
+    result.set(column.id, Math.max(width, minWidth));
   }
-  return result;
+  // TODO: return map
+  return Object.fromEntries(result.entries());
 }
 
 function updateWidths(
@@ -145,17 +146,18 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
     if (!resizableColumns) {
       return;
     }
-    const updates: Record<PropertyKey, number> = {};
+    const updates = new Map<PropertyKey, number>();
     const lastVisible = visibleColumnsRef.current;
     if (lastVisible) {
       for (let index = 0; index < visibleColumns.length; index++) {
         const column = visibleColumns[index];
         if (!columnWidths?.[column.id] && lastVisible.indexOf(column.id) === -1) {
-          updates[column.id] = (column.width as number) || DEFAULT_COLUMN_WIDTH;
+          updates.set(column.id, (column.width as number) || DEFAULT_COLUMN_WIDTH);
         }
       }
-      if (Object.keys(updates).length > 0) {
-        setColumnWidths(columnWidths => ({ ...columnWidths, ...updates }));
+      if (updates.size > 0) {
+        // TODO: use maps as is
+        setColumnWidths(columnWidths => ({ ...columnWidths, ...Object.fromEntries(updates.entries()) }));
       }
     }
     visibleColumnsRef.current = visibleColumns.map(column => column.id);


### PR DESCRIPTION
### Description

The refactoring is made to prevent issues similar to one occurred recently in table resizable columns: https://github.com/cloudscape-design/components/pull/1745#discussion_r1398860225

The PR covers part of the codebase, related PRs: https://github.com/cloudscape-design/components/pull/1801, https://github.com/cloudscape-design/components/pull/1806, https://github.com/cloudscape-design/components/pull/1808.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
