### PR TITLE
fix: Prevent chart popovers from overflowing horizontally

### DIFF
--- a/src/bar-chart/__tests__/chart-series-details.test.tsx
+++ b/src/bar-chart/__tests__/chart-series-details.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../../lib/components/popover/utils/positions', () => ({
   ...jest.requireActual('../../../lib/components/popover/utils/positions'),
   calculatePosition: () => ({
     internalPosition: 'top-right',
-    boundingOffset: { top: 100, left: 100, width: 200, height: 100 },
+    rect: { top: 100, left: 100, width: 200, height: 100 },
   }),
   getOffsetDimensions: () => ({ offsetWidth: 100, offsetHeight: 200 }),
 }));

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -98,6 +98,9 @@ function ChartPopover(
     };
   }, [container, onDismiss]);
 
+  // In chart popovers, dismiss button is present when they are pinned, so both values are equivalent.
+  const isPinned = dismissButton;
+
   return (
     <div
       {...baseProps}
@@ -123,6 +126,8 @@ function ChartPopover(
           </div>
         )}
         keepPosition={true}
+        allowVerticalOverflow={true}
+        allowScrollToFit={isPinned}
       >
         <div className={styles['hover-area']}>
           <PopoverBody

--- a/src/internal/components/dropdown/dropdown-fit-handler.ts
+++ b/src/internal/components/dropdown/dropdown-fit-handler.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { getBreakpointValue } from '../../breakpoints';
-import { Dimensions, getOverflowParents, getOverflowParentDimensions } from '../../utils/scrollable-containers';
+import { BoundingBox, getOverflowParents, getOverflowParentDimensions } from '../../utils/scrollable-containers';
 import styles from './styles.css.js';
 
 const AVAILABLE_SPACE_RESERVE_DEFAULT = 50;
