### PR TITLE
fix: Remove html form from table cell inline editor

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -467,7 +467,9 @@ Object {
   ],
   "table": Array [
     "awsui_body-cell-edit-active_c6tup",
+    "awsui_body-cell-editor-cancel-button_c6tup",
     "awsui_body-cell-editor-controls_c6tup",
+    "awsui_body-cell-editor-save-button_c6tup",
     "awsui_body-cell-editor_c6tup",
     "awsui_body-cell_c6tup",
     "awsui_empty_wih1l",

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -92,4 +92,9 @@ export interface InternalFormFieldProps extends FormFieldProps, InternalBaseComp
    * Disable the gutter applied by default.
    */
   __disableGutters?: boolean;
+
+  /**
+   * Provide custom form ID to associate inputs with.
+   */
+  __formId?: string;
 }

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -83,6 +83,7 @@ export default function InternalFormField({
   __hideLabel,
   __internalRootRef = null,
   __disableGutters = false,
+  __formId,
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
@@ -112,6 +113,7 @@ export default function InternalFormField({
     ariaLabelledby: joinStrings(parentAriaLabelledby, slotIds.label) || undefined,
     ariaDescribedby: joinStrings(parentAriaDescribedby, ariaDescribedBy) || undefined,
     invalid: !!errorText || !!parentInvalid,
+    form: __formId,
   };
 
   const analyticsAttributes = {

--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -110,6 +110,7 @@ function InternalInput(
     placeholder,
     autoFocus,
     id: controlId,
+    form: formFieldContext.form,
     className: clsx(
       styles.input,
       type && styles[`input-type-${type}`],

--- a/src/internal/context/form-field-context.ts
+++ b/src/internal/context/form-field-context.ts
@@ -47,7 +47,14 @@ export interface FormFieldValidationControlProps extends FormFieldControlProps {
   invalid?: boolean;
 }
 
-export const FormFieldContext = createContext<FormFieldValidationControlProps>({});
+export interface InternalFormFieldContentProps extends FormFieldValidationControlProps {
+  /**
+   * Provides custom form ID to associate inputs with.
+   */
+  form?: string;
+}
+
+export const FormFieldContext = createContext<InternalFormFieldContentProps>({});
 
 function applyDefault<T>(fields: T, defaults: T, keys: (keyof T)[]) {
   const result = <T>{};
@@ -59,5 +66,11 @@ function applyDefault<T>(fields: T, defaults: T, keys: (keyof T)[]) {
 
 export function useFormFieldContext(props: FormFieldValidationControlProps) {
   const context = useContext(FormFieldContext);
-  return applyDefault(props, context, ['invalid', 'controlId', 'ariaLabelledby', 'ariaDescribedby']);
+  return applyDefault<InternalFormFieldContentProps>(props, context, [
+    'invalid',
+    'controlId',
+    'ariaLabelledby',
+    'ariaDescribedby',
+    'form',
+  ]);
 }

--- a/src/table/__tests__/inline-editing-test-utils.test.tsx
+++ b/src/table/__tests__/inline-editing-test-utils.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import Table, { TableProps } from '../../../lib/components/table';
+import styles from '../../../lib/components/table/body-cell/styles.css.js';
 
 interface Item {
   id: number;
@@ -72,7 +73,9 @@ describe('Editable Table TestUtils', () => {
     const { wrapper, getByTestId } = renderTable(<Table columnDefinitions={editableColumns} items={defaultItems} />);
     const cellId0 = wrapper.findBodyCell(1, 1)!.getElement()!;
     fireEvent.click(cellId0);
-    const buttons = getByTestId('id-editing-1').closest('form')!.querySelectorAll('button')!;
+    const buttons = getByTestId('id-editing-1')
+      .closest(`.${styles['body-cell-editor-form']}`)!
+      .querySelectorAll('button')!;
     expect(wrapper.findEditingCellCancelButton()!.getElement()!).toBe(buttons[0]);
     expect(wrapper.findEditingCellSaveButton()!.getElement()!).toBe(buttons[1]);
   });

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -127,6 +127,7 @@ export function InlineEditor<ItemType>({
                 <SpaceBetween direction="horizontal" size="xxs">
                   {!currentEditLoading ? (
                     <Button
+                      className={styles['body-cell-editor-cancel-button']}
                       ariaLabel={ariaLabels?.cancelEditLabel?.(column)}
                       formAction="none"
                       iconName="close"
@@ -135,6 +136,7 @@ export function InlineEditor<ItemType>({
                     />
                   ) : null}
                   <Button
+                    className={styles['body-cell-editor-save-button']}
                     ariaLabel={ariaLabels?.submitEditLabel?.(column)}
                     formAction="none"
                     iconName="check"

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -55,8 +55,7 @@ export function InlineEditor<ItemType>({
     onEditEnd({ cancelled, refocusCell: refocusCell });
   }
 
-  async function onSubmitClick(evt: React.FormEvent) {
-    evt.preventDefault();
+  async function onSubmitClick() {
     if (currentEditValue === undefined) {
       finishEdit();
       return;
@@ -112,7 +111,7 @@ export function InlineEditor<ItemType>({
         aria-label={ariaLabels?.activateEditLabel?.(column, item)}
         onKeyDown={handleEscape}
       >
-        <form onSubmit={onSubmitClick} className={styles['body-cell-editor-form']}>
+        <div className={styles['body-cell-editor-form']}>
           <FormField
             stretch={true}
             label={ariaLabel}
@@ -137,10 +136,11 @@ export function InlineEditor<ItemType>({
                   ) : null}
                   <Button
                     ariaLabel={ariaLabels?.submitEditLabel?.(column)}
-                    formAction="submit"
+                    formAction="none"
                     iconName="check"
                     variant="inline-icon"
                     loading={currentEditLoading}
+                    onClick={onSubmitClick}
                   />
                 </SpaceBetween>
                 <LiveRegion>
@@ -151,7 +151,7 @@ export function InlineEditor<ItemType>({
               </span>
             </div>
           </FormField>
-        </form>
+        </div>
       </div>
     </FocusLock>
   );

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -239,6 +239,11 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
       }
     }
 
+    &-cancel-button,
+    &-save-button {
+      /* used in test-utils */
+    }
+
     &-row {
       display: flex;
       flex-flow: row nowrap;

--- a/src/test-utils/dom/table/index.ts
+++ b/src/test-utils/dom/table/index.ts
@@ -160,10 +160,10 @@ export default class TableWrapper extends ComponentWrapper {
   }
 
   findEditingCellSaveButton(): ElementWrapper | null {
-    return this._findEditingCellControls()?.find('button[type="submit"]') ?? null;
+    return this._findEditingCellControls()?.findByClassName(bodyCellStyles['body-cell-editor-save-button']) ?? null;
   }
 
   findEditingCellCancelButton(): ElementWrapper | null {
-    return this._findEditingCellControls()?.find('button:first-child') ?? null;
+    return this._findEditingCellControls()?.findByClassName(bodyCellStyles['body-cell-editor-cancel-button']) ?? null;
   }
 }


### PR DESCRIPTION
### Description

The form we use inside table cell inline editor cause issues if the table is nested as part of another form:
* Causes invalid HTML (form nesting is not allowed);
* In React 17+ causes page refresh.

If we remove the form the issue is gone but then the submit cannot be completing by pressing Enter while focused on an input. Instead, we can:
* Move the form to a portal and refer to it using the `form` attribute. That prevents form nesting and also resolves the issue with page refresh.
* Stop form submit event propagation for it to not reach the outer form. 

See AWSUI-30406

### How has this been tested?

Existing unit- and integration tests, manual testing with React 16 and React 18.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
