### PR TITLE
chore: Keyboard nav preserve user index

### DIFF
--- a/pages/table-fragments/grid-navigation-custom.page.tsx
+++ b/pages/table-fragments/grid-navigation-custom.page.tsx
@@ -115,6 +115,7 @@ export default function Page() {
               prev.map(prevItem => (prevItem.id !== item.id ? prevItem : { ...prevItem, id: generateId() }))
             )
           }
+          canUpdate={item.state === 'PENDING' || item.state === 'RUNNING'}
         />
       ),
     },
@@ -291,20 +292,43 @@ export default function Page() {
                     </tr>
                   </thead>
                   <tbody>
-                    {sortedItems.map((item, rowIndex) => (
-                      <tr key={item.id} {...getTableRowRoleProps({ tableRole, rowIndex, firstIndex: 0 })}>
-                        {visibleColumnDefinitions.map((column, colIndex) => (
-                          <Cell
-                            tag="td"
-                            key={column.key}
-                            className={styles['custom-table-cell']}
-                            {...getTableCellRoleProps({ tableRole, colIndex })}
-                          >
-                            {column.render(item)}
-                          </Cell>
-                        ))}
-                      </tr>
-                    ))}
+                    {sortedItems.map((item, rowIndex) => {
+                      rowIndex = rowIndex > 10 ? rowIndex + 1 : rowIndex;
+                      const row = (
+                        <tr key={item.id} {...getTableRowRoleProps({ tableRole, rowIndex, firstIndex: 0 })}>
+                          {visibleColumnDefinitions.map((column, colIndex) => (
+                            <Cell
+                              tag="td"
+                              key={column.key}
+                              className={styles['custom-table-cell']}
+                              {...getTableCellRoleProps({ tableRole, colIndex })}
+                            >
+                              {column.render(item)}
+                            </Cell>
+                          ))}
+                        </tr>
+                      );
+
+                      if (rowIndex === 10) {
+                        return (
+                          <React.Fragment key={item.id}>
+                            {row}
+                            <tr {...getTableRowRoleProps({ tableRole, rowIndex: rowIndex + 1, firstIndex: 0 })}>
+                              <Cell
+                                tag="td"
+                                className={styles['custom-table-cell']}
+                                {...getTableCellRoleProps({ tableRole, colIndex: 0 })}
+                                colSpan={visibleColumnDefinitions.length}
+                              >
+                                Summary row
+                              </Cell>
+                            </tr>
+                          </React.Fragment>
+                        );
+                      }
+
+                      return row;
+                    })}
                   </tbody>
                 </table>
               </div>
@@ -316,10 +340,14 @@ export default function Page() {
   );
 }
 
