### PR TITLE
refactor: Restructure table grid navigation utils

### DIFF
--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -2,91 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getFocusables as getActualFocusables } from '../../internal/components/focus-lock/utils';
-import { FocusedCell } from './interfaces';
 
 // For the grid to have a single Tab stop all interactive element indices are updated to be -999.
 // The elements having tab index -999 are eligible for keyboard navigation but not for Tab navigation.
 const PSEUDO_FOCUSABLE_TAB_INDEX = -999;
 const FOCUSABLES_SELECTOR = `[tabIndex="0"],[tabIndex="${PSEUDO_FOCUSABLE_TAB_INDEX}"]`;
-
-/**
- * Finds focused cell props corresponding the focused element inside the table.
- * The function relies on ARIA colindex/rowindex attributes being correctly applied.
- */
-export function findFocusedCell(focusedElement: HTMLElement): null | FocusedCell {
-  const cellElement = focusedElement.closest('td,th') as null | HTMLTableCellElement;
-  const rowElement = cellElement?.closest('tr');
-
-  if (!cellElement || !rowElement) {
-    return null;
-  }
-
-  const colIndex = parseInt(cellElement.getAttribute('aria-colindex') ?? '');
-  const rowIndex = parseInt(rowElement.getAttribute('aria-rowindex') ?? '');
-  if (isNaN(colIndex) || isNaN(rowIndex)) {
-    return null;
-  }
-
-  const cellFocusables = getFocusables(cellElement);
-  const elementIndex = cellFocusables.indexOf(focusedElement);
-
-  return { rowIndex, colIndex, rowElement, cellElement, element: focusedElement, elementIndex };
-}
-
-/**
- * Finds element to be focused next. The focus can transition between cells or interactive elements inside cells.
- */
-export function getNextFocusable(table: HTMLTableElement, from: FocusedCell, delta: { y: number; x: number }) {
-  // Find next row to move focus into (can be null if the top/bottom is reached).
-  const targetAriaRowIndex = from.rowIndex + delta.y;
-  const targetRow = findTableRowByAriaRowIndex(table, targetAriaRowIndex, delta.y);
-  if (!targetRow) {
-    return null;
-  }
-
-  // Return next interactive cell content element if available.
-  const cellFocusables = getFocusables(from.cellElement);
-  const nextElementIndex = from.elementIndex + delta.x;
-  if (delta.x && from.elementIndex !== -1 && 0 <= nextElementIndex && nextElementIndex < cellFocusables.length) {
-    return cellFocusables[nextElementIndex];
-  }
-
-  // Find next cell to focus or move focus into (can be null if the left/right edge is reached).
-  const targetAriaColIndex = from.colIndex + delta.x;
-  const targetCell = findTableRowCellByAriaColIndex(targetRow, targetAriaColIndex, delta.x);
-  if (!targetCell) {
-    return null;
-  }
-
-  // When target cell matches the current cell it means we reached the left or right boundary.
-  if (targetCell === from.cellElement && delta.x !== 0) {
-    return null;
-  }
-
-  // Return cell interactive content or the cell itself.
-  const targetCellFocusables = getFocusables(targetCell);
-  const focusIndex = delta.x < 0 ? targetCellFocusables.length - 1 : delta.x > 0 ? 0 : from.elementIndex;
-  const focusTarget = targetCellFocusables[focusIndex] ?? targetCell;
-  return focusTarget;
-}
-
-/**
- * Makes the cell element, the first interactive element or the first cell of the table user-focusable.
- */
-export function ensureSingleFocusable(table: HTMLTableElement, cell: null | FocusedCell) {
-  const firstTableCell = table.querySelector('td,th') as null | HTMLTableCellElement;
-
-  // A single element of the table is made user-focusable.
-  // It defaults to the first interactive element of the first cell or the first cell itself otherwise.
-  let focusTarget: null | HTMLElement = (firstTableCell && getFocusables(firstTableCell)[0]) ?? firstTableCell;
-
-  // When a navigation-focused element is present in the table it is used for user-navigation instead.
-  if (cell) {
-    focusTarget = getNextFocusable(table, cell, { x: 0, y: 0 });
-  }
-
-  setTabIndex(focusTarget, 0);
-}
 
 /**
  * Makes all element focusable children pseudo-focusable unless the grid navigation is suppressed.
@@ -161,7 +81,7 @@ export function getFirstFocusable(element: HTMLElement) {
 /**
  * Finds the closest row to the targetAriaRowIndex+delta in the direction of delta.
  */
-function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex: number, delta: number) {
+export function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex: number, delta: number) {
   let targetRow: null | HTMLTableRowElement = null;
   const rowElements = Array.from(table.querySelectorAll('tr[aria-rowindex]'));
   if (delta < 0) {
@@ -187,7 +107,11 @@ function findTableRowByAriaRowIndex(table: HTMLTableElement, targetAriaRowIndex:
 /**
  * Finds the closest column to the targetAriaColIndex+delta in the direction of delta.
  */
-function findTableRowCellByAriaColIndex(tableRow: HTMLTableRowElement, targetAriaColIndex: number, delta: number) {
+export function findTableRowCellByAriaColIndex(
+  tableRow: HTMLTableRowElement,
+  targetAriaColIndex: number,
+  delta: number
+) {
   let targetCell: null | HTMLTableCellElement = null;
   const cellElements = Array.from(tableRow.querySelectorAll('td[aria-colindex],th[aria-colindex]'));
   if (delta < 0) {
@@ -210,7 +134,7 @@ function findTableRowCellByAriaColIndex(tableRow: HTMLTableRowElement, targetAri
   return targetCell;
 }
 
-function setTabIndex(element: null | HTMLElement, tabIndex: number) {
+export function setTabIndex(element: null | HTMLElement, tabIndex: number) {
   if (element && element.tabIndex !== tabIndex) {
     element.tabIndex = tabIndex;
   }


### PR DESCRIPTION
### Description

Restructuring code to reduce diff in the upcoming update. The findFocusedCell, getNextFocusable, and ensureSingleFocusable are moved inside the processor to inject a dependency on registered components, see: https://github.com/cloudscape-design/components/pull/1760

### How has this been tested?

Existing tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
