### PR TITLE
chore: Deprecate npm_package argument

### DIFF
--- a/.github/workflows/release-gh-notes.yml
+++ b/.github/workflows/release-gh-notes.yml
@@ -8,11 +8,11 @@ on:
         description: 'Specify the version for this release'
         type: string
       npm_package:
-        required: true
-        description: 'npm package of the release repo'
+        required: false
+        description: 'npm package of the release repo (deprecated)'
         type: string
       commit:
-        required: false
+        required: true
         description: 'commit to generate release notes'
         type: string
 


### PR DESCRIPTION
### Description

Following https://github.com/cloudscape-design/actions/pull/5 we can now cleanup the unused argument.

First, we mark it here as optional, then remove from the main workflow and then doing the final cleanup here.


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
