### PR TITLE
chore: Add i18n strings for date picker at month granularity

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -70,6 +70,9 @@ export interface I18nFormatArgTypes {
     "nextMonthAriaLabel": never;
     "previousMonthAriaLabel": never;
     "todayAriaLabel": never;
+    "i18nStrings.nextYearAriaLabel": never;
+    "i18nStrings.previousYearAriaLabel": never;
+    "i18nStrings.currentMonthAriaLabel": never;
   }
   "cards": {
     "ariaLabels.selectionGroupLabel": never;

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Nächster Monat",
     "previousMonthAriaLabel": "Vorheriger Monat",
-    "todayAriaLabel": "Heute"
+    "todayAriaLabel": "Heute",
+    "i18nStrings.nextYearAriaLabel": "Nächstes Jahr",
+    "i18nStrings.previousYearAriaLabel": "Vorheriges Jahr",
+    "i18nStrings.currentMonthAriaLabel": "Kosten des aktuellen Monats"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Elementauswahl"

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",
-    "todayAriaLabel": "Today"
+    "todayAriaLabel": "Today",
+    "i18nStrings.nextYearAriaLabel": "Next year",
+    "i18nStrings.previousYearAriaLabel": "Previous year",
+    "i18nStrings.currentMonthAriaLabel": "Current month"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Item selection"

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Next month",
     "previousMonthAriaLabel": "Previous month",
-    "todayAriaLabel": "Today"
+    "todayAriaLabel": "Today",
+    "i18nStrings.nextYearAriaLabel": "Next year",
+    "i18nStrings.previousYearAriaLabel": "Previous year",
+    "i18nStrings.currentMonthAriaLabel": "Current month"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Item selection"

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Próximo mes",
     "previousMonthAriaLabel": "Mes anterior",
-    "todayAriaLabel": "Hoy"
+    "todayAriaLabel": "Hoy",
+    "i18nStrings.nextYearAriaLabel": "Próximo año",
+    "i18nStrings.previousYearAriaLabel": "Año anterior",
+    "i18nStrings.currentMonthAriaLabel": "Mes actual"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Selección de elementos"

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Mois suivant",
     "previousMonthAriaLabel": "Mois précédent",
-    "todayAriaLabel": "Aujourd'hui"
+    "todayAriaLabel": "Aujourd'hui",
+    "i18nStrings.nextYearAriaLabel": "Année suivante",
+    "i18nStrings.previousYearAriaLabel": "Année précédente",
+    "i18nStrings.currentMonthAriaLabel": "Mois en cours"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Sélection de l'élément"

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Bulan berikutnya",
     "previousMonthAriaLabel": "Bulan sebelumnya",
-    "todayAriaLabel": "Hari ini"
+    "todayAriaLabel": "Hari ini",
+    "i18nStrings.nextYearAriaLabel": "Tahun berikutnya",
+    "i18nStrings.previousYearAriaLabel": "Tahun sebelumnya",
+    "i18nStrings.currentMonthAriaLabel": "Bulan saat ini"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Pemilihan item"

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Mese successivo",
     "previousMonthAriaLabel": "Mese precedente",
-    "todayAriaLabel": "Oggi"
+    "todayAriaLabel": "Oggi",
+    "i18nStrings.nextYearAriaLabel": "Anno successivo",
+    "i18nStrings.previousYearAriaLabel": "Anno precedente",
+    "i18nStrings.currentMonthAriaLabel": "Mese corrente"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Selezione dell'elemento"

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "来月",
     "previousMonthAriaLabel": "前月",
-    "todayAriaLabel": "今日"
+    "todayAriaLabel": "今日",
+    "i18nStrings.nextYearAriaLabel": "翌年",
+    "i18nStrings.previousYearAriaLabel": "前年",
+    "i18nStrings.currentMonthAriaLabel": "当月"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "項目の選択"

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "다음 달",
     "previousMonthAriaLabel": "이전 달",
-    "todayAriaLabel": "오늘"
+    "todayAriaLabel": "오늘",
+    "i18nStrings.nextYearAriaLabel": "내년",
+    "i18nStrings.previousYearAriaLabel": "작년",
+    "i18nStrings.currentMonthAriaLabel": "이번 달"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "항목 선택"

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Próximo mês",
     "previousMonthAriaLabel": "Mês anterior",
-    "todayAriaLabel": "Hoje"
+    "todayAriaLabel": "Hoje",
+    "i18nStrings.nextYearAriaLabel": "Próximo ano",
+    "i18nStrings.previousYearAriaLabel": "Ano anterior",
+    "i18nStrings.currentMonthAriaLabel": "Mês atual"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Seleção de item"

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "Gelecek ay",
     "previousMonthAriaLabel": "Önceki ay",
-    "todayAriaLabel": "Bugün"
+    "todayAriaLabel": "Bugün",
+    "i18nStrings.nextYearAriaLabel": "Gelecek yıl",
+    "i18nStrings.previousYearAriaLabel": "Önceki yıl",
+    "i18nStrings.currentMonthAriaLabel": "Geçerli ay"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "Öğe seçimi"

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "下个月",
     "previousMonthAriaLabel": "上个月",
-    "todayAriaLabel": "今天"
+    "todayAriaLabel": "今天",
+    "i18nStrings.nextYearAriaLabel": "下一年",
+    "i18nStrings.previousYearAriaLabel": "上一年",
+    "i18nStrings.currentMonthAriaLabel": "本月"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "项目选择"

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -52,7 +52,10 @@
   "calendar": {
     "nextMonthAriaLabel": "下個月",
     "previousMonthAriaLabel": "上個月",
-    "todayAriaLabel": "今天"
+    "todayAriaLabel": "今天",
+    "i18nStrings.nextYearAriaLabel": "下一年",
+    "i18nStrings.previousYearAriaLabel": "上一年",
+    "i18nStrings.currentMonthAriaLabel": "當前月份"
   },
   "cards": {
     "ariaLabels.selectionGroupLabel": "項目選擇"


### PR DESCRIPTION
### Description

Add i18n files necessary for #1942.

Related API doc: `GaXpAdXYZDe2`

i18n process doc: `U6XMA8nIG5U2`

### How has this been tested?

No specific tests for the new i18n strings. Tests for the actual ARIA labels will be provided as part of #1942.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
