### PR TITLE
fix: Increase space between chart popover list items

### DIFF
--- a/src/internal/components/chart-series-details/index.tsx
+++ b/src/internal/components/chart-series-details/index.tsx
@@ -37,12 +37,13 @@ export interface ChartSeriesDetailsProps extends BaseComponentProps {
   expandedSeries?: ExpandedSeries;
   setPopoverText?: (s: string) => void;
   setExpandedState?: (seriesTitle: string, state: boolean) => void;
+  compactList?: boolean;
 }
 
 export default memo(forwardRef(ChartSeriesDetails));
 
 function ChartSeriesDetails(
-  { details, expandedSeries, setPopoverText, setExpandedState, ...restProps }: ChartSeriesDetailsProps,
+  { details, expandedSeries, setPopoverText, setExpandedState, compactList, ...restProps }: ChartSeriesDetailsProps,
   ref: React.Ref<HTMLDivElement>
 ) {
   const baseProps = getBaseProps(restProps);
@@ -67,7 +68,7 @@ function ChartSeriesDetails(
 
   return (
     <div {...baseProps} className={className} ref={mergedRef}>
-      <ul className={styles.list}>
+      <ul className={clsx(styles.list, compactList && styles.compact)}>
         {details.map(({ key, value, markerType, color, isDimmed, subItems, expandableId }, index) => (
           <li
             key={index}

--- a/src/internal/components/chart-series-details/styles.scss
+++ b/src/internal/components/chart-series-details/styles.scss
@@ -41,6 +41,11 @@ $font-weight-bold: awsui.$font-weight-heading-s;
   }
 }
 
+.list-item:not(:first-child),
+.inner-list-item {
+  margin-top: awsui.$space-scaled-xxs;
+}
+
 .sub-items {
   &:not(.expandable) {
     padding-inline-start: calc(marker.$marker-width + marker.$marker-margin-right);

--- a/src/internal/components/chart-series-details/styles.scss
+++ b/src/internal/components/chart-series-details/styles.scss
@@ -41,11 +41,6 @@ $font-weight-bold: awsui.$font-weight-heading-s;
   }
 }
 
-.list-item:not(:first-child),
-.inner-list-item {
-  margin-top: awsui.$space-scaled-xxs;
-}
-
 .sub-items {
   &:not(.expandable) {
     padding-inline-start: calc(marker.$marker-width + marker.$marker-margin-right);
@@ -72,6 +67,12 @@ $font-weight-bold: awsui.$font-weight-heading-s;
 
     &.dimmed {
       opacity: 0.35;
+    }
+  }
+  &:not(.compact) {
+    > .list-item:not(:first-child),
+    > .inner-list-item {
+      margin-top: awsui.$space-scaled-xxs;
     }
   }
 }

--- a/src/internal/components/chart-series-details/styles.scss
+++ b/src/internal/components/chart-series-details/styles.scss
@@ -69,12 +69,11 @@ $font-weight-bold: awsui.$font-weight-heading-s;
       opacity: 0.35;
     }
   }
-  &:not(.compact) {
-    > .list-item:not(:first-child),
-    > .inner-list-item {
-      margin-top: awsui.$space-scaled-xxs;
-    }
-  }
+}
+
+.list:not(.compact) > .list-item:not(:first-child),
+.inner-list-item {
+  margin-top: awsui.$space-scaled-xxs;
 }
 
 .list-item.with-sub-items:not(.expandable) > .key-value-pair {

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -124,7 +124,7 @@ export default <T extends PieChartProps.Datum>({
   const detailFunction = detailPopoverContent || defaultDetails(i18n, i18nStrings);
   const details = popoverData ? detailFunction(popoverData.datum, dataSum) : [];
   const popoverContentRef = useRef<HTMLDivElement | null>(null);
-  const popoverContent = popoverData && <SeriesDetails details={details} ref={popoverContentRef} />;
+  const popoverContent = popoverData && <SeriesDetails details={details} compactList={true} ref={popoverContentRef} />;
 
   const popoverDismissedRecently = useRef(false);
   const escapePressed = useRef(false);


### PR DESCRIPTION
### Description

Add space of 4px (`space-scaled-xxs`) between list items in chart popovers for bar, line, mixed and area charts (but not pie and donut charts).

See AWSUI-28805

### How has this been tested?

- Manually verified all affected chart types, including the metric drilldown feature (expandable and non-expandable) when applicable
- Visual regression tests exist

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
