### PR TITLE
chore: Add test page for default theme resolution and styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.23.0",
+        "ace-builds": "^1.32.6",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -4200,9 +4200,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.0.tgz",
-      "integrity": "sha512-PKRuQaQkjIhg1zeqJPW1QFtJO2fx13Nlv7N/VLhQS/kIQ/2aGAgWvYVcE9X64gbSiLzPdY3jcxv5wJJpLj1gLw=="
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.6.tgz",
+      "integrity": "sha512-dO5BnyDOhCnznhOpILzXq4jqkbhRXxNkf3BuVTmyxGyRLrhddfdyk6xXgy+7A8LENrcYoFi/sIxMuH3qjNUN4w=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -23694,9 +23694,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.0.tgz",
-      "integrity": "sha512-PKRuQaQkjIhg1zeqJPW1QFtJO2fx13Nlv7N/VLhQS/kIQ/2aGAgWvYVcE9X64gbSiLzPdY3jcxv5wJJpLj1gLw=="
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.6.tgz",
+      "integrity": "sha512-dO5BnyDOhCnznhOpILzXq4jqkbhRXxNkf3BuVTmyxGyRLrhddfdyk6xXgy+7A8LENrcYoFi/sIxMuH3qjNUN4w=="
     },
     "acorn": {
       "version": "8.8.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.23.0",
+    "ace-builds": "^1.32.6",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",

--- a/pages/code-editor/themes.page.tsx
+++ b/pages/code-editor/themes.page.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import CodeEditor, { CodeEditorProps } from '~components/code-editor';
+import SpaceBetween from '~components/space-between';
+import ScreenshotArea from '../utils/screenshot-area';
+import { i18nStrings } from './base-props';
+import { sayHelloSample } from './code-samples';
+
+import 'ace-builds/css/ace.css';
+import 'ace-builds/css/theme/dawn.css';
+import 'ace-builds/css/theme/tomorrow_night_bright.css';
+import 'ace-builds/css/theme/cloud_editor.css';
+import 'ace-builds/css/theme/cloud_editor_dark.css';
+
+const THEME_GROUPS = [
+  // Default (dawn/tomorrow_night_bright)
+  { light: ['dawn', 'github'], dark: ['tomorrow_night_bright', 'dracula'] },
+  // Default if cloud editor themes are provided (cloud_editor/cloud_editor_dark)
+  { light: ['cloud_editor', 'dawn'], dark: ['cloud_editor_dark', 'tomorrow_night_bright'] },
+];
+
+interface IState {
+  ace: any;
+  value: string;
+  language: CodeEditorProps.Language;
+  preferences?: CodeEditorProps.Preferences;
+  loading: boolean;
+}
+
+export default class App extends React.PureComponent<null, IState> {
+  initialValue = sayHelloSample;
+
+  constructor(props: null) {
+    super(props);
+    this.state = {
+      ace: undefined,
+      value: this.initialValue,
+      language: 'javascript',
+      preferences: undefined,
+      loading: true,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ loading: true });
+
+    import('ace-builds').then(ace => {
+      ace.config.set('basePath', './ace/');
+      ace.config.set('themePath', './ace/');
+      ace.config.set('modePath', './ace/');
+      ace.config.set('workerPath', './ace/');
+      ace.config.set('useStrictCSP', true);
+      this.setState({ ace, loading: false });
+    });
+  }
+
+  onPreferencesChange(preferences: CodeEditorProps.Preferences) {
+    this.setState({ preferences });
+  }
+
+  render() {
+    return (
+      <article>
+        <h1>Code Editor - themes</h1>
+        <ScreenshotArea style={{ maxWidth: 960 }}>
+          <SpaceBetween size="xs">
+            {THEME_GROUPS.map((themes, i) => (
+              <CodeEditor
+                key={i}
+                ace={this.state.ace}
+                value={this.state.value}
+                language="javascript"
+                onDelayedChange={e => this.setState({ value: e.detail.value })}
+                preferences={this.state.preferences}
+                onPreferencesChange={e => this.onPreferencesChange(e.detail)}
+                loading={this.state.loading}
+                themes={themes}
+                i18nStrings={i18nStrings}
+              />
+            ))}
+          </SpaceBetween>
+        </ScreenshotArea>
+      </article>
+    );
+  }
+}

