### PR TITLE
fix: Fix clicking inside chart popovers when rendered inside tabs

### DIFF
--- a/pages/mixed-line-bar-chart/in-tabs.page.tsx
+++ b/pages/mixed-line-bar-chart/in-tabs.page.tsx
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import Box from '~components/box';
+
+import { barChartInstructions, commonProps, data3 } from './common';
+import { BarChart, Tabs } from '~components';
+
+export default function () {
+  return (
+    <Box margin="m">
+      <h1>Mixed chart integration test</h1>
+      <Tabs
+        tabs={[{ id: 'chart', label: 'Chart', content: <Chart /> }]}
+        i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+      />
+    </Box>
+  );
+}
+
+function Chart() {
+  return (
+    <BarChart
+      {...commonProps}
+      id="chart"
+      height={250}
+      series={[{ title: 'Calories', type: 'bar', data: data3 }]}
+      xDomain={['Potatoes', 'Tangerines', 'Chocolate', 'Apples', 'Oranges']}
+      yDomain={[0, 700]}
+      xTitle="Food"
+      yTitle="Calories (kcal)"
+      xScaleType="categorical"
+      ariaLabel="Bar chart"
+      ariaDescription={barChartInstructions}
+    />
+  );
+}

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -106,6 +106,9 @@ function ChartPopover(
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onBlur={onBlur}
+      // The tabIndex makes it so that clicking inside popover assigns this element as blur target.
+      // That is necessary in charts to ensure the blur target is within the chart and no cleanup is needed.
+      tabIndex={-1}
     >
       <PopoverContainer
         size={size}

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -348,6 +348,33 @@ describe('Details popover', () => {
   );
 
   test(
+    'can be pinned and unpinned in a chart with mouse when rendered inside tabs',
+    setupTest('#/light/mixed-line-bar-chart/in-tabs', async page => {
+      // Hover over third group in the first chart
+      await page.hoverElement(chartWrapper.findBarGroups().get(3).toSelector());
+      await expect(page.getText(popoverHeaderSelector())).resolves.toContain('Chocolate');
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(false);
+
+      // Click on it to reveal the dismiss button
+      await page.click(chartWrapper.toSelector());
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(true);
+      await page.waitForAssertion(() => expect(page.isFocused(popoverDismissSelector())).resolves.toBe(true));
+
+      // Click inside popover to ensure it remains visible.
+      await page.click(popoverContentSelector());
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(true);
+
+      // Ensure the next focus target is the dismiss button.
+      await page.keys(['Tab']);
+      await page.waitForAssertion(() => expect(page.isFocused(popoverDismissSelector())).resolves.toBe(true));
+
+      // Click dismiss to unpin
+      await page.click(popoverDismissSelector());
+      await expect(page.isDisplayed(popoverDismissSelector())).resolves.toBe(false);
+    })
+  );
+
+  test(
     'can be hidden after hover by pressing Escape',
     setupTest('#/light/mixed-line-bar-chart/test', async page => {
       // Hover over first group


### PR DESCRIPTION
### Description

When charts are rendered inside tabs the blur target resolves to tabs content which is not inside the chart. As result, the chart's state is cleaned up and the popover is closed.

Rel: AWSUI-25756

### How has this been tested?

New integration test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
