### PR TITLE
fix: Fix click interactions of dropdown components inside portals

### DIFF
--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PropertyFilterProps } from '~components/property-filter';
 import { states, TableItem } from './table.data';
-import { DateForm, DateTimeForm, formatDateTime, YesNoForm, yesNoFormat } from './custom-forms';
+import {
+  DateForm,
+  DateTimeForm,
+  formatDateTime,
+  formatOwners,
+  OwnerMultiSelectForm,
+  YesNoForm,
+  yesNoFormat,
+} from './custom-forms';
 
 const getStateLabel = (value: TableItem['state']) => (value !== undefined && states[value]) || 'Unknown';
 
@@ -205,6 +213,18 @@ export const filteringProperties: readonly PropertyFilterProps.FilteringProperty
         form: YesNoForm,
         format: yesNoFormat,
         match: (itemValue: boolean, tokenValue: boolean) => itemValue === tokenValue,
+      },
+    ];
+  }
+
+  // This is not recommended as it nests
+  if (def.id === 'owner') {
+    operators = [
+      {
+        operator: '=',
+        form: OwnerMultiSelectForm,
+        format: formatOwners,
+        match: (itemValue: string, tokenValue: string[]) => tokenValue.some(value => itemValue === value),
       },
     ];
   }

--- a/pages/property-filter/custom-forms.tsx
+++ b/pages/property-filter/custom-forms.tsx
@@ -5,8 +5,10 @@ import React, { useEffect, useState } from 'react';
 import { ExtendedOperatorFormProps } from '~components/property-filter/interfaces';
 import Calendar from '~components/calendar';
 import DateInput from '~components/date-input';
+import Multiselect from '~components/multiselect';
 import { FormField, RadioGroup, TimeInput } from '~components';
 import styles from './custom-forms.scss';
+import { allItems } from './table.data';
 
 export function YesNoForm({ value, onChange }: ExtendedOperatorFormProps<boolean>) {
   return (
@@ -181,4 +183,29 @@ function formatTimezoneOffset(isoDate: string, offsetInMinutes?: number) {
     .toFixed(0)
     .padStart(2, '0');
   return `${sign}${hoursOffset}:${minuteOffset}`;
+}
+
+const allOwners = [...new Set(allItems.map(({ owner }) => owner))];
+
+export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormProps<string[]>) {
+  return (
+    <FormField>
+      <Multiselect
+        options={allOwners.map(owner => ({ value: owner, label: owner }))}
+        selectedOptions={value?.map(owner => ({ value: owner, label: owner })) ?? []}
+        onChange={event =>
+          onChange(
+            event.detail.selectedOptions
+              .map(({ value }) => value)
+              .filter((value): value is string => typeof value !== 'undefined')
+          )
+        }
+        expandToViewport={true}
+      />
+    </FormField>
+  );
+}
+
+export function formatOwners(owners: string[]) {
+  return owners.join(', ');
 }

--- a/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
+++ b/src/internal/components/autosuggest-input/__tests__/autosuggest-input.test.tsx
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render as renderJsx } from '@testing-library/react';
+import { fireEvent, render as renderJsx } from '@testing-library/react';
 import AutosuggestInputWrapper from '../../../../../lib/components/test-utils/dom/internal/autosuggest-input';
 import AutosuggestInput, {
   AutosuggestInputRef,
 } from '../../../../../lib/components/internal/components/autosuggest-input';
+import Dropdown from '../../../../../lib/components/internal/components/dropdown';
 import { KeyCode } from '@cloudscape-design/test-utils-core/utils';
 
 function render(jsx: React.ReactElement) {
@@ -285,6 +286,28 @@ describe('blur handling', () => {
     wrapper.findInput().findNativeInput().focus();
     getByTestId('target').focus();
     expect(onBlur).not.toBeCalled();
+    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
+  });
+
+  test('ignores clicks inside dropdown content even if they are rendered in a portal', () => {
+    const onClose = jest.fn();
+    const { wrapper, getByTestId } = render(
+      <div>
+        <AutosuggestInput
+          value="1"
+          onChange={() => undefined}
+          onCloseDropdown={onClose}
+          dropdownContent={
+            <Dropdown trigger={<button />} open={true} expandToViewport={true}>
+              <button data-testid="target">target</button>
+            </Dropdown>
+          }
+        />
+      </div>
+    );
+    wrapper.findInput().findNativeInput().focus();
+    fireEvent.mouseDown(getByTestId('target'));
+    expect(onClose).not.toBeCalled();
     expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
   });
 });

--- a/src/internal/components/autosuggest-input/index.tsx
+++ b/src/internal/components/autosuggest-input/index.tsx
@@ -22,6 +22,7 @@ import { InternalBaseComponentProps } from '../../hooks/use-base-component';
 import { KeyCode } from '../../keycode';
 import styles from './styles.css.js';
 import clsx from 'clsx';
+import { nodeBelongs } from '../../utils/node-belongs';
 
 export interface AutosuggestInputProps
   extends BaseComponentProps,
