### PR TITLE
feat: Adds internal tooltip component

### DIFF
--- a/src/breadcrumb-group/__integ__/breadcrumb-group.test.ts
+++ b/src/breadcrumb-group/__integ__/breadcrumb-group.test.ts
@@ -3,7 +3,7 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-import styles from '../../../lib/components/breadcrumb-group/item/styles.selectors.js';
+import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const breadcrumbGroupWrapper = createWrapper().findBreadcrumbGroup();
 const dropdownWrapper = breadcrumbGroupWrapper.findDropdown();
@@ -81,9 +81,7 @@ describe('BreadcrumbGroup', () => {
       await page.setWindowSize({ width: 1200, height: 800 });
       await page.click('#focus-target-long-text');
       await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${styles['item-popover']}`).toSelector())).resolves.toBe(
-        false
-      );
+      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
     })
   );
 
@@ -93,18 +91,12 @@ describe('BreadcrumbGroup', () => {
       await page.setMobileViewport();
       await page.click('#focus-target-long-text');
       await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${styles['item-popover']}`).toSelector())).resolves.toBe(
-        true
-      );
+      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(true);
       await page.keys('Escape');
-      await expect(page.isExisting(createWrapper().find(`.${styles['item-popover']}`).toSelector())).resolves.toBe(
-        false
-      );
+      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
       await page.click('#focus-target-short-text');
       await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${styles['item-popover']}`).toSelector())).resolves.toBe(
-        false
-      );
+      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
     })
   );
 

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -7,6 +7,11 @@ import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../../lib/components/internal/analytics/selectors';
+import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
+
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  useMobile: jest.fn().mockReturnValue(true),
+}));
 
 const renderBreadcrumbGroup = (props: BreadcrumbGroupProps) => {
   const { container } = render(<BreadcrumbGroup {...props} />);
@@ -128,6 +133,18 @@ describe('BreadcrumbGroup Item', () => {
       const expectedFunnelName = items[items.length - 1].text;
       const element = wrapper.find(`[${DATA_ATTR_FUNNEL_KEY}="${FUNNEL_KEY_FUNNEL_NAME}"]`)!.getElement();
       expect(element.innerHTML).toBe(expectedFunnelName);
+    });
+  });
+
+  describe('compressed item', () => {
+    beforeEach(() => {
+      (useMobile as jest.Mock).mockReturnValue(true);
+    });
+
+    test('renders item content', () => {
+      const wrapper = renderBreadcrumbGroup({ items });
+
+      expect(wrapper.findBreadcrumbLinks()[0].getElement()).toHaveTextContent(items[0].text);
     });
   });
 });

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -7,13 +7,10 @@ import styles from './styles.css.js';
 import clsx from 'clsx';
 import { fireCancelableEvent, isPlainLeftClick } from '../../internal/events';
 import { getEventDetail } from '../internal';
-import { Transition } from '../../internal/components/transition';
-import PopoverContainer from '../../popover/container';
-import PopoverBody from '../../popover/body';
-import Portal from '../../internal/components/portal';
-import popoverStyles from '../../popover/styles.css.js';
+
 import { DATA_ATTR_FUNNEL_KEY } from '../../internal/analytics/selectors';
 import { FUNNEL_KEY_FUNNEL_NAME } from '../../internal/analytics/selectors';
+import Tooltip from '../../internal/components/tooltip';
 
 type BreadcrumbItemWithPopoverProps<T extends BreadcrumbGroupProps.Item> = React.HTMLAttributes<HTMLElement> & {
   item: T;
@@ -45,32 +42,7 @@ const BreadcrumbItemWithPopover = <T extends BreadcrumbGroupProps.Item>({
     return false;
   };
 
-  const popoverContent = (
-    <Portal>
-      <div className={styles['item-popover']}>
-        <Transition in={true}>
-          {() => (
-            <PopoverContainer
-              trackRef={textRef}
-              size="small"
-              fixedWidth={false}
-              position="bottom"
-              arrow={position => (
-                <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
-                  <div className={popoverStyles['arrow-outer']} />
-                  <div className={popoverStyles['arrow-inner']} />
-                </div>
-              )}
-            >
-              <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
-                {item.text}
-              </PopoverBody>
-            </PopoverContainer>
-          )}
-        </Transition>
-      </div>
-    </Portal>
-  );
+  const popoverContent = <Tooltip trackRef={textRef} value={item.text} />;
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -54,6 +54,3 @@
   @include styles.awsui-util-hide;
   visibility: hidden;
 }
-.item-popover {
-  /* used in tests */
-}

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
+import createWrapper, { ElementWrapper, PopoverWrapper } from '../../../../../lib/components/test-utils/dom';
+import styles from '../../../../../lib/components/popover/styles.selectors.js';
+
+class TooltipInternalWrapper extends PopoverWrapper {
+  findContent(): ElementWrapper | null {
+    return createWrapper().findByClassName(styles.content);
+  }
+  findArrow(): ElementWrapper | null {
+    return createWrapper().findByClassName(styles.arrow);
+  }
+  findHeader(): ElementWrapper | null {
+    return createWrapper().findByClassName(styles.header);
+  }
+}
+
+const dummyRef = { current: null };
+function renderTooltip(props: Partial<TooltipProps>) {
+  const { container } = render(<Tooltip trackRef={dummyRef} value={props.value ?? ''} />);
+  return new TooltipInternalWrapper(container);
+}
+
+describe('Tooltip', () => {
+  it('renders text correctly', () => {
+    const wrapper = renderTooltip({ value: 'Value' });
+
+    expect(wrapper.findContent()?.getElement()).toHaveTextContent('Value');
+  });
+
+  it('renders arrow', () => {
+    const wrapper = renderTooltip({ value: 'Value' });
+
+    expect(wrapper.findArrow()).not.toBeNull();
+  });
+
+  it('not does render a header', () => {
+    const wrapper = renderTooltip({ value: 'Value' });
+
+    expect(wrapper.findHeader()).toBeNull();
+  });
+});

--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -28,7 +28,7 @@ describe('Tooltip', () => {
   it('renders text correctly', () => {
     const wrapper = renderTooltip({ value: 'Value' });
 
-    expect(wrapper.findContent()?.getElement()).toHaveTextContent('Value');
+    expect(wrapper.findContent()!.getElement()).toHaveTextContent('Value');
   });
 
   it('renders arrow', () => {
@@ -37,7 +37,7 @@ describe('Tooltip', () => {
     expect(wrapper.findArrow()).not.toBeNull();
   });
 
-  it('not does render a header', () => {
+  it('does not render a header', () => {
     const wrapper = renderTooltip({ value: 'Value' });
 
     expect(wrapper.findHeader()).toBeNull();

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -8,6 +8,7 @@ import PopoverContainer from '../../../popover/container';
 import PopoverBody from '../../../popover/body';
 import Portal from '../portal';
 import popoverStyles from '../../../popover/styles.css.js';
+import styles from './styles.css.js';
 
 export interface TooltipProps {
   value: number | string;
@@ -17,27 +18,29 @@ export interface TooltipProps {
 export default function Tooltip({ value, trackRef }: TooltipProps) {
   return (
     <Portal>
-      <Transition in={true}>
-        {() => (
-          <PopoverContainer
-            trackRef={trackRef}
-            trackKey={value}
-            size="small"
-            fixedWidth={false}
-            position="top"
-            arrow={position => (
-              <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
-                <div className={popoverStyles['arrow-outer']} />
-                <div className={popoverStyles['arrow-inner']} />
-              </div>
-            )}
-          >
-            <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
-              {value}
-            </PopoverBody>
-          </PopoverContainer>
-        )}
-      </Transition>
+      <div className={styles.root}>
+        <Transition in={true}>
+          {() => (
+            <PopoverContainer
+              trackRef={trackRef}
+              trackKey={value}
+              size="small"
+              fixedWidth={false}
+              position="top"
+              arrow={position => (
+                <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
+                  <div className={popoverStyles['arrow-outer']} />
+                  <div className={popoverStyles['arrow-inner']} />
+                </div>
+              )}
+            >
+              <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
+                {value}
+              </PopoverBody>
+            </PopoverContainer>
+          )}
+        </Transition>
+      </div>
     </Portal>
   );
 }

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import clsx from 'clsx';
+
+import { Transition } from '../transition';
+import PopoverContainer from '../../../popover/container';
+import PopoverBody from '../../../popover/body';
+import Portal from '../portal';
+import popoverStyles from '../../../popover/styles.css.js';
+
+export interface TooltipProps {
+  value: number | string;
+  trackRef: React.RefObject<Element>;
+}
+
+export default function Tooltip({ value, trackRef }: TooltipProps) {
+  return (
+    <Portal>
+      <Transition in={true}>
+        {() => (
+          <PopoverContainer
+            trackRef={trackRef}
+            trackKey={value}
+            size="small"
+            fixedWidth={false}
+            position="top"
+            arrow={position => (
+              <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
+                <div className={popoverStyles['arrow-outer']} />
+                <div className={popoverStyles['arrow-inner']} />
+              </div>
+            )}
+          >
+            <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
+              {value}
+            </PopoverBody>
+          </PopoverContainer>
+        )}
+      </Transition>
+    </Portal>
+  );
+}

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -34,7 +34,7 @@ export default function Tooltip({ value, trackRef }: TooltipProps) {
                 </div>
               )}
             >
-              <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={() => {}} header={undefined}>
+              <PopoverBody dismissButton={false} dismissAriaLabel={undefined} onDismiss={undefined} header={undefined}>
                 {value}
               </PopoverBody>
             </PopoverContainer>

--- a/src/internal/components/tooltip/styles.scss
+++ b/src/internal/components/tooltip/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /* used in tests */
+}

--- a/src/popover/body.tsx
+++ b/src/popover/body.tsx
@@ -15,7 +15,7 @@ import { useInternalI18n } from '../i18n/context';
 export interface PopoverBodyProps {
   dismissButton: boolean;
   dismissAriaLabel: string | undefined;
-  onDismiss: () => void;
+  onDismiss: (() => void) | undefined;
 
   header: React.ReactNode | undefined;
   children: React.ReactNode;
@@ -46,7 +46,7 @@ export default function PopoverBody({
     (event: React.KeyboardEvent) => {
       if (event.keyCode === KeyCode.escape) {
         event.stopPropagation();
-        onDismiss();
+        onDismiss?.();
       }
     },
     [onDismiss]
@@ -70,7 +70,7 @@ export default function PopoverBody({
         iconName="close"
         className={styles['dismiss-control']}
         ariaLabel={i18n('dismissAriaLabel', dismissAriaLabel)}
-        onClick={() => onDismiss()}
+        onClick={() => onDismiss?.()}
         ref={dismissButtonRef}
       />
     </div>


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
A simple tooltip component, that has the same styles as our Popover component, but not triggered via a click. It is currently used in the Breadcrumb component, and soon to be Slider component. There are also several other discussions around other places to use this component in the future.

The component was simply moved from the Breadcrumb component to our internal folder, for reusability.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
I tested using the Breadcrumb testing pages to make sure there was no change.

Only basic tests were added to the component itself since it uses the same internal components as the Popover.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
