### PR TITLE
fix: Unify drawer widths treatment

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -756,6 +756,7 @@ If set to \`Number.MAX_VALUE\`, the main content panel will occupy the full avai
       "type": "boolean",
     },
     Object {
+      "defaultValue": "280",
       "description": "Navigation drawer width in pixels.",
       "name": "navigationWidth",
       "optional": true,
@@ -812,6 +813,7 @@ content area so it is always visible.",
       "type": "boolean",
     },
     Object {
+      "defaultValue": "290",
       "description": "Tools drawer width in pixels.",
       "name": "toolsWidth",
       "optional": true,

--- a/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
+++ b/src/app-layout/__integ__/app-layout-refresh-content-width.test.ts
@@ -51,7 +51,7 @@ describe('Default width per contentType', () => {
   const testCases = [
     { viewPortWidth: 1920, navigationWidth: 280, contentWidth: 1280, toolsWidth: 290 }, // XXXS - L breakpoint
     { viewPortWidth: 1921, navigationWidth: 280, contentWidth: 1440, toolsWidth: 290 }, // L -XL breakpoint
-    { viewPortWidth: 2541, navigationWidth: 320, contentWidth: 1620, toolsWidth: 360 }, // XL - > XXL breakpoint
+    { viewPortWidth: 2541, navigationWidth: 280, contentWidth: 1620, toolsWidth: 290 }, // XL - > XXL breakpoint
   ];
 
   testCases.forEach(({ viewPortWidth, navigationWidth, contentWidth, toolsWidth }) => {

--- a/src/app-layout/__tests__/widgetized-layout.test.tsx
+++ b/src/app-layout/__tests__/widgetized-layout.test.tsx
@@ -18,6 +18,8 @@ const defaultProps: AppLayoutPropsWithDefaults = {
   headerSelector: '#h',
   footerSelector: '#f',
   contentType: 'default',
+  navigationWidth: 0,
+  toolsWidth: 0,
 };
 
 function findLoader(container: HTMLElement) {

--- a/src/app-layout/classic.tsx
+++ b/src/app-layout/classic.tsx
@@ -44,11 +44,11 @@ const ClassicAppLayout = React.forwardRef(
   (
     {
       navigation,
-      navigationWidth = 280,
+      navigationWidth,
       navigationHide,
       navigationOpen: controlledNavigationOpen,
       tools,
-      toolsWidth = 290,
+      toolsWidth,
       toolsHide,
       toolsOpen: controlledToolsOpen,
       breadcrumbs,

--- a/src/app-layout/index.tsx
+++ b/src/app-layout/index.tsx
@@ -12,7 +12,14 @@ export { AppLayoutProps };
 
 const AppLayout = React.forwardRef(
   (
-    { contentType = 'default', headerSelector = '#b #h', footerSelector = '#b #f', ...rest }: AppLayoutProps,
+    {
+      contentType = 'default',
+      headerSelector = '#b #h',
+      footerSelector = '#b #f',
+      navigationWidth = 280,
+      toolsWidth = 290,
+      ...rest
+    }: AppLayoutProps,
     ref: React.Ref<AppLayoutProps.Ref>
   ) => {
     const { __internalRootRef } = useBaseComponent<HTMLDivElement>('AppLayout', {
@@ -20,10 +27,10 @@ const AppLayout = React.forwardRef(
         contentType,
         disableContentPaddings: rest.disableContentPaddings,
         disableBodyScroll: rest.disableBodyScroll,
-        navigationWidth: rest.navigationWidth,
+        navigationWidth,
         navigationHide: rest.navigationHide,
         toolsHide: rest.toolsHide,
-        toolsWidth: rest.toolsWidth,
+        toolsWidth,
         maxContentWidth: rest.maxContentWidth,
         minContentWidth: rest.minContentWidth,
         stickyNotifications: rest.stickyNotifications,
@@ -46,7 +53,7 @@ const AppLayout = React.forwardRef(
     };
 
     // This re-builds the props including the default values
-    const props = { contentType, headerSelector, footerSelector, ...rest, ariaLabels };
+    const props = { contentType, headerSelector, footerSelector, navigationWidth, toolsWidth, ...rest, ariaLabels };
 
     const baseProps = getBaseProps(rest);
 

--- a/src/app-layout/interfaces.ts
+++ b/src/app-layout/interfaces.ts
@@ -330,5 +330,5 @@ export namespace AppLayoutProps {
 
 export type AppLayoutPropsWithDefaults = SomeRequired<
   AppLayoutProps,
-  'headerSelector' | 'footerSelector' | 'contentType'
+  'headerSelector' | 'footerSelector' | 'contentType' | 'navigationWidth' | 'toolsWidth'
 >;

--- a/src/app-layout/utils/use-resize.tsx
+++ b/src/app-layout/utils/use-resize.tsx
@@ -23,14 +23,21 @@ export interface DrawerResizeProps {
   drawersRefs: FocusControlRefs;
   isToolsOpen: boolean;
   drawersMaxWidth: number;
+  drawersMinWidth: number;
 }
 
 function useResize(
   drawerRefObject: React.RefObject<HTMLDivElement>,
-  { activeDrawer, activeDrawerSize, onActiveDrawerResize, drawersRefs, isToolsOpen, drawersMaxWidth }: DrawerResizeProps
+  {
+    activeDrawer,
+    activeDrawerSize,
+    onActiveDrawerResize,
+    drawersRefs,
+    isToolsOpen,
+    drawersMinWidth,
+    drawersMaxWidth,
+  }: DrawerResizeProps
 ) {
-  const toolsWidth = 290;
-  const MIN_WIDTH = Math.min(activeDrawer?.defaultSize ?? Number.POSITIVE_INFINITY, toolsWidth);
   const [relativeSize, setRelativeSize] = useState(0);
 
   const drawerSize = !activeDrawer && !isToolsOpen ? 0 : activeDrawerSize;
@@ -40,17 +47,17 @@ function useResize(
     // wait one frame to allow app-layout to complete its calculations
     const handle = requestAnimationFrame(() => {
       const maxSize = drawersMaxWidth;
-      setRelativeSize(((drawerSize - MIN_WIDTH) / (maxSize - MIN_WIDTH)) * 100);
+      setRelativeSize(((drawerSize - drawersMinWidth) / (maxSize - drawersMinWidth)) * 100);
     });
     return () => cancelAnimationFrame(handle);
-  }, [drawerSize, drawersMaxWidth, MIN_WIDTH]);
+  }, [drawerSize, drawersMaxWidth, drawersMinWidth]);
 
   const setSidePanelWidth = (width: number) => {
     const maxWidth = drawersMaxWidth;
-    const size = getLimitedValue(MIN_WIDTH, width, maxWidth);
+    const size = getLimitedValue(drawersMinWidth, width, maxWidth);
     const id = activeDrawer?.id;
 
-    if (id && maxWidth >= MIN_WIDTH) {
+    if (id && maxWidth >= drawersMinWidth) {
       onActiveDrawerResize({ size, id });
     }
   };

--- a/src/app-layout/visual-refresh/context.tsx
+++ b/src/app-layout/visual-refresh/context.tsx
@@ -31,6 +31,7 @@ import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import useBackgroundOverlap from './use-background-overlap';
 import { useDrawers } from '../utils/use-drawers';
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
+import { SPLIT_PANEL_MIN_WIDTH } from '../split-panel';
 
 interface AppLayoutInternals extends AppLayoutProps {
   activeDrawerId: string | null;
@@ -51,7 +52,6 @@ interface AppLayoutInternals extends AppLayoutProps {
   handleSplitPanelPreferencesChange: (detail: AppLayoutProps.SplitPanelPreferences) => void;
   handleSplitPanelResize: (newSize: number) => void;
   handleToolsClick: (value: boolean, skipFocusControl?: boolean) => void;
-  hasDefaultToolsWidth: boolean;
   hasBackgroundOverlap: boolean;
   hasDrawerViewportOverlay: boolean;
   hasNotificationsContent: boolean;
@@ -80,7 +80,6 @@ interface AppLayoutInternals extends AppLayoutProps {
   footerHeight: number;
   splitPanelControlId: string;
   splitPanelMaxWidth: number;
-  splitPanelMinWidth: number;
   splitPanelPosition: AppLayoutProps.SplitPanelPosition;
   splitPanelReportedSize: number;
   splitPanelReportedHeaderHeight: number;
@@ -199,6 +198,8 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       }
     }, [isMobile, handleNavigationClick]);
 
+    const toolsWidth = props.toolsWidth;
+
     /**
      * The useControllable hook will set the default value and manage either
      * the controlled or uncontrolled state of the Tools drawer. The logic
@@ -210,9 +211,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
      * useControllable hook and also fire the onToolsChange function to
      * emit the state change.
      */
-    const toolsWidth = props.toolsWidth ?? 290;
-    const hasDefaultToolsWidth = props.toolsWidth === undefined;
-
     const [isToolsOpen = false, setIsToolsOpen] = useControllable(
       controlledToolsOpen,
       props.onToolsChange,
@@ -249,8 +247,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
      * widths will potentially trigger a side effect that will put the Split Panel into
      * a forced position on the bottom.
      */
-    const splitPanelMinWidth = 280;
-    const [splitPanelMaxWidth, setSplitPanelMaxWidth] = useState(splitPanelMinWidth);
+    const [splitPanelMaxWidth, setSplitPanelMaxWidth] = useState(SPLIT_PANEL_MIN_WIDTH);
 
     /**
      * The useControllable hook will set the default value and manage either
@@ -316,9 +313,9 @@ export const AppLayoutInternalsProvider = React.forwardRef(
 
     useLayoutEffect(
       function handleSplitPanelForcePosition() {
-        setSplitPanelForcedPosition(splitPanelMinWidth > splitPanelMaxWidth);
+        setSplitPanelForcedPosition(SPLIT_PANEL_MIN_WIDTH > splitPanelMaxWidth);
       },
-      [splitPanelMaxWidth, splitPanelMinWidth]
+      [splitPanelMaxWidth]
     );
 
     /**
@@ -401,6 +398,7 @@ export const AppLayoutInternalsProvider = React.forwardRef(
       drawersRefs,
       isToolsOpen,
       drawersMaxWidth,
+      drawersMinWidth,
     });
 
     const handleDrawersClick = (id: string | null, skipFocusControl?: boolean) => {
@@ -624,7 +622,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           drawersTriggerCount,
           headerHeight,
           footerHeight,
-          hasDefaultToolsWidth,
           hasDrawerViewportOverlay,
           handleDrawersClick,
           handleNavigationClick,
@@ -662,7 +659,6 @@ export const AppLayoutInternalsProvider = React.forwardRef(
           splitPanelControlId,
           splitPanelDisplayed,
           splitPanelMaxWidth,
-          splitPanelMinWidth,
           splitPanelPosition,
           splitPanelPreferences,
           splitPanelReportedSize,

--- a/src/app-layout/visual-refresh/navigation.scss
+++ b/src/app-layout/visual-refresh/navigation.scss
@@ -8,7 +8,6 @@
 @use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
 
 .navigation-container {
-  #{custom-props.$navigationWidth}: 280px;
   display: flex;
   grid-column: 1;
   grid-row: 1 / span 10;
@@ -28,10 +27,6 @@
   the panels and toggle buttons.
   */
   pointer-events: none;
-
-  @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
-    #{custom-props.$navigationWidth}: 320px;
-  }
 
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     inset-inline-start: 0;

--- a/src/app-layout/visual-refresh/navigation.tsx
+++ b/src/app-layout/visual-refresh/navigation.tsx
@@ -60,8 +60,7 @@ export default function Navigation() {
             [styles.unfocusable]: isUnfocusable,
             [testutilStyles['drawer-closed']]: !isNavigationOpen,
           })}
-          // Overwrite the default nav width (depends on breakpoints) only when the `navigationWidth` property is set.
-          style={{ ...(navigationWidth && { [customCssProps.navigationWidth]: `${navigationWidth}px` }) }}
+          style={{ [customCssProps.navigationWidth]: `${navigationWidth}px` }}
         >
           {!isMobile && (
             <nav

--- a/src/app-layout/visual-refresh/split-panel.tsx
+++ b/src/app-layout/visual-refresh/split-panel.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { useAppLayoutInternals } from './context';
 import styles from './styles.css.js';
-import { SplitPanelProvider, SplitPanelProviderProps } from '../split-panel';
+import { SPLIT_PANEL_MIN_WIDTH, SplitPanelProvider, SplitPanelProviderProps } from '../split-panel';
 import { AppLayoutProps } from '../interfaces';
 import { Transition } from '../../internal/components/transition';
 import customCssProps from '../../internal/generated/custom-css-properties';
@@ -121,7 +121,6 @@ function SplitPanelSide() {
     splitPanel,
     splitPanelPosition,
     splitPanelMaxWidth,
-    splitPanelMinWidth,
     splitPanelControlId,
     isToolsOpen,
     activeDrawerId,
@@ -141,7 +140,7 @@ function SplitPanelSide() {
       })}
       style={{
         [customCssProps.splitPanelMaxWidth]: `${splitPanelMaxWidth}px`,
-        [customCssProps.splitPanelMinWidth]: `${splitPanelMinWidth}px`,
+        [customCssProps.splitPanelMinWidth]: `${SPLIT_PANEL_MIN_WIDTH}px`,
       }}
     >
       {splitPanelPosition === 'side' && splitPanel}

--- a/src/app-layout/visual-refresh/tools.scss
+++ b/src/app-layout/visual-refresh/tools.scss
@@ -23,7 +23,6 @@ viewport size and state of the Tools drawer.
       var(#{custom-props.$defaultMinContentWidth}) - var(#{custom-props.$contentGapRight})
   );
   /* stylelint-enable scss/operator-no-newline-after */
-  #{custom-props.$toolsWidth}: 290px;
   display: flex;
   grid-column: 5;
   grid-row: 1 / span 10;
@@ -34,10 +33,6 @@ viewport size and state of the Tools drawer.
   z-index: 830;
 
   pointer-events: none;
-
-  @include styles.media-breakpoint-up(styles.$breakpoint-xx-large) {
-    #{custom-props.$toolsWidth}: 360px;
-  }
 
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     #{custom-props.$toolsMaxWidth}: none;

--- a/src/app-layout/visual-refresh/tools.tsx
+++ b/src/app-layout/visual-refresh/tools.tsx
@@ -30,7 +30,6 @@ export default function Tools({ children }: ToolsProps) {
     drawers,
     handleSplitPanelClick,
     handleToolsClick,
-    hasDefaultToolsWidth,
     hasDrawerViewportOverlay,
     isMobile,
     isSplitPanelOpen,
@@ -73,8 +72,7 @@ export default function Tools({ children }: ToolsProps) {
           })}
           style={{
             [customCssProps.toolsAnimationStartingOpacity]: `${hasSplitPanel && isSplitPanelOpen ? 1 : 0}`,
-            // Overwrite the default tools width (depends on breakpoints) only when the `toolsWidth` property has been set.
-            [customCssProps.toolsWidth]: hasDefaultToolsWidth ? '' : `${toolsWidth}px`,
+            [customCssProps.toolsWidth]: `${toolsWidth}px`,
           }}
           onBlur={e => {
             if (!e.relatedTarget || !e.currentTarget.contains(e.relatedTarget)) {


### PR DESCRIPTION
### Description

Consolidate all 280/290 values in a single place

Related links, issue #, if available: n/a

### How has this been tested?

* Locally
* PR build
* Screenshot tests in my pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
