### PR TITLE
feat: Add ariaLabels to token group for "Show fewer" and "Show more" buttons

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -9845,6 +9845,20 @@ Provide an empty array to clear the selection.",
       "type": "number",
     },
     Object {
+      "description": "Adds an aria-label to the \\"Show fewer\\" button for the token group control.
+Use to assign unique labels when there are multiple token groups with the same \`tokenLimitShowFewer\` label on one page.",
+      "name": "tokenLimitShowFewerAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds an aria-label to the \\"Show more\\" button for the token group control.
+Use to assign unique labels when there are multiple token groups with the same \`tokenLimitShowMore\` label on one page.",
+      "name": "tokenLimitShowMoreAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "If you have more than 500 options, enable this flag to apply a performance optimization
 that makes the filtering experience smoother. We don't recommend enabling the feature if you
 have less than 500 options, because the improvements to performance are offset by a
@@ -11227,6 +11241,20 @@ Each token has the following properties:
       "name": "tokenLimit",
       "optional": true,
       "type": "number",
+    },
+    Object {
+      "description": "Adds an aria-label to the \\"Show fewer\\" button for the token group control.
+Use to assign unique labels when there are multiple token groups with the same \`tokenLimitShowFewer\` label on one page.",
+      "name": "tokenLimitShowFewerAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds an aria-label to the \\"Show more\\" button for the token group control.
+Use to assign unique labels when there are multiple token groups with the same \`tokenLimitShowMore\` label on one page.",
+      "name": "tokenLimitShowMoreAriaLabel",
+      "optional": true,
+      "type": "string",
     },
     Object {
       "description": "If you have more than 500 \`filteringOptions\`, enable this flag to apply a performance optimization that makes
@@ -15222,6 +15250,20 @@ We recommend to always enable this property.",
       "name": "limit",
       "optional": true,
       "type": "number",
+    },
+    Object {
+      "description": "Adds an \`aria-label\` to the \\"Show fewer\\" button.
+Use to assign unique labels when there are multiple token groups with the same \`limitShowFewer\` label on one page.",
+      "name": "limitShowFewerAriaLabel",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
+      "description": "Adds an \`aria-label\` to the \\"Show more\\" button.
+Use to assign unique labels when there are multiple token groups with the same \`limitShowMore\` label on one page.",
+      "name": "limitShowMoreAriaLabel",
+      "optional": true,
+      "type": "string",
     },
   ],
   "regions": Array [],

--- a/src/internal/components/token-list/index.tsx
+++ b/src/internal/components/token-list/index.tsx
@@ -17,6 +17,8 @@ export default function TokenList<Item>({
   limit,
   after,
   i18nStrings,
+  limitShowFewerAriaLabel,
+  limitShowMoreAriaLabel,
   moveFocusNextToIndex,
   onExpandedClick = () => undefined,
 }: TokenListProps<Item>) {
@@ -37,6 +39,8 @@ export default function TokenList<Item>({
         expanded={expanded}
         numberOfHiddenOptions={items.length - visibleItems.length}
         i18nStrings={i18nStrings}
+        limitShowFewerAriaLabel={limitShowFewerAriaLabel}
+        limitShowMoreAriaLabel={limitShowMoreAriaLabel}
         onClick={() => {
           const isExpanded = !expanded;
           setExpanded(isExpanded);

--- a/src/internal/components/token-list/interfaces.ts
+++ b/src/internal/components/token-list/interfaces.ts
@@ -12,6 +12,8 @@ export interface TokenListProps<Item> {
   i18nStrings?: I18nStrings;
   moveFocusNextToIndex?: null | number;
   onExpandedClick?: (isExpanded: boolean) => void;
+  limitShowFewerAriaLabel?: string;
+  limitShowMoreAriaLabel?: string;
 }
 
 export interface I18nStrings {

--- a/src/internal/components/token-list/token-limit-toggle.tsx
+++ b/src/internal/components/token-list/token-limit-toggle.tsx
@@ -15,6 +15,8 @@ interface TokenLimitToggleProps {
   numberOfHiddenOptions: number;
   onClick?: NonCancelableEventHandler<null>;
   i18nStrings?: I18nStrings;
+  limitShowFewerAriaLabel?: string;
+  limitShowMoreAriaLabel?: string;
 }
 
 export default function TokenLimitToggle({
@@ -24,6 +26,8 @@ export default function TokenLimitToggle({
   numberOfHiddenOptions,
   onClick,
   i18nStrings = {},
+  limitShowFewerAriaLabel,
+  limitShowMoreAriaLabel,
 }: TokenLimitToggleProps) {
   const i18n = useInternalI18n('token-group');
 
@@ -31,6 +35,7 @@ export default function TokenLimitToggle({
   const description = expanded
     ? i18n('i18nStrings.limitShowFewer', i18nStrings.limitShowFewer)
     : `${i18n('i18nStrings.limitShowMore', i18nStrings.limitShowMore) || ''} (${numberOfHiddenOptionLabel})`;
+  const ariaLabel = expanded ? limitShowFewerAriaLabel : limitShowMoreAriaLabel;
 
   const handleClick = useCallback(() => {
     fireNonCancelableEvent(onClick, null);
@@ -43,6 +48,7 @@ export default function TokenLimitToggle({
       onClick={handleClick}
       aria-controls={controlId}
       aria-expanded={expanded}
+      aria-label={ariaLabel}
     >
       <InternalIcon name={expanded ? 'treeview-collapse' : 'treeview-expand'} />
       <span className={styles.description}>{description}</span>

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -259,6 +259,103 @@ test('does not render token group when no tokens are present', () => {
   expect(wrapper.findByClassName(tokenGroupStyles.root)).toBeNull();
 });
 
+describe('Token group', () => {
+  const i18nStrings = {
+    tokenLimitShowFewer: 'Show fewer',
+    tokenLimitShowMore: 'Show more',
+  };
+
+  test('displays no show more button when tokenLimit is higher than selected token count', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={100}
+      />
+    );
+    expect(wrapper.findTokenToggle()).toBeNull();
+  });
+
+  test('displays show more button when tokenLimit is collapsed', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+      />
+    );
+    expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show more (+1)');
+  });
+
+  test('displays show fewer button when tokenlist is expanded', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+      />
+    );
+    wrapper.findTokenToggle()!.click();
+    expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show fewer');
+  });
+
+  test('sets no aria-label text on the expand button by default', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+      />
+    );
+    expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show more (+1)');
+    expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+  });
+
+  test('sets aria-label text on the expand button when provided', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+        tokenLimitShowMoreAriaLabel="Show more dummy token"
+      />
+    );
+    expect(wrapper.findTokenToggle()!.getElement()!.getAttribute('aria-label')).toBe('Show more dummy token');
+  });
+
+  test('sets no aria-label text on the collapse button by default', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+      />
+    );
+    wrapper.findTokenToggle()!.click();
+    expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show fewer');
+    expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+  });
+
+  test('sets aria-label text on the collapse button when provided', () => {
+    const { wrapper } = renderMultiselect(
+      <Multiselect
+        selectedOptions={defaultOptions.slice(0, 2)}
+        options={defaultOptions}
+        i18nStrings={i18nStrings}
+        tokenLimit={1}
+        tokenLimitShowFewerAriaLabel="Show fewer dummy token"
+      />
+    );
+    wrapper.findTokenToggle()!.click();
+    expect(wrapper.findTokenToggle()!.getElement()!.getAttribute('aria-label')).toBe('Show fewer dummy token');
+  });
+});
 describe('Dropdown states', () => {
   [
     ['loading', true],

--- a/src/multiselect/interfaces.ts
+++ b/src/multiselect/interfaces.ts
@@ -45,6 +45,17 @@ export interface MultiselectProps extends BaseSelectProps {
    * Automatically focuses the trigger when component is mounted.
    */
   autoFocus?: boolean;
+
+  /**
+   * Adds an aria-label to the "Show fewer" button for the token group control.
+   * Use to assign unique labels when there are multiple token groups with the same `tokenLimitShowFewer` label on one page.
+   */
+  tokenLimitShowFewerAriaLabel?: string;
+  /**
+   * Adds an aria-label to the "Show more" button for the token group control.
+   * Use to assign unique labels when there are multiple token groups with the same `tokenLimitShowMore` label on one page.
+   */
+  tokenLimitShowMoreAriaLabel?: string;
 }
 
 export namespace MultiselectProps {

--- a/src/multiselect/internal.tsx
+++ b/src/multiselect/internal.tsx
@@ -73,6 +73,8 @@ const InternalMultiselect = React.forwardRef(
       inlineTokens = false,
       hideTokens = false,
       expandToViewport,
+      tokenLimitShowFewerAriaLabel,
+      tokenLimitShowMoreAriaLabel,
       __internalRootRef = null,
       autoFocus,
       ...restProps
@@ -356,6 +358,8 @@ const InternalMultiselect = React.forwardRef(
             items={tokens}
             onDismiss={handleTokenDismiss}
             i18nStrings={tokenGroupI18nStrings}
+            limitShowMoreAriaLabel={tokenLimitShowMoreAriaLabel}
+            limitShowFewerAriaLabel={tokenLimitShowFewerAriaLabel}
             disableOuterPadding={true}
           />
         )}

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -773,6 +773,45 @@ describe('property filter parts', () => {
       });
       expect(wrapper.findTokenToggle()).toBeNull();
     });
+
+    describe('aria-label on toggle fewer/more button', () => {
+      const propertiesWithMultipleTokens: Partial<PropertyFilterProps> = {
+        tokenLimit: 1,
+        query: {
+          tokens: [
+            { propertyKey: 'string', value: 'first', operator: ':' },
+            { propertyKey: 'string', value: 'second', operator: ':' },
+          ],
+          operation: 'or',
+        },
+      };
+
+      test('sets no aria-label text on the expand button by default', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent(propertiesWithMultipleTokens);
+        expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+      });
+      test('sets aria-label text on the expand button when provided', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent({
+          ...propertiesWithMultipleTokens,
+          tokenLimitShowMoreAriaLabel: 'Show more token',
+        });
+        expect(wrapper.findTokenToggle()!.getElement()).toHaveAttribute('aria-label', 'Show more token');
+      });
+      test('sets no aria-label text on the collapse button by default', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent(propertiesWithMultipleTokens);
+        wrapper.findTokenToggle()!.click();
+        expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+      });
+      test('sets aria-label text on the collapse button when provided', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent({
+          ...propertiesWithMultipleTokens,
+          tokenLimitShowFewerAriaLabel: 'Show fewer token',
+        });
+        wrapper.findTokenToggle()!.click();
+        expect(wrapper.findTokenToggle()!.getElement()).toHaveAttribute('aria-label', 'Show fewer token');
+      });
+    });
+
     test('toggles the visibility of tokens past the limit', () => {
       const { propertyFilterWrapper: wrapper } = renderComponent({
         tokenLimit: 1,

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -98,6 +98,8 @@ const PropertyFilter = React.forwardRef(
       asyncProperties,
       tokenLimit,
       expandToViewport,
+      tokenLimitShowFewerAriaLabel,
+      tokenLimitShowMoreAriaLabel,
       ...rest
     }: PropertyFilterProps,
     ref: React.Ref<Ref>
@@ -409,6 +411,8 @@ const PropertyFilter = React.forwardRef(
                 alignment="inline"
                 limit={tokenLimit}
                 items={internalQuery.tokens}
+                limitShowFewerAriaLabel={tokenLimitShowFewerAriaLabel}
+                limitShowMoreAriaLabel={tokenLimitShowMoreAriaLabel}
                 renderItem={(token, tokenIndex) => (
                   <TokenButton
                     token={token}

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -192,6 +192,17 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * * `error` - Indicates that an error occurred during fetch. You should use `recoveryText` to enable the user to recover.
    **/
   filteringStatusType?: DropdownStatusProps.StatusType;
+
+  /**
+   * Adds an aria-label to the "Show fewer" button for the token group control.
+   * Use to assign unique labels when there are multiple token groups with the same `tokenLimitShowFewer` label on one page.
+   */
+  tokenLimitShowFewerAriaLabel?: string;
+  /**
+   * Adds an aria-label to the "Show more" button for the token group control.
+   * Use to assign unique labels when there are multiple token groups with the same `tokenLimitShowMore` label on one page.
+   */
+  tokenLimitShowMoreAriaLabel?: string;
 }
 
 export namespace PropertyFilterProps {

--- a/src/token-group/__tests__/token-group.test.tsx
+++ b/src/token-group/__tests__/token-group.test.tsx
@@ -210,6 +210,38 @@ describe('TokenGroup', () => {
       const icon = wrapper.findTokenToggle()!.find('svg');
       expect(icon!.getElement()).toContainHTML(icons['treeview-collapse']);
     });
+
+    test('sets no aria-label text on the expand button by default', () => {
+      const wrapper = renderTokenGroup({ items: generateItems(2), i18nStrings, limit: 1 });
+      expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show more (+1)');
+      expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+    });
+
+    test('sets aria-label text on the expand button when provided', () => {
+      const wrapper = renderTokenGroup({
+        items: generateItems(2),
+        limit: 1,
+        limitShowMoreAriaLabel: 'Show more dummy token',
+      });
+      expect(wrapper.findTokenToggle()!.getElement()!.getAttribute('aria-label')).toBe('Show more dummy token');
+    });
+
+    test('sets no aria-label text on the collapse button by default', () => {
+      const wrapper = renderTokenGroup({ items: generateItems(2), i18nStrings, limit: 1 });
+      wrapper.findTokenToggle()!.click();
+      expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Show less');
+      expect(wrapper.findTokenToggle()!.getElement()).not.toHaveAttribute('aria-label');
+    });
+
+    test('sets aria-label text on the collapse button when provided', () => {
+      const wrapper = renderTokenGroup({
+        items: generateItems(2),
+        limit: 1,
+        limitShowFewerAriaLabel: 'Show fewer dummy token',
+      });
+      wrapper.findTokenToggle()!.click();
+      expect(wrapper.findTokenToggle()!.getElement()!.getAttribute('aria-label')).toBe('Show fewer dummy token');
+    });
   });
 
   describe('Focus management', () => {

--- a/src/token-group/interfaces.ts
+++ b/src/token-group/interfaces.ts
@@ -49,6 +49,16 @@ export interface TokenGroupProps extends BaseComponentProps {
    *  Make sure that you add a listener to this event to update your application state.
    */
   onDismiss?: NonCancelableEventHandler<TokenGroupProps.DismissDetail>;
+  /**
+   * Adds an `aria-label` to the "Show fewer" button.
+   * Use to assign unique labels when there are multiple token groups with the same `limitShowFewer` label on one page.
+   */
+  limitShowFewerAriaLabel?: string;
+  /**
+   * Adds an `aria-label` to the "Show more" button.
+   * Use to assign unique labels when there are multiple token groups with the same `limitShowMore` label on one page.
+   */
+  limitShowMoreAriaLabel?: string;
 }
 
 export namespace TokenGroupProps {

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -24,6 +24,8 @@ export default function InternalTokenGroup({
   limit,
   i18nStrings,
   disableOuterPadding,
+  limitShowFewerAriaLabel,
+  limitShowMoreAriaLabel,
   __internalRootRef,
   ...props
 }: InternalTokenGroupProps) {
@@ -62,6 +64,8 @@ export default function InternalTokenGroup({
           </Token>
         )}
         i18nStrings={i18nStrings}
+        limitShowFewerAriaLabel={limitShowFewerAriaLabel}
+        limitShowMoreAriaLabel={limitShowMoreAriaLabel}
         moveFocusNextToIndex={removedItemIndex}
         onExpandedClick={isExpanded => {
           if (isExpanded && limit) {


### PR DESCRIPTION
### Description

For the [TokenGroup component](https://cloudscape.design/components/token-group/) (used in [Multiselect](https://cloudscape.design/components/multiselect/) and [PropertyFilter](https://cloudscape.design/components/property-filter/?tabId=playground&example=with-hidden-tokens)), we have [writing guidelines](https://cloudscape.design/components/token-group/?tabId=usage) for the show more/show fewer button labels. When multiple TokenGroups/Multiselect/PropertyFilter components are used on one page with identical show more/show fewer button labels, the button’s aria-label should be different to ensure uniqueness across the page. This enables screen reader users to determine the purpose of the button.

Related links, issue #, if available:
- AWSUI-36423
- O2aiARe6YDXL

### How has this been tested?

- added additional unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
