### PR TITLE
fix: Autosuggest enteredTextLabel required iteration

### DIFF
--- a/src/autosuggest/__tests__/i18n.test.tsx
+++ b/src/autosuggest/__tests__/i18n.test.tsx
@@ -23,7 +23,6 @@ jest.mock('@cloudscape-design/component-toolkit/internal', () => {
 });
 beforeEach(() => {
   (warnOnce as any).mockClear();
-  console.log('clear');
 });
 
 const defaultOptions: AutosuggestProps.Options = [{ value: '1' }, { value: '2' }, { value: '3' }, { value: '4' }];

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -87,7 +87,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   }
 
   const enteredTextLabelI18nTestValue = i18n('enteredTextLabel', undefined, format => format({ value: '' }));
-  if (!enteredTextLabel && enteredTextLabelI18nTestValue === undefined) {
+  if (!enteredTextLabel && !enteredTextLabelI18nTestValue) {
     warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
   }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Further augments the existing AutoSuggest `enteredTextLabel` check from #1966 to also check whether the built-in i18n provider is in use and configured properly so that it no longer provides false positive warnings when using the provider correctly.

<!-- Also include relevant motivation and context. -->

https://github.com/cloudscape-design/components/pull/1966#discussion_r1490853524

Related links, issue #, if available: #1926 

### How has this been tested?

<!-- How did you test to verify your changes? -->

Augmented my previous two new unit tests for ensuring desired behaviors and added two more for testing that the provider is configured properly.

<!-- How can reviewers test these changes efficiently? -->

```sh
npx jest -c jest.unit.config.js src/autosuggest/__tests__/i18n.test.tsx
```

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