-function Cell({ tag: Tag, ...rest }: React.HTMLAttributes<HTMLTableCellElement> & { tag: 'th' | 'td' }) {
+function Cell({
+  tag: Tag,
+  colSpan,
+  ...rest
+}: React.HTMLAttributes<HTMLTableCellElement> & { tag: 'th' | 'td'; colSpan?: number }) {
   const cellRef = useRef<HTMLTableCellElement>(null);
   const { tabIndex } = useSingleTabStopNavigation(cellRef);
-  return <Tag {...rest} ref={cellRef} tabIndex={tabIndex} />;
+  return <Tag {...rest} ref={cellRef} tabIndex={tabIndex} colSpan={colSpan} />;
 }
 
 function SortingHeader({
@@ -383,11 +411,13 @@ function ItemActionsCell({
   onDuplicate,
   onUpdate,
   mode,
+  canUpdate = true,
 }: {
   onDelete: () => void;
   onDuplicate: () => void;
   onUpdate: () => void;
   mode: ActionsMode;
+  canUpdate?: boolean;
 }) {
   if (mode === 'dropdown') {
     return (
@@ -398,7 +428,7 @@ function ItemActionsCell({
           items={[
             { id: 'delete', text: 'Delete' },
             { id: 'duplicate', text: 'Duplicate' },
-            { id: 'update', text: 'Update' },
+            { id: 'update', text: 'Update', disabled: !canUpdate },
           ]}
           onItemClick={event => {
             switch (event.detail.id) {
@@ -419,7 +449,13 @@ function ItemActionsCell({
     <div style={{ display: 'flex', gap: '8px', flexWrap: 'nowrap' }}>
       <Button variant="inline-icon" iconName="remove" ariaLabel="Delete item" onClick={onDelete} />
       <Button variant="inline-icon" iconName="copy" ariaLabel="Duplicate item" onClick={onDuplicate} />
-      <Button variant="inline-icon" iconName="refresh" ariaLabel="Update item" onClick={onUpdate} />
+      <Button
+        variant="inline-icon"
+        iconName="refresh"
+        ariaLabel="Update item"
+        onClick={onUpdate}
+        disabled={!canUpdate}
+      />
     </div>
   );
 }

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -108,10 +108,10 @@ test(
     await page.click('[data-testid="link-before"]');
     await page.keys('Tab');
     await page.keys(['ArrowRight', 'ArrowDown', 'ArrowRight', 'ArrowRight']);
-    await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="2"] button[aria-label="Update item"]')).resolves.toBe(true);
 
     await page.keys(['ArrowDown', 'ArrowDown', 'ArrowDown', 'ArrowDown']);
-    await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="6"] button[aria-label="Update item"]')).resolves.toBe(true);
   })
 );
 
@@ -121,12 +121,12 @@ test(
     await page.click('[data-testid="link-before"]');
     await page.keys('Tab');
     await page.keys(['ArrowRight', 'ArrowDown', 'ArrowRight']);
-    await expect(page.isFocused('button[aria-label="Duplicate item"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="2"] button[aria-label="Duplicate item"]')).resolves.toBe(true);
 
     await page.keys(range(0, 11).map(() => 'ArrowDown'));
     await expect(page.getFocusedElementText()).resolves.toBe('Summary row');
 
     await page.keys(['ArrowDown']);
-    await expect(page.isFocused('button[aria-label="Duplicate item"]')).resolves.toBe(true);
+    await expect(page.isFocused('tr[aria-rowindex="14"] button[aria-label="Duplicate item"]')).resolves.toBe(true);
   })
 );

--- a/src/table/table-role/__integ__/grid-navigation.test.ts
+++ b/src/table/table-role/__integ__/grid-navigation.test.ts
@@ -4,6 +4,7 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../../lib/components/test-utils/selectors';
 import { GridNavigationPageObject } from './page-object';
+import { range } from 'lodash';
 
 interface Options {
   actionsMode?: 'dropdown' | 'inline';
@@ -98,5 +99,34 @@ test(
 
     await page.keys(['Shift', 'Tab', 'Null']);
     await expect(page.isFocused('[data-testid="link-before"]')).resolves.toBe(true);
+  })
+);
+
+test(
+  'element index is preserved when moving cursor down',
+  setupTest({ actionsMode: 'inline' }, async page => {
+    await page.click('[data-testid="link-before"]');
+    await page.keys('Tab');
+    await page.keys(['ArrowRight', 'ArrowDown', 'ArrowRight', 'ArrowRight']);
+    await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
+
+    await page.keys(['ArrowDown', 'ArrowDown', 'ArrowDown', 'ArrowDown']);
+    await expect(page.isFocused('button[aria-label="Update item"]')).resolves.toBe(true);
+  })
+);
+
+test(
+  'column index is preserved when moving cursor down',
+  setupTest({ actionsMode: 'inline' }, async page => {
+    await page.click('[data-testid="link-before"]');
+    await page.keys('Tab');
+    await page.keys(['ArrowRight', 'ArrowDown', 'ArrowRight']);
+    await expect(page.isFocused('button[aria-label="Duplicate item"]')).resolves.toBe(true);
+
+    await page.keys(range(0, 11).map(() => 'ArrowDown'));
+    await expect(page.getFocusedElementText()).resolves.toBe('Summary row');
+
+    await page.keys(['ArrowDown']);
+    await expect(page.isFocused('button[aria-label="Duplicate item"]')).resolves.toBe(true);
   })
 );


### PR DESCRIPTION
### Description

Updated table keyboard navigation so that column- and element indices are preserved when the user moves vertically with arrow keys or page-up/page-down. This way when the number of interactive elements in the column is inconsistent or there are columns with colspan > 1 the horizontal cursor position is preserved so that the user does not have to start over from column 1.

That colspan > 1 columns are not supported yet but are planned as part of progressive loading, see: eDjiAKchzKda.


https://github.com/cloudscape-design/components/assets/20790937/d80f2854-fb03-4545-bfd4-bd7effe32c50



### How has this been tested?

New integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
