### PR TITLE
fix: Add missing drawer id

### DIFF
--- a/pages/app-layout/with-one-open-drawer.page.tsx
+++ b/pages/app-layout/with-one-open-drawer.page.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState, useRef } from 'react';
+import { AppLayout, ContentLayout, Header } from '~components';
+import { AppLayoutProps } from '~components/app-layout';
+import appLayoutLabels from './utils/labels';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import ScreenshotArea from '../utils/screenshot-area';
+import { drawerItems, drawerLabels } from './utils/drawers';
+
+export default function WithDrawers() {
+  const [activeDrawerId, setActiveDrawerId] = useState<string | null>(drawerItems[0].id);
+  const appLayoutRef = useRef<AppLayoutProps.Ref>(null);
+
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ref={appLayoutRef}
+        ariaLabels={{ ...appLayoutLabels, ...drawerLabels }}
+        breadcrumbs={<Breadcrumbs />}
+        navigationHide={true}
+        content={
+          <ContentLayout
+            data-test-id="content"
+            header={
+              <Header variant="h1" description="Sometimes you need custom drawers to get the job done.">
+                One drawer opened
+              </Header>
+            }
+          >
+            <Containers />
+          </ContentLayout>
+        }
+        drawers={drawerItems.slice(0, 2)}
+        onDrawerChange={event => setActiveDrawerId(event.detail.activeDrawerId)}
+        activeDrawerId={activeDrawerId}
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -21,6 +21,8 @@ jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   useMobile: jest.fn().mockReturnValue(true),
 }));
 
+const testIf = (condition: boolean) => (condition ? test : test.skip);
+
 jest.mock('@cloudscape-design/component-toolkit', () => ({
   ...jest.requireActual('@cloudscape-design/component-toolkit'),
   useContainerQuery: () => [100, () => {}],
@@ -130,5 +132,16 @@ describeEachAppLayout(size => {
   test('registers public drawers api', () => {
     const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
+  });
+
+  testIf(size !== 'mobile')('aria-controls points to an existing drawer id', () => {
+    const { wrapper } = renderComponent(<AppLayout drawers={singleDrawerPublic} />);
+    const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
+    expect(drawerTrigger!.getElement()).not.toHaveAttribute('aria-controls');
+
+    drawerTrigger.click();
+    expect(drawerTrigger!.getElement()).toHaveAttribute('aria-controls', 'security');
+    console.log(wrapper.findActiveDrawer()!.getElement());
+    expect(wrapper.findActiveDrawer()!.getElement()).toHaveAttribute('id', 'security');
   });
 });

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -76,7 +76,6 @@ export const Drawer = React.forwardRef(
 
     return (
       <div
-        id={id}
         ref={ref}
         className={clsx(styles.drawer, {
           [styles.hide]: isHidden,
@@ -110,6 +109,7 @@ export const Drawer = React.forwardRef(
         }}
       >
         <div
+          id={id}
           style={{ width: drawerContentWidth, top: topOffset, bottom: bottomOffset }}
           className={clsx(styles['drawer-content'], styles['drawer-content-clickable'], contentClassName)}
         >

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -114,12 +114,12 @@ export const Drawer = React.forwardRef(
           className={clsx(styles['drawer-content'], styles['drawer-content-clickable'], contentClassName)}
         >
           {!isMobile && !hideOpenButton && regularOpenButton}
-          {resizeHandle}
           <TagName
             className={clsx(resizeHandle && styles['drawer-resize-content'])}
             aria-label={mainLabel}
             aria-hidden={!isOpen}
           >
+            {!isMobile && isOpen && resizeHandle}
             <CloseButton
               ref={toggleRefs.close}
               className={closeClassName}

--- a/src/app-layout/drawer/resizable-drawer.tsx
+++ b/src/app-layout/drawer/resizable-drawer.tsx
@@ -81,6 +81,7 @@ export const ResizableDrawer = ({
   return (
     <Drawer
       {...props}
+      id={activeDrawer?.id}
       ref={drawerRefObject}
       isHidden={!activeDrawer}
       resizeHandle={


### PR DESCRIPTION
### Description

In classic mode aria-controls was pointing to a non-existent id, cause it wasn't passed from parent

Related links, issue #, if available: AWSUI-25664

### How has this been tested?

new unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
