### PR TITLE
[POC] DO NOT MERGE: Feat: Support Interactive Element in Default Header

### DIFF
--- a/pages/expandable-section/inline-button-variant.page.tsx
+++ b/pages/expandable-section/inline-button-variant.page.tsx
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import ExpandableSection from '~components/expandable-section';
+import SpaceBetween from '~components/space-between';
+import Button from '~components/button';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function SimpleContainers() {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <article>
+      <h1>Expandable Default Variants Section with interactive elements</h1>
+      <ScreenshotArea>
+        <h2>Default - unchanged</h2>
+        <SpaceBetween size="xs">
+          <ExpandableSection headerText="Static website hosting">
+            After you enable your S3 bucket for static website hosting, web browsers can access your content through the
+            Amazon S3 website endpoint for the bucket.
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Static website hosting (controlled)"
+            expanded={expanded}
+            onChange={({ detail }) => setExpanded(detail.expanded)}
+          >
+            After you enable your S3 bucket for static website hosting, web browsers can access your content through the
+            Amazon S3 website endpoint for the bucket.
+          </ExpandableSection>
+          <ExpandableSection headerText="Static website hosting" defaultExpanded={true}>
+            After you enable your S3 bucket for static website hosting, web browsers can access your content through the
+            Amazon S3 website endpoint for the bucket.
+          </ExpandableSection>
+        </SpaceBetween>
+
+        <h2>Default with Actions Example 1</h2>
+        <SpaceBetween size="xs">
+          <ExpandableSection
+            headerText="Security group rule 1 (TCP, 22, 0.0.0.0/0)"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Security group rule 2 (TCP, 0)"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Security group rule 3 (TCP, 22)"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+        </SpaceBetween>
+
+        <h2>Default with Actions Example 2</h2>
+        <SpaceBetween size="xs">
+          <ExpandableSection headerText="Volume 1 (AMI Root) (Custom) (8 GiB, EBS)">
+            Configuration Form here
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Volume 2 (Custom) (8 GiB, EBS)"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Volume 3 (Custom) (16 GiB, EBS)"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+          <ExpandableSection
+            headerText="Volume 4 (Custom) (64 GiB, EBS, General Purpose SSD (gp3))"
+            headerActions={<Button variant="inline-link">Remove</Button>}
+          >
+            Configuration Form here
+          </ExpandableSection>
+        </SpaceBetween>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -253,7 +253,11 @@ export const ExpandableSectionHeader = ({
     warnOnce(componentName, `The \`headerDescription\` prop is not supported for the ${variant} variant.`);
   }
 
-  const wrapperClassName = clsx(styles.wrapper, styles[`wrapper-${variant}`], expanded && styles['wrapper-expanded']);
+  const wrapperClassName = clsx(
+    styles.wrapper,
+    styles[`wrapper-${variant}`],
+    (expanded || headerActions !== undefined) && styles['wrapper-expanded']
+  );
   if (variant === 'navigation') {
     return (
       <ExpandableNavigationHeader

--- a/src/expandable-section/utils.ts
+++ b/src/expandable-section/utils.ts
@@ -7,5 +7,5 @@ export function variantSupportsDescription(variant: InternalVariant) {
 }
 
 export function variantSupportsInteractiveElements(variant: InternalVariant) {
-  return ['container', 'compact'].includes(variant);
+  return ['container', 'compact', 'default'].includes(variant);
 }


### PR DESCRIPTION
Adds support for default variant to use actions in header Adds a page inline-button-variant to showcase some use cases

This is a prototype to share with designer & visual team.

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
