### PR TITLE
refactor: Simpler grid navigation implementation

### DIFF
--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -1,22 +1,30 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../../lib/components/test-utils/selectors';
+import { GridNavigationPageObject } from './page-object';
 
-interface ExtendedWindow extends Window {
-  refreshItems: () => void;
+interface Options {
+  actionsMode?: 'dropdown' | 'inline';
 }
-declare const window: ExtendedWindow;
+
+const setupTest = (
+  { actionsMode = 'dropdown' }: Options,
+  testFn: (page: GridNavigationPageObject) => Promise<void>
+) => {
+  return useBrowser(async browser => {
+    const page = new GridNavigationPageObject(browser);
+    const query = new URLSearchParams({ actionsMode });
+    await browser.url(`#/light/table-fragments/grid-navigation-custom/?${query.toString()}`);
+    await page.waitForVisible('table');
+    await testFn(page);
+  });
+};
 
 test(
   'cell action remains focused when row re-renders',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
-    await page.waitForVisible('table');
-
+  setupTest({ actionsMode: 'inline' }, async page => {
     await page.click('button[aria-label="Update item"]');
     await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
   })
@@ -24,11 +32,7 @@ test(
 
 test(
   'cell focus stays in the same position when row gets removed',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
-    await page.waitForVisible('table');
-
+  setupTest({ actionsMode: 'inline' }, async page => {
     await page.click('button[aria-label="Delete item"]');
     await expect(page.isFocused('button[aria-label="Delete item"]')).resolves.toBe(true);
   })
@@ -36,28 +40,20 @@ test(
 
 test(
   'cell focus stays in the same position when row gets removed with auto-refresh',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
-    await page.waitForVisible('table');
-
+  setupTest({}, async page => {
     const firstButtonDropdown = createWrapper().findButtonDropdown();
     await page.click(firstButtonDropdown.toSelector());
     await page.click(firstButtonDropdown.findHighlightedItem().toSelector());
     await expect(page.isFocused(firstButtonDropdown.findNativeButton().toSelector())).resolves.toBe(true);
 
-    await browser.execute(() => window.refreshItems());
+    await page.refreshItems();
     await expect(page.isFocused(firstButtonDropdown.findNativeButton().toSelector())).resolves.toBe(true);
   })
 );
 
 test(
   'keeps last focused cell position when row gets removed from outside table',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
-    await page.waitForVisible('table');
-
+  setupTest({}, async page => {
     const firstButtonDropdown = createWrapper().findButtonDropdown();
     await page.click(firstButtonDropdown.toSelector());
     await page.click('button[aria-label="Refresh"]');
@@ -70,11 +66,7 @@ test(
 
 test(
   'retains cell focus when existing inline edit',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
-    await page.waitForVisible('table');
-
+  setupTest({}, async page => {
     await page.click('[aria-label="Edit DNS name"]');
     await page.click('button[aria-label="Save"]');
     await expect(page.isFocused('[aria-label="Edit DNS name"]')).resolves.toBe(true);
@@ -83,11 +75,7 @@ test(
 
 test(
   'table has a single tab stop',
-  useBrowser({}, async browser => {
-    const page = new BasePageObject(browser);
-    await browser.url('#/light/table-fragments/grid-navigation-custom');
-    await page.waitForVisible('table');
-
+  setupTest({}, async page => {
     await page.click('[data-testid="link-before"]');
     await page.keys('Tab');
     await expect(page.isFocused('tr[aria-rowindex="1"] > th[aria-colindex="1"] button')).resolves.toBe(true);

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -3,10 +3,16 @@
 
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../../lib/components/test-utils/selectors';
+
+interface ExtendedWindow extends Window {
+  refreshItems: () => void;
+}
+declare const window: ExtendedWindow;
 
 test(
   'cell action remains focused when row re-renders',
-  useBrowser({ width: 1800, height: 800 }, async browser => {
+  useBrowser({}, async browser => {
     const page = new BasePageObject(browser);
     await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
     await page.waitForVisible('table');
@@ -18,7 +24,7 @@ test(
 
 test(
   'cell focus stays in the same position when row gets removed',
-  useBrowser({ width: 1800, height: 800 }, async browser => {
+  useBrowser({}, async browser => {
     const page = new BasePageObject(browser);
     await browser.url('#/light/table-fragments/grid-navigation-custom/?actionsMode=inline');
     await page.waitForVisible('table');
@@ -29,8 +35,55 @@ test(
 );
 
 test(
+  'cell focus stays in the same position when row gets removed with auto-refresh',
+  useBrowser({}, async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/table-fragments/grid-navigation-custom');
+    await page.waitForVisible('table');
+
+    const firstButtonDropdown = createWrapper().findButtonDropdown();
+    await page.click(firstButtonDropdown.toSelector());
+    await page.click(firstButtonDropdown.findHighlightedItem().toSelector());
+    await expect(page.isFocused(firstButtonDropdown.findNativeButton().toSelector())).resolves.toBe(true);
+
+    await browser.execute(() => window.refreshItems());
+    await expect(page.isFocused(firstButtonDropdown.findNativeButton().toSelector())).resolves.toBe(true);
+  })
+);
+
+test(
+  'keeps last focused cell position when row gets removed from outside table',
+  useBrowser({}, async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/table-fragments/grid-navigation-custom');
+    await page.waitForVisible('table');
+
+    const firstButtonDropdown = createWrapper().findButtonDropdown();
+    await page.click(firstButtonDropdown.toSelector());
+    await page.click('button[aria-label="Refresh"]');
+    await expect(page.isFocused('button[aria-label="Refresh"]')).resolves.toBe(true);
+
+    await page.keys(['Tab', 'Tab']);
+    await expect(page.isFocused(firstButtonDropdown.findNativeButton().toSelector())).resolves.toBe(true);
+  })
+);
+
+test(
+  'retains cell focus when existing inline edit',
+  useBrowser({}, async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/table-fragments/grid-navigation-custom');
+    await page.waitForVisible('table');
+
+    await page.click('[aria-label="Edit DNS name"]');
+    await page.click('button[aria-label="Save"]');
+    await expect(page.isFocused('[aria-label="Edit DNS name"]')).resolves.toBe(true);
+  })
+);
+
+test(
   'table has a single tab stop',
-  useBrowser({ width: 1800, height: 800 }, async browser => {
+  useBrowser({}, async browser => {
     const page = new BasePageObject(browser);
     await browser.url('#/light/table-fragments/grid-navigation-custom');
     await page.waitForVisible('table');

--- a/src/table/table-role/__integ__/page-object.ts
+++ b/src/table/table-role/__integ__/page-object.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+
+interface ExtendedWindow extends Window {
+  refreshItems: () => void;
+}
+declare const window: ExtendedWindow;
+
+export class GridNavigationPageObject extends BasePageObject {
+  async refreshItems() {
+    await this.browser.execute(() => window.refreshItems());
+  }
+}

--- a/src/table/table-role/__tests__/stubs.tsx
+++ b/src/table/table-role/__tests__/stubs.tsx
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useRef, useState } from 'react';
+import { GridNavigationProvider } from '../../../../lib/components/table/table-role';
+
+export interface Item {
+  id: string;
+  name: string;
+  value: number;
+}
+
+export const items: Item[] = [
+  { id: 'id1', name: 'First', value: 1 },
+  { id: 'id2', name: 'Second', value: 2 },
+  { id: 'id3', name: 'Third', value: 3 },
+  { id: 'id4', name: 'Fourth', value: 4 },
+];
+
+export const idColumn = { header: 'ID', cell: (item: Item) => item.id };
+export const nameColumn = {
+  header: (
+    <span>
+      Name <button aria-label="Sort by name" />
+    </span>
+  ),
+  cell: (item: Item) => item.name,
+};
+export const valueColumn = {
+  header: (
+    <span>
+      Value <button aria-label="Sort by value" />
+    </span>
+  ),
+  cell: (item: Item) => <ValueCell item={item} />,
+};
+export const actionsColumn = {
+  header: 'Actions',
+  cell: (item: Item) => (
+    <span>
+      <button aria-label={`Delete item ${item.id}`} />
+      <button aria-label={`Copy item ${item.id}`} />
+    </span>
+  ),
+};
+
+export function TestTable<T extends object>({
+  keyboardNavigation = true,
+  columns,
+  items,
+  startIndex = 0,
+  pageSize = 2,
+}: {
+  keyboardNavigation?: boolean;
+  columns: { header: React.ReactNode; cell: (item: T) => React.ReactNode }[];
+  items: T[];
+  startIndex?: number;
+  pageSize?: number;
+}) {
+  const tableRef = useRef<HTMLTableElement>(null);
+  return (
+    <GridNavigationProvider
+      keyboardNavigation={keyboardNavigation}
+      pageSize={pageSize}
+      getTable={() => tableRef.current}
+    >
+      <table role="grid" ref={tableRef}>
+        <thead>
+          <tr aria-rowindex={1}>
+            {columns.map((column, columnIndex) => (
+              <th key={columnIndex} aria-colindex={columnIndex + 1} tabIndex={-1}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, itemIndex) => (
+            <tr key={itemIndex} aria-rowindex={startIndex + itemIndex + 1 + 1}>
+              {columns.map((column, columnIndex) => (
+                <td key={columnIndex} aria-colindex={columnIndex + 1} tabIndex={-1}>
+                  {column.cell(item)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </GridNavigationProvider>
+  );
+}
+
+function ValueCell({ item }: { item: Item }) {
+  const [active, setActive] = useState(false);
+
+  return !active ? (
+    <span>
+      {item.value ?? 0} <button aria-label={`Edit value ${item.value}`} onClick={() => setActive(true)} />
+    </span>
+  ) : (
+    <span role="dialog">
+      <input value={item.value} autoFocus={true} aria-label="Value input" tabIndex={0} />
+      <button aria-label="Save" onClick={() => setActive(false)} />
+      <button aria-label="Discard" onClick={() => setActive(false)} />
+    </span>
+  );
+}

--- a/src/table/table-role/__tests__/table-role-helper.test.ts
+++ b/src/table/table-role/__tests__/table-role-helper.test.ts
@@ -104,8 +104,8 @@ test('grid row and cell props', () => {
 
   expect(headerRow).toEqual({ 'aria-rowindex': 1 });
   expect(bodyRow).toEqual({ 'aria-rowindex': 2 });
-  expect(headerCell1).toEqual({ 'aria-colindex': 1, scope: 'col', 'aria-sort': 'ascending' });
-  expect(headerCell2).toEqual({ 'aria-colindex': 2, scope: 'col' });
-  expect(bodyCell1).toEqual({ 'aria-colindex': 1, scope: 'row' });
-  expect(bodyCell2).toEqual({ 'aria-colindex': 2 });
+  expect(headerCell1).toEqual({ 'aria-colindex': 1, scope: 'col', 'aria-sort': 'ascending', tabIndex: -1 });
+  expect(headerCell2).toEqual({ 'aria-colindex': 2, scope: 'col', tabIndex: -1 });
+  expect(bodyCell1).toEqual({ 'aria-colindex': 1, scope: 'row', tabIndex: -1 });
+  expect(bodyCell2).toEqual({ 'aria-colindex': 2, tabIndex: -1 });
 });

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -93,12 +93,12 @@ class GridNavigationProcessor {
 
   public refresh() {
     if (this._table) {
-      const cellSuppressed = this.focusedCell ? this.isSuppressed(this.focusedCell.element) : false;
-
       // Update focused cell indices in case table rows, columns, or firstIndex change.
       if (this.focusedCell) {
         this.focusedCell = findFocusedCell(this.focusedCell.element);
       }
+
+      const cellSuppressed = this.focusedCell ? this.isSuppressed(this.focusedCell.element) : false;
 
       // Ensure newly added elements if any are muted.
       muteElementFocusables(this.table, cellSuppressed);
@@ -144,7 +144,7 @@ class GridNavigationProcessor {
   };
 
   private onFocusout = () => {
-    // When focus leaves the cell and the cell becomes no longer belong to the table it indicates the focused element has been unmounted.
+    // When focus leaves the cell and the cell no longer belong to the table it indicates the focused element has been unmounted.
     // In that case the focus needs to be restored on the same coordinates.
     setTimeout(() => {
       if (this.focusedCell && !nodeBelongs(this.table, this.focusedCell.element)) {

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -4,32 +4,29 @@
 import { useEffect, useMemo } from 'react';
 import {
   defaultIsSuppressed,
-  findFocusinCell,
-  moveFocusBy,
   muteElementFocusables,
   restoreElementFocusables,
   ensureSingleFocusable,
   getFirstFocusable,
+  findFocusedCell,
+  getNextFocusable,
 } from './utils';
 import { FocusedCell, GridNavigationProps } from './interfaces';
 import { KeyCode } from '../../internal/keycode';
-import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import React from 'react';
+import { nodeBelongs } from '../../internal/utils/node-belongs';
 
 /**
  * Makes table navigable with keyboard commands.
- * See https://www.w3.org/WAI/ARIA/apg/patterns/grid
- *
- * The hook attaches the GridNavigationHelper helper when active=true.
- * See GridNavigationHelper for more details.
+ * See grid-navigation.md
  */
 export function GridNavigationProvider({ keyboardNavigation, pageSize, getTable, children }: GridNavigationProps) {
-  const gridNavigation = useMemo(() => new GridNavigationHelper(), []);
+  const gridNavigation = useMemo(() => new GridNavigationProcessor(), []);
 
   const getTableStable = useStableCallback(getTable);
 
-  // Initialize the helper with the table container assuming it is mounted synchronously and only once.
+  // Initialize the processor with the table container assuming it is mounted synchronously and only once.
   useEffect(() => {
     if (keyboardNavigation) {
       const table = getTableStable();
@@ -38,10 +35,17 @@ export function GridNavigationProvider({ keyboardNavigation, pageSize, getTable,
     return () => gridNavigation.cleanup();
   }, [keyboardNavigation, gridNavigation, getTableStable]);
 
-  // Notify the helper of the props change.
+  // Notify the processor of the props change.
   useEffect(() => {
     gridNavigation.update({ pageSize });
   }, [gridNavigation, pageSize]);
+
+  // Notify the processor of the new render.
+  useEffect(() => {
+    if (keyboardNavigation) {
+      gridNavigation.refresh();
+    }
+  });
 
   return <>{children}</>;
 }
@@ -50,22 +54,14 @@ export function GridNavigationProvider({ keyboardNavigation, pageSize, getTable,
  * This helper encapsulates the grid navigation behaviors which are:
  * 1. Responding to keyboard commands and moving the focus accordingly;
  * 2. Muting table interactive elements for only one to be user-focusable at a time;
- * 3. Suppressing the above behaviors when focusing an element inside a dialog or when instructed by the isSuppressed callback.
- *
- * All behaviors are attached upon initialization and are re-evaluated with every focusin, focusout, and keydown events,
- * and also when a node removal inside the table is observed to ensure consistency at any given moment.
- *
- * When the navigation is suppressed the keyboard commands are no longer intercepted and all table interactive elements are made
- * user-focusable to unblock the Tab navigation. The suppression should only be used for interactive elements inside the table that would
- * otherwise conflict with the navigation. Once the interactive element is deactivated or lose focus the table navigation becomes active again.
+ * 3. Suppressing the above behaviors when focusing an element inside a dialog or when instructed explicitly.
  */
-class GridNavigationHelper {
+class GridNavigationProcessor {
   // Props
   private _pageSize = 0;
   private _table: null | HTMLTableElement = null;
 
   // State
-  private prevFocusedCell: null | FocusedCell = null;
   private focusedCell: null | FocusedCell = null;
 
   public init(table: HTMLTableElement) {
@@ -75,9 +71,6 @@ class GridNavigationHelper {
     this.table.addEventListener('focusout', this.onFocusout);
     this.table.addEventListener('keydown', this.onKeydown);
 
-    const tableNodesObserver = new MutationObserver(this.onTableNodeMutation);
-    tableNodesObserver.observe(table, { childList: true, subtree: true });
-
     muteElementFocusables(this.table, false);
     ensureSingleFocusable(this.table, null);
 
@@ -85,8 +78,6 @@ class GridNavigationHelper {
       this.table.removeEventListener('focusin', this.onFocusin);
       this.table.removeEventListener('focusout', this.onFocusout);
       this.table.removeEventListener('keydown', this.onKeydown);
-
-      tableNodesObserver.disconnect();
 
       restoreElementFocusables(this.table);
     };
@@ -100,13 +91,28 @@ class GridNavigationHelper {
     this._pageSize = pageSize;
   }
 
+  public refresh() {
+    if (this._table) {
+      const cellSuppressed = this.focusedCell ? this.isSuppressed(this.focusedCell.element) : false;
+
+      // Update focused cell indices in case table rows, columns, or firstIndex change.
+      if (this.focusedCell) {
+        this.focusedCell = findFocusedCell(this.focusedCell.element);
+      }
+
+      // Ensure newly added elements if any are muted.
+      muteElementFocusables(this.table, cellSuppressed);
+      ensureSingleFocusable(this.table, this.focusedCell);
+    }
+  }
+
   private get pageSize() {
     return this._pageSize;
   }
 
   private get table(): HTMLTableElement {
     if (!this._table) {
-      throw new Error('Invariant violation: GridNavigationHelper is used before initialization.');
+      throw new Error('Invariant violation: GridNavigationProcessor is used before initialization.');
     }
     return this._table;
   }
@@ -116,12 +122,15 @@ class GridNavigationHelper {
   }
 
   private onFocusin = (event: FocusEvent) => {
-    const cell = findFocusinCell(event);
+    if (!(event.target instanceof HTMLElement)) {
+      return;
+    }
+
+    const cell = findFocusedCell(event.target);
     if (!cell) {
       return;
     }
 
-    this.prevFocusedCell = cell;
     this.focusedCell = cell;
 
     muteElementFocusables(this.table, this.isSuppressed(cell.element));
@@ -135,7 +144,13 @@ class GridNavigationHelper {
   };
 
   private onFocusout = () => {
-    this.focusedCell = null;
+    // When focus leaves the cell and the cell becomes no longer belong to the table it indicates the focused element has been unmounted.
+    // In that case the focus needs to be restored on the same coordinates.
+    setTimeout(() => {
+      if (this.focusedCell && !nodeBelongs(this.table, this.focusedCell.element)) {
+        this.moveFocusBy(this.focusedCell, { x: 0, y: 0 });
+      }
+    }, 0);
   };
 
   private onKeydown = (event: KeyboardEvent) => {
@@ -168,74 +183,50 @@ class GridNavigationHelper {
     switch (key) {
       case KeyCode.up:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: -1, x: 0 });
+        return this.moveFocusBy(from, { y: -1, x: 0 });
 
       case KeyCode.down:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: 1, x: 0 });
+        return this.moveFocusBy(from, { y: 1, x: 0 });
 
       case KeyCode.left:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: 0, x: -1 });
+        return this.moveFocusBy(from, { y: 0, x: -1 });
 
       case KeyCode.right:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: 0, x: 1 });
+        return this.moveFocusBy(from, { y: 0, x: 1 });
 
       case KeyCode.pageUp:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: -this.pageSize, x: 0 });
+        return this.moveFocusBy(from, { y: -this.pageSize, x: 0 });
 
       case KeyCode.pageDown:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: this.pageSize, x: 0 });
+        return this.moveFocusBy(from, { y: this.pageSize, x: 0 });
 
       case KeyCode.home:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: 0, x: minExtreme });
+        return this.moveFocusBy(from, { y: 0, x: minExtreme });
 
       case KeyCode.end:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: 0, x: maxExtreme });
+        return this.moveFocusBy(from, { y: 0, x: maxExtreme });
 
       case -KeyCode.home:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: minExtreme, x: minExtreme });
+        return this.moveFocusBy(from, { y: minExtreme, x: minExtreme });
 
       case -KeyCode.end:
         event.preventDefault();
-        return moveFocusBy(this.table, from, { y: maxExtreme, x: maxExtreme });
+        return this.moveFocusBy(from, { y: maxExtreme, x: maxExtreme });
 
       default:
         return;
     }
   };
 
-  private onTableNodeMutation = (mutationRecords: MutationRecord[]) => {
-    // When focused cell is un-mounted the focusout event handler removes this.cell,
-    // while this.prevFocusedCell is retained until the next focusin event.
-    const cell = this.focusedCell ?? this.prevFocusedCell;
-    const cellSuppressed = cell ? this.isSuppressed(cell.element) : false;
-
-    // Update table elements focus if new nodes were added.
-    if (mutationRecords.some(record => record.addedNodes.length > 0)) {
-      muteElementFocusables(this.table, cellSuppressed);
-      ensureSingleFocusable(this.table, cell);
-    }
-
-    if (cell) {
-      for (const record of mutationRecords) {
-        if (record.type === 'childList') {
-          // The lost focus in an unmount event is reapplied to the table using the previous cell position.
-          // The moveFocusBy takes care of finding the closest position if the previous one no longer exists.
-          for (const removedNode of Array.from(record.removedNodes)) {
-            if (removedNode === cell.element || nodeContains(removedNode, cell.element)) {
-              ensureSingleFocusable(this.table, cell);
-              moveFocusBy(this.table, cell, { y: 0, x: 0 });
-            }
-          }
-        }
-      }
-    }
-  };
+  private moveFocusBy(cell: FocusedCell, delta: { x: number; y: number }) {
+    getNextFocusable(this.table, cell, delta)?.focus();
+  }
 }

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -103,6 +103,10 @@ export function getTableColHeaderRoleProps(options: {
     nativeProps['aria-sort'] = getAriaSort(options.sortingStatus);
   }
 
+  if (options.tableRole === 'grid') {
+    nativeProps.tabIndex = -1;
+  }
+
   return nativeProps;
 }
 
@@ -115,6 +119,10 @@ export function getTableCellRoleProps(options: { tableRole: TableRole; colIndex:
 
   if (options.isRowHeader) {
     nativeProps.scope = 'row';
+  }
+
+  if (options.tableRole === 'grid') {
+    nativeProps.tabIndex = -1;
   }
 
   return nativeProps;

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -96,15 +96,12 @@ export function getTableColHeaderRoleProps(options: {
   nativeProps.scope = 'col';
 
   if (options.tableRole === 'grid') {
+    nativeProps.tabIndex = -1;
     nativeProps['aria-colindex'] = options.colIndex + 1;
   }
 
   if (options.sortingStatus) {
     nativeProps['aria-sort'] = getAriaSort(options.sortingStatus);
-  }
-
-  if (options.tableRole === 'grid') {
-    nativeProps.tabIndex = -1;
   }
 
   return nativeProps;
@@ -114,15 +111,12 @@ export function getTableCellRoleProps(options: { tableRole: TableRole; colIndex:
   const nativeProps: React.TdHTMLAttributes<HTMLTableCellElement> = {};
 
   if (options.tableRole === 'grid') {
+    nativeProps.tabIndex = -1;
     nativeProps['aria-colindex'] = options.colIndex + 1;
   }
 
   if (options.isRowHeader) {
     nativeProps.scope = 'row';
-  }
-
-  if (options.tableRole === 'grid') {
-    nativeProps.tabIndex = -1;
   }
 
   return nativeProps;

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -13,13 +13,8 @@ const FOCUSABLES_SELECTOR = `[tabIndex="0"],[tabIndex="${PSEUDO_FOCUSABLE_TAB_IN
  * Finds focused cell props corresponding the focused element inside the table.
  * The function relies on ARIA colindex/rowindex attributes being correctly applied.
  */
-export function findFocusinCell(event: FocusEvent): null | FocusedCell {
-  if (!(event.target instanceof HTMLElement)) {
-    return null;
-  }
-  const element = event.target;
-
-  const cellElement = element.closest('td,th') as null | HTMLTableCellElement;
+export function findFocusedCell(focusedElement: HTMLElement): null | FocusedCell {
+  const cellElement = focusedElement.closest('td,th') as null | HTMLTableCellElement;
   const rowElement = cellElement?.closest('tr');
 
   if (!cellElement || !rowElement) {
@@ -33,53 +28,52 @@ export function findFocusinCell(event: FocusEvent): null | FocusedCell {
   }
 
   const cellFocusables = getFocusables(cellElement);
-  const elementIndex = cellFocusables.indexOf(element);
+  const elementIndex = cellFocusables.indexOf(focusedElement);
 
-  return { rowIndex, colIndex, rowElement, cellElement, element, elementIndex };
+  return { rowIndex, colIndex, rowElement, cellElement, element: focusedElement, elementIndex };
 }
 
 /**
  * Moves table focus in the provided direction. The focus can transition between cells or interactive elements inside cells.
  */
-export function moveFocusBy(table: HTMLTableElement, from: FocusedCell, delta: { y: number; x: number }) {
+export function getNextFocusable(table: HTMLTableElement, from: FocusedCell, delta: { y: number; x: number }) {
   // Find next row to move focus into (can be null if the top/bottom is reached).
   const targetAriaRowIndex = from.rowIndex + delta.y;
   const targetRow = findTableRowByAriaRowIndex(table, targetAriaRowIndex, delta.y);
   if (!targetRow) {
-    return;
+    return null;
   }
 
   // Move focus to the next interactive cell content element if available.
   const cellFocusables = getFocusables(from.cellElement);
   const nextElementIndex = from.elementIndex + delta.x;
   if (delta.x && from.elementIndex !== -1 && 0 <= nextElementIndex && nextElementIndex < cellFocusables.length) {
-    focus(cellFocusables[nextElementIndex]);
-    return;
+    return cellFocusables[nextElementIndex];
   }
 
   // Find next cell to focus or move focus into (can be null if the left/right edge is reached).
   const targetAriaColIndex = from.colIndex + delta.x;
   const targetCell = findTableRowCellByAriaColIndex(targetRow, targetAriaColIndex, delta.x);
   if (!targetCell) {
-    return;
+    return null;
   }
 
   // When target cell matches the current cell it means we reached the left or right boundary.
-  if (targetCell === from.cellElement) {
-    return;
+  if (targetCell === from.cellElement && delta.x !== 0) {
+    return null;
   }
 
   // Move focus on the cell interactive content or the cell itself.
   const targetCellFocusables = getFocusables(targetCell);
   const focusIndex = delta.x < 0 ? targetCellFocusables.length - 1 : delta.x > 0 ? 0 : from.elementIndex;
   const focusTarget = targetCellFocusables[focusIndex] ?? targetCell;
-  focus(focusTarget);
+  return focusTarget;
 }
 
 /**
  * Makes the cell element, the first interactive element or the first cell of the table user-focusable.
  */
-export function ensureSingleFocusable(table: HTMLElement, cell: null | FocusedCell) {
+export function ensureSingleFocusable(table: HTMLTableElement, cell: null | FocusedCell) {
   const firstTableCell = table.querySelector('td,th') as null | HTMLTableCellElement;
 
   // A single element of the table is made user-focusable.
@@ -87,8 +81,8 @@ export function ensureSingleFocusable(table: HTMLElement, cell: null | FocusedCe
   let focusTarget: null | HTMLElement = (firstTableCell && getFocusables(firstTableCell)[0]) ?? firstTableCell;
 
   // When a navigation-focused element is present in the table it is used for user-navigation instead.
-  if (cell && table.contains(cell.element) && isUserFocusable(cell.element)) {
-    focusTarget = cell.element;
+  if (cell) {
+    focusTarget = getNextFocusable(table, cell, { x: 0, y: 0 });
   }
 
   setTabIndex(focusTarget, 0);
@@ -216,17 +210,8 @@ function findTableRowCellByAriaColIndex(tableRow: HTMLTableRowElement, targetAri
   return targetCell;
 }
 
-function focus(element: null | HTMLElement) {
-  setTabIndex(element, 0);
-  element?.focus();
-}
-
 function setTabIndex(element: null | HTMLElement, tabIndex: number) {
   if (element && element.tabIndex !== tabIndex) {
     element.tabIndex = tabIndex;
   }
-}
-
-function isUserFocusable(element: HTMLElement) {
-  return element.matches(FOCUSABLES_SELECTOR);
 }

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -34,7 +34,7 @@ export function findFocusedCell(focusedElement: HTMLElement): null | FocusedCell
 }
 
 /**
- * Moves table focus in the provided direction. The focus can transition between cells or interactive elements inside cells.
+ * Finds element to be focused next. The focus can transition between cells or interactive elements inside cells.
  */
 export function getNextFocusable(table: HTMLTableElement, from: FocusedCell, delta: { y: number; x: number }) {
   // Find next row to move focus into (can be null if the top/bottom is reached).
@@ -44,7 +44,7 @@ export function getNextFocusable(table: HTMLTableElement, from: FocusedCell, del
     return null;
   }
 
-  // Move focus to the next interactive cell content element if available.
+  // Return next interactive cell content element if available.
   const cellFocusables = getFocusables(from.cellElement);
   const nextElementIndex = from.elementIndex + delta.x;
   if (delta.x && from.elementIndex !== -1 && 0 <= nextElementIndex && nextElementIndex < cellFocusables.length) {
@@ -63,7 +63,7 @@ export function getNextFocusable(table: HTMLTableElement, from: FocusedCell, del
     return null;
   }
 
-  // Move focus on the cell interactive content or the cell itself.
+  // Return cell interactive content or the cell itself.
   const targetCellFocusables = getFocusables(targetCell);
   const focusIndex = delta.x < 0 ? targetCellFocusables.length - 1 : delta.x > 0 ? 0 : from.elementIndex;
   const focusTarget = targetCellFocusables[focusIndex] ?? targetCell;


### PR DESCRIPTION
### Description

Use simpler grid navigation implementation (no mutation observer and a single variable to keep focused cell) based on https://github.com/cloudscape-design/components/pull/1750 to prepare for the register-based implementation based on https://github.com/cloudscape-design/components/pull/1760.

### How has this been tested?

New integration tests, reworked unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
