### PR TITLE
fix: Prevent filtering highlighting from crashing when match is too long

### DIFF
--- a/src/internal/components/option/__tests__/option.test.tsx
+++ b/src/internal/components/option/__tests__/option.test.tsx
@@ -300,6 +300,16 @@ describe('Option component', () => {
       });
       checkMatches(optionWrapper, 1, '^${}[]().*+?<>-&');
     });
+    test('skips highlighting if the label text is too long', () => {
+      const optionWrapper = renderOption({
+        option: {
+          label: 'a'.repeat(1000000),
+          value: '1',
+        },
+        highlightText: 'a'.repeat(500000),
+      });
+      checkMatches(optionWrapper, 0, '');
+    });
   });
 });
 

--- a/src/internal/components/option/highlight-match.tsx
+++ b/src/internal/components/option/highlight-match.tsx
@@ -5,6 +5,12 @@ import styles from './styles.css.js';
 import clsx from 'clsx';
 
 const splitOnFiltering = (str: string, highlightText: string) => {
+  // We match by creating a regex using user-provided strings, so we skip
+  // highlighting if the generated regex would be too memory intensive.
+  if (highlightText.length > 100000) {
+    return { noMatches: [str], matches: null };
+  }
+
   // Filtering needs to be case insensitive
   const filteringPattern = highlightText.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
   const regexp = new RegExp(filteringPattern, 'gi');
@@ -23,9 +29,7 @@ const Highlight = ({ str }: HighlightMatchProps) =>
   str ? <span className={clsx(styles['filtering-match-highlight'])}>{str}</span> : null;
 
 export default function HighlightMatch({ str, highlightText }: HighlightMatchProps) {
-  // splitOnFiltering creates a regex using user-provided strings, so we skip
-  // highlighting if the generated regex would be too memory intensive.
-  if (!str || !highlightText || highlightText.length > 100000) {
+  if (!str || !highlightText) {
     return <span>{str}</span>;
   }
 

--- a/src/internal/components/option/highlight-match.tsx
+++ b/src/internal/components/option/highlight-match.tsx
@@ -23,7 +23,9 @@ const Highlight = ({ str }: HighlightMatchProps) =>
   str ? <span className={clsx(styles['filtering-match-highlight'])}>{str}</span> : null;
 
 export default function HighlightMatch({ str, highlightText }: HighlightMatchProps) {
-  if (!str || !highlightText) {
+  // splitOnFiltering creates a regex using user-provided strings, so we skip
+  // highlighting if the generated regex would be too memory intensive.
+  if (!str || !highlightText || highlightText.length > 100000) {
     return <span>{str}</span>;
   }
 


### PR DESCRIPTION
### Description

Quick fix for a rare case. Imagine pasting a 100,000 character string into the autosuggest component 😨 

Tested manually on Chrome and Firefox as well.

Related links, issue #, if available: P112982985

### How has this been tested?

Added a test case.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
