### PR TITLE
fix: Ensure scrollbars in fit-height containers don't leave rounded corners

### DIFF
--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -78,6 +78,8 @@
   &-fit-height {
     block-size: 100%;
     overflow: hidden;
+    border-end-start-radius: awsui.$border-radius-container;
+    border-end-end-radius: awsui.$border-radius-container;
   }
 }
 


### PR DESCRIPTION
### Description

Big part of this fix. Looks nicer on Mac, but still need to check Windows (because it has the buttons at the end).

Related links, issue #, if available: AWSUI-35910

### How has this been tested?

Might be tested in screenshot tests? I'll have to look into that next - it looks like we hide scrollbars in screenshot tests, so we're not getting the best coverage for cases where we expect to see scrollbars...

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
