### PR TITLE
fix: Don't include split panel offset when there is no split panel

### DIFF
--- a/pages/app-layout/with-split-panel.page.tsx
+++ b/pages/app-layout/with-split-panel.page.tsx
@@ -1,132 +1,133 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
-import AppLayout from '~components/app-layout';
+import React, { useContext, useState } from 'react';
+import AppLayout, { AppLayoutProps } from '~components/app-layout';
 import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
 import Toggle from '~components/toggle';
-import Table from '~components/table';
-import Box from '~components/box';
-import Link from '~components/link';
-import Button from '~components/button';
+import AppContext, { AppContextType } from '../app/app-context';
+import ScreenshotArea from '../utils/screenshot-area';
+import { Containers, Navigation, Tools, Breadcrumbs } from './utils/content-blocks';
+import * as toolsContent from './utils/tools-content';
+import labels from './utils/labels';
+
+type SplitPanelDemoContext = React.Context<
+  AppContextType<{
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+    splitPanelEnabled: boolean;
+    toolsEnabled: boolean;
+  }>
+>;
+
+const DEMO_CONTENT = (
+  <div>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec sagittis
+      aliquam malesuada bibendum arcu vitae elementum. Lectus proin nibh nisl condimentum id venenatis. Penatibus et
+      magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
+      Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
+    </p>
+    <p>
+      Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
+      vulputate eu scelerisque felis imperdiet proin fermentum.
+    </p>
+    <p>
+      Orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Varius quam quisque id diam vel.
+      Risus viverra adipiscing at in. Orci sagittis eu volutpat odio facilisis mauris. Mauris vitae ultricies leo
+      integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam pellentesque.
+    </p>
+    <p>Ante in nibh mauris cursus mattis molestie.</p>
+    <p>
+      Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
+      eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi vitae
+      suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu felis bibendum ut
+      tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. In hac habitasse
+      platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean euismod elementum
+      nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras adipiscing enim eu. Id
+      interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi etiam. Sodales neque sodales
+      ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend mi in. Urna condimentum mattis
+      pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id leo in vitae turpis massa sed.
+      Pharetra pharetra massa massa ultricies mi.
+    </p>
+  </div>
+);
 
 export default function () {
-  const [splitPanelExists, setSplitPanelExists] = useState(true);
+  const { urlParams, setUrlParams } = useContext(AppContext as SplitPanelDemoContext);
+  const [splitPanelEnabled, setSplitPanelEnabled] = useState(urlParams.splitPanelEnabled ?? true);
+  const [toolsPanelEnabled, setToolsPanelEnabled] = useState(urlParams.toolsEnabled ?? true);
 
   return (
-    <AppLayout
-      toolsHide={true}
-      navigationHide={true}
-      splitPanel={
-        splitPanelExists ? <SplitPanel header="Split panel header">Split panel content</SplitPanel> : undefined
-      }
-      content={
-        <SpaceBetween size="l">
-          <Toggle checked={splitPanelExists} onChange={e => setSplitPanelExists(e.detail.checked)}>
-            Has split panel
-          </Toggle>
-          {table}
-        </SpaceBetween>
-      }
-    />
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        breadcrumbs={<Breadcrumbs />}
+        navigation={<Navigation />}
+        tools={<Tools>{toolsContent.long}</Tools>}
+        toolsHide={!toolsPanelEnabled}
+        splitPanelPreferences={{
+          position: urlParams.splitPanelPosition,
+        }}
+        onSplitPanelPreferencesChange={event => {
+          const { position } = event.detail;
+          setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+        }}
+        splitPanel={
+          splitPanelEnabled && (
+            <SplitPanel
+              header="Split panel header withlongwordthatshouldbesplitinsteadofmakingthepanelscroll"
+              i18nStrings={{
+                preferencesTitle: 'Preferences',
+                preferencesPositionLabel: 'Split panel position',
+                preferencesPositionDescription: 'Choose the default split panel position for the service.',
+                preferencesPositionSide: 'Side',
+                preferencesPositionBottom: 'Bottom',
+                preferencesConfirm: 'Confirm',
+                preferencesCancel: 'Cancel',
+                closeButtonAriaLabel: 'Close panel',
+                openButtonAriaLabel: 'Open panel',
+                resizeHandleAriaLabel: 'Slider',
+              }}
+            >
+              {DEMO_CONTENT}
+            </SplitPanel>
+          )
+        }
+        content={
+          <>
+            <div style={{ marginBottom: '1rem' }}>
+              <Header variant="h1" description="Basic demo with split panel">
+                Demo page
+              </Header>
+            </div>
+            <SpaceBetween size="l">
+              <Toggle
+                id="enable-split-panel"
+                checked={splitPanelEnabled}
+                onChange={e => {
+                  setSplitPanelEnabled(e.detail.checked);
+                  setUrlParams({ splitPanelEnabled: e.detail.checked });
+                }}
+              >
+                Enable split panel
+              </Toggle>
+              <Toggle
+                id="enable-tools-panel"
+                checked={toolsPanelEnabled}
+                onChange={e => {
+                  setToolsPanelEnabled(e.detail.checked);
+                  setUrlParams({ toolsEnabled: e.detail.checked });
+                }}
+              >
+                Enable tools panel
+              </Toggle>
+              <Containers />
+            </SpaceBetween>
+          </>
+        }
+      />
+    </ScreenshotArea>
   );
 }
