### PR TITLE
fix: Fix button-dropdown bottom border for non-VR

### DIFF
--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -14,6 +14,7 @@ import InternalIcon, { InternalIconProps } from '../../icon/internal';
 import { useDropdownContext } from '../../internal/components/dropdown/context';
 import { getMenuItemProps } from '../utils/menu-item';
 import { useMobile } from '../../internal/hooks/use-mobile';
+import { useVisualRefresh } from '../../internal/hooks/use-visual-mode';
 
 const ItemElement = ({
   item,
@@ -29,6 +30,8 @@ const ItemElement = ({
   variant = 'normal',
 }: ItemProps) => {
   const isMobile = useMobile();
+  const isVisualRefresh = useVisualRefresh();
+
   const isLink = isLinkItem(item);
   const onClick = (event: React.MouseEvent) => {
     // Stop propagation to parent node and handle event exclusively in here. This ensures
@@ -54,7 +57,7 @@ const ItemElement = ({
         [styles.first]: first,
         [styles.last]: last,
         [styles['has-category-header']]: hasCategoryHeader,
-        [styles['show-divider']]: last && (!hasExpandableGroups || isMobile),
+        [styles['show-divider']]: last && (!hasExpandableGroups || isMobile || !isVisualRefresh),
         [styles['is-focused']]: isKeyboardHighlighted,
       })}
       role="presentation"


### PR DESCRIPTION
### Description

Fixing a regression from https://github.com/cloudscape-design/components/pull/1902

In Classic the dropdown has no border so relying on the item borders.

<img width="563" alt="Screenshot 2024-01-26 at 07 31 42" src="https://github.com/cloudscape-design/components/assets/20790937/7a07b18e-2fd7-4260-97e2-1d0ccf9e7ac0">

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
