### PR TITLE
fix: Ensure contexts are consistently reset in different modal-type environments

### DIFF
--- a/src/date-range-picker/index.tsx
+++ b/src/date-range-picker/index.tsx
@@ -16,7 +16,7 @@ import Dropdown from '../internal/components/dropdown';
 import { useFocusTracker } from '../internal/hooks/use-focus-tracker';
 import { useMobile } from '../internal/hooks/use-mobile';
 import ButtonTrigger from '../internal/components/button-trigger';
-import { FormFieldContext, useFormFieldContext } from '../internal/context/form-field-context';
+import { useFormFieldContext } from '../internal/context/form-field-context';
 import InternalIcon from '../icon/internal';
 import { normalizeTimeOffset, shiftTimeOffset } from './time-offset';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -30,6 +30,7 @@ import { joinStrings } from '../internal/utils/strings/join-strings';
 import { formatDateRange, isIsoDateOnly } from '../internal/utils/date-time';
 import { useInternalI18n } from '../i18n/context';
 import { formatValue } from './utils';
+import ResetContextsForModal from '../internal/context/reset-contexts-for-modal.js';
 
 export { DateRangePickerProps };
 
@@ -282,7 +283,7 @@ const DateRangePicker = React.forwardRef(
           dropdownId={dropdownId}
         >
           {/* Reset form field context to prevent a wrapper form field from labelling all inputs inside the dropdown. */}
-          <FormFieldContext.Provider value={{}}>
+          <ResetContextsForModal>
             {isDropDownOpen && (
               <DateRangePickerDropdown
                 startOfWeek={startOfWeek}
@@ -305,7 +306,7 @@ const DateRangePicker = React.forwardRef(
                 customAbsoluteRangeControl={customAbsoluteRangeControl}
               />
             )}
-          </FormFieldContext.Provider>
+          </ResetContextsForModal>
         </Dropdown>
       </div>
     );

--- a/src/internal/context/app-layout-context.ts
+++ b/src/internal/context/app-layout-context.ts
@@ -9,11 +9,13 @@ export interface AppLayoutContextProps {
   setHasStickyBackground?: (hasBackground: boolean) => void;
 }
 
-export const AppLayoutContext = createContext<AppLayoutContextProps>({
+export const defaultValue: AppLayoutContextProps = {
   stickyOffsetTop: 0,
   stickyOffsetBottom: 0,
   mobileBarHeight: 0,
-});
+};
+
+export const AppLayoutContext = createContext(defaultValue);
 
 export function useAppLayoutContext() {
   return useContext(AppLayoutContext);

--- a/src/internal/context/link-default-variant-context.ts
+++ b/src/internal/context/link-default-variant-context.ts
@@ -3,6 +3,8 @@
 import { createContext } from 'react';
 import { LinkProps } from '../../link/interfaces';
 
-export const LinkDefaultVariantContext = createContext<{ defaultVariant: LinkProps.Variant }>({
+export const defaultValue: { defaultVariant: LinkProps.Variant } = {
   defaultVariant: 'secondary',
-});
+};
+
+export const LinkDefaultVariantContext = createContext(defaultValue);

--- a/src/internal/context/reset-contexts-for-modal.tsx
+++ b/src/internal/context/reset-contexts-for-modal.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { FormFieldContext } from './form-field-context';
+import { ButtonContext } from './button-context';
+import { CollectionLabelContext } from './collection-label-context';
+import { InfoLinkLabelContext } from './info-link-label-context';
+import { AppLayoutContext, defaultValue as appLayoutDefaultValue } from './app-layout-context';
+import { LinkDefaultVariantContext, defaultValue as linkDefaultValue } from './link-default-variant-context';
+import {
+  SingleTabStopNavigationContext,
+  defaultValue as singleTabStopDefaultValue,
+} from './single-tab-stop-navigation-context';
+
+/*
+ Use this context-resetter when creating a new modal-type context where typically the contents
+ of the modal should not be affected by the surrounding components/DOM.
+ */
+const ResetContextsForModal = ({ children }: { children: React.ReactNode }) => (
+  <AppLayoutContext.Provider value={appLayoutDefaultValue}>
+    <ButtonContext.Provider value={{ onClick: () => {} }}>
+      <CollectionLabelContext.Provider value={{ assignId: () => {} }}>
+        <FormFieldContext.Provider value={{}}>
+          <InfoLinkLabelContext.Provider value="">
+            <LinkDefaultVariantContext.Provider value={linkDefaultValue}>
+              <SingleTabStopNavigationContext.Provider value={singleTabStopDefaultValue}>
+                {children}
+              </SingleTabStopNavigationContext.Provider>
+            </LinkDefaultVariantContext.Provider>
+          </InfoLinkLabelContext.Provider>
+        </FormFieldContext.Provider>
+      </CollectionLabelContext.Provider>
+    </ButtonContext.Provider>
+  </AppLayoutContext.Provider>
+);
+
+export default ResetContextsForModal;

--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -9,17 +9,19 @@ export interface SingleTabStopNavigationOptions {
   tabIndex?: number;
 }
 
+export const defaultValue: {
+  navigationActive: boolean;
+  registerFocusable(focusable: Element, handler: FocusableChangeHandler): () => void;
+} = {
+  navigationActive: false,
+  registerFocusable: () => () => {},
+};
+
 /**
  * Single tab stop navigation context is used together with keyboard navigation that requires a single tab stop.
  * It instructs interactive elements to override tab indices for just a single one to remain user-focusable.
  */
-export const SingleTabStopNavigationContext = createContext<{
-  navigationActive: boolean;
-  registerFocusable(focusable: Element, handler: FocusableChangeHandler): () => void;
-}>({
-  navigationActive: false,
-  registerFocusable: () => () => {},
-});
+export const SingleTabStopNavigationContext = createContext(defaultValue);
 
 export function useSingleTabStopNavigation(
   focusable: null | React.RefObject<Element>,

--- a/src/modal/__tests__/modal.test.tsx
+++ b/src/modal/__tests__/modal.test.tsx
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import { act, render, fireEvent } from '@testing-library/react';
 import Modal, { ModalProps } from '../../../lib/components/modal';
+import FormField from '../../../lib/components/form-field';
+import Input from '../../../lib/components/input';
 import Select from '../../../lib/components/select';
 import Multiselect from '../../../lib/components/multiselect';
 import Autosuggest from '../../../lib/components/autosuggest';
@@ -504,6 +506,26 @@ describe('Modal component', () => {
 
       unmount();
       expect(document.body).not.toHaveClass(styles['modal-open']);
+    });
+  });
+
+  describe('contexts', () => {
+    it('should not label inputs using a FormField context outside the modal', () => {
+      const modalRoot = document.createElement('div');
+      document.body.appendChild(modalRoot);
+      const { container } = render(
+        <FormField label="Outer label">
+          <Modal onDismiss={() => null} visible={true} modalRoot={modalRoot}>
+            <Input value="input" />
+          </Modal>
+        </FormField>,
+        {
+          container: modalRoot,
+        }
+      );
+      const wrapper = createWrapper(container).findModal()!;
+
+      expect(wrapper.findContent().findInput()!.getElement()).not.toHaveAccessibleName('Outer label');
     });
   });
 });

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -14,7 +14,6 @@ import InternalHeader from '../header/internal';
 import Portal from '../internal/components/portal';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { FormFieldContext } from '../internal/context/form-field-context';
 
 import { disableBodyScrolling, enableBodyScrolling } from './body-scroll';
 import { ModalProps } from './interfaces';
