### PR TITLE
chore: Update i18n strings

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -180,6 +180,7 @@ export interface I18nFormatArgTypes {
   }
   "form-field": {
     "i18nStrings.errorIconAriaLabel": never;
+    "i18nStrings.warningIconAriaLabel": never;
   }
   "form": {
     "errorIconAriaLabel": never;
@@ -236,6 +237,7 @@ export interface I18nFormatArgTypes {
     "i18nStrings.operatorLessOrEqualText": never;
     "i18nStrings.operatorLessText": never;
     "i18nStrings.operatorStartsWithText": never;
+    "i18nStrings.operatorDoesNotStartWithText": never;
     "i18nStrings.operatorText": never;
     "i18nStrings.operatorsText": never;
     "i18nStrings.propertyText": never;

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Warnung"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Fehler"
+    "i18nStrings.errorIconAriaLabel": "Fehler",
+    "i18nStrings.warningIconAriaLabel": "Warnung"
   },
   "form": {
     "errorIconAriaLabel": "Fehler"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Ist kleiner als oder gleich",
     "i18nStrings.operatorLessText": "Ist kleiner als",
     "i18nStrings.operatorStartsWithText": "Beginnt mit",
+    "i18nStrings.operatorDoesNotStartWithText": "Beginnt nicht mit",
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operatoren",
     "i18nStrings.propertyText": "Eigenschaft",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Ressourcen werden geladen",
     "i18nStrings.inContextUriLabel": "S3-URI",
     "i18nStrings.inContextVersionSelectLabel": "Objektversion auswählen",
-    "i18nStrings.modalTitle": "Ein Archiv in S3 auswählen",
+    "i18nStrings.modalTitle": "Wählen Sie ein Objekt in S3",
     "i18nStrings.modalCancelButton": "Abbrechen",
     "i18nStrings.modalSubmitButton": "Auswählen",
     "i18nStrings.modalBreadcrumbRootItem": "S3-Buckets",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Error"
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning"
   },
   "form": {
     "errorIconAriaLabel": "Error"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Less than or equal to",
     "i18nStrings.operatorLessText": "Less than",
     "i18nStrings.operatorStartsWithText": "Starts with",
+    "i18nStrings.operatorDoesNotStartWithText": "Does not start with",
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operators",
     "i18nStrings.propertyText": "Property",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Loading resource",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "Object version",
-    "i18nStrings.modalTitle": "Choose an archive in S3",
+    "i18nStrings.modalTitle": "Choose an object in S3",
     "i18nStrings.modalCancelButton": "Cancel",
     "i18nStrings.modalSubmitButton": "Choose",
     "i18nStrings.modalBreadcrumbRootItem": "S3 buckets",

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Warning"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Error"
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Warning"
   },
   "form": {
     "errorIconAriaLabel": "Error"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Less than or equal",
     "i18nStrings.operatorLessText": "Less than",
     "i18nStrings.operatorStartsWithText": "Starts with",
+    "i18nStrings.operatorDoesNotStartWithText": "Does not start with",
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operators",
     "i18nStrings.propertyText": "Property",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Loading resource",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "Object version",
-    "i18nStrings.modalTitle": "Choose an archive in S3",
+    "i18nStrings.modalTitle": "Choose an object in S3",
     "i18nStrings.modalCancelButton": "Cancel",
     "i18nStrings.modalSubmitButton": "Choose",
     "i18nStrings.modalBreadcrumbRootItem": "S3 buckets",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -135,10 +135,11 @@
     "i18nStrings.notificationBarAriaLabel": "Todas las notificaciones",
     "i18nStrings.notificationBarText": "Notificaciones",
     "i18nStrings.successIconAriaLabel": "Éxito",
-    "i18nStrings.warningIconAriaLabel": "Aviso"
+    "i18nStrings.warningIconAriaLabel": "Advertencia"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Error"
+    "i18nStrings.errorIconAriaLabel": "Error",
+    "i18nStrings.warningIconAriaLabel": "Advertencia"
   },
   "form": {
     "errorIconAriaLabel": "Error"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Menor o igual que",
     "i18nStrings.operatorLessText": "Menor que",
     "i18nStrings.operatorStartsWithText": "Empieza con",
+    "i18nStrings.operatorDoesNotStartWithText": "No empieza con",
     "i18nStrings.operatorText": "Operador",
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propiedad",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Cargando recurso",
     "i18nStrings.inContextUriLabel": "URI de S3",
     "i18nStrings.inContextVersionSelectLabel": "Versión del objeto",
-    "i18nStrings.modalTitle": "Elija un archivo en S3",
+    "i18nStrings.modalTitle": "Elige un objeto en S3",
     "i18nStrings.modalCancelButton": "Cancelar",
     "i18nStrings.modalSubmitButton": "Elija",
     "i18nStrings.modalBreadcrumbRootItem": "Buckets de S3",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Avertissement"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Erreur"
+    "i18nStrings.errorIconAriaLabel": "Erreur",
+    "i18nStrings.warningIconAriaLabel": "Avertissement"
   },
   "form": {
     "errorIconAriaLabel": "Erreur"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Inférieur ou égal à",
     "i18nStrings.operatorLessText": "Inférieur à",
     "i18nStrings.operatorStartsWithText": "Commence par",
+    "i18nStrings.operatorDoesNotStartWithText": "Ne commence pas par",
     "i18nStrings.operatorText": "Opérateur",
     "i18nStrings.operatorsText": "Opérateurs",
     "i18nStrings.propertyText": "Propriété",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Chargement de la ressource",
     "i18nStrings.inContextUriLabel": "URI S3",
     "i18nStrings.inContextVersionSelectLabel": "Version de l'objet",
-    "i18nStrings.modalTitle": "Choisir une archive dans S3",
+    "i18nStrings.modalTitle": "Choisir un objet dans S3",
     "i18nStrings.modalCancelButton": "Annuler",
     "i18nStrings.modalSubmitButton": "Choisir",
     "i18nStrings.modalBreadcrumbRootItem": "Compartiments S3",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Peringatan"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Kesalahan"
+    "i18nStrings.errorIconAriaLabel": "Kesalahan",
+    "i18nStrings.warningIconAriaLabel": "Peringatan"
   },
   "form": {
     "errorIconAriaLabel": "Kesalahan"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Kurang dari atau sama dengan",
     "i18nStrings.operatorLessText": "Kurang dari",
     "i18nStrings.operatorStartsWithText": "Dimulai dengan",
+    "i18nStrings.operatorDoesNotStartWithText": "Tidak dimulai dengan",
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operator",
     "i18nStrings.propertyText": "Properti",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Memuat sumber daya",
     "i18nStrings.inContextUriLabel": "URI S3",
     "i18nStrings.inContextVersionSelectLabel": "Versi objek",
-    "i18nStrings.modalTitle": "Pilih arsip di S3",
+    "i18nStrings.modalTitle": "Pilih objek di S3",
     "i18nStrings.modalCancelButton": "Batalkan",
     "i18nStrings.modalSubmitButton": "Pilih",
     "i18nStrings.modalBreadcrumbRootItem": "Bucket S3",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Avviso"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Errore"
+    "i18nStrings.errorIconAriaLabel": "Errore",
+    "i18nStrings.warningIconAriaLabel": "Avviso"
   },
   "form": {
     "errorIconAriaLabel": "Errore"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Minore o uguale a",
     "i18nStrings.operatorLessText": "Minore di",
     "i18nStrings.operatorStartsWithText": "Inizia con",
+    "i18nStrings.operatorDoesNotStartWithText": "Non inizia con",
     "i18nStrings.operatorText": "Operatore",
     "i18nStrings.operatorsText": "Operatori",
     "i18nStrings.propertyText": "Proprietà",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Caricamento delle risorse in corso",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "Versione dell’oggetto",
-    "i18nStrings.modalTitle": "Scegli un archivio in S3",
+    "i18nStrings.modalTitle": "Scegli un oggetto in S3",
     "i18nStrings.modalCancelButton": "Annulla",
     "i18nStrings.modalSubmitButton": "Scegli",
     "i18nStrings.modalBreadcrumbRootItem": "Bucket S3",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "エラー"
+    "i18nStrings.errorIconAriaLabel": "エラー",
+    "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form": {
     "errorIconAriaLabel": "エラー"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "次以下",
     "i18nStrings.operatorLessText": "次より少ない",
     "i18nStrings.operatorStartsWithText": "次で始まる:",
+    "i18nStrings.operatorDoesNotStartWithText": "次始まらない:",
     "i18nStrings.operatorText": "演算子",
     "i18nStrings.operatorsText": "演算子",
     "i18nStrings.propertyText": "プロパティ",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "リソースのロード中",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "オブジェクトのバージョン",
-    "i18nStrings.modalTitle": "S3 のアーカイブを選択",
+    "i18nStrings.modalTitle": "S3 のオブジェクトを選択",
     "i18nStrings.modalCancelButton": "キャンセル",
     "i18nStrings.modalSubmitButton": "選択",
     "i18nStrings.modalBreadcrumbRootItem": "S3 バケット",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "경고"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "오류"
+    "i18nStrings.errorIconAriaLabel": "오류",
+    "i18nStrings.warningIconAriaLabel": "경고"
   },
   "form": {
     "errorIconAriaLabel": "오류"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "작거나 같음",
     "i18nStrings.operatorLessText": "보다 작음",
     "i18nStrings.operatorStartsWithText": "로 시작",
+    "i18nStrings.operatorDoesNotStartWithText": "(으)로 시작하지 않음",
     "i18nStrings.operatorText": "연산자",
     "i18nStrings.operatorsText": "연산자",
     "i18nStrings.propertyText": "속성",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "리소스 로드 중",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "객체 버전",
-    "i18nStrings.modalTitle": "S3에서 아카이브 선택",
+    "i18nStrings.modalTitle": "S3에서 객체 선택",
     "i18nStrings.modalCancelButton": "취소",
     "i18nStrings.modalSubmitButton": "선택",
     "i18nStrings.modalBreadcrumbRootItem": "S3 버킷",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Aviso"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Erro"
+    "i18nStrings.errorIconAriaLabel": "Erro",
+    "i18nStrings.warningIconAriaLabel": "Aviso"
   },
   "form": {
     "errorIconAriaLabel": "Erro"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "Menor que ou igual a",
     "i18nStrings.operatorLessText": "Menor que",
     "i18nStrings.operatorStartsWithText": "Começa com",
+    "i18nStrings.operatorDoesNotStartWithText": "Não começa com",
     "i18nStrings.operatorText": "Operador",
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propriedade",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Carregando recurso",
     "i18nStrings.inContextUriLabel": "URI do S3",
     "i18nStrings.inContextVersionSelectLabel": "Versão do objeto",
-    "i18nStrings.modalTitle": "Escolher um arquivo no S3",
+    "i18nStrings.modalTitle": "Escolha um objeto no S3",
     "i18nStrings.modalCancelButton": "Cancelar",
     "i18nStrings.modalSubmitButton": "Escolher",
     "i18nStrings.modalBreadcrumbRootItem": "Buckets do S3",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "Uyarı"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "Hata"
+    "i18nStrings.errorIconAriaLabel": "Hata",
+    "i18nStrings.warningIconAriaLabel": "Uyarı"
   },
   "form": {
     "errorIconAriaLabel": "Hata"
@@ -190,7 +191,8 @@
     "i18nStrings.operatorGreaterText": "Büyüktür",
     "i18nStrings.operatorLessOrEqualText": "Küçük veya eşittir",
     "i18nStrings.operatorLessText": "Küçüktür",
-    "i18nStrings.operatorStartsWithText": "İle başlar",
+    "i18nStrings.operatorStartsWithText": "Şununla başlıyor:",
+    "i18nStrings.operatorDoesNotStartWithText": "Şununla başlamıyor:",
     "i18nStrings.operatorText": "Operatör",
     "i18nStrings.operatorsText": "Operatörler",
     "i18nStrings.propertyText": "Özellik",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "Kaynak yükleniyor",
     "i18nStrings.inContextUriLabel": "S3 URI'si",
     "i18nStrings.inContextVersionSelectLabel": "Nesne sürümü",
-    "i18nStrings.modalTitle": "S3'te bir arşiv seç",
+    "i18nStrings.modalTitle": "S3'te bir nesne seçin",
     "i18nStrings.modalCancelButton": "İptal",
     "i18nStrings.modalSubmitButton": "Seç",
     "i18nStrings.modalBreadcrumbRootItem": "S3 bucket'ları",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "错误"
+    "i18nStrings.errorIconAriaLabel": "错误",
+    "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form": {
     "errorIconAriaLabel": "错误"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "小于或等于",
     "i18nStrings.operatorLessText": "小于",
     "i18nStrings.operatorStartsWithText": "开头为",
+    "i18nStrings.operatorDoesNotStartWithText": "开头不为",
     "i18nStrings.operatorText": "运算符",
     "i18nStrings.operatorsText": "运算符",
     "i18nStrings.propertyText": "属性",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "正在加载资源",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "对象版本",
-    "i18nStrings.modalTitle": "在 S3 中选择档案",
+    "i18nStrings.modalTitle": "在 S3 中选择一个对象",
     "i18nStrings.modalCancelButton": "取消",
     "i18nStrings.modalSubmitButton": "选择",
     "i18nStrings.modalBreadcrumbRootItem": "S3 存储桶",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -138,7 +138,8 @@
     "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form-field": {
-    "i18nStrings.errorIconAriaLabel": "錯誤"
+    "i18nStrings.errorIconAriaLabel": "錯誤",
+    "i18nStrings.warningIconAriaLabel": "警告"
   },
   "form": {
     "errorIconAriaLabel": "錯誤"
@@ -191,6 +192,7 @@
     "i18nStrings.operatorLessOrEqualText": "小於或等於",
     "i18nStrings.operatorLessText": "小於",
     "i18nStrings.operatorStartsWithText": "開始為",
+    "i18nStrings.operatorDoesNotStartWithText": "開頭不能為",
     "i18nStrings.operatorText": "運算子",
     "i18nStrings.operatorsText": "運算子",
     "i18nStrings.propertyText": "屬性",
@@ -207,7 +209,7 @@
     "i18nStrings.inContextLoadingText": "正在載入資源",
     "i18nStrings.inContextUriLabel": "S3 URI",
     "i18nStrings.inContextVersionSelectLabel": "選取版本",
-    "i18nStrings.modalTitle": "選擇 S3 中的存檔",
+    "i18nStrings.modalTitle": "在 S3 中選擇一個對象",
     "i18nStrings.modalCancelButton": "取消",
     "i18nStrings.modalSubmitButton": "選擇",
     "i18nStrings.modalBreadcrumbRootItem": "S3 儲存貯體",


### PR DESCRIPTION
### Description

Updated strings based on i18n process doc: `w07VAyVxf86q`

Contains necessary strings for #2036.

### How has this been tested?

Existing tests

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