-
-const items = [
-  {
-    name: 'Item 1',
-    alt: 'First',
-    description: 'This is the first item',
-    type: '1A',
-    size: 'Small',
-  },
-  {
-    name: 'Item 2',
-    alt: 'Second',
-    description: 'This is the second item',
-    type: '1B',
-    size: 'Large',
-  },
-  {
-    name: 'Item 3',
-    alt: 'Third',
-    description: '-',
-    type: '1A',
-    size: 'Large',
-  },
-  {
-    name: 'Item 4',
-    alt: 'Fourth',
-    description: 'This is the fourth item',
-    type: '2A',
-    size: 'Small',
-  },
-  {
-    name: 'Item 5',
-    alt: '-',
-    description: 'This is the fifth item with a longer description',
-    type: '2A',
-    size: 'Large',
-  },
-  {
-    name: 'Item 6',
-    alt: 'Sixth',
-    description: 'This is the sixth item',
-    type: '1A',
-    size: 'Small',
-  },
-];
-
-const table = (
-  <Table
-    columnDefinitions={[
-      {
-        id: 'variable',
-        header: 'Variable name',
-        cell: item => <Link href="#">{item.name || '-'}</Link>,
-        sortingField: 'name',
-        isRowHeader: true,
-      },
-      {
-        id: 'alt',
-        header: 'Text value',
-        cell: item => item.alt || '-',
-        sortingField: 'alt',
-      },
-      {
-        id: 'description',
-        header: 'Description',
-        cell: item => item.description || '-',
-      },
-      {
-        id: 'description2',
-        header: 'Description',
-        cell: item => item.description || '-',
-      },
-      {
-        id: 'description3',
-        header: 'Description',
-        cell: item => item.description || '-',
-      },
-      {
-        id: 'description4',
-        header: 'Description',
-        cell: item => item.description || '-',
-      },
-    ]}
-    enableKeyboardNavigation={true}
-    items={[...items, ...items, ...items, ...items]}
-    loadingText="Loading resources"
-    sortingDisabled={true}
-    empty={
-      <Box margin={{ vertical: 'xs' }} textAlign="center" color="inherit">
-        <SpaceBetween size="m">
-          <b>No resources</b>
-          <Button>Create resource</Button>
-        </SpaceBetween>
-      </Box>
-    }
-    header={<Header> Simple table </Header>}
-  />
-);

--- a/pages/app-layout/with-split-panel.page.tsx
+++ b/pages/app-layout/with-split-panel.page.tsx
@@ -6,10 +6,10 @@ import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
 import Toggle from '~components/toggle';
-import Table from '~components/Table';
-import Box from '~components/Box';
-import Link from '~components/Link';
-import Button from '~components/Button';
+import Table from '~components/table';
+import Box from '~components/box';
+import Link from '~components/link';
+import Button from '~components/button';
 
 export default function () {
   const [splitPanelExists, setSplitPanelExists] = useState(true);

--- a/pages/app-layout/with-split-panel.page.tsx
+++ b/pages/app-layout/with-split-panel.page.tsx
@@ -1,133 +1,132 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useState } from 'react';
-import AppLayout, { AppLayoutProps } from '~components/app-layout';
+import React, { useState } from 'react';
+import AppLayout from '~components/app-layout';
 import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
 import Toggle from '~components/toggle';