@@ -24,10 +23,10 @@ import FocusLock from '../internal/components/focus-lock';
 import { useInternalI18n } from '../i18n/context';
 import { useIntersectionObserver } from '../internal/hooks/use-intersection-observer';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
-import { ButtonContext } from '../internal/context/button-context';
 import { FunnelNameSelectorContext } from '../internal/analytics/context/analytics-context';
 import { ModalContext } from '../internal/context/modal-context';
 import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
+import ResetContextsForModal from '../internal/context/reset-contexts-for-modal';
 
 type InternalModalProps = SomeRequired<ModalProps, 'size'> & InternalBaseComponentProps;
 
@@ -121,73 +120,71 @@ function InnerModal({
 
   return (
     <FunnelNameSelectorContext.Provider value={`.${styles['header--text']}`}>
-      <ButtonContext.Provider value={{ onClick: () => {} }}>
-        <FormFieldContext.Provider value={{}}>
-          <ModalContext.Provider value={{ isInModal: true }}>
-            <div
-              {...baseProps}
-              className={clsx(
-                styles.root,
-                { [styles.hidden]: !visible },
-                baseProps.className,
-                isRefresh && styles.refresh
-              )}
-              role="dialog"
-              aria-modal={true}
-              aria-labelledby={headerId}
-              onMouseDown={onOverlayMouseDown}
-              onClick={onOverlayClick}
-              ref={mergedRef}
-              style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
-              data-awsui-referrer-id={subStepRef.current?.id}
-            >
-              <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
-                <div
-                  className={clsx(
-                    styles.dialog,
-                    styles[size],
-                    styles[`breakpoint-${breakpoint}`],
-                    isRefresh && styles.refresh
-                  )}
-                  onKeyDown={escKeyHandler}
-                >
-                  <div className={styles.container}>
-                    <div className={styles.header}>
-                      <InternalHeader
-                        variant="h2"
-                        __disableActionsWrapping={true}
-                        actions={
-                          <InternalButton
-                            ariaLabel={closeAriaLabel}
-                            className={styles['dismiss-control']}
-                            variant="modal-dismiss"
-                            iconName="close"
-                            formAction="none"
-                            onClick={onCloseButtonClick}
-                          />
-                        }
-                      >
-                        <span id={headerId} className={styles['header--text']}>
-                          {header}
-                        </span>
-                      </InternalHeader>
-                    </div>
-                    <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
-                      {children}
-                      <div ref={stickySentinelRef} />
-                    </div>
-                    {footer && (
-                      <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
-                        {footer}
-                      </div>
-                    )}
+      <ResetContextsForModal>
+        <ModalContext.Provider value={{ isInModal: true }}>
+          <div
+            {...baseProps}
+            className={clsx(
+              styles.root,
+              { [styles.hidden]: !visible },
+              baseProps.className,
+              isRefresh && styles.refresh
+            )}
+            role="dialog"
+            aria-modal={true}
+            aria-labelledby={headerId}
+            onMouseDown={onOverlayMouseDown}
+            onClick={onOverlayClick}
+            ref={mergedRef}
+            style={footerHeight ? { scrollPaddingBottom: footerHeight } : undefined}
+            data-awsui-referrer-id={subStepRef.current?.id}
+          >
+            <FocusLock disabled={!visible} autoFocus={true} restoreFocus={true} className={styles['focus-lock']}>
+              <div
+                className={clsx(
+                  styles.dialog,
+                  styles[size],
+                  styles[`breakpoint-${breakpoint}`],
+                  isRefresh && styles.refresh
+                )}
+                onKeyDown={escKeyHandler}
+              >
+                <div className={styles.container}>
+                  <div className={styles.header}>
+                    <InternalHeader
+                      variant="h2"
+                      __disableActionsWrapping={true}
+                      actions={
+                        <InternalButton
+                          ariaLabel={closeAriaLabel}
+                          className={styles['dismiss-control']}
+                          variant="modal-dismiss"
+                          iconName="close"
+                          formAction="none"
+                          onClick={onCloseButtonClick}
+                        />
+                      }
+                    >
+                      <span id={headerId} className={styles['header--text']}>
+                        {header}
+                      </span>
+                    </InternalHeader>
                   </div>
+                  <div className={clsx(styles.content, { [styles['no-paddings']]: disableContentPaddings })}>
+                    {children}
+                    <div ref={stickySentinelRef} />
+                  </div>
+                  {footer && (
+                    <div ref={footerRef} className={clsx(styles.footer, footerStuck && styles['footer--stuck'])}>
+                      {footer}
+                    </div>
+                  )}
                 </div>
-              </FocusLock>
-            </div>
-          </ModalContext.Provider>
-        </FormFieldContext.Provider>
-      </ButtonContext.Provider>
+              </div>
+            </FocusLock>
+          </div>
+        </ModalContext.Provider>
+      </ResetContextsForModal>
     </FunnelNameSelectorContext.Provider>
   );
 }

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx';
 
 import { KeyCode } from '../internal/keycode';
 import { getBaseProps } from '../internal/base-component';
-import { FormFieldContext } from '../internal/context/form-field-context';
 
 import Arrow from './arrow';
 import Portal from '../internal/components/portal';
@@ -22,6 +21,7 @@ import { useInternalI18n } from '../i18n/context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
+import ResetContextsForModal from '../internal/context/reset-contexts-for-modal';
 
 export interface InternalPopoverProps extends PopoverProps, InternalBaseComponentProps {
   __onOpen?: NonCancelableEventHandler<null>;
@@ -190,9 +190,9 @@ function InternalPopover(
           {children}
         </span>
       )}
-      <FormFieldContext.Provider value={{}}>
+      <ResetContextsForModal>
         {renderWithPortal ? <Portal>{popoverContent}</Portal> : popoverContent}
-      </FormFieldContext.Provider>
+      </ResetContextsForModal>
     </span>
   );
 }


### PR DESCRIPTION
### Description

This ensures contexts are consistently reset across different modal-type components, both now and hopefully more so in the future.

Amongst other possible edge cases, this fixes a known bug in Table where a Modal in the `header` slot can
override the table's implicit aria label.

Related links, issue #, if available: n/a

### How has this been tested?

Tested locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
