### PR TITLE
fix: Keep previous/next button focused when they are disabled

### DIFF
--- a/src/button/__tests__/internal.test.tsx
+++ b/src/button/__tests__/internal.test.tsx
@@ -30,6 +30,23 @@ test('supports __iconClass property', () => {
   expect(container.querySelector(`button .${styles.icon}`)).toHaveClass('example-class');
 });
 
+test('sets disabled and does not set aria-disabled, when __focusable is not provided', () => {
+  const { container } = render(<InternalButton disabled={true} />);
+
+  const button = container.querySelector('button');
+
+  expect(button).toHaveAttribute('disabled');
+  expect(button).not.toHaveAttribute('aria-disabled');
+});
+
+test('sets aria-disabled when __focusable is provided', () => {
+  const { container } = render(<InternalButton disabled={true} __focusable={true} />);
+  const button = container.querySelector('button');
+
+  expect(button).toHaveAttribute('aria-disabled', 'true');
+  expect(button).not.toHaveAttribute('disabled');
+});
+
 describe('Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -31,7 +31,7 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
     | (React.HTMLAttributes<HTMLAnchorElement> & React.HTMLAttributes<HTMLButtonElement>)
     | Record<`data-${string}`, string>;
   __iconClass?: string;
-  __activated?: boolean;
+  __focusable?: boolean;
 } & InternalBaseComponentProps<HTMLAnchorElement | HTMLButtonElement>;
 
 export const InternalButton = React.forwardRef(
@@ -64,7 +64,7 @@ export const InternalButton = React.forwardRef(
       badge,
       __nativeAttributes,
       __internalRootRef = null,
-      __activated = false,
+      __focusable = false,
       ...props
     }: InternalButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -72,6 +72,7 @@ export const InternalButton = React.forwardRef(
     checkSafeUrl('Button', href);
     const isAnchor = Boolean(href);
     const isNotInteractive = loading || disabled;
+    const hasAriaDisabled = (loading && !disabled) || (disabled && __focusable);
     const shouldHaveContent =
       children && ['icon', 'inline-icon', 'flashbar-icon', 'modal-dismiss'].indexOf(variant) === -1;
 
@@ -132,7 +133,6 @@ export const InternalButton = React.forwardRef(
       [styles.disabled]: isNotInteractive,
       [styles['button-no-wrap']]: !wrapText,
       [styles['button-no-text']]: !shouldHaveContent,
-      [styles['is-activated']]: __activated,
       [styles['full-width']]: shouldHaveContent && fullWidth,
     });
 
@@ -215,8 +215,8 @@ export const InternalButton = React.forwardRef(
         <button
           {...buttonProps}
           type={formAction === 'none' ? 'button' : 'submit'}
-          disabled={disabled}
-          aria-disabled={loading && !disabled ? true : undefined}
+          disabled={disabled && !__focusable}
+          aria-disabled={hasAriaDisabled ? true : undefined}
         >
           {buttonContent}
         </button>

--- a/src/button/styles.scss
+++ b/src/button/styles.scss
@@ -28,8 +28,7 @@
     text-decoration: none;
   }
 
-  &:active,
-  &.is-activated {
+  &:active {
     background: map.get($variant, 'active-background');
     color: map.get($variant, 'active-color');
     border-color: map.get($variant, 'active-border-color');

--- a/src/tabs/__integ__/tabs.test.ts
+++ b/src/tabs/__integ__/tabs.test.ts
@@ -124,12 +124,14 @@ test(
 );
 
 test(
-  'disables left/right arrow when first/last tab is selected',
+  'left/right arrow should have aria-disabled when first/last tab is selected',
   setupTest(async page => {
     await page.hasPaginationButtons(true);
     await expect(page.isExisting(page.paginationButton('left', true))).resolves.toBe(false);
     await expect(page.isExisting(page.paginationButton('right', true))).resolves.toBe(true);
     await page.focusTabHeader();
+    // arrows have a focus ring (and a tab stop) even in disabled state
+    await page.keys(['Tab']);
     // TODO: understand why the following line does not work, and keys have to be sent in a different way
     // await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
     await page.keys(['ArrowRight']);
@@ -160,7 +162,8 @@ test(
   setupTest(async page => {
     await page.setWindowSize({ width: 500, height: 1000 });
     await page.focusTabHeader();
-    await page.keys(['Tab', 'Space']);
+    // arrows have a focus ring (and a tab stop) even in disabled state
+    await page.keys(['Tab', 'Tab', 'Space']);
     await expect(page.isExisting(page.paginationButton('left', true))).resolves.toBe(true);
     await expect(page.isExisting(page.paginationButton('right', true))).resolves.toBe(false);
     await page.keys(['Shift', 'Tab', 'Tab', 'Space']);
@@ -175,6 +178,8 @@ test(
     // This test assumes that one pagination event leads to the end/beginning of the tabs header
     await page.setWindowSize({ width: 500, height: 1000 });
     await page.focusTabHeader();
+    // arrows have a focus ring (and a tab stop) even in disabled state
+    await page.keys('Tab');
     await page.keys('PageDown');
     await expect(page.isExisting(page.paginationButton('left', true))).resolves.toBe(true);
     await expect(page.isExisting(page.paginationButton('right', true))).resolves.toBe(false);
@@ -242,6 +247,10 @@ test(
     setupTest(async page => {
       await page.click('#before');
       await expect(page.findActiveTabIndex()).resolves.toBe(0);
+      if (smallViewport) {
+        // arrows have a focus ring (and a tab stop) even in disabled state
+        await page.keys('Tab');
+      }
       await page.keys(['Tab', 'ArrowRight']);
       await expect(page.findActiveTabIndex()).resolves.toBe(1);
       // TODO: understand why the following line does not work, and keys have to be sent in a different way
@@ -261,6 +270,10 @@ test(
     'has the same arrow home/end keys behavior when paginated',
     setupTest(async page => {
       await page.focusTabHeader();
+      if (smallViewport) {
+        // arrows have a focus ring (and a tab stop) even in disabled state
+        await page.keys('Tab');
+      }
       await page.keys(['End']);
       await expect(page.findActiveTabIndex()).resolves.toBe(5);
       await page.keys(['Home']);

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -133,6 +133,7 @@ export function TabHeaderBar({
             variant="icon"
             iconName="angle-left"
             disabled={!leftOverflow}
+            __focusable={true}
             onClick={() => onPaginationClick(headerBarRef, -1)}
             ariaLabel={i18n('i18nStrings.scrollLeftAriaLabel', i18nStrings?.scrollLeftAriaLabel)}
           />
@@ -155,6 +156,7 @@ export function TabHeaderBar({
             variant="icon"
             iconName="angle-right"
             disabled={!rightOverflow}
+            __focusable={true}
             onClick={() => onPaginationClick(headerBarRef, 1)}
             ariaLabel={i18n('i18nStrings.scrollRightAriaLabel', i18nStrings?.scrollRightAriaLabel)}
           />


### PR DESCRIPTION
### Description

After reaching the end of the tabs list, focus ring gets lost, because previous / next button becomes disabled. It's confusing for users, that's why we want to keep the focus ring while still communicating that button is disabled.

Related links, issue #, if available: AWSUI-30507

### How has this been tested?

* Manually with VO+Chrome 
* New unit test for internal button

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
