### PR TITLE
chore: Remove caching from bundle size workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -39,15 +39,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           path: 'components'
 
-      - name: Restore the cache for the base branch size measurement
-        uses: actions/cache/restore@v3
-        id: restore-cache-basebranch
-        with:
-          path: bundle-size/output-basebranch.json
-          key: bundlesize-${{ hashFiles('bundle-size/build.js','bundle-size/main.js','bundle-size/package-lock.json','bundle-size/package.json') }}-${{ github.event.pull_request.base.sha }}
-
       - name: Measure the bundle size of the base branch
-        if: steps.restore-cache-basebranch.outputs.cache-hit != 'true'
         run: |
           cd components
           npm i --force
@@ -58,13 +50,6 @@ jobs:
 
           mv output.json output-basebranch.json
           cat output-basebranch.json
-
-      - name: Cache the base branch size
-        uses: actions/cache/save@v3
-        if: steps.restore-cache-basebranch.outputs.cache-hit != 'true'
-        with:
-          path: bundle-size/output-basebranch.json
-          key: ${{ steps.restore-cache-basebranch.outputs.cache-primary-key }}
 
       # ------- Pull request size measurement -----------------------------
 


### PR DESCRIPTION
### Description

We use a deprecated version

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache/restore@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Since #2032, the workflow is fast enough, we can simply remove the dependency instead of upgrading

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
