### PR TITLE
fix: Show button dropdown dividers when in mobile

### DIFF
--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -13,6 +13,7 @@ import useHiddenDescription from '../utils/use-hidden-description';
 import InternalIcon, { InternalIconProps } from '../../icon/internal';
 import { useDropdownContext } from '../../internal/components/dropdown/context';
 import { getMenuItemProps } from '../utils/menu-item';
+import { useMobile } from '../../internal/hooks/use-mobile';
 
 const ItemElement = ({
   item,
@@ -27,6 +28,7 @@ const ItemElement = ({
   isKeyboardHighlighted = false,
   variant = 'normal',
 }: ItemProps) => {
+  const isMobile = useMobile();
   const isLink = isLinkItem(item);
   const onClick = (event: React.MouseEvent) => {
     // Stop propagation to parent node and handle event exclusively in here. This ensures
@@ -52,7 +54,7 @@ const ItemElement = ({
         [styles.first]: first,
         [styles.last]: last,
         [styles['has-category-header']]: hasCategoryHeader,
-        [styles['has-expandable-groups']]: hasExpandableGroups,
+        [styles['show-divider']]: last && (!hasExpandableGroups || isMobile),
         [styles['is-focused']]: isKeyboardHighlighted,
       })}
       role="presentation"

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -23,7 +23,7 @@
   &:first-child {
     margin-top: 0;
   }
-  &:not(.has-expandable-groups).last {
+  &.show-divider {
     border-bottom: awsui.$border-item-width solid awsui.$color-border-dropdown-group;
   }
   &.highlighted {


### PR DESCRIPTION
### Description

Fixing a regression from https://github.com/cloudscape-design/components/pull/1902

The dividers between items must be shown when groups are expandable but the viewport is narrow.

### How has this been tested?

Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
