### PR TITLE
chore: Fix bundle size script to account for new dependencies

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -113,8 +113,7 @@ jobs:
           npm run quick-build
 
           cd ../bundle-size
-          rm -rf node_modules/@cloudscape-design/components
-          cp -r $GITHUB_WORKSPACE/components/lib/components node_modules/@cloudscape-design/components
+          npm i $GITHUB_WORKSPACE/components/lib/components
           cp main-with-cloudscape.jsx main.jsx
           npm run build
 


### PR DESCRIPTION
### Description

When 3rd party dependencies are added or updated the measure-bundle job should use the updated node_modules. The issue was spotted here: https://github.com/cloudscape-design/components/pull/1842

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
