### PR TITLE
fix: hide popover on line charts when relatedTarget is not a DOM node

### DIFF
--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -303,6 +303,47 @@ describe('useChartModel', () => {
 
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('');
       });
+
+      test('clear highlighted X when mouse exited from the page', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+
+        const mouseMoveEvent = {
+          relatedTarget: wrapper.findPlot()?.getElement(),
+          clientX: 100,
+          clientY: 100,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseMove(wrapper.findPlot()!.getElement(), mouseMoveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+
+        const mouseLeaveEvent = {
+          relatedTarget: window, // when mouse exited the page, relatedTarget is set to window.
+          clientX: 0,
+          clientY: 0,
+        } as any;
+
+        act(() => {
+          fireEvent.mouseLeave(wrapper.findDetailPopover()!.getElement(), mouseLeaveEvent);
+        });
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('');
+      });
+
       test('keep highlighted X when mouse leaves popover but in plot', () => {
         const { wrapper } = renderChartModelHook({
           height: 0,

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -147,7 +147,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
       }
 
       // Check if the target is contained within svg to allow hovering on the popover body.
-      if (!nodeContains(plotRef.current!.svg, event.relatedTarget as Element)) {
+      if (!nodeContains(plotRef.current!.svg, event.relatedTarget)) {
         interactions.clearHighlightedLegend();
         interactions.clearHighlight();
       }
@@ -319,7 +319,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     const onPopoverLeave = (event: MouseEvent) => {
-      if (nodeContains(plotRef.current!.svg, event.relatedTarget as Element) || interactions.get().isPopoverPinned) {
+      if (nodeContains(plotRef.current!.svg, event.relatedTarget) || interactions.get().isPopoverPinned) {
         return;
       }
       interactions.clearHighlight();

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -319,11 +319,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     const onPopoverLeave = (event: MouseEvent) => {
-      // pointing device exited from the page or from an element within the svg
-      if (
-        (event.relatedTarget !== window && plotRef.current!.svg.contains(event.relatedTarget as Node)) ||
-        interactions.get().isPopoverPinned
-      ) {
+      if (nodeContains(plotRef.current!.svg, event.relatedTarget as Element) || interactions.get().isPopoverPinned) {
         return;
       }
       interactions.clearHighlight();

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -147,7 +147,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
       }
 
       // Check if the target is contained within svg to allow hovering on the popover body.
-      if (!nodeContains(plotRef.current!.svg, event.relatedTarget)) {
+      if (!nodeContains(plotRef.current!.svg, event.relatedTarget as Element)) {
         interactions.clearHighlightedLegend();
         interactions.clearHighlight();
       }
@@ -319,7 +319,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     const onPopoverLeave = (event: MouseEvent) => {
-      if (nodeContains(plotRef.current!.svg, event.relatedTarget) || interactions.get().isPopoverPinned) {
+      if (nodeContains(plotRef.current!.svg, event.relatedTarget as Element) || interactions.get().isPopoverPinned) {
         return;
       }
       interactions.clearHighlight();

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -319,7 +319,11 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     const onPopoverLeave = (event: MouseEvent) => {
-      if (plotRef.current!.svg.contains(event.relatedTarget as Node) || interactions.get().isPopoverPinned) {
+      // pointing device exited from the page or from an element within the svg
+      if (
+        (event.relatedTarget !== window && plotRef.current!.svg.contains(event.relatedTarget as Node)) ||
+        interactions.get().isPopoverPinned
+      ) {
         return;
       }
       interactions.clearHighlight();

--- a/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
+++ b/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
@@ -144,28 +144,18 @@ describe('Mouse hover hook', () => {
   });
 
   test('clears highlightX when onPopoverLeave is called', () => {
-    const customProps = {
-      highlightX: jest.fn(),
-      clearHighlightedSeries: jest.fn(),
-    };
-    const { hook } = renderMouseHoverHook(customProps);
-    const event = {
-      relatedTarget: null,
-    } as any;
-    act(() => hook.current.onPopoverLeave(event));
-    expect(customProps.highlightX).toHaveBeenCalledWith(null);
-    expect(customProps.clearHighlightedSeries).toHaveBeenCalledTimes(1);
-  });
+    const SvgElementDummy = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const lineElement = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    SvgElementDummy.appendChild(lineElement);
 
-  test('clears highlightX when onPopoverLeave is called (pointing device exited from the page)', () => {
     const customProps = {
       highlightX: jest.fn(),
       clearHighlightedSeries: jest.fn(),
+      plotRef: { current: { svg: SvgElementDummy, focusApplication: jest.fn(), focusPlot: jest.fn() } },
     };
     const { hook } = renderMouseHoverHook(customProps);
-    // When leaving a page, relatedTarget points to window
     const event = {
-      relatedTarget: window,
+      relatedTarget: lineElement,
     } as any;
     act(() => hook.current.onPopoverLeave(event));
     expect(customProps.highlightX).toHaveBeenCalledWith(null);

--- a/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
+++ b/src/mixed-line-bar-chart/__tests__/use-mouse-hover.test.ts
@@ -157,6 +157,45 @@ describe('Mouse hover hook', () => {
     expect(customProps.clearHighlightedSeries).toHaveBeenCalledTimes(1);
   });
 
+  test('clears highlightX when onPopoverLeave is called (pointing device exited from the page)', () => {
+    const customProps = {
+      highlightX: jest.fn(),
+      clearHighlightedSeries: jest.fn(),
+    };
+    const { hook } = renderMouseHoverHook(customProps);
+    // When leaving a page, relatedTarget points to window
+    const event = {
+      relatedTarget: window,
+    } as any;
+    act(() => hook.current.onPopoverLeave(event));
+    expect(customProps.highlightX).toHaveBeenCalledWith(null);
+    expect(customProps.clearHighlightedSeries).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not clear highlightX when onPopoverLeave is called (pointing device exited from the svg)', () => {
+    const svgMock = { contains: () => true } as unknown as SVGSVGElement;
+    const customProps = {
+      highlightX: jest.fn(),
+      clearHighlightedSeries: jest.fn(),
+      isHandlersDisabled: true,
+      plotRef: {
+        current: {
+          svg: svgMock,
+          focusApplication: jest.fn(),
+          focusPlot: jest.fn(),
+        },
+      },
+    };
+
+    const { hook } = renderMouseHoverHook(customProps);
+    const event = {
+      relatedTarget: null,
+    } as any;
+    act(() => hook.current.onPopoverLeave(event));
+    expect(customProps.highlightX).not.toHaveBeenCalled();
+    expect(customProps.clearHighlightedSeries).not.toHaveBeenCalled();
+  });
+
   test('does not clear highlightX when onPopoverLeave is called if isHandlersDisabled is true', () => {
     const customProps = {
       highlightX: jest.fn(),

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -134,7 +134,11 @@ export function useMouseHover<T>({
   };
 
   const onPopoverLeave = (event: React.MouseEvent) => {
-    if (!isHandlersDisabled && !plotRef.current!.svg.contains(event.relatedTarget as Node)) {
+    if (
+      !isHandlersDisabled &&
+      // pointing device exited from the page or from an element within the svg
+      (event.relatedTarget === window || !plotRef.current!.svg.contains(event.relatedTarget as Node))
+    ) {
       highlightX(null);
       clearHighlightedSeries();
     }

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -134,11 +134,7 @@ export function useMouseHover<T>({
   };
 
   const onPopoverLeave = (event: React.MouseEvent) => {
-    if (
-      !isHandlersDisabled &&
-      // pointing device exited from the page or from an element within the svg
-      (event.relatedTarget === window || !plotRef.current!.svg.contains(event.relatedTarget as Node))
-    ) {
+    if (!isHandlersDisabled && nodeContains(plotRef.current!.svg, event.relatedTarget as Element)) {
       highlightX(null);
       clearHighlightedSeries();
     }

--- a/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-mouse-hover.ts
@@ -125,7 +125,7 @@ export function useMouseHover<T>({
       return;
     }
     if (
-      !nodeContains(plotRef.current!.svg, event.relatedTarget as Element) ||
+      !nodeContains(plotRef.current!.svg, event.relatedTarget) ||
       (event.relatedTarget && (event.relatedTarget as Element).classList.contains(styles.series))
     ) {
       highlightX(null);
@@ -134,7 +134,7 @@ export function useMouseHover<T>({
   };
 
   const onPopoverLeave = (event: React.MouseEvent) => {
-    if (!isHandlersDisabled && nodeContains(plotRef.current!.svg, event.relatedTarget as Element)) {
+    if (!isHandlersDisabled && nodeContains(plotRef.current!.svg, event.relatedTarget)) {
       highlightX(null);
       clearHighlightedSeries();
     }


### PR DESCRIPTION
### Description

This PR addresses the issue where an exception was thrown when leaving the popover on a chart by either:
- Focusing another element outside the page (all browsers)
- Right-clicking on a popover (Firefox only)

The root cause was that `event.relatedTarget` pointed to the `window` object in these cases. The `useMouseHover` hook has been updated to account for this scenario.

Related links, issue #, if available: AWSUI-35614

---

Why FF acts differently?
Firefox is firing the `onmousleave` event on a right click, all other browsers don't. Try it on the [mouseleave MDN page's Examples](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event#examples). The [onmouseleave specs](https://w3c.github.io/uievents/#event-type-mouseleave) mentions
> A [user agent](https://w3c.github.io/uievents/#user-agent) MUST also dispatch this event when the element or one of its descendants moves to be no longer underneath the primary pointing device.

Not sure how the context menu is handled in this case, it could be interpreted as "no longer underneath the primary pointing device". I'm searching for references and existing FF bug reports, in case I won't find any, I'll create one.

### How has this been tested?

- Verified the fix manually in Firefox, Chrome, and Safari.
- Added unit tests to cover the `useMouseHover` hook's edge cases.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
