### PR TITLE
feat: Configurable operators for free text filtering in property filter

### DIFF
--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -224,7 +224,8 @@ export const filteringProperties: readonly PropertyFilterProps.FilteringProperty
         operator: '=',
         form: OwnerMultiSelectForm,
         format: formatOwners,
-        match: (itemValue: string, tokenValue: string[]) => tokenValue.some(value => itemValue === value),
+        match: (itemValue: string, tokenValue: string[]) =>
+          Array.isArray(tokenValue) && tokenValue.some(value => itemValue === value),
       },
     ];
   }

--- a/pages/property-filter/hooks.page.tsx
+++ b/pages/property-filter/hooks.page.tsx
@@ -38,6 +38,7 @@ export default function () {
         </Box>
       ),
       filteringProperties,
+      freeTextFiltering: { operators: ['=', '!=', ':', '!:'] },
     },
     sorting: {},
   });

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -86,6 +86,23 @@ export default function () {
           countText="5 matches"
           i18nStrings={i18nStrings}
         />
+        <PropertyFilter
+          className="property-filter-free-text-operators"
+          query={{
+            tokens: [
+              { operator: '!=', value: 'not equal filtering token' },
+              { operator: '^', value: 'starts with filtering token' },
+            ],
+            operation: 'and',
+          }}
+          onChange={() => {}}
+          filteringProperties={filteringProperties}
+          filteringOptions={[]}
+          freeTextFiltering={{ operators: [':', '!:', '=', '!=', '^', '!^'] }}
+          virtualScroll={true}
+          countText="5 matches"
+          i18nStrings={i18nStrings}
+        />
       </ScreenshotArea>
     </>
   );

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10990,6 +10990,20 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "type": "string",
     },
     Object {
+      "description": "An object configuring the operators for free text filtering, which has the following properties:
+* operators [Array]: A list of all operators supported for free text filtering. If you omit the contains operator because your API does not support it, make sure to set \`defaultOperator\` to a supported operator from this list.
+* defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support \\"contains\\" free test filtering terms.
+",
+      "inlineType": Object {
+        "name": "PropertyFilterProps.FreeTextFiltering",
+        "properties": Array [],
+        "type": "object",
+      },
+      "name": "freeTextFiltering",
+      "optional": true,
+      "type": "PropertyFilterProps.FreeTextFiltering",
+    },
+    Object {
       "description": "If hideOperations it set, the indicator of the operation (that is, \`and\` or \`or\`) and the selection of operations
 (applied to the property and value token) are hidden from the user. Only use when you have a custom
 filtering logic which combines tokens in different way than the default one. When used, ensure that

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -478,6 +478,13 @@ describe('property filter parts', () => {
         });
         expect(wrapper.findTokens()![0].getElement()).toHaveTextContent('!: first');
       });
+      test('custom operator free text token', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent({
+          freeTextFiltering: { operators: ['!^'] },
+          query: { tokens: [{ value: 'first', operator: '!^' }], operation: 'or' },
+        });
+        expect(wrapper.findTokens()![0].getElement()).toHaveTextContent('!^ first');
+      });
       test('property token', () => {
         const { propertyFilterWrapper: wrapper } = renderComponent({
           query: { tokens: [{ propertyKey: 'range', value: 'value', operator: '>' }], operation: 'or' },
@@ -627,6 +634,24 @@ describe('property filter parts', () => {
             .findOptions()!
             .map(optionWrapper => optionWrapper.getElement().textContent)
         ).toEqual(['string', 'string-other', 'default', 'string!=', 'state', 'range']);
+      });
+      test('with custom free text operators', () => {
+        const { propertyFilterWrapper: wrapper } = renderComponent({
+          freeTextFiltering: { operators: ['=', '!=', ':', '!:'] },
+          query: { tokens: [{ value: 'first', operator: '!=' }], operation: 'or' },
+        });
+        const [contentWrapper] = openTokenEditor(wrapper);
+        expect(contentWrapper.getElement()).toHaveTextContent(
+          'PropertyAll propertiesOperator!=Does not equalValueCancelApply'
+        );
+        const operatorSelectWrapper = findOperatorSelector(contentWrapper);
+        act(() => operatorSelectWrapper.openDropdown());
+        expect(
+          operatorSelectWrapper
+            .findDropdown()
+            .findOptions()!
+            .map(optionWrapper => optionWrapper.getElement().textContent)
+        ).toEqual(['=Equals', '!=Does not equal', ':Contains', '!:Does not contain']);
       });
       test('preserves fields, when one is edited', () => {
         const { propertyFilterWrapper: wrapper } = renderComponent({

--- a/src/property-filter/controller.ts
+++ b/src/property-filter/controller.ts
@@ -8,6 +8,7 @@ import {
   I18nStrings,
   InternalFilteringOption,
   InternalFilteringProperty,
+  InternalFreeTextFiltering,
   JoinOperation,
   ParsedText,
   Query,
@@ -15,7 +16,7 @@ import {
 } from './interfaces';
 import { fireNonCancelableEvent, NonCancelableEventHandler } from '../internal/events';
 import { AutosuggestProps } from '../autosuggest/interfaces';
-import { matchFilteringProperty, matchOperator, matchOperatorPrefix, trimFirstSpace, trimStart } from './utils';
+import { matchFilteringProperty, matchOperator, matchOperatorPrefix, removeOperator, trimStart } from './utils';
 import { AutosuggestInputRef } from '../internal/components/autosuggest-input';
 
 export const getQueryActions = (
@@ -75,19 +76,26 @@ export const getAllowedOperators = (property: InternalFilteringProperty): Compar
 export const parseText = (
   filteringText: string,
   filteringProperties: readonly InternalFilteringProperty[],
-  disableFreeTextFiltering: boolean
+  freeTextFiltering: InternalFreeTextFiltering
 ): ParsedText => {
-  const negatedGlobalQuery = /^(!:|!)(.*)/.exec(filteringText);
-  if (!disableFreeTextFiltering && negatedGlobalQuery) {
-    return {
-      step: 'free-text',
-      operator: '!:',
-      value: negatedGlobalQuery[2],
-    };
-  }
-
   const property = matchFilteringProperty(filteringProperties, filteringText);
   if (!property) {
+    if (!freeTextFiltering.disabled) {
+      // For free text filtering, we allow ! as a shortcut for !:
+      const freeTextOperators =
+        freeTextFiltering.operators.indexOf('!:') >= 0
+          ? ['!', ...freeTextFiltering.operators]
+          : freeTextFiltering.operators;
+      const operator = matchOperator(freeTextOperators, filteringText);
+      if (operator) {
+        return {
+          step: 'free-text',
+          operator: operator === '!' ? '!:' : operator,
+          value: removeOperator(filteringText, operator),
+        };
+      }
+    }
+
     return {
       step: 'free-text',
       value: filteringText,
@@ -99,14 +107,12 @@ export const parseText = (
   const textWithoutProperty = filteringText.substring(property.propertyLabel.length);
   const operator = matchOperator(allowedOps, trimStart(textWithoutProperty));
   if (operator) {
-    const operatorLastIndex = textWithoutProperty.indexOf(operator) + operator.length;
-    const textWithoutPropertyAndOperator = textWithoutProperty.slice(operatorLastIndex);
-    // We need to remove the first leading space in case the user presses space
-    // after the operator, for example: Owner: admin, will result in value of ` admin`
-    // and we need to remove the first space, if the user added any more spaces only the
-    // first one will be removed.
-    const value = trimFirstSpace(textWithoutPropertyAndOperator);
-    return { step: 'property', property, operator, value };
+    return {
+      step: 'property',
+      property,
+      operator,
+      value: removeOperator(textWithoutProperty, operator),
+    };
   }
 
   const operatorPrefix = matchOperatorPrefix(allowedOps, trimStart(textWithoutProperty));

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -9,6 +9,7 @@ import { AutosuggestProps } from '../autosuggest/interfaces';
 import { ExpandToViewport } from '../internal/components/dropdown/interfaces';
 import { FormFieldControlProps } from '../internal/context/form-field-context';
 import {
+  PropertyFilterFreeTextFiltering,
   PropertyFilterOperation,
   PropertyFilterOperator,
   PropertyFilterOperatorExtended,
@@ -110,6 +111,13 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   disableFreeTextFiltering?: boolean;
   /**
+   * An object configuring the operators for free text filtering, which has the following properties:
+   *
+   * * operators [Array]: A list of all operators supported for free text filtering. If you omit the contains operator because your API does not support it, make sure to set `defaultOperator` to a supported operator from this list.
+   * * defaultOperator [ComparisonOperator]: An optional parameter that changes the default operator used for free text filtering. Use this parameter only if your API does not support "contains" free test filtering terms.
+   */
+  freeTextFiltering?: PropertyFilterProps.FreeTextFiltering;
+  /**
    * Use this event to asynchronously load filteringOptions, component currently needs.  The detail object contains following properties:
    *
    * * `filteringProperty` - The property for which you need to fetch the options.
@@ -196,6 +204,7 @@ export namespace PropertyFilterProps {
   export type ExtendedOperatorFormat<TokenValue> = PropertyFilterOperatorFormat<TokenValue>;
   export type FilteringOption = PropertyFilterOption;
   export type FilteringProperty = PropertyFilterProperty;
+  export type FreeTextFiltering = PropertyFilterFreeTextFiltering;
 
   export interface Query {
     tokens: ReadonlyArray<PropertyFilterProps.Token>;
@@ -313,6 +322,12 @@ export interface InternalFilteringOption {
   property: null | InternalFilteringProperty;
   value: string;
   label: string;
+}
+
+export interface InternalFreeTextFiltering {
+  disabled: boolean;
+  operators: readonly PropertyFilterOperator[];
+  defaultOperator: PropertyFilterOperator;
 }
 
 export interface InternalToken<TokenValue = any> {

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -12,6 +12,7 @@ import {
   I18nStrings,
   InternalFilteringOption,
   InternalFilteringProperty,
+  InternalFreeTextFiltering,
   InternalToken,
   LoadItemsDetail,
   Token,
@@ -30,12 +31,10 @@ import InternalButton from '../button/internal';
 import InternalFormField from '../form-field/internal';
 import { matchTokenValue } from './utils';
 
-const freeTextOperators: ComparisonOperator[] = [':', '!:'];
-
 interface PropertyInputProps {
   asyncProps: null | DropdownStatusProps;
   customGroupsText: readonly GroupText[];
-  disableFreeTextFiltering?: boolean;
+  freeTextFiltering: InternalFreeTextFiltering;
   filteringProperties: readonly InternalFilteringProperty[];
   i18nStrings: I18nStrings;
   onChangePropertyKey: (propertyKey: undefined | string) => void;
@@ -51,7 +50,7 @@ function PropertyInput({
   onLoadItems,
   customGroupsText,
   i18nStrings,
-  disableFreeTextFiltering,
+  freeTextFiltering,
 }: PropertyInputProps) {
   const propertySelectHandlers = useLoadItems(onLoadItems);
   const asyncPropertySelectProps = asyncProps ? { ...asyncProps, ...propertySelectHandlers } : {};
@@ -82,7 +81,7 @@ function PropertyInput({
     label: i18nStrings.allPropertiesLabel,
     value: undefined,
   };
-  if (!disableFreeTextFiltering) {
+  if (!freeTextFiltering.disabled) {
     propertyOptions.unshift(allPropertiesOption);
   }
   return (
@@ -107,11 +106,11 @@ interface OperatorInputProps {
   onChangeOperator: (operator: ComparisonOperator) => void;
   operator: undefined | ComparisonOperator;
   property: null | InternalFilteringProperty;
+  freeTextFiltering: InternalFreeTextFiltering;
 }
 
-function OperatorInput({ property, operator, onChangeOperator, i18nStrings }: OperatorInputProps) {
-  const freeTextOperators: ComparisonOperator[] = [':', '!:'];
-  const operatorOptions = (property ? getAllowedOperators(property) : freeTextOperators).map(operator => ({
+function OperatorInput({ property, operator, onChangeOperator, i18nStrings, freeTextFiltering }: OperatorInputProps) {
+  const operatorOptions = (property ? getAllowedOperators(property) : freeTextFiltering.operators).map(operator => ({
     value: operator,
     label: operator,
     description: operatorToDescription(operator, i18nStrings),
@@ -190,7 +189,7 @@ interface TokenEditorProps {
   asyncProps: DropdownStatusProps;
   customGroupsText: readonly GroupText[];
   disabled?: boolean;
-  disableFreeTextFiltering?: boolean;
+  freeTextFiltering: InternalFreeTextFiltering;
   expandToViewport?: boolean;
   filteringProperties: readonly InternalFilteringProperty[];
   filteringOptions: readonly InternalFilteringOption[];
@@ -205,7 +204,7 @@ export function TokenEditor({
   asyncProperties,
   asyncProps,
   customGroupsText,
-  disableFreeTextFiltering,
+  freeTextFiltering,
   expandToViewport,
   filteringProperties,
   filteringOptions,
@@ -227,7 +226,7 @@ export function TokenEditor({
       (acc, property) => (property.propertyKey === newPropertyKey ? property : acc),
       undefined
     );
-    const allowedOperators = filteringProperty ? getAllowedOperators(filteringProperty) : freeTextOperators;
+    const allowedOperators = filteringProperty ? getAllowedOperators(filteringProperty) : freeTextFiltering.operators;
     const operator =
       temporaryToken.operator && allowedOperators.indexOf(temporaryToken.operator) !== -1
         ? temporaryToken.operator
@@ -269,7 +268,7 @@ export function TokenEditor({
                 onLoadItems={onLoadItems}
                 customGroupsText={customGroupsText}
                 i18nStrings={i18nStrings}
-                disableFreeTextFiltering={disableFreeTextFiltering}
+                freeTextFiltering={freeTextFiltering}
               />
             </InternalFormField>
 
@@ -279,6 +278,7 @@ export function TokenEditor({
                 operator={operator}
                 onChangeOperator={onChangeOperator}
                 i18nStrings={i18nStrings}
+                freeTextFiltering={freeTextFiltering}
               />
             </InternalFormField>
 

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -7,6 +7,7 @@ import {
   I18nStrings,
   InternalFilteringOption,
   InternalFilteringProperty,
+  InternalFreeTextFiltering,
   InternalToken,
   JoinOperation,
   LoadItemsDetail,
@@ -25,7 +26,7 @@ interface TokenProps {
   asyncProps: DropdownStatusProps;
   customGroupsText: readonly GroupText[];
   disabled?: boolean;
-  disableFreeTextFiltering?: boolean;
+  freeTextFiltering: InternalFreeTextFiltering;
   expandToViewport?: boolean;
   filteringProperties: readonly InternalFilteringProperty[];
   filteringOptions: readonly InternalFilteringOption[];
@@ -56,7 +57,7 @@ export const TokenButton = ({
   hideOperations,
   customGroupsText,
   disabled,
-  disableFreeTextFiltering,
+  freeTextFiltering,
   expandToViewport,
 }: TokenProps) => {
   const externalToken = { ...token, propertyKey: token.property?.propertyKey };
@@ -89,7 +90,7 @@ export const TokenButton = ({
         i18nStrings={i18nStrings}
         asyncProperties={asyncProperties}
         customGroupsText={customGroupsText}
-        disableFreeTextFiltering={disableFreeTextFiltering}
+        freeTextFiltering={freeTextFiltering}
         expandToViewport={expandToViewport}
       />
     </FilteringToken>

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -114,6 +114,16 @@ export function trimFirstSpace(source: string): string {
   return source[0] === ' ' ? source.slice(1) : source;
 }
 
+export function removeOperator(source: string, operator: string) {
+  const operatorLastIndex = source.indexOf(operator) + operator.length;
+  const textWithoutOperator = source.slice(operatorLastIndex);
+  // We need to remove the first leading space in case the user presses space
+  // after the operator, for example: Owner: admin, will result in value of ` admin`
+  // and we need to remove the first space, if the user added any more spaces only the
+  // first one will be removed.
+  return trimFirstSpace(textWithoutOperator);
+}
+
 function startsWith(source: string, target: string): boolean {
   return source.indexOf(target) === 0;
 }


### PR DESCRIPTION
### Description

This CR adds the ability to customize free text filtering operators for the Property Filter, just like every other property operator. The corresponding update has already been merged into collection-hooks: https://github.com/cloudscape-design/collection-hooks/commit/59dcd9cd5e46c492e13939e59505f229782c202d.

See: k6RfAb8hHR1t

### How has this been tested?

1. Updated 2 pages in the dev app (general property filter hooks page, and token editor page) and confirmed both worked with the new feature as expected.
2. Ran unit, integ and motion tests.
3. Fully ran visual regression testing because I expected the token-editor page to be part of it, but since it's only the permutations page every one of the 144 tests passed.

Video of various interactions with free text filtering in the dev app:
https://github.com/cloudscape-design/components/assets/4647197/fadd9b3c-f8a9-45d3-bb71-07db40001d09

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ ✅
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ ✅
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ ✅
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ ✅

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