-import AppContext, { AppContextType } from '../app/app-context';
-import ScreenshotArea from '../utils/screenshot-area';
-import { Containers, Navigation, Tools, Breadcrumbs } from './utils/content-blocks';
-import * as toolsContent from './utils/tools-content';
-import labels from './utils/labels';
-
-type SplitPanelDemoContext = React.Context<
-  AppContextType<{
-    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
-    splitPanelEnabled: boolean;
-    toolsEnabled: boolean;
-  }>
->;
-
-const DEMO_CONTENT = (
-  <div>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec sagittis
-      aliquam malesuada bibendum arcu vitae elementum. Lectus proin nibh nisl condimentum id venenatis. Penatibus et
-      magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
-      Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
-    </p>
-    <p>
-      Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
-      vulputate eu scelerisque felis imperdiet proin fermentum.
-    </p>
-    <p>
-      Orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Varius quam quisque id diam vel.
-      Risus viverra adipiscing at in. Orci sagittis eu volutpat odio facilisis mauris. Mauris vitae ultricies leo
-      integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam pellentesque.
-    </p>
-    <p>Ante in nibh mauris cursus mattis molestie.</p>
-    <p>
-      Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
-      eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi vitae
-      suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu felis bibendum ut
-      tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. In hac habitasse
-      platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean euismod elementum
-      nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras adipiscing enim eu. Id
-      interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi etiam. Sodales neque sodales
-      ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend mi in. Urna condimentum mattis
-      pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id leo in vitae turpis massa sed.
-      Pharetra pharetra massa massa ultricies mi.
-    </p>
-  </div>
-);
+import Table from '~components/Table';
+import Box from '~components/Box';
+import Link from '~components/Link';
+import Button from '~components/Button';
 
 export default function () {
-  const { urlParams, setUrlParams } = useContext(AppContext as SplitPanelDemoContext);
-  const [splitPanelEnabled, setSplitPanelEnabled] = useState(urlParams.splitPanelEnabled ?? true);
-  const [toolsPanelEnabled, setToolsPanelEnabled] = useState(urlParams.toolsEnabled ?? true);
+  const [splitPanelExists, setSplitPanelExists] = useState(true);
 
   return (
-    <ScreenshotArea gutters={false}>
-      <AppLayout
-        ariaLabels={labels}
-        breadcrumbs={<Breadcrumbs />}
-        navigation={<Navigation />}
-        tools={<Tools>{toolsContent.long}</Tools>}
-        toolsHide={!toolsPanelEnabled}
-        splitPanelPreferences={{
-          position: urlParams.splitPanelPosition,
-        }}
-        onSplitPanelPreferencesChange={event => {
-          const { position } = event.detail;
-          setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
-        }}
-        splitPanel={
-          splitPanelEnabled && (
-            <SplitPanel
-              header="Split panel header withlongwordthatshouldbesplitinsteadofmakingthepanelscroll"
-              i18nStrings={{
-                preferencesTitle: 'Preferences',
-                preferencesPositionLabel: 'Split panel position',
-                preferencesPositionDescription: 'Choose the default split panel position for the service.',
-                preferencesPositionSide: 'Side',
-                preferencesPositionBottom: 'Bottom',
-                preferencesConfirm: 'Confirm',
-                preferencesCancel: 'Cancel',
-                closeButtonAriaLabel: 'Close panel',
-                openButtonAriaLabel: 'Open panel',
-                resizeHandleAriaLabel: 'Slider',
-              }}
-            >
-              {DEMO_CONTENT}
-            </SplitPanel>
-          )
-        }
-        content={
-          <>
-            <div style={{ marginBottom: '1rem' }}>
-              <Header variant="h1" description="Basic demo with split panel">
-                Demo page
-              </Header>
-            </div>
-            <SpaceBetween size="l">
-              <Toggle
-                id="enable-split-panel"
-                checked={splitPanelEnabled}
-                onChange={e => {
-                  setSplitPanelEnabled(e.detail.checked);
-                  setUrlParams({ splitPanelEnabled: e.detail.checked });
-                }}
-              >
-                Enable split panel
-              </Toggle>
-              <Toggle
-                id="enable-tools-panel"
-                checked={toolsPanelEnabled}
-                onChange={e => {
-                  setToolsPanelEnabled(e.detail.checked);
-                  setUrlParams({ toolsEnabled: e.detail.checked });
-                }}
-              >
-                Enable tools panel
-              </Toggle>
-              <Containers />
-            </SpaceBetween>
-          </>
-        }
-      />
-    </ScreenshotArea>
+    <AppLayout
+      toolsHide={true}
+      navigationHide={true}
+      splitPanel={
+        splitPanelExists ? <SplitPanel header="Split panel header">Split panel content</SplitPanel> : undefined
+      }
+      content={
+        <SpaceBetween size="l">
+          <Toggle checked={splitPanelExists} onChange={e => setSplitPanelExists(e.detail.checked)}>
+            Has split panel
+          </Toggle>
+          {table}
+        </SpaceBetween>
+      }
+    />
   );
 }
