### PR TITLE
refactor: Deduplicate app layout default prop values

### DIFF
--- a/src/app-layout/__tests__/widgetized-layout.test.tsx
+++ b/src/app-layout/__tests__/widgetized-layout.test.tsx
@@ -3,16 +3,22 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { createWidgetizedAppLayout } from '../../../lib/components/app-layout/widget';
-import { AppLayoutProps } from '../../../lib/components/app-layout/interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from '../../../lib/components/app-layout/interfaces';
 import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../../../lib/components/internal/utils/global-flags';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import createWrapper from '../../../lib/components/test-utils/dom';
 
 declare const window: Window & FlagsHolder;
 
-const LoaderSkeleton = React.forwardRef<AppLayoutProps.Ref, AppLayoutProps>(() => {
+const LoaderSkeleton = React.forwardRef<AppLayoutProps.Ref, AppLayoutPropsWithDefaults>(() => {
   return <div data-testid="loader">Loading...</div>;
 });
+
+const defaultProps: AppLayoutPropsWithDefaults = {
+  headerSelector: '#h',
+  footerSelector: '#f',
+  contentType: 'default',
+};
 
 function findLoader(container: HTMLElement) {
   return container.querySelector('[data-testid="loader"]');
@@ -51,14 +57,14 @@ describe('Classic layout', () => {
   });
 
   test('should render normal layout by default', () => {
-    const { wrapper, container } = renderComponent(<WidgetizedLayout />);
+    const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
     expect(wrapper).toBeTruthy();
     expect(findLoader(container)).toBeFalsy();
   });
 
   describeWithFeatureFlag(() => {
     test('should render normal layout', () => {
-      const { wrapper, container } = renderComponent(<WidgetizedLayout />);
+      const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
       expect(wrapper).toBeTruthy();
       expect(findLoader(container)).toBeFalsy();
     });
@@ -71,14 +77,14 @@ describe('Refresh layout', () => {
   });
 
   test('should render normal layout by default', () => {
-    const { wrapper, container } = renderComponent(<WidgetizedLayout />);
+    const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
     expect(wrapper).toBeTruthy();
     expect(findLoader(container)).toBeFalsy();
   });
 
   describeWithFeatureFlag(() => {
     test('should render loader', () => {
-      const { wrapper, container } = renderComponent(<WidgetizedLayout />);
+      const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
       expect(wrapper).toBeFalsy();
       expect(findLoader(container)).toBeTruthy();
     });

--- a/src/app-layout/classic.tsx
+++ b/src/app-layout/classic.tsx
@@ -6,7 +6,7 @@ import { useControllable } from '../internal/hooks/use-controllable';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { fireNonCancelableEvent } from '../internal/events';
 import { applyDefaults } from './defaults';
-import { AppLayoutProps } from './interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
 import { Notifications } from './notifications';
 import { MobileToolbar } from './mobile-toolbar';
 import { useFocusControl } from './utils/use-focus-control';
@@ -57,13 +57,13 @@ const ClassicAppLayout = React.forwardRef(
       contentHeader,
       disableContentHeaderOverlap,
       content,
-      contentType = 'default',
+      contentType,
       disableContentPaddings,
       disableBodyScroll,
       maxContentWidth,
       minContentWidth,
-      headerSelector = '#b #h',
-      footerSelector = '#b #f',
+      headerSelector,
+      footerSelector,
       ariaLabels,
       splitPanel,
       splitPanelSize: controlledSplitPanelSize,
@@ -78,7 +78,7 @@ const ClassicAppLayout = React.forwardRef(
       onDrawerChange,
       activeDrawerId: controlledActiveDrawerId,
       ...rest
-    }: AppLayoutProps,
+    }: AppLayoutPropsWithDefaults,
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
     if (isDevelopment) {

--- a/src/app-layout/implementation.tsx
+++ b/src/app-layout/implementation.tsx
@@ -4,9 +4,11 @@ import React from 'react';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import ClassicAppLayout from './classic';
 import RefreshedAppLayout from './visual-refresh';
-import { AppLayoutProps } from './interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
 
-export const AppLayoutImplementation = React.forwardRef<AppLayoutProps.Ref, AppLayoutProps>((props, ref) => {
-  const isRefresh = useVisualRefresh();
-  return isRefresh ? <RefreshedAppLayout ref={ref} {...props} /> : <ClassicAppLayout ref={ref} {...props} />;
-});
+export const AppLayoutImplementation = React.forwardRef<AppLayoutProps.Ref, AppLayoutPropsWithDefaults>(
+  (props, ref) => {
+    const isRefresh = useVisualRefresh();
+    return isRefresh ? <RefreshedAppLayout ref={ref} {...props} /> : <ClassicAppLayout ref={ref} {...props} />;
+  }
+);

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -4,6 +4,7 @@ import React from 'react';
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
 import { IconProps } from '../icon/interfaces';
+import { SomeRequired } from '../internal/types';
 
 export interface AppLayoutProps extends BaseComponentProps {
   /**
@@ -326,3 +327,8 @@ export namespace AppLayoutProps {
     activeDrawerId: string | null;
   }
 }
+
+export type AppLayoutPropsWithDefaults = SomeRequired<
+  AppLayoutProps,
+  'headerSelector' | 'footerSelector' | 'contentType'
+>;

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -13,7 +13,7 @@ import React, {
 import { applyDefaults } from '../defaults';
 import { AppLayoutContext } from '../../internal/context/app-layout-context';
 import { DynamicOverlapContext } from '../../internal/context/dynamic-overlap-context';
-import { AppLayoutProps } from '../interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from '../interfaces';
 import { fireNonCancelableEvent } from '../../internal/events';
 import { FocusControlRefs, useFocusControl } from '../utils/use-focus-control';
 import { getSplitPanelDefaultSize } from '../../split-panel/utils/size-utils';
@@ -51,8 +51,8 @@ interface AppLayoutInternals extends AppLayoutProps {
   handleSplitPanelPreferencesChange: (detail: AppLayoutProps.SplitPanelPreferences) => void;
   handleSplitPanelResize: (newSize: number) => void;
   handleToolsClick: (value: boolean, skipFocusControl?: boolean) => void;
-  hasBackgroundOverlap: boolean;
   hasDefaultToolsWidth: boolean;
+  hasBackgroundOverlap: boolean;
   hasDrawerViewportOverlay: boolean;
   hasNotificationsContent: boolean;
   hasOpenDrawer?: boolean;
@@ -100,7 +100,7 @@ interface AppLayoutInternals extends AppLayoutProps {
  */
 const AppLayoutInternalsContext = createContext<AppLayoutInternals | null>(null);
 
-interface AppLayoutProviderInternalsProps extends AppLayoutProps {
+interface AppLayoutProviderInternalsProps extends AppLayoutPropsWithDefaults {
   children: React.ReactNode;
 }
 
@@ -119,9 +119,9 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       toolsOpen: controlledToolsOpen,
       navigationHide,
       navigationOpen: controlledNavigationOpen,
-      contentType = 'default',
-      headerSelector = '#b #h',
-      footerSelector = '#b #h',
+      contentType,
+      headerSelector,
+      footerSelector,
       children,
       splitPanel,
       ...props

--- a/src/app-layout/visual-refresh/index.tsx
+++ b/src/app-layout/visual-refresh/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { AppLayoutInternalsProvider } from './context';
-import { AppLayoutProps } from '../interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from '../interfaces';
 import Background from './background';
 import Breadcrumbs from './breadcrumbs';
 import Drawers from './drawers';
@@ -16,7 +16,7 @@ import SplitPanel from './split-panel';
 import Tools from './tools';
 
 const AppLayoutWithRef = React.forwardRef(function AppLayout(
-  props: AppLayoutProps,
+  props: AppLayoutPropsWithDefaults,
   ref: React.Ref<AppLayoutProps.Ref>
 ) {
   return (

--- a/src/app-layout/widget.tsx
+++ b/src/app-layout/widget.tsx
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { getGlobalFlag } from '../internal/utils/global-flags';
-import { AppLayoutProps } from './interfaces';
+import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { AppLayoutImplementation } from './implementation';
 
-type AppLayoutType = React.ForwardRefExoticComponent<AppLayoutProps & React.RefAttributes<AppLayoutProps.Ref>>;
+type AppLayoutType = React.ForwardRefExoticComponent<
+  AppLayoutPropsWithDefaults & React.RefAttributes<AppLayoutProps.Ref>
+>;
 
 export function createWidgetizedAppLayout(AppLayoutLoader?: AppLayoutType): AppLayoutType {
   return React.forwardRef((props, ref) => {


### PR DESCRIPTION
### Description

Move separate defaults from Classic and Refresh versions in a single place

Related links, issue #, if available: n/a

### How has this been tested?

PR build + locally, no regressions

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
