### PR TITLE
chore: Do not call creation-edit-flow-done event when funnel cancels

### DIFF
--- a/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
+++ b/src/internal/analytics/__tests__/components/analytics-funnel.test.tsx
@@ -718,13 +718,13 @@ describe('emit awsui-creation-flow-done event', () => {
     });
   });
 
-  test('emit awsui-creation-flow-done event when funnelCancelled', () => {
+  test('does not emit awsui-creation-flow-done event when funnelCancelled', () => {
     const { unmount } = render(
       <AnalyticsFunnel funnelType="single-page" optionalStepNumbers={[]} totalFunnelSteps={1} />
     );
     act(() => void jest.runAllTimers());
     unmount();
-    expect(doneSpy).toHaveBeenCalled();
+    expect(doneSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -67,7 +67,6 @@ const dispatchCreateEditFlowDoneEvent = () => {
 
 const onFunnelCancelled = ({ funnelInteractionId }: { funnelInteractionId: string }) => {
   FunnelMetrics.funnelCancelled({ funnelInteractionId });
-  dispatchCreateEditFlowDoneEvent();
 };
 
 const onFunnelComplete = ({ funnelInteractionId }: { funnelInteractionId: string }) => {


### PR DESCRIPTION
### Description

Update logic for better semantics

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
