### PR TITLE
revert: "fix: Use border radius design token for column headers in sticky header table (#1857)"

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -280,19 +280,6 @@ const permutations = createPermutations<TableProps>([
     preferences: ['preferences'],
     items: [createSimpleItems(3)],
   },
-  {
-    columnDefinitions: [PROPERTY_COLUMNS],
-    items: [
-      [
-        {
-          name: 'Color',
-          value: '#000000',
-          type: 'String',
-        },
-      ],
-    ],
-    stickyHeader: [true],
-  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -156,7 +156,7 @@ the default white background of the container component.
   scrollbar-width: none; /* Firefox */
   box-sizing: border-box;
   width: 100%;
-  border-radius: awsui.$border-radius-container;
+  border-radius: 0;
   background: awsui.$color-background-table-header;
   &.variant-stacked,
   &.variant-container {


### PR DESCRIPTION


This reverts commit f27444b90511cf402bb59a5fa200ad08dac4f14b.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
