### PR TITLE
fix: Tabs generates unstable IDs

### DIFF
--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -138,7 +138,7 @@ describe('Tabs', () => {
 
     defaultTabs.forEach((tab, index) => {
       const renderedTabId = tabContents[index].getElement().getAttribute('id');
-      expect(renderedTabId).toMatch(new RegExp(`awsui-tabs-\\d*-\\d*-${tab.id}-panel`));
+      expect(renderedTabId).toMatch(new RegExp(`awsui-tabs-.*-${tab.id}-panel`));
 
       expect(tabLinks[index].getElement()).toHaveAttribute('aria-controls', renderedTabId);
     });

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React from 'react';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import InternalContainer from '../container/internal';
@@ -12,11 +12,9 @@ import { useControllable } from '../internal/hooks/use-controllable';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 export { TabsProps };
-
-let lastGeneratedId = 0;
-export const nextGeneratedId = () => `awsui-tabs-${lastGeneratedId++}-${Math.round(Math.random() * 10000)}`;
 
 function firstEnabledTab(tabs: ReadonlyArray<TabsProps.Tab>) {
   const enabledTabs = tabs.filter(tab => !tab.disabled);
@@ -41,7 +39,7 @@ export default function Tabs({
     checkSafeUrl('Tabs', tab.href);
   }
   const { __internalRootRef } = useBaseComponent('Tabs');
-  const [idNamespace] = useState(() => nextGeneratedId());
+  const idNamespace = useUniqueId('awsui-tabs-');
 
   const [activeTabId, setActiveTabId] = useControllable(controlledTabId, onChange, firstEnabledTab(tabs)?.id ?? '', {
     componentName: 'Tabs',


### PR DESCRIPTION
### Description

The Tabs component used its own algorithm for generating IDs, which did not support server-side rendering. This led to inconsistent IDs between the server-generated HTML and the hydrated HTML.
This PR replaces that algorithm with our central hook for generating IDs, which uses React's `useId` hook (when available).

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/1834

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
