### PR TITLE
fix: In stacked bar chart threshold series can be added at any position in the series array

### DIFF
--- a/pages/bar-chart/stacked-permutations.page.tsx
+++ b/pages/bar-chart/stacked-permutations.page.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import BarChart, { BarChartProps } from '~components/bar-chart';
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+import { commonProps, multipleNegativeBarsDataWithThreshold } from '../mixed-line-bar-chart/common';
+
+const data1 = multipleNegativeBarsDataWithThreshold;
+
+// Position of the threshold series in a stacked chart must not affect chart's presentation.
+const thresholdSeries = multipleNegativeBarsDataWithThreshold.find(s => s.type === 'threshold')!;
+const data2 = multipleNegativeBarsDataWithThreshold.filter(s => s.type === 'bar');
+data2.splice(Math.floor(Math.random() * data2.length), 0, thresholdSeries);
+
+/* eslint-disable react/jsx-key */
+const permutations = createPermutations<BarChartProps<string>>([
+  {
+    i18nStrings: [commonProps.i18nStrings],
+    ariaLabel: ['Test chart'],
+    height: [200],
+    series: [data1, data2],
+    xScaleType: ['categorical'],
+    xDomain: [['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']],
+    yDomain: [[-6, 10]],
+    horizontalBars: [true, false],
+    stackedBars: [true],
+    xTitle: ['X Title'],
+    yTitle: ['Y Title'],
+  },
+]);
+
+export default function () {
+  return (
+    <>
+      <h1>Stacked bar chart permutations</h1>
+      <ScreenshotArea disableAnimations={true}>
+        <PermutationsView permutations={permutations} render={permutation => <BarChart<any> {...permutation} />} />
+      </ScreenshotArea>
+    </>
+  );
+}

--- a/src/bar-chart/__tests__/bar-chart.test.tsx
+++ b/src/bar-chart/__tests__/bar-chart.test.tsx
@@ -15,7 +15,7 @@ function renderBarChart(jsx: React.ReactElement) {
   };
 }
 
-const barSeries: MixedLineBarChartProps.BarDataSeries<string> = {
+const barSeries1: MixedLineBarChartProps.BarDataSeries<string> = {
   type: 'bar',
   title: 'Bar Series 1',
   data: [
@@ -25,20 +25,41 @@ const barSeries: MixedLineBarChartProps.BarDataSeries<string> = {
     { x: 'Group 4', y: 9 },
   ],
 };
+const barSeries2: MixedLineBarChartProps.BarDataSeries<string> = {
+  type: 'bar',
+  title: 'Bar Series 2',
+  data: [
+    { x: 'Group 1', y: -2 },
+    { x: 'Group 2', y: 0 },
+    { x: 'Group 3', y: 0 },
+    { x: 'Group 4', y: 5 },
+  ],
+};
+const thresholdSeries: MixedLineBarChartProps.ThresholdSeries = {
+  type: 'threshold',
+  title: 'Threshold 1',
+  y: 5,
+};
 
 // Main rendering and testing is done in the MixedChart component. We just make sure that everything is passed down correctly.
 describe('Bar chart', () => {
-  test('can render bar series', () => {
-    const { wrapper } = renderBarChart(
-      <BarChart
-        series={[barSeries]}
-        xScaleType="categorical"
-        xDomain={['Group 1', 'Group 2', 'Group 3', 'Group 4']}
-        yDomain={[0, 10]}
-      />
-    );
+  test.each([{ stackedBars: false }, { stackedBars: true }])(
+    'can render bar series with stackedBars=$stackedBars',
+    ({ stackedBars }) => {
+      const { wrapper } = renderBarChart(
+        <BarChart
+          series={[barSeries1, thresholdSeries, barSeries2]}
+          stackedBars={stackedBars}
+          xScaleType="categorical"
+          xDomain={['Group 1', 'Group 2', 'Group 3', 'Group 4']}
+          yDomain={[0, 10]}
+        />
+      );
 
-    expect(wrapper.findSeries()).toHaveLength(1);
-    expect(wrapper.findSeries()[0].getElement()).toHaveAttribute('aria-label', barSeries.title);
-  });
+      expect(wrapper.findSeries()).toHaveLength(3);
+      expect(wrapper.findSeries()[0].getElement()).toHaveAttribute('aria-label', barSeries1.title);
+      expect(wrapper.findSeries()[1].getElement()).toHaveAttribute('aria-label', thresholdSeries.title);
+      expect(wrapper.findSeries()[2].getElement()).toHaveAttribute('aria-label', barSeries2.title);
+    }
+  );
 });

--- a/src/mixed-line-bar-chart/data-series.tsx
+++ b/src/mixed-line-bar-chart/data-series.tsx
@@ -58,6 +58,8 @@ export default function DataSeries<T extends ChartDataTypes>({
     visibleSeries.forEach(({ series }) => {
       if (series.type === 'bar') {
         barData.push(series.data);
+      } else {
+        barData.push([]);
       }
     });
     return calculateOffsetMaps(barData);


### PR DESCRIPTION
### Description

There was a bug caused by mismatched indexes. In a stacked bar chart if the threshold series come before bar series this results in a miscalculated offsets.

Rel: AWSUI-40910

### How has this been tested?

* New permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
