### PR TITLE
fix: Table with mixed cell content and grid navigation to allow text selection

### DIFF
--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -8,6 +8,7 @@ import { renderHook } from '../../__tests__/render-hook';
 import { useStickyColumns } from '../../../lib/components/table/sticky-columns';
 import wrapper from '../../../lib/components/test-utils/dom';
 import styles from '../../../lib/components/table/body-cell/styles.selectors.js';
+import { renderWithSingleTabStopNavigation } from '../../internal/context/__tests__/utils';
 
 const tableRole = 'table';
 
@@ -335,5 +336,16 @@ describe('TableBodyCell', () => {
       fireEvent.mouseLeave(container.querySelector('[data-inline-editing-active]')!);
       expect(wrapper(container).findIcon()).toBeNull();
     });
+  });
+
+  test('does not set tab index when negative', () => {
+    const { setCurrentTarget } = renderWithSingleTabStopNavigation(<TestComponent />, { navigationActive: true });
+    const tableCell = wrapper().find('td')!.getElement();
+
+    expect(tableCell).not.toHaveAttribute('tabIndex');
+    setCurrentTarget(tableCell);
+    expect(tableCell).toHaveAttribute('tabIndex', '0');
+    setCurrentTarget(null);
+    expect(tableCell).not.toHaveAttribute('tabIndex');
   });
 });

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -120,7 +120,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         onMouseLeave={onMouseLeave}
         ref={mergedRef}
         {...nativeAttributes}
-        tabIndex={cellTabIndex}
+        tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       >
         {level !== undefined && isExpandable && (
           <div className={styles['expandable-toggle-wrapper']}>

--- a/src/table/header-cell/index.tsx
+++ b/src/table/header-cell/index.tsx
@@ -15,7 +15,7 @@ import { TableRole } from '../table-role';
 import { TableThElement } from './th-element';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 
-interface TableHeaderCellProps<ItemType> {
+export interface TableHeaderCellProps<ItemType> {
   className?: string;
   style?: React.CSSProperties;
   tabIndex: number;

--- a/src/table/header-cell/th-element.tsx
+++ b/src/table/header-cell/th-element.tsx
@@ -68,7 +68,7 @@ export function TableThElement({
       style={{ ...style, ...stickyStyles.style }}
       ref={mergedRef}
       {...getTableColHeaderRoleProps({ tableRole, sortingStatus, colIndex })}
-      tabIndex={cellTabIndex}
+      tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
     >
       {children}
     </th>

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -7,6 +7,7 @@ import {
   defaultIsSuppressed,
   findTableRowByAriaRowIndex,
   findTableRowCellByAriaColIndex,
+  focusNextElement,
   getClosestCell,
   isElementDisabled,
   isTableCell,
@@ -262,7 +263,7 @@ class GridNavigationProcessor {
     if (delta.y !== 0 && delta.x === 0) {
       this.keepUserIndex = true;
     }
-    this.getNextFocusable(cell, delta)?.focus();
+    focusNextElement(this.getNextFocusable(cell, delta));
   }
 
   private updateFocusTarget() {

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -93,3 +93,12 @@ export function findTableRowCellByAriaColIndex(
 export function isTableCell(element: Element) {
   return element.tagName === 'TD' || element.tagName === 'TH';
 }
+
+export function focusNextElement(element: null | HTMLElement) {
+  if (element) {
+    if (isTableCell(element)) {
+      element.tabIndex = 0;
+    }
+    element.focus();
+  }
+}


### PR DESCRIPTION
### Description

In tables with keyboard navigation all cells were assigned tabIndex="-1". This way, the cells are still not reachable with Tab navigation, but receive focus upon clicking: when clicking on a cell the focus event is emitted and the cell becomes the active element. In case a cell includes an interactive element such as an expand toggle, that interactive element receives focus instead of the cell. That breaks the browser's text selection behaviour:
1. The user starts selection by clicking and dragging over text content in a cell;
2. The cell receives focus;
3. The focus is dispatched to the first interactive element of the cell (the expand toggle);
4. The text selection is not performed.

The problem is fixed by not assigning the negative tab index to cells unless immediately before issuing focus. A side effect is that now clicking on a text cell will no longer result in the underlying cell receiving focus. However, a click followed up by a Tab press works as expected.

Rel: AWSUI-40396

### How has this been tested?

* New unit tests to secure the update
* Manual tests to ensure correct behaviour

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
