### PR TITLE
revert: Add table expandable rows to metrics

### DIFF
--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -23,7 +23,6 @@ const Table = React.forwardRef(
         variant,
         wrapLines: props.wrapLines,
         enableKeyboardNavigation: props.enableKeyboardNavigation,
-        expandableRows: !!props.expandableRows,
       },
     });
 


### PR DESCRIPTION
This metric is implemented incorrectly. Only original props should be passed to that object

Reverts cloudscape-design/components#2097