### PR TITLE
chore: Update the styles reset mixin to use flow relative text alignment

### DIFF
--- a/src/internal/styles/utils/styles-reset.scss
+++ b/src/internal/styles/utils/styles-reset.scss
@@ -24,7 +24,7 @@
   letter-spacing: normal;
   list-style: disc outside none;
   tab-size: 8;
-  text-align: left;
+  text-align: start;
   text-indent: 0;
   text-shadow: none;
   text-transform: none;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -32,6 +32,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   word-wrap: break-word;
   border-bottom: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
+  text-align: start;
   &:not(.body-cell-wrap) {
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
This PR sets the `text-align` property to a flow relative value in order to respond to the direction of the document subtree.