### PR TITLE
feat: Add "th" locale

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -128,6 +128,9 @@ export interface I18nFormatArgTypes {
       "finalPosition": string | number;
     }
   }
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": never;
+  }
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": never;
     "i18nStrings.absoluteModeTitle": never;
@@ -151,12 +154,12 @@ export interface I18nFormatArgTypes {
       "endDate": string | number;
     }
     "i18nStrings.formatRelativeRange": {
+      "unit": string;
       "amount": number;
-      "unit": string | number;
     }
     "i18nStrings.formatUnit": {
+      "unit": string;
       "amount": number;
-      "unit": string | number;
     }
   }
   "drawer": {

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Objekt zurück an die Position {currentPosition} von {total} verschieben} false {Objekt an Position {currentPosition} von {total} verschieben} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Das Objekt wurde zurück an seine ursprüngliche Position {initialPosition} von {total} verschoben} false {Das Objekt wurde von Position {initialPosition} zu Position {finalPosition} von {total} verschoben} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Kopieren"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Relativer Modus",
     "i18nStrings.absoluteModeTitle": "Absoluter Modus",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Verwenden Sie für Datum JJJJ/MM/TT. Verwenden Sie für die Zeit das 24-Stunden-Format.",
     "i18nStrings.errorIconAriaLabel": "Fehler",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Bereich ausgewählt von {startDate} bis {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Letzte {amount} {unit}} other {Letzte {amount} {unit}s}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Letzte {amount} Sekunden} one {Letzte {amount} Sekunde} other {Letzte {amount} Sekunden}}} minute {{amount, plural, zero {Letzte {amount} Minuten} one {Letzte {amount} Minute} other {Letzte {amount} Minuten}}} hour {{amount, plural, zero {Letzte {amount} Stunden} one {Letzte {amount} Stunde} other {Letzte {amount} Stunden}}} day {{amount, plural, zero {Letzte {amount} Tage} one {Letzter {amount} Tag} other {Letzte {amount} Tage}}} week {{amount, plural, zero {Letzte {amount} Wochen} one {Letzte {amount} Woche} other {Letzte {amount} Wochen}}} month {{amount, plural, zero {Letzte {amount} Monate} one {Letzter {amount} Monat} other {Letzte {amount} Monate}}} year {{amount, plural, zero {Letzte {amount} Jahre} one {Letztes {amount} Jahr} other {Letzte {amount} Jahre}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {Sekunden} one {Sekunde} other {Sekunden}}} minute {{amount, plural, zero {Minuten} one {Minute} other {Minuten}}} hour {{amount, plural, zero {Stunden} one {Stunde} other {Stunden}}} day {{amount, plural, zero {Tage} one {Tag} other {Tage}}} week {{amount, plural, zero {Wochen} one {Woche} other {Wochen}}} month {{amount, plural, zero {Monate} one {Monat} other {Monate}}} year {{amount, plural, zero {Jahre} one {Jahr} other {Jahre}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Inhalte werden geladen"

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copy"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Relative mode",
     "i18nStrings.absoluteModeTitle": "Absolute mode",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "For date, use DD/MM/YYYY. For time, use 24-hr format.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Range selected from {startDate} to {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Last {amount} {unit}} other {Last {amount} {unit}s}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Last {amount} seconds} one {Last {amount} second} other {Last {amount} seconds}}} minute {{amount, plural, zero {Last {amount} minutes} one {Last {amount} minute} other {Last {amount} minutes}}} hour {{amount, plural, zero {Last {amount} hours} one {Last {amount} hour} other {Last {amount} hours}}} day {{amount, plural, zero {Last {amount} days} one {Last {amount} day} other {Last {amount} days}}} week {{amount, plural, zero {Last {amount} weeks} one {Last {amount} week} other {Last {amount} weeks}}} month {{amount, plural, zero {Last {amount} months} one {Last {amount} month} other {Last {amount} months}}} year {{amount, plural, zero {Last {amount} years} one {Last {amount} year} other {Last {amount} years}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {seconds} one {second} other {seconds}}} minute {{amount, plural, zero {minutes} one {minute} other {minutes}}} hour {{amount, plural, zero {hours} one {hour} other {hours}}} day {{amount, plural, zero {days} one {day} other {days}}} week {{amount, plural, zero {weeks} one {week} other {weeks}}} month {{amount, plural, zero {months} one {Month} other {months}}} year {{amount, plural, zero {years} one {year} other {years}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Loading content"

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Moving item back to position {currentPosition} of {total}} false {Moving item to position {currentPosition} of {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item moved back to its original position {initialPosition} of {total}} false {Item moved from position {initialPosition} to position {finalPosition} of {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copy"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Relative mode",
     "i18nStrings.absoluteModeTitle": "Absolute mode",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "For date, use YYYY/MM/DD. For time, use 24 hr format.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Range selected from {startDate} to {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Last {amount} {unit}} other {Last {amount} {unit}s}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Last {amount} seconds} one {Last {amount} second} other {Last {amount} seconds}}} minute {{amount, plural, zero {Last {amount} minutes} one {Last {amount} minute} other {Last {amount} minutes}}} hour {{amount, plural, zero {Last {amount} hours} one {Last {amount} hour} other {Last {amount} hours}}} day {{amount, plural, zero {Last {amount} days} one {Last {amount} day} other {Last {amount} days}}} week {{amount, plural, zero {Last {amount} weeks} one {Last {amount} week} other {Last {amount} weeks}}} month {{amount, plural, zero {Last {amount} months} one {Last {amount} month} other {Last {amount} months}}} year {{amount, plural, zero {Last {amount} years} one {Last {amount} year} other {Last {amount} years}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {seconds} one {second} other {seconds}}} minute {{amount, plural, zero {minutes} one {minute} other {minutes}}} hour {{amount, plural, zero {hours} one {hour} other {hours}}} day {{amount, plural, zero {days} one {day} other {days}}} week {{amount, plural, zero {weeks} one {week} other {weeks}}} month {{amount, plural, zero {months} one {month} other {months}}} year {{amount, plural, zero {years} one {year} other {years}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Loading content"

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Mover el elemento de nuevo a la posición {currentPosition} de {total}} false {Mover el elemento a la posición {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {El artículo ha vuelto a su posición original {initialPosition} de {total}} false {El artículo se movió de la posición {initialPosition} a la posición {finalPosition} de {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copiar"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modo relativo",
     "i18nStrings.absoluteModeTitle": "Modo absoluto",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Para la fecha, utilice AAAA/MM/DD. Para la hora, utilice el formato de 24 horas.",
     "i18nStrings.errorIconAriaLabel": "Error",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rango seleccionado de {startDate} a {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Último {amount} {unit}} other {Últimos {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Últimos {amount} segundos} one {Último {amount} segundo} other {Últimos {amount} segundos}}} minute {{amount, plural, zero {Últimos {amount} minutos} one {Último {amount} minuto} other {Últimos {amount} minutos}}} hour {{amount, plural, zero {Últimas {amount} horas} one {Última {amount} hora} other {Últimas {amount} horas}}} day {{amount, plural, zero {Últimos {amount} días} one {Último {amount} día} other {Últimos {amount} días}}} week {{amount, plural, zero {Últimas {amount} semanas} one {Última {amount} semana} other {Últimas {amount} semanas}}} month {{amount, plural, zero {Últimos {amount} meses} one {Último {amount} mes} other {Últimos {amount} meses}}} year {{amount, plural, zero {Últimos {amount} años} one {Último {amount} año} other {Últimos {amount} años}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {segundos} one {segundo} other {segundos}}} minute {{amount, plural, zero {minutos} one {minuto} other {minutos}}} hour {{amount, plural, zero {horas} one {hora} other {horas}}} day {{amount, plural, zero {días} one {día} other {días}}} week {{amount, plural, zero {semanas} one {semana} other {semanas}}} month {{amount, plural, zero {meses} one {mes} other {meses}}} year {{amount, plural, zero {años} one {año} other {años}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Cargando contenido"

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Remettre l'élément à la position {currentPosition} de {total}} false {Déplacer l'élément vers la position {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'élément a été replacé dans sa position initiale {initialPosition} de {total}} false {L'élément a été déplacé de la position {initialPosition} à {finalPosition} de {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copier"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Mode relatif",
     "i18nStrings.absoluteModeTitle": "Mode absolu",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Pour la date, utilisez le format AAAA/MM/JJ. Pour l'heure, utilisez le format 24 heures.",
     "i18nStrings.errorIconAriaLabel": "Erreur",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Plage sélectionnée de {startDate} à {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Dernier {amount} {unit}} other {Dernières {amount} {unit}s}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Dernières {amount} secondes} one {Dernière {amount} seconde} other {Dernières {amount} secondes}}} minute {{amount, plural, zero {Dernières {amount} minutes} one {Dernière {amount} minute} other {Dernières {amount} minutes}}} hour {{amount, plural, zero {Dernières {amount} heures} one {Dernière {amount} heure} other {Dernières {amount} heures}}} day {{amount, plural, zero {Derniers {amount} jours} one {Dernier {amount} jour} other {Derniers {amount} jours}}} week {{amount, plural, zero {Dernières {amount} semaines} one {Dernière {amount} semaine} other {Dernières {amount} semaines}}} month {{amount, plural, zero {Derniers {amount} mois} one {Dernier {amount} mois} other {Derniers {amount} mois}}} year {{amount, plural, zero {Dernières {amount} années} one {Dernière {amount} année} other {Dernières {amount} années}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {secondes} one {seconde} other {secondes}}} minute {{amount, plural, zero {minutes} one {minute} other {minutes}}} hour {{amount, plural, zero {heures} one {heure} other {heures}}} day {{amount, plural, zero {jours} one {jour} other {jours}}} week {{amount, plural, zero {semaines} one {semaine} other {semaines}}} month {{amount, plural, zero {mois} one {mois} other {mois}}} year {{amount, plural, zero {années} one {année} other {années}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Chargement du contenu en cours"

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Memindahkan item kembali ke posisi {currentPosition} dari {total}} false {Memindahkan item ke posisi {currentPosition} dari {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item dipindahkan kembali ke posisi aslinya {initialPosition} dari {total}} false {Item dipindahkan dari posisi {initialPosition} ke posisi {finalPosition} dari {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Salin"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Mode relatif",
     "i18nStrings.absoluteModeTitle": "Mode absolut",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Untuk tanggal, gunakan HH/BB/TTTT. Untuk waktu, gunakan format 24 jam.",
     "i18nStrings.errorIconAriaLabel": "Kesalahan",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Rentang dipilih dari {startDate} hingga {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {{amount} {unit} terakhir} other {{amount} {unit} terakhir}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {{amount} detik terakhir} one {{amount} detik terakhir} other {{amount} detik terakhir}}} minute {{amount, plural, zero {{amount} menit terakhir} one {{amount} menit terakhir} other {{amount} menit terakhir}}} hour {{amount, plural, zero {{amount} jam terakhir} one {{amount} jam terakhir} other {{amount} jam terakhir}}} day {{amount, plural, zero {{amount} hari terakhir} one {{amount} hari terakhir} other {{amount} hari terakhir}}} week {{amount, plural, zero {{amount} minggu terakhir} one {{amount} minggu terakhir} other {{amount} minggu terakhir}}} month {{amount, plural, zero {{amount} bulan terakhir} one {{amount} bulan terakhir} other {{amount} bulan terakhir}}} year {{amount, plural, zero {{amount} tahun terakhir} one {{amount} tahun terakhir} other {{amount} tahun terakhir}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {detik} one {detik} other {detik}}} minute {{amount, plural, zero {menit} one {menit} other {menit}}} hour {{amount, plural, zero {jam} one {jam} other {jam}}} day {{amount, plural, zero {hari} one {hari} other {hari}}} week {{amount, plural, zero {minggu} one {minggu} other {minggu}}} month {{amount, plural, zero {bulan} one {bulan} other {bulan}}} year {{amount, plural, zero {tahun} one {tahun} other {tahun}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Memuat konten"

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Spostamento dell'elemento di nuovo nella posizione {currentPosition} di {total}} false {Spostamento dell'elemento nella posizione {currentPosition} di {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {L'elemento è stato spostato di nuovo nella posizione originale {initialPosition} di {total}} false {Elemento spostato da una posizione {initialPosition} alla posizione {finalPosition} di {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copia"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modalità relativa",
     "i18nStrings.absoluteModeTitle": "Modalità assoluta",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Per la data, utilizza il formato GG/MM/AAAA. Per l'ora, usa il formato 24 ore.",
     "i18nStrings.errorIconAriaLabel": "Errore",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervallo selezionato da {startDate} a {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Ultimo {amount} {unit}} other {Ultimi {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Ultimi {amount} secondi} one {Ultimo secondo} other {Ultimi {amount} secondi}}} minute {{amount, plural, zero {Ultimi {amount} minuti} one {Ultimo minuto} other {Ultimi {amount} minuti}}} hour {{amount, plural, zero {Ultime {amount} ore} one {Ultima ora} other {Ultime {amount} ore}}} day {{amount, plural, zero {Ultimi {amount} giorni} one {Ultimo giorno} other {Ultimi {amount} giorni}}} week {{amount, plural, zero {Ultime {amount} settimane} one {Ultima settimana} other {Ultime {amount} settimane}}} month {{amount, plural, zero {Ultimi {amount} mesi} one {Ultimo mese} other {Ultimi {amount} mesi}}} year {{amount, plural, zero {Ultimi {amount} anni} one {Ultimo anno} other {Ultimi {amount} anni}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {secondi} one {secondo} other {secondi}}} minute {{amount, plural, zero {minuti} one {minuto} other {minuti}}} hour {{amount, plural, zero {ore} one {ora} other {ore}}} day {{amount, plural, zero {giorni} one {giorno} other {giorni}}} week {{amount, plural, zero {settimane} one {settimana} other {settimane}}} month {{amount, plural, zero {mesi} one {mese} other {mesi}}} year {{amount, plural, zero {anni} one {anno} other {anni}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Caricamento dei contenuti"

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {項目を位置 {currentPosition}/{total} に戻しています} false {項目を位置 {currentPosition}/{total} に移動しています} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目は元の位置 {initialPosition}/{total} に戻りました} false {項目が位置 {initialPosition} から位置 {finalPosition}/{total} に移動しました} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "コピー"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相対モード",
     "i18nStrings.absoluteModeTitle": "絶対モード",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "日付には YYYY/MM/DD を使用します。時刻には 24 時間形式を使用します。",
     "i18nStrings.errorIconAriaLabel": "エラー",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate} から {endDate} で選択された範囲",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {最後の {amount} {unit}} other {最後の {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {直近 {amount} 秒間} one {直近 {amount} 秒間} other {直近 {amount} 秒間}}} minute {{amount, plural, zero {直近 {amount} 分間} one {直近 {amount} 分間} other {直近 {amount} 分間}}} hour {{amount, plural, zero {直近 {amount} 時間} one {直近 {amount} 時間} other {直近 {amount} 時間}}} day {{amount, plural, zero {直近 {amount} 日間} one {直近 {amount} 日間} other {直近 {amount} 日間}}} week {{amount, plural, zero {直近 {amount} 週間} one {直近 {amount} 週間} other {直近 {amount} 週間}}} month {{amount, plural, zero {直近 {amount} か月間} one {直近 {amount} か月間} other {直近 {amount} か月間}}} year {{amount, plural, zero {直近 {amount} 年間} one {直近 {amount} 年間} other {直近 {amount} 年間}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {秒間} one {秒間} other {秒間}}} minute {{amount, plural, zero {分間} one {分間} other {分間}}} hour {{amount, plural, zero {時間} one {時間} other {時間}}} day {{amount, plural, zero {日間} one {日間} other {日間}}} week {{amount, plural, zero {週間} one {週間} other {週間}}} month {{amount, plural, zero {か月間} one {か月間} other {か月間}}} year {{amount, plural, zero {年間} one {年間} other {年間}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "コンテンツのロード中"

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {{currentPosition}/{total} 위치로 항목 다시 이동} false {{currentPosition}/{total} 위치로 항목 이동} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {항목이 원래 위치인 {initialPosition}/{total} 위치로 다시 이동됨} false {항목이 {initialPosition}/{total} 위치에서 인 {finalPosition}/{total} 위치로 이동됨} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "복사"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "상대 모드",
     "i18nStrings.absoluteModeTitle": "절대 모드",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "날짜에는 YYYY/MM/DD를 사용합니다. 시간에는 24시간 형식을 사용합니다.",
     "i18nStrings.errorIconAriaLabel": "오류",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate}~{endDate}에서 선택한 범위",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {마지막 {amount}{unit}} other {마지막 {amount}{unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {지난 {amount}초} one {지난 {amount}초} other {지난 {amount}초}}} minute {{amount, plural, zero {지난 {amount}분} one {지난 {amount}분} other {지난 {amount}분}}} hour {{amount, plural, zero {지난 {amount}시간} one {지난 {amount}시간} other {지난 {amount}시간}}} day {{amount, plural, zero {지난 {amount}일} one {지난 {amount}일} other {지난 {amount}일}}} week {{amount, plural, zero {지난 {amount}주} one {지난 {amount}주} other {지난 {amount}주}}} month {{amount, plural, zero {지난 {amount}개월} one {지난 {amount}개월} other {지난 {amount}개월}}} year {{amount, plural, zero {지난 {amount}년} one {지난 {amount}년} other {지난 {amount}년}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {초} one {초} other {초}}} minute {{amount, plural, zero {분} one {분} other {분}}} hour {{amount, plural, zero {시간} one {시간} other {시간}}} day {{amount, plural, zero {일} one {일} other {일}}} week {{amount, plural, zero {주} one {주} other {주}}} month {{amount, plural, zero {개월} one {개월} other {개월}}} year {{amount, plural, zero {년} one {년} other {년}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "콘텐츠 로드 중"

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Movendo o item de volta para a posição {currentPosition} de {total}} false {Movendo o item para a posição {currentPosition} de {total}} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Item movido de volta à sua posição original {initialPosition} de {total}} false {Item movido da posição {initialPosition} para a posição {finalPosition} de {total}} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Copiar"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Modo relativo",
     "i18nStrings.absoluteModeTitle": "Modo absoluto",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Para a data, use o formato AAAA/MM/DD. Para o horário, use o formato de 24 horas.",
     "i18nStrings.errorIconAriaLabel": "Erro",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "Intervalo selecionado de {startDate} a {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Último(a) {amount} {unit}} other {Últimos(as) {amount} {unit}s}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}s}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Últimos {amount} segundos} one {Último {amount} segundo} other {Últimos {amount} segundos}}} minute {{amount, plural, zero {Últimos {amount} minutos} one {Último {amount} minuto} other {Últimos {amount} minutos}}} hour {{amount, plural, zero {Últimas {amount} horas} one {Última {amount} hora} other {Últimas {amount} horas}}} day {{amount, plural, zero {Últimos {amount} dias} one {Último {amount} dia} other {Últimos {amount} dias}}} week {{amount, plural, zero {Últimas {amount} semanas} one {Última {amount} semana} other {Últimas {amount} semanas}}} month {{amount, plural, zero {Últimos {amount} meses} one {Último {amount} mês} other {Últimos {amount} meses}}} year {{amount, plural, zero {Últimos {amount} anos} one {Último {amount} ano} other {Últimos {amount} anos}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {segundos} one {segundo} other {segundos}}} minute {{amount, plural, zero {minutos} one {minuto} other {minutos}}} hour {{amount, plural, zero {horas} one {hora} other {horas}}} day {{amount, plural, zero {dias} one {dia} other {dias}}} week {{amount, plural, zero {semanas} one {semana} other {semanas}}} month {{amount, plural, zero {meses} one {mês} other {meses}}} year {{amount, plural, zero {anos} one {ano} other {anos}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "Carregando conteúdo"

--- a/src/i18n/messages/all.th.json
+++ b/src/i18n/messages/all.th.json
@@ -1,0 +1,356 @@
+{
+  "[charts]": {
+    "loadingText": "กำลังโหลดแผนภูมิ",
+    "errorText": "ไม่สามารถดึงข้อมูลได้ โปรดลองอีกครั้งในภายหลัง",
+    "recoveryText": "ลองอีกครั้ง",
+    "i18nStrings.filterLabel": "กรองข้อมูลที่แสดง",
+    "i18nStrings.filterPlaceholder": "กรองข้อมูล",
+    "i18nStrings.legendAriaLabel": "รายละเอียด",
+    "i18nStrings.chartAriaRoleDescription": "แผนภูมิ",
+    "i18nStrings.xAxisAriaRoleDescription": "แกน x",
+    "i18nStrings.yAxisAriaRoleDescription": "แกน y"
+  },
+  "alert": {
+    "dismissAriaLabel": "ยกเลิกการแจ้งเตือน"
+  },
+  "annotation-context": {
+    "i18nStrings.nextButtonText": "ถัดไป",
+    "i18nStrings.previousButtonText": "ก่อนหน้า",
+    "i18nStrings.finishButtonText": "เสร็จสิ้น",
+    "i18nStrings.labelDismissAnnotation": "ยกเลิกคำอธิบายประกอบ",
+    "i18nStrings.stepCounterText": "ขั้นตอน {stepNumber} จาก {totalStepCount}",
+    "i18nStrings.taskTitle": "งาน {taskNumber}: {taskTitle}",
+    "i18nStrings.labelHotspot": "{openState, select, true {ปิดคำอธิบายประกอบสำหรับขั้นตอนของ {stepNumber} จาก {totalStepCount}} false {เปิดคำอธิบายประกอบสำหรับขั้นตอนของ {stepNumber} จาก {totalStepCount}} other {}}"
+  },
+  "app-layout": {
+    "ariaLabels.drawers": "ลิ้นชัก",
+    "ariaLabels.drawersOverflow": "ลิ้นชักล้น",
+    "ariaLabels.drawersOverflowWithBadge": "ลิ้นชักล้นพร้อมป้าย",
+    "ariaLabels.navigation": "การนำทางด้านข้าง",
+    "ariaLabels.navigationClose": "ปิดการนำทางด้านข้าง",
+    "ariaLabels.navigationToggle": "เปิดการนำทางด้านข้าง",
+    "ariaLabels.notifications": "การแจ้งเตือน",
+    "ariaLabels.tools": "แผงช่วยเหลือ",
+    "ariaLabels.toolsClose": "ปิดแผงช่วยเหลือ",
+    "ariaLabels.toolsToggle": "เปิดแผงช่วยเหลือ"
+  },
+  "area-chart": {
+    "i18nStrings.detailTotalLabel": "ทั้งหมด"
+  },
+  "attribute-editor": {
+    "removeButtonText": "ลบ"
+  },
+  "autosuggest": {
+    "errorIconAriaLabel": "ข้อผิดพลาด",
+    "selectedAriaLabel": "เลือกไว้",
+    "enteredTextLabel": "ใช้: \"{value}\"",
+    "recoveryText": "ลองอีกครั้ง"
+  },
+  "breadcrumb-group": {
+    "expandAriaLabel": "แสดงเส้นทาง"
+  },
+  "calendar": {
+    "nextMonthAriaLabel": "เดือนถัดไป",
+    "previousMonthAriaLabel": "เดือนก่อนหน้า",
+    "todayAriaLabel": "วันนี้"
+  },
+  "cards": {
+    "ariaLabels.selectionGroupLabel": "การเลือกรายการ"
+  },
+  "code-editor": {
+    "i18nStrings.loadingState": "กำลังโหลดโปรแกรมแก้ไขรหัส",
+    "i18nStrings.errorState": "มีข้อผิดพลาดในการโหลดโปรแกรมแก้ไขรหัส",
+    "i18nStrings.errorStateRecovery": "ลองอีกครั้ง",
+    "i18nStrings.editorGroupAriaLabel": "โปรแกรมแก้ไขรหัส",
+    "i18nStrings.statusBarGroupAriaLabel": "แถบสถานะ",
+    "i18nStrings.cursorPosition": "บรรทัด {row} คอลัมน์ {column}",
+    "i18nStrings.errorsTab": "ข้อผิดพลาด",
+    "i18nStrings.warningsTab": "คำเตือน",
+    "i18nStrings.preferencesButtonAriaLabel": "การตั้งค่า",
+    "i18nStrings.paneCloseButtonAriaLabel": "ปิด",
+    "i18nStrings.preferencesModalHeader": "การตั้งค่า",
+    "i18nStrings.preferencesModalCancel": "ยกเลิก",
+    "i18nStrings.preferencesModalConfirm": "ยืนยัน",
+    "i18nStrings.preferencesModalWrapLines": "ตัดบรรทัด",
+    "i18nStrings.preferencesModalTheme": "ธีม",
+    "i18nStrings.preferencesModalLightThemes": "ธีมสีอ่อน",
+    "i18nStrings.preferencesModalDarkThemes": "ธีมสีเข้ม"
+  },
+  "collection-preferences": {
+    "title": "การตั้งค่า",
+    "confirmLabel": "ยืนยัน",
+    "cancelLabel": "ยกเลิก",
+    "pageSizePreference.title": "ขนาดหน้าเว็บ",
+    "wrapLinesPreference.label": "ตัดบรรทัด",
+    "wrapLinesPreference.description": "เลือกเพื่อดูข้อความทั้งหมดและตัดบรรทัด",
+    "stripedRowsPreference.label": "แถวลายทาง",
+    "stripedRowsPreference.description": "เลือกเพื่อเพิ่มแถวเฉดสลับกัน",
+    "contentDensityPreference.label": "โหมดบีบอัด",
+    "contentDensityPreference.description": "เลือกเพื่อแสดงเนื้อหาในโหมดที่หนาแน่นและบีบอัดมากขึ้น",
+    "contentDisplayPreference.title": "การตั้งค่าคอลัมน์",
+    "contentDisplayPreference.description": "ปรับแต่งการมองเห็นและลำดับคอลัมน์",
+    "contentDisplayPreference.dragHandleAriaLabel": "ลากที่จับ",
+    "contentDisplayPreference.dragHandleAriaDescription": "ใช้ปุ่ม Space หรือ Enter เพื่อเปิดใช้งานการลากสำหรับรายการ จากนั้นใช้ปุ่มลูกศรเพื่อย้ายตำแหน่งของรายการ หากต้องการย้ายตำแหน่งให้เสร็จสิ้น ให้ใช้ปุ่ม Space หรือ Enter หรือหากต้องการยกเลิกการย้ายให้ใช้ปุ่ม Escape",
+    "contentDisplayPreference.liveAnnouncementDndStarted": "รับรายการที่ตำแหน่ง {position} จาก {total}",
+    "contentDisplayPreference.liveAnnouncementDndDiscarded": "ยกเลิกการจัดเรียงใหม่",
+    "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {ย้ายรายการกลับไปยังตำแหน่ง {currentPosition} จาก {total}} false {ย้ายรายการไปยังตำแหน่ง {currentPosition} จาก {total}} other {}}",
+    "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {รายการย้ายกลับไปยังตำแหน่งเดิม {initialPosition} จาก {total}} false {รายการย้ายจากตำแหน่ง {initialPosition} ไปยังตำแหน่ง {finalPosition} จาก {total}} other {}}"
+  },
+  "date-range-picker": {
+    "i18nStrings.relativeModeTitle": "โหมดสัมพัทธ์",
+    "i18nStrings.absoluteModeTitle": "โหมดสัมบูรณ์",
+    "i18nStrings.relativeRangeSelectionHeading": "เลือกช่วง",
+    "i18nStrings.cancelButtonLabel": "ยกเลิก",
+    "i18nStrings.clearButtonLabel": "ล้างและยกเลิก",
+    "i18nStrings.applyButtonLabel": "นำไปใช้",
+    "i18nStrings.customRelativeRangeOptionLabel": "ช่วงที่กำหนดเอง",
+    "i18nStrings.customRelativeRangeOptionDescription": "ตั้งค่าช่วงที่กำหนดเองในอดีต",
+    "i18nStrings.customRelativeRangeUnitLabel": "หน่วยเวลา",
+    "i18nStrings.customRelativeRangeDurationLabel": "ระยะเวลา",
+    "i18nStrings.customRelativeRangeDurationPlaceholder": "ป้อนระยะเวลา",
+    "i18nStrings.startDateLabel": "วันที่เริ่มต้น",
+    "i18nStrings.startTimeLabel": "เวลาเริ่มต้น",
+    "i18nStrings.endDateLabel": "วันสิ้นสุด",
+    "i18nStrings.endTimeLabel": "เวลาสิ้นสุด",
+    "i18nStrings.dateTimeConstraintText": "สำหรับวันที่ให้ใช้ YYYY/MM/DD สำหรับเวลาให้ใช้รูปแบบ 24 ชม.",
+    "i18nStrings.errorIconAriaLabel": "ข้อผิดพลาด",
+    "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "ช่วงที่เลือกตั้งแต่ {startDate} ถึง {endDate}",
+    "i18nStrings.formatRelativeRange": "{amount, plural, one {{amount} {unit} ครั้งล่าสุด} other {{amount} {unit} ครั้งล่าสุด}}",
+    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit} วินาที}}"
+  },
+  "drawer": {
+    "i18nStrings.loadingText": "กำลังโหลดเนื้อหา"
+  },
+  "flashbar": {
+    "i18nStrings.ariaLabel": "การแจ้งเตือน",
+    "i18nStrings.errorIconAriaLabel": "ข้อผิดพลาด",
+    "i18nStrings.inProgressIconAriaLabel": "กำลังดำเนินการ",
+    "i18nStrings.infoIconAriaLabel": "ข้อมูล",
+    "i18nStrings.notificationBarAriaLabel": "การแจ้งเตือนทั้งหมด",
+    "i18nStrings.notificationBarText": "การแจ้งเตือน",
+    "i18nStrings.successIconAriaLabel": "สำเร็จ",
+    "i18nStrings.warningIconAriaLabel": "คำเตือน"
+  },
+  "form-field": {
+    "i18nStrings.errorIconAriaLabel": "ข้อผิดพลาด"
+  },
+  "form": {
+    "errorIconAriaLabel": "ข้อผิดพลาด"
+  },
+  "help-panel": {
+    "loadingText": "กำลังโหลดเนื้อหา"
+  },
+  "input": {
+    "clearAriaLabel": "ล้าง"
+  },
+  "link": {
+    "externalIconAriaLabel": "เปิดในแท็บใหม่"
+  },
+  "modal": {
+    "closeAriaLabel": "ปิดโมแดล"
+  },
+  "multiselect": {
+    "deselectAriaLabel": "ลบ {option__label}"
+  },
+  "pagination": {
+    "ariaLabels.nextPageLabel": "หน้าถัดไป",
+    "ariaLabels.pageLabel": "หน้า {pageNumber} จากทุกหน้า",
+    "ariaLabels.previousPageLabel": "หน้าก่อนหน้า"
+  },
+  "pie-chart": {
+    "i18nStrings.detailsValue": "ค่า",
+    "i18nStrings.detailsPercentage": "เปอร์เซ็นต์",
+    "i18nStrings.chartAriaRoleDescription": "แผนภูมิวงกลม",
+    "i18nStrings.segmentAriaRoleDescription": "ส่วน"
+  },
+  "popover": {
+    "dismissAriaLabel": "ปิดป๊อปโอเวอร์"
+  },
+  "property-filter": {
+    "i18nStrings.allPropertiesLabel": "คุณสมบัติทั้งหมด",
+    "i18nStrings.applyActionText": "นำไปใช้",
+    "i18nStrings.cancelActionText": "ยกเลิก",
+    "i18nStrings.clearFiltersText": "ล้างตัวกรอง",
+    "i18nStrings.editTokenHeader": "แก้ไขตัวกรอง",
+    "i18nStrings.groupPropertiesText": "เลิกทำ",
+    "i18nStrings.groupValuesText": "ค่า",
+    "i18nStrings.operationAndText": "และ",
+    "i18nStrings.operationOrText": "หรือ",
+    "i18nStrings.operatorContainsText": "ประกอบด้วย",
+    "i18nStrings.operatorDoesNotContainText": "ไม่มี",
+    "i18nStrings.operatorDoesNotEqualText": "ไม่เท่ากับ",
+    "i18nStrings.operatorEqualsText": "เท่ากับ",
+    "i18nStrings.operatorGreaterOrEqualText": "มากกว่าหรือเท่ากับ",
+    "i18nStrings.operatorGreaterText": "มากกว่า",
+    "i18nStrings.operatorLessOrEqualText": "น้อยกว่าหรือเท่ากับ",
+    "i18nStrings.operatorLessText": "น้อยกว่า",
+    "i18nStrings.operatorStartsWithText": "เริ่มต้นด้วย",
+    "i18nStrings.operatorText": "ตัวดำเนินการ",
+    "i18nStrings.operatorsText": "ตัวดำเนินการ",
+    "i18nStrings.propertyText": "คุณสมบัติ",
+    "i18nStrings.tokenLimitShowFewer": "แสดงน้อยลง",
+    "i18nStrings.tokenLimitShowMore": "แสดงเพิ่มเติม",
+    "i18nStrings.valueText": "ค่า",
+    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {ลบตัวกรอง {token__propertyKey} เท่ากับ {token__value}} not_equals {ลบตัวกรอง {token__propertyKey} ไม่เท่ากับ {token__value}} greater_than {ลบตัวกรอง {token__propertyKey} มากกว่า {token__value}} greater_than_equal {ลบตัวกรอง {token__propertyKey} มากกว่าหรือเท่ากับ {token__value}} less_than {ลบตัวกรอง {token__propertyKey} น้อยกว่า {token__value}} less_than_equal {ลบตัวกรอง {token__propertyKey} น้อยกว่าหรือเท่ากับ {token__value}} contains {ลบตัวกรอง {token__propertyKey} ประกอบด้วย {token__value}} not_contains {ลบตัวกรอง {token__propertyKey} ไม่มี {token__value}} starts_with {ลบตัวกรอง {token__propertyKey} เริ่มต้นด้วย {token__value}} other {}}"
+  },
+  "s3-resource-selector": {
+    "i18nStrings.inContextSelectPlaceholder": "เลือกเวอร์ชัน",
+    "i18nStrings.inContextBrowseButton": "เรียกดู S3",
+    "i18nStrings.inContextViewButton": "ดู",
+    "i18nStrings.inContextViewButtonAriaLabel": "เปิดในแท็บใหม่",
+    "i18nStrings.inContextLoadingText": "กำลังโหลดทรัพยากร",
+    "i18nStrings.inContextUriLabel": "S3 URI",
+    "i18nStrings.inContextVersionSelectLabel": "เวอร์ชันวัตถุ",
+    "i18nStrings.modalTitle": "เลือกไฟล์เก็บถาวรใน S3",
+    "i18nStrings.modalCancelButton": "ยกเลิก",
+    "i18nStrings.modalSubmitButton": "เลือก",
+    "i18nStrings.modalBreadcrumbRootItem": "บัคเก็ต S3",
+    "i18nStrings.selectionBuckets": "บัคเก็ต",
+    "i18nStrings.selectionObjects": "วัตถุ",
+    "i18nStrings.selectionVersions": "เวอร์ชัน",
+    "i18nStrings.selectionBucketsSearchPlaceholder": "ค้นหาบัคเก็ต",
+    "i18nStrings.selectionObjectsSearchPlaceholder": "ค้นหาวัตถุตามคำนำหน้า",
+    "i18nStrings.selectionVersionsSearchPlaceholder": "ค้นหาเวอร์ชัน",
+    "i18nStrings.selectionBucketsLoading": "โหลดบัคเก็ต",
+    "i18nStrings.selectionBucketsNoItems": "ไม่มีบัคเก็ต",
+    "i18nStrings.selectionObjectsLoading": "กำลังโหลดวัตถุ",
+    "i18nStrings.selectionObjectsNoItems": "ไม่มีวัตถุ",
+    "i18nStrings.selectionVersionsLoading": "กำลังโหลดเวอร์ชัน",
+    "i18nStrings.selectionVersionsNoItems": "ไม่มีเวอร์ชัน",
+    "i18nStrings.filteringNoMatches": "ไม่มีที่ตรงกัน",
+    "i18nStrings.filteringCantFindMatch": "เราไม่พบคู่ที่ตรงกัน",
+    "i18nStrings.clearFilterButtonText": "ล้างตัวกรอง",
+    "i18nStrings.columnBucketID": "ID",
+    "i18nStrings.columnBucketName": "ชื่อ",
+    "i18nStrings.columnBucketCreationDate": "วันที่สร้าง",
+    "i18nStrings.columnBucketRegion": "ภูมิภาค",
+    "i18nStrings.columnObjectKey": "คีย์",
+    "i18nStrings.columnObjectLastModified": "แก้ไขล่าสุด",
+    "i18nStrings.columnObjectSize": "ขนาด",
+    "i18nStrings.columnVersionID": "รหัสเวอร์ชัน",
+    "i18nStrings.columnVersionLastModified": "แก้ไขล่าสุด",
+    "i18nStrings.columnVersionSize": "ขนาด",
+    "i18nStrings.validationPathMustBegin": "เส้นทางต้องเริ่มต้นด้วย s3://จึงจะถูกต้อง",
+    "i18nStrings.validationBucketLowerCase": "ชื่อบัคเก็ตต้องเริ่มต้นด้วยตัวอักษรตัวพิมพ์เล็กหรือตัวเลข",
+    "i18nStrings.validationBucketMustNotContain": "ชื่อบัคเก็ตต้องไม่มีตัวอักษรตัวพิมพ์ใหญ่",
+    "i18nStrings.validationBucketLength": "ชื่อบัคเก็ตต้องมีตั้งแต่ 3 ถึง 63 ตัวอักษร",
+    "i18nStrings.validationBucketMustComplyDns": "ชื่อบัคเก็ตต้องเป็นไปตามข้อตกลงการตั้งชื่อ DNS",
+    "i18nStrings.labelSortedDescending": "{columnName} เรียงลำดับจากมากไปน้อย",
+    "i18nStrings.labelSortedAscending": "{columnName} เรียงลำดับจากน้อยไปมาก",
+    "i18nStrings.labelNotSorted": "{columnName} ไม่ได้เรียงลำดับ",
+    "i18nStrings.labelsBucketsSelection.selectionGroupLabel": "บัคเก็ต",
+    "i18nStrings.labelsBucketsSelection.itemSelectionLabel": "{item__Name}",
+    "i18nStrings.labelsObjectsSelection.selectionGroupLabel": "วัตถุ",
+    "i18nStrings.labelsObjectsSelection.itemSelectionLabel": "{item__Key}",
+    "i18nStrings.labelsVersionsSelection.selectionGroupLabel": "เวอร์ชัน",
+    "i18nStrings.labelsVersionsSelection.itemSelectionLabel": "{item__VersionId}",
+    "i18nStrings.labelFiltering": "ค้นหา {itemsType}",
+    "i18nStrings.labelRefresh": "รีเฟรชข้อมูล",
+    "i18nStrings.labelBreadcrumbs": "การนำทาง S3",
+    "i18nStrings.filteringCounterText": "{count, plural, one {1 คู่ที่ตรงกัน} other {{count} คู่ที่ตรงกัน}}"
+  },
+  "select": {
+    "errorIconAriaLabel": "ข้อผิดพลาด",
+    "selectedAriaLabel": "เลือกไว้",
+    "recoveryText": "ลองอีกครั้ง"
+  },
+  "split-panel": {
+    "i18nStrings.closeButtonAriaLabel": "ปิดแผง",
+    "i18nStrings.openButtonAriaLabel": "เปิดแผง",
+    "i18nStrings.preferencesTitle": "การตั้งค่าแผงแยก",
+    "i18nStrings.preferencesPositionLabel": "ตำแหน่งแผงแยก",
+    "i18nStrings.preferencesPositionDescription": "เลือกตำแหน่งแผงแยกเริ่มต้นสำหรับบริการ",
+    "i18nStrings.preferencesPositionSide": "ด้านข้าง",
+    "i18nStrings.preferencesPositionBottom": "ด้านล่าง",
+    "i18nStrings.preferencesConfirm": "ยืนยัน",
+    "i18nStrings.preferencesCancel": "ยกเลิก",
+    "i18nStrings.resizeHandleAriaLabel": "ปรับขนาดแผงแยก"
+  },
+  "table": {
+    "ariaLabels.resizerRoleDescription": "ปุ่มปรับขนาด",
+    "ariaLabels.submittingEditText": "การส่งแก้ไข",
+    "ariaLabels.successfulEditLabel": "แก้ไขเรียบร้อยแล้ว",
+    "columnDefinitions.editConfig.errorIconAriaLabel": "ข้อผิดพลาด",
+    "columnDefinitions.editConfig.editIconAriaLabel": "ที่สามารถแก้ไขได้"
+  },
+  "tabs": {
+    "i18nStrings.scrollLeftAriaLabel": "เลื่อนไปทางซ้าย",
+    "i18nStrings.scrollRightAriaLabel": "เลื่อนไปทางขวา"
+  },
+  "tag-editor": {
+    "i18nStrings.keyPlaceholder": "ป้อนคีย์",
+    "i18nStrings.valuePlaceholder": "ป้อนค่า",
+    "i18nStrings.addButton": "เพิ่มแท็กใหม่",
+    "i18nStrings.removeButton": "ลบ",
+    "i18nStrings.removeButtonAriaLabel": "ลบ {tag__key}",
+    "i18nStrings.undoButton": "ยกเลิก",
+    "i18nStrings.undoPrompt": "แท็กนี้จะถูกลบออกเมื่อบันทึกการเปลี่ยนแปลง",
+    "i18nStrings.loading": "กำลังโหลดแท็กที่เชื่อมโยงกับทรัพยากรนี้",
+    "i18nStrings.keyHeader": "คีย์",
+    "i18nStrings.valueHeader": "ค่า",
+    "i18nStrings.optional": "ไม่จำเป็น",
+    "i18nStrings.keySuggestion": "คีย์แท็กที่กำหนดเอง",
+    "i18nStrings.valueSuggestion": "ค่าแท็กที่กำหนดเอง",
+    "i18nStrings.emptyTags": "ไม่มีแท็กที่เกี่ยวข้องกับทรัพยากร",
+    "i18nStrings.tooManyKeysSuggestion": "คุณมีคีย์มากกว่าที่สามารถแสดงได้",
+    "i18nStrings.tooManyValuesSuggestion": "คุณมีค่ามากกว่าที่สามารถแสดงได้",
+    "i18nStrings.keysSuggestionLoading": "กำลังโหลดปุ่มแท็ก",
+    "i18nStrings.keysSuggestionError": "ไม่สามารถดึงคีย์แท็กได้",
+    "i18nStrings.valuesSuggestionLoading": "กำลังโหลดค่าแท็ก",
+    "i18nStrings.valuesSuggestionError": "ไม่สามารถดึงค่าแท็กได้",
+    "i18nStrings.emptyKeyError": "คุณต้องระบุคีย์แท็ก",
+    "i18nStrings.maxKeyCharLengthError": "จำนวนอักขระสูงสุดที่คุณสามารถใช้ในคีย์แท็กได้คือ 128",
+    "i18nStrings.maxValueCharLengthError": "จำนวนอักขระสูงสุดที่คุณสามารถใช้ในค่าแท็กได้คือ 256",
+    "i18nStrings.duplicateKeyError": "คุณต้องระบุคีย์แท็กที่ไม่ซ้ำกัน",
+    "i18nStrings.invalidKeyError": "คีย์ไม่ถูกต้อง คีย์สามารถประกอบด้วยตัวอักษร Unicode ตัวเลข ช่องว่าง และเครื่องหมายต่อไปนี้เท่านั้น: _.:/=+@-",
+    "i18nStrings.invalidValueError": "ค่าไม่ถูกต้อง ค่าสามารถประกอบด้วยตัวอักษร Unicode ตัวเลข ช่องว่าง และเครื่องหมายต่อไปนี้เท่านั้น: _.:/=+@-",
+    "i18nStrings.awsPrefixError": "ไม่สามารถเริ่มด้วย aws:",
+    "i18nStrings.tagLimitReached": "{tagLimit, plural, one {คุณถึงขีด จำกัด 1 แท็กแล้ว} other {คุณถึงขีดจำกัด {tagLimit} แท็กแล้ว}}",
+    "i18nStrings.tagLimitExceeded": "{tagLimit, plural, one {คุณเกินขีด จำกัด 1 แท็กแล้ว} other {คุณเกินขีดจำกัด {tagLimit} แท็กแล้ว}}",
+    "i18nStrings.tagLimit": "{tagLimitAvailable, select, true {{availableTags, plural, other {คุณสามารถเพิ่มแท็กได้มากถึง {tagLimit} แท็ก}}} false {{availableTags, plural, one {คุณสามารถเพิ่มแท็กได้อีก 1 แท็ก} other {คุณสามารถเพิ่มแท็กได้อีก {availableTags} แท็ก}}} other {}}"
+  },
+  "token-group": {
+    "i18nStrings.limitShowFewer": "แสดงน้อยลง",
+    "i18nStrings.limitShowMore": "แสดงเพิ่มเติม"
+  },
+  "top-navigation": {
+    "i18nStrings.searchIconAriaLabel": "ค้นหา",
+    "i18nStrings.searchDismissIconAriaLabel": "ปิดการค้นหา",
+    "i18nStrings.overflowMenuTriggerText": "เพิ่มเติม",
+    "i18nStrings.overflowMenuDismissIconAriaLabel": "ปิดเมนู",
+    "i18nStrings.overflowMenuBackIconAriaLabel": "ย้อนกลับ",
+    "i18nStrings.overflowMenuTitleText": "ทั้งหมด"
+  },
+  "tutorial-panel": {
+    "i18nStrings.loadingText": "กำลังโหลด",
+    "i18nStrings.tutorialListTitle": "เลือกบทช่วยสอน",
+    "i18nStrings.tutorialListDownloadLinkText": "ดาวน์โหลดเวอร์ชัน PDF",
+    "i18nStrings.labelTutorialListDownloadLink": "ดาวน์โหลดเวอร์ชัน PDF ของบทช่วยสอนนี้",
+    "i18nStrings.tutorialCompletedText": "บทช่วยสอนเสร็จสมบูรณ์แล้ว",
+    "i18nStrings.learnMoreLinkText": "เรียนรู้เพิ่มเติม",
+    "i18nStrings.startTutorialButtonText": "เริ่มบทช่วยสอน",
+    "i18nStrings.restartTutorialButtonText": "เริ่มบทช่วยสอนใหม่",
+    "i18nStrings.completionScreenTitle": "ขอแสดงความยินดีด้วย! คุณทำบทช่วยสอนเสร็จสมบูรณ์แล้ว",
+    "i18nStrings.feedbackLinkText": "ข้อเสนอแนะ",
+    "i18nStrings.dismissTutorialButtonText": "ยกเลิกบทช่วยสอน",
+    "i18nStrings.taskTitle": "งาน {taskNumber}: {taskTitle}",
+    "i18nStrings.stepTitle": "ขั้นตอน {stepNumber}: {stepTitle}",
+    "i18nStrings.labelExitTutorial": "ยกเลิกบทช่วยสอน",
+    "i18nStrings.labelTotalSteps": "ขั้นตอนทั้งหมด: {totalStepCount}",
+    "i18nStrings.labelsTaskStatus.pending": "รอดำเนินการ",
+    "i18nStrings.labelsTaskStatus.in-progress": "กำลังดำเนินการ",
+    "i18nStrings.labelsTaskStatus.success": "สำเร็จ"
+  },
+  "wizard": {
+    "i18nStrings.stepNumberLabel": "ขั้นตอน {stepNumber}",
+    "i18nStrings.collapsedStepsLabel": "ขั้นตอน {stepNumber} จาก {stepsCount}",
+    "i18nStrings.skipToButtonLabel": "ข้ามไปที่ {task__title}",
+    "i18nStrings.navigationAriaLabel": "ขั้นตอน",
+    "i18nStrings.cancelButton": "ยกเลิก",
+    "i18nStrings.previousButton": "ก่อนหน้า",
+    "i18nStrings.nextButton": "ถัดไป",
+    "i18nStrings.optional": "ไม่จำเป็น",
+    "i18nStrings.nextButtonLoadingAnnouncement": "กำลังโหลดขั้นตอนถัดไป",
+    "i18nStrings.submitButtonLoadingAnnouncement": "กำลังส่งแบบฟอร์ม"
+  }
+}

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {Öğe {currentPosition}/{total} konumuna geri taşınıyor} false {Öğe {currentPosition}/{total} konumuna taşınıyor} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {Öğe ilk {initialPosition}/{total} konumuna geri taşındı} false {Öğe {initialPosition} konumundan {finalPosition}/{total} konumuna taşındı} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "Kopyala"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "Göreceli mod",
     "i18nStrings.absoluteModeTitle": "Mutlak mod",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "Tarih için YYYY/AA/GG kullanın. Zaman için 24 saat biçimini kullanın.",
     "i18nStrings.errorIconAriaLabel": "Hata",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "{startDate}-{endDate} aralığı seçildi",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {Son {amount} {unit}} other {Son {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {Son {amount} saniye} one {Son {amount} saniye} other {Son {amount} saniye}}} minute {{amount, plural, zero {Son {amount} dakika} one {Son {amount} dakika} other {Son {amount} dakika}}} hour {{amount, plural, zero {Son {amount} saat} one {Son {amount} saat} other {Son {amount} saat}}} day {{amount, plural, zero {Son {amount} gün} one {Son {amount} gün} other {Son {amount} gün}}} week {{amount, plural, zero {Son {amount} hafta} one {Son {amount} hafta} other {Son {amount} hafta}}} month {{amount, plural, zero {Son {amount} ay} one {Son {amount} ay} other {Son {amount} ay}}} year {{amount, plural, zero {Son {amount} yıl} one {Son {amount} yıl} other {Son {amount} yıl}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {saniye} one {saniye} other {saniye}}} minute {{amount, plural, zero {dakika} one {dakika} other {dakika}}} hour {{amount, plural, zero {saat} one {saat} other {saat}}} day {{amount, plural, zero {gün} one {gün} other {gün}}} week {{amount, plural, zero {hafta} one {hafta} other {hafta}}} month {{amount, plural, zero {ay} one {ay} other {ay}}} year {{amount, plural, zero {yıl} one {yıl} other {yıl}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "İçerik yükleniyor"

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {正在将项目移回位置 {currentPosition}（共 {total} 个位置）} false {正在将项目移动到位置 {currentPosition}（共 {total} 个位置）} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {已将项目移回其原始位置 {initialPosition}（共 {total} 个位置）} false {已将项目从位置 {initialPosition} 移动到位置 {finalPosition}（共 {total} 个位置）} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "复制"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相对模式",
     "i18nStrings.absoluteModeTitle": "绝对模式",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "对于日期，请使用 YYYY/MM/DD。对于时间，请使用 24 小时格式。",
     "i18nStrings.errorIconAriaLabel": "错误",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "选定范围从 {startDate} 到 {endDate}",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {最近 {amount} {unit}} other {最近 {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {过去 {amount} 秒} one {过去 {amount} 秒} other {过去 {amount} 秒}}} minute {{amount, plural, zero {过去 {amount} 分钟} one {过去 {amount} 分钟} other {过去 {amount} 分钟}}} hour {{amount, plural, zero {过去 {amount} 小时} one {过去 {amount} 小时} other {过去 {amount} 小时}}} day {{amount, plural, zero {过去 {amount} 天} one {过去 {amount} 天} other {过去 {amount} 天}}} week {{amount, plural, zero {过去 {amount} 周} one {过去 {amount} 周} other {过去 {amount} 周}}} month {{amount, plural, zero {过去 {amount} 月} one {过去 {amount} 月} other {过去 {amount} 月}}} year {{amount, plural, zero {过去 {amount} 年} one {过去 {amount} 年} other {过去 {amount} 年}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {秒} one {秒} other {秒}}} minute {{amount, plural, zero {分钟} one {分钟} other {分钟}}} hour {{amount, plural, zero {小时} one {小时} other {小时}}} day {{amount, plural, zero {天} one {天} other {天}}} week {{amount, plural, zero {周} one {周} other {周}}} month {{amount, plural, zero {月} one {月} other {月}}} year {{amount, plural, zero {年} one {年} other {年}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "正在加载内容"

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -96,6 +96,9 @@
     "contentDisplayPreference.liveAnnouncementDndItemReordered": "{isInitialPosition, select, true {將項目移回 {currentPosition} 位置 (共 {total} 個位置)} false {將項目移到 {currentPosition} 位置 (共 {total} 個位置)} other {}}",
     "contentDisplayPreference.liveAnnouncementDndItemCommitted": "{isInitialPosition, select, true {項目移回原來的 {initialPosition} 位置 (共 {total} 個位置)} false {項目已從 {initialPosition} 位置移到 {finalPosition} 位置 (共 {total} 個位置)} other {}}"
   },
+  "copy-to-clipboard": {
+    "i18nStrings.copyButtonText": "複製"
+  },
   "date-range-picker": {
     "i18nStrings.relativeModeTitle": "相對模式",
     "i18nStrings.absoluteModeTitle": "絕對模式",
@@ -115,8 +118,8 @@
     "i18nStrings.dateTimeConstraintText": "日期請使用 YYYY/MM/DD 格式。時間請使用 24 小時格式。",
     "i18nStrings.errorIconAriaLabel": "錯誤",
     "i18nStrings.renderSelectedAbsoluteRangeAriaLive": "已選取從 {startDate} 到 {endDate} 的範圍",
-    "i18nStrings.formatRelativeRange": "{amount, plural, one {最後 {amount} {unit}} other {最後 {amount} {unit}}}",
-    "i18nStrings.formatUnit": "{amount, plural, one {{unit}} other {{unit}}}"
+    "i18nStrings.formatRelativeRange": "{unit, select, second {{amount, plural, zero {最後{amount}秒} one {最後{amount}秒} other {最後{amount}秒}}} minute {{amount, plural, zero {最後{amount}分鐘} one {最後{amount}分鐘} other {最後{amount}分鐘}}} hour {{amount, plural, zero {最後{amount}小時} one {最後{amount}小時} other {最後{amount}小時}}} day {{amount, plural, zero {最後{amount}天} one {最後{amount}天} other {最後{amount}天}}} week {{amount, plural, zero {最後{amount}週} one {最後{amount}週} other {最後{amount}週}}} month {{amount, plural, zero {最後{amount}個月} one {最後{amount}個月} other {最後{amount}個月}}} year {{amount, plural, zero {最後{amount}年} one {最後{amount}年} other {最後{amount}年}}} other {}}",
+    "i18nStrings.formatUnit": "{unit, select, second {{amount, plural, zero {秒} one {秒} other {秒}}} minute {{amount, plural, zero {分鐘} one {分鐘} other {分鐘}}} hour {{amount, plural, zero {小時} one {小時} other {小時}}} day {{amount, plural, zero {天} one {天} other {天}}} week {{amount, plural, zero {週} one {週} other {週}}} month {{amount, plural, zero {個月} one {個月} other {個月}}} year {{amount, plural, zero {年} one {年} other {年}}} other {}}"
   },
   "drawer": {
     "i18nStrings.loadingText": "載入內容"


### PR DESCRIPTION
### Description

Synchronizing translation strings. The big change is the introduction of the `all.th.json` file. But there are also other changes included, like fixes for units in date range picker and one new string for the copy to clipboard component.

Related links, issue #, if available: AWSUI-26332

### How has this been tested?

Only copy to clipboard needs new tests, but it's best to bundle that with the component changes.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
