### PR TITLE
fix: Fix table keyboard navigation for TH cells

### DIFF
--- a/src/table/table-role/__tests__/grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/grid-navigation.test.tsx
@@ -337,7 +337,7 @@ test('respects element order when navigating between extremes', () => {
   expect(readActiveElement()).toBe('BUTTON[1]');
 });
 
-test('focuses on the element registered inside focused table cell', () => {
+test.each(['td', 'th'] as const)('focuses on the element registered inside focused table %s', tag => {
   function TestTable({ contentType }: { contentType: 'text' | 'button' }) {
     const tableRef = useRef<HTMLTableElement>(null);
     return (
@@ -345,7 +345,7 @@ test('focuses on the element registered inside focused table cell', () => {
         <table role="grid" ref={tableRef}>
           <tbody>
             <tr aria-rowindex={1}>
-              <Cell tag="td" aria-colindex={1}>
+              <Cell tag={tag} aria-colindex={1}>
                 {contentType === 'text' ? 'text' : <Button>action</Button>}
               </Cell>
             </tr>
@@ -355,10 +355,10 @@ test('focuses on the element registered inside focused table cell', () => {
     );
   }
   const { container, rerender } = render(<TestTable contentType="text" />);
-  const cell = container.querySelector('td')!;
+  const cell = container.querySelector('td,th') as HTMLElement;
 
   cell.focus();
-  expect(readActiveElement()).toEqual('TD[text]');
+  expect(readActiveElement()).toEqual(`${tag.toUpperCase()}[text]`);
 
   rerender(<TestTable contentType="button" />);
   expect(readActiveElement()).toEqual('BUTTON[action]');

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -9,6 +9,7 @@ import {
   findTableRowCellByAriaColIndex,
   getClosestCell,
   isElementDisabled,
+  isTableCell,
 } from './utils';
 import { FocusedCell, GridNavigationProps } from './interfaces';
 import { KeyCode } from '../../internal/keycode';
@@ -127,7 +128,8 @@ class GridNavigationProcessor {
       changeHandler(newIsFocusable);
     }
     // When newly registered element belongs to the focused cell the focus must transition to it.
-    if (this.focusedCell?.element.tagName === 'TD' && this.focusedCell?.element.contains(focusableElement)) {
+    const focusedElement = this.focusedCell?.element;
+    if (focusedElement && isTableCell(focusedElement) && focusedElement.contains(focusableElement)) {
       // Scroll is unnecessary when moving focus from a cell to element within the cell.
       focusableElement.focus({ preventScroll: true });
     }
@@ -165,7 +167,7 @@ class GridNavigationProcessor {
     // Focusing on cell is not eligible when it contains focusable elements in the content.
     // If content focusables are available - move the focus to the first one.
     const focusedElement = this.focusedCell.element;
-    const nextTarget = focusedElement.tagName === 'TD' ? this.getFocusablesFrom(focusedElement)[0] : null;
+    const nextTarget = isTableCell(focusedElement) ? this.getFocusablesFrom(focusedElement)[0] : null;
     if (nextTarget) {
       // Scroll is unnecessary when moving focus from a cell to element within the cell.
       nextTarget.focus({ preventScroll: true });

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -20,7 +20,7 @@ export function defaultIsSuppressed(target: Element) {
   let current: null | Element = target;
   while (current) {
     // Stop checking for parents upon reaching the cell element as the function only aims at the cell content.
-    if (current.tagName === 'TD') {
+    if (isTableCell(current)) {
       return false;
     }
     if (
@@ -88,4 +88,8 @@ export function findTableRowCellByAriaColIndex(
     }
   }
   return targetCell;
+}
+
+export function isTableCell(element: Element) {
+  return element.tagName === 'TD' || element.tagName === 'TH';
 }


### PR DESCRIPTION
### Description

A follow-up for https://github.com/cloudscape-design/components/pull/2118#discussion_r1551818397.

Table keyboard navigation must support both TD and TH cells.

### How has this been tested?

* Updated unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
