### PR TITLE
fix: Render live announcements in Table and Cards when no pagination

### DIFF
--- a/pages/table/expandable-rows-test.page.tsx
+++ b/pages/table/expandable-rows-test.page.tsx
@@ -99,6 +99,8 @@ export default () => {
             stripedRows={settings.stripedRows}
             columnDefinitions={columnDefinitions}
             items={tableData.items}
+            // TODO: remove when supplemented by collection hooks (https://github.com/cloudscape-design/collection-hooks/pull/72)
+            totalItemsCount={tableData.items.length}
             ariaLabels={ariaLabels}
             wrapLines={preferences.wrapLines}
             pagination={settings.usePagination && <Pagination {...tableData.paginationProps} />}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4005,9 +4005,9 @@ Don't use this property if the card has any other interactive elements.",
       "type": "boolean",
     },
     Object {
+      "defaultValue": "1",
       "description": " Use this property to inform screen readers which range of cards is currently displayed.
- It specifies the index (1-based) of the first card.
- If the cards list has no pagination, leave this property undefined.",
+ It specifies the index (1-based) of the first card.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -4059,7 +4059,10 @@ The \`cardDefinition\` property handles the display of this data.
     },
     Object {
       "description": "Use this function to announce page changes to screen reader users.
-Requires the properties firstIndex and totalItemsCount to be set correctly.",
+The function argument takes the following properties:
+* \`firstIndex\` (number) - The provided \`firstIndex\` property which defaults to 1 when not defined.
+* \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.
+* \`lastIndex\` (number) - The index of the last visible item of the table.",
       "name": "renderAriaLive",
       "optional": true,
       "type": "(data: CardsProps.LiveAnnouncement) => string",
@@ -13473,9 +13476,9 @@ By default, the keyboard navigation is active for tables with expandable rows.
       "type": "TableProps.ExpandableRows<T>",
     },
     Object {
+      "defaultValue": "1",
       "description": " Use this property to inform screen readers which range of items is currently displayed in the table.
- It specifies the index (1-based) of the first item in the table.
- If the table has no pagination, leave this property undefined.",
+ It specifies the index (1-based) of the first item in the table.",
       "name": "firstIndex",
       "optional": true,
       "type": "number",
@@ -13526,7 +13529,11 @@ by the \`cell\` property of each column definition in the \`columnDefinitions\` 
     },
     Object {
       "description": "Use this function to announce page changes to screen reader users.
-Requires the properties firstIndex and totalItemsCount to be set correctly.",
+The function argument takes the following properties:
+* \`firstIndex\` (number) - The provided \`firstIndex\` property which defaults to 1 when not defined.
+* \`totalItemsCount\` (optional, number) - The provided \`totalItemsCount\` property.
+* \`lastIndex\` (number) - The index of the last visible item of the table.
+Important: in tables with expandable rows the \`firstIndex\`, \`lastIndex\`, and \`totalItemsCount\` reflect the top-level items only.",
       "name": "renderAriaLive",
       "optional": true,
       "type": "(data: TableProps.LiveAnnouncement) => string",

--- a/src/cards/__tests__/cards.test.tsx
+++ b/src/cards/__tests__/cards.test.tsx
@@ -271,27 +271,32 @@ describe('Cards', () => {
     });
   });
   describe('live region', () => {
-    test('Should render a live region with table total count and indices when renderAriaLive and firstIndex are available', () => {
-      const firstIndex = 1;
-      const totalItemsCount = defaultItems.length;
-      const lastIndex = firstIndex + defaultItems.length - 1;
+    test.each([
+      { firstIndex: 1, totalItemsCount: defaultItems.length },
+      { firstIndex: undefined, totalItemsCount: undefined },
+    ])(
+      'Should render a live region when firstIndex="$firstIndex" and totalItemsCount="$totalItemsCount"',
+      ({ firstIndex, totalItemsCount }) => {
+        const expectedFirstIndex = firstIndex ?? 1;
+        const lastIndex = expectedFirstIndex + defaultItems.length - 1;
 
-      const wrapper = renderCards(
-        <Cards<Item>
-          cardDefinition={cardDefinition}
-          items={defaultItems}
-          firstIndex={firstIndex}
-          totalItemsCount={totalItemsCount}
-          renderAriaLive={({ firstIndex, lastIndex, totalItemsCount }) =>
-            `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
-          }
-        />
-      ).wrapper;
+        const wrapper = renderCards(
+          <Cards<Item>
+            cardDefinition={cardDefinition}
+            items={defaultItems}
+            firstIndex={firstIndex}
+            totalItemsCount={totalItemsCount}
+            renderAriaLive={({ firstIndex, lastIndex, totalItemsCount }) =>
+              `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
+            }
+          />
+        ).wrapper;
 
-      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
-        `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
-      );
-    });
+        expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
+          `Displaying items from ${expectedFirstIndex} to ${lastIndex} of ${totalItemsCount} items`
+        );
+      }
+    );
   });
 
   describe('i18n', () => {

--- a/src/cards/index.tsx
+++ b/src/cards/index.tsx
@@ -58,7 +58,7 @@ const Cards = React.forwardRef(function <T = any>(
     stickyHeaderVerticalOffset,
     variant = 'container',
     renderAriaLive,
-    firstIndex,
+    firstIndex = 1,
     totalItemsCount,
     entireCardClickable,
     ...rest

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -186,16 +186,20 @@ export interface CardsProps<T = any> extends BaseComponentProps {
   /**
    * Use this property to inform screen readers how many cards there are.
    * It specifies the total number of cards.
-   * If there is an unknown total number of cards, leave this property undefined.   */
+   * If there is an unknown total number of cards, leave this property undefined.
+   */
   totalItemsCount?: number;
   /**
    *  Use this property to inform screen readers which range of cards is currently displayed.
    *  It specifies the index (1-based) of the first card.
-   *  If the cards list has no pagination, leave this property undefined.   */
+   */
   firstIndex?: number;
   /**
    * Use this function to announce page changes to screen reader users.
-   * Requires the properties firstIndex and totalItemsCount to be set correctly.
+   * The function argument takes the following properties:
+   * * `firstIndex` (number) - The provided `firstIndex` property which defaults to 1 when not defined.
+   * * `totalItemsCount` (optional, number) - The provided `totalItemsCount` property.
+   * * `lastIndex` (number) - The index of the last visible item of the table.
    */
   renderAriaLive?: (data: CardsProps.LiveAnnouncement) => string;
 
@@ -254,9 +258,9 @@ export namespace CardsProps {
   }
 
   export interface LiveAnnouncement {
-    totalItemsCount?: number;
     firstIndex: number;
     lastIndex: number;
+    totalItemsCount?: number;
   }
 
   export interface Ref {

--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -124,33 +124,39 @@ describe('labels', () => {
       expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('-1');
     });
 
-    test('sets aria-rowindex on table rows', () => {
-      const wrapper = renderTableWrapper({ firstIndex: 21 });
+    test.each([undefined, 21])('sets aria-rowindex on table rows', firstIndex => {
+      const expectedFirstIndex = firstIndex ?? 1;
+      const wrapper = renderTableWrapper({ firstIndex });
       const [headerRow, firstRowInTable] = wrapper.findAll('tr');
       // header row is always index 1
       expect(headerRow!.getElement().getAttribute('aria-rowindex')).toEqual('1');
       // rows in a table are index + 1 as header row is index 1
-      expect(firstRowInTable!.getElement().getAttribute('aria-rowindex')).toEqual('22');
+      expect(firstRowInTable!.getElement().getAttribute('aria-rowindex')).toEqual((expectedFirstIndex + 1).toString());
     });
   });
 
   describe('live region', () => {
-    test('Should render a live region with table total count and indices when renderAriaLive and firstIndex are available', () => {
-      const firstIndex = 1;
-      const totalItemsCount = defaultItems.length;
-      const lastIndex = firstIndex + defaultItems.length - 1;
+    test.each([
+      { firstIndex: 1, totalItemsCount: defaultItems.length },
+      { firstIndex: undefined, totalItemsCount: undefined },
+    ])(
+      'Should render a live region when firstIndex="$firstIndex" and totalItemsCount="$totalItemsCount"',
+      ({ firstIndex, totalItemsCount }) => {
+        const expectedFirstIndex = firstIndex ?? 1;
+        const lastIndex = expectedFirstIndex + defaultItems.length - 1;
 
-      const wrapper = renderTableWrapper({
-        firstIndex,
-        totalItemsCount,
-        renderAriaLive: ({ firstIndex, lastIndex, totalItemsCount }) =>
-          `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`,
-      });
+        const wrapper = renderTableWrapper({
+          firstIndex,
+          totalItemsCount,
+          renderAriaLive: ({ firstIndex, lastIndex, totalItemsCount }) =>
+            `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`,
+        });
 
-      expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
-        `Displaying items from ${firstIndex} to ${lastIndex} of ${totalItemsCount} items`
-      );
-    });
+        expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe(
+          `Displaying items from ${expectedFirstIndex} to ${lastIndex} of ${totalItemsCount} items`
+        );
+      }
+    );
 
     test('The table items live region must not include nested items', () => {
       const firstIndex = 1;

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -10,7 +10,14 @@ import { AnalyticsFunnelSubStep } from '../internal/analytics/components/analyti
 export { TableProps };
 const Table = React.forwardRef(
   <T,>(
-    { items = [], selectedItems = [], variant = 'container', contentDensity = 'comfortable', ...props }: TableProps<T>,
+    {
+      items = [],
+      selectedItems = [],
+      variant = 'container',
+      contentDensity = 'comfortable',
+      firstIndex = 1,
+      ...props
+    }: TableProps<T>,
     ref: React.Ref<TableProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Table', {
@@ -34,6 +41,7 @@ const Table = React.forwardRef(
       selectedItems,
       variant,
       contentDensity,
+      firstIndex,
       ...props,
       ...baseComponentProps,
       ref,

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -305,12 +305,15 @@ export interface TableProps<T = any> extends BaseComponentProps {
   /**
    *  Use this property to inform screen readers which range of items is currently displayed in the table.
    *  It specifies the index (1-based) of the first item in the table.
-   *  If the table has no pagination, leave this property undefined.
    */
   firstIndex?: number;
   /**
    * Use this function to announce page changes to screen reader users.
-   * Requires the properties firstIndex and totalItemsCount to be set correctly.
+   * The function argument takes the following properties:
+   * * `firstIndex` (number) - The provided `firstIndex` property which defaults to 1 when not defined.
+   * * `totalItemsCount` (optional, number) - The provided `totalItemsCount` property.
+   * * `lastIndex` (number) - The index of the last visible item of the table.
+   * Important: in tables with expandable rows the `firstIndex`, `lastIndex`, and `totalItemsCount` reflect the top-level items only.
    */
   renderAriaLive?: (data: TableProps.LiveAnnouncement) => string;
   /**
@@ -461,9 +464,9 @@ export namespace TableProps {
   }
 
   export interface LiveAnnouncement {
-    totalItemsCount?: number;
     firstIndex: number;
     lastIndex: number;
+    totalItemsCount?: number;
   }
 
   export interface Ref {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -55,7 +55,7 @@ const GRID_NAVIGATION_PAGE_SIZE = 10;
 const SELECTION_COLUMN_WIDTH = 54;
 const selectionColumnId = Symbol('selection-column-id');
 
-type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant'> &
+type InternalTableProps<T> = SomeRequired<TableProps<T>, 'items' | 'selectedItems' | 'variant' | 'firstIndex'> &
   InternalBaseComponentProps & {
     __funnelSubStepProps?: InternalContainerProps['__funnelSubStepProps'];
   };


### PR DESCRIPTION
### Description

#### The problem
In Table and Cards we announce changes to items with `renderAriaLive`. The changes are only announced when the `firstIndex` is defined which we require for when the pagination is used. However, the announcements are relevant in one of the two cases:
1. Page changes (represented by a change of the first index)
2. Filter changes (represented by a change of the total items)

The second case remains uncovered when there is no pagination and the first index is not provided explicitly which is against our recommendation.

#### The change

When `firstIndex` is not defined it defaults to 1 in both Table and Cards. As result, the live announcement is consistently performed. The `totalItemsCount` can remain undefined though when the actual count is unknown. That is expected to be handled by the `renderAriaLive` which signature assumes the total might be missing.

A related change to the collection hooks (https://github.com/cloudscape-design/collection-hooks/pull/72) makes it so the `firstIndex` and `totalItemsCount` are always present in the collection result.

A side change to the Table is that now the `aria-rowcount` and `aria-rowindex` attributes are always assigned even though there is no strict need when the pagination is missing.

#### Implications

The change caused our demos dry run to fail on expandable- and server-side tables. The first one fails because it does not use pagination and the second - because it does not use collection-hooks. In both cases, the `totalItemsCount` is missing but the `renderAriaLive` is defined. Previously, the `renderAriaLive` has never been called (the feature was not working) and now it is called with `totalItemsCount` missing, causing the unexpected "undefined" error.

The same failure is not expected to happen in the real applications because there should be either no `renderAriaLive` or the function must handle the missing `totalItemsCount` which is already a part of the API contract. The collection-hooks update (https://github.com/cloudscape-design/collection-hooks/pull/72) will make the issue less likely to appear. Additionally, the demos will be updated to handle the optional `totalItemsCount` correctly.

### How has this been tested?

* New unit tests
* Manual testing in the expandable rows test page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
