### PR TITLE
test: Add permutations for table editable cells

### DIFF
--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -9,12 +9,22 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 import { useStickyColumns } from '~components/table/sticky-columns';
+import { Box } from '~components';
 
-const baseColumnDefinition = { cell: () => 'Cell content', header: 'Column header' };
+const baseColumnDefinition = {
+  cell: () => 'Editable cell content shown inline when not editing',
+  header: 'Column header',
+};
 
 const options = ['A', 'B', 'C', 'D', 'E', 'F'].map(value => ({ value, label: `Option ${value}` }));
 
-const editPermutations = createPermutations<TableProps.EditConfig<unknown>>([
+interface PermutationProps extends TableProps.EditConfig<unknown> {
+  isEditing: boolean;
+  successfulEdit?: boolean;
+  disabledReason?: () => string;
+}
+
+const editPermutations = createPermutations<PermutationProps>([
   {
     ariaLabel: ['Editable column'],
     editIconAriaLabel: ['editable'],
@@ -32,6 +42,27 @@ const editPermutations = createPermutations<TableProps.EditConfig<unknown>>([
     ],
     constraintText: [undefined, 'This requirement needs to be met.'],
     validation: [undefined, () => 'There was an error!'],
+    isEditing: [true],
+  },
+  {
+    ariaLabel: ['Editable column'],
+    editIconAriaLabel: ['editable'],
+    errorIconAriaLabel: ['Error'],
+    editingCell: [() => null],
+    constraintText: [undefined],
+    validation: [undefined],
+    isEditing: [false],
+    successfulEdit: [false, true],
+  },
+  {
+    ariaLabel: ['Editable column'],
+    editIconAriaLabel: ['editable'],
+    errorIconAriaLabel: ['Error'],
+    editingCell: [() => null],
+    constraintText: [undefined],
+    validation: [undefined],
+    isEditing: [false],
+    disabledReason: [() => 'Disabled reason popover content'],
   },
 ]);
 
@@ -44,36 +75,37 @@ export default function InlineEditorPermutations() {
         <PermutationsView
           permutations={editPermutations}
           render={permutation => (
-            <table>
-              <tbody>
-                <tr>
-                  <TableBodyCell
-                    ariaLabels={{
-                      activateEditLabel: column => `Edit ${column.header}`,
-                      cancelEditLabel: column => `Cancel editing ${column.header}`,
-                      submitEditLabel: column => `Submit edit ${column.header}`,
-                    }}
-                    item={{}}
-                    column={{ ...baseColumnDefinition, editConfig: permutation }}
-                    isEditing={true}
-                    isEditable={true}
-                    isFirstRow={false}
-                    isLastRow={false}
-                    isNextSelected={false}
-                    isPrevSelected={false}
-                    isSelected={false}
-                    onEditStart={() => {}}
-                    onEditEnd={() => {}}
-                    wrapLines={false}
-                    columnId="id"
-                    colIndex={0}
-                    stickyState={stickyState}
-                    tableRole="grid"
-                    {...permutation}
-                  />
-                </tr>
-              </tbody>
-            </table>
+            <Box>
+              <table style={{ tableLayout: 'fixed', width: 300 }}>
+                <tbody>
+                  <tr>
+                    <TableBodyCell
+                      ariaLabels={{
+                        activateEditLabel: column => `Edit ${column.header}`,
+                        cancelEditLabel: column => `Cancel editing ${column.header}`,
+                        submitEditLabel: column => `Submit edit ${column.header}`,
+                      }}
+                      item={{}}
+                      column={{ ...baseColumnDefinition, editConfig: permutation }}
+                      isEditable={true}
+                      isFirstRow={false}
+                      isLastRow={false}
+                      isNextSelected={false}
+                      isPrevSelected={false}
+                      isSelected={false}
+                      onEditStart={() => {}}
+                      onEditEnd={() => {}}
+                      wrapLines={false}
+                      columnId="id"
+                      colIndex={0}
+                      stickyState={stickyState}
+                      tableRole="grid"
+                      {...permutation}
+                    />
+                  </tr>
+                </tbody>
+              </table>
+            </Box>
           )}
         />
       </ScreenshotArea>


### PR DESCRIPTION
### Description

Table editable cells styles are to be updated in https://github.com/cloudscape-design/components/pull/2060. 

In this PR I am adding more permutations to compare before and after in screenshots.

### How has this been tested?

The updates made to the test page will be visible in screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
