### PR TITLE
fix: Table wrapper is scrollable regardless of table role

### DIFF
--- a/src/table/table-role/__tests__/table-role-helper.test.ts
+++ b/src/table/table-role/__tests__/table-role-helper.test.ts
@@ -64,7 +64,7 @@ test('scrollable grid props', () => {
   const tableWrapper = getTableWrapperRoleProps({ tableRole, ariaLabel, isScrollable: true });
   const tableProps = getTableRoleProps({ tableRole, ariaLabel, totalItemsCount, totalColumnsCount });
 
-  expect(tableWrapper).toEqual({});
+  expect(tableWrapper).toEqual({ 'aria-label': 'table', role: 'region', tabIndex: 0 });
   expect(tableProps).toEqual({
     role: tableRole,
     'aria-label': ariaLabel,

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -51,7 +51,7 @@ export function getTableWrapperRoleProps(options: { tableRole: TableRole; isScro
   const nativeProps: React.HTMLAttributes<HTMLDivElement> = {};
 
   // When the table is scrollable, the wrapper is made focusable so that keyboard users can scroll it horizontally with arrow keys.
-  if (options.isScrollable && options.tableRole !== 'grid') {
+  if (options.isScrollable) {
     nativeProps.role = 'region';
     nativeProps.tabIndex = 0;
     nativeProps['aria-label'] = options.ariaLabel;


### PR DESCRIPTION
### Description

The table wrapper when scrollable must be always focusable.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
