### PR TITLE
chore: remove Internet Explorer mention from the API documentation

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -794,9 +794,7 @@ By default, the preference is \`{ position: 'bottom' }\`
     },
     Object {
       "description": "If true, the notification slot is rendered above the scrollable
-content area so it is always visible.
-Note that sticky notifications are not supported in Internet Explorer.
-",
+content area so it is always visible.",
       "name": "stickyNotifications",
       "optional": true,
       "type": "boolean",

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -103,8 +103,6 @@ export interface AppLayoutProps extends BaseComponentProps {
   /**
    * If true, the notification slot is rendered above the scrollable
    * content area so it is always visible.
-   *
-   * Note that sticky notifications are not supported in Internet Explorer.
    */
   stickyNotifications?: boolean;
 


### PR DESCRIPTION
### Description

We do not support this browser in any way, no need for special notes.

Checked all other documentation texts, this is the only one remaining

Related links, issue #, if available: n/a

### How has this been tested?

n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
