### PR TITLE
fix: Prevent closed popovers from altering the layout in Firefox

### DIFF
--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -140,7 +140,7 @@ function InternalPopover(
     <div
       aria-live={dismissButton ? undefined : 'polite'}
       aria-atomic={dismissButton ? undefined : true}
-      className={clsx(popoverClasses, styles['popover-content'])}
+      className={clsx(popoverClasses, visible && styles['popover-content'])}
       data-awsui-referrer-id={referrerId}
     >
       {visible && (


### PR DESCRIPTION
### Description

There is a [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1592017) that causes empty inline elements to have non-zero offsetHeight. This seems to not affect the page layout in most cases, but under certain circumstances it can also cause extra scrollHeight and therefore unexpected overflow to the parent of the parent (see [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1592017#c10)). This is affecting our popover component in closed state when rendering it in a portal, since the popover container has `display: inline` applied and is wrapped inside a div at the end of the body.

The solution applied in this PR is to apply the class `popover-content`, whose sole effect is to apply a CSS rule of `display: inline`, only when the popover is open, i.e, the popover container is not empty.

### How has this been tested?

- Manually, this can be tested with any existing test page which uses popovers with `renderWithPortal` in Firefox. When the popover is closed, `document.body.scrollHeight - document.body.offsetHeight` should return 0, but before these changes it returns 4.
- Ran through my pipeline and got some screenshot test diffs in Firefox which are desired

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
