### PR TITLE
chore: Table expandable test page server mock

### DIFF
--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import Table from '~components/table';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
@@ -27,6 +27,7 @@ import messages from '~components/i18n/messages/all.en';
 import I18nProvider from '~components/i18n';
 import { createColumns, createPreferences, filteringProperties } from './expandable-rows/expandable-rows-configs';
 import { ariaLabels, getHeaderCounterText } from './expandable-rows/common';
+import { isEqual } from 'lodash';
 
 type PageContext = React.Context<
   AppContextType<{
@@ -38,6 +39,7 @@ type PageContext = React.Context<
     groupResources: boolean;
     keepSelection: boolean;
     usePagination: boolean;
+    useServerMock: boolean;
   }>
 >;
 
@@ -45,67 +47,33 @@ export default () => {
   const settings = usePageSettings();
   const [toolsOpen, setToolsOpen] = useState(true);
   const [preferences, setPreferences] = useState<CollectionPreferencesProps.Preferences>({
-    pageSize: 10,
     wrapLines: true,
     stickyColumns: { first: 0, last: 1 },
   });
-  const [selectedCluster, setSelectedCluster] = useState<null | string>(null);
-  const getScopedInstances = (selected: null | string) =>
-    selected === null ? allInstances : allInstances.filter(i => i.path.includes(selected));
 
-  const { items, collectionProps, paginationProps, propertyFilterProps, filteredItemsCount, actions } = useCollection(
-    getScopedInstances(selectedCluster),
-    {
-      pagination: settings.usePagination ? { pageSize: preferences.pageSize } : undefined,
-      sorting: {},
-      filtering: {},
-      propertyFiltering: { filteringProperties },
-      selection: { trackBy: 'name', keepSelection: settings.keepSelection },
-      expandableRows: settings.groupResources
-        ? {
-            getId: item => item.name,
-            getParentId: item => (item.name === selectedCluster ? null : item.parentName),
-          }
-        : undefined,
-    }
-  );
-
-  // Decorate path options to only show the last node and not the full path.
-  const filteringOptions = propertyFilterProps.filteringOptions.map(option =>
-    option.propertyKey === 'path' ? { ...option, value: option.value.split(',')[0] } : option
-  );
-
-  const expandedInstances = collectionProps.expandableRows?.expandedItems ?? [];
+  const tableData = useTableData();
 
   const columnDefinitions = createColumns({
     getInstanceProps: instance => {
-      const children = collectionProps.expandableRows?.getItemChildren(instance).length ?? 0;
-      const scopedInstances = getScopedInstances(instance.name);
+      const children = tableData.collectionProps.expandableRows?.getItemChildren(instance).length ?? 0;
       const instanceActions = [
         {
           id: 'drill-down',
           text: `Show ${instance.name} cluster only`,
           hidden: !children,
-          onClick: () => {
-            actions.setExpandedItems(scopedInstances);
-            setSelectedCluster(instance.name);
-          },
+          onClick: () => tableData.actions.drillDown(instance.name),
         },
         {
           id: 'expand-all',
           text: `Expand cluster`,
           hidden: !children,
-          onClick: () => {
-            actions.setExpandedItems([...expandedInstances, ...scopedInstances]);
-          },
+          onClick: () => tableData.actions.expandDeep(instance.name),
         },
         {
           id: 'collapse-all',
           text: `Collapse cluster`,
           hidden: !children,
-          onClick: () => {
-            actions.setExpandedItems(expandedInstances.filter(i => !scopedInstances.includes(i)));
-          },
+          onClick: () => tableData.actions.collapseDeep(instance.name),
         },
       ];
       return { children, actions: instanceActions };
@@ -122,7 +90,7 @@ export default () => {
         onToolsChange={({ detail: { open } }) => setToolsOpen(open)}
         content={
           <Table
-            {...collectionProps}
+            {...tableData.collectionProps}
             stickyColumns={preferences.stickyColumns}
             resizableColumns={settings.resizableColumns}
             stickyHeader={settings.stickyHeader}
@@ -130,21 +98,23 @@ export default () => {
             selectionType={settings.selectionType !== 'none' ? settings.selectionType : undefined}
             stripedRows={settings.stripedRows}
             columnDefinitions={columnDefinitions}
-            items={items}
+            items={tableData.items}
             ariaLabels={ariaLabels}
             wrapLines={preferences.wrapLines}
-            pagination={settings.usePagination && <Pagination {...paginationProps} />}
+            pagination={settings.usePagination && <Pagination {...tableData.paginationProps} />}
             columnDisplay={preferences.contentDisplay}
             preferences={createPreferences({ preferences, setPreferences })}
             submitEdit={() => {}}
             variant="full-page"
             renderAriaLive={renderAriaLive}
+            loading={tableData.loading}
+            loadingText="Loading instances"
             header={
               <SpaceBetween size="m">
                 <Header
                   variant="h1"
                   description="Table with expandable rows test page"
-                  counter={getHeaderCounterText(allInstances, collectionProps.selectedItems)}
+                  counter={getHeaderCounterText(allInstances, tableData.collectionProps.selectedItems)}
                   actions={
                     <SpaceBetween size="s" direction="horizontal" alignItems="center">
                       <Toggle
@@ -162,17 +132,17 @@ export default () => {
                           {
                             id: 'terminate-selected',
                             text: 'Terminate selected instances',
-                            disabled: collectionProps.selectedItems?.length === 0,
+                            disabled: tableData.collectionProps.selectedItems?.length === 0,
                           },
                         ]}
                         onItemClick={event => {
                           switch (event.detail.id) {
                             case 'expand-all':
-                              return actions.setExpandedItems(allInstances);
+                              return tableData.actions.expandAll();
                             case 'collapse-all':
-                              return actions.setExpandedItems([]);
+                              return tableData.actions.collapseAll();
                             case 'terminate-selected':
-                              return actions.setSelectedItems([]);
+                              return tableData.actions.clearSelection();
                             default:
                               throw new Error('Invariant violation: unsupported action.');
                           }
@@ -185,14 +155,14 @@ export default () => {
                 >
                   Databases
                 </Header>
-                {selectedCluster && (
+                {tableData.selectedCluster && (
                   <Alert
                     type="info"
-                    action={<Button onClick={() => setSelectedCluster(null)}>Show all databases</Button>}
+                    action={<Button onClick={() => tableData.actions.resetClusterFilter()}>Show all databases</Button>}
                   >
                     Showing databases that belong to{' '}
                     <Box variant="span" fontWeight="bold">
-                      {selectedCluster}
+                      {tableData.selectedCluster}
                     </Box>{' '}
                     cluster.
                   </Alert>
@@ -201,9 +171,8 @@ export default () => {
             }
             filter={
               <PropertyFilter
-                {...propertyFilterProps}
-                filteringOptions={filteringOptions}
-                countText={getMatchesCountText(filteredItemsCount ?? 0)}
+                {...tableData.propertyFilterProps}
+                countText={getMatchesCountText(tableData.filteredItemsCount ?? 0)}
                 filteringPlaceholder="Search databases"
               />
             }
@@ -213,6 +182,93 @@ export default () => {
     </I18nProvider>
   );
 };
+
+const SERVER_DELAY = 1500;
+function useTableData() {
+  const settings = usePageSettings();
+  const delay = settings.useServerMock ? SERVER_DELAY : 0;
+
+  const [loading, setLoading] = useState(false);
+
+  // Imitate server-side delay when fetching items for the first time.
+  const [readyInstances, setReadyInstances] = useState(settings.useServerMock ? [] : allInstances);
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setReadyInstances(allInstances);
+      setLoading(false);
+    }, delay);
+  }, [delay]);
+
+  const [selectedCluster, setSelectedCluster] = useState<null | string>(null);
+  const getScopedInstances = (selected: null | string) =>
+    selected === null ? readyInstances : readyInstances.filter(i => i.path.includes(selected));
+
+  const collectionResult = useCollection(getScopedInstances(selectedCluster), {
+    pagination: settings.usePagination ? { pageSize: 10 } : undefined,
+    sorting: {},
+    filtering: {},
+    propertyFiltering: { filteringProperties },
+    selection: { trackBy: 'name', keepSelection: settings.keepSelection },
+    expandableRows: settings.groupResources
+      ? {
+          getId: item => item.name,
+          getParentId: item => (item.name === selectedCluster ? null : item.parentName),
+        }
+      : undefined,
+  });
+
+  // Imitate server-side delay when items update.
+  const memoItems = useEqualsMemo(collectionResult.items);
+  const [readyItems, setReadyItems] = useState(memoItems);
+  useEffect(() => {
+    setLoading(true);
+    const timeoutId = setTimeout(() => {
+      setLoading(false);
+      setReadyItems(memoItems);
+    }, delay);
+    return () => clearTimeout(timeoutId);
+  }, [delay, memoItems]);
+
+  // Decorate path options to only show the last node and not the full path.
+  collectionResult.propertyFilterProps.filteringOptions = collectionResult.propertyFilterProps.filteringOptions.map(
+    option => (option.propertyKey === 'path' ? { ...option, value: option.value.split(',')[0] } : option)
+  );
+
+  return {
+    ...collectionResult,
+    loading: settings.useServerMock ? loading : false,
+    items: settings.useServerMock ? readyItems : memoItems,
+    selectedCluster,
+    actions: {
+      resetClusterFilter: () => setSelectedCluster(null),
+      drillDown: (instanceName: string) => {
+        const scopedInstances = getScopedInstances(instanceName);
+        collectionResult.actions.setExpandedItems(scopedInstances);
+        setSelectedCluster(instanceName);
+      },
+      expandDeep: (instanceName: string) => {
+        const expandedInstances = collectionResult.collectionProps.expandableRows?.expandedItems ?? [];
+        const scopedInstances = getScopedInstances(instanceName);
+        collectionResult.actions.setExpandedItems([...expandedInstances, ...scopedInstances]);
+      },
+      collapseDeep: (instanceName: string) => {
+        const expandedInstances = collectionResult.collectionProps.expandableRows?.expandedItems ?? [];
+        const scopedInstances = getScopedInstances(instanceName);
+        collectionResult.actions.setExpandedItems(expandedInstances.filter(i => !scopedInstances.includes(i)));
+      },
+      expandAll: () => {
+        collectionResult.actions.setExpandedItems(allInstances);
+      },
+      collapseAll: () => {
+        collectionResult.actions.setExpandedItems([]);
+      },
+      clearSelection: () => {
+        collectionResult.actions.setSelectedItems([]);
+      },
+    },
+  };
+}
 
 function usePageSettings() {
   const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
@@ -225,6 +281,7 @@ function usePageSettings() {
     keepSelection: urlParams.keepSelection ?? false,
     usePagination: urlParams.usePagination ?? false,
     groupResources: urlParams.groupResources ?? true,
+    useServerMock: urlParams.useServerMock ?? false,
     setUrlParams,
   };
 }
@@ -234,8 +291,8 @@ function PageSettings() {
   const settings = usePageSettings();
   return (
     <Drawer header={<Header variant="h2">Page settings</Header>}>
-      <SpaceBetween direction="horizontal" size="m">
-        <FormField label="Table flags">
+      <SpaceBetween size="l">
+        <FormField label="Table settings">
           <Checkbox
             checked={settings.resizableColumns}
             onChange={event => settings.setUrlParams({ resizableColumns: event.detail.checked })}
@@ -280,22 +337,42 @@ function PageSettings() {
           >
             Use pagination
           </Checkbox>
+
+          <Box margin={{ top: 'xs' }}>
+            <FormField label={<Box>Selection type</Box>}>
+              <Select
+                selectedOption={
+                  selectionTypeOptions.find(option => option.value === settings.selectionType) ??
+                  selectionTypeOptions[0]
+                }
+                options={selectionTypeOptions}
+                onChange={event =>
+                  settings.setUrlParams({
+                    selectionType: event.detail.selectedOption.value as 'none' | 'single' | 'multi',
+                  })
+                }
+              />
+            </FormField>
+          </Box>
         </FormField>
 
-        <FormField label="Selection type">
-          <Select
-            selectedOption={
-              selectionTypeOptions.find(option => option.value === settings.selectionType) ?? selectionTypeOptions[0]
-            }
-            options={selectionTypeOptions}
-            onChange={event =>
-              settings.setUrlParams({
-                selectionType: event.detail.selectedOption.value as 'none' | 'single' | 'multi',
-              })
-            }
-          />
+        <FormField label="Mock server settings">
+          <Checkbox
+            checked={settings.useServerMock}
+            onChange={event => settings.setUrlParams({ useServerMock: event.detail.checked })}
+          >
+            Use server mock
+          </Checkbox>
         </FormField>
       </SpaceBetween>
     </Drawer>
   );
+}
+
+function useEqualsMemo<T>(value: T): T {
+  const ref = useRef<T>(value);
+  if (!isEqual(value, ref.current)) {
+    ref.current = value;
+  }
+  return ref.current;
 }

--- a/pages/table/expandable-rows/expandable-rows-configs.tsx
+++ b/pages/table/expandable-rows/expandable-rows-configs.tsx
@@ -177,14 +177,6 @@ export function createPreferences({
       cancelLabel="Cancel"
       onConfirm={({ detail }) => setPreferences(detail)}
       preferences={preferences}
-      pageSizePreference={{
-        title: 'Select page size',
-        options: [
-          { value: 10, label: '10 Instances' },
-          { value: 25, label: '25 Instances' },
-          { value: 50, label: '50 Instances' },
-        ],
-      }}
       contentDisplayPreference={{
         title: 'Column preferences',
         description: 'Customize the columns visibility and order.',

--- a/pages/table/expandable-rows/expandable-rows-data.ts
+++ b/pages/table/expandable-rows/expandable-rows-data.ts
@@ -27,7 +27,7 @@ function generateLevelItems(level: number, path: string[], parent: null | Instan
   const nextPath = [instanceDetail.name, ...path];
   const children = generateChildren(type, level, nextPath, instanceDetail);
   const selectsPerSecond = getSelectsPerSecond(type, children);
-  const stateGrouped = getGroupedState(type, instanceDetail.state, children);
+  const stateGrouped = getGroupedState(instanceDetail.state, children);
   const sizeGrouped = getGroupedSize(type, instanceDetail.size, children);
   const regionGrouped = getGroupedRegion(type, instanceDetail.region, children);
   return [
@@ -113,16 +113,10 @@ function getSelectsPerSecond(instanceType: InstanceType, children: Instance[]): 
     : sumBy(children, instance => instance.selectsPerSecond ?? 0);
 }
 
-function getGroupedState(instanceType: InstanceType, state: InstanceState, children: Instance[]) {
-  const grouped = { RUNNING: 0, STOPPED: 0, TERMINATED: 0 };
-  if (instanceType === 'instance') {
-    grouped[state] += 1;
-  } else {
-    for (const instance of children) {
-      grouped.RUNNING += instance.stateGrouped.RUNNING;
-      grouped.STOPPED += instance.stateGrouped.STOPPED;
-      grouped.TERMINATED += instance.stateGrouped.TERMINATED;
-    }
+function getGroupedState(state: InstanceState, children: Instance[]) {
+  const grouped = { RUNNING: 0, STOPPED: 0, TERMINATED: 0, [state]: 1 };
+  for (const instance of children) {
+    grouped[instance.state]++;
   }
   return grouped;
 }


### PR DESCRIPTION
### Description

An update to a table test page to support https://github.com/cloudscape-design/components/pull/2131

The test page is enhanced with a server mock to imitate server-side data processing. The update is primarily needed for 2131 to ensure progressive loading behaves as expected with both client- and server side resolution.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
