### PR TITLE
fix: Prevent ariaLabel on code editor from conflicting with ace's built-in aria-label

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4542,6 +4542,11 @@ The object should contain, among others:
             "type": "(row: number, column: number) => string",
           },
           Object {
+            "name": "cursorPositionAriaLabel",
+            "optional": true,
+            "type": "(row: number) => string",
+          },
+          Object {
             "name": "editorGroupAriaLabel",
             "optional": true,
             "type": "string",

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -253,8 +253,20 @@ describe('Code editor component', () => {
       i18nStrings: { cursorPositionAriaLabel: row => `Cursor at row ${row}` },
     });
     expect(editorMock.renderer.textarea).toHaveAttribute('aria-labelledby');
-    const ariaLabelledById = editorMock.renderer.textarea.getAttribute('aria-labelledby')!;
-    expect(document.getElementById(ariaLabelledById)).toHaveTextContent('test aria label Cursor at row 1');
+    const ariaLabelledByIds = editorMock.renderer.textarea.getAttribute('aria-labelledby')!.split(' ');
+    expect(document.getElementById(ariaLabelledByIds[0])).toHaveTextContent('test aria label');
+    expect(document.getElementById(ariaLabelledByIds[1])).toHaveTextContent('Cursor at row 1');
+  });
+
+  it('appends cursorPositionAriaLabel to the ariaLabelledby if provided', () => {
+    renderCodeEditor({
+      ariaLabelledby: 'test-id',
+      i18nStrings: { cursorPositionAriaLabel: row => `Cursor at row ${row}` },
+    });
+    expect(editorMock.renderer.textarea).toHaveAttribute('aria-labelledby');
+    const ariaLabelledByIds = editorMock.renderer.textarea.getAttribute('aria-labelledby')!.split(' ');
+    expect(ariaLabelledByIds[0]).toBe('test-id');
+    expect(document.getElementById(ariaLabelledByIds[1])).toHaveTextContent('Cursor at row 1');
   });
 
   describe('onDelayedChange', () => {

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -247,6 +247,16 @@ describe('Code editor component', () => {
     expect(document.getElementById(ariaLabelledById)).toHaveTextContent('test aria label');
   });
 
+  it('appends cursorPositionAriaLabel to the ariaLabel if provided', () => {
+    renderCodeEditor({
+      ariaLabel: 'test aria label',
+      i18nStrings: { cursorPositionAriaLabel: row => `Cursor at row ${row}` },
+    });
+    expect(editorMock.renderer.textarea).toHaveAttribute('aria-labelledby');
+    const ariaLabelledById = editorMock.renderer.textarea.getAttribute('aria-labelledby')!;
+    expect(document.getElementById(ariaLabelledById)).toHaveTextContent('test aria label Cursor at row 1');
+  });
+
   describe('onDelayedChange', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -233,7 +233,7 @@ describe('Code editor component', () => {
     editorMock.on.mockRestore();
   });
 
-  it('provides ariaLabel to the underlying textarea', () => {
+  it('provides ariaLabel to the underlying textarea using aria-labelledby', () => {
     const textarea = editorMock.renderer.textarea;
     editorMock.renderer.textarea = null as any;
 
@@ -242,7 +242,9 @@ describe('Code editor component', () => {
     editorMock.renderer.textarea = textarea;
 
     renderCodeEditor({ ariaLabel: 'test aria label' });
-    expect(editorMock.renderer.textarea).toHaveAttribute('aria-label', 'test aria label');
+    expect(editorMock.renderer.textarea).toHaveAttribute('aria-labelledby');
+    const ariaLabelledById = editorMock.renderer.textarea.getAttribute('aria-labelledby')!;
+    expect(document.getElementById(ariaLabelledById)).toHaveTextContent('test aria label');
   });
 
   describe('onDelayedChange', () => {

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -82,6 +82,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
 
   const paneId = useUniqueId('code-editor-pane');
   const ariaLabelId = useUniqueId('code-editor-textarea');
+  const cursorPositionLabelId = useUniqueId('code-editor-cursor-position');
 
   const [paneStatus, setPaneStatus] = useState<PaneStatus>('hidden');
   const [annotations, setAnnotations] = useState<Ace.Annotation[]>([]);
@@ -105,12 +106,16 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     };
   }, [ace, editor]);
 
+  const cursorPositionAriaLabel = i18nStrings?.cursorPositionAriaLabel?.(cursorPosition.row + 1);
   useSyncEditorLabels(editor, {
     controlId,
     // Treat ariaLabel as if it overrides ariaLabelledby. This is similar to how
     // other Cloudscape components (e.g. input) behave. Internally, we do the opposite:
     // use aria-labelledby to override ace's built-in aria-label.
-    ariaLabelledby: ariaLabel && !ariaLabelledby ? ariaLabelId : ariaLabelledby,
+    ariaLabelledby: joinStrings(
+      ariaLabel && !ariaLabelledby ? ariaLabelId : ariaLabelledby,
+      cursorPositionAriaLabel ? cursorPositionLabelId : undefined
+    ),
     ariaDescribedby,
   });
 
@@ -221,11 +226,11 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
 
       {ace && !loading && (
         <>
-          {ariaLabel && (
-            <ScreenreaderOnly id={ariaLabelId}>
-              {joinStrings(ariaLabel, i18nStrings?.cursorPositionAriaLabel?.(cursorPosition.row + 1))}
-            </ScreenreaderOnly>
-          )}
+          <ScreenreaderOnly>
+            <span id={ariaLabelId}>{ariaLabel}</span>
+            <span id={cursorPositionLabelId}>{cursorPositionAriaLabel}</span>
+          </ScreenreaderOnly>
+
           <ResizableBox
             height={Math.max(editorHeight, 20)}
             minHeight={20}

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -79,6 +79,7 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
   const mergedRef = useMergeRefs(codeEditorMeasureRef, __internalRootRef);
 
   const paneId = useUniqueId('code-editor-pane');
+  const ariaLabelId = useUniqueId('code-editor-textarea');
 
   const [paneStatus, setPaneStatus] = useState<PaneStatus>('hidden');
   const [annotations, setAnnotations] = useState<Ace.Annotation[]>([]);
@@ -102,7 +103,13 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
     };
   }, [ace, editor]);
 
-  useSyncEditorLabels(editor, { controlId, ariaLabel, ariaLabelledby, ariaDescribedby });
+  useSyncEditorLabels(editor, {
+    controlId,
+    // Treat ariaLabel as if it overrides ariaLabelledby. This is similar to how
+    // other Cloudscape components (e.g. input) behave.
+    ariaLabelledby: ariaLabel && !ariaLabelledby ? ariaLabelId : ariaLabelledby,
+    ariaDescribedby,
+  });
 
   const { onResize } = useSyncEditorSize(editor, { width: codeEditorWidth, height: editorContentHeight });
 
@@ -194,6 +201,12 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
       className={clsx(styles['code-editor'], baseProps.className, { [styles['code-editor-refresh']]: isRefresh })}
       ref={mergedRef}
     >
+      {ariaLabel && (
+        <div id={ariaLabelId} className={styles['aria-label-wrapper']}>
+          {ariaLabel}
+        </div>
+      )}
+
       {loading && (
         <LoadingScreen>
           <LiveRegion visible={true}>{i18n('i18nStrings.loadingState', i18nStrings?.loadingState)}</LiveRegion>

--- a/src/code-editor/index.tsx
+++ b/src/code-editor/index.tsx
@@ -8,6 +8,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { getBaseProps } from '../internal/base-component';
 import { KeyCode } from '../internal/keycode';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { joinStrings } from '../internal/utils/strings';
 import { CodeEditorProps } from './interfaces';
 import { Pane } from './pane';
 import { useChangeEffect } from './listeners';
@@ -29,6 +30,7 @@ import { useFormFieldContext } from '../internal/context/form-field-context';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { useControllable } from '../internal/hooks/use-controllable';
 import LiveRegion from '../internal/components/live-region';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
 
 import styles from './styles.css.js';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
@@ -106,7 +108,8 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
   useSyncEditorLabels(editor, {
     controlId,
     // Treat ariaLabel as if it overrides ariaLabelledby. This is similar to how
-    // other Cloudscape components (e.g. input) behave.
+    // other Cloudscape components (e.g. input) behave. Internally, we do the opposite:
+    // use aria-labelledby to override ace's built-in aria-label.
     ariaLabelledby: ariaLabel && !ariaLabelledby ? ariaLabelId : ariaLabelledby,
     ariaDescribedby,
   });
@@ -201,12 +204,6 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
       className={clsx(styles['code-editor'], baseProps.className, { [styles['code-editor-refresh']]: isRefresh })}
       ref={mergedRef}
     >
-      {ariaLabel && (
-        <div id={ariaLabelId} className={styles['aria-label-wrapper']}>
-          {ariaLabel}
-        </div>
-      )}
-
       {loading && (
         <LoadingScreen>
           <LiveRegion visible={true}>{i18n('i18nStrings.loadingState', i18nStrings?.loadingState)}</LiveRegion>
@@ -224,6 +221,11 @@ const CodeEditor = forwardRef((props: CodeEditorProps, ref: React.Ref<CodeEditor
 
       {ace && !loading && (
         <>
+          {ariaLabel && (
+            <ScreenreaderOnly id={ariaLabelId}>
+              {joinStrings(ariaLabel, i18nStrings?.cursorPositionAriaLabel?.(cursorPosition.row + 1))}
+            </ScreenreaderOnly>
+          )}
           <ResizableBox
             height={Math.max(editorHeight, 20)}
             minHeight={20}

--- a/src/code-editor/interfaces.ts
+++ b/src/code-editor/interfaces.ts
@@ -148,6 +148,7 @@ export namespace CodeEditorProps {
 
     editorGroupAriaLabel?: string;
     statusBarGroupAriaLabel?: string;
+    cursorPositionAriaLabel?: (row: number) => string;
 
     cursorPosition?: (row: number, column: number) => string;
     errorsTab?: string;

--- a/src/code-editor/use-editor.tsx
+++ b/src/code-editor/use-editor.tsx
@@ -33,10 +33,9 @@ export function useSyncEditorLabels(
   editor: null | Ace.Editor,
   {
     controlId,
-    ariaLabel,
     ariaLabelledby,
     ariaDescribedby,
-  }: { controlId?: string; ariaLabel?: string; ariaLabelledby?: string; ariaDescribedby?: string }
+  }: { controlId?: string; ariaLabelledby?: string; ariaDescribedby?: string }
 ) {
   useEffect(() => {
     if (!editor) {
@@ -49,10 +48,9 @@ export function useSyncEditorLabels(
     const updateAttribute = (attribute: string, value: string | undefined) =>
       value ? textarea.setAttribute(attribute, value) : textarea.removeAttribute(attribute);
     updateAttribute('id', controlId);
-    updateAttribute('aria-label', ariaLabel);
     updateAttribute('aria-labelledby', ariaLabelledby);
     updateAttribute('aria-describedby', ariaDescribedby);
-  }, [ariaLabel, ariaDescribedby, ariaLabelledby, controlId, editor]);
+  }, [ariaDescribedby, ariaLabelledby, controlId, editor]);
 }
 
 export function useSyncEditorSize(


### PR DESCRIPTION
### Description

We're overriding ace's built-in `aria-label` by using our own `aria-labelledby`, which is a property not touched by ace. Ace's built-in aria-label provides cursor information, so we need to fetch and include that information ourselves. After consulation, using aria-describedby to provide the label has been ruled out, so we have to go with this approach. A number of other alternatives (using `setMessages`, using the `groupAriaLabel` instead of the textarea, etc.) have also been ruled out.

**Important:** The strings are being translated now, and they'll be included in a separate PR, but merged at this same time as this one.

Related links, issue #, if available: AWSUI-24619

#### API changes

- New `i18nStrings` property for code editor: `cursorPositionAriaLabel`
  - Expected usage: `cursorPositionAriaLabel: row => 'Cursor at row ' + row`
  - This string is combined with the ariaLabel.
  - The idea is that we release with `I18nProvider` support from the very beginning, so it's a no-touch upgrade for all internationalization users, and even if they don't, having a working `ariaLabel` is a better alternative than just getting just the cursor position (but obviously, both would be great).

### How has this been tested?

Updated relevant tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
