### PR TITLE
chore: Remove cross-component css-variables

### DIFF
--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -26,8 +26,6 @@ explicitly set in script.
   #{custom-props.$contentGapLeft}: 0px;
   #{custom-props.$contentGapRight}: 0px;
   #{custom-props.$contentHeight}: calc(100vh - var(#{custom-props.$headerHeight}) - var(#{custom-props.$footerHeight}));
-  #{custom-props.$containerFirstGap}: 0px;
-  #{custom-props.$containerFirstOverlapExtension}: 0px;
   #{custom-props.$defaultMaxContentWidth}: 1280px;
   #{custom-props.$defaultMinContentWidth}: 0px;
   #{custom-props.$footerHeight}: 0px;
@@ -227,11 +225,6 @@ explicitly set in script.
     #{custom-props.$mainGap}: #{awsui.$space-xs};
   }
 
-  // Set gap to be used by content that has a container on top (e.g. content-layout without header) when breadcrumbs are present
-  &.has-breadcrumbs:not(.has-header) {
-    #{custom-props.$containerFirstGap}: calc(var(#{custom-props.$breadcrumbsGap}) - var(#{custom-props.$mainGap}));
-  }
-
   // Set the Main gap when it follows the Breadcrumbs without an overlap
   &.has-breadcrumbs:not(.has-header).is-overlap-disabled {
     #{custom-props.$mainGap}: #{awsui.$space-scaled-m};
@@ -251,14 +244,6 @@ explicitly set in script.
   &.content-first-child-main:not(.is-overlap-disabled),
   &.content-first-child-main.is-overlap-disabled:not(.disable-content-paddings) {
     #{custom-props.$mainGap}: #{awsui.$space-scaled-s};
-  }
-
-  // Set an extension of the overlap and an additional gap on top to be used by content-layout without header
-  @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
-    &.content-first-child-main:not(.has-header) {
-      #{custom-props.$containerFirstOverlapExtension}: #{awsui.$space-m};
-      #{custom-props.$containerFirstGap}: #{awsui.$space-xxs};
-    }
   }
 
   /*

--- a/src/content-layout/styles.scss
+++ b/src/content-layout/styles.scss
@@ -27,7 +27,7 @@ nodes will directly touch with no gap between them.
 .layout.is-visual-refresh {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto #{awsui.$space-dark-header-overlap-distance} 1fr;
+  grid-template-rows: auto awsui.$space-dark-header-overlap-distance 1fr;
   min-block-size: 100%;
 
   > .background {
@@ -53,14 +53,9 @@ nodes will directly touch with no gap between them.
   }
 
   &:not(.has-header) {
-    grid-template-rows:
-      auto calc(
-        #{awsui.$space-dark-header-overlap-distance} + var(#{custom-props.$containerFirstOverlapExtension}, 0px) + var(#{custom-props.$containerFirstGap}, 0px)
-      )
-      1fr;
-
+    grid-template-rows: auto calc(awsui.$space-dark-header-overlap-distance + awsui.$space-xs + awsui.$space-scaled-xxs) 1fr;
     > .content {
-      padding-block-start: var(#{custom-props.$containerFirstGap}, 0px);
+      padding-block-start: calc(awsui.$space-xs + awsui.$space-scaled-xxs);
     }
   }
 

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -10,8 +10,6 @@ const customCssPropertiesList = [
   'contentGapLeft',
   'contentGapRight',
   'contentHeight',
-  'containerFirstGap',
-  'containerFirstOverlapExtension',
   'defaultMaxContentWidth',
   'defaultMinContentWidth',
   'drawerSize',

--- a/src/wizard/styles.scss
+++ b/src/wizard/styles.scss
@@ -36,7 +36,7 @@
 .navigation.refresh {
   grid-column: 1;
   grid-row: 1 / span 2;
-  padding-block-start: var(#{custom-props.$containerFirstGap}, 0px);
+  padding-block-start: calc(awsui.$space-xs + awsui.$space-scaled-xxs);
 
   > ul.refresh {
     background: awsui.$color-background-container-content;
@@ -241,13 +241,13 @@
   }
 
   > .form-header > .form-header-content {
-    padding-block-start: calc(var(#{custom-props.$containerFirstGap}, 0px) + awsui.$space-m - awsui.$space-xxxs);
+    padding-block-start: calc(awsui.$space-xl + awsui.$space-scaled-xxxs);
     padding-block-end: awsui.$space-scaled-s;
   }
 
   &:not(.remove-high-contrast-header) {
     > .form-header > .form-header-content {
-      padding-block-start: calc(var(#{custom-props.$containerFirstGap}, 0px) + awsui.$space-s);
+      padding-block-start: calc(awsui.$space-l + awsui.$space-scaled-xxs);
       padding-block-end: awsui.$space-scaled-m;
     }
   }


### PR DESCRIPTION
### Description

Remove inter-dependencies between css-variables in app layout and other components.

This inter-dependency only works when both instances are coming from the same bundle, but we cannot guarantee that in real world

Related links, issue #, if available: n/a

### How has this been tested?

* Screenshot tests in my dev pipeline. There will be differences and they are expected

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
