### PR TITLE
chore: Remove i18n support in docs for props that aren't fully supported

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1788,7 +1788,6 @@ receive focus.",
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
-      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -5059,8 +5058,8 @@ It contains the following:
 - \`label\` (string) - Specifies the label for each radio group.
 - \`description\` (string) - Specifies the text displayed below each radio group label.
 
-You must set the current value in the \`preferences.stickyColumns\` property.",
-      "i18nTag": true,
+You must set the current value in the \`preferences.stickyColumns\` property.
+",
       "inlineType": Object {
         "name": "CollectionPreferencesProps.StickyColumnsPreference",
         "properties": Array [
@@ -9565,7 +9564,6 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
-      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -12136,7 +12134,6 @@ To use it correctly, define an ID for the element you want to use as label and s
     },
     Object {
       "description": "Specifies the text to display when a data fetching error occurs. Make sure that you provide \`recoveryText\`.",
-      "i18nTag": true,
       "name": "errorText",
       "optional": true,
       "type": "string",
@@ -13167,7 +13164,6 @@ add a meaningful description to the whole selection.
                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
 * \`submittingEditText\` (EditableColumnDefinition) => string -
                      Specifies a text that is announced to screen readers when a cell edit operation is submitted.",
-      "i18nTag": true,
       "inlineType": Object {
         "name": "TableProps.AriaLabels",
         "properties": Array [

--- a/src/collection-preferences/interfaces.ts
+++ b/src/collection-preferences/interfaces.ts
@@ -87,7 +87,6 @@ export interface CollectionPreferencesProps<CustomPreferenceType = any> extends 
    * - `description` (string) - Specifies the text displayed below each radio group label.
    *
    * You must set the current value in the `preferences.stickyColumns` property.
-   * @i18n
    */
   stickyColumnsPreference?: CollectionPreferencesProps.StickyColumnsPreference;
   /**

--- a/src/internal/components/dropdown-status/interfaces.ts
+++ b/src/internal/components/dropdown-status/interfaces.ts
@@ -18,7 +18,6 @@ export interface DropdownStatusProps {
   finishedText?: string;
   /**
    * Specifies the text to display when a data fetching error occurs. Make sure that you provide `recoveryText`.
-   * @i18n
    **/
   errorText?: string;
   /**

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -180,7 +180,6 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *                      Specifies an alternative text for the success icon in editable cells. This text is also announced to screen readers.
    * * `submittingEditText` (EditableColumnDefinition) => string -
    *                      Specifies a text that is announced to screen readers when a cell edit operation is submitted.
-   * @i18n
    */
   ariaLabels?: TableProps.AriaLabels<T>;
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
