### PR TITLE
feat: Add support for undismissible tokens in token group

### DIFF
--- a/pages/token-group/permutations.page.tsx
+++ b/pages/token-group/permutations.page.tsx
@@ -13,94 +13,132 @@ const i18nStrings: TokenGroupProps.I18nStrings = {
   limitShowMore: 'Show more',
 };
 
+const mixedItems: Array<TokenGroupProps.Item> = [
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    iconAlt: 'amazon-logo',
+    iconUrl: img,
+    description: 'This is item 1',
+    tags: ['CPU-v2', '2Gb RAM'],
+    disabled: false,
+    dismissLabel: 'dismiss',
+  },
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    description: 'This is item 1',
+    tags: [
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+      'CPU-v2',
+      '2Gb RAM',
+    ],
+    disabled: false,
+    dismissLabel: 'dismiss',
+  },
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    iconName: 'calendar',
+    disabled: true,
+    dismissLabel: 'dismiss',
+  },
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    iconName: 'calendar',
+    disabled: false,
+    dismissLabel: 'dismiss',
+  },
+  {
+    label: 'Simple and basic',
+    disabled: true,
+    dismissLabel: 'dismiss',
+  },
+];
+
+const wordWrapItems: Array<TokenGroupProps.Item> = [
+  {
+    label:
+      'AVeryLongWordLabelEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+    labelTag: 'Small label tag',
+  },
+  {
+    label: 'Small label',
+    labelTag:
+      'AVeryLongWordLabelTagEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+  },
+  {
+    label:
+      'A very long label, long enough to wrap the label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
+    labelTag:
+      'A very long label tag, long enough to wrap the tag label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
+  },
+  {
+    label:
+      'AVeryLongWordLabelEnoughToWrapTheLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+    labelTag:
+      'AVeryLongWordLabelTagEnoughToWrapTheTagLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+  },
+];
+
+const withSvgItems: Array<TokenGroupProps.Item> = [
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    iconSvg: (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" key="0">
+        <g>
+          <line x1="5.5" y1="12" x2="5.5" y2="15" />
+          <line x1="0.5" y1="15" x2="10.5" y2="15" />
+          <rect x="1" y="5" width="9" height="7" />
+          <polyline points="5 4 5 1 14 1 14 8 10 8" />
+        </g>
+      </svg>
+    ),
+    description: 'This is item 1',
+    tags: ['CPU-v2', '2Gb RAM'],
+    disabled: false,
+    dismissLabel: 'dismiss',
+  },
+  {
+    label: 'Item 1',
+    labelTag: '128Gb',
+    iconSvg: (
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false">
+        <circle cx="8" cy="8" r="7" />
+        <circle cx="8" cy="8" r="3" />
+      </svg>
+    ),
+    disabled: true,
+    dismissLabel: 'dismiss',
+  },
+];
+
 const permutations = createPermutations<TokenGroupProps>([
   {
+    onDismiss: [
+      () => {
+        /*empty handler to suppress react controlled property warning*/
+      },
+    ],
     i18nStrings: [i18nStrings],
     limit: [undefined, 3],
     alignment: ['horizontal', 'vertical'],
     items: [
-      [
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          iconAlt: 'amazon-logo',
-          iconUrl: img,
-          description: 'This is item 1',
-          tags: ['CPU-v2', '2Gb RAM'],
-          disabled: false,
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          description: 'This is item 1',
-          tags: [
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-            'CPU-v2',
-            '2Gb RAM',
-          ],
-          disabled: false,
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          iconName: 'calendar',
-          disabled: true,
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          iconName: 'calendar',
-          disabled: false,
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Simple and basic',
-          disabled: true,
-          dismissLabel: 'dismiss',
-        },
-      ],
-      [
-        {
-          label:
-            'AVeryLongWordLabelEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
-          labelTag: 'Small label tag',
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Small label',
-          labelTag:
-            'AVeryLongWordLabelTagEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
-          dismissLabel: 'dismiss',
-        },
-        {
-          label:
-            'A very long label, long enough to wrap the label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
-          labelTag:
-            'A very long label tag, long enough to wrap the tag label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
-          dismissLabel: 'dismiss',
-        },
-        {
-          label:
-            'AVeryLongWordLabelEnoughToWrapTheLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
-          labelTag:
-            'AVeryLongWordLabelTagEnoughToWrapTheTagLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
-          dismissLabel: 'dismiss',
-        },
-      ],
+      mixedItems,
+      wordWrapItems,
       [
         {
           label: 'Small label',
@@ -145,39 +183,17 @@ const permutations = createPermutations<TokenGroupProps>([
           dismissLabel: 'dismiss',
         },
       ],
-      [
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          iconSvg: (
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" key="0">
-              <g>
-                <line x1="5.5" y1="12" x2="5.5" y2="15" />
-                <line x1="0.5" y1="15" x2="10.5" y2="15" />
-                <rect x="1" y="5" width="9" height="7" />
-                <polyline points="5 4 5 1 14 1 14 8 10 8" />
-              </g>
-            </svg>
-          ),
-          description: 'This is item 1',
-          tags: ['CPU-v2', '2Gb RAM'],
-          disabled: false,
-          dismissLabel: 'dismiss',
-        },
-        {
-          label: 'Item 1',
-          labelTag: '128Gb',
-          iconSvg: (
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false">
-              <circle cx="8" cy="8" r="7" />
-              <circle cx="8" cy="8" r="3" />
-            </svg>
-          ),
-          disabled: true,
-          dismissLabel: 'dismiss',
-        },
-      ],
+      withSvgItems,
     ],
+  },
+
+  // Non-dimissible token group
+  {
+    onDismiss: [undefined],
+    i18nStrings: [i18nStrings],
+    limit: [undefined],
+    alignment: ['horizontal', 'vertical'],
+    items: [mixedItems, wordWrapItems, withSvgItems],
   },
 ]);
 
@@ -186,17 +202,7 @@ export default function TokenGroupPermutations() {
     <>
       <h1>TokenGroup permutations</h1>
       <ScreenshotArea disableAnimations={true}>
-        <PermutationsView
-          permutations={permutations}
-          render={permutation => (
-            <TokenGroup
-              onDismiss={() => {
-                /*empty handler to suppress react controlled property warning*/
-              }}
-              {...permutation}
-            />
-          )}
-        />
+        <PermutationsView permutations={permutations} render={permutation => <TokenGroup {...permutation} />} />
       </ScreenshotArea>
     </>
   );

--- a/pages/token-group/permutations.page.tsx
+++ b/pages/token-group/permutations.page.tsx
@@ -73,23 +73,27 @@ const wordWrapItems: Array<TokenGroupProps.Item> = [
     label:
       'AVeryLongWordLabelEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
     labelTag: 'Small label tag',
+    dismissLabel: 'dismiss',
   },
   {
     label: 'Small label',
     labelTag:
       'AVeryLongWordLabelTagEnoughToWrapTheTabLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+    dismissLabel: 'dismiss',
   },
   {
     label:
       'A very long label, long enough to wrap the label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
     labelTag:
       'A very long label tag, long enough to wrap the tag label. Ut eleifend nisi non dui imperdiet iaculis. Vestibulum volutpat est mi, nec luctus augue eleifend vel. Ut tellus nisl, ultrices mattis leo non, faucibus aliquet est. Ut eleifend nisi non dui imperdiet iaculis.',
+    dismissLabel: 'dismiss',
   },
   {
     label:
       'AVeryLongWordLabelEnoughToWrapTheLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
     labelTag:
       'AVeryLongWordLabelTagEnoughToWrapTheTagLabelUtEleifendNisiNonDuiImperdietIaculisVestibulumVolutpatEstMiNecLuctusAugueEleifendVelUtTellusNislUltricesMattisLeoNonFaucibusAliquetEstUtEleifendNisiNonDuiImperdietIaculis',
+    dismissLabel: 'dismiss',
   },
 ];
 

