### PR TITLE
fix: Make removal of high-contrast header independent of bundling

### DIFF
--- a/src/app-layout/visual-refresh/background.tsx
+++ b/src/app-layout/visual-refresh/background.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 
@@ -21,7 +21,7 @@ export default function Background() {
   }
 
   return (
-    <div className={clsx(styles.background, contentHeaderClassName)}>
+    <div className={clsx(styles.background, getContentHeaderClassName())}>
       <div className={styles['scrolling-background']} />
 
       {!isMobile && hasStickyBackground && (

--- a/src/app-layout/visual-refresh/breadcrumbs.tsx
+++ b/src/app-layout/visual-refresh/breadcrumbs.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -22,7 +22,7 @@ export default function Breadcrumbs() {
         {
           [styles['has-sticky-background']]: hasStickyBackground,
         },
-        contentHeaderClassName
+        getContentHeaderClassName()
       )}
     >
       {breadcrumbs}

--- a/src/app-layout/visual-refresh/header.tsx
+++ b/src/app-layout/visual-refresh/header.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 
@@ -22,7 +22,7 @@ export default function Header() {
           [styles['has-notifications-content']]: hasNotificationsContent,
           [styles.unfocusable]: hasDrawerViewportOverlay,
         },
-        contentHeaderClassName
+        getContentHeaderClassName()
       )}
     >
       {contentHeader}

--- a/src/app-layout/visual-refresh/mobile-toolbar.tsx
+++ b/src/app-layout/visual-refresh/mobile-toolbar.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { InternalButton } from '../../button/internal';
 import { MobileTriggers as DrawersMobileTriggers } from './drawers';
 import { useAppLayoutInternals } from './context';
@@ -46,8 +46,8 @@ export default function MobileToolbar() {
           [styles.unfocusable]: hasDrawerViewportOverlay,
         },
         testutilStyles['mobile-bar'],
-        contentHeaderClassName,
-        shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+        getContentHeaderClassName(),
+        shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
       )}
     >
       {!navigationHide && (

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import clsx from 'clsx';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
 import testutilStyles from '../test-classes/styles.css.js';
@@ -30,7 +30,7 @@ export default function Notifications() {
           [styles.unfocusable]: hasDrawerViewportOverlay,
         },
         testutilStyles.notifications,
-        contentHeaderClassName
+        getContentHeaderClassName()
       )}
     >
       <div ref={notificationsElement}>{notifications}</div>

