### PR TITLE
feat: Add aria-controls to Button

### DIFF
--- a/pages/button/show-more.page.tsx
+++ b/pages/button/show-more.page.tsx
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import Button from '~components/button';
+import styles from './styles.scss';
+import range from 'lodash/range';
+
+const LIST_ID = 'expanded-list-id';
+
+interface ListItem {
+  index: number;
+  label: string;
+}
+
+const defaultItems: ListItem[] = range(8).map(index => ({
+  label: '' + index,
+  index,
+}));
+
+export default function ButtonControlsScenario() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const visibleItems = isExpanded ? defaultItems : defaultItems.slice(0, 2);
+
+  return (
+    <article>
+      <h1>Button controls another element</h1>
+      <ul id={LIST_ID}>
+        {visibleItems.map(({ label, index }) => (
+          <li key={index} aria-setsize={defaultItems.length} aria-posinset={index + 1}>
+            {label}
+          </li>
+        ))}
+      </ul>
+      <div className={styles.buttonWrapper}>
+        <Button
+          variant="inline-link"
+          iconName={isExpanded ? 'treeview-collapse' : 'treeview-expand'}
+          onClick={() => setIsExpanded(!isExpanded)}
+          ariaExpanded={isExpanded}
+          ariaControls={LIST_ID}
+        >
+          {isExpanded ? 'Show less' : 'Show more'}
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2991,7 +2991,7 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
   "name": "Button",
   "properties": Array [
     Object {
-      "description": "Adds \`aria-controls\` to the button. Use when the button controls contents or presence of an element.",
+      "description": "Adds \`aria-controls\` to the button. Use when the button controls the contents or presence of an element.",
       "name": "ariaControls",
       "optional": true,
       "type": "string",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2991,6 +2991,12 @@ modifier keys (that is, CTRL, ALT, SHIFT, META), and the button has an \`href\` 
   "name": "Button",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-controls\` to the button. Use when the button controls contents or presence of an element.",
+      "name": "ariaControls",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds \`aria-describedby\` to the button.",
       "name": "ariaDescribedby",
       "optional": true,

--- a/src/button/__tests__/button.test.tsx
+++ b/src/button/__tests__/button.test.tsx
@@ -108,6 +108,13 @@ describe('Button Component', () => {
     });
   });
 
+  describe('ariaControls property', () => {
+    test('adds aria-controls property to button', () => {
+      const wrapper = renderButton({ ariaControls: 'test-element' });
+      expect(wrapper.getElement()).toHaveAttribute('aria-controls', 'test-element');
+    });
+  });
+
   describe('ariaDescribedby property', () => {
     test('adds aria-describedby property to button', () => {
       const wrapper = renderButton({ ariaDescribedby: 'my-element' });

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -33,6 +33,7 @@ const Button = React.forwardRef(
       onClick,
       onFollow,
       ariaExpanded,
+      ariaControls,
       fullWidth,
       form,
       ...props
@@ -66,6 +67,7 @@ const Button = React.forwardRef(
         onClick={onClick}
         onFollow={onFollow}
         ariaExpanded={ariaExpanded}
+        ariaControls={ariaControls}
         fullWidth={fullWidth}
         form={form}
       >

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -145,6 +145,11 @@ export interface ButtonProps extends BaseComponentProps {
   ariaExpanded?: boolean;
 
   /**
+   * Adds `aria-controls` to the button. Use when the button controls contents or presence of an element.
+   */
+  ariaControls?: string;
+
+  /**
    * Sets the button width to be 100% of the parent container width. Button content is centered.
    */
   fullWidth?: boolean;

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -145,7 +145,7 @@ export interface ButtonProps extends BaseComponentProps {
   ariaExpanded?: boolean;
 
   /**
-   * Adds `aria-controls` to the button. Use when the button controls contents or presence of an element.
+   * Adds `aria-controls` to the button. Use when the button controls the contents or presence of an element.
    */
   ariaControls?: string;
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -58,6 +58,7 @@ export const InternalButton = React.forwardRef(
       ariaLabel,
       ariaDescribedby,
       ariaExpanded,
+      ariaControls,
       fullWidth,
       badge,
       __nativeAttributes,
@@ -142,6 +143,7 @@ export const InternalButton = React.forwardRef(
       'aria-label': ariaLabel,
       'aria-describedby': ariaDescribedby,
       'aria-expanded': ariaExpanded,
+      'aria-controls': ariaControls,
       // add ariaLabel as `title` as visible hint text
       title: ariaLabel,
       className: buttonClass,


### PR DESCRIPTION
### Description

Expose `aria-controls` on button.

We already exposed `aria-expanded` (see [PR](https://github.com/cloudscape-design/components/pull/16)), which is often accompanied with `aria-controls` to indicate a relationship between elements.  It'll allow to create a correct markup for custom components.

Related links, issue #, if available: AWSUI-23016

### How has this been tested?

Unit test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
