### PR TITLE
chore: Remove unnecessary timeout in Chart plot application re-attachment logic

### DIFF
--- a/src/internal/components/chart-plot/__tests__/chart-plot.test.tsx
+++ b/src/internal/components/chart-plot/__tests__/chart-plot.test.tsx
@@ -463,7 +463,8 @@ describe('application focus delegation', () => {
     plotWrapper.keydown(KeyCode.right);
 
     expect(externalFocusCounter).toBe(1);
-    expect(internalFocusCounter).toBe(1);
+    // We get one extra internal focus because we re-attach and re-focus the application to trigger a screen reader update.
+    expect(internalFocusCounter).toBe(2);
 
     rerender(
       <ChartPlot width={0} height={0} activeElementKey="1:4" onApplicationFocus={externalOnFocus}>
@@ -473,6 +474,6 @@ describe('application focus delegation', () => {
     jest.runAllTimers();
 
     expect(externalFocusCounter).toBe(1);
-    expect(internalFocusCounter).toBe(2);
+    expect(internalFocusCounter).toBe(3);
   });
 });

--- a/src/internal/components/chart-plot/application-controller.tsx
+++ b/src/internal/components/chart-plot/application-controller.tsx
@@ -66,17 +66,10 @@ function ApplicationController(
     if (!isFocused || focusTransitionRef.current === true) {
       return;
     }
-
-    // Delay focus juggle to let the last focus event settle in Firefox.
-    // Without the delay the focus is getting lost.
-    const timeoutId = setTimeout(() => {
-      focusTransitionRef.current = true;
-      containerRef.current!.removeChild(applicationRef.current!);
-      containerRef.current!.appendChild(applicationRef.current!);
-      focusApplication(applicationRef.current!, activeElementRef?.current || null);
-    }, 0);
-
-    return () => clearTimeout(timeoutId);
+    focusTransitionRef.current = true;
+    containerRef.current!.removeChild(applicationRef.current!);
+    containerRef.current!.appendChild(applicationRef.current!);
+    focusApplication(applicationRef.current!, activeElementRef?.current || null);
   }, [isFocused, activeElementKey, activeElementRef]);
 
   return (


### PR DESCRIPTION
### Description

The timeout seems to not be necessary anymore and led to a race condition in Safari, which would cause the area chart popover dismiss button to lose focus after the changes in #1804, which had to be reverted for that reason.

### How has this been tested?

- Manually tested with Firefox, Chrome and Safari.
- Tested VoiceOver+Firefox myself, and @pan-kot kindly tested NVDA+Firefox as well.
- Deployed to my pipeline together with the changes in #1804.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
