### PR TITLE
feat: Activate table keyboard nav in s3 resource selector

### DIFF
--- a/src/s3-resource-selector/__integ__/focus-interactions.test.ts
+++ b/src/s3-resource-selector/__integ__/focus-interactions.test.ts
@@ -67,7 +67,7 @@ test(
     await page.setValue(tableFilteringInputSelector, 'wave-function-4ns.sim');
     await page.click(wrapper.findTable().findRowSelectionArea(1).toSelector());
     // navigate to submit button using keyboard
-    await page.keys(['Tab', 'Tab', 'Tab', 'Enter']);
+    await page.keys(['Tab', 'Tab', 'Enter']);
 
     await expect(page.isDisplayed(wrapper.findModal().toSelector())).resolves.toBe(false);
     await expect(page.isFocused(uriInputSelector)).resolves.toBe(true);

--- a/src/s3-resource-selector/s3-modal/basic-table.tsx
+++ b/src/s3-resource-selector/s3-modal/basic-table.tsx
@@ -166,6 +166,7 @@ export function BasicS3Table<T>({
       visibleColumns={visibleColumns}
       isItemDisabled={isItemDisabled}
       columnDefinitions={columnDefinitions}
+      enableKeyboardNavigation={true}
     />
   );
 }


### PR DESCRIPTION
### Description

Using table keyboard navigation for S3 resource selector buckets table.

### How has this been tested?

Updated existing integration test, CI integration tests, dry run.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