--- a/pages/token-group/simple.page.tsx
+++ b/pages/token-group/simple.page.tsx
@@ -30,6 +30,9 @@ export default function TokenGroupPage() {
     <Box padding="xl">
       <h1>Token Group</h1>
       <TokenGroup items={items} onDismiss={onDismiss} i18nStrings={i18nStrings} limit={5} />
+
+      <h1>Non-dismissible token group</h1>
+      <TokenGroup items={items} i18nStrings={i18nStrings} limit={5} />
     </Box>
   );
 }

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14876,8 +14876,10 @@ Object {
   "events": Array [
     Object {
       "cancelable": false,
-      "description": " Called when the user clicks on the dismiss button. The token won't be automatically removed.
- Make sure that you add a listener to this event to update your application state.",
+      "description": "Defining an \`onDismiss\` event makes all tokens in the token group dismissable.
+Called when the user clicks on the dismiss button. The token won't be automatically removed.
+Make sure that you add a listener to this event to update your application state.
+",
       "detailInlineType": Object {
         "name": "TokenGroupProps.DismissDetail",
         "properties": Array [

--- a/src/token-group/__tests__/token-group.test.tsx
+++ b/src/token-group/__tests__/token-group.test.tsx
@@ -49,15 +49,6 @@ describe('TokenGroup', () => {
     },
   ] as TokenGroupProps.Item[];
 
-  test('raises warning without onDismiss property', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    renderTokenGroup({ items });
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      `[AwsUi] [TokenGroup] You provided \`items\` prop without an \`onDismiss\` handler. This will render a read-only component. If the component should be mutable, set an \`onDismiss\` handler.`
-    );
-    consoleWarnSpy.mockRestore();
-  });
-
   test('does not apply "has-items" class when provided an empty items list', () => {
     const wrapper = renderTokenGroup({ items: [], onDismiss });
     expect(wrapper.getElement()).not.toHaveClass(selectors['has-items']);
@@ -66,6 +57,11 @@ describe('TokenGroup', () => {
   test('applies "has-items" class with a non-empty list', () => {
     const wrapper = renderTokenGroup({ items, onDismiss });
     expect(wrapper.getElement()).toHaveClass(selectors['has-items']);
+  });
+
+  test('does not show dismiss buttons if no onDismiss handler is provided', () => {
+    const wrapper = renderTokenGroup({ items });
+    expect(wrapper.findToken(1)?.findDismiss()).toBeNull();
   });
 
   test('aligns tokens horizontally by default', () => {

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -45,8 +45,10 @@ export interface TokenGroupProps extends BaseComponentProps {
    */
   items?: ReadonlyArray<TokenGroupProps.Item>;
   /**
-   *  Called when the user clicks on the dismiss button. The token won't be automatically removed.
-   *  Make sure that you add a listener to this event to update your application state.
+   * Defining an `onDismiss` event makes all tokens in the token group dismissable.
+   *
+   * Called when the user clicks on the dismiss button. The token won't be automatically removed.
+   * Make sure that you add a listener to this event to update your application state.
    */
   onDismiss?: NonCancelableEventHandler<TokenGroupProps.DismissDetail>;
 }

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 
 import Option from '../internal/components/option';
 import { fireNonCancelableEvent } from '../internal/events';
-import checkControlled from '../internal/hooks/check-controlled';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 import { TokenGroupProps } from './interfaces';
@@ -27,12 +26,12 @@ export default function InternalTokenGroup({
   __internalRootRef,
   ...props
 }: InternalTokenGroupProps) {
-  checkControlled('TokenGroup', 'items', items, 'onDismiss', onDismiss);
-
   const [removedItemIndex, setRemovedItemIndex] = useState<null | number>(null);
 
   const baseProps = getBaseProps(props);
   const hasItems = items.length > 0;
+  const dismissible = !!onDismiss;
+
   return (
     <div
       {...baseProps}
@@ -52,10 +51,14 @@ export default function InternalTokenGroup({
           <Token
             ariaLabel={item.label}
             dismissLabel={item.dismissLabel}
-            onDismiss={() => {
-              fireNonCancelableEvent(onDismiss, { itemIndex });
-              setRemovedItemIndex(itemIndex);
-            }}
+            onDismiss={
+              dismissible
+                ? () => {
+                    fireNonCancelableEvent(onDismiss, { itemIndex });
+                    setRemovedItemIndex(itemIndex);
+                  }
+                : undefined
+            }
             disabled={item.disabled}
           >
             <Option option={item} isGenericGroup={false} />

--- a/src/token-group/styles.scss
+++ b/src/token-group/styles.scss
@@ -47,14 +47,17 @@
 .token-box {
   height: 100%;
   border: awsui.$border-field-width solid constants.$token-border-color;
-  padding: styles.$control-padding-vertical awsui.$space-xxs styles.$control-padding-vertical
-    styles.$control-padding-horizontal;
+  padding: styles.$control-padding-vertical styles.$control-padding-horizontal;
   display: flex;
   align-items: flex-start;
   background: constants.$token-background;
   border-radius: awsui.$border-radius-token;
   color: awsui.$color-text-body-default;
   box-sizing: border-box;
+}
+.token-box-dismissible {
+  padding: styles.$control-padding-vertical awsui.$space-xxs styles.$control-padding-vertical
+    styles.$control-padding-horizontal;
 }
 .token-box-error {
   border-color: awsui.$color-border-status-error;

--- a/src/token-group/token.tsx
+++ b/src/token-group/token.tsx
@@ -33,6 +33,7 @@ export function Token({
 }: TokenProps) {
   const errorId = useUniqueId('error');
   const baseProps = getBaseProps(restProps);
+  const dismissible = !!onDismiss;
   return (
     <div
       {...baseProps}
@@ -45,6 +46,7 @@ export function Token({
       <div
         className={clsx(
           styles['token-box'],
+          dismissible && styles['token-box-dismissible'],
           disabled && styles['token-box-disabled'],
           errorText && styles['token-box-error']
         )}


### PR DESCRIPTION
### Description
This change adds support for undismissible tokens in Token Group. When no `onDismiss` event handler is provided, the tokens will no longer render a dismiss button.

Related links, issue #, if available: AWSUI-24723

![Screenshot of regular and non-dismissible token groups](https://github.com/cloudscape-design/components/assets/2446349/f3110d8f-2b9f-45f5-bca6-f03bd7fad267)

Preview: https://d21d5uik3ws71m.cloudfront.net/components/393ba3296dcc838fd33263b240453f3906021b53/dev-pages/index.html#/light/token-group/simple


#### Using the `onDismiss` event vs. adding a new `dismissible` property
I've decided to use the existence of the `onDismiss` function as an indicator for displaying or hiding the dismiss icons. The mean reason for this is that it requires no changes to the component interface. This is not the first time we've used this pattern in the system. Autosuggest determines which loading mechanism to use by checking the existence of a `onLoadItems` callback. The internal Token component also uses this behavior already: https://github.com/cloudscape-design/components/blob/30552b551ca3f17f8523104a6d67a156356a45a2/src/token-group/token.tsx#L53.

Alternatively we could add a new property `dismissible` to control this behavior, but I currently don't see a reason to make that addition to the API.

#### State management changes
This change means that the Token group components changes from being **controlled** to being **controllable**, depending on whether or not the tokens can be dismissed. This will be reflected in the development guidelines.

Note that this would happen even if we decided to go with the new `dismissible` property approach.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
