### PR TITLE
test: Add unit test coverage for calendar header buttons

### DIFF
--- a/src/calendar/__tests__/calendar.test.tsx
+++ b/src/calendar/__tests__/calendar.test.tsx
@@ -72,6 +72,22 @@ describe('Calendar locale DE', () => {
   });
 });
 
+describe('Calendar header', () => {
+  test('previous button navigates to previous month', () => {
+    const { wrapper } = renderCalendar({ value: '2022-01-07' });
+    expect(wrapper.findHeader().getElement()).toHaveTextContent('January 2022');
+    wrapper.findPreviousButton().click();
+    expect(wrapper.findHeader().getElement()).toHaveTextContent('December 2021');
+  });
+
+  test('next button navigates to next month', () => {
+    const { wrapper } = renderCalendar({ value: '2022-01-07' });
+    expect(wrapper.findHeader().getElement()).toHaveTextContent('January 2022');
+    wrapper.findNextButton().click();
+    expect(wrapper.findHeader().getElement()).toHaveTextContent('February 2022');
+  });
+});
+
 describe('aria labels', () => {
   describe('aria-label', () => {
     test('can be set', () => {


### PR DESCRIPTION
### Description

Moving across months by using the previous month and next month buttons in the Calendar header was not covered by tests.

### How has this been tested?

Added two unit tests, one for navigating to the previous month and one for navigating to the next month.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
