### PR TITLE
feat: Add `fitHeight` property to Tabs

### DIFF
--- a/pages/tabs/permutations.page.tsx
+++ b/pages/tabs/permutations.page.tsx
@@ -51,6 +51,28 @@ const permutations = createPermutations<TabsProps>([
   },
 ]);
 
+const fitHeightPermutations = createPermutations<TabsProps>([
+  {
+    activeTabId: ['first', 'second'],
+    variant: ['default', 'container'],
+    fitHeight: [true],
+    tabs: [
+      [
+        {
+          label: 'First tab',
+          id: 'first',
+          content: new Array(10).fill('').map((_, index) => <p key={index}>First content</p>),
+        },
+        {
+          label: 'Second tab',
+          id: 'second',
+          content: <div style={{ height: '100%', display: 'flex', alignItems: 'flex-end' }}>Second content</div>,
+        },
+      ],
+    ],
+  },
+]);
+
 export default function TabsPermutations() {
   return (
     <>
@@ -64,6 +86,18 @@ export default function TabsPermutations() {
               activeTabId={permutation.activeTabId}
               i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
             />
+          )}
+        />
+        <PermutationsView
+          permutations={fitHeightPermutations}
+          render={permutation => (
+            <div style={{ height: '200px' }}>
+              <Tabs
+                {...permutation}
+                activeTabId={permutation.activeTabId}
+                i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+              />
+            </div>
           )}
         />
       </ScreenshotArea>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13683,6 +13683,13 @@ Don't use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "type": "boolean",
     },
     Object {
+      "description": "Enabling this property will make the tabs fit to the available height. If content is too short, the tab content
+will stretch, if too long, the content will shrink and show a vertical scrollbar.",
+      "name": "fitHeight",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "description": "An object containing all the necessary localized strings required by the component.",
       "i18nTag": true,
       "inlineType": Object {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13683,8 +13683,8 @@ Don't use \`ariaLabel\` and \`ariaLabelledby\` at the same time.",
       "type": "boolean",
     },
     Object {
-      "description": "Enabling this property will make the tabs fit to the available height. If content is too short, the tab content
-will stretch, if too long, the content will shrink and show a vertical scrollbar.",
+      "description": "Enabling this property makes the tab content fit to the available height.
+If the tab content is too short, it will stretch. If the tab content is too long, a vertical scrollbar will be shown.",
       "name": "fitHeight",
       "optional": true,
       "type": "boolean",

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -33,6 +33,7 @@ export default function Tabs({
   ariaLabelledby,
   disableContentPaddings = false,
   i18nStrings,
+  fitHeight,
   ...rest
 }: TabsProps) {
   for (const tab of tabs) {
@@ -114,6 +115,7 @@ export default function Tabs({
         __internalRootRef={__internalRootRef}
         disableContentPaddings={true}
         variant={variant === 'stacked' ? 'stacked' : 'default'}
+        fitHeight={fitHeight}
       >
         {content()}
       </InternalContainer>
@@ -121,7 +123,11 @@ export default function Tabs({
   }
 
   return (
-    <div {...baseProps} className={clsx(baseProps.className, styles.root, styles.tabs)} ref={__internalRootRef}>
+    <div
+      {...baseProps}
+      className={clsx(baseProps.className, styles.root, styles.tabs, { [styles['fit-height']]: fitHeight })}
+      ref={__internalRootRef}
+    >
       {header}
       {content()}
     </div>

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -65,8 +65,8 @@ export interface TabsProps extends BaseComponentProps {
    */
   i18nStrings?: TabsProps.I18nStrings;
   /**
-   * Enabling this property will make the tabs fit to the available height. If content is too short, the tab content
-   * will stretch, if too long, the content will shrink and show a vertical scrollbar.
+   * Enabling this property makes the tab content fit to the available height.
+   * If the tab content is too short, it will stretch. If the tab content is too long, a vertical scrollbar will be shown.
    */
   fitHeight?: boolean;
 }

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -64,6 +64,11 @@ export interface TabsProps extends BaseComponentProps {
    * @i18n
    */
   i18nStrings?: TabsProps.I18nStrings;
+  /**
+   * Enabling this property will make the tabs fit to the available height. If content is too short, the tab content
+   * will stretch, if too long, the content will shrink and show a vertical scrollbar.
+   */
+  fitHeight?: boolean;
 }
 export namespace TabsProps {
   export type Variant = 'default' | 'container' | 'stacked';

--- a/src/tabs/styles.scss
+++ b/src/tabs/styles.scss
@@ -23,8 +23,15 @@
   display: none;
 }
 
+.fit-height {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+}
+
 .tabs-content-active {
   display: block;
+  flex: 1;
   @include focus-visible.when-visible {
     @include styles.container-focus();
   }
@@ -35,9 +42,20 @@
     padding-block: awsui.$space-scaled-m;
     padding-inline: 0;
   }
+  .fit-height > & {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
 }
 
 .tabs-container-content-wrapper {
+  .fit-height > .tabs-content-wrapper > & {
+    block-size: 100%;
+    display: flex;
+    flex-direction: column;
+  }
   &.with-paddings > .tabs-content {
     padding-block-start: awsui.$space-tabs-content-top;
     padding-block-end: awsui.$space-scaled-l;


### PR DESCRIPTION
### Description

Add a new property to Tabs component to allow the tab content to fit available height (that is, to expand or scroll accordingly)

Related links, issue #, if available: AWSUI-19223

### How has this been tested?

Local testing, including integration in an application that requested this feature. New permutations added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
