### PR TITLE
chore: Use `button` role on anchors without `href` in top-navigation menu in mobile

### DIFF
--- a/src/top-navigation/__integ__/top-navigation.test.ts
+++ b/src/top-navigation/__integ__/top-navigation.test.ts
@@ -114,6 +114,17 @@ describe('Top navigation', () => {
     const overflowMenu = wrapper.findOverflowMenu();
 
     test(
+      'focuses utilities with no href in mobile using keyboard navigation',
+      setupTest(pageWidth, async page => {
+        await page.click(wrapper.findOverflowMenuButton().toSelector());
+        await page.click(overflowMenu.findUtility(3).toSelector());
+        await page.keys(['Tab', 'Tab']);
+        const signOutButton = overflowMenu.findMenuDropdownItemById('signout').toSelector();
+        await expect(page.isFocused(signOutButton)).resolves.toBe(true);
+      })
+    );
+
+    test(
       'collapses all utilities except ones marked "disableUtilityCollapse"',
       setupTest(pageWidth, async page => {
         await expect(page.getElementsCount(wrapper.findUtilities().toSelector())).resolves.toBe(1);

--- a/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
+++ b/src/top-navigation/__tests__/top-navigation-overflow-menu.test.tsx
@@ -186,6 +186,22 @@ describe('Submenu', () => {
     act(() => wrapper.click());
     expect(onClose).toBeCalledTimes(1);
   });
+
+  test('renders menu items with role `button` if no href provided', () => {
+    const wrapper = createWrapper(
+      render(
+        <SubmenuView
+          definition={{
+            type: 'menu-dropdown',
+            items: [{ id: 'one', text: 'One' }],
+          }}
+        />
+      ).container
+    ).find('a')!;
+    const element = wrapper.getElement() as HTMLAnchorElement;
+    expect(element.getAttribute('role')).toEqual('button');
+    expect(element.tabIndex).toEqual(0);
+  });
 });
 
 describe('UtilityMenuItem', () => {

--- a/src/top-navigation/parts/overflow-menu/menu-item.tsx
+++ b/src/top-navigation/parts/overflow-menu/menu-item.tsx
@@ -41,6 +41,7 @@ const LinkItem = forwardRef(
   ) => {
     const anchorTarget = target ?? (external ? '_blank' : undefined);
     const anchorRel = rel ?? (anchorTarget === '_blank' ? 'noopener noreferrer' : undefined);
+    const role = !href ? 'button' : undefined;
 
     return (
       <a
@@ -51,6 +52,8 @@ const LinkItem = forwardRef(
           styles['overflow-menu-control-link'],
           context && styles[`overflow-menu-control-${context}`]
         )}
+        role={role}
+        tabIndex={0}
         href={href}
         target={anchorTarget}
         rel={anchorRel}


### PR DESCRIPTION
### Description

When rendering the top-navigation in a narrow width (mobile width for example) the top navigation utilities turns into menu dropdown, the items are always rendered as an `a` element.

When the items inside the menu dropdown does not have an `href` they are rendered with a `tabIndex` of 0 and with a `role` of `link`, this leads to an a11y issue where they are not announced and can not be accessed using the keyboard by using tab.

This PR adds a role `button` whenever there is no `href` provided and sets the `tabIndex` to be always 0.


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a
issue: AWSUI-38331

### How has this been tested?

Added unit and integ tests


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
