### PR TITLE
chore: add screenshot tests report deployment

### DIFF
--- a/.github/workflows/visuals.yml
+++ b/.github/workflows/visuals.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   buildReference:
     name: Generate reference images
@@ -44,6 +48,9 @@ jobs:
   test:
     name: Test for regressions
     runs-on: ubuntu-latest
+    environment:
+      name: visual-regression-report
+      url: ${{ steps.deploy-report.outputs.preview-url }}index.html
     needs:
       - buildReference
     steps:
@@ -66,11 +73,12 @@ jobs:
         run: npm run start:integ &
       - name: Run visual regression tests
         run: npm run test:visual test
-      - name: Upload results
-        uses: actions/upload-artifact@v3
+      - name: Deploy report
         if: always()
+        id: deploy-report
+        uses: cloudscape-design/actions/.github/actions/deploy-static@main
         with:
-          name: visual-regression-results
-          path: |
-            backstop
-            !backstop/node_modules
+          role-to-assume: ${{ secrets.AWS_PREVIEW_ROLE_ARN }}
+          deployment-bucket: ${{ secrets.AWS_PREVIEW_BUCKET_NAME }}
+          source-path: backstop/html_report
+          target-path: visual-regressions


### PR DESCRIPTION
### Description

With this PR, you can review BackstopJS screenshot test report with one click. See the latest deployment.

Related links, issue #, if available: n/a

### How has this been tested?

This works: https://d21d5uik3ws71m.cloudfront.net/components/ccba6e21aeeac824d9e090aeef3c7108de0b26eb/visual-regressions/index.html

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
