### PR TITLE
fix: Append `todayAriaLabel` in Calendar only if it is provided

### DIFF
--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -124,9 +124,15 @@ describe('aria labels', () => {
       );
       expect(getTodayLabelText(container)).toMatch('TEST TODAY');
     });
+
     test('from deprecated top-level property', () => {
       const { container } = render(<Calendar {...defaultProps} i18nStrings={undefined} todayAriaLabel="TEST TODAY" />);
       expect(getTodayLabelText(container)).toMatch('TEST TODAY');
+    });
+
+    test('does not add `undefined` if not provided', () => {
+      const { container } = render(<Calendar {...defaultProps} i18nStrings={undefined} />);
+      expect(getTodayLabelText(container)).not.toContain('undefined');
     });
   });
 

--- a/src/calendar/grid/index.tsx
+++ b/src/calendar/grid/index.tsx
@@ -152,7 +152,7 @@ export default function Grid({
 
               // Screen-reader announcement for the focused day.
               let dayAnnouncement = getDateLabel(locale, date, 'short');
-              if (isDateOnSameDay) {
+              if (isDateOnSameDay && todayAriaLabel) {
                 dayAnnouncement += '. ' + todayAriaLabel;
               }
 


### PR DESCRIPTION
### Description

In the Calendar, the item representing the current day (i.e, today, regardless whether it is selected or not), is labeled with the date (e.g, `February 12, 2024`) and the `todayAriaLabel` (e.g, `Today`), separated by a dot and a space, like this: `February 12, 2024. Today`. However, if the `todayAriaLabel` happens to not be provided, the resulting ARIA label was `February 12, 2024. undefined`.

This change handles this more gracefully by just not appending the second part and leaving the ARIA label as `February 12, 2024` if the `todayAriaLabel` is not provided.

Noticed while working on #1942.

### How has this been tested?

- New unit test. Verified that it failed before the change
- Manually verified by inspecting the element in the `calendar/simple` dev page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
