### PR TITLE
fix: Allow i18nStrings for code editor to be partially provided

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4466,72 +4466,72 @@ The object should contain, among others:
         "properties": Array [
           Object {
             "name": "cursorPosition",
-            "optional": false,
+            "optional": true,
             "type": "(row: number, column: number) => string",
           },
           Object {
             "name": "editorGroupAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "errorState",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "errorStateRecovery",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "errorsTab",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "loadingState",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "paneCloseButtonAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesButtonAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalCancel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalConfirm",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalDarkThemes",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalHeader",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalLightThemes",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "preferencesModalTheme",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
@@ -4551,17 +4551,17 @@ The object should contain, among others:
           },
           Object {
             "name": "preferencesModalWrapLines",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "statusBarGroupAriaLabel",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
           Object {
             "name": "warningsTab",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -517,6 +517,10 @@ describe('Code editor component', () => {
   });
 
   describe('i18n', () => {
+    test("doesn't crash if i18nStrings is an empty object", () => {
+      renderCodeEditor({ i18nStrings: {} });
+    });
+
     test('supports using i18nStrings.loadingState from i18n provider', () => {
       const { container } = render(
         <TestI18nProvider messages={{ 'code-editor': { 'i18nStrings.loadingState': 'Custom loading' } }}>

--- a/src/code-editor/__tests__/preferences-modal.test.tsx
+++ b/src/code-editor/__tests__/preferences-modal.test.tsx
@@ -6,11 +6,11 @@ import { i18nStrings } from './common';
 import { renderCodeEditor } from './util';
 
 function submitPreferences() {
-  screen.getByText(i18nStrings.preferencesModalConfirm).click();
+  screen.getByText(i18nStrings.preferencesModalConfirm!).click();
 }
 
 function cancelPreferences() {
-  screen.getByText(i18nStrings.preferencesModalCancel).click();
+  screen.getByText(i18nStrings.preferencesModalCancel!).click();
 }
 
 function findWrapLinesCheckbox() {

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -235,7 +235,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
               languageLabel={languageLabel}
               cursorPosition={i18n(
                 'i18nStrings.cursorPosition',
-                i18nStrings?.cursorPosition(cursorPosition.row + 1, cursorPosition.column + 1),
+                i18nStrings?.cursorPosition?.(cursorPosition.row + 1, cursorPosition.column + 1),
                 format => format({ row: cursorPosition.row + 1, column: cursorPosition.column + 1 })
               )}
               errorCount={errorCount}

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -140,26 +140,26 @@ export namespace CodeEditorProps {
   }
 
   export interface I18nStrings {
-    loadingState: string;
-    errorState: string;
-    errorStateRecovery: string;
+    loadingState?: string;
+    errorState?: string;
+    errorStateRecovery?: string;
 
-    editorGroupAriaLabel: string;
-    statusBarGroupAriaLabel: string;
+    editorGroupAriaLabel?: string;
+    statusBarGroupAriaLabel?: string;
 
-    cursorPosition: (row: number, column: number) => string;
-    errorsTab: string;
-    warningsTab: string;
-    preferencesButtonAriaLabel: string;
-    paneCloseButtonAriaLabel: string;
+    cursorPosition?: (row: number, column: number) => string;
+    errorsTab?: string;
+    warningsTab?: string;
+    preferencesButtonAriaLabel?: string;
+    paneCloseButtonAriaLabel?: string;
 
-    preferencesModalHeader: string;
-    preferencesModalCancel: string;
-    preferencesModalConfirm: string;
-    preferencesModalWrapLines: string;
-    preferencesModalTheme: string;
-    preferencesModalLightThemes: string;
-    preferencesModalDarkThemes: string;
+    preferencesModalHeader?: string;
+    preferencesModalCancel?: string;
+    preferencesModalConfirm?: string;
+    preferencesModalWrapLines?: string;
+    preferencesModalTheme?: string;
+    preferencesModalLightThemes?: string;
+    preferencesModalDarkThemes?: string;
 
     preferencesModalThemeFilteringPlaceholder?: string;
     preferencesModalThemeFilteringAriaLabel?: string;


### PR DESCRIPTION
### Description

This is something we're supposed to do for all components - this is just one I missed.

Related links, issue #, if available: AWSUI-31051

### How has this been tested?

Unit test. Maybe a little unnecessary, but why not.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
