### PR TITLE
test: Add screenshot tests for nested items in Side Navigation

### DIFF
--- a/pages/side-navigation/permutations.page.tsx
+++ b/pages/side-navigation/permutations.page.tsx
@@ -366,6 +366,92 @@ const permutations = createPermutations<SideNavigationProps>([
       ],
     ],
   },
+  {
+    header: [{ text: 'Nested items', href: '#/' }],
+    items: [
+      [
+        {
+          type: 'section',
+          text: 'Section level 1',
+          items: [
+            {
+              type: 'section',
+              text: 'Section level 2',
+              items: [
+                {
+                  type: 'section',
+                  text: 'Section level 3',
+                  items: [
+                    { type: 'section', text: 'Section level 4', items: [{ type: 'link', text: 'Link', href: '#/' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'link-group',
+          text: 'Link Group level 1',
+          href: '#/',
+          items: [
+            {
+              type: 'link-group',
+              text: 'Link Group level 2',
+              href: '#/',
+              items: [
+                {
+                  type: 'link-group',
+                  text: 'Link Group level 3',
+                  href: '#/',
+                  items: [
+                    {
+                      type: 'link-group',
+                      text: 'Link Group level 4',
+                      href: '#/',
+                      items: [{ type: 'link', text: 'Link', href: '#/' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'expandable-link-group',
+          text: 'Expandable Link Group level 1',
+          href: '#/',
+          defaultExpanded: true,
+          items: [
+            {
+              type: 'expandable-link-group',
+              text: 'Expandable Link Group level 2',
+              href: '#/',
+              defaultExpanded: true,
+
+              items: [
+                {
+                  type: 'expandable-link-group',
+                  text: 'Expandable Link Group level 3',
+                  href: '#/',
+                  defaultExpanded: true,
+
+                  items: [
+                    {
+                      type: 'expandable-link-group',
+                      text: 'Expandable Link Group level 3',
+                      href: '#/',
+                      defaultExpanded: true,
+                      items: [{ type: 'link', text: 'Link', href: '#/' }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    ],
+  },
 ]);
 
 export default function SideNavigationPermutations() {


### PR DESCRIPTION
### Description

Side Navigation component allows any level of items nesting but we don't have any tests for more than 1 level, this PR adds screenshot tests for 4 levels of nesting for the 3 item types that allows nesting: `section`, `link-group` and `expandable-link-group`

Our [API says](https://cloudscape.design/components/side-navigation/?tabId=api):
> Although there is no technical limitation to the nesting level, our UX recommendation is to use only one level.

But it's still possible to use nested items in Side Navigation and we want to avoid any regressions to these untested levels of nesting. 

Related links, issue #, if available: AWSUI-40872

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