--- a/pages/code-editor/themes.page.tsx
+++ b/pages/code-editor/themes.page.tsx
@@ -40,7 +40,6 @@ function DemoCodeEditor({
 
 export default function ThemesPage() {
   const [ace, setAce] = useState<any>();
-  console.log(ace);
 
   useEffect(() => {
     import('ace-builds').then(loadedAce => {

--- a/pages/code-editor/themes.page.tsx
+++ b/pages/code-editor/themes.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import CodeEditor, { CodeEditorProps } from '~components/code-editor';
 import SpaceBetween from '~components/space-between';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -13,75 +13,74 @@ import 'ace-builds/css/theme/tomorrow_night_bright.css';
 import 'ace-builds/css/theme/cloud_editor.css';
 import 'ace-builds/css/theme/cloud_editor_dark.css';
 
-const THEME_GROUPS = [
-  // Default (dawn/tomorrow_night_bright)
-  { light: ['dawn', 'github'], dark: ['tomorrow_night_bright', 'dracula'] },
-  // Default if cloud editor themes are provided (cloud_editor/cloud_editor_dark)
-  { light: ['cloud_editor', 'dawn'], dark: ['cloud_editor_dark', 'tomorrow_night_bright'] },
-];
-
-interface IState {
+function DemoCodeEditor({
+  ace,
+  loading,
+  themes,
+  preferences,
+}: {
   ace: any;
-  value: string;
-  language: CodeEditorProps.Language;
-  preferences?: CodeEditorProps.Preferences;
   loading: boolean;
+  themes: CodeEditorProps.AvailableThemes;
+  preferences?: CodeEditorProps.Preferences;
+}) {
+  return (
+    <CodeEditor
+      ace={ace}
+      value={sayHelloSample}
+      language="javascript"
+      preferences={preferences}
+      onPreferencesChange={() => {}}
+      loading={loading}
+      themes={themes}
+      i18nStrings={i18nStrings}
+    />
+  );
 }
 
-export default class App extends React.PureComponent<null, IState> {
-  initialValue = sayHelloSample;
+export default function ThemesPage() {
+  const [ace, setAce] = useState<any>();
+  console.log(ace);
 
-  constructor(props: null) {
-    super(props);
-    this.state = {
-      ace: undefined,
-      value: this.initialValue,
-      language: 'javascript',
-      preferences: undefined,
-      loading: true,
-    };
-  }
-
-  componentDidMount() {
-    this.setState({ loading: true });
-
-    import('ace-builds').then(ace => {
-      ace.config.set('basePath', './ace/');
-      ace.config.set('themePath', './ace/');
-      ace.config.set('modePath', './ace/');
-      ace.config.set('workerPath', './ace/');
-      ace.config.set('useStrictCSP', true);
-      this.setState({ ace, loading: false });
+  useEffect(() => {
+    import('ace-builds').then(loadedAce => {
+      loadedAce.config.set('basePath', './ace/');
+      loadedAce.config.set('themePath', './ace/');
+      loadedAce.config.set('modePath', './ace/');
+      loadedAce.config.set('workerPath', './ace/');
+      loadedAce.config.set('useStrictCSP', true);
+      setAce(loadedAce);
     });
-  }
+  }, []);
 
-  onPreferencesChange(preferences: CodeEditorProps.Preferences) {
-    this.setState({ preferences });
-  }
+  return (
+    <article>
+      <h1>Code Editor - themes</h1>
+      <ScreenshotArea style={{ maxWidth: 960 }}>
+        <SpaceBetween size="xs">
+          {/* Default (dawn/tomorrow_night_bright) */}
+          <DemoCodeEditor
+            ace={ace}
+            loading={!ace}
+            themes={{ light: ['dawn', 'github'], dark: ['tomorrow_night_bright', 'dracula'] }}
+          />
 
-  render() {
-    return (
-      <article>
-        <h1>Code Editor - themes</h1>
-        <ScreenshotArea style={{ maxWidth: 960 }}>
-          <SpaceBetween size="xs">
-            {THEME_GROUPS.map((themes, i) => (
-              <CodeEditor
-                key={i}
-                ace={this.state.ace}
-                value={this.state.value}
-                language="javascript"
-                onDelayedChange={e => this.setState({ value: e.detail.value })}
-                preferences={this.state.preferences}
-                onPreferencesChange={e => this.onPreferencesChange(e.detail)}
-                loading={this.state.loading}
-                themes={themes}
-                i18nStrings={i18nStrings}
-              />
-            ))}
-          </SpaceBetween>
-        </ScreenshotArea>
-      </article>
-    );
-  }
+          {/* Default if cloud editor themes are provided (cloud_editor/cloud_editor_dark) */}
+          <DemoCodeEditor
+            ace={ace}
+            loading={!ace}
+            themes={{ light: ['cloud_editor', 'dawn'], dark: ['cloud_editor_dark', 'tomorrow_night_bright'] }}
+          />
+
+          {/* Invalid theme value */}
+          <DemoCodeEditor
+            ace={ace}
+            loading={!ace}
+            themes={{ light: ['cloud_editor'], dark: ['cloud_editor_dark'] }}
+            preferences={{ theme: 'ambiance', wrapLines: true }}
+          />
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
 }


### PR DESCRIPTION
### Description

Ongoing discussion internally about themes and testing. Let's just add another dev page, why not

Related links, issue #, if available: n/a

### How has this been tested?

This page will be screenshot tested. One group of themes for light mode, and another group for dark mode.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
