### PR TITLE
fix: Make cloud editor themes opt-in using the `themes` property of code editor

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4652,7 +4652,8 @@ You can use any theme provided by Ace.
     },
     Object {
       "description": "List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
-least one dark theme. If not set explicitly, it will render all Ace themes available for selection.",
+least one dark theme. If not set explicitly, it will render all Ace themes available for selection, except
+\\"cloud_editor\\" and \\"cloud_editor_dark\\".",
       "inlineType": Object {
         "name": "CodeEditorProps.AvailableThemes",
         "properties": Array [

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -31,14 +31,8 @@ afterEach(() => {
 });
 
 describe('Code editor component', () => {
-  const versionSpy = jest.spyOn(aceMock, 'version', 'get').mockReturnValue('1.0.0');
-
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    versionSpy.mockRestore();
   });
 
   it('displays loading screen', () => {
@@ -70,40 +64,35 @@ describe('Code editor component', () => {
     expect(editorMock.session.setMode).toHaveBeenLastCalledWith('ace/mode/javascript');
   });
 
-  it("sets the default light mode theme to dawn if cloud_editor isn't supported", () => {
-    versionSpy.mockReturnValue('1.0.0');
-    renderCodeEditor();
+  it("sets the default light mode theme to dawn if cloud_editor isn't explicitly provided", () => {
+    renderCodeEditor({ themes: { light: ['textmate', 'dawn'], dark: [] } });
     expect(editorMock.setTheme).toHaveBeenLastCalledWith('ace/theme/dawn');
   });
 
-  it('sets the default light mode theme to cloud_editor if ace supports it', () => {
-    versionSpy.mockReturnValue('1.33.0');
-    renderCodeEditor();
+  it('sets the default light mode theme to cloud_editor if explicitly provided', () => {
+    renderCodeEditor({ themes: { light: ['dawn', 'cloud_editor'], dark: [] } });
     expect(editorMock.setTheme).toHaveBeenLastCalledWith('ace/theme/cloud_editor');
   });
 
-  it("sets the default dark mode theme to tomorrow_night_bright if cloud_editor_dark isn't supported", () => {
-    versionSpy.mockReturnValue('1.0.0');
+  it("sets the default dark mode theme to tomorrow_night_bright if cloud_editor_dark isn't provided", () => {
     render(
       <div className="awsui-polaris-dark-mode">
-        <CodeEditor {...defaultProps} />
+        <CodeEditor {...defaultProps} themes={{ light: [], dark: ['tomorrow_night_bright', 'dracula'] }} />
       </div>
     );
     expect(editorMock.setTheme).toHaveBeenLastCalledWith('ace/theme/tomorrow_night_bright');
   });
 
-  it('sets the default dark mode theme to cloud_editor_dark if ace supports it', () => {
-    versionSpy.mockReturnValue('1.33.0');
+  it('sets the default dark mode theme to cloud_editor_dark if explicitly provided', () => {
     render(
       <div className="awsui-polaris-dark-mode">
-        <CodeEditor {...defaultProps} />
+        <CodeEditor {...defaultProps} themes={{ light: [], dark: ['tomorrow_night_bright', 'cloud_editor_dark'] }} />
       </div>
     );
     expect(editorMock.setTheme).toHaveBeenLastCalledWith('ace/theme/cloud_editor_dark');
   });
 
   it('detects alternative dark mode class', () => {
-    versionSpy.mockReturnValue('1.0.0');
     render(
       <div className="awsui-dark-mode">
         <CodeEditor {...defaultProps} />
@@ -113,7 +102,6 @@ describe('Code editor component', () => {
   });
 
   it('does not detect dark mode on non-parent elements', () => {
-    versionSpy.mockReturnValue('1.0.0');
     render(
       <div>
         <div className="awsui-polaris-dark-mode"></div>

--- a/src/code-editor/__tests__/preferences-modal.test.tsx
+++ b/src/code-editor/__tests__/preferences-modal.test.tsx
@@ -3,7 +3,7 @@
 import { screen } from '@testing-library/react';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { i18nStrings } from './common';
-import { renderCodeEditor, aceMock } from './util';
+import { renderCodeEditor } from './util';
 
 function submitPreferences() {
   screen.getByText(i18nStrings.preferencesModalConfirm!).click();
@@ -17,14 +17,8 @@ function findWrapLinesCheckbox() {
   return createWrapper().findModal()!.findContent().findCheckbox()!;
 }
 
-const versionSpy = jest.spyOn(aceMock, 'version', 'get').mockReturnValue('1.0.0');
-
 afterEach(() => {
   jest.clearAllMocks();
-});
-
-afterAll(() => {
-  versionSpy.mockRestore();
 });
 
 test('should not render modal when preferences are not displayed', () => {
@@ -74,7 +68,6 @@ test('should change syntax theme preference via modal', () => {
 });
 
 test('renders all themes by default except cloud editor themes if not supported', () => {
-  versionSpy.mockReturnValue('1.0.0');
   const { wrapper } = renderCodeEditor();
   wrapper.findSettingsButton()!.click();
   const select = createWrapper().findModal()!.findContent().findSelect()!;
@@ -82,13 +75,12 @@ test('renders all themes by default except cloud editor themes if not supported'
   expect(select.findDropdown().findOptions()).toHaveLength(38);
 });
 
-test('renders all themes by default including cloud editor themes if supported', () => {
-  versionSpy.mockReturnValue('1.45.0');
-  const { wrapper } = renderCodeEditor();
+test('renders cloud editor theme if provided', () => {
+  const { wrapper } = renderCodeEditor({ themes: { light: ['cloud_editor'], dark: ['cloud_editor_dark'] } });
   wrapper.findSettingsButton()!.click();
   const select = createWrapper().findModal()!.findContent().findSelect()!;
   select.openDropdown();
-  expect(select.findDropdown().findOptions()).toHaveLength(40);
+  expect(select.findDropdown().findOptions()).toHaveLength(2);
 });
 
 test('should allow limiting themes selection via property', () => {

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -11,7 +11,7 @@ import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { CodeEditorProps } from './interfaces';
 import { Pane } from './pane';
 import { useChangeEffect } from './listeners';
-import { PaneStatus, getLanguageLabel, getDefaultTheme, getDefaultSupportedThemes } from './util';
+import { PaneStatus, getLanguageLabel, getDefaultTheme, DEFAULT_AVAILABLE_THEMES } from './util';
 import { fireNonCancelableEvent } from '../internal/events';
 import { setupEditor } from './setup-editor';
 import { ResizableBox } from './resizable-box';
@@ -84,7 +84,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
   const [cursorPosition, setCursorPosition] = useState<Ace.Point>({ row: 0, column: 0 });
   const [isTabFocused, setTabFocused] = useState<boolean>(false);
 
-  const { editorRef, editor } = useEditor(ace, loading);
+  const { editorRef, editor } = useEditor(ace, themes, loading);
 
   useForwardFocus(ref, editorRef);
 
@@ -110,7 +110,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
 
   useSyncEditorWrapLines(editor, preferences?.wrapLines);
 
-  const defaultTheme = getDefaultTheme(ace, mode);
+  const defaultTheme = getDefaultTheme(mode, themes);
   useSyncEditorTheme(editor, preferences?.theme ?? defaultTheme);
 
   // Change listeners
@@ -274,7 +274,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
             <PreferencesModal
               onConfirm={onPreferencesConfirm}
               onDismiss={onPreferencesDismiss}
-              themes={themes ?? getDefaultSupportedThemes(ace)}
+              themes={themes ?? DEFAULT_AVAILABLE_THEMES}
               preferences={preferences}
               defaultTheme={defaultTheme}
               i18nStrings={{

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -67,7 +67,8 @@ export interface CodeEditorProps extends BaseComponentProps, FormFieldControlPro
 
   /**
    * List of Ace themes available for selection in preferences dialog. Make sure you include at least one light and at
-   * least one dark theme. If not set explicitly, it will render all Ace themes available for selection.
+   * least one dark theme. If not set explicitly, it will render all Ace themes available for selection, except
+   * "cloud_editor" and "cloud_editor_dark".
    */
   themes?: CodeEditorProps.AvailableThemes;
 

--- a/src/code-editor/use-editor.tsx
+++ b/src/code-editor/use-editor.tsx
@@ -7,10 +7,10 @@ import { useCurrentMode } from '@cloudscape-design/component-toolkit/internal';
 import { getAceTheme, getDefaultConfig, getDefaultTheme } from './util';
 import { CodeEditorProps } from './interfaces';
 
-export function useEditor(ace: any, loading?: boolean) {
+export function useEditor(ace: any, themes?: CodeEditorProps.AvailableThemes, loading?: boolean) {
   const editorRef = useRef<HTMLDivElement>(null);
   const [editor, setEditor] = useState<null | Ace.Editor>(null);
-  const [initialMode] = useState(useCurrentMode(editorRef));
+  const [initialTheme] = useState(getAceTheme(getDefaultTheme(useCurrentMode(editorRef), themes)));
 
   useEffect(() => {
     const elem = editorRef.current;
@@ -21,10 +21,10 @@ export function useEditor(ace: any, loading?: boolean) {
     setEditor(
       ace.edit(elem, {
         ...config,
-        theme: getAceTheme(getDefaultTheme(ace, initialMode)),
+        theme: initialTheme,
       })
     );
-  }, [ace, loading, initialMode]);
+  }, [ace, loading, initialTheme]);
 
   return { editorRef, editor };
 }

--- a/src/code-editor/util.ts
+++ b/src/code-editor/util.ts
@@ -8,10 +8,15 @@ import { CodeEditorProps } from './interfaces';
 
 export type PaneStatus = 'error' | 'warning' | 'hidden';
 
-const DEFAULT_LIGHT_THEME: typeof LightThemes[number]['value'] = 'cloud_editor';
-const DEFAULT_DARK_THEME: typeof DarkThemes[number]['value'] = 'cloud_editor_dark';
+const CLOUD_EDITOR_LIGHT_THEME: typeof LightThemes[number]['value'] = 'cloud_editor';
+const CLOUD_EDITOR_DARK_THEME: typeof DarkThemes[number]['value'] = 'cloud_editor_dark';
 const FALLBACK_LIGHT_THEME: typeof LightThemes[number]['value'] = 'dawn';
 const FALLBACK_DARK_THEME: typeof DarkThemes[number]['value'] = 'tomorrow_night_bright';
+
+export const DEFAULT_AVAILABLE_THEMES = {
+  light: LightThemes.map(theme => theme.value).filter(value => value !== CLOUD_EDITOR_LIGHT_THEME),
+  dark: DarkThemes.map(theme => theme.value).filter(value => value !== CLOUD_EDITOR_DARK_THEME),
+};
 
 function isAceVersionAtLeast(ace: any, minVersion: [number, number, number]): boolean {
   // Split semantic version numbers. We don't need a full semver parser for this.
@@ -35,10 +40,6 @@ export function supportsKeyboardAccessibility(ace: any): boolean {
   return isAceVersionAtLeast(ace, [1, 23, 0]);
 }
 
-export function supportsCloudEditorThemes(ace: any): boolean {
-  return isAceVersionAtLeast(ace, [1, 32, 0]);
-}
-
 export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
   return {
     behavioursEnabled: true,
@@ -46,23 +47,19 @@ export function getDefaultConfig(ace: any): Partial<Ace.EditorOptions> {
   };
 }
 
-export function getDefaultTheme(ace: any, mode: 'light' | 'dark'): CodeEditorProps.Theme {
-  if (supportsCloudEditorThemes(ace)) {
-    return mode === 'dark' ? DEFAULT_DARK_THEME : DEFAULT_LIGHT_THEME;
+export function getDefaultTheme(
+  mode: 'light' | 'dark',
+  themes?: CodeEditorProps.AvailableThemes
+): CodeEditorProps.Theme {
+  if (mode === 'light') {
+    return themes?.light.some(value => value === CLOUD_EDITOR_LIGHT_THEME)
+      ? CLOUD_EDITOR_LIGHT_THEME
+      : FALLBACK_LIGHT_THEME;
   } else {
-    return mode === 'dark' ? FALLBACK_DARK_THEME : FALLBACK_LIGHT_THEME;
+    return themes?.dark.some(value => value === CLOUD_EDITOR_DARK_THEME)
+      ? CLOUD_EDITOR_DARK_THEME
+      : FALLBACK_DARK_THEME;
   }
-}
-
-export function getDefaultSupportedThemes(ace: any): CodeEditorProps.AvailableThemes {
-  return {
-    light: LightThemes.map(theme => theme.value).filter(
-      value => value !== 'cloud_editor' || supportsCloudEditorThemes(ace)
-    ),
-    dark: DarkThemes.map(theme => theme.value).filter(
-      value => value !== 'cloud_editor_dark' || supportsCloudEditorThemes(ace)
-    ),
-  };
 }
 
 export function getAceTheme(theme: CodeEditorProps.Theme) {


### PR DESCRIPTION
### Description

A follow up from #1951 - because of the way people load themes, we can't really be sure that they'll have the right theme even if it's technically included in an ace version. So we can no longer do version checks to decide whether we support that theme.

Instead, it's now decided through a kind of hidden "flag" of being provided through the `themes` property. So if you explicitly provide `"cloud_editor"` and `"cloud_editor_dark"` in your list of supported themes, you'll get it.

Related links, issue #, if available: AWSUI-29990

### How has this been tested?

Unit testing, as usual.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
