### PR TITLE
fix: Autosuggest warning for undefined enteredTextLabel when using built-in i18n

### DIFF
--- a/src/autosuggest/__tests__/i18n.test.tsx
+++ b/src/autosuggest/__tests__/i18n.test.tsx
@@ -82,4 +82,22 @@ describe('i18n provider', () => {
         .getElement()
     ).toHaveTextContent('Custom selected');
   });
+
+  const spyOnConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+
+  test('should warn when enteredTextLabel is undefined and not using the i18n provider', () => {
+    renderElement(<Autosuggest {...defaultProps} value="1" />);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('A value for enteredTextLabel must be provided'));
+    spyOnConsoleWarn.mockClear();
+  });
+
+  test('should not warn when enteredTextLabel is undefined when using the i18n provider', () => {
+    renderElement(
+      <TestI18nProvider messages={{ autosuggest: { enteredTextLabel: 'Use' } }}>
+        <Autosuggest {...defaultProps} value="1" />
+      </TestI18nProvider>
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+    spyOnConsoleWarn.mockClear();
+  });
 });

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -86,7 +86,8 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     warnOnce('Autosuggest', '`onLoadItems` must be provided for `recoveryText` to be displayed.');
   }
 
-  if (!enteredTextLabel) {
+  const enteredTextLabelI18nTestValue = i18n('enteredTextLabel', undefined, format => format({ value: '' }));
+  if (!enteredTextLabel && enteredTextLabelI18nTestValue === undefined) {
     warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
   }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->


Augments the existing AutoSuggest `enteredTextLabel` check to also check whether the built-in i18n provider is in use so that it no longer provides false positive warnings when using the provider.

<!-- Also include relevant motivation and context. -->

Ran into this issue and thought I'd fix it to prevent it from confusing others.

Related links, issue #, if available: n/a

* Fixes #1926

### How has this been tested?

<!-- How did you test to verify your changes? -->

Added two new unit tests for ensuring desired behaviors:
1. The existing warning is ***still*** triggered when `enteredTextLabel` is undefined and the i18n provider is not in use.
2. No warnings are triggered when `enteredTextLabel` is undefined and the i18n provider is in use.

<!-- How can reviewers test these changes efficiently? -->

```sh
npx jest -c jest.unit.config.js src/autosuggest/__tests__/i18n.test.tsx
```

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
