### PR TITLE
chore: Fix integration test for chart popover focus

### DIFF
--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -376,18 +376,19 @@ describe('Details popover', () => {
     })
   );
 
-  test('can be hidden by moving focus away', () => {
+  test(
+    'can be hidden by moving focus away',
     setupTest('#/light/mixed-line-bar-chart/test', async page => {
       await page.click('#focus-target');
       await page.keys(['Tab', 'Tab', 'ArrowRight']);
       await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
       await page.keys(['Tab']);
-      expect(await page.getFocusedElementText()).toBe('Filter by Apples');
+      expect(await page.getFocusedElementText()).toBe('Filter by Potatoes');
       await page.keys(['Tab']);
       expect(await page.getFocusedElementText()).toBe('Happiness');
       await expect(page.isDisplayed(popoverContentSelector())).resolves.toBe(false);
-    });
-  });
+    })
+  );
 
   test(
     'can be pinned by clicking on chart background and dismissed by clicking outside chart area in line chart',


### PR DESCRIPTION
### Description

An integration test had two errors:
- The text content that it was checking for was incorrect
- The second parameter passed to `test` was a function calling `setupTest` inside, instead of the result of calling `setupTest` directly. This was making the test pass unconditionally because the function is not run, despite the other error above.

Related links, issue #, if available: n/a

### How has this been tested?

Looked for other possible cases like this in the same component, found none.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