@@ -52,7 +52,7 @@ export const getAvailableSpace = ({
   isMobile,
 }: {
   trigger: HTMLElement;
-  overflowParents: ReadonlyArray<Dimensions>;
+  overflowParents: ReadonlyArray<BoundingBox>;
   stretchWidth?: boolean;
   stretchHeight?: boolean;
   isMobile?: boolean;
@@ -94,7 +94,7 @@ export const getInteriorAvailableSpace = ({
   isMobile,
 }: {
   trigger: HTMLElement;
-  overflowParents: ReadonlyArray<Dimensions>;
+  overflowParents: ReadonlyArray<BoundingBox>;
   isMobile?: boolean;
 }): AvailableSpace => {
   const AVAILABLE_SPACE_RESERVE_VERTICAL = isMobile
@@ -205,7 +205,7 @@ export const getDropdownPosition = ({
 }: {
   triggerElement: HTMLElement;
   dropdownElement: HTMLElement;
-  overflowParents: ReadonlyArray<Dimensions>;
+  overflowParents: ReadonlyArray<BoundingBox>;
   minWidth?: number;
   preferCenter?: boolean;
   stretchWidth?: boolean;
@@ -274,7 +274,7 @@ export const getDropdownPosition = ({
 export const getInteriorDropdownPosition = (
   trigger: HTMLElement,
   dropdown: HTMLElement,
-  overflowParents: ReadonlyArray<Dimensions>,
+  overflowParents: ReadonlyArray<BoundingBox>,
   isMobile?: boolean
 ): InteriorDropdownPosition => {
   const availableSpace = getInteriorAvailableSpace({ trigger, overflowParents, isMobile });

--- a/src/internal/utils/__tests__/scrollable-containers.test.ts
+++ b/src/internal/utils/__tests__/scrollable-containers.test.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { scrollRectangleIntoView } from '../scrollable-containers';
+
+const originalScrollBy = window.scrollBy;
+
+beforeEach(() => {
+  window.scrollBy = jest.fn();
+  window.innerHeight = 500;
+});
+afterEach(() => {
+  window.scrollBy = originalScrollBy;
+});
+
+describe('scrollRectangleIntoView', () => {
+  test("scrolls up until the rectangle's top position fits the viewport top, if the rectangle's top position was further up", () => {
+    scrollRectangleIntoView({ top: -50, height: 100, width: 100, left: 0 });
+    expect(window.scrollBy).toHaveBeenCalledWith(0, -50);
+  });
+  test("scrolls down until the rectangle's bottom position fits the viewport bottom, if the rectangle's bottom position was further down", () => {
+    scrollRectangleIntoView({ top: 300, height: 300, width: 100, left: 0 });
+    expect(window.scrollBy).toHaveBeenCalledWith(0, 100);
+  });
+  test("scrolls down only until the rectangle's top position fits the viewport top, if the rectangle's bottom position was further down but it is taller than the viewport", () => {
+    scrollRectangleIntoView({ top: 300, height: 600, width: 100, left: 0 });
+    expect(window.scrollBy).toHaveBeenCalledWith(0, 300);
+  });
+});

--- a/src/internal/utils/scrollable-containers.ts
+++ b/src/internal/utils/scrollable-containers.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export interface Dimensions {
+export interface BoundingBox {
   height: number;
   width: number;
   top: number;
@@ -27,7 +27,7 @@ export const getOverflowParentDimensions = ({
   excludeClosestParent: boolean;
   expandToViewport: boolean;
   canExpandOutsideViewport: boolean;
-}): Dimensions[] => {
+}): BoundingBox[] => {
   const parents = expandToViewport
     ? []
     : getOverflowParents(element).map(el => {
@@ -83,4 +83,29 @@ export function scrollElementIntoView(
   options: ScrollIntoViewOptions = { block: 'nearest', inline: 'nearest' }
 ) {
   element?.scrollIntoView?.(options);
+}
+
+export function calculateScroll({ top, height }: BoundingBox) {
+  if (top < 0) {
+    return top;
+  } else if (top + height > window.innerHeight) {
+    if (height > window.innerHeight) {
+      return top;
+    } else {
+      return top + height - window.innerHeight;
+    }
+  }
+  return 0;
+}
+
+/**
+ * For elements with fixed position, the browser's native scrollIntoView API doesn't work,
+ * so we need to manually scroll to the element's position.
+ * Supports only vertical scrolling.
+ */
+export function scrollRectangleIntoView(box: BoundingBox) {
+  const scrollAmount = calculateScroll(box);
+  if (scrollAmount) {
+    window.scrollBy(0, scrollAmount);
+  }
 }

--- a/src/line-chart/__tests__/chart-series-details.test.tsx
+++ b/src/line-chart/__tests__/chart-series-details.test.tsx
@@ -17,7 +17,7 @@ jest.mock('../../../lib/components/popover/utils/positions', () => ({
   ...jest.requireActual('../../../lib/components/popover/utils/positions'),
   calculatePosition: () => ({
     internalPosition: 'top-right',
-    boundingOffset: { top: 100, left: 100, width: 200, height: 100 },
+    rect: { top: 100, left: 100, width: 200, height: 100 },
   }),
   getOffsetDimensions: () => ({ offsetWidth: 100, offsetHeight: 200 }),
 }));

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -496,6 +496,34 @@ describe('Details popover', () => {
     })
   );
 
+  test(
+    'scrolls if necessary on click',
+    setupTest('#/light/bar-chart/drilldown', async page => {
+      await page.setWindowSize({ width: 360, height: 650 });
+      await page.windowScrollTo({ top: 150 });
+      const barChart = createWrapper().findBarChart();
+      const barGroup = barChart.findBarGroups().get(1).toSelector();
+      await page.clickBarGroup(barGroup);
+      await page.waitForVisible(barChart.findDetailPopover().toSelector());
+      await expect(page.getText(barChart.findDetailPopover().findHeader().toSelector())).resolves.toContain('Apr 2023');
+      await expect(page.getWindowScroll()).resolves.toEqual({ top: 0, left: 0 });
+    })
+  );
+
+  test(
+    'does not scroll on hover',
+    setupTest('#/light/bar-chart/drilldown', async page => {
+      await page.setWindowSize({ width: 360, height: 650 });
+      await page.windowScrollTo({ top: 150 });
+      const barChart = createWrapper().findBarChart();
+      const barGroup = barChart.findBarGroups().get(1).toSelector();
+      await page.hoverElement(barGroup);
+      await expect(page.getWindowScroll()).resolves.toEqual({ top: 150, left: 0 });
+      await expect(page.getText(barChart.findDetailPopover().findHeader().toSelector())).resolves.toContain('Apr 2023');
+      await expect(page.getWindowScroll()).resolves.toEqual({ top: 150, left: 0 });
+    })
+  );
+
   describe('keeps the popover position when it resizes due to interacting with the popover itself', () => {
     test.each(['hover', 'click', 'keyboard'])('Interaction type: %s', interactionType =>
       setupPopoverPositionTest(async page => {

--- a/src/mixed-line-bar-chart/__tests__/chart-series-details.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/chart-series-details.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../../lib/components/popover/utils/positions', () => ({
   ...jest.requireActual('../../../lib/components/popover/utils/positions'),
   calculatePosition: () => ({
     internalPosition: 'top-right',
-    boundingOffset: { top: 100, left: 100, width: 200, height: 100 },
+    rect: { top: 100, left: 100, width: 200, height: 100 },
   }),
   getOffsetDimensions: () => ({ offsetWidth: 100, offsetHeight: 200 }),
 }));

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -15,7 +15,7 @@ import EmphasizedBaseline from '../internal/components/cartesian-chart/emphasize
 import HighlightedPoint from '../internal/components/cartesian-chart/highlighted-point';
 import VerticalMarker from '../internal/components/cartesian-chart/vertical-marker';
 import { ChartScale, NumericChartScale } from '../internal/components/cartesian-chart/scales';
-import ChartPopover from './chart-popover';
+import MixedChartPopover from './chart-popover';
 import { ChartDataTypes, InternalChartSeries, MixedLineBarChartProps, ScaleType, VerticalMarkerX } from './interfaces';
 import { computeDomainX, computeDomainY } from './domain';
 import { isXThreshold } from './utils';
@@ -629,7 +629,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
         </ChartPlot>
       }
       popover={
-        <ChartPopover
+        <MixedChartPopover
           ref={popoverRef}
           containerRef={containerRefObject}
           trackRef={highlightedElementRef}

--- a/src/popover/__tests__/positions.test.ts
+++ b/src/popover/__tests__/positions.test.ts
@@ -173,8 +173,8 @@ describe('calculatePosition', () => {
           renderWithPortal,
         });
         expect(position.scrollable).toBe(true);
-        expect(position.boundingOffset.width).toBe(250);
-        expect(position.boundingOffset.height).toBeLessThan(900);
+        expect(position.rect.width).toBe(250);
+        expect(position.rect.height).toBeLessThan(900);
       });
     });
   });

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -1,15 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { CSSProperties, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import { getContainingBlock } from '../internal/utils/dom';
-import { BoundingOffset, InternalPosition, Offset, PopoverProps } from './interfaces';
-import { calculatePosition, getDimensions, getOffsetDimensions } from './utils/positions';
+import { InternalPosition, PopoverProps } from './interfaces';
 import styles from './styles.css.js';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import usePopoverPosition from './use-popover-position.js';
 
 export interface PopoverContainerProps {
   /** References the element the container is positioned against. */
@@ -34,9 +33,11 @@ export interface PopoverContainerProps {
   variant?: 'annotation';
   // When keepPosition is true, the popover will not recalculate its position when it resizes nor when it receives clicks.
   keepPosition?: boolean;
+  // When allowScrollToFit is true, we will scroll to the the popover if it overflows the viewport even when choosing the best possible position for it.
+  // Do not use this if the popover is open on hover, in order to avoid unexpected movement.
+  allowScrollToFit?: boolean;
+  allowVerticalOverflow?: boolean;
 }
-
-const INITIAL_STYLES: CSSProperties = { top: -9999, left: -9999 };
 
 export default function PopoverContainer({
   position,
@@ -50,129 +51,29 @@ export default function PopoverContainer({
   fixedWidth,
   variant,
   keepPosition,
+  allowScrollToFit,
+  allowVerticalOverflow,
 }: PopoverContainerProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const arrowRef = useRef<HTMLDivElement | null>(null);
-  const previousInternalPositionRef = useRef<InternalPosition | null>(null);
 
-  const [popoverStyle, setPopoverStyle] = useState<CSSProperties>(INITIAL_STYLES);
-  const [internalPosition, setInternalPosition] = useState<InternalPosition | null>(null);
   const isRefresh = useVisualRefresh();
 
-  // Store the handler in a ref so that it can still be replaced from outside of the listener closure.
-  const positionHandlerRef = useRef<() => void>(() => {});
-
   // Updates the position handler.
-  const updatePositionHandler = useCallback(
-    (onContentResize = false) => {
-      if (!trackRef.current || !popoverRef.current || !bodyRef.current || !contentRef.current || !arrowRef.current) {
-        return;
-      }
-
-      // Get important elements
-      const popover = popoverRef.current;
-      const body = bodyRef.current;
-      const arrow = arrowRef.current;
-      const document = popover.ownerDocument;
-      const track = trackRef.current;
-
-      // If the popover body isn't being rendered for whatever reason (e.g. "display: none" or JSDOM),
-      // or track does not belong to the document - bail on calculating dimensions.
-      const { offsetWidth, offsetHeight } = getOffsetDimensions(popover);
-      if (offsetWidth === 0 || offsetHeight === 0 || !nodeContains(document.body, track)) {
-        return;
-      }
-
-      // Imperatively move body off-screen to give it room to expand.
-      // Not doing this in React because this recalculation should happen
-      // in the span of a single frame without rerendering anything.
-      const prevTop = popover.style.top;
-      const prevLeft = popover.style.left;
-
-      popover.style.top = '0';
-      popover.style.left = '0';
-      // Imperatively remove body styles that can remain from the previous computation.
-      body.style.maxHeight = '';
-      body.style.overflowX = '';
-      body.style.overflowY = '';
-
-      // Get rects representing key elements
-      // Use getComputedStyle for arrowRect to avoid modifications made by transform
-      const viewportRect = getViewportRect(document.defaultView!);
-      const trackRect = track.getBoundingClientRect();
-      const arrowRect = getDimensions(arrow);
-      const containingBlock = getContainingBlock(popover);
-      const containingBlockRect = containingBlock ? containingBlock.getBoundingClientRect() : viewportRect;
-
-      const bodyBorderWidth = getBorderWidth(body);
-      const contentRect = contentRef.current.getBoundingClientRect();
-      const contentBoundingBox = {
-        width: contentRect.width + 2 * bodyBorderWidth,
-        height: contentRect.height + 2 * bodyBorderWidth,
-      };
-
-      // When keepPosition is true and the recalculation was triggered by a resize of the popover content,
-      // we maintain the previously defined internal position,
-      // but we still call calculatePosition to know if the popover should be scrollable.
-      const shouldKeepPosition = keepPosition && onContentResize && !!previousInternalPositionRef.current;
-      const fixedInternalPosition = (shouldKeepPosition && previousInternalPositionRef.current) ?? undefined;
-
-      // Calculate the arrow direction and viewport-relative position of the popover.
-      const {
-        scrollable,
-        internalPosition: newInternalPosition,
-        boundingOffset,
-      } = calculatePosition({
-        preferredPosition: position,
-        fixedInternalPosition,
-        trigger: trackRect,
-        arrow: arrowRect,
-        body: contentBoundingBox,
-        container: containingBlock ? containingBlockRect : getDocumentRect(document),
-        viewport: viewportRect,
-        renderWithPortal,
-      });
-
-      // Get the position of the popover relative to the offset parent.
-      const popoverOffset = toRelativePosition(boundingOffset, containingBlockRect);
-
-      // Cache the distance between the trigger and the popover (which stays the same as you scroll),
-      // and use that to recalculate the new popover position.
-      const trackRelativeOffset = toRelativePosition(popoverOffset, toRelativePosition(trackRect, containingBlockRect));
-
-      // Bring back the container to its original position to prevent any flashing.
-      popover.style.top = prevTop;
-      popover.style.left = prevLeft;
-
-      // Allow popover body to scroll if can't fit the popover into the container/viewport otherwise.
-      if (scrollable) {
-        body.style.maxHeight = boundingOffset.height + 'px';
-        body.style.overflowX = 'hidden';
-        body.style.overflowY = 'auto';
-      }
-
-      // Remember the internal position in case we want to keep it later.
-      previousInternalPositionRef.current = newInternalPosition;
-
-      // Position the popover
-      setInternalPosition(newInternalPosition);
-      setPopoverStyle({ top: popoverOffset.top, left: popoverOffset.left });
-
-      positionHandlerRef.current = () => {
-        const newTrackOffset = toRelativePosition(
-          track.getBoundingClientRect(),
-          containingBlock ? containingBlock.getBoundingClientRect() : viewportRect
-        );
-        setPopoverStyle({
-          top: newTrackOffset.top + trackRelativeOffset.top,
-          left: newTrackOffset.left + trackRelativeOffset.left,
-        });
-      };
-    },
-    [trackRef, keepPosition, position, renderWithPortal]
-  );
+  const { updatePositionHandler, popoverStyle, internalPosition, positionHandlerRef } = usePopoverPosition({
+    popoverRef,
+    bodyRef,
+    arrowRef,
+    trackRef,
+    contentRef,
+    allowScrollToFit,
+    allowVerticalOverflow,
+    preferredPosition: position,
+    renderWithPortal,
+    keepPosition,
+  });
 
   // Recalculate position when properties change.
   useLayoutEffect(() => {
@@ -221,7 +122,7 @@ export default function PopoverContainer({
       window.removeEventListener('resize', updatePositionOnResize);
       window.removeEventListener('scroll', refreshPosition, true);
     };
-  }, [keepPosition, trackRef, updatePositionHandler]);
+  }, [keepPosition, positionHandlerRef, trackRef, updatePositionHandler]);
 
   return (
     <div
@@ -248,40 +149,4 @@ export default function PopoverContainer({
       </div>
     </div>
   );
-}
-
-function getBorderWidth(element: HTMLElement) {
-  return parseInt(getComputedStyle(element).borderWidth) || 0;
-}
-
-/**
- * Convert a viewport-relative offset to an element-relative offset.
- */
-function toRelativePosition(element: Offset, parent: Offset): Offset {
-  return {
-    top: element.top - parent.top,
-    left: element.left - parent.left,
-  };
-}
-
-/**
- * Get a BoundingOffset that represents the visible viewport.
- */
-function getViewportRect(window: Window): BoundingOffset {
-  return {
-    top: 0,
-    left: 0,
-    width: window.innerWidth,
-    height: window.innerHeight,
-  };
-}
-
-function getDocumentRect(document: Document): BoundingOffset {
-  const { top, left } = document.documentElement.getBoundingClientRect();
-  return {
-    top,
-    left,
-    width: document.documentElement.scrollWidth,
-    height: document.documentElement.scrollHeight,
-  };
 }

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -93,12 +93,12 @@ export interface Offset {
   top: number;
 }
 
-export interface BoundingBox {
+export interface Dimensions {
   width: number;
   height: number;
 }
 
-export type BoundingOffset = BoundingBox & Offset;
+export type BoundingBox = Dimensions & Offset;
 
 export namespace PopoverProps {
   export type Position = 'top' | 'right' | 'bottom' | 'left';

--- a/src/popover/use-popover-position.ts
+++ b/src/popover/use-popover-position.ts
@@ -1,0 +1,204 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useRef, useState } from 'react';
+import { BoundingBox, InternalPosition, Offset, PopoverProps } from './interfaces';
+import { calculatePosition, getDimensions, getOffsetDimensions } from './utils/positions';
+import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
+import { calculateScroll, scrollRectangleIntoView } from '../internal/utils/scrollable-containers';
+import { getContainingBlock } from '../internal/utils/dom';
+
+export default function usePopoverPosition({
+  popoverRef,
+  bodyRef,
+  arrowRef,
+  trackRef,
+  contentRef,
+  allowScrollToFit,
+  allowVerticalOverflow,
+  preferredPosition,
+  renderWithPortal,
+  keepPosition,
+}: {
+  popoverRef: React.RefObject<HTMLDivElement | null>;
+  bodyRef: React.RefObject<HTMLDivElement | null>;
+  arrowRef: React.RefObject<HTMLDivElement | null>;
+  trackRef: React.RefObject<Element | null>;
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  allowScrollToFit?: boolean;
+  allowVerticalOverflow?: boolean;
+  preferredPosition: PopoverProps.Position;
+  renderWithPortal?: boolean;
+  keepPosition?: boolean;
+}) {
+  const previousInternalPositionRef = useRef<InternalPosition | null>(null);
+  const [popoverStyle, setPopoverStyle] = useState<Partial<Offset>>({});
+  const [internalPosition, setInternalPosition] = useState<InternalPosition | null>(null);
+
+  // Store the handler in a ref so that it can still be replaced from outside of the listener closure.
+  const positionHandlerRef = useRef<() => void>(() => {});
+
+  const updatePositionHandler = useCallback(
+    (onContentResize = false) => {
+      if (!trackRef.current || !popoverRef.current || !bodyRef.current || !contentRef.current || !arrowRef.current) {
+        return;
+      }
+
+      // Get important elements
+      const popover = popoverRef.current;
+      const body = bodyRef.current;
+      const arrow = arrowRef.current;
+      const document = popover.ownerDocument;
+      const track = trackRef.current;
+
+      // If the popover body isn't being rendered for whatever reason (e.g. "display: none" or JSDOM),
+      // or track does not belong to the document - bail on calculating dimensions.
+      const { offsetWidth, offsetHeight } = getOffsetDimensions(popover);
+      if (offsetWidth === 0 || offsetHeight === 0 || !nodeContains(document.body, track)) {
+        return;
+      }
+
+      // Imperatively move body off-screen to give it room to expand.
+      // Not doing this in React because this recalculation should happen
+      // in the span of a single frame without rerendering anything.
+      const prevTop = popover.style.top;
+      const prevLeft = popover.style.left;
+
+      popover.style.top = '0';
+      popover.style.left = '0';
+      // Imperatively remove body styles that can remain from the previous computation.
+      body.style.maxHeight = '';
+      body.style.overflowX = '';
+      body.style.overflowY = '';
+
+      // Get rects representing key elements
+      // Use getComputedStyle for arrowRect to avoid modifications made by transform
+      const viewportRect = getViewportRect(document.defaultView!);
+      const trackRect = track.getBoundingClientRect();
+      const arrowRect = getDimensions(arrow);
+      const containingBlock = getContainingBlock(popover);
+      const containingBlockRect = containingBlock ? containingBlock.getBoundingClientRect() : viewportRect;
+
+      const bodyBorderWidth = getBorderWidth(body);
+      const contentRect = contentRef.current.getBoundingClientRect();
+      const contentBoundingBox = {
+        width: contentRect.width + 2 * bodyBorderWidth,
+        height: contentRect.height + 2 * bodyBorderWidth,
+      };
+
+      // When keepPosition is true and the recalculation was triggered by a resize of the popover content,
+      // we maintain the previously defined internal position,
+      // but we still call calculatePosition to know if the popover should be scrollable.
+      const shouldKeepPosition = keepPosition && onContentResize && !!previousInternalPositionRef.current;
+      const fixedInternalPosition = (shouldKeepPosition && previousInternalPositionRef.current) ?? undefined;
+
+      // Calculate the arrow direction and viewport-relative position of the popover.
+      const {
+        scrollable,
+        internalPosition: newInternalPosition,
+        rect,
+      } = calculatePosition({
+        preferredPosition,
+        fixedInternalPosition,
+        trigger: trackRect,
+        arrow: arrowRect,
+        body: contentBoundingBox,
+        container: containingBlock ? containingBlockRect : getDocumentRect(document),
+        viewport: viewportRect,
+        renderWithPortal,
+        allowVerticalOverflow,
+      });
+
+      // Get the position of the popover relative to the offset parent.
+      const popoverOffset = toRelativePosition(rect, containingBlockRect);
+
+      // Cache the distance between the trigger and the popover (which stays the same as you scroll),
+      // and use that to recalculate the new popover position.
+      const trackRelativeOffset = toRelativePosition(popoverOffset, toRelativePosition(trackRect, containingBlockRect));
+
+      // Bring back the container to its original position to prevent any flashing.
+      popover.style.top = prevTop;
+      popover.style.left = prevLeft;
+
+      // Allow popover body to scroll if can't fit the popover into the container/viewport otherwise.
+      if (scrollable) {
+        body.style.maxHeight = rect.height + 'px';
+        body.style.overflowX = 'hidden';
+        body.style.overflowY = 'auto';
+      }
+
+      // Remember the internal position in case we want to keep it later.
+      previousInternalPositionRef.current = newInternalPosition;
+      setInternalPosition(newInternalPosition);
+
+      const shouldScroll = allowScrollToFit && !shouldKeepPosition;
+
+      // Position the popover
+      const top = shouldScroll ? popoverOffset.top + calculateScroll(rect) : popoverOffset.top;
+      setPopoverStyle({ top, left: popoverOffset.left });
+      if (shouldScroll) {
+        scrollRectangleIntoView(rect);
+      }
+
+      positionHandlerRef.current = () => {
+        const newTrackOffset = toRelativePosition(
+          track.getBoundingClientRect(),
+          containingBlock ? containingBlock.getBoundingClientRect() : viewportRect
+        );
+        setPopoverStyle({
+          top: newTrackOffset.top + trackRelativeOffset.top,
+          left: newTrackOffset.left + trackRelativeOffset.left,
+        });
+      };
+    },
+    [
+      trackRef,
+      popoverRef,
+      bodyRef,
+      contentRef,
+      arrowRef,
+      keepPosition,
+      allowScrollToFit,
+      preferredPosition,
+      renderWithPortal,
+      allowVerticalOverflow,
+    ]
+  );
+  return { updatePositionHandler, popoverStyle, internalPosition, positionHandlerRef };
+}
+
+function getBorderWidth(element: HTMLElement) {
+  return parseInt(getComputedStyle(element).borderWidth) || 0;
+}
+
+/**
+ * Convert a viewport-relative offset to an element-relative offset.
+ */
+function toRelativePosition(element: Offset, parent: Offset): Offset {
+  return {
+    top: element.top - parent.top,
+    left: element.left - parent.left,
+  };
+}
+
+/**
+ * Get a BoundingBox that represents the visible viewport.
+ */
+function getViewportRect(window: Window): BoundingBox {
+  return {
+    top: 0,
+    left: 0,
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+function getDocumentRect(document: Document): BoundingBox {
+  const { top, left } = document.documentElement.getBoundingClientRect();
+  return {
+    top,
+    left,
+    width: document.documentElement.scrollWidth,
+    height: document.documentElement.scrollHeight,
+  };
+}


### PR DESCRIPTION
### Description

This is an exact copy of #1804, which had to be reverted because of a race condition that was fixed by #1884.

### How has this been tested?

Ran these changes together with #1884 in my pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
