### PR TITLE
fix: Fix funnel handling when component is already unmounted

### DIFF
--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -279,16 +279,25 @@ function useStepChangeListener(stepNumber: number, handler: (stepConfiguration: 
     };
   }, []);
 
+  useEffect(() => {
+    const handle = setTimeout(
+      () => subStepConfiguration.current.set(stepNumber, getSubStepConfiguration()),
+      SUBSTEP_CHANGE_DEBOUNCE
+    );
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [stepNumber]);
+
   /* We debounce this handler, so that multiple containers can change at once without causing 
   too many events. */
   const stepChangeCallback = useDebounceCallback(() => {
-    subStepConfiguration.current.set(stepNumber, getSubStepConfiguration());
-
     // We don't want to emit the event after the component has been unmounted.
     if (!listenForSubStepChanges.current) {
       return;
     }
 
+    subStepConfiguration.current.set(stepNumber, getSubStepConfiguration());
     handler(subStepConfiguration.current.get(stepNumber)!);
   }, SUBSTEP_CHANGE_DEBOUNCE);
 


### PR DESCRIPTION
### Description

This code should not fire when component is already unmounted. 

The current behavior causes issues in tests for our consumers

Related links, issue #, if available: AWSUI-26406

### How has this been tested?

Is there a way to tear down the document in Jest? I do not think so.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