+
+const items = [
+  {
+    name: 'Item 1',
+    alt: 'First',
+    description: 'This is the first item',
+    type: '1A',
+    size: 'Small',
+  },
+  {
+    name: 'Item 2',
+    alt: 'Second',
+    description: 'This is the second item',
+    type: '1B',
+    size: 'Large',
+  },
+  {
+    name: 'Item 3',
+    alt: 'Third',
+    description: '-',
+    type: '1A',
+    size: 'Large',
+  },
+  {
+    name: 'Item 4',
+    alt: 'Fourth',
+    description: 'This is the fourth item',
+    type: '2A',
+    size: 'Small',
+  },
+  {
+    name: 'Item 5',
+    alt: '-',
+    description: 'This is the fifth item with a longer description',
+    type: '2A',
+    size: 'Large',
+  },
+  {
+    name: 'Item 6',
+    alt: 'Sixth',
+    description: 'This is the sixth item',
+    type: '1A',
+    size: 'Small',
+  },
+];
+
+const table = (
+  <Table
+    columnDefinitions={[
+      {
+        id: 'variable',
+        header: 'Variable name',
+        cell: item => <Link href="#">{item.name || '-'}</Link>,
+        sortingField: 'name',
+        isRowHeader: true,
+      },
+      {
+        id: 'alt',
+        header: 'Text value',
+        cell: item => item.alt || '-',
+        sortingField: 'alt',
+      },
+      {
+        id: 'description',
+        header: 'Description',
+        cell: item => item.description || '-',
+      },
+      {
+        id: 'description2',
+        header: 'Description',
+        cell: item => item.description || '-',
+      },
+      {
+        id: 'description3',
+        header: 'Description',
+        cell: item => item.description || '-',
+      },
+      {
+        id: 'description4',
+        header: 'Description',
+        cell: item => item.description || '-',
+      },
+    ]}
+    enableKeyboardNavigation={true}
+    items={[...items, ...items, ...items, ...items]}
+    loadingText="Loading resources"
+    sortingDisabled={true}
+    empty={
+      <Box margin={{ vertical: 'xs' }} textAlign="center" color="inherit">
+        <SpaceBetween size="m">
+          <b>No resources</b>
+          <Button>Create resource</Button>
+        </SpaceBetween>
+      </Box>
+    }
+    header={<Header> Simple table </Header>}
+  />
+);

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -338,7 +338,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       displayed: false,
       ariaLabel: undefined,
     });
-    const splitPanelDisplayed = !!(splitPanelToggle.displayed || (isSplitPanelOpen && !!splitPanel));
+    const splitPanelDisplayed = !!(splitPanelToggle.displayed || isSplitPanelOpen) && !!splitPanel;
     const splitPanelControlId = useUniqueId('split-panel-');
     const toolsControlId = useUniqueId('tools-');
 


### PR DESCRIPTION
### Description

Fixes the scrollbar position in table when split panel was removed, but `splitPanelOpen` is still `true`

Related links, issue #, if available: AWSUI-36917

### How has this been tested?

Check [this](https://d21d5uik3ws71m.cloudfront.net/components/9e026d15b245a834e065078fd545bde5fc4fdd41/dev-pages/index.html#/light/app-layout/with-split-panel) dev page

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
