### PR TITLE
chore: Support feature flags in SSR

### DIFF
--- a/src/internal/utils/__tests__/global-flags-ssr.test.ts
+++ b/src/internal/utils/__tests__/global-flags-ssr.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable header/header */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as globalFlags from '../global-flags';
+import { awsuiGlobalFlagsSymbol, FlagsHolder } from '../global-flags';
+const { getGlobalFlag } = globalFlags;
+
+declare const global: typeof globalThis & FlagsHolder;
+
+afterEach(() => {
+  delete global[awsuiGlobalFlagsSymbol];
+});
+
+describe('getGlobalFlag', () => {
+  test('ensure no window in this environment', () => {
+    expect(typeof window === 'undefined').toBe(true);
+  });
+
+  test('returns undefined if the global flags object does not exist', () => {
+    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+  });
+  test('returns undefined if the global flags object exists but the flag is not set', () => {
+    global[awsuiGlobalFlagsSymbol] = {};
+    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+  });
+  test('returns removeHighContrastHeader value when defined', () => {
+    global[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: false };
+    expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
+    global[awsuiGlobalFlagsSymbol].removeHighContrastHeader = true;
+    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+  });
+});

--- a/src/internal/utils/__tests__/global-flags.test.ts
+++ b/src/internal/utils/__tests__/global-flags.test.ts
@@ -1,17 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as globalFlags from '../global-flags';
+import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../global-flags';
 const { getGlobalFlag } = globalFlags;
 
-const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
-interface GlobalFlags {
-  removeHighContrastHeader?: boolean;
-}
-
-interface ExtendedWindow extends Window {
-  [awsuiGlobalFlagsSymbol]?: GlobalFlags;
-}
-declare const window: ExtendedWindow;
+declare const window: Window & FlagsHolder;
 
 afterEach(() => {
   delete window[awsuiGlobalFlagsSymbol];
@@ -19,14 +12,14 @@ afterEach(() => {
 });
 
 describe('getGlobalFlag', () => {
-  test('returns undefined if there global flags are not defined', () => {
+  test('returns undefined if the global flags object does not exist', () => {
     expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
   });
-  test('returns undefined if global flags are defined but flag is not set', () => {
+  test('returns undefined if the global flags object exists but the flag is not set', () => {
     window[awsuiGlobalFlagsSymbol] = {};
     expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
   });
-  test('returns removeHighContrastHeader value', () => {
+  test('returns removeHighContrastHeader value when defined', () => {
     window[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: false };
     expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
     window[awsuiGlobalFlagsSymbol].removeHighContrastHeader = true;
@@ -35,31 +28,31 @@ describe('getGlobalFlag', () => {
   test('returns removeHighContrastHeader value when defined in top window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as unknown as ExtendedWindow);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as typeof window);
     expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
     jest.restoreAllMocks();
 
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as unknown as ExtendedWindow);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as typeof window);
     expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
   });
   test('privileges values in the self window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as unknown as ExtendedWindow);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as typeof window);
     window[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: true };
     expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
   });
   test('returns top window value when not defined in the self window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as unknown as ExtendedWindow);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as typeof window);
     window[awsuiGlobalFlagsSymbol] = {};
     expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
   });
-  test('returns undefined when top window is undefined', () => {
-    jest.spyOn(globalFlags, 'getTopWindow').mockReturnValue(undefined);
+  test('returns undefined when top window is not available', () => {
+    jest.spyOn(globalFlags, 'getTopWindow').mockReturnValue(null);
     expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
   });
   test('returns undefined when an error is thrown and flag is not defined in own window', () => {

--- a/src/internal/utils/global-flags.ts
+++ b/src/internal/utils/global-flags.ts
@@ -6,25 +6,26 @@ interface GlobalFlags {
   removeHighContrastHeader?: boolean;
 }
 
-interface ExtendedWindow extends Window {
+export interface FlagsHolder {
   [awsuiGlobalFlagsSymbol]?: GlobalFlags;
 }
-declare const window: ExtendedWindow;
 
-export const getTopWindow = (): ExtendedWindow | undefined => {
-  return window.top as ExtendedWindow;
+export const getTopWindow = () => {
+  return window.top;
 };
 
-function readFlag(window: ExtendedWindow | undefined, flagName: keyof GlobalFlags) {
-  if (typeof window === 'undefined' || !window[awsuiGlobalFlagsSymbol]) {
-    return undefined;
-  }
-  return window[awsuiGlobalFlagsSymbol][flagName];
+function getGlobal() {
+  return typeof window !== 'undefined' ? window : globalThis;
+}
+
+function readFlag(window: unknown, flagName: keyof GlobalFlags) {
+  const holder = window as FlagsHolder | null;
+  return holder?.[awsuiGlobalFlagsSymbol]?.[flagName];
 }
 
 export const getGlobalFlag = (flagName: keyof GlobalFlags): GlobalFlags[keyof GlobalFlags] | undefined => {
   try {
-    const ownFlag = readFlag(window, flagName);
+    const ownFlag = readFlag(getGlobal(), flagName);
     if (ownFlag !== undefined) {
       return ownFlag;
     }


### PR DESCRIPTION
### Description

Make it possible to define feature flags in SSR

```js
// remove dark header
global[Symbol.for('awsui-global-flags')] = { removeHighContrastHeader: true };
```

Related links, issue #, if available: n/a

### How has this been tested?

Added an SSR test suite

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
