### PR TITLE
feat: Add findDrawersOverflowTrigger test util

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -40,6 +40,7 @@ Object {
     "awsui_navigation-toggle_1fj9k",
     "awsui_navigation_1fj9k",
     "awsui_notifications_1fj9k",
+    "awsui_overflow-menu_1fj9k",
     "awsui_root_1fj9k",
     "awsui_tools-close_1fj9k",
     "awsui_tools-toggle_1fj9k",

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -9,9 +9,8 @@ import {
   manyDrawersWithBadges,
   findActiveDrawerLandmark,
 } from './utils';
-import createWrapper from '../../../lib/components/test-utils/dom';
 
-import { render, act } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
@@ -48,9 +47,8 @@ describeEachAppLayout(size => {
   });
 
   test('should open active drawer on click of overflow item', () => {
-    const { container } = render(<AppLayout drawers={manyDrawers} />);
-    const wrapper = createWrapper(container).findAppLayout()!;
-    const buttonDropdown = createWrapper(container).findButtonDropdown();
+    const { wrapper } = renderComponent(<AppLayout drawers={manyDrawers} />);
+    const buttonDropdown = wrapper.findDrawersOverflowTrigger();
 
     expect(wrapper.findActiveDrawer()).toBeFalsy();
     buttonDropdown!.openDropdown();
@@ -63,8 +61,8 @@ describeEachAppLayout(size => {
       drawersOverflow: 'Overflow drawers',
       drawersOverflowWithBadge: 'Overflow drawers (Unread notifications)',
     };
-    const { container, rerender } = render(<AppLayout drawers={manyDrawers} ariaLabels={ariaLabels} />);
-    const buttonDropdown = createWrapper(container).findButtonDropdown();
+    const { wrapper, rerender } = renderComponent(<AppLayout drawers={manyDrawers} ariaLabels={ariaLabels} />);
+    const buttonDropdown = wrapper.findDrawersOverflowTrigger();
 
     expect(buttonDropdown!.findNativeButton().getElement()).toHaveAttribute('aria-label', 'Overflow drawers');
 
@@ -75,8 +73,8 @@ describeEachAppLayout(size => {
     );
   });
 
-  test('renders aria-labels', async () => {
-    const { wrapper } = await renderComponent(<AppLayout drawers={[testDrawer]} />);
+  test('renders aria-labels', () => {
+    const { wrapper } = renderComponent(<AppLayout drawers={[testDrawer]} />);
     expect(wrapper.findDrawerTriggerById('security')!.getElement()).toHaveAttribute(
       'aria-label',
       'Security trigger button'
@@ -86,8 +84,8 @@ describeEachAppLayout(size => {
     expect(wrapper.findActiveDrawerCloseButton()!.getElement()).toHaveAttribute('aria-label', 'Security close button');
   });
 
-  test('renders resize only on resizable drawer', async () => {
-    const { wrapper } = await renderComponent(
+  test('renders resize only on resizable drawer', () => {
+    const { wrapper } = renderComponent(
       <AppLayout
         drawers={[
           testDrawer,

--- a/src/app-layout/drawer/overflow-menu.tsx
+++ b/src/app-layout/drawer/overflow-menu.tsx
@@ -5,6 +5,7 @@ import InternalButtonDropdown from '../../button-dropdown/internal';
 import { ButtonDropdownProps, InternalButtonDropdownProps } from '../../button-dropdown/interfaces';
 import { CancelableEventHandler } from '../../internal/events';
 import { AppLayoutProps } from '../interfaces';
+import testutilStyles from '../test-classes/styles.css.js';
 
 interface OverflowMenuProps {
   items: Array<AppLayoutProps.Drawer>;
@@ -23,6 +24,7 @@ export default function OverflowMenu({ items, onItemClick, customTriggerBuilder,
         iconSvg: item.trigger.iconSvg,
         badge: item.badge,
       }))}
+      className={testutilStyles['overflow-menu']}
       onItemClick={onItemClick}
       ariaLabel={ariaLabel}
       variant="icon"

--- a/src/app-layout/test-classes/styles.scss
+++ b/src/app-layout/test-classes/styles.scss
@@ -51,6 +51,9 @@
 .active-drawer-close-button {
   /* used in tests */
 }
+.overflow-menu {
+  /* used in test-utils */
+}
 
 .drawers-slider {
   /* used in tests */

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -3,6 +3,7 @@
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import SplitPanelWrapper from '../split-panel';
 import testutilStyles from '../../../app-layout/test-classes/styles.selectors.js';
+import ButtonDropdownWrapper from '../button-dropdown';
 
 export default class AppLayoutWrapper extends ComponentWrapper {
   static rootSelector = testutilStyles.root;
@@ -61,6 +62,10 @@ export default class AppLayoutWrapper extends ComponentWrapper {
 
   findDrawerTriggerById(id: string): ElementWrapper<HTMLButtonElement> | null {
     return this.find(`.${testutilStyles['drawers-trigger']}[data-testid="awsui-app-layout-trigger-${id}"]`);
+  }
+
+  findDrawersOverflowTrigger(): ButtonDropdownWrapper | null {
+    return this.findComponent(`.${testutilStyles['overflow-menu']}`, ButtonDropdownWrapper);
   }
 
   findActiveDrawerResizeHandle(): ElementWrapper | null {


### PR DESCRIPTION
### Description

This change adds a new test util function to find the trigger that shows the AppLayout drawers when they overflow.
<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-39169

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
