### PR TITLE
fix: Remove native focus outline from expandable section button

### DIFF
--- a/src/expandable-section/styles.scss
+++ b/src/expandable-section/styles.scss
@@ -27,7 +27,7 @@ $icon-total-space-medium: calc(#{$icon-width-medium} + #{$icon-margin-left} + #{
 }
 
 .expand-button {
-  /* used in test-utils */
+  outline: none;
 }
 
 .icon {


### PR DESCRIPTION
### Description

Fixing a bug in expandable section when default focus outline is shown when clicking on expandable header after focusing on it with the keyboard.

Ref: AWSUI-30684

### How has this been tested?

Before:

https://github.com/cloudscape-design/components/assets/20790937/abf0de6c-5c1d-4ee3-a0ef-bc29dcf88232

After:

https://github.com/cloudscape-design/components/assets/20790937/2e248ed6-8699-418c-b51b-42f97e19f65d




<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
