### PR TITLE
feat: Handle drawers focus when focusTools is fired 

### DIFF
--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -7,6 +7,7 @@ import {
   singleDrawer,
   manyDrawers,
   manyDrawersWithBadges,
+  multipleDrawers,
   findActiveDrawerLandmark,
   singleDrawerOpen,
   singleDrawerPublic,
@@ -126,6 +127,30 @@ describeEachAppLayout(size => {
     const { wrapper } = renderComponent(<AppLayout ref={newRef => (ref = newRef)} {...(singleDrawerOpen as any)} />);
     expect(wrapper.findActiveDrawer()).toBeTruthy();
     act(() => ref!.focusActiveDrawer());
+    expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveFocus();
+  });
+
+  test('moves focus on focusToolsClose if tools are rendered as part of drawers', () => {
+    let ref: AppLayoutProps.Ref | null = null;
+    const { wrapper, rerender } = renderComponent(
+      <AppLayout
+        ref={newRef => (ref = newRef)}
+        activeDrawerId={null}
+        drawers={multipleDrawers}
+        tools={<div>Tools</div>}
+      />
+    );
+    expect(wrapper.findActiveDrawer()).toBeFalsy();
+    rerender(
+      <AppLayout
+        ref={newRef => (ref = newRef)}
+        activeDrawerId={multipleDrawers[0].id}
+        drawers={multipleDrawers}
+        tools={<div>Tools</div>}
+      />
+    );
+    expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveFocus();
+    act(() => ref!.focusToolsClose());
     expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveFocus();
   });
 

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -7,7 +7,6 @@ import {
   singleDrawer,
   manyDrawers,
   manyDrawersWithBadges,
-  multipleDrawers,
   findActiveDrawerLandmark,
   singleDrawerOpen,
   singleDrawerPublic,
@@ -136,7 +135,7 @@ describeEachAppLayout(size => {
       <AppLayout
         ref={newRef => (ref = newRef)}
         activeDrawerId={null}
-        drawers={multipleDrawers}
+        drawers={singleDrawerPublic}
         tools={<div>Tools</div>}
       />
     );
@@ -144,8 +143,8 @@ describeEachAppLayout(size => {
     rerender(
       <AppLayout
         ref={newRef => (ref = newRef)}
-        activeDrawerId={multipleDrawers[0].id}
-        drawers={multipleDrawers}
+        activeDrawerId={singleDrawerPublic[0].id}
+        drawers={singleDrawerPublic}
         tools={<div>Tools</div>}
       />
     );

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -284,32 +284,3 @@ export const singleDrawerPublic: Array<AppLayoutProps.Drawer> = [
     },
   },
 ];
-
-export const multipleDrawers: Array<AppLayoutProps.Drawer> = [
-  {
-    ariaLabels: {
-      closeButton: 'Help close button',
-      drawerName: 'Help drawer content',
-      triggerButton: 'Help trigger button',
-      resizeHandle: 'Help resize handle',
-    },
-    content: <span>Help</span>,
-    id: 'help',
-    trigger: {
-      iconName: 'status-info',
-    },
-  },
-  {
-    ariaLabels: {
-      closeButton: 'Security close button',
-      drawerName: 'Security drawer content',
-      triggerButton: 'Security trigger button',
-      resizeHandle: 'Security resize handle',
-    },
-    content: <span>Security</span>,
-    id: 'security',
-    trigger: {
-      iconName: 'security',
-    },
-  },
-];

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -284,3 +284,32 @@ export const singleDrawerPublic: Array<AppLayoutProps.Drawer> = [
     },
   },
 ];
+
+export const multipleDrawers: Array<AppLayoutProps.Drawer> = [
+  {
+    ariaLabels: {
+      closeButton: 'Help close button',
+      drawerName: 'Help drawer content',
+      triggerButton: 'Help trigger button',
+      resizeHandle: 'Help resize handle',
+    },
+    content: <span>Help</span>,
+    id: 'help',
+    trigger: {
+      iconName: 'status-info',
+    },
+  },
+  {
+    ariaLabels: {
+      closeButton: 'Security close button',
+      drawerName: 'Security drawer content',
+      triggerButton: 'Security trigger button',
+      resizeHandle: 'Security resize handle',
+    },
+    content: <span>Security</span>,
+    id: 'security',
+    trigger: {
+      iconName: 'security',
+    },
+  },
+];

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -492,7 +492,7 @@ const OldAppLayout = React.forwardRef(
         }
       },
       focusToolsClose: () => {
-        if (activeDrawerId) {
+        if (drawers && drawers.length) {
           focusDrawersButtons(true);
         } else {
           focusToolsButtons(true);

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -492,7 +492,7 @@ const OldAppLayout = React.forwardRef(
         }
       },
       focusToolsClose: () => {
-        if (drawers && drawers.length) {
+        if (hasDrawers) {
           focusDrawersButtons(true);
         } else {
           focusToolsButtons(true);

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -491,7 +491,13 @@ const OldAppLayout = React.forwardRef(
           onNavigationToggle(false);
         }
       },
-      focusToolsClose: () => focusToolsButtons(true),
+      focusToolsClose: () => {
+        if (activeDrawerId) {
+          focusDrawersButtons(true);
+        } else {
+          focusToolsButtons(true);
+        }
+      },
       focusActiveDrawer: () => focusDrawersButtons(true),
       focusSplitPanel: () => splitPanelRefs.slider.current?.focus(),
     }));

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -582,12 +582,26 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           openTools: function () {
             handleToolsClick(true);
           },
-          focusToolsClose: () => focusToolsButtons(true),
+          focusToolsClose: () => {
+            if (drawers && drawers.length) {
+              focusDrawersButtons(true);
+            } else {
+              focusToolsButtons(true);
+            }
+          },
           focusActiveDrawer: () => focusDrawersButtons(true),
           focusSplitPanel: () => splitPanelRefs.slider.current?.focus(),
         };
       },
-      [isMobile, handleNavigationClick, handleToolsClick, focusToolsButtons, focusDrawersButtons, splitPanelRefs.slider]
+      [
+        isMobile,
+        handleNavigationClick,
+        handleToolsClick,
+        focusToolsButtons,
+        focusDrawersButtons,
+        splitPanelRefs.slider,
+        drawers,
+      ]
     );
 
     return (

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -385,6 +385,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
     });
 
     const [drawersMaxWidth, setDrawersMaxWidth] = useState(toolsWidth);
+    const hasDrawers = !!drawers && drawers.length > 0;
 
     const {
       refs: drawersRefs,
@@ -583,7 +584,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
             handleToolsClick(true);
           },
           focusToolsClose: () => {
-            if (drawers && drawers.length) {
+            if (hasDrawers) {
               focusDrawersButtons(true);
             } else {
               focusToolsButtons(true);
@@ -600,7 +601,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
         focusToolsButtons,
         focusDrawersButtons,
         splitPanelRefs.slider,
-        drawers,
+        hasDrawers,
       ]
     );
 


### PR DESCRIPTION
### Description

This is a fallback for a situation when app layout has both tools and drawers set. Tools panel won't be rendered, if drawers are present. The fallback logic of rendering tools content as a drawer already exists (somewhere), but existing focus management logic doesn't work at the moment.  

Related links, issue #, if available: AWSUI-26132

### How has this been tested?

new unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
