### PR TITLE
chore: changed deprecated charCode with key event property

### DIFF
--- a/src/select/__tests__/use-native-search.test.ts
+++ b/src/select/__tests__/use-native-search.test.ts
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderHook, act } from '../../__tests__/render-hook';
+import type { DropdownOption } from '../../internal/components/option/interfaces';
+import { useNativeSearch } from '../utils/use-native-search';
+
+const options: DropdownOption[] = [
+  { option: { label: 'option 1', value: 'option1' } },
+  { option: { label: 'option 2', value: 'option2' } },
+];
+
+const highlightOption = jest.fn();
+
+const initialProps = {
+  isEnabled: true,
+  options,
+  highlightOption,
+  highlightedOption: null,
+};
+
+describe('useNativeSearch', () => {
+  const hook = renderHook(useNativeSearch, {
+    initialProps: initialProps,
+  });
+
+  beforeEach(() => {
+    highlightOption.mockClear();
+  });
+
+  test('should highlight the correct option when a key is pressed', () => {
+    act(() => {
+      const event = { key: 'o' } as React.KeyboardEvent;
+      hook.result.current(event);
+    });
+
+    expect(highlightOption).toHaveBeenCalledWith(options[0]);
+  });
+
+  test('should not highlight an option when a non-character key is pressed', () => {
+    act(() => {
+      const event = { key: 'Enter' } as React.KeyboardEvent;
+      hook.result.current(event);
+    });
+
+    expect(highlightOption).not.toHaveBeenCalled();
+  });
+
+  test('should not highlight an option when isEnabled is false', () => {
+    const hook = renderHook(useNativeSearch, {
+      initialProps: {
+        ...initialProps,
+        isEnabled: false,
+      },
+    });
+
+    act(() => {
+      const event = { key: 'o' } as React.KeyboardEvent;
+      hook.result.current(event);
+    });
+
+    expect(highlightOption).not.toHaveBeenCalled();
+  });
+});

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -235,7 +235,7 @@ const InternalSelect = React.forwardRef(
         {...baseProps}
         ref={mergedRef}
         className={clsx(styles.root, baseProps.className)}
-        onKeyPress={handleNativeSearch}
+        onKeyDown={handleNativeSearch}
       >
         <Dropdown
           {...dropdownProps}

--- a/src/select/utils/use-native-search.ts
+++ b/src/select/utils/use-native-search.ts
@@ -1,19 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef } from 'react';
-import { KeyCode } from '../../internal/keycode';
+
 import {
   filterOptions,
   isInteractive,
   isGroupInteractive,
   isGroup,
 } from '../../internal/components/option/utils/filter-options';
-import { DropdownOption, OptionDefinition, OptionGroup } from '../../internal/components/option/interfaces';
+import type { DropdownOption, OptionDefinition, OptionGroup } from '../../internal/components/option/interfaces';
 import { useDebounceCallback } from '../../internal/hooks/use-debounce-callback';
-
-export const isChar = (keyCode: number): boolean => {
-  return [0, KeyCode.enter, KeyCode.space, KeyCode.tab].indexOf(keyCode) === -1;
-};
 
 export const isRepeatedChar = (str: string) => str.split('').every(c => c === str[0]);
 
@@ -84,12 +80,14 @@ export function useNativeSearch({
       return;
     }
 
-    const { charCode } = event;
-    if (!isChar(charCode)) {
+    const { key } = event;
+
+    if (!key || key.length !== 1) {
       return;
     }
+
     delayedResetValue();
-    const newValue = value.current + String.fromCharCode(charCode);
+    const newValue = value.current + key;
     value.current = newValue;
 
     const nextHighlight = findMatchingOption(options, newValue, highlightedOption, useInteractiveGroups);


### PR DESCRIPTION
### Description

While browsing the code, I stumbled across two deprecated markers. In the KeyboardEvent details, the charCode property is no longer supported. It may have already been removed from the relevant web standards. Furthermore, React onKeyPress is also marked as deprecated. 

see here https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode

### How has this been tested?

Added missing unit test for hook

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