@@ -235,9 +236,9 @@ const AutosuggestInput = React.forwardRef(
 
       const clickListener = (event: MouseEvent) => {
         if (
-          !inputRef.current?.contains(event.target as Node) &&
-          !dropdownContentRef.current?.contains(event.target as Node) &&
-          !dropdownFooterRef.current?.contains(event.target as Node)
+          !nodeBelongs(inputRef.current, event.target) &&
+          !nodeBelongs(dropdownContentRef.current, event.target) &&
+          !nodeBelongs(dropdownFooterRef.current, event.target)
         ) {
           closeDropdown();
         }

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -24,6 +24,7 @@ import { getFirstFocusable, getLastFocusable } from '../focus-lock/utils.js';
 import { useUniqueId } from '../../hooks/use-unique-id/index.js';
 import customCssProps from '../../generated/custom-css-properties';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
+import { nodeBelongs } from '../../utils/node-belongs';
 
 interface DropdownContainerProps {
   children?: React.ReactNode;
@@ -264,8 +265,8 @@ const Dropdown = ({
   };
 
   const isOutsideDropdown = (element: Element) =>
-    (!wrapperRef.current || !wrapperRef.current.contains(element)) &&
-    (!dropdownContainerRef.current || !dropdownContainerRef.current.contains(element));
+    (!wrapperRef.current || !nodeBelongs(wrapperRef.current, element)) &&
+    (!dropdownContainerRef.current || !nodeBelongs(dropdownContainerRef.current, element));
 
   const focusHandler = (event: React.FocusEvent) => {
     if (!event.relatedTarget || isOutsideDropdown(event.relatedTarget)) {
@@ -360,7 +361,7 @@ const Dropdown = ({
       return;
     }
     const clickListener = (e: MouseEvent) => {
-      if (!dropdownRef.current?.contains(e.target as Node) && !triggerRef.current?.contains(e.target as Node)) {
+      if (!nodeBelongs(dropdownRef.current, e.target) && !nodeBelongs(triggerRef.current, e.target)) {
         fireNonCancelableEvent(onDropdownClose);
       }
     };

--- a/src/internal/utils/__tests__/node-belongs.test.ts
+++ b/src/internal/utils/__tests__/node-belongs.test.ts
@@ -47,4 +47,16 @@ describe('nodeBelongs', () => {
     `;
     expect(nodeBelongs(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(true);
   });
+
+  test('returns "true" when the node is a descendant of the container, both inside a portal', () => {
+    div.innerHTML = `
+      <div id="portal"></div>
+      <div data-awsui-referrer-id="portal">
+        <div id="container1">
+          <div id="node"></div>
+        </div>
+      </div>
+    `;
+    expect(nodeBelongs(div.querySelector('#container1'), div.querySelector('#node') as Node)).toBe(true);
+  });
 });

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -17,8 +17,12 @@ export function nodeBelongs(container: Node | null, target: Node | EventTarget |
   }
   const portal = findUpUntil(
     target as HTMLElement,
-    node => node instanceof HTMLElement && !!node.dataset.awsuiReferrerId
+    node => node === container || (node instanceof HTMLElement && !!node.dataset.awsuiReferrerId)
   );
+  if (portal && portal === container) {
+    // We found the container as a direct ancestor without a portal
+    return true;
+  }
   const referrer = portal instanceof HTMLElement ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
   return referrer ? nodeContains(container, referrer) : nodeContains(container, target);
 }


### PR DESCRIPTION
### Description

Dropdown and Autosuggest had a bug were they only looked at `element.contains()` on the containers to identify clicks and focus/blur events outside of the dropdown. This broke when the some of the contents of a dropdown were rendered through a portal themselves, which specifically happened for the [PropertyFilter with custom forms](https://cloudscape.design/components/property-filter?tabId=playground&example=with-custom-form) when the custom form contained an informational popover or a Select.

Nested dropdowns are clearly not recommended by Cloudscape, but this seems like a general enough issue to want to address as it seems to be recurring (recently in Charts).

In order to fix this, I simply leveraged the existing `nodeBelongs()` utility which was used to fix the mentioned charts issue, using it as a 1:1 replacement for `element.contains()` in Dropdown and Autosuggest.

Related links, issue #, if available: None

### How has this been tested?

<!-- How did you test to verify your changes? -->
1. Tested locally by adding a custom form with Select to the local dev PropertyFilter page. Tested with screenreader, keyboard-only and mouse interactions.
2. Added 5 unit tests and confirmed the entire `unit` suite passed.
3. Confirmed the entire `integ` suite passed with no modifications to tests.

<!-- How can reviewers test these changes efficiently? -->

I updated one of the PropertyFilter dev pages to include one custom form with a Select. You can try it yourself to ensure click and focus behaviors are correct.
![cloudscape-2001](https://github.com/cloudscape-design/components/assets/4647197/17a51279-9fa0-417b-8dd5-ecff601e6cf9)

Once again, I know this pattern isn't recommended, but it's the most straightforward way to test portals in Dropdown.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ ✅
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ ✅
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ ✅

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
