### PR TITLE
fix: Fix navigation for tables with expandable rows and multi-selection

### DIFF
--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -491,7 +491,6 @@ const InternalTable = React.forwardRef(
                                 colIndex={0}
                               >
                                 <SelectionControl
-                                  tableRole={tableRole}
                                   onFocusDown={moveFocusDown}
                                   onFocusUp={moveFocusUp}
                                   onShiftToggle={updateShiftToggle}

--- a/src/table/selection/selection-control.tsx
+++ b/src/table/selection/selection-control.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { KeyboardEvent, KeyboardEventHandler, MouseEvent } from 'react';
+import React, { KeyboardEvent, KeyboardEventHandler, MouseEvent, useContext } from 'react';
 import { KeyCode } from '../../internal/keycode';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import InternalCheckbox from '../../checkbox/internal';
@@ -9,10 +9,9 @@ import RadioButton from '../../radio-group/radio-button';
 
 import styles from './styles.css.js';
 import { SelectionProps } from './interfaces';
-import { TableRole } from '../table-role';
+import { SingleTabStopNavigationContext } from '../../internal/context/single-tab-stop-navigation-context';
 
 export interface SelectionControlProps extends SelectionProps {
-  tableRole?: TableRole;
   onShiftToggle?(shiftPressed: boolean): void;
   onFocusUp?: KeyboardEventHandler;
   onFocusDown?: KeyboardEventHandler;
@@ -22,7 +21,6 @@ export interface SelectionControlProps extends SelectionProps {
 }
 
 export function SelectionControl({
-  tableRole,
   selectionType,
   indeterminate = false,
   onShiftToggle,
@@ -35,6 +33,7 @@ export function SelectionControl({
 }: SelectionControlProps) {
   const controlId = useUniqueId();
   const isMultiSelection = selectionType === 'multi';
+  const { navigationActive } = useContext(SingleTabStopNavigationContext);
 
   const setShiftState = (event: KeyboardEvent | MouseEvent) => {
     if (isMultiSelection) {
@@ -55,7 +54,7 @@ export function SelectionControl({
   // native checkboxes do not have focus move via keyboard, we implement it here programmatically
   const handleKeyDown = (event: KeyboardEvent) => {
     setShiftState(event);
-    if (isMultiSelection && tableRole !== 'grid') {
+    if (isMultiSelection && !navigationActive) {
       if (event.keyCode === KeyCode.up) {
         event.preventDefault();
         onFocusUp && onFocusUp(event);

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -120,7 +120,6 @@ const Thead = React.forwardRef(
             >
               {selectionType === 'multi' ? (
                 <SelectionControl
-                  tableRole={tableRole}
                   onFocusDown={event => {
                     onFocusMove!(event.target as HTMLElement, -1, +1);
                   }}


### PR DESCRIPTION
### Description

Fixed an issue when for multi-selection checkboxes in table two independent navigation handlers were present at once: grid navigation and selection control navigation.

### How has this been tested?

Manually tested as part of https://github.com/cloudscape-design/components/pull/2108.
No automated test because the issue was not stably reproducible.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