--- a/src/app-layout/visual-refresh/trigger-button.tsx
+++ b/src/app-layout/visual-refresh/trigger-button.tsx
@@ -40,7 +40,7 @@ function TriggerButton(
     <div
       className={clsx(
         styles['trigger-wrapper'],
-        shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+        shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
       )}
     >
       <button

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -149,7 +149,7 @@ const Cards = React.forwardRef(function <T = any>(
                     styles.header,
                     isRefresh && styles['header-refresh'],
                     styles[`header-variant-${computedVariant}`],
-                    shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+                    shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
                   )}
                 >
                   <CollectionLabelContext.Provider value={{ assignId: setHeaderRef }}>
@@ -173,7 +173,7 @@ const Cards = React.forwardRef(function <T = any>(
                 hasToolsHeader && styles['has-header'],
                 isRefresh && styles.refresh,
                 styles[`header-variant-${computedVariant}`],
-                shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+                shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
               )}
             >
               {!!renderAriaLive && !!firstIndex && (

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -6,7 +6,7 @@ import { ContainerProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
 import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { contentHeaderClassName } from '../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../internal/utils/content-header-utils';
 import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
 import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -157,7 +157,7 @@ export default function InternalContainer({
                 isRefresh && styles.refresh,
                 styles.header,
                 styles[`header-variant-${variant}`],
-                shouldRemoveHighContrastHeader && styles['remove-high-contrast-header'],
+                shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header'],
                 {
                   [styles['header-sticky-disabled']]: __stickyHeader && !isSticky,
                   [styles['header-sticky-enabled']]: isSticky,
@@ -172,7 +172,7 @@ export default function InternalContainer({
               ref={headerMergedRef}
             >
               {__darkHeader ? (
-                <div className={clsx(styles['dark-header'], contentHeaderClassName)}>{header}</div>
+                <div className={clsx(styles['dark-header'], getContentHeaderClassName())}>{header}</div>
               ) : (
                 header
               )}
@@ -183,7 +183,7 @@ export default function InternalContainer({
           className={clsx(
             styles.content,
             fitHeight && styles['content-fit-height'],
-            shouldRemoveHighContrastHeader && styles['remove-high-contrast-header'],
+            shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header'],
             {
               [styles['with-paddings']]: !disableContentPaddings,
             }

--- a/src/content-layout/__tests__/content-layout.test.tsx
+++ b/src/content-layout/__tests__/content-layout.test.tsx
@@ -20,6 +20,9 @@ function renderContentLayout(props: ContentLayoutProps = {}) {
     rerender: (props: ContentLayoutProps) => rerender(<ContentLayout {...props} />),
   };
 }
+afterEach(() => {
+  delete (window as any)[Symbol.for('awsui-global-flags')];
+});
 
 describe('ContentLayout component', () => {
   describe('slots', () => {
@@ -29,6 +32,7 @@ describe('ContentLayout component', () => {
       });
 
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Header text');
+      expect(wrapper.findByClassName('awsui-context-content-header')).toBeTruthy();
     });
 
     test('renders the content slot', () => {
@@ -97,6 +101,15 @@ describe('ContentLayout component', () => {
         header: <>Header text</>,
       });
       expect(isOverlapEnabled()).toBe(true);
+    });
+
+    test('hides dark header when global flag is set', () => {
+      (window as any)[Symbol.for('awsui-global-flags')] = { removeHighContrastHeader: true };
+      const { wrapper } = renderContentLayout({
+        children: <>Content text</>,
+        header: <>Header text</>,
+      });
+      expect(wrapper.findByClassName('awsui-context-content-header')).toBeFalsy();
     });
   });
 });

--- a/src/content-layout/internal.tsx
+++ b/src/content-layout/internal.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import clsx from 'clsx';
 import { ContentLayoutProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
-import { contentHeaderClassName } from '../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../internal/utils/content-header-utils';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -43,12 +43,12 @@ export default function InternalContentLayout({
         className={clsx(
           styles.background,
           { [styles['is-overlap-disabled']]: isOverlapDisabled },
-          contentHeaderClassName
+          getContentHeaderClassName()
         )}
         ref={overlapElement}
       />
 
-      {header && <div className={clsx(styles.header, contentHeaderClassName)}>{header}</div>}
+      {header && <div className={clsx(styles.header, getContentHeaderClassName())}>{header}</div>}
 
       <div className={styles.content}>{children}</div>
     </div>

--- a/src/internal/components/dark-ribbon/index.tsx
+++ b/src/internal/components/dark-ribbon/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useRef } from 'react';
 import { useMutationObserver } from '../../hooks/use-mutation-observer';
-import { contentHeaderClassName } from '../../utils/content-header-utils';
+import { getContentHeaderClassName } from '../../utils/content-header-utils';
 import styles from './styles.css.js';
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 
@@ -55,7 +55,7 @@ export default function DarkRibbon({ children, isRefresh, hasPlainStyling }: Dar
   }
 
   return (
-    <div ref={containerRef} className={contentHeaderClassName}>
+    <div ref={containerRef} className={getContentHeaderClassName()}>
       <div ref={fillRef} className={styles['background-fill']} />
       <div className={styles.content}>{children}</div>
     </div>

--- a/src/internal/utils/content-header-utils.ts
+++ b/src/internal/utils/content-header-utils.ts
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { getGlobalFlag } from './global-flags';
 
-export const shouldRemoveHighContrastHeader = !!getGlobalFlag('removeHighContrastHeader');
-export const contentHeaderClassName = shouldRemoveHighContrastHeader ? '' : 'awsui-context-content-header';
+export const shouldRemoveHighContrastHeader = (): boolean => !!getGlobalFlag('removeHighContrastHeader');
+export const getContentHeaderClassName = (): string =>
+  shouldRemoveHighContrastHeader() ? '' : 'awsui-context-content-header';

--- a/src/split-panel/icons/bottom-icon-refresh.tsx
+++ b/src/split-panel/icons/bottom-icon-refresh.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import { getClassName, SVGTableRowProps } from './side-position-refresh';
 
 const TableRow = ({ offset, isHeader }: SVGTableRowProps) => {
@@ -49,7 +49,7 @@ const bottomPositionIcon = (
     <g className="awsui-context-top-navigation">
       <rect x="2" y="2" width="226" height="6" className={getClassName('layout-top')} />
     </g>
-    <g className={contentHeaderClassName}>
+    <g className={getContentHeaderClassName()}>
       <path d="M2 8H228V23H2V8Z" className={getClassName('layout-main')} />
       <g className={getClassName('default')}>
         <path

--- a/src/split-panel/icons/side-position-refresh.tsx
+++ b/src/split-panel/icons/side-position-refresh.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { contentHeaderClassName } from '../../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../../internal/utils/content-header-utils';
 import styles from '../styles.css.js';
 
 export interface SVGTableRowProps {
@@ -55,7 +55,7 @@ const bottomPositionIcon = (
     <g className="awsui-context-top-navigation">
       <rect x="2" y="2" width="212" height="6" className={getClassName('layout-top')} />
     </g>
-    <g className={contentHeaderClassName}>
+    <g className={getContentHeaderClassName()}>
       <path d="M2 8H214V23H2V8Z" className={getClassName('layout-main')} />
       <g className={getClassName('default')}>
         <path

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -42,7 +42,7 @@ import { CollectionLabelContext } from '../internal/context/collection-label-con
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import { NoDataCell } from './no-data-cell';
 import { usePerformanceMarks } from '../internal/hooks/use-performance-marks';
-import { contentHeaderClassName } from '../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../internal/utils/content-header-utils';
 
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
@@ -294,7 +294,7 @@ const InternalTable = React.forwardRef(
                 {hasHeader && (
                   <div
                     ref={overlapElement}
-                    className={clsx(hasDynamicHeight && [styles['dark-header'], contentHeaderClassName])}
+                    className={clsx(hasDynamicHeight && [styles['dark-header'], getContentHeaderClassName()])}
                   >
                     <div
                       ref={toolsHeaderWrapper}

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -12,7 +12,7 @@ import { useControllable } from '../internal/hooks/use-controllable';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
-import { contentHeaderClassName } from '../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../internal/utils/content-header-utils';
 
 import { useInternalI18n } from '../i18n/context';
 
@@ -153,7 +153,7 @@ export default function InternalWizard({
           styles.wizard,
           isVisualRefresh && styles.refresh,
           smallContainer && styles['small-container'],
-          shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+          shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
         )}
       >
         <WizardNavigation
@@ -173,10 +173,10 @@ export default function InternalWizard({
             styles.form,
             isVisualRefresh && styles.refresh,
             smallContainer && styles['small-container'],
-            shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+            shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
           )}
         >
-          {isVisualRefresh && <div className={clsx(styles.background, contentHeaderClassName)} />}
+          {isVisualRefresh && <div className={clsx(styles.background, getContentHeaderClassName())} />}
           <WizardForm
             steps={steps}
             isVisualRefresh={isVisualRefresh}

--- a/src/wizard/wizard-form-header.tsx
+++ b/src/wizard/wizard-form-header.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx';
 import React from 'react';
 import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
-import { contentHeaderClassName } from '../internal/utils/content-header-utils';
+import { getContentHeaderClassName } from '../internal/utils/content-header-utils';
 import styles from './styles.css.js';
 import { shouldRemoveHighContrastHeader } from '../internal/utils/content-header-utils';
 
@@ -21,14 +21,14 @@ export default function WizardFormHeader({ children, isVisualRefresh }: WizardFo
       className={clsx(
         styles['form-header'],
         isVisualRefresh && styles['form-header-refresh'],
-        isVisualRefresh && contentHeaderClassName
+        isVisualRefresh && getContentHeaderClassName()
       )}
       ref={overlapElement}
     >
       <div
         className={clsx(
           styles['form-header-content'],
-          shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+          shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
         )}
       >
         {children}

--- a/src/wizard/wizard-navigation.tsx
+++ b/src/wizard/wizard-navigation.tsx
@@ -55,14 +55,14 @@ export default function Navigation({
         styles.navigation,
         hidden && styles.hidden,
         isVisualRefresh && styles.refresh,
-        shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+        shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
       )}
       aria-label={i18nStrings.navigationAriaLabel}
     >
       <ul
         className={clsx(
           isVisualRefresh && styles.refresh,
-          shouldRemoveHighContrastHeader && styles['remove-high-contrast-header']
+          shouldRemoveHighContrastHeader() && styles['remove-high-contrast-header']
         )}
       >
         {steps.map((step, index: number) =>


### PR DESCRIPTION
### Description

Caching the value of the global flag makes its evaluation dependent on the order in which bundles are loaded and evaluated. This change prevents that from happening.


### How has this been tested?

<!-- How did you test to verify your changes? --> Unit test

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Yes
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ No
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ No
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
