### PR TITLE
feat: Add new `colorBackgroundPageContent` design token for content-rich websites without app layout

### DIFF
--- a/style-dictionary/utils/token-names.ts
+++ b/style-dictionary/utils/token-names.ts
@@ -261,6 +261,7 @@ export type ColorsTokenName =
   | 'colorBackgroundLayoutToggleSelectedDefault'
   | 'colorBackgroundLayoutToggleSelectedHover'
   | 'colorBackgroundLayoutToggleSelectedActive'
+  | 'colorBackgroundPageContent'
   | 'colorBackgroundModalOverlay'
   | 'colorBackgroundNotificationBlue'
   | 'colorBackgroundNotificationGreen'

--- a/style-dictionary/visual-refresh/colors.ts
+++ b/style-dictionary/visual-refresh/colors.ts
@@ -57,6 +57,7 @@ const tokens: StyleDictionary.ColorsDictionary = {
   colorBackgroundLayoutToggleSelectedActive: { light: '{colorBlue600}', dark: '{colorBlue500}' },
   colorBackgroundLayoutToggleSelectedDefault: { light: '{colorBlue600}', dark: '{colorBlue500}' },
   colorBackgroundLayoutToggleSelectedHover: { light: '{colorBlue700}', dark: '{colorBlue400}' },
+  colorBackgroundPageContent: { light: '{colorWhite}', dark: '{colorGrey900}' },
   colorBackgroundModalOverlay: '{colorGreyOpaque70}',
   colorBackgroundNotificationBlue: '{colorBlue600}',
   colorBackgroundNotificationGreen: '{colorGreen600}',

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -162,6 +162,12 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorBackgroundPageContent: {
+    description:
+      "The background color of the entire page on a content-rich website that doesn't use app layout. For example: product pages.",
+    public: true,
+    themeable: true,
+  },
   colorBackgroundNotificationBlue: {
     description: 'Background color for blue notifications. For example: blue badges and info flash messages.',
     public: true,


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
