### PR TITLE
feat: Support async rendering container in modal components

### DIFF
--- a/pages/modal/async-modal-root.page.tsx
+++ b/pages/modal/async-modal-root.page.tsx
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Modal, Button, ModalProps } from '~components';
+
+const getModalRoot: ModalProps['getModalRoot'] = async () => {
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  const element = document.createElement('div');
+  element.setAttribute('id', 'async-modal-root');
+  document.body.appendChild(element);
+  return element;
+};
+
+const removeModalRoot: ModalProps['removeModalRoot'] = root => {
+  document.body.removeChild(root);
+};
+
+export default function () {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <article>
+      <h1>Modal with async root</h1>
+      <Button data-testid="modal-trigger" onClick={() => setVisible(true)}>
+        Show modal
+      </Button>
+      {visible && (
+        <Modal
+          header="Modal"
+          visible={true}
+          getModalRoot={getModalRoot}
+          removeModalRoot={removeModalRoot}
+          onDismiss={() => setVisible(false)}
+          closeAriaLabel="Close modal"
+        >
+          This modal was rendered in lazy-loaded container
+        </Modal>
+      )}
+    </article>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4519,6 +4519,13 @@ is provided by its parent form field component.
       "type": "number",
     },
     Object {
+      "description": "Use this property to specify a different dynamic modal root for the dialog.
+The function will be called when a user clicks on the trigger button.",
+      "name": "getModalRoot",
+      "optional": true,
+      "type": "() => Promise<HTMLElement>",
+    },
+    Object {
       "description": "An object containing all the necessary localized strings required by the component.
 The object should contain, among others:
 * \`loadingState\` - Specifies the text to display while the component is loading.
@@ -4684,6 +4691,14 @@ You can use any theme provided by Ace.
       "name": "preferences",
       "optional": true,
       "type": "Partial<CodeEditorProps.Preferences>",
+    },
+    Object {
+      "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
+element after a user closes the dialog. The function receives the return value
+of the most recent getModalRoot call as an argument.",
+      "name": "removeModalRoot",
+      "optional": true,
+      "type": "(rootElement: HTMLElement) => void",
     },
     Object {
       "description": "List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
@@ -4958,6 +4973,13 @@ the custom content is displayed at the bottom of the left column within the moda
       "type": "boolean",
     },
     Object {
+      "description": "Use this property to specify a different dynamic modal root for the dialog.
+The function will be called when a user clicks on the trigger button.",
+      "name": "getModalRoot",
+      "optional": true,
+      "type": "() => Promise<HTMLElement>",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
@@ -5054,6 +5076,14 @@ It contains the following:
       "name": "preferences",
       "optional": true,
       "type": "CollectionPreferencesProps.Preferences<CustomPreferenceType>",
+    },
+    Object {
+      "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
+element after a user closes the dialog. The function receives the return value
+of the most recent getModalRoot call as an argument.",
+      "name": "removeModalRoot",
+      "optional": true,
+      "type": "(rootElement: HTMLElement) => void",
     },
     Object {
       "description": "Configures the sticky columns preference.
@@ -9338,6 +9368,13 @@ The event detail contains the \`reason\`, which can be any of the following:
       "type": "boolean",
     },
     Object {
+      "description": "Use this property to specify a different dynamic modal root for the dialog.
+The function will be called when a user clicks on the trigger button.",
+      "name": "getModalRoot",
+      "optional": true,
+      "type": "() => Promise<HTMLElement>",
+    },
+    Object {
       "deprecatedTag": "Custom CSS is not supported. For other use cases, use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).",
       "description": "Adds the specified ID to the root element of the component.",
       "name": "id",
@@ -9346,10 +9383,19 @@ The event detail contains the \`reason\`, which can be any of the following:
     },
     Object {
       "description": "Specifies the HTML element where the modal is rendered.
-If a modal root isn't provided, the modal will render to an element under \`document.body\`.",
+If neither \`modalRoot\` or \`getModalRoot\` properties are provided, the modal will
+render to an element under \`document.body\`.",
       "name": "modalRoot",
       "optional": true,
       "type": "HTMLElement",
+    },
+    Object {
+      "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
+element after a user closes the dialog. The function receives the return value
+of the most recent getModalRoot call as an argument.",
+      "name": "removeModalRoot",
+      "optional": true,
+      "type": "(rootElement: HTMLElement) => void",
     },
     Object {
       "defaultValue": "\\"medium\\"",
@@ -11514,6 +11560,13 @@ The return type of the function should be a promise that resolves to a list of v
       "type": "(bucketName: string, pathPrefix: string) => Promise<ReadonlyArray<S3ResourceSelectorProps.Version>>",
     },
     Object {
+      "description": "Use this property to specify a different dynamic modal root for the dialog.
+The function will be called when a user clicks on the trigger button.",
+      "name": "getModalRoot",
+      "optional": true,
+      "type": "() => Promise<HTMLElement>",
+    },
+    Object {
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": Object {
@@ -11851,6 +11904,14 @@ and 'Size'.",
       "name": "objectsVisibleColumns",
       "optional": true,
       "type": "ReadonlyArray<string>",
+    },
+    Object {
+      "description": "Use this property when \`getModalRoot\` is used to clean up the modal root
+element after a user closes the dialog. The function receives the return value
+of the most recent getModalRoot call as an argument.",
+      "name": "removeModalRoot",
+      "optional": true,
+      "type": "(rootElement: HTMLElement) => void",
     },
     Object {
       "description": "The current selected resource. Resource has the following properties:

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -57,6 +57,8 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     preferences,
     loading,
     themes,
+    getModalRoot,
+    removeModalRoot,
     ...rest
   } = props;
   const { __internalRootRef } = useBaseComponent('CodeEditor', { props: { language } });
@@ -272,6 +274,8 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
           </div>
           {isPreferencesModalVisible && (
             <PreferencesModal
+              getModalRoot={getModalRoot}
+              removeModalRoot={removeModalRoot}
               onConfirm={onPreferencesConfirm}
               onDismiss={onPreferencesDismiss}
               themes={themes ?? DEFAULT_AVAILABLE_THEMES}

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -6,8 +6,9 @@ import { NonCancelableEventHandler } from '../internal/events';
 import { AceModes } from './ace-modes';
 import { DarkThemes, LightThemes } from './ace-themes';
 import { FormFieldControlProps } from '../internal/context/form-field-context';
+import { BaseModalProps } from '../modal/interfaces';
 
-export interface CodeEditorProps extends BaseComponentProps, FormFieldControlProps {
+export interface CodeEditorProps extends BaseComponentProps, FormFieldControlProps, BaseModalProps {
   /**
    * The ace object.
    */

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -30,6 +30,8 @@ interface PreferencesModali18nStrings {
 
 interface PreferencesModalProps {
   preferences?: Partial<CodeEditorProps.Preferences>;
+  getModalRoot: CodeEditorProps['getModalRoot'];
+  removeModalRoot: CodeEditorProps['removeModalRoot'];
 
   i18nStrings: PreferencesModali18nStrings;
 
@@ -70,6 +72,8 @@ export default (props: PreferencesModalProps) => {
     <InternalModal
       size="medium"
       visible={true}
+      getModalRoot={props.getModalRoot}
+      removeModalRoot={props.removeModalRoot}
       onDismiss={props.onDismiss}
       header={props.i18nStrings.header}
       closeAriaLabel={props.i18nStrings.cancel}

--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -51,6 +51,8 @@ export default function CollectionPreferences({
 
   preferences,
   customPreference,
+  getModalRoot,
+  removeModalRoot,
   ...rest
 }: CollectionPreferencesProps) {
   const { __internalRootRef } = useBaseComponent('CollectionPreferences');
@@ -121,6 +123,8 @@ export default function CollectionPreferences({
         <InternalModal
           className={styles['modal-root']}
           visible={true}
+          getModalRoot={getModalRoot}
+          removeModalRoot={removeModalRoot}
           header={i18n('title', title)}
           footer={
             <InternalBox float="right">

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { BaseModalProps } from '../modal/interfaces';
 
-export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps {
+export interface CollectionPreferencesProps<CustomPreferenceType = any> extends BaseComponentProps, BaseModalProps {
   /**
    * Specifies the title of the preferences modal dialog. It is also used as an `aria-label` for the trigger button.
    * @i18n

--- a/src/internal/components/portal/__tests__/portal.test.tsx
+++ b/src/internal/components/portal/__tests__/portal.test.tsx
@@ -1,13 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import Portal, { PortalProps } from '../../../../../lib/components/internal/components/portal';
 
 function renderPortal(props: PortalProps) {
   const { rerender, unmount } = render(<Portal {...props} />);
   return { unmount, rerender: (props: PortalProps) => rerender(<Portal {...props} />) };
 }
+
+jest.mock('@cloudscape-design/component-toolkit/internal', () => ({
+  ...jest.requireActual('@cloudscape-design/component-toolkit/internal'),
+  warnOnce: jest.fn(),
+}));
+
+afterEach(() => {
+  expect(warnOnce).not.toHaveBeenCalled();
+  jest.clearAllMocks();
+});
 
 describe('Portal', () => {
   describe('when container is provided', () => {
@@ -27,6 +38,15 @@ describe('Portal', () => {
       expect(container).toContainHTML('<p>Hello!</p>');
     });
 
+    test('ignores getContainer property', () => {
+      const getContainer = jest.fn();
+      const removeContainer = jest.fn();
+      renderPortal({ children: <p>Hello!</p>, container, getContainer, removeContainer });
+      expect(container).toContainHTML('<p>Hello!</p>');
+      expect(getContainer).not.toHaveBeenCalled();
+      expect(removeContainer).not.toHaveBeenCalled();
+    });
+
     test('cleans up react content inside container when unmounted', () => {
       const { unmount } = renderPortal({ children: <p>Hello!</p>, container });
       unmount();
@@ -38,6 +58,76 @@ describe('Portal', () => {
       rerender({ children: <p>Hello!</p> });
       expect(container).toBeEmptyDOMElement();
       expect(document.body).toHaveTextContent('Hello!');
+    });
+  });
+
+  describe('when getContainer/removeContainer property is provided', () => {
+    test('falls back to default if only getContainer is provided', () => {
+      const getContainer = jest.fn();
+      renderPortal({ children: <p>Hello!</p>, getContainer });
+      expect(getContainer).not.toHaveBeenCalled();
+      expect(warnOnce).toHaveBeenCalledWith('portal', '`removeContainer` is required when `getContainer` is provided');
+      jest.mocked(warnOnce).mockReset();
+    });
+
+    test('falls back to default if only removeContainer is provided', () => {
+      const removeContainer = jest.fn();
+      renderPortal({ children: <p>Hello!</p>, removeContainer });
+      expect(removeContainer).not.toHaveBeenCalled();
+      expect(warnOnce).toHaveBeenCalledWith('portal', '`getContainer` is required when `removeContainer` is provided');
+      jest.mocked(warnOnce).mockReset();
+    });
+
+    test('renders and cleans up async container', async () => {
+      const container = document.createElement('div');
+      const getContainer = jest.fn(async () => {
+        await Promise.resolve();
+        document.body.appendChild(container);
+        return container;
+      });
+      const removeContainer = jest.fn(element => document.body.removeChild(element));
+      const { unmount } = renderPortal({
+        children: <p data-testid="portal-content">Hello!</p>,
+        getContainer,
+        removeContainer,
+      });
+      expect(screen.queryByTestId('portal-content')).toBeFalsy();
+      expect(container).not.toBeInTheDocument();
+      expect(getContainer).toHaveBeenCalled();
+
+      // wait a tick to resolve pending promises
+      await act(() => Promise.resolve());
+      expect(container).toBeInTheDocument();
+      expect(container).toContainElement(screen.queryByTestId('portal-content'));
+
+      unmount();
+      expect(removeContainer).toHaveBeenCalledWith(container);
+      expect(screen.queryByTestId('portal-content')).toBeFalsy();
+      expect(container).not.toBeInTheDocument();
+    });
+
+    describe('console logging', () => {
+      beforeEach(() => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      test('prints a warning if getContainer rejects a promise', async () => {
+        const getContainer = jest.fn(() => Promise.reject('Error for testing'));
+        const removeContainer = jest.fn(() => {});
+        renderPortal({
+          children: <p data-testid="portal-content">Hello!</p>,
+          getContainer,
+          removeContainer,
+        });
+        expect(screen.queryByTestId('portal-content')).toBeFalsy();
+        expect(getContainer).toHaveBeenCalled();
+        expect(console.warn).not.toHaveBeenCalled();
+
+        await Promise.resolve();
+        expect(screen.queryByTestId('portal-content')).toBeFalsy();
+        expect(removeContainer).not.toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalledWith('[AwsUi] [portal]: failed to load portal root', 'Error for testing');
+      });
     });
   });
 

--- a/src/internal/components/portal/index.tsx
+++ b/src/internal/components/portal/index.tsx
@@ -2,17 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useLayoutEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { isDevelopment } from '../../is-development';
 
 export interface PortalProps {
   container?: null | Element;
+  getContainer?: () => Promise<HTMLElement>;
+  removeContainer?: (container: HTMLElement) => void;
   children: React.ReactNode;
+}
+
+function manageDefaultContainer(setState: React.Dispatch<React.SetStateAction<Element | null>>) {
+  const newContainer = document.createElement('div');
+  document.body.appendChild(newContainer);
+  setState(newContainer);
+  return () => {
+    document.body.removeChild(newContainer);
+  };
+}
+
+function manageAsyncContainer(
+  getContainer: () => Promise<HTMLElement>,
+  removeContainer: (container: HTMLElement) => void,
+  setState: React.Dispatch<React.SetStateAction<Element | null>>
+) {
+  let newContainer: HTMLElement;
+  getContainer().then(
+    container => {
+      newContainer = container;
+      setState(container);
+    },
+    error => {
+      console.warn('[AwsUi] [portal]: failed to load portal root', error);
+    }
+  );
+  return () => {
+    removeContainer(newContainer);
+  };
 }
 
 /**
  * A safe react portal component that renders to a provided node.
  * If a node isn't provided, it creates one under document.body.
  */
-export default function Portal({ container, children }: PortalProps) {
+export default function Portal({ container, getContainer, removeContainer, children }: PortalProps) {
   const [activeContainer, setActiveContainer] = useState<Element | null>(container ?? null);
 
   useLayoutEffect(() => {
@@ -20,14 +53,20 @@ export default function Portal({ container, children }: PortalProps) {
       setActiveContainer(container);
       return;
     }
-    const newContainer = document.createElement('div');
-    document.body.appendChild(newContainer);
-    setActiveContainer(newContainer);
-    return () => {
-      document.body.removeChild(newContainer);
-      setActiveContainer(null);
-    };
-  }, [container]);
+    if (isDevelopment) {
+      if (getContainer && !removeContainer) {
+        warnOnce('portal', '`removeContainer` is required when `getContainer` is provided');
+      }
+      if (!getContainer && removeContainer) {
+        warnOnce('portal', '`getContainer` is required when `removeContainer` is provided');
+      }
+    }
+
+    if (getContainer && removeContainer) {
+      return manageAsyncContainer(getContainer, removeContainer, setActiveContainer);
+    }
+    return manageDefaultContainer(setActiveContainer);
+  }, [container, getContainer, removeContainer]);
 
   return activeContainer && createPortal(children, activeContainer);
 }

--- a/src/modal/__integ__/modal.test.ts
+++ b/src/modal/__integ__/modal.test.ts
@@ -94,3 +94,22 @@ test(
     await page.click(footerSelector);
   })
 );
+
+test(
+  'renders modal in async root',
+  useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    const modal = createWrapper().findModal();
+    await browser.url('#/light/modal/async-modal-root');
+
+    // Open modal
+    await page.click('[data-testid="modal-trigger"]');
+    // wait for async modal to appear
+    await page.waitForVisible(modal.toSelector());
+
+    await expect(page.isExisting('#async-modal-root')).resolves.toBe(true);
+
+    await page.click(modal.findDismissButton().toSelector());
+    await expect(page.isExisting('#async-modal-root')).resolves.toBe(false);
+  })
+);

--- a/src/modal/interfaces.ts
+++ b/src/modal/interfaces.ts
@@ -4,7 +4,22 @@ import { BaseComponentProps } from '../internal/base-component';
 import React from 'react';
 import { NonCancelableEventHandler } from '../internal/events';
 
-export interface ModalProps extends BaseComponentProps {
+export interface BaseModalProps {
+  /**
+   * Use this property to specify a different dynamic modal root for the dialog.
+   * The function will be called when a user clicks on the trigger button.
+   */
+  getModalRoot?: () => Promise<HTMLElement>;
+
+  /**
+   * Use this property when `getModalRoot` is used to clean up the modal root
+   * element after a user closes the dialog. The function receives the return value
+   * of the most recent getModalRoot call as an argument.
+   */
+  removeModalRoot?: (rootElement: HTMLElement) => void;
+}
+
+export interface ModalProps extends BaseComponentProps, BaseModalProps {
   /**
    * Sets the width of the modal. `max` uses variable width up to the
    * largest size allowed by the design guidelines. Other sizes
@@ -46,7 +61,8 @@ export interface ModalProps extends BaseComponentProps {
   onDismiss?: NonCancelableEventHandler<ModalProps.DismissDetail>;
   /**
    * Specifies the HTML element where the modal is rendered.
-   * If a modal root isn't provided, the modal will render to an element under `document.body`.
+   * If neither `modalRoot` or `getModalRoot` properties are provided, the modal will
+   * render to an element under `document.body`.
    */
   modalRoot?: HTMLElement;
 }

--- a/src/modal/internal.tsx
+++ b/src/modal/internal.tsx
@@ -30,17 +30,19 @@ import ResetContextsForModal from '../internal/context/reset-contexts-for-modal'
 
 type InternalModalProps = SomeRequired<ModalProps, 'size'> & InternalBaseComponentProps;
 
-export default function InternalModal({ modalRoot, ...rest }: InternalModalProps) {
+export default function InternalModal({ modalRoot, getModalRoot, removeModalRoot, ...rest }: InternalModalProps) {
   return (
-    <Portal container={modalRoot}>
-      <InnerModal {...rest} />
+    <Portal container={modalRoot} getContainer={getModalRoot} removeContainer={removeModalRoot}>
+      <PortaledModal {...rest} />
     </Portal>
   );
 }
 
+type PortaledModalProps = Omit<InternalModalProps, 'modalRoot' | 'getModalRoot' | 'removeModalRoot'>;
+
 // Separate component to prevent the Portal from getting in the way of refs, as it needs extra cycles to render the inner components.
 // useContainerQuery needs its targeted element to exist on the first render in order to work properly.
-function InnerModal({
+function PortaledModal({
   size,
   visible,
   header,
@@ -50,7 +52,7 @@ function InnerModal({
   onDismiss,
   __internalRootRef = null,
   ...rest
-}: InternalModalProps) {
+}: PortaledModalProps) {
   const instanceUniqueId = useUniqueId();
   const headerId = `${rest.id || instanceUniqueId}-header`;
   const lastMouseDownElementRef = useRef<HTMLElement | null>(null);

--- a/src/s3-resource-selector/index.tsx
+++ b/src/s3-resource-selector/index.tsx
@@ -39,6 +39,8 @@ const S3ResourceSelector = React.forwardRef(
       versionsIsItemDisabled,
       onChange,
       ariaLabel,
+      getModalRoot,
+      removeModalRoot,
       ...rest
     }: S3ResourceSelectorProps,
     ref: React.Ref<S3ResourceSelectorProps.Ref>
@@ -74,6 +76,8 @@ const S3ResourceSelector = React.forwardRef(
       fetchVersions,
       versionsVisibleColumns,
       versionsIsItemDisabled,
+      getModalRoot,
+      removeModalRoot,
       onSubmit: resource => {
         fireNonCancelableEvent(onChange, { resource });
         setModalOpen(false);

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -5,8 +5,9 @@ import { TableProps } from '../table/interfaces';
 import { PaginationProps } from '../pagination/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { BaseModalProps } from '../modal/interfaces';
 
-export interface S3ResourceSelectorProps extends BaseComponentProps {
+export interface S3ResourceSelectorProps extends BaseComponentProps, BaseModalProps {
   /**
    * Specifies additional information about component status.
    */

--- a/src/s3-resource-selector/s3-modal/__tests__/utils.ts
+++ b/src/s3-resource-selector/s3-modal/__tests__/utils.ts
@@ -17,6 +17,8 @@ export const modalDefaultProps = {
   objectsIsItemDisabled: undefined,
   versionsIsItemDisabled: undefined,
   i18nStrings,
+  getModalRoot: undefined,
+  removeModalRoot: undefined,
   onSubmit: () => {},
   onDismiss: () => {},
 } as const;

--- a/src/s3-resource-selector/s3-modal/index.tsx
+++ b/src/s3-resource-selector/s3-modal/index.tsx
@@ -29,6 +29,8 @@ export interface S3ModalProps {
   versionsVisibleColumns: ReadonlyArray<string>;
   versionsIsItemDisabled: S3ResourceSelectorProps['versionsIsItemDisabled'];
   i18nStrings: S3ResourceSelectorProps.I18nStrings | undefined;
+  getModalRoot: S3ResourceSelectorProps['getModalRoot'];
+  removeModalRoot: S3ResourceSelectorProps['removeModalRoot'];
   onDismiss: () => void;
   onSubmit: (resource: S3ResourceSelectorProps.Resource) => void;
 }
@@ -103,6 +105,8 @@ export function S3Modal({
   fetchVersions,
   versionsVisibleColumns,
   versionsIsItemDisabled,
+  getModalRoot,
+  removeModalRoot,
   onSubmit,
   onDismiss,
 }: S3ModalProps) {
@@ -121,6 +125,8 @@ export function S3Modal({
       <InternalModal
         visible={true}
         size="max"
+        getModalRoot={getModalRoot}
+        removeModalRoot={removeModalRoot}
         closeAriaLabel={i18nStrings?.labelModalDismiss}
         onDismiss={onDismiss}
         header={i18n('i18nStrings.modalTitle', i18nStrings?.modalTitle)}


### PR DESCRIPTION
### Description

Add `getModalRoot`/`removeModalRoot` properties to support lazy-loaded containers.

Related links, issue #, if available: 6M8sAlwBF9g5

### How has this been tested?

1. Locally, on all changed components
2. Added related unit and integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
