### PR TITLE
fix: Do not display popover inline when using portal

### DIFF
--- a/pages/popover/inline.page.tsx
+++ b/pages/popover/inline.page.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+import ScreenshotArea from '../utils/screenshot-area';
+import AppContext, { AppContextType } from '../app/app-context';
+import Popover from '~components/popover';
+import SpaceBetween from '~components/space-between';
+
+type NestedPopoversContext = React.Context<
+  AppContextType<{
+    renderWithPortal: boolean;
+  }>
+>;
+
+export default function () {
+  const {
+    urlParams: { renderWithPortal = true },
+    setUrlParams,
+  } = useContext(AppContext as NestedPopoversContext);
+
+  return (
+    <article>
+      <h1>Inline popover</h1>
+      <SpaceBetween size="m">
+        <label>
+          <input
+            id="renderWithPortal"
+            type="checkbox"
+            checked={renderWithPortal}
+            onChange={e => setUrlParams({ renderWithPortal: !!e.target.checked })}
+          />{' '}
+          renderWithPortal
+        </label>
+        <ScreenshotArea>
+          There is a{' '}
+          <Popover
+            header="Popover header"
+            content="Popover content"
+            dismissAriaLabel="Close"
+            renderWithPortal={renderWithPortal}
+          >
+            popover
+          </Popover>{' '}
+          in the middle of a sentence.
+        </ScreenshotArea>
+      </SpaceBetween>
+    </article>
+  );
+}

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -136,11 +136,12 @@ function InternalPopover(
   const { tabIndex: triggerTabIndex } = useSingleTabStopNavigation(triggerRef);
 
   const referrerId = useUniqueId();
+
   const popoverContent = (
     <div
       aria-live={dismissButton ? undefined : 'polite'}
       aria-atomic={dismissButton ? undefined : true}
-      className={clsx(popoverClasses, styles['popover-content'])}
+      className={clsx(popoverClasses, !renderWithPortal && styles['popover-inline-content'])}
       data-awsui-referrer-id={referrerId}
     >
       {visible && (

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -51,6 +51,6 @@
   }
 }
 
-.popover-content {
+.popover-inline-content {
   display: inline;
 }


### PR DESCRIPTION
### Description

Corrected rework of #2116 (reverted by #2133), but having inline popovers into account. The new corrected logic is to add `display: inline` only if not using a portal.

Issue: AWSUI-40397

### How has this been tested?

- Ran in my pipeline, getting the same expected diffs in the Firefox diffs as in #2116
- Added test page to cover inline popovers. Tested manually and will add a visual regression test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
