### PR TITLE
fix: Add explicit inline padding to drawer buttons

### DIFF
--- a/src/app-layout/visual-refresh/trigger-button.scss
+++ b/src/app-layout/visual-refresh/trigger-button.scss
@@ -61,6 +61,7 @@ handleSplitPanelMaxWidth function in the context.
   @include trigger-button-styles();
   border-block: none;
   border-inline: none;
+  padding-inline: 0;
   color: awsui.$color-text-layout-toggle;
   cursor: pointer;
   pointer-events: auto;


### PR DESCRIPTION
### Description

Fixes #2008 by setting an explicit inline padding of 0 to drawer buttons. Without it, different devices would add a different padding. Since the text is centered, in most cases this did not matter except in iPad where this padding is big enough (14px) for the text not to fit and be brought to the right.

### How has this been tested?

Tested the `app-layout/default` page in an iPad simulator; compared [this version](https://d21d5uik3ws71m.cloudfront.net/components/ed329558ed7accf4b2859d8bba2c0ea1e35366fb/dev-pages/index.html#/light/app-layout/default) with the fix against [another version](https://d21d5uik3ws71m.cloudfront.net/components/7b579408e48b68b3bc2b6dc98b989c9af62a8b87/dev-pages/index.html#/light/) without the fix.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
