### PR TITLE
refactor: Move table sticky header offset into the table styles

### DIFF
--- a/pages/app/app-context.tsx
+++ b/pages/app/app-context.tsx
@@ -12,6 +12,7 @@ interface AppUrlParams {
   visualRefresh: boolean;
   motionDisabled: boolean;
   removeHighContrastHeader: boolean;
+  appLayoutWidget: boolean;
 }
 
 export interface AppContextType<T = unknown> {
@@ -31,6 +32,7 @@ const appContextDefaults: AppContextType = {
     visualRefresh: THEME === 'default',
     motionDisabled: false,
     removeHighContrastHeader: false,
+    appLayoutWidget: false,
   },
   setMode: () => {},
   setUrlParams: () => {},

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -19,6 +19,7 @@ import AppContext, { AppContextProvider, parseQuery } from './app-context';
 
 interface GlobalFlags {
   removeHighContrastHeader?: boolean;
+  appLayoutWidget?: boolean;
 }
 const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
 const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
@@ -83,16 +84,15 @@ function App() {
 }
 
 const history = createHashHistory();
-const { direction, visualRefresh, removeHighContrastHeader } = parseQuery(history.location.search);
+const { direction, visualRefresh, appLayoutWidget, removeHighContrastHeader } = parseQuery(history.location.search);
 
 // The VR class needs to be set before any React rendering occurs.
 window[awsuiVisualRefreshFlag] = () => visualRefresh;
 if (!window[awsuiGlobalFlagsSymbol]) {
   window[awsuiGlobalFlagsSymbol] = {};
 }
-if (removeHighContrastHeader) {
-  window[awsuiGlobalFlagsSymbol].removeHighContrastHeader = true;
-}
+window[awsuiGlobalFlagsSymbol].removeHighContrastHeader = !!removeHighContrastHeader;
+window[awsuiGlobalFlagsSymbol].appLayoutWidget = !!appLayoutWidget;
 
 // Apply the direction value to the HTML element dir attribute
 document.documentElement.setAttribute('dir', direction);

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -15,6 +15,7 @@ import { CollectionLabelContext } from '../internal/context/collection-label-con
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_SUBSTEP_NAME } from '../internal/analytics/selectors';
 import { useContainerHeader } from '../internal/context/container-header';
+import { getGlobalFlag } from '../internal/utils/global-flags';
 
 interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, InternalBaseComponentProps {
   __disableActionsWrapping?: boolean;
@@ -46,6 +47,7 @@ export default function InternalHeader({
   // If is mobile there is no need to have the dynamic variant because it's scrolled out of view
   const dynamicVariant = !isMobile && isStuck ? 'h2' : 'h1';
   const variantOverride = variant === 'awsui-h1-sticky' ? (isRefresh ? dynamicVariant : 'h2') : variant;
+  const hasToolbarHeader = getGlobalFlag('appLayoutWidget');
 
   return (
     <div
@@ -55,6 +57,7 @@ export default function InternalHeader({
         baseProps.className,
         styles[`root-variant-${variantOverride}`],
         isRefresh && styles.refresh,
+        hasToolbarHeader && styles['root-with-toolbar'],
         !actions && [styles[`root-no-actions`]],
         description && [styles[`root-has-description`]]
       )}

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -17,6 +17,9 @@
   inline-size: 100%;
   flex-wrap: wrap;
   justify-content: space-between;
+  &-with-toolbar {
+    padding-block-start: awsui.$space-scaled-s;
+  }
 
   &.refresh,
   &:not(.root-no-actions) {


### PR DESCRIPTION
### Description

Make table managing its sticky header on its own, regardless app layout presence

Related links, issue #, if available: n/a

### How has this been tested?

Screenshot tests in my dev pipeline, no differences there

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
