### PR TITLE
chore: Update global flags tests to prepare for removal of high-contr…

### DIFF
--- a/src/internal/utils/__tests__/global-flags-ssr.test.ts
+++ b/src/internal/utils/__tests__/global-flags-ssr.test.ts
@@ -20,16 +20,16 @@ describe('getGlobalFlag', () => {
   });
 
   test('returns undefined if the global flags object does not exist', () => {
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns undefined if the global flags object exists but the flag is not set', () => {
     global[awsuiGlobalFlagsSymbol] = {};
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
-  test('returns removeHighContrastHeader value when defined', () => {
-    global[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: false };
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
-    global[awsuiGlobalFlagsSymbol].removeHighContrastHeader = true;
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+  test('returns appLayoutWidget value when defined', () => {
+    global[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+    global[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
 });

--- a/src/internal/utils/__tests__/global-flags.test.ts
+++ b/src/internal/utils/__tests__/global-flags.test.ts
@@ -13,59 +13,59 @@ afterEach(() => {
 
 describe('getGlobalFlag', () => {
   test('returns undefined if the global flags object does not exist', () => {
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns undefined if the global flags object exists but the flag is not set', () => {
     window[awsuiGlobalFlagsSymbol] = {};
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
-  test('returns removeHighContrastHeader value when defined', () => {
-    window[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: false };
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
-    window[awsuiGlobalFlagsSymbol].removeHighContrastHeader = true;
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+  test('returns appLayoutWidget value when defined', () => {
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+    window[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
-  test('returns removeHighContrastHeader value when defined in top window', () => {
+  test('returns appLayoutWidget value when defined in top window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as typeof window);
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: true } } as typeof window);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
     jest.restoreAllMocks();
 
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as typeof window);
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(false);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: false } } as typeof window);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
   });
   test('privileges values in the self window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: false } } as typeof window);
-    window[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: true };
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: false } } as typeof window);
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
   test('returns top window value when not defined in the self window', () => {
     jest
       .spyOn(globalFlags, 'getTopWindow')
-      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { removeHighContrastHeader: true } } as typeof window);
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: true } } as typeof window);
     window[awsuiGlobalFlagsSymbol] = {};
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
   test('returns undefined when top window is not available', () => {
     jest.spyOn(globalFlags, 'getTopWindow').mockReturnValue(null);
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns undefined when an error is thrown and flag is not defined in own window', () => {
     jest.spyOn(globalFlags, 'getTopWindow').mockImplementation(() => {
       throw new Error('whatever');
     });
-    expect(getGlobalFlag('removeHighContrastHeader')).toBeUndefined();
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns value when an error is thrown and flag is defined in own window', () => {
     jest.spyOn(globalFlags, 'getTopWindow').mockImplementation(() => {
       throw new Error('whatever');
     });
-    window[awsuiGlobalFlagsSymbol] = { removeHighContrastHeader: true };
-    expect(getGlobalFlag('removeHighContrastHeader')).toBe(true);
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
 });


### PR DESCRIPTION
…ast header

### Description

Small change that can be merged now in view of the removal of high-contrast header


### How has this been tested?

Locally
<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Y
- _Changes are covered with new/existing integration tests?_ N
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
