### PR TITLE
fix: Ensure toggle is visible in high-contrast/forced-color mode

### DIFF
--- a/src/toggle/styles.scss
+++ b/src/toggle/styles.scss
@@ -23,6 +23,9 @@ $shadow-color: rgba(0, 0, 0, 0.25);
 }
 
 .toggle-control {
+  // this is a "drawing" element, and therefore we want it (and children) to retain
+  // background colors in high-contrast/forced-color mode
+  forced-color-adjust: none;
   @include styles.make-control-size($toggle-height, $toggle-width);
   background: awsui.$color-background-toggle-default;
   border-radius: 0.8 * styles.$base-size;


### PR DESCRIPTION
### Description

Ensure that toggle graphics are visible in forced-color mode. Previously they weren't, because the component relies purely on background color to "draw" the control, and forced-color overrides all background colors.

Related links, issue #, if available: AWSUI-24890

### How has this been tested?

Tested locally by emulating forced-color mode in Chrome

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
