### PR TITLE
feat: Announce form field errors using ARIA live region

### DIFF
--- a/pages/form/with-validation.page.tsx
+++ b/pages/form/with-validation.page.tsx
@@ -88,6 +88,7 @@ export default function FormScenario() {
                   attemptedToSubmit && value.length > 4 ? 'The text must not be longer than 4 letters' : undefined
                 }
                 constraintText="Maximum length: 4 letters"
+                i18nStrings={{ errorIconAriaLabel: 'Error' }}
               >
                 <Input value={value} onChange={e => setValue(e.detail.value)} disabled={loading} />
               </FormField>

--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import FormField, { FormFieldProps } from '../../../lib/components/form-field';
 import createWrapper, { FormFieldWrapper } from '../../../lib/components/test-utils/dom';
+import liveRegionStyles from '../../../lib/components/internal/components/live-region/styles.css.js';
 
 function renderFormField(props: FormFieldProps = {}) {
   const renderResult = render(<FormField {...props} />);
@@ -112,5 +113,17 @@ describe('FormField component', () => {
     });
     expect(wrapper.findConstraint()?.getElement()).toHaveTextContent(constraintText);
     expect(wrapper.findError()?.getElement()).toHaveTextContent(errorText);
+  });
+
+  describe('live-region', () => {
+    test('Should render live region for error text', () => {
+      const errorText = 'Nope do it again';
+      const wrapper = renderFormField({
+        errorText,
+        i18nStrings: { errorIconAriaLabel: 'Error' },
+      });
+
+      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`Error ${errorText}`);
+    });
   });
 });

--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -124,9 +124,7 @@ describe('FormField component', () => {
         i18nStrings: { errorIconAriaLabel },
       });
 
-      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
-        `${errorIconAriaLabel}${errorText}`
-      );
+      expect(wrapper.findByClassName(liveRegionStyles.root)?.getElement()).toBeInTheDocument();
     });
   });
 });

--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -118,12 +118,15 @@ describe('FormField component', () => {
   describe('live-region', () => {
     test('Should render live region for error text', () => {
       const errorText = 'Nope do it again';
+      const errorIconAriaLabel = 'Error';
       const wrapper = renderFormField({
         errorText,
-        i18nStrings: { errorIconAriaLabel: 'Error' },
+        i18nStrings: { errorIconAriaLabel },
       });
 
-      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(`Error ${errorText}`);
+      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
+        `${errorIconAriaLabel}${errorText}`
+      );
     });
   });
 });

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
 import { getBaseProps } from '../internal/base-component';
@@ -37,6 +37,7 @@ interface FormFieldErrorProps {
 
 export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldErrorProps) {
   const i18n = useInternalI18n('form-field');
+  const contentRef = useRef<HTMLDivElement | null>(null);
 
   return (
     <>
@@ -50,12 +51,12 @@ export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldEr
             <InternalIcon name="status-warning" size="small" />
           </div>
         </div>
-        <span className={styles.error__message}>{children}</span>
+        <span className={styles.error__message} ref={contentRef}>
+          {children}
+        </span>
       </div>
-      <LiveRegion assertive={true}>
-        <span>{errorIconAriaLabel}</span>
-        <span>{children}</span>
-      </LiveRegion>
+
+      <LiveRegion assertive={true} source={[errorIconAriaLabel, contentRef]} />
     </>
   );
 }

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -53,7 +53,8 @@ export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldEr
         <span className={styles.error__message}>{children}</span>
       </div>
       <LiveRegion assertive={true}>
-        {errorIconAriaLabel} {children}
+        <span>{errorIconAriaLabel}</span>
+        <span>{children}</span>
       </LiveRegion>
     </>
   );

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -27,6 +27,7 @@ import {
   getNameFromSelector,
   getSubStepAllSelector,
 } from '../internal/analytics/selectors';
+import LiveRegion from '../internal/components/live-region';
 
 interface FormFieldErrorProps {
   id?: string;
@@ -38,18 +39,23 @@ export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldEr
   const i18n = useInternalI18n('form-field');
 
   return (
-    <div id={id} className={styles.error}>
-      <div className={styles['error-icon-shake-wrapper']}>
-        <div
-          role="img"
-          aria-label={i18n('i18nStrings.errorIconAriaLabel', errorIconAriaLabel)}
-          className={styles['error-icon-scale-wrapper']}
-        >
-          <InternalIcon name="status-warning" size="small" />
+    <>
+      <div id={id} className={styles.error}>
+        <div className={styles['error-icon-shake-wrapper']}>
+          <div
+            role="img"
+            aria-label={i18n('i18nStrings.errorIconAriaLabel', errorIconAriaLabel)}
+            className={styles['error-icon-scale-wrapper']}
+          >
+            <InternalIcon name="status-warning" size="small" />
+          </div>
         </div>
+        <span className={styles.error__message}>{children}</span>
       </div>
-      <span className={styles.error__message}>{children}</span>
-    </div>
+      <LiveRegion assertive={true}>
+        {errorIconAriaLabel} {children}
+      </LiveRegion>
+    </>
   );
 }
 


### PR DESCRIPTION
### Description

Added aria live to form field error messages as part of validation improvements. These changes allow error messages to be announced in form field, attribute editor, tag editor, file upload, etc (components that use FormFieldError component).

Issue: AWSDesignSystem-432

### How has this been tested?

Tested manually (to try yourself; go to pages/form/with-validation, turn on screen reader, type text longer than 4 letters to the input field and click submit)
Also added and ran unit test

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
