### PR TITLE
refactor: Better efficient grid navigation

### DIFF
--- a/src/internal/context/__tests__/utils.tsx
+++ b/src/internal/context/__tests__/utils.tsx
@@ -5,7 +5,6 @@ import React, { createRef, forwardRef, useCallback, useImperativeHandle, useRef 
 import { render } from '@testing-library/react';
 import {
   FocusableChangeHandler,
-  FocusableDefinition,
   SingleTabStopNavigationContext,
 } from '../../../../lib/components/internal/context/single-tab-stop-navigation-context';
 
@@ -18,9 +17,9 @@ const FakeSingleTabStopNavigationProvider = forwardRef(
     { children, navigationActive }: { children: React.ReactNode; navigationActive: boolean },
     ref: React.Ref<ProviderRef>
   ) => {
-    const focusablesRef = useRef(new Set<FocusableDefinition>());
-    const focusHandlersRef = useRef(new Map<FocusableDefinition, FocusableChangeHandler>());
-    const registerFocusable = useCallback((focusable: FocusableDefinition, changeHandler: FocusableChangeHandler) => {
+    const focusablesRef = useRef(new Set<Element>());
+    const focusHandlersRef = useRef(new Map<Element, FocusableChangeHandler>());
+    const registerFocusable = useCallback((focusable: Element, changeHandler: FocusableChangeHandler) => {
       focusablesRef.current.add(focusable);
       focusHandlersRef.current.set(focusable, changeHandler);
       return () => {
@@ -30,11 +29,10 @@ const FakeSingleTabStopNavigationProvider = forwardRef(
     }, []);
 
     useImperativeHandle(ref, () => ({
-      setCurrentTarget: (focusTarget: null | Element, suppressed: (null | Element)[] = []) => {
+      setCurrentTarget: (focusTarget: null | Element, suppressed: Element[] = []) => {
         focusablesRef.current.forEach(focusable => {
-          const element = focusable.current;
           const handler = focusHandlersRef.current.get(focusable)!;
-          handler(focusTarget, element ? suppressed.includes(element) : false);
+          handler(focusTarget === focusable || suppressed.includes(focusable));
         });
       },
     }));

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -249,11 +249,11 @@ class GridNavigationProcessor {
 
   private updateFocusTarget() {
     this.focusTarget = this.getSingleFocusable();
-    for (const [focusable, prevIsFocusable] of this.focusables) {
-      const isFocusable = this.focusTarget === focusable || this.isSuppressed(focusable);
-      if (isFocusable !== prevIsFocusable) {
-        this.focusables.set(focusable, isFocusable);
-        this.focusHandlers.get(focusable)!(isFocusable);
+    for (const [focusableElement, isFocusable] of this.focusables) {
+      const newIsFocusable = this.focusTarget === focusableElement || this.isSuppressed(focusableElement);
+      if (newIsFocusable !== isFocusable) {
+        this.focusables.set(focusableElement, newIsFocusable);
+        this.focusHandlers.get(focusableElement)!(newIsFocusable);
       }
     }
   }

--- a/src/table/table-role/interfaces.ts
+++ b/src/table/table-role/interfaces.ts
@@ -14,7 +14,5 @@ export interface FocusedCell {
   rowIndex: number;
   colIndex: number;
   elementIndex: number;
-  rowElement: HTMLTableRowElement;
-  cellElement: HTMLTableCellElement;
   element: HTMLElement;
 }

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+export function getClosestCell(element: Element) {
+  return element.closest('td,th') as null | HTMLTableCellElement;
+}
+
 /**
  * Returns true if the target element or one of its parents is a dialog or is marked with data-awsui-table-suppress-navigation attribute.
  * This is used to suppress navigation for interactive content without a need to use a custom suppression check.


### PR DESCRIPTION
### Description

Refactored grid navigation and single tab stop navigation context for better performance. The main change is that the focusables are registered as elements rather than element references. That makes the overall process simpler and removes the need to iterate over focusables to transform a set of refs into a set of elements.

### How has this been tested?

Existing tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
