### PR TITLE
refactor: Remove unneeded API from grid navigation and refactor code structure

### DIFF
--- a/pages/table-fragments/grid-navigation-performance.page.tsx
+++ b/pages/table-fragments/grid-navigation-performance.page.tsx
@@ -13,7 +13,7 @@ import {
   getTableRoleProps,
   getTableRowRoleProps,
   getTableWrapperRoleProps,
-  useGridNavigation,
+  GridNavigationProvider,
 } from '~components/table/table-role';
 import styles from './styles.scss';
 
@@ -79,48 +79,48 @@ function Table({ useGridNavigation: gridNavigationActive }: { useGridNavigation:
   const tableRole = 'grid';
   const tableRef = useRef<HTMLTableElement>(null);
 
-  useGridNavigation({ keyboardNavigation: gridNavigationActive, pageSize: 10, getTable: () => tableRef.current });
-
   return (
-    <div className={styles['custom-table']} {...getTableWrapperRoleProps({ tableRole, isScrollable: false })}>
-      <table
-        ref={tableRef}
-        className={styles['custom-table-table']}
-        {...getTableRoleProps({
-          tableRole,
-          totalItemsCount: items.length,
-          totalColumnsCount: columnDefinitions.length,
-        })}
-      >
-        <thead>
-          <tr {...getTableHeaderRowRoleProps({ tableRole })}>
-            {columnDefinitions.map((column, colIndex) => (
-              <th
-                key={column.key}
-                className={styles['custom-table-cell']}
-                {...getTableColHeaderRoleProps({ tableRole, colIndex })}
-              >
-                {column.label}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item, rowIndex) => (
-            <tr key={item.id} {...getTableRowRoleProps({ tableRole, rowIndex, firstIndex: 0 })}>
+    <GridNavigationProvider keyboardNavigation={gridNavigationActive} pageSize={10} getTable={() => tableRef.current}>
+      <div className={styles['custom-table']} {...getTableWrapperRoleProps({ tableRole, isScrollable: false })}>
+        <table
+          ref={tableRef}
+          className={styles['custom-table-table']}
+          {...getTableRoleProps({
+            tableRole,
+            totalItemsCount: items.length,
+            totalColumnsCount: columnDefinitions.length,
+          })}
+        >
+          <thead>
+            <tr {...getTableHeaderRowRoleProps({ tableRole })}>
               {columnDefinitions.map((column, colIndex) => (
-                <td
+                <th
                   key={column.key}
                   className={styles['custom-table-cell']}
-                  {...getTableCellRoleProps({ tableRole, colIndex })}
+                  {...getTableColHeaderRoleProps({ tableRole, colIndex })}
                 >
-                  {column.render(item)}
-                </td>
+                  {column.label}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {items.map((item, rowIndex) => (
+              <tr key={item.id} {...getTableRowRoleProps({ tableRole, rowIndex, firstIndex: 0 })}>
+                {columnDefinitions.map((column, colIndex) => (
+                  <td
+                    key={column.key}
+                    className={styles['custom-table-cell']}
+                    {...getTableCellRoleProps({ tableRole, colIndex })}
+                  >
+                    {column.render(item)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </GridNavigationProvider>
   );
 }

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -15,6 +15,7 @@ import { FocusedCell, GridNavigationProps } from './interfaces';
 import { KeyCode } from '../../internal/keycode';
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
+import React from 'react';
 
 /**
  * Makes table navigable with keyboard commands.
@@ -23,38 +24,26 @@ import { useStableCallback } from '@cloudscape-design/component-toolkit/internal
  * The hook attaches the GridNavigationHelper helper when active=true.
  * See GridNavigationHelper for more details.
  */
-export function useGridNavigation({
-  keyboardNavigation,
-  suppressKeyboardNavigationFor,
-  pageSize,
-  getTable,
-}: GridNavigationProps) {
+export function GridNavigationProvider({ keyboardNavigation, pageSize, getTable, children }: GridNavigationProps) {
   const gridNavigation = useMemo(() => new GridNavigationHelper(), []);
 
   const getTableStable = useStableCallback(getTable);
-  const isSuppressedStable = useStableCallback((element: HTMLElement) => {
-    if (typeof suppressKeyboardNavigationFor === 'function') {
-      return suppressKeyboardNavigationFor(element);
-    }
-    if (typeof suppressKeyboardNavigationFor === 'string') {
-      return element.matches(suppressKeyboardNavigationFor);
-    }
-    return false;
-  });
 
-  // Initialize the model with the table container assuming it is mounted synchronously and only once.
+  // Initialize the helper with the table container assuming it is mounted synchronously and only once.
   useEffect(() => {
     if (keyboardNavigation) {
       const table = getTableStable();
-      table && gridNavigation.init(table, isSuppressedStable);
+      table && gridNavigation.init(table);
     }
     return () => gridNavigation.cleanup();
-  }, [keyboardNavigation, gridNavigation, getTableStable, isSuppressedStable]);
+  }, [keyboardNavigation, gridNavigation, getTableStable]);
 
-  // Notify the model of the props change.
+  // Notify the helper of the props change.
   useEffect(() => {
     gridNavigation.update({ pageSize });
   }, [gridNavigation, pageSize]);
+
+  return <>{children}</>;
 }
 
 /**
@@ -74,15 +63,13 @@ class GridNavigationHelper {
   // Props
   private _pageSize = 0;
   private _table: null | HTMLTableElement = null;
-  private _isSuppressed: (focusedElement: HTMLElement) => boolean = () => false;
 
   // State
   private prevFocusedCell: null | FocusedCell = null;
   private focusedCell: null | FocusedCell = null;
 
-  public init(table: HTMLTableElement, isSuppressed: (focusedElement: HTMLElement) => boolean) {
+  public init(table: HTMLTableElement) {
     this._table = table;
-    this._isSuppressed = isSuppressed;
 
     this.table.addEventListener('focusin', this.onFocusin);
     this.table.addEventListener('focusout', this.onFocusout);
@@ -125,7 +112,7 @@ class GridNavigationHelper {
   }
 
   private isSuppressed(focusedElement: HTMLElement): boolean {
-    return defaultIsSuppressed(focusedElement) || this._isSuppressed(focusedElement);
+    return defaultIsSuppressed(focusedElement);
   }
 
   private onFocusin = (event: FocusEvent) => {

--- a/src/table/table-role/index.ts
+++ b/src/table/table-role/index.ts
@@ -12,4 +12,4 @@ export {
   getTableWrapperRoleProps,
 } from './table-role-helper';
 
-export { useGridNavigation } from './use-grid-navigation';
+export { GridNavigationProvider } from './grid-navigation';

--- a/src/table/table-role/interfaces.ts
+++ b/src/table/table-role/interfaces.ts
@@ -5,9 +5,9 @@ export type TableRole = 'table' | 'grid' | 'grid-default';
 
 export interface GridNavigationProps {
   keyboardNavigation: boolean;
-  suppressKeyboardNavigationFor?: string | ((focusedElement: HTMLElement) => boolean);
   pageSize: number;
   getTable: () => null | HTMLTableElement;
+  children: React.ReactNode;
 }
 
 export interface FocusedCell {


### PR DESCRIPTION
### Description

The grid navigation is an upcoming table feature. It is to be reimplemented with React contexts, see: https://github.com/cloudscape-design/components/pull/1760, KtAVARsTM7ko, 5uPHAylzAuFG.

The explicit suppression API is not yet needed and is therefore removed. The code structure is changed to feature render-prop component (provider) instead of the hook. That is to minimise difference when introducing the React context.

### How has this been tested?

Existing tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
