### PR TITLE
chore: Replace dir attribute with dir pseduo-class

### DIFF
--- a/src/internal/styles/direction.scss
+++ b/src/internal/styles/direction.scss
@@ -3,10 +3,10 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-/* stylelint-disable @cloudscape-design/no-implicit-descendant, plugin/no-unsupported-browser-features, selector-combinator-disallowed-list */
+/* stylelint-disable plugin/no-unsupported-browser-features */
 @mixin with-direction($direction) {
-  html[dir='#{$direction}'] & {
+  &:dir(#{$direction}) {
     @content;
   }
 }
-/* stylelint-enable @cloudscape-design/no-implicit-descendant, plugin/no-unsupported-browser-features, selector-combinator-disallowed-list */
+/* stylelint-enable plugin/no-unsupported-browser-features */


### PR DESCRIPTION
This PR modifies the change made in #1980 due to an autoprefixer limitation. Direction detection will by implemented exclusively by the `:dir()` pseudo-class without browser support detection.