### PR TITLE
fix: Ensure that categorical line chart series are sorted as expected

### DIFF
--- a/pages/mixed-line-bar-chart/common.tsx
+++ b/pages/mixed-line-bar-chart/common.tsx
@@ -131,8 +131,8 @@ export const data3 = [
 
 export const data4 = [
   { x: 'Potatoes', y: 300 },
-  { x: 'Chocolate', y: 280 },
   { x: 'Apples', y: 100 },
+  { x: 'Chocolate', y: 280 },
   { x: 'Oranges', y: 180 },
 ];
 

--- a/src/mixed-line-bar-chart/line-series.tsx
+++ b/src/mixed-line-bar-chart/line-series.tsx
@@ -36,7 +36,14 @@ export default function LineSeries<T>({ axis, series, color, xScale, yScale, cha
       .y((d: MixedLineBarChartProps.Datum<T>) => yScale.d3Scale(d.y) || 0);
 
     // Filter out any data that is not part of the xScale
-    const visibleData = series.data.filter(({ x }) => xScale.d3Scale(x as any) !== undefined);
+    let visibleData = series.data.filter(({ x }) => xScale.d3Scale(x as any) !== undefined);
+
+    if (xScale.isCategorical()) {
+      // sort the data points in the same order as the categories provided in `xDomain`
+      visibleData = visibleData.sort(
+        (a, b) => xScale.domain.indexOf(a.x as string) - xScale.domain.indexOf(b.x as string)
+      );
+    }
 
     return (
       <path


### PR DESCRIPTION
### Description

Ensure that categorical line series are re-sorted by the provided category sort order. Previously the points were plotted in the correct places, but the line connecting them didn't follow the expected order.

Related links, issue #, if available: AWSUI-38160

### How has this been tested?

Updated screenshot test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
