### PR TITLE
chore: Remove beta drawer API from app layout unit tests

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
-import { describeEachAppLayout, drawerWithoutLabels, isDrawerClosed, renderComponent, testDrawer } from './utils';
+import { describeEachAppLayout, isDrawerClosed, renderComponent, testDrawer, testDrawerWithoutLabels } from './utils';
 import AppLayout from '../../../lib/components/app-layout';
 
 jest.mock('@cloudscape-design/component-toolkit', () => ({
@@ -299,14 +299,9 @@ describeEachAppLayout(size => {
     });
 
     test('Close button does not render a label if is not defined', () => {
-      const drawersOpen = {
-        drawers: {
-          activeDrawerId: 'security',
-          items: drawerWithoutLabels.drawers.items,
-        },
-      };
-
-      const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawersOpen as any)} />);
+      const { wrapper } = renderComponent(
+        <AppLayout activeDrawerId={testDrawerWithoutLabels.id} drawers={[testDrawerWithoutLabels]} />
+      );
 
       expect(wrapper.findActiveDrawerCloseButton()!.getElement()).not.toHaveAttribute('aria-label');
     });

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -34,13 +34,7 @@ describeEachAppLayout(size => {
   });
 
   test('should not apply drawers treatment to the tools if the drawers array is empty', () => {
-    const emptyDrawerItems = {
-      drawers: {
-        ariaLabel: 'Drawers',
-        items: [],
-      },
-    };
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(emptyDrawerItems as any)} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={[]} />);
 
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findToolsToggle()).toBeFalsy();

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -5,12 +5,12 @@ import { act } from 'react-dom/test-utils';
 import { within } from '@testing-library/react';
 import {
   describeEachThemeAppLayout,
-  drawerWithoutLabels,
   isDrawerClosed,
   renderComponent,
   testDrawer,
   manyDrawers,
   splitPanelI18nStrings,
+  testDrawerWithoutLabels,
 } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 import SplitPanel from '../../../lib/components/split-panel';
@@ -480,7 +480,7 @@ describeEachThemeAppLayout(true, theme => {
   });
 
   test('renders roles only when aria labels are not provided', () => {
-    const { wrapper } = renderComponent(<AppLayout contentType="form" {...(drawerWithoutLabels as any)} />);
+    const { wrapper } = renderComponent(<AppLayout drawers={[testDrawerWithoutLabels]} />);
     const drawersAside = within(findMobileToolbar(wrapper)!.getElement()).getByRole('region');
 
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).not.toHaveAttribute('aria-label');

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -10,7 +10,6 @@ import {
   testDrawer,
 } from './utils';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
-import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 import { TOOLS_DRAWER_ID } from '../../../lib/components/app-layout/utils/use-drawers';
 import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
@@ -537,13 +536,11 @@ describeEachAppLayout(size => {
         ariaLabels: { triggerButton: 'ccc' },
         orderPriority: -1,
       });
-      const drawers: { drawers: BetaDrawersProps } = {
-        drawers: {
-          items: [{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd' } }],
-        },
-      };
       const { wrapper } = await renderComponent(
-        <AppLayout {...(drawers as any)} ariaLabels={{ toolsToggle: 'tools toggle' }} />
+        <AppLayout
+          drawers={[{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd', drawerName: 'ddd' } }]}
+          ariaLabels={{ toolsToggle: 'tools toggle' }}
+        />
       );
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
         'bbb',

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -10,7 +10,6 @@ import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-vis
 import { findUpUntil } from '../../../lib/components/internal/utils/dom';
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
 import testutilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
-import { BetaDrawersProps } from '../../../lib/components/app-layout/drawer/interfaces';
 import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';
 import iconStyles from '../../../lib/components/icon/styles.css.js';
 
@@ -150,6 +149,12 @@ export const testDrawer: AppLayoutProps.Drawer = {
   },
 };
 
+export const testDrawerWithoutLabels = {
+  ...testDrawer,
+  // not allowed by types, but we still would like to test this
+  ariaLabels: undefined as unknown as AppLayoutProps.DrawerAriaLabels,
+};
+
 const getDrawerItem = (id: string, badge: boolean): AppLayoutProps.Drawer => {
   return {
     ariaLabels: {
@@ -175,39 +180,3 @@ export const manyDrawers: Array<AppLayoutProps.Drawer> = [
 export const manyDrawersWithBadges: Array<AppLayoutProps.Drawer> = Array.from({ length: 100 }, (_, index) =>
   getDrawerItem(`${index}`, true)
 );
-
-export const resizableDrawer: { drawers: BetaDrawersProps } = {
-  drawers: {
-    ariaLabel: 'Drawers',
-    items: [
-      {
-        ariaLabels: {
-          closeButton: 'Security close button',
-          content: 'Security drawer content',
-          triggerButton: 'Security trigger button',
-          resizeHandle: 'Security resize handle',
-        },
-        resizable: true,
-        content: <span>Security</span>,
-        id: 'security',
-        trigger: {
-          iconName: 'security',
-        },
-      },
-    ],
-  },
-};
-
-export const drawerWithoutLabels: { drawers: BetaDrawersProps } = {
-  drawers: {
-    items: [
-      {
-        content: <span>Security</span>,
-        id: 'security',
-        trigger: {
-          iconName: 'security',
-        },
-      } as BetaDrawersProps['items'][number],
-    ],
-  },
-};

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -615,7 +615,7 @@ const OldAppLayout = React.forwardRef(
               ariaLabels={{
                 openLabel: activeDrawer?.ariaLabels?.triggerButton,
                 closeLabel: activeDrawer?.ariaLabels?.closeButton,
-                mainLabel: activeDrawer?.ariaLabels.drawerName,
+                mainLabel: activeDrawer?.ariaLabels?.drawerName,
                 resizeHandle: activeDrawer?.ariaLabels?.resizeHandle,
               }}
               minWidth={minDrawerSize}


### PR DESCRIPTION
### Description

Still removing beta API from our code. Previous PR: https://github.com/cloudscape-design/components/pull/1955

The source code will be removed in the next batch along with [this dev page](https://github.com/cloudscape-design/components/blob/main/pages/app-layout/with-beta-drawers.page.tsx)

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
