### PR TITLE
fix: Dismiss unpinned chart popover when mouse exits to different chart

### DIFF
--- a/src/internal/components/chart-popover/__tests__/chart-popover.test.tsx
+++ b/src/internal/components/chart-popover/__tests__/chart-popover.test.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { render, fireEvent } from '@testing-library/react';
+import ChartPopover from '../../../../../lib/components/internal/components/chart-popover';
+import React from 'react';
+
+describe('ChartPopover', () => {
+  it('dismisses the popover when mouse leaves to another chart', () => {
+    const handleDismiss1 = jest.fn();
+    const handleDismiss2 = jest.fn();
+
+    const containerElement1 = document.createElement('div');
+    const containerElement2 = document.createElement('div');
+
+    const renderResult = render(
+      <>
+        <ChartPopover
+          data-testid="chart-popover"
+          size="medium"
+          dismissButton={false}
+          onDismiss={handleDismiss1}
+          trackRef={React.createRef()}
+          container={containerElement1}
+        />
+        <ChartPopover
+          data-testid="chart-popover"
+          size="medium"
+          dismissButton={false}
+          onDismiss={handleDismiss2}
+          trackRef={React.createRef()}
+          container={containerElement2}
+        />
+      </>
+    );
+
+    const [chart1, chart2] = renderResult.getAllByTestId('chart-popover');
+
+    // Simulate mouse leaving chart1 and entering chart2
+    fireEvent.mouseLeave(chart1, { relatedTarget: chart2 });
+    fireEvent.mouseEnter(chart2);
+
+    expect(handleDismiss1).toHaveBeenCalled();
+    expect(handleDismiss2).not.toHaveBeenCalled();
+  });
+});

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -536,29 +536,6 @@ describe('Details popover', () => {
     expect(detailPopover?.findHeader()?.getElement()).toHaveTextContent(defaultData[0].title);
   });
 
-  test('allow mouse to be move between segment and popover ', () => {
-    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
-    fireEvent.mouseOver(wrapper!.findSegments()[0].getElement());
-
-    expect(wrapper.findDetailPopover()).toBeTruthy();
-
-    fireEvent.mouseOut(wrapper.findDetailPopover()!.getElement(), {
-      relatedTarget: wrapper!.findSegments()[0].getElement(),
-    });
-
-    expect(wrapper.findDetailPopover()).toBeTruthy();
-
-    fireEvent.mouseOut(wrapper!.findSegments()[0].getElement(), {
-      relatedTarget: wrapper.findDetailPopover()!.getElement(),
-    });
-
-    expect(wrapper.findDetailPopover()).toBeTruthy();
-
-    fireEvent.mouseOut(wrapper!.findSegments()[0].getElement(), { relatedTarget: window });
-
-    expect(wrapper.findDetailPopover()).toBeFalsy();
-  });
-
   test('close popover when mouse leaves it ', () => {
     const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
     wrapper.findApplication()!.focus();


### PR DESCRIPTION
### Description

I stumbled across an issue with the chart popover component. The current behavior didn't have it dismiss properly when the mouse exits to another chart or out of any chart through a popover...

https://github.com/cloudscape-design/components/assets/68167311/e2b848bc-491c-41b5-afa0-b34af369c0cf

... or when the mouse pointer exits to its inner chart container (e.g its labels) ...

https://github.com/cloudscape-design/components/assets/68167311/851425fb-cf1e-46ee-9d99-c06c852241eb 

Added this as the default when no onMouseLeave event is passed

### How has this been tested?

I've added a test to verify the new behavior. I had to remove a test from the pie chart, as it was not aligned with the new behavior. 

Furthermore, I've noticed the chart popover is extensively tested within different charts. It might be worthwhile to relocate these tests to the chart popover test file for a better structure and efficiency.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
