### PR TITLE
fix: Downgrade BackstopJS

### DIFF
--- a/backstop/package-lock.json
+++ b/backstop/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@cloudscape-design/components-backstop",
       "version": "1.0.0",
       "devDependencies": {
-        "backstopjs": "^6.3.19"
+        "backstopjs": "6.3.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -182,17 +182,16 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.1.0.tgz",
-      "integrity": "sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -200,7 +199,7 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.3.0"
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/debug": {
@@ -220,38 +219,11 @@
         }
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@puppeteer/browsers/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -404,9 +376,9 @@
       "dev": true
     },
     "node_modules/backstopjs": {
-      "version": "6.3.19",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-6.3.19.tgz",
-      "integrity": "sha512-LK/Vg5t0rSRYNihD51kfz7Aam01vQgXeHu+sUGOSCAm4H9+jPRzQWRC4ZHZf0DMw/HgXXGCpo073gzHG2np1xQ==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-6.3.11.tgz",
+      "integrity": "sha512-rAeMuJ4x20+DBbZUNMBHtTQ8R2CzmFmfko28IYp16n2eqS8xHoyGLXOnZFhvGY4ALkFiMqFeczsgS+5omoFKEg==",
       "dev": true,
       "dependencies": {
         "@mirzazeyrek/node-resemble-js": "^1.2.1",
@@ -424,7 +396,7 @@
         "path": "^0.12.7",
         "playwright": "^1.40.1",
         "portfinder": "^1.0.32",
-        "puppeteer": "^22.1.0",
+        "puppeteer": "^21.11.0",
         "super-simple-web-server": "^1.1.4",
         "temp": "^0.9.4"
       },
@@ -448,36 +420,6 @@
       "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/bare-fs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.0.tgz",
-      "integrity": "sha512-+VhW202E9eTVGkX7p+TNXtZC4RTzj9JfJW7PtfIbZ7mIQ/QT9uOafQTx7lx2n9ERmWsXvLHF4hStAFn4gl2mQw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "bare-events": "^2.0.0",
-        "bare-os": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
-      "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/bare-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
-      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^2.1.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -624,9 +566,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.9.tgz",
-      "integrity": "sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dev": true,
       "dependencies": {
         "mitt": "3.0.1",
@@ -829,9 +771,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true
     },
     "node_modules/diff": {
@@ -1756,6 +1698,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2119,15 +2067,15 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -2177,38 +2125,38 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.2.0.tgz",
-      "integrity": "sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+      "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
+        "@puppeteer/browsers": "1.9.1",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.2.0"
+        "puppeteer-core": "21.11.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.2.0.tgz",
-      "integrity": "sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
-        "chromium-bidi": "0.5.9",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1249869",
+        "devtools-protocol": "0.0.1232444",
         "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core/node_modules/debug": {
@@ -2571,17 +2519,14 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dev": true,
       "dependencies": {
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
       }
     },
     "node_modules/tar-stream": {
@@ -2800,12 +2745,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -2987,17 +2926,16 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.1.0.tgz",
-      "integrity": "sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dev": true,
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -3011,29 +2949,11 @@
             "ms": "2.1.2"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -3161,9 +3081,9 @@
       "dev": true
     },
     "backstopjs": {
-      "version": "6.3.19",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-6.3.19.tgz",
-      "integrity": "sha512-LK/Vg5t0rSRYNihD51kfz7Aam01vQgXeHu+sUGOSCAm4H9+jPRzQWRC4ZHZf0DMw/HgXXGCpo073gzHG2np1xQ==",
+      "version": "6.3.11",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-6.3.11.tgz",
+      "integrity": "sha512-rAeMuJ4x20+DBbZUNMBHtTQ8R2CzmFmfko28IYp16n2eqS8xHoyGLXOnZFhvGY4ALkFiMqFeczsgS+5omoFKEg==",
       "dev": true,
       "requires": {
         "@mirzazeyrek/node-resemble-js": "^1.2.1",
@@ -3181,7 +3101,7 @@
         "path": "^0.12.7",
         "playwright": "^1.40.1",
         "portfinder": "^1.0.32",
-        "puppeteer": "^22.1.0",
+        "puppeteer": "^21.11.0",
         "super-simple-web-server": "^1.1.4",
         "temp": "^0.9.4"
       }
@@ -3198,36 +3118,6 @@
       "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
       "dev": true,
       "optional": true
-    },
-    "bare-fs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.0.tgz",
-      "integrity": "sha512-+VhW202E9eTVGkX7p+TNXtZC4RTzj9JfJW7PtfIbZ7mIQ/QT9uOafQTx7lx2n9ERmWsXvLHF4hStAFn4gl2mQw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bare-events": "^2.0.0",
-        "bare-os": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
-      }
-    },
-    "bare-os": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
-      "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
-      "dev": true,
-      "optional": true
-    },
-    "bare-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
-      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bare-os": "^2.1.0"
-      }
     },
     "base64-js": {
       "version": "1.5.1",
@@ -3321,9 +3211,9 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.9.tgz",
-      "integrity": "sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dev": true,
       "requires": {
         "mitt": "3.0.1",
@@ -3472,9 +3362,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true
     },
     "diff": {
@@ -4165,6 +4055,12 @@
         "minimist": "^1.2.6"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4434,15 +4330,15 @@
       }
     },
     "proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "dev": true,
       "requires": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -4483,27 +4379,27 @@
       }
     },
     "puppeteer": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.2.0.tgz",
-      "integrity": "sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+      "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "2.1.0",
+        "@puppeteer/browsers": "1.9.1",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.2.0"
+        "puppeteer-core": "21.11.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.2.0.tgz",
-      "integrity": "sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "requires": {
-        "@puppeteer/browsers": "2.1.0",
-        "chromium-bidi": "0.5.9",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1249869",
+        "devtools-protocol": "0.0.1232444",
         "ws": "8.16.0"
       },
       "dependencies": {
@@ -4779,13 +4675,12 @@
       }
     },
     "tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dev": true,
       "requires": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0",
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
       }
@@ -4959,12 +4854,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/backstop/package.json
+++ b/backstop/package.json
@@ -2,6 +2,6 @@
   "name": "@cloudscape-design/components-backstop",
   "version": "1.0.0",
   "devDependencies": {
-    "backstopjs": "^6.3.19"
+    "backstopjs": "6.3.11"
   }
 }


### PR DESCRIPTION
### Description

This PR downgrades BackstopJS. A [recent BackstopJS upgrade](https://github.com/cloudscape-design/components/pull/2005) introduced errors in visual regression checks.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
