### PR TITLE
fix: Table navigation to focus element registered inside focused cell

### DIFF
--- a/src/internal/context/__tests__/utils.tsx
+++ b/src/internal/context/__tests__/utils.tsx
@@ -19,7 +19,7 @@ const FakeSingleTabStopNavigationProvider = forwardRef(
   ) => {
     const focusablesRef = useRef(new Set<Element>());
     const focusHandlersRef = useRef(new Map<Element, FocusableChangeHandler>());
-    const registerFocusable = useCallback((focusable: Element, changeHandler: FocusableChangeHandler) => {
+    const registerFocusable = useCallback((focusable: HTMLElement, changeHandler: FocusableChangeHandler) => {
       focusablesRef.current.add(focusable);
       focusHandlersRef.current.set(focusable, changeHandler);
       return () => {

--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -11,7 +11,7 @@ export interface SingleTabStopNavigationOptions {
 
 export const defaultValue: {
   navigationActive: boolean;
-  registerFocusable(focusable: Element, handler: FocusableChangeHandler): () => void;
+  registerFocusable(focusable: HTMLElement, handler: FocusableChangeHandler): () => void;
 } = {
   navigationActive: false,
   registerFocusable: () => () => {},
@@ -24,7 +24,7 @@ export const defaultValue: {
 export const SingleTabStopNavigationContext = createContext(defaultValue);
 
 export function useSingleTabStopNavigation(
-  focusable: null | React.RefObject<Element>,
+  focusable: null | React.RefObject<HTMLElement>,
   options?: { tabIndex?: number }
 ) {
   const { navigationActive: contextNavigationActive, registerFocusable } = useContext(SingleTabStopNavigationContext);

--- a/src/table/table-role/__tests__/grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/grid-navigation.test.tsx
@@ -336,3 +336,30 @@ test('respects element order when navigating between extremes', () => {
   fireEvent.keyDown(table, { keyCode: KeyCode.home });
   expect(readActiveElement()).toBe('BUTTON[1]');
 });
+
+test('focuses on the element registered inside focused table cell', () => {
+  function TestTable({ contentType }: { contentType: 'text' | 'button' }) {
+    const tableRef = useRef<HTMLTableElement>(null);
+    return (
+      <GridNavigationProvider keyboardNavigation={true} pageSize={10} getTable={() => tableRef.current}>
+        <table role="grid" ref={tableRef}>
+          <tbody>
+            <tr aria-rowindex={1}>
+              <Cell tag="td" aria-colindex={1}>
+                {contentType === 'text' ? 'text' : <Button>action</Button>}
+              </Cell>
+            </tr>
+          </tbody>
+        </table>
+      </GridNavigationProvider>
+    );
+  }
+  const { container, rerender } = render(<TestTable contentType="text" />);
+  const cell = container.querySelector('td')!;
+
+  cell.focus();
+  expect(readActiveElement()).toEqual('TD[text]');
+
+  rerender(<TestTable contentType="button" />);
+  expect(readActiveElement()).toEqual('BUTTON[action]');
+});

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -117,7 +117,7 @@ class GridNavigationProcessor {
     }, 0);
   }
 
-  public registerFocusable = (focusableElement: Element, changeHandler: FocusableChangeHandler) => {
+  public registerFocusable = (focusableElement: HTMLElement, changeHandler: FocusableChangeHandler) => {
     this.focusables.add(focusableElement);
     this.focusHandlers.set(focusableElement, changeHandler);
     const isFocusable = this.focusablesState.get(focusableElement) ?? false;
@@ -125,6 +125,14 @@ class GridNavigationProcessor {
     if (newIsFocusable !== isFocusable) {
       this.focusablesState.set(focusableElement, newIsFocusable);
       changeHandler(newIsFocusable);
+    }
+    // When newly registered element belongs to the focused cell the focus must transition to it.
+    if (
+      this.focusedCell &&
+      this.focusedCell.element instanceof HTMLTableCellElement &&
+      this.focusedCell.element.contains(focusableElement)
+    ) {
+      focusableElement.focus();
     }
     return () => this.unregisterFocusable(focusableElement);
   };

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -129,7 +129,7 @@ class GridNavigationProcessor {
     // When newly registered element belongs to the focused cell the focus must transition to it.
     if (
       this.focusedCell &&
-      this.focusedCell.element instanceof HTMLTableCellElement &&
+      this.focusedCell.element.tagName === 'TD' &&
       this.focusedCell.element.contains(focusableElement)
     ) {
       focusableElement.focus();


### PR DESCRIPTION
### Description

In tables with keyboard nav when a cell does not have interactive elements the cell itself is focused.
When there are interactive elements we always expect one of those to be focused instead of the cell.

The PR fixes the issue when table cell content updates dynamically so that the cell receives interactive element. When the cell is focused the focus must transition to the newly added element.

The problem was originally found as part of https://github.com/cloudscape-design/components/pull/2108 testing. When progressive loading transitions from "load more" to "loading" and back to "load more" the focus should transition between the load-more button and the text-only loading cell.

### How has this been tested?

* New unit test
* New integration test as part of https://github.com/cloudscape-design/components/pull/2108

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
