### PR TITLE
fix: Bar chart to show popover when inside modal

### DIFF
--- a/pages/mixed-line-bar-chart/in-modal.page.tsx
+++ b/pages/mixed-line-bar-chart/in-modal.page.tsx
@@ -17,7 +17,7 @@ export default function () {
       <h1>Mixed chart integration test</h1>
       <Button onClick={() => setIsOpen(true)}>Show in modal</Button>
       {isOpen ? (
-        <Modal visible={true} onDismiss={() => setIsOpen(false)}>
+        <Modal visible={true} onDismiss={() => setIsOpen(false)} closeAriaLabel="Close" header="Chart modal">
           <Chart />
         </Modal>
       ) : (

--- a/pages/mixed-line-bar-chart/in-modal.page.tsx
+++ b/pages/mixed-line-bar-chart/in-modal.page.tsx
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import Box from '~components/box';
+import Button from '~components/button';
+import MixedLineBarChart from '~components/mixed-line-bar-chart';
+import { colorChartsThresholdInfo } from '~design-tokens';
+
+import { barChartInstructions, commonProps, data3, data4 } from './common';
+import { Modal } from '~components';
+
+export default function () {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Box margin="m">
+      <h1>Mixed chart integration test</h1>
+      <Button onClick={() => setIsOpen(true)}>Show in modal</Button>
+      {isOpen ? (
+        <Modal visible={true} onDismiss={() => setIsOpen(false)}>
+          <Chart />
+        </Modal>
+      ) : (
+        <Chart />
+      )}
+    </Box>
+  );
+}
+
+function Chart() {
+  return (
+    <MixedLineBarChart
+      id="chart"
+      {...commonProps}
+      height={250}
+      series={[
+        { title: 'Happiness', type: 'bar', data: data4.filter(({ x }) => x !== 'Chocolate') },
+        { title: 'Calories', type: 'line', data: data3 },
+        { title: 'Threshold', type: 'threshold', y: 420, color: colorChartsThresholdInfo },
+      ]}
+      xDomain={data3.map(d => d.x)}
+      yDomain={[0, 650]}
+      xTitle="Food"
+      yTitle="Calories (kcal)"
+      xScaleType="categorical"
+      ariaLabel="Mixed chart 1"
+      ariaDescription={barChartInstructions}
+      detailPopoverFooter={xValue => <Button>Filter by {xValue}</Button>}
+    />
+  );
+}

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -302,6 +302,15 @@ describe('Details popover', () => {
   );
 
   test(
+    'shows on hover in a mixed line/bar chart inside modal',
+    setupTest('#/light/mixed-line-bar-chart/in-modal', async page => {
+      // Hover over first group
+      await page.hoverElement(chartWrapper.findBarGroups().get(1).toSelector());
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Potatoes');
+    })
+  );
+
+  test(
     'shows on hover in a mixed line/bar chart',
     setupTest('#/light/mixed-line-bar-chart/test', async page => {
       // Hover over first group

--- a/src/mixed-line-bar-chart/styles.scss
+++ b/src/mixed-line-bar-chart/styles.scss
@@ -34,5 +34,5 @@
 }
 
 .bar-group {
-  /* used in dom query */
+  pointer-events: none;
 }


### PR DESCRIPTION
### Description

In bar chart the segments were not highlighted with mouse when the chart is rendered inside popover. The root cause is that the condition `event.target === plotRef.current!.svg` in mouse handler was false when hovering over the invisible bar series rects. When the chart is rendered inside modal those act as hover targets despite being invisible.

Rel: AWSUI-25950

### How has this been tested?

New integration test, screenshot tests. Manual testing confirms the issue was only reproducible in the bar chart. The area-, line-, and pie charts are unaffected.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
