### PR TITLE
refactor: Move entered text label check to the actual use

### DIFF
--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -10,7 +10,6 @@ import { getTestOptionIndexes } from '../internal/components/options-list/utils/
 import styles from './styles.css.js';
 import { AutosuggestItem } from './interfaces';
 import { HighlightType } from '../internal/components/options-list/utils/use-highlight-option';
-import { useInternalI18n } from '../i18n/context';
 
 export interface AutosuggestOptionProps extends BaseComponentProps {
   nativeAttributes?: React.HTMLAttributes<HTMLDivElement>;
@@ -19,7 +18,6 @@ export interface AutosuggestOptionProps extends BaseComponentProps {
   highlighted: boolean;
   highlightType: HighlightType;
   current: boolean;
-  enteredTextLabel?: (value: string) => string;
   virtualPosition?: number;
   padBottom?: boolean;
   screenReaderContent?: string;
@@ -35,7 +33,6 @@ const AutosuggestOption = (
     highlighted,
     highlightType,
     current,
-    enteredTextLabel,
     virtualPosition,
     padBottom,
     screenReaderContent,
@@ -46,7 +43,6 @@ const AutosuggestOption = (
   ref: React.Ref<HTMLDivElement>
 ) => {
   const baseProps = getBaseProps(rest);
-  const i18n = useInternalI18n('autosuggest');
   const useEntered = 'type' in option && option.type === 'use-entered';
   const isParent = 'type' in option && option.type === 'parent';
   const isChild = 'type' in option && option.type === 'child';
@@ -54,9 +50,7 @@ const AutosuggestOption = (
 
   let optionContent;
   if (useEntered) {
-    optionContent = i18n('enteredTextLabel', enteredTextLabel?.(option.value || ''), format =>
-      format({ value: option.value || '' })
-    );
+    optionContent = option.label;
     // we don't want fancy generated content for screenreader for the "Use..." option,
     // just the visible text is fine
     screenReaderContent = undefined;

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -86,16 +86,12 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     warnOnce('Autosuggest', '`onLoadItems` must be provided for `recoveryText` to be displayed.');
   }
 
-  const enteredTextLabelI18nTestValue = i18n('enteredTextLabel', undefined, format => format({ value: '' }));
-  if (!enteredTextLabel && !enteredTextLabelI18nTestValue) {
-    warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
-  }
-
   const [autosuggestItemsState, autosuggestItemsHandlers] = useAutosuggestItems({
     options: options || [],
     filterValue: value,
     filterText: value,
     filteringType,
+    enteredTextLabel,
     hideEnteredTextLabel: false,
     onSelectItem: (option: AutosuggestItem) => {
       const value = option.value || '';
@@ -225,7 +221,6 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
             highlightText={value}
             listId={listId}
             controlId={controlId}
-            enteredTextLabel={enteredTextLabel}
             handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
             hasDropdownStatus={dropdownStatus.content !== null}
             virtualScroll={virtualScroll}

--- a/src/autosuggest/options-list.tsx
+++ b/src/autosuggest/options-list.tsx
@@ -10,10 +10,7 @@ import PlainList from './plain-list';
 import { useAnnouncement } from '../select/utils/use-announcement';
 
 export interface AutosuggestOptionsListProps
-  extends Pick<
-    AutosuggestProps,
-    'enteredTextLabel' | 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive'
-  > {
+  extends Pick<AutosuggestProps, 'virtualScroll' | 'selectedAriaLabel' | 'renderHighlightedAriaLive'> {
   statusType: AutosuggestProps.StatusType;
   autosuggestItemsState: AutosuggestItemsState;
   autosuggestItemsHandlers: AutosuggestItemsHandlers;
@@ -42,7 +39,6 @@ export default function AutosuggestOptionsList({
   highlightText,
   listId,
   controlId,
-  enteredTextLabel,
   handleLoadMore,
   hasDropdownStatus,
   virtualScroll,
@@ -70,7 +66,6 @@ export default function AutosuggestOptionsList({
       handleLoadMore={handleLoadMore}
       autosuggestItemsState={autosuggestItemsState}
       highlightText={highlightText}
-      enteredTextLabel={enteredTextLabel}
       highlightedA11yProps={highlightedOptionId ? { id: highlightedOptionId } : {}}
       hasDropdownStatus={hasDropdownStatus}
       menuProps={{

--- a/src/autosuggest/plain-list.tsx
+++ b/src/autosuggest/plain-list.tsx
@@ -7,7 +7,7 @@ import { scrollElementIntoView } from '../internal/utils/scrollable-containers';
 import { getBaseProps } from '../internal/base-component';
 
 import AutosuggestOption from './autosuggest-option';
-import { AutosuggestProps, AutosuggestItem } from './interfaces';
+import { AutosuggestItem } from './interfaces';
 import styles from './styles.css.js';
 import { AutosuggestItemsState } from './options-controller';
 
@@ -15,7 +15,6 @@ export interface ListProps {
   autosuggestItemsState: AutosuggestItemsState;
   menuProps: Omit<OptionsListProps, 'children'>;
   handleLoadMore: () => void;
-  enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
   highlightedA11yProps: Record<string, string | number | boolean>;
   hasDropdownStatus?: boolean;
   highlightText: string;
@@ -44,7 +43,6 @@ const PlainList = ({
   autosuggestItemsState,
   handleLoadMore,
   menuProps,
-  enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
   highlightText,
@@ -88,7 +86,6 @@ const PlainList = ({
             current={item.value === highlightText}
             key={index}
             data-mouse-target={index}
-            enteredTextLabel={enteredTextLabel}
             screenReaderContent={screenReaderContent}
             highlightType={autosuggestItemsState.highlightType}
             {...optionProps}

--- a/src/autosuggest/virtual-list.tsx
+++ b/src/autosuggest/virtual-list.tsx
@@ -14,7 +14,6 @@ const VirtualList = ({
   autosuggestItemsState,
   handleLoadMore,
   menuProps,
-  enteredTextLabel,
   highlightedA11yProps,
   hasDropdownStatus,
   highlightText,
@@ -79,7 +78,6 @@ const VirtualList = ({
             highlighted={item === autosuggestItemsState.highlightedOption}
             current={item.value === highlightText}
             data-mouse-target={index}
-            enteredTextLabel={enteredTextLabel}
             virtualPosition={start + (index === 0 ? 1 : 0)}
             screenReaderContent={screenReaderContent}
             ariaSetsize={autosuggestItemsState.items.length}

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -80,6 +80,7 @@ const PropertyFilterAutosuggest = React.forwardRef(
       filterValue: value,
       filterText: highlightText,
       filteringType: 'manual',
+      enteredTextLabel,
       hideEnteredTextLabel: hideEnteredTextOption,
       onSelectItem: (option: AutosuggestItem) => {
         const value = option.value || '';
@@ -177,7 +178,6 @@ const PropertyFilterAutosuggest = React.forwardRef(
           highlightText={highlightText}
           listId={listId}
           controlId={controlId}
-          enteredTextLabel={enteredTextLabel}
           handleLoadMore={autosuggestLoadMoreHandlers.fireLoadMoreOnScroll}
           hasDropdownStatus={dropdownStatus.content !== null}
           virtualScroll={virtualScroll}


### PR DESCRIPTION
### Description

Remove code duplication. Now the warning is printed in the place where the value is actually used

Related links, issue #, if available: n/a

### How has this been tested?

PR build passes. Test for the warning has been already added here: https://github.com/cloudscape-design/components/pull/1966

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
