### PR TITLE
test: Mock date in date picker test

### DIFF
--- a/src/date-picker/__tests__/month-granularity.test.tsx
+++ b/src/date-picker/__tests__/month-granularity.test.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import MockDate from 'mockdate';
 import { createWrapper } from '@cloudscape-design/test-utils-core/dom.js';
 import DatePickerWrapper from '../../../lib/components/test-utils/dom/date-picker';
 import DatePicker, { DatePickerProps } from '../../../lib/components/date-picker';
@@ -42,11 +43,15 @@ describe('Date picker calendar at month granularity', () => {
   };
 
   beforeEach(() => {
-    // Set default locale of the browser to en-US for more consistent tests
+    // Set default locale of the browser to en-US and a fixed date for more consistent tests
     const locale = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' });
     jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => locale);
+    MockDate.set(new Date(2024, 1, 15));
   });
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+    MockDate.reset();
+  });
 
   describe('localization', () => {
     test('should render calendar with the default locale', () => {


### PR DESCRIPTION
### Description

Mock date in date picker month granularity date to make the test consistent and prevent failures due to changing dates.

### How has this been tested?

Ran the failing test locally.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
