### PR TITLE
fix: Updates drawer comments so it shows on API tab

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -693,6 +693,16 @@ Each Drawer is an item in the drawers wrapper with the following properties:
 * resizable (boolean) - if the drawer is resizable or not.
 * defaultSize (number) - starting size of the drawer. if not set, defaults to 290.
 * onResize (({ size: number }) => void) - Fired when the active drawer is resized.
+
+#### DrawerTrigger
+- \`iconName\` (IconProps.Name) - (Optional) Specifies the icon to be displayed.
+- \`iconSvg\` (React.ReactNode) - (Optional) Specifies the SVG of a custom icon. For more information, see [SVG icon guidelines](/components/icon/?tabId=api#slots)
+
+#### DrawerAriaLabels
+- \`drawerName\` (string) - Label for the drawer itself.
+- \`closeButton\` (string) - (Optional) Label for the close button.
+- \`triggerButton\` (string) - (Optional) Label for the trigger button.
+- \`resizeHandle\` (string) - (Optional) Label for the resize handle.
 ",
       "name": "drawers",
       "optional": true,

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -24,6 +24,16 @@ export interface AppLayoutProps extends BaseComponentProps {
    * * resizable (boolean) - if the drawer is resizable or not.
    * * defaultSize (number) - starting size of the drawer. if not set, defaults to 290.
    * * onResize (({ size: number }) => void) - Fired when the active drawer is resized.
+   * 
+   * #### DrawerTrigger
+   * - `iconName` (IconProps.Name) - (Optional) Specifies the icon to be displayed.
+   * - `iconSvg` (React.ReactNode) - (Optional) Specifies the SVG of a custom icon. For more information, see [SVG icon guidelines](/components/icon/?tabId=api#slots)
+   *
+   * #### DrawerAriaLabels
+   * - `drawerName` (string) - Label for the drawer itself.
+   * - `closeButton` (string) - (Optional) Label for the close button.
+   * - `triggerButton` (string) - (Optional) Label for the trigger button.
+   * - `resizeHandle` (string) - (Optional) Label for the resize handle.
    */
   drawers?: Array<AppLayoutProps.Drawer>;
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
AppLayout API tab did not include specifics around DrawerTrigger or DrawerAriaLabels. This updates the comment so that the API tab shows them.


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
