### PR TITLE
feat: Implements actions and optional dismissible on tabs component

### DIFF
--- a/pages/tabs/actions.page.tsx
+++ b/pages/tabs/actions.page.tsx
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { Container, Header } from '~components';
+import ButtonDropdown from '~components/button-dropdown';
+import SpaceBetween from '~components/space-between';
+import Tabs, { TabsProps } from '~components/tabs';
+
+export default function TabsDemoPage() {
+  const tabsNoActions: Array<TabsProps.Tab> = [
+    {
+      label: 'First tab',
+      id: 'first',
+      content:
+        'Diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+    },
+    {
+      label: 'Second tab',
+      id: 'second',
+      content:
+        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+    },
+  ];
+  const [tabsXORActions, setTabsXORActions] = useState([
+    {
+      label: 'First tab',
+      id: 'first',
+      dismissible: true,
+      dismissLabel: 'Dismiss message',
+      onDismiss: () => setTabsXORActions(prevTabs => prevTabs.slice(1)),
+      content: (
+        <>
+          Diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et
+          accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+          dolor sit amet.,
+        </>
+      ),
+    },
+    {
+      label: 'Second tab',
+      id: 'second',
+      action: (
+        <ButtonDropdown
+          variant="icon"
+          ariaLabel="Query actions"
+          items={[
+            { id: 'save', text: 'Save', disabled: true },
+            { id: 'saveAs', text: 'Save as' },
+            { id: 'rename', text: 'Rename', disabled: true },
+            { id: 'delete', text: 'Delete', disabled: true },
+          ]}
+          expandToViewport={true}
+        />
+      ),
+      content:
+        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+    },
+  ]);
+
+  const [tabsBoth, setTabsBoth] = useState([
+    {
+      id: 'first',
+      label: 'Tab w/ action',
+      action: (
+        <ButtonDropdown
+          variant="icon"
+          ariaLabel="Query actions"
+          items={[
+            { id: 'save', text: 'Save', disabled: true },
+            { id: 'saveAs', text: 'Save as' },
+            { id: 'rename', text: 'Rename', disabled: true },
+            { id: 'delete', text: 'Delete', disabled: true },
+          ]}
+          expandToViewport={true}
+        />
+      ),
+      content: <p>First tab content</p>,
+    },
+    {
+      id: 'second',
+      label: 'Second tab label',
+      content: <p>Second tab content</p>,
+    },
+    {
+      id: 'third',
+      label: 'Athena-like tab',
+      dismissible: true,
+      dismissLabel: 'third-dismiss-button',
+      onDismiss: () => setTabsBoth(prevTabs => prevTabs.splice(0, 2)),
+      action: (
+        <ButtonDropdown
+          variant="icon"
+          ariaLabel="Query actions"
+          items={[
+            { id: 'save', text: 'Save', disabled: true },
+            { id: 'saveAs', text: 'Save as' },
+            { id: 'rename', text: 'Rename', disabled: true },
+            { id: 'delete', text: 'Delete', disabled: true },
+          ]}
+          expandToViewport={true}
+        />
+      ),
+      content: (
+        <Container
+          header={
+            <Header variant="h2" description="Container description">
+              Container title
+            </Header>
+          }
+        >
+          Container content
+        </Container>
+      ),
+    },
+  ]);
+
+  return (
+    <>
+      <h1>Tabs</h1>
+
+      <SpaceBetween size="xs">
+        <div>
+          <h2>Tabs with no actions</h2>
+          <Tabs
+            tabs={tabsNoActions}
+            i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+          />
+        </div>
+        <div>
+          <h2>Tabs with action or dismissible</h2>
+          <Tabs
+            tabs={tabsXORActions}
+            i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+          />
+        </div>
+        <div>
+          <h2>Tabs with actions and dismissibles</h2>
+          <Tabs
+            tabs={tabsBoth}
+            i18nStrings={{ scrollLeftAriaLabel: 'Scroll left', scrollRightAriaLabel: 'Scroll right' }}
+          />
+        </div>
+      </SpaceBetween>
+    </>
+  );
+}

--- a/src/tabs/interfaces.ts
+++ b/src/tabs/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import { NonCancelableEventHandler } from '../internal/events';
+import { ButtonProps } from '../button/interfaces';
 
 export interface TabsProps extends BaseComponentProps {
   /**
@@ -90,6 +91,24 @@ export namespace TabsProps {
      * Whether this tab is disabled.
      */
     disabled?: boolean;
+    /**
+     * (Optional) Determines whether the tab includes a close icon button. By default, the close button is not included.
+     * When a user clicks on this button the `onClose` handler is called.
+     */
+    dismissible?: boolean;
+    /**
+     * (Optional) Specifies an `aria-label` for the close icon button for improved accessibility.
+     */
+    dismissLabel?: string;
+    /**
+     * (Optional) Action for the tab, rendered next to its label. Although it is technically possible to insert any content,
+     * our UX guidelines only allow you to add an icon button or icon button dropdown.
+     */
+    action?: React.ReactNode;
+    /**
+     * (event => void) Called when a user clicks on the close button.
+     */
+    onDismiss?: ButtonProps['onClick'];
     /**
      * You can use this parameter to change the default `href` of the internal tab anchor. The
      * `click` event default behavior is prevented, unless the user clicks the tab with a key modifier (CTRL,

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -70,28 +70,85 @@ $label-horizontal-spacing: awsui.$space-l;
   flex-shrink: 0;
   display: flex;
   max-inline-size: calc(90% - #{$label-horizontal-spacing});
-
-  & > button {
-    background-color: transparent;
-  }
 }
 
 .tabs-tab-label {
   display: flex;
   align-items: center;
-  padding-block: awsui.$space-scaled-2x-xxs;
-  padding-inline: $label-horizontal-spacing;
   text-align: start;
   position: relative;
 
   @include styles.text-wrapping;
 }
 
+.tabs-tab-header-content {
+  position: relative;
+
+  border-block: awsui.$border-divider-section-width solid transparent;
+  border-inline: awsui.$border-divider-section-width solid transparent;
+
+  padding-block: awsui.$space-scaled-2x-xxs;
+  padding-inline: $label-horizontal-spacing;
+
+  &,
+  & > button {
+    background-color: transparent;
+    display: flex;
+    align-items: center;
+    text-align: start;
+  }
+
+  &:focus {
+    outline: none;
+  }
+  @include styles.font-smoothing;
+
+  @include focus-visible.when-visible {
+    z-index: 1;
+    @include styles.focus-highlight(awsui.$space-tabs-focus-outline-gutter);
+    border-inline-end-color: transparent;
+  }
+}
+
+.tabs-tab-header-content:not(.tabs-tab-disabled) {
+  // This is the underline for the currently selected tab.
+  &:after {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    inline-size: 100%;
+    inset-block-end: calc(-1 * #{awsui.$border-divider-section-width});
+    block-size: awsui.$border-active-width;
+    border-start-start-radius: awsui.$border-radius-tabs-focus-ring;
+    border-start-end-radius: awsui.$border-radius-tabs-focus-ring;
+    border-end-start-radius: awsui.$border-radius-tabs-focus-ring;
+    border-end-end-radius: awsui.$border-radius-tabs-focus-ring;
+    background: awsui.$color-border-tabs-underline;
+    opacity: 0;
+  }
+
+  &.refresh {
+    &:after {
+      @include styles.with-motion {
+        transition: opacity awsui.$motion-duration-refresh-only-medium awsui.$motion-easing-refresh-only-c;
+      }
+    }
+  }
+}
+
 .tabs-tab:not(:last-child) {
-  & > a > .tabs-tab-label,
-  & > button > .tabs-tab-label {
+  & > .tabs-tab-header-content {
     margin-inline-end: calc(-1 * #{awsui.$border-divider-section-width});
-    border-inline-end: awsui.$border-divider-section-width solid $separator-color;
+    &:before {
+      content: '';
+      block-size: 1.7rem;
+      inline-size: #{awsui.$border-divider-section-width};
+      position: absolute;
+      inset-inline-end: 0;
+      margin-inline-end: calc(-1 * #{awsui.$border-divider-section-width});
+      background: $separator-color;
+      opacity: 1;
+    }
   }
 }
 
@@ -125,23 +182,16 @@ $label-horizontal-spacing: awsui.$space-l;
   &:focus {
     outline: none;
   }
-  @include styles.font-smoothing;
+}
 
-  @include focus-visible.when-visible {
-    z-index: 1;
-    @include styles.focus-highlight(awsui.$space-tabs-focus-outline-gutter);
-    & > a > .tabs-tab-label,
-    & > button > .tabs-tab-label {
-      border-inline-end-color: transparent;
-    }
-  }
+.tabs-tab-link-only {
+  margin-inline-end: awsui.$space-scaled-m;
 }
 
 // Remediate focus shadow
 .tabs-tab:first-child {
   margin-inline-start: 1px;
-  & > a > .tabs-tab-label,
-  & > button > .tabs-tab-label {
+  & > .tabs-tab-header-content {
     padding-inline-start: calc(#{$label-horizontal-spacing} - 1px);
   }
 }
@@ -149,8 +199,7 @@ $label-horizontal-spacing: awsui.$space-l;
 // Remediate focus shadow
 .tabs-tab:last-child {
   margin-inline-end: 1px;
-  & > a > .tabs-tab-label,
-  & > button > .tabs-tab-label {
+  & > .tabs-tab-header-content {
     padding-inline-end: calc(#{$label-horizontal-spacing} - 1px);
   }
 }
@@ -162,32 +211,6 @@ $label-horizontal-spacing: awsui.$space-l;
     cursor: default;
     color: awsui.$color-text-interactive-disabled;
     font-weight: awsui.$font-tabs-disabled-weight;
-  }
-}
-
-.tabs-tab-link:not(.tabs-tab-disabled) {
-  // This is the underline for the currently selected tab.
-  &:after {
-    content: '';
-    position: absolute;
-    inset-inline-start: 0;
-    inline-size: 100%;
-    inset-block-end: calc(-1 * #{awsui.$border-divider-section-width});
-    block-size: awsui.$border-active-width;
-    border-start-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-start-end-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-start-radius: awsui.$border-radius-tabs-focus-ring;
-    border-end-end-radius: awsui.$border-radius-tabs-focus-ring;
-    background: awsui.$color-border-tabs-underline;
-    opacity: 0;
-  }
-
-  &.refresh {
-    &:after {
-      @include styles.with-motion {
-        transition: opacity awsui.$motion-duration-refresh-only-medium awsui.$motion-easing-refresh-only-c;
-      }
-    }
   }
 }
 

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef, useState, useEffect } from 'react';
 import { TabsProps } from './interfaces';
+import { ButtonProps } from '../button/interfaces';
 import clsx from 'clsx';
 import styles from './styles.css.js';
 import { InternalButton } from '../button/internal';
@@ -18,6 +19,19 @@ import { hasModifierKeys, isPlainLeftClick } from '../internal/events';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { useInternalI18n } from '../i18n/context';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
+
+function dismissButton(dismissLabel: TabsProps.Tab['dismissLabel'], onDismiss: TabsProps.Tab['onDismiss']) {
+  return (
+    <InternalButton
+      onClick={onDismiss}
+      className={styles['dismiss-button']}
+      variant="icon"
+      iconName="close"
+      formAction="none"
+      ariaLabel={dismissLabel}
+    />
+  );
+}
 
 export interface TabHeaderBarProps {
   onChange: (changeDetail: TabsProps.ChangeDetail) => void;
@@ -168,6 +182,11 @@ export function TabHeaderBar({
 
   function renderTabHeader(tab: TabsProps.Tab) {
     const enabledTabsWithCurrentTab = tabs.filter(tab => !tab.disabled || tab.id === activeTabId);
+    const { dismissible, dismissLabel, action, onDismiss } = tab;
+
+    const handleDismiss: ButtonProps['onClick'] = event => {
+      onDismiss && onDismiss(event);
+    };
 
     const highlightTab = function (enabledTabIndex: number) {
       const tab = enabledTabsWithCurrentTab[enabledTabIndex];
@@ -236,6 +255,14 @@ export function TabHeaderBar({
       [styles['tabs-tab-link']]: true,
       [styles.refresh]: isVisualRefresh,
       [styles['tabs-tab-active']]: activeTabId === tab.id && !tab.disabled,
+      [styles['tabs-tab-link-only']]: action || dismissible,
+      [styles['tabs-tab-disabled']]: tab.disabled,
+    });
+
+    const tabHeaderContentClasses = clsx({
+      [styles['tabs-tab-header-content']]: true,
+      [styles.refresh]: isVisualRefresh,
+      [styles['tabs-tab-active']]: activeTabId === tab.id && !tab.disabled,
       [styles['tabs-tab-disabled']]: tab.disabled,
     });
 
@@ -286,7 +313,11 @@ export function TabHeaderBar({
         role="presentation"
         key={tab.id}
       >
-        {trigger}
+        <span className={tabHeaderContentClasses}>
+          {trigger}
+          {action && action}
+          {dismissible && dismissButton(dismissLabel, handleDismiss)}
+        </span>
       </li>
     );
   }

--- a/src/test-utils/dom/tabs/index.ts
+++ b/src/test-utils/dom/tabs/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import ButtonWrapper from '../button';
 import styles from '../../../tabs/styles.selectors.js';
 
 export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
@@ -25,17 +26,55 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
   /**
    * Finds the tab with the given ID and returns the clickable element from its tab label.
    *
-   * @param index ID of the clickable element to return
+   * @param id ID of the clickable element to return
    */
   findTabLinkById(id: string): ElementWrapper<HTMLAnchorElement | HTMLButtonElement> | null {
     return this.find(`.${styles['tabs-tab-link']}[data-testid="${id}"]`);
   }
 
   /**
+   * Finds the close button by using the tab index
+   * @param index 1-based index of the clickable element to return
+   */
+  findCloseButtonByTabIndex(index: number): ButtonWrapper | null {
+    return this.findComponent(
+      `.${styles['tabs-tab']}:nth-child(${index}) .${styles['tabs-tab-dismiss-button']}`,
+      ButtonWrapper
+    );
+  }
+
+  /**
+   * Finds the close button by using the tab id
+   * @param id ID of the clickable element to return
+   */
+  findCloseButtonByTabId(id: string): ButtonWrapper | null {
+    return this.findComponent(
+      `.${styles['tabs-tab-link']}[data-testid="${id}"] ~ .${styles['tabs-tab-dismiss-button']}`,
+      ButtonWrapper
+    );
+  }
+
+  /**
+   * Finds the tab action by using the tab id
+   * @param id ID of the clickable element to return
+   */
+  findActionByTabId(id: string): ElementWrapper | null {
+    return this.find(`.${styles['tabs-tab-link']}[data-testid="${id}"] ~ .${styles['tabs-tab-action']}`);
+  }
+
+  /**
+   * Finds the tab action by using the tab index
+   * @param index 1-based index of the clickable element to return
+   */
+  findActionByTabIndex(index: number): ElementWrapper | null {
+    return this.find(`.${styles['tabs-tab']}:nth-child(${index}) .${styles['tabs-tab-action']}`);
+  }
+
+  /**
    * Finds the currently active tab and returns the clickable element from its tab label.
    */
   findActiveTab(): ElementWrapper<HTMLAnchorElement | HTMLButtonElement> | null {
-    return this.find(`.${styles['tabs-tab-active']}`);
+    return this.find(`.${styles['tabs-tab-active']} .${styles['tabs-tab-link']}`);
   }
 
   /**
@@ -43,5 +82,19 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
    */
   findTabContent(): ElementWrapper<HTMLDivElement> | null {
     return this.find(`.${styles['tabs-content-active']}`);
+  }
+
+  /**
+   * Finds the dismissible button for the active tab
+   */
+  findActiveTabCloseButton(): ButtonWrapper | null {
+    return this.findComponent(`.${styles['tabs-tab-active']} ~ .${styles['tabs-tab-dismiss-button']}`, ButtonWrapper);
+  }
+
+  /**
+   * Finds the tab action for the active tab
+   */
+  findActiveTabAction(): ElementWrapper | null {
+    return this.find(`.${styles['tabs-tab-active']} ~ .${styles['tabs-tab-action']}`);
   }
 }


### PR DESCRIPTION
## WIP

### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

This is not yet in a state to merge, but this implements actions (button dropdowns here) along with a dismissible prop.

I will follow up with a change to implement a tab focus trap as we agreed the current tab flow w/ actions is not acceptable accessibility wise.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>


ref: https://github.com/cloudscape-design/components/pull/2154
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
