### PR TITLE
feat: Include user interaction in latency metrics

### DIFF
--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -48,7 +48,7 @@ const Button = React.forwardRef(
       componentName: 'Button',
       elementRef: baseComponentProps.__internalRootRef,
       loading,
-      // TODO: Add the instanceId when it becomes available.
+      // TODO: Add the instanceId when it becomes available (see document WlbaA28k7yCw).
       instanceId: undefined,
     });
 

--- a/src/internal/utils/__tests__/panorama.ts
+++ b/src/internal/utils/__tests__/panorama.ts
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const panorama = jest.fn();
+(window as any).panorama = panorama;
+
+export const expectDetailInPanoramaCall = (callNumber: number) =>
+  expect(JSON.parse(panorama.mock.calls[callNumber - 1][1].eventDetail));

--- a/src/spinner/index.tsx
+++ b/src/spinner/index.tsx
@@ -17,7 +17,7 @@ export default function Spinner({ size = 'normal', variant = 'normal', ...props 
     elementRef: baseComponentProps.__internalRootRef,
     loading: true,
     componentType: 'spinner',
-    // TODO: Add the instanceId when it becomes available.
+    // TODO: Add the instanceId when it becomes available (see document WlbaA28k7yCw).
     instanceId: undefined,
   });
 

--- a/src/table/__tests__/header-cell.test.tsx
+++ b/src/table/__tests__/header-cell.test.tsx
@@ -55,6 +55,7 @@ it('renders a fake focus outline on the sort control', () => {
         tabIndex={0}
         updateColumn={() => {}}
         onClick={() => {}}
+        onClickCapture={() => {}}
         onResizeFinish={() => {}}
         stickyState={result.current}
         columnId="id"
@@ -79,6 +80,7 @@ it('renders a fake focus outline on the resize control', () => {
         resizableColumns={true}
         updateColumn={() => {}}
         onClick={() => {}}
+        onClickCapture={() => {}}
         onResizeFinish={() => {}}
         stickyState={result.current}
         columnId="id"
@@ -104,6 +106,7 @@ describe('i18n', () => {
             resizableColumns={true}
             updateColumn={() => {}}
             onClick={() => {}}
+            onClickCapture={() => {}}
             onResizeFinish={() => {}}
             stickyState={result.current}
             columnId="id"

--- a/src/table/__tests__/interaction-metrics.test.tsx
+++ b/src/table/__tests__/interaction-metrics.test.tsx
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { RefObject } from 'react';
+import Table from '../../../lib/components/table';
+import { expectDetailInPanoramaCall, panorama } from '../../internal/utils/__tests__/panorama';
+import { render } from '@testing-library/react';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+jest.useFakeTimers();
+beforeEach(() => jest.resetAllMocks());
+
+describe('Table interaction latency metrics', () => {
+  it('reports sorting user action in interaction latency metrics', () => {
+    const { container, rerender } = render(
+      <Table columnDefinitions={[{ id: 'column', header: 'Column', cell() {}, sortingField: 'column' }]} items={[]} />
+    );
+    const wrapper = createWrapper(container).findTable()!;
+    jest.runAllTimers();
+
+    wrapper.findColumnSortingArea(1)!.click();
+    rerender(<Table columnDefinitions={[]} items={[]} loading={true} />);
+
+    expect(panorama).toHaveBeenCalledTimes(2);
+    expectDetailInPanoramaCall(2).toEqual(
+      expect.objectContaining({
+        userAction: 'sort',
+      })
+    );
+  });
+
+  it('reports filtering user action in interaction latency metrics', () => {
+    const divRef: RefObject<HTMLDivElement> = { current: null };
+    const { rerender } = render(<Table columnDefinitions={[]} items={[]} filter={<div ref={divRef} />} />);
+    jest.runAllTimers();
+
+    divRef.current!.click();
+    rerender(<Table columnDefinitions={[]} items={[]} loading={true} />);
+
+    expect(panorama).toHaveBeenCalledTimes(2);
+    expectDetailInPanoramaCall(2).toEqual(
+      expect.objectContaining({
+        userAction: 'filter',
+      })
+    );
+  });
+
+  it('reports pagination user action in interaction latency metrics', () => {
+    const divRef: RefObject<HTMLDivElement> = { current: null };
+    const { rerender } = render(<Table columnDefinitions={[]} items={[]} pagination={<div ref={divRef} />} />);
+    jest.runAllTimers();
+
+    divRef.current!.click();
+    rerender(<Table columnDefinitions={[]} items={[]} loading={true} />);
+
+    expect(panorama).toHaveBeenCalledTimes(2);
+    expectDetailInPanoramaCall(2).toEqual(
+      expect.objectContaining({
+        userAction: 'paginate',
+      })
+    );
+  });
+
+  it('reports preferences user action in interaction latency metrics', () => {
+    const divRef: RefObject<HTMLDivElement> = { current: null };
+    const { rerender } = render(<Table columnDefinitions={[]} items={[]} preferences={<div ref={divRef} />} />);
+    jest.runAllTimers();
+
+    divRef.current!.click();
+    rerender(<Table columnDefinitions={[]} items={[]} loading={true} />);
+
+    expect(panorama).toHaveBeenCalledTimes(2);
+    expectDetailInPanoramaCall(2).toEqual(
+      expect.objectContaining({
+        userAction: 'preferences',
+      })
+    );
+  });
+});

--- a/src/table/__tests__/interaction-metrics.test.tsx
+++ b/src/table/__tests__/interaction-metrics.test.tsx
@@ -24,7 +24,7 @@ describe('Table interaction latency metrics', () => {
     expect(panorama).toHaveBeenCalledTimes(2);
     expectDetailInPanoramaCall(2).toEqual(
       expect.objectContaining({
-        userAction: 'sort',
+        userAction: 'sorting',
       })
     );
   });
@@ -56,7 +56,7 @@ describe('Table interaction latency metrics', () => {
     expect(panorama).toHaveBeenCalledTimes(2);
     expectDetailInPanoramaCall(2).toEqual(
       expect.objectContaining({
-        userAction: 'paginate',
+        userAction: 'pagination',
       })
     );
   });

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -26,6 +26,7 @@ interface TableHeaderCellProps<ItemType> {
   wrapLines?: boolean;
   hidden?: boolean;
   onClick(detail: TableProps.SortingState<any>): void;
+  onClickCapture(): void;
   onResizeFinish: () => void;
   colIndex: number;
   updateColumn: (columnId: PropertyKey, newWidth: number) => void;
@@ -51,6 +52,7 @@ export function TableHeaderCell<ItemType>({
   focusedComponent,
   hidden,
   onClick,
+  onClickCapture,
   colIndex,
   updateColumn,
   resizableColumns,
@@ -78,6 +80,7 @@ export function TableHeaderCell<ItemType>({
   // https://bugzilla.mozilla.org/show_bug.cgi?id=843003
   const handleKeyPress = ({ nativeEvent: e }: React.KeyboardEvent) => {
     if (e.keyCode === KeyCode.enter || e.keyCode === KeyCode.space) {
+      onClickCapture();
       e.preventDefault();
       handleClick();
     }
@@ -123,6 +126,7 @@ export function TableHeaderCell<ItemType>({
               tabIndex: clickableHeaderTabIndex,
               role: 'button',
               onClick: handleClick,
+              onClickCapture,
             }
           : {})}
       >

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { TableForwardRefType, TableProps } from './interfaces';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
-import InternalTable, { InternalTableAsSubstep } from './internal';
+import InternalTable, { InternalTableAsSubstep, InternalTableProps } from './internal';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analytics-funnel';
 import { useLatencyMetrics } from '../internal/hooks/use-latency-metrics';
@@ -27,7 +27,15 @@ const Table = React.forwardRef(
       },
     });
 
-    const tableProps: Parameters<typeof InternalTable<T>>[0] = {
+    const { setLastUserAction } = useLatencyMetrics({
+      componentName: 'Table',
+      elementRef: baseComponentProps.__internalRootRef,
+      loading: props.loading,
+      // TODO: Add the instanceId when it becomes available.
+      instanceId: undefined,
+    });
+
+    const tableProps: Parameters<typeof InternalTable<T>>[0] & InternalTableProps<T> = {
       items,
       selectedItems,
       variant,
@@ -35,15 +43,8 @@ const Table = React.forwardRef(
       ...props,
       ...baseComponentProps,
       ref,
+      setLastUserAction,
     };
-
-    useLatencyMetrics({
-      componentName: 'Table',
-      elementRef: baseComponentProps.__internalRootRef,
-      loading: props.loading,
-      // TODO: Add the instanceId when it becomes available.
-      instanceId: undefined,
-    });
 
     if (variant === 'borderless' || variant === 'embedded') {
       return <InternalTable {...tableProps} />;

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -31,7 +31,7 @@ const Table = React.forwardRef(
       componentName: 'Table',
       elementRef: baseComponentProps.__internalRootRef,
       loading: props.loading,
-      // TODO: Add the instanceId when it becomes available.
+      // TODO: Add the instanceId when it becomes available (see document WlbaA28k7yCw).
       instanceId: undefined,
     });
 

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -51,9 +51,10 @@ const GRID_NAVIGATION_PAGE_SIZE = 10;
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
 
-type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
+export type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
   InternalBaseComponentProps & {
     __funnelSubStepProps?: InternalContainerProps['__funnelSubStepProps'];
+    setLastUserAction?: (name: string) => void;
   };
 
 export const InternalTableAsSubstep = React.forwardRef(
@@ -113,6 +114,7 @@ const InternalTable = React.forwardRef(
       columnDisplay,
       enableKeyboardNavigation = false,
       __funnelSubStepProps,
+      setLastUserAction,
       ...rest
     }: InternalTableProps<T>,
     ref: React.Ref<TableProps.Ref>
@@ -242,6 +244,7 @@ const InternalTable = React.forwardRef(
       stickyState,
       selectionColumnId,
       tableRole,
+      setLastUserAction,
     };
 
     const wrapperRef = useMergeRefs(wrapperRefObject, stickyState.refs.wrapper);
@@ -300,6 +303,7 @@ const InternalTable = React.forwardRef(
                           filter={filter}
                           pagination={pagination}
                           preferences={preferences}
+                          setLastUserAction={setLastUserAction}
                         />
                       </CollectionLabelContext.Provider>
                     </div>

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -42,6 +42,7 @@ export interface TheadProps {
   focusedComponent?: null | string;
   onFocusedComponentChange?: (focusId: null | string) => void;
   tableRole: TableRole;
+  setLastUserAction?: (name: string) => void;
 }
 
 const Thead = React.forwardRef(
@@ -70,6 +71,7 @@ const Thead = React.forwardRef(
       onFocusedComponentChange,
       tableRole,
       resizerRoleDescription,
+      setLastUserAction,
     }: TheadProps,
     outerRef: React.Ref<HTMLTableRowElement>
   ) => {
@@ -153,6 +155,7 @@ const Thead = React.forwardRef(
                 updateColumn={updateColumn}
                 onResizeFinish={() => onResizeFinish(columnWidths)}
                 resizableColumns={resizableColumns}
+                onClickCapture={() => setLastUserAction?.('sort')}
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 isEditable={!!column.editConfig}
                 stickyState={stickyState}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -155,7 +155,7 @@ const Thead = React.forwardRef(
                 updateColumn={updateColumn}
                 onResizeFinish={() => onResizeFinish(columnWidths)}
                 resizableColumns={resizableColumns}
-                onClickCapture={() => setLastUserAction?.('sort')}
+                onClickCapture={() => setLastUserAction?.('sorting')}
                 onClick={detail => fireNonCancelableEvent(onSortingChange, detail)}
                 isEditable={!!column.editConfig}
                 stickyState={stickyState}

--- a/src/table/tools-header.tsx
+++ b/src/table/tools-header.tsx
@@ -41,7 +41,7 @@ export default function ToolsHeader({ header, filter, pagination, preferences, s
           )}
           <div className={styles['tools-align-right']}>
             {pagination && (
-              <div className={styles['tools-pagination']} onClickCapture={() => setLastUserAction?.('paginate')}>
+              <div className={styles['tools-pagination']} onClickCapture={() => setLastUserAction?.('pagination')}>
                 {pagination}
               </div>
             )}

--- a/src/table/tools-header.tsx
+++ b/src/table/tools-header.tsx
@@ -12,9 +12,10 @@ interface ToolsHeaderProps {
   filter?: React.ReactNode;
   pagination?: React.ReactNode;
   preferences?: React.ReactNode;
+  setLastUserAction?: (name: string) => void;
 }
 
-export default function ToolsHeader({ header, filter, pagination, preferences }: ToolsHeaderProps) {
+export default function ToolsHeader({ header, filter, pagination, preferences, setLastUserAction }: ToolsHeaderProps) {
   const [breakpoint, ref] = useContainerBreakpoints(['xs']);
   const isHeaderString = typeof header === 'string';
   const assignHeaderId = useContext(CollectionLabelContext).assignId;
@@ -29,10 +30,26 @@ export default function ToolsHeader({ header, filter, pagination, preferences }:
       {isHeaderString ? <span id={headingId}>{header}</span> : header}
       {hasTools && (
         <div ref={ref} className={clsx(styles.tools, isSmall && styles['tools-small'])}>
-          {filter && <div className={styles['tools-filtering']}>{filter}</div>}
+          {filter && (
+            <div
+              className={styles['tools-filtering']}
+              onClickCapture={() => setLastUserAction?.('filter')}
+              onKeyDownCapture={() => setLastUserAction?.('filter')}
+            >
+              {filter}
+            </div>
+          )}
           <div className={styles['tools-align-right']}>
-            {pagination && <div className={styles['tools-pagination']}>{pagination}</div>}
-            {preferences && <div className={styles['tools-preferences']}>{preferences}</div>}
+            {pagination && (
+              <div className={styles['tools-pagination']} onClickCapture={() => setLastUserAction?.('paginate')}>
+                {pagination}
+              </div>
+            )}
+            {preferences && (
+              <div className={styles['tools-preferences']} onClickCapture={() => setLastUserAction?.('preferences')}>
+                {preferences}
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
### Description

This PR extends the latency metrics for loading states with information about what user action likely caused the loading state. For example, if the user interacts with the pagination of a table, and then the table enters a loading state, the resulting latency metric will include the field `userAction: 'paginate'`.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
