### PR TITLE
chore: Stable bar chart permutations

### DIFF
--- a/pages/bar-chart/stacked-permutations.page.tsx
+++ b/pages/bar-chart/stacked-permutations.page.tsx
@@ -7,14 +7,13 @@ import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
-import { commonProps, multipleNegativeBarsDataWithThreshold } from '../mixed-line-bar-chart/common';
+import { commonProps, multipleNegativeBarsData as data } from '../mixed-line-bar-chart/common';
 
-const data1 = multipleNegativeBarsDataWithThreshold;
+const thresholdSeries = { type: 'threshold', title: 'Limit', y: 4 } as const;
 
-// Position of the threshold series in a stacked chart must not affect chart's presentation.
-const thresholdSeries = multipleNegativeBarsDataWithThreshold.find(s => s.type === 'threshold')!;
-const data2 = multipleNegativeBarsDataWithThreshold.filter(s => s.type === 'bar');
-data2.splice(Math.floor(Math.random() * data2.length), 0, thresholdSeries);
+const data1 = [...data, thresholdSeries];
+// Position of the threshold series in a stacked chart must not affect chart's plot.
+const data2 = [data[0], thresholdSeries, data[1], data[2]];
 
 /* eslint-disable react/jsx-key */
 const permutations = createPermutations<BarChartProps<string>>([


### PR DESCRIPTION
### Description

The random order of threshold series in bar chart permutations affected series order in the legend making the VR tests flaky.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
