### PR TITLE
chore: Temporarily remove @supports query for :dir() pseudo-class.

### DIFF
--- a/src/internal/styles/direction.scss
+++ b/src/internal/styles/direction.scss
@@ -5,16 +5,8 @@
 
 /* stylelint-disable @cloudscape-design/no-implicit-descendant, plugin/no-unsupported-browser-features, selector-combinator-disallowed-list */
 @mixin with-direction($direction) {
-  @supports selector(:dir(#{$direction})) {
-    &:dir(#{$direction}) {
-      @content;
-    }
-  }
-
-  @supports not selector(:dir(#{$direction})) {
-    html[dir='#{$direction}'] & {
-      @content;
-    }
+  html[dir='#{$direction}'] & {
+    @content;
   }
 }
 /* stylelint-enable @cloudscape-design/no-implicit-descendant, plugin/no-unsupported-browser-features, selector-combinator-disallowed-list */


### PR DESCRIPTION
An [issue is reported in autoprefixer](https://github.com/postcss/autoprefixer/issues/1391) when using the `@supports` query with a pseudo-class. This PR will temporarily remove the use of the `:dir()` pseudo-class in the `with-direction` mixin and instead use on the `dir` attribute selector.