### PR TITLE
chore: Add i18n for table expandable rows

### DIFF
--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -343,6 +343,8 @@ export interface I18nFormatArgTypes {
     "ariaLabels.resizerRoleDescription": never;
     "ariaLabels.submittingEditText": never;
     "ariaLabels.successfulEditLabel": never;
+    "ariaLabels.expandButtonLabel": never;
+    "ariaLabels.collapseButtonLabel": never;
     "columnDefinitions.editConfig.errorIconAriaLabel": never;
     "columnDefinitions.editConfig.editIconAriaLabel": never;
   }

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "Schaltfläche für die Größenänderung",
     "ariaLabels.submittingEditText": "Bearbeitung wird gesendet",
     "ariaLabels.successfulEditLabel": "Bearbeitung erfolgreich",
+    "ariaLabels.expandButtonLabel": "Erweitern",
+    "ariaLabels.collapseButtonLabel": "Minimieren",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Fehler",
     "columnDefinitions.editConfig.editIconAriaLabel": "bearbeitbar"
   },

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "resize button",
     "ariaLabels.submittingEditText": "Submitting edit",
     "ariaLabels.successfulEditLabel": "Edit successful",
+    "ariaLabels.expandButtonLabel": "Expand",
+    "ariaLabels.collapseButtonLabel": "Collapse",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
     "columnDefinitions.editConfig.editIconAriaLabel": "editable"
   },

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "resize button",
     "ariaLabels.submittingEditText": "Submitting edit",
     "ariaLabels.successfulEditLabel": "Edit successful",
+    "ariaLabels.expandButtonLabel": "Expand",
+    "ariaLabels.collapseButtonLabel": "Collapse",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
     "columnDefinitions.editConfig.editIconAriaLabel": "editable"
   },

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "botón de redimensionamiento",
     "ariaLabels.submittingEditText": "Envío de edición",
     "ariaLabels.successfulEditLabel": "Se ha editado correctamente",
+    "ariaLabels.expandButtonLabel": "Ampliar",
+    "ariaLabels.collapseButtonLabel": "Contraer",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Error",
     "columnDefinitions.editConfig.editIconAriaLabel": "editable"
   },

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "bouton de redimensionnement",
     "ariaLabels.submittingEditText": "Soumission de modification",
     "ariaLabels.successfulEditLabel": "Modification réussie",
+    "ariaLabels.expandButtonLabel": "Élargir",
+    "ariaLabels.collapseButtonLabel": "Réduire",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erreur",
     "columnDefinitions.editConfig.editIconAriaLabel": "modifiable"
   },

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "tombol ubah ukuran",
     "ariaLabels.submittingEditText": "Mengirimkan pengeditan",
     "ariaLabels.successfulEditLabel": "Edit berhasil",
+    "ariaLabels.expandButtonLabel": "Luaskan",
+    "ariaLabels.collapseButtonLabel": "Ciutkan",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Kesalahan",
     "columnDefinitions.editConfig.editIconAriaLabel": "dapat diedit"
   },

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "pulsante di ridimensionamento",
     "ariaLabels.submittingEditText": "Invio della modifica in corso",
     "ariaLabels.successfulEditLabel": "Modifica eseguita correttamente",
+    "ariaLabels.expandButtonLabel": "Espandi",
+    "ariaLabels.collapseButtonLabel": "Comprimi",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Errore",
     "columnDefinitions.editConfig.editIconAriaLabel": "modificabile"
   },

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "[サイズを変更] ボタン",
     "ariaLabels.submittingEditText": "編集を送信中",
     "ariaLabels.successfulEditLabel": "編集に成功しました",
+    "ariaLabels.expandButtonLabel": "展開する",
+    "ariaLabels.collapseButtonLabel": "折りたたむ",
     "columnDefinitions.editConfig.errorIconAriaLabel": "エラー",
     "columnDefinitions.editConfig.editIconAriaLabel": "編集可能"
   },

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "크기 조정 버튼",
     "ariaLabels.submittingEditText": "편집 제출 중",
     "ariaLabels.successfulEditLabel": "편집 성공",
+    "ariaLabels.expandButtonLabel": "확장",
+    "ariaLabels.collapseButtonLabel": "축소",
     "columnDefinitions.editConfig.errorIconAriaLabel": "오류",
     "columnDefinitions.editConfig.editIconAriaLabel": "편집 가능"
   },

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "botão de redimensionamento",
     "ariaLabels.submittingEditText": "Envio de edição",
     "ariaLabels.successfulEditLabel": "A edição foi bem sucedida",
+    "ariaLabels.expandButtonLabel": "Expandir",
+    "ariaLabels.collapseButtonLabel": "Recolher",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Erro",
     "columnDefinitions.editConfig.editIconAriaLabel": "editável"
   },

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "yeniden boyutlandırma düğmesi",
     "ariaLabels.submittingEditText": "Düzenleme gönderiliyor",
     "ariaLabels.successfulEditLabel": "Düzenleme başarılı",
+    "ariaLabels.expandButtonLabel": "Genişlet",
+    "ariaLabels.collapseButtonLabel": "Daralt",
     "columnDefinitions.editConfig.errorIconAriaLabel": "Hata",
     "columnDefinitions.editConfig.editIconAriaLabel": "düzenlenebilir"
   },

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "调整按钮大小",
     "ariaLabels.submittingEditText": "正在提交编辑",
     "ariaLabels.successfulEditLabel": "编辑成功",
+    "ariaLabels.expandButtonLabel": "展开",
+    "ariaLabels.collapseButtonLabel": "折叠",
     "columnDefinitions.editConfig.errorIconAriaLabel": "错误",
     "columnDefinitions.editConfig.editIconAriaLabel": "可编辑"
   },

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -278,6 +278,8 @@
     "ariaLabels.resizerRoleDescription": "調整按鈕大小",
     "ariaLabels.submittingEditText": "提交編輯",
     "ariaLabels.successfulEditLabel": "編輯成功",
+    "ariaLabels.expandButtonLabel": "展開",
+    "ariaLabels.collapseButtonLabel": "摺疊",
     "columnDefinitions.editConfig.errorIconAriaLabel": "錯誤",
     "columnDefinitions.editConfig.editIconAriaLabel": "可編輯"
   },


### PR DESCRIPTION
### Description

A dependency to https://github.com/cloudscape-design/components/pull/2000

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
