### PR TITLE
chore: Add table cell content wrapper element

### DIFF
--- a/src/table/__tests__/table.test.tsx
+++ b/src/table/__tests__/table.test.tsx
@@ -7,6 +7,7 @@ import PropertyFilter from '../../../lib/components/property-filter';
 import Select from '../../../lib/components/select';
 import createWrapper, { ElementWrapper, PaginationWrapper, TableWrapper } from '../../../lib/components/test-utils/dom';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
+import bodyCellStyles from '../../../lib/components/table/body-cell/styles.css.js';
 import headerCellStyles from '../../../lib/components/table/header-cell/styles.css.js';
 import styles from '../../../lib/components/table/styles.css.js';
 
@@ -294,10 +295,12 @@ test('should render table with react content', () => {
     },
   ];
   const { wrapper } = renderTable(<Table columnDefinitions={columns} items={defaultItems} />);
+  const findCellContent = (row: number, col: number) =>
+    wrapper.findBodyCell(row, col)!.findByClassName(bodyCellStyles['body-cell-content'])!;
   expect(wrapper.findColumnHeaders().map(getHeaderHtmlContent)).toEqual(['id', 'name', 'Advanced <span>header</span>']);
   expect(wrapper.findRows()).toHaveLength(3);
-  expect(wrapper.findBodyCell(1, 3)!.getElement().innerHTML).toEqual('<input readonly="" value="Apples">');
-  expect(wrapper.findBodyCell(2, 3)!.getElement().innerHTML).toEqual('<input readonly="" value="Oranges">');
+  expect(findCellContent(1, 3)!.getElement().innerHTML).toEqual('<input readonly="" value="Apples">');
+  expect(findCellContent(2, 3)!.getElement().innerHTML).toEqual('<input readonly="" value="Oranges">');
 });
 
 test('should render only columns with id in visibleColumns', () => {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -69,7 +69,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   text-align: start;
 
   &-content {
-    // This style is empty yet.
+    display: inline;
   }
   &:not(.body-cell-wrap) {
     white-space: nowrap;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -60,18 +60,17 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   box-sizing: border-box;
   padding-block-start: $cell-vertical-padding;
   padding-block-end: $cell-vertical-padding-w-border;
-  @include cell-offset($cell-horizontal-padding);
   padding-inline-end: $cell-horizontal-padding;
   border-block-start: awsui.$border-divider-list-width solid transparent;
   word-wrap: break-word;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
 
-  @include focus-visible.when-visible {
-    @include cell-focus-outline;
-  }
-
   text-align: start;
+
+  &-content {
+    // This style is empty yet.
+  }
   &:not(.body-cell-wrap) {
     white-space: nowrap;
     overflow: hidden;
@@ -438,5 +437,10 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     &.body-cell-first-row > .expandable-cell-content > .body-cell-editor-wrapper {
       padding-block-start: awsui.$border-divider-list-width;
     }
+  }
+  @include cell-offset($cell-horizontal-padding);
+
+  @include focus-visible.when-visible {
+    @include cell-focus-outline;
   }
 }

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -69,7 +69,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   text-align: start;
 
   &-content {
-    display: inline;
+    /* used for testing */
   }
   &:not(.body-cell-wrap) {
     white-space: nowrap;

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -118,7 +118,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
             <ExpandToggle {...expandableProps} />
           </div>
         )}
-        <div className={styles['body-cell-content']}>{children}</div>
+        <span className={styles['body-cell-content']}>{children}</span>
       </Element>
     );
   }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -118,7 +118,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
             <ExpandToggle {...expandableProps} />
           </div>
         )}
-        {children}
+        <div className={styles['body-cell-content']}>{children}</div>
       </Element>
     );
   }


### PR DESCRIPTION
### Description

In table component cell content is rendered directly into the TD elements. All cell styles are also applied to the TD elements, including min width, overflow and other. That is limiting though:

1. In VR tables there are no left/right paddings for the edge cells. As result, the focus outline is smaller than we would like it to be. It is not possible to extend it past the TD edges though because of the `overflow: hidden` style. See https://github.com/cloudscape-design/components/pull/2070.
2. In tables with expandable rows we add expand toggles to the first column. If the same column includes editable content the current solution is to disable the editing for the first column. That is because we cannot make the entire cell clickable while it also includes the clickable toggle element.
3. Resizable columns require a complex approach (see https://github.com/cloudscape-design/components/pull/1745) to maintain widths and content overflow because TD elements disregard min/max width style.

The PR introduces a wrapper for table cell content so that the above issues can be fixed.  

### How has this been tested?

Screenshot tests and dry-run

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
