### PR TITLE
feat: Add support for cloud_editor and cloud_editor_dark themes to code editor

### DIFF
--- a/src/code-editor/ace-themes.ts
+++ b/src/code-editor/ace-themes.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 export const LightThemes = [
   { value: 'chrome', label: 'Chrome' },
   { value: 'clouds', label: 'Clouds' },
@@ -16,6 +17,7 @@ export const LightThemes = [
   { value: 'kuroir', label: 'Kuroir' },
   { value: 'katzenmilch', label: 'KatzenMilch' },
   { value: 'sqlserver', label: 'SQL Server' },
+  { value: 'cloud_editor', label: 'CloudEditor' },
 ] as const;
 
 export const DarkThemes = [
@@ -42,4 +44,5 @@ export const DarkThemes = [
   { value: 'tomorrow_night_eighties', label: 'Tomorrow Night 80s' },
   { value: 'twilight', label: 'Twilight' },
   { value: 'vibrant_ink', label: 'Vibrant Ink' },
+  { value: 'cloud_editor_dark', label: 'CloudEditor Dark' },
 ] as const;

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -11,7 +11,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { CodeEditorProps } from './interfaces';
 import { Pane } from './pane';
 import { useChangeEffect } from './listeners';
-import { DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME, PaneStatus, getLanguageLabel } from './util';
+import { PaneStatus, getLanguageLabel, getDefaultTheme, getDefaultSupportedThemes } from './util';
 import { fireNonCancelableEvent } from '../internal/events';
 import { setupEditor } from './setup-editor';
 import { ResizableBox } from './resizable-box';
@@ -110,7 +110,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
 
   useSyncEditorWrapLines(editor, preferences?.wrapLines);
 
-  const defaultTheme = mode === 'dark' ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME;
+  const defaultTheme = getDefaultTheme(ace, mode);
   useSyncEditorTheme(editor, preferences?.theme ?? defaultTheme);
 
   // Change listeners
@@ -273,7 +273,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
             <PreferencesModal
               onConfirm={onPreferencesConfirm}
               onDismiss={onPreferencesDismiss}
-              themes={themes}
+              themes={themes ?? getDefaultSupportedThemes(ace)}
               preferences={preferences}
               defaultTheme={defaultTheme}
               i18nStrings={{

--- a/src/code-editor/preferences-modal.tsx
+++ b/src/code-editor/preferences-modal.tsx
@@ -33,17 +33,14 @@ interface PreferencesModalProps {
 
   i18nStrings: PreferencesModali18nStrings;
 
-  themes: CodeEditorProps['themes'];
+  themes: CodeEditorProps.AvailableThemes;
   defaultTheme: CodeEditorProps.Theme;
 
   onConfirm: (preferences: CodeEditorProps.Preferences) => void;
   onDismiss: () => void;
 }
 
-function filterThemes(allThemes: ReadonlyArray<SelectProps.Option>, available: ReadonlyArray<string> | undefined) {
-  if (!available) {
-    return allThemes;
-  }
+function filterThemes(allThemes: ReadonlyArray<SelectProps.Option>, available: ReadonlyArray<string>) {
   return allThemes.filter(theme => available.indexOf(theme.value!) > -1);
 }
 
@@ -53,11 +50,11 @@ export default (props: PreferencesModalProps) => {
   const themeOptions = [
     {
       label: props.i18nStrings.lightThemes,
-      options: filterThemes(LightThemes, props.themes?.light),
+      options: filterThemes(LightThemes, props.themes.light),
     },
     {
       label: props.i18nStrings.darkThemes,
-      options: filterThemes(DarkThemes, props.themes?.dark),
+      options: filterThemes(DarkThemes, props.themes.dark),
     },
   ];
   const [selectedThemeOption, setSelectedThemeOption] = useState<SelectProps.Option>(

--- a/src/code-editor/use-editor.tsx
+++ b/src/code-editor/use-editor.tsx
@@ -3,12 +3,14 @@
 
 import { Ace } from 'ace-builds';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCurrentMode } from '@cloudscape-design/component-toolkit/internal';
 import { getAceTheme, getDefaultConfig, getDefaultTheme } from './util';
 import { CodeEditorProps } from './interfaces';
 
 export function useEditor(ace: any, loading?: boolean) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [editor, setEditor] = useState<null | Ace.Editor>(null);
+  const [initialMode] = useState(useCurrentMode(editorRef));
 
   useEffect(() => {
     const elem = editorRef.current;
@@ -19,10 +21,10 @@ export function useEditor(ace: any, loading?: boolean) {
     setEditor(
       ace.edit(elem, {
         ...config,
-        theme: getAceTheme(getDefaultTheme(elem)),
+        theme: getAceTheme(getDefaultTheme(ace, initialMode)),
       })
     );
-  }, [ace, loading]);
+  }, [ace, loading, initialMode]);
 
   return { editorRef, editor };
 }

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -5,16 +5,15 @@ import { Ace } from 'ace-builds';
 import { AceModes } from './ace-modes';
 import { LightThemes, DarkThemes } from './ace-themes';
 import { CodeEditorProps } from './interfaces';
-import { findUpUntil } from '../internal/utils/dom';
 
 export type PaneStatus = 'error' | 'warning' | 'hidden';
 
-export const DEFAULT_LIGHT_THEME: typeof LightThemes[number]['value'] = 'dawn';
-export const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_night_bright';
+const DEFAULT_LIGHT_THEME: typeof LightThemes[number]['value'] = 'cloud_editor';
+const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'cloud_editor_dark';
+const FALLBACK_LIGHT_THEME: typeof LightThemes[number]['value'] = 'dawn';
+const FALLBACK_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_night_bright';
 
-const KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION = [1, 23];
-
-export function supportsKeyboardAccessibility(ace: any): boolean {
+function isAceVersionAbove(ace: any, minVersion: [number, number, number]): boolean {
   // Split semantic version numbers. We don't need a full semver parser for this.
   const semanticVersion = ace?.version?.split('.').map((part: string) => {
     const parsed = parseInt(part);
@@ -24,10 +23,20 @@ export function supportsKeyboardAccessibility(ace: any): boolean {
   return (
     !!semanticVersion &&
     typeof semanticVersion[0] === 'number' &&
-    semanticVersion[0] >= KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION[0] &&
+    semanticVersion[0] >= minVersion[0] &&
     typeof semanticVersion[1] === 'number' &&
-    semanticVersion[1] >= KEYBOARD_ACCESSIBILITY_MIN_ACE_VERSION[1]
+    semanticVersion[1] >= minVersion[1] &&
+    typeof semanticVersion[2] === 'number' &&
+    semanticVersion[2] >= minVersion[2]
   );
+}
+
+export function supportsKeyboardAccessibility(ace: any): boolean {
+  return isAceVersionAbove(ace, [1, 23, 0]);
+}
+
+export function supportsCloudEditorThemes(ace: any): boolean {
+  return isAceVersionAbove(ace, [1, 32, 0]);
 }
 
 export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
@@ -37,12 +46,23 @@ export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
   };
 }
 
-export function getDefaultTheme(element: HTMLElement): CodeEditorProps.Theme {
-  const isDarkMode = !!findUpUntil(
-    element,
-    node => node.classList.contains('awsui-polaris-dark-mode') || node.classList.contains('awsui-dark-mode')
-  );
-  return isDarkMode ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME;
+export function getDefaultTheme(ace: any, mode: 'light' | 'dark'): CodeEditorProps.Theme {
+  if (supportsCloudEditorThemes(ace)) {
+    return mode === 'dark' ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME;
+  } else {
+    return mode === 'dark' ? FALLBACK_DARK_THEME : FALLBACK_LIGHT_THEME;
+  }
+}
+
+export function getDefaultSupportedThemes(ace: any): CodeEditorProps.AvailableThemes {
+  return {
+    light: LightThemes.map(theme => theme.value).filter(
+      value => value !== 'cloud_editor' || supportsCloudEditorThemes(ace)
+    ),
+    dark: DarkThemes.map(theme => theme.value).filter(
+      value => value !== 'cloud_editor_dark' || supportsCloudEditorThemes(ace)
+    ),
+  };
 }
 
 export function getAceTheme(theme: CodeEditorProps.Theme) {


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
