### PR TITLE
chore: Move cell paddings and overflow to cell content

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -71,16 +71,15 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   border-block-start: awsui.$border-divider-list-width solid transparent;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
-
   text-align: start;
+
   & > .body-cell-content {
     display: block;
     padding-block-start: $cell-vertical-padding;
     padding-block-end: $cell-vertical-padding-w-border;
     padding-inline: $cell-horizontal-padding;
   }
-
-  &:not(.body-cell-wrap) {
+  &:not(.body-cell-wrap) > .body-cell-content {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -348,7 +347,9 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     }
 
     &.body-cell-edit-active {
-      overflow: visible;
+      & > .body-cell-content {
+        overflow: visible;
+      }
       &.sticky-cell {
         position: sticky;
       }

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -62,26 +62,25 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   }
 }
 
+/* stylelint-disable no-descending-specificity */
 .body-cell {
   box-sizing: border-box;
   padding-block: 0;
   padding-inline: 0;
-  & > .body-cell-content {
-    padding-block-start: $cell-vertical-padding;
-    padding-block-end: $cell-vertical-padding-w-border;
-    padding-inline: $cell-horizontal-padding;
-    border-block-start: awsui.$border-divider-list-width solid transparent;
-  }
   word-wrap: break-word;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
 
   text-align: start;
-
-  &-content {
-    /* used for testing */
+  & > .body-cell-content {
+    display: block;
+    padding-block-start: $cell-vertical-padding;
+    padding-block-end: $cell-vertical-padding-w-border;
+    padding-inline: $cell-horizontal-padding;
+    border-block-start: awsui.$border-divider-list-width solid transparent;
   }
-  &:not(.body-cell-wrap) > .body-cell-content {
+
+  &:not(.body-cell-wrap) {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -230,10 +229,10 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     }
   }
   &-selected.body-cell-prev-selected {
+    border-block-start: $selected-border-placeholder;
     & > .body-cell-content {
       padding-block-start: $cell-vertical-padding-w-border;
     }
-    border-block-start: $selected-border-placeholder;
   }
   &-selected.body-cell-next-selected {
     border-block-end-width: awsui.$border-divider-list-width;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -68,6 +68,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   padding-block: 0;
   padding-inline: 0;
   word-wrap: break-word;
+  border-block-start: awsui.$border-divider-list-width solid transparent;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
 
@@ -77,7 +78,6 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     padding-block-start: $cell-vertical-padding;
     padding-block-end: $cell-vertical-padding-w-border;
     padding-inline: $cell-horizontal-padding;
-    border-block-start: awsui.$border-divider-list-width solid transparent;
   }
 
   &:not(.body-cell-wrap) {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -44,24 +44,34 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
 }
 
 @mixin cell-offset($padding) {
-  padding-inline-start: $padding;
+  & > .body-cell-content {
+    padding-inline-start: $padding;
+  }
 
   @for $i from 1 through 9 {
     &.body-cell-expandable-level-#{$i} {
-      padding-inline-start: calc($padding + $i * (#{awsui.$space-m} + #{awsui.$space-xs}));
+      & > .body-cell-content {
+        padding-inline-start: calc($padding + $i * (#{awsui.$space-m} + #{awsui.$space-xs}));
+      }
     }
   }
   &.body-cell-expandable-level-next {
-    padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
+    & > .body-cell-content {
+      padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
+    }
   }
 }
 
 .body-cell {
   box-sizing: border-box;
-  padding-block-start: $cell-vertical-padding;
-  padding-block-end: $cell-vertical-padding-w-border;
-  padding-inline-end: $cell-horizontal-padding;
-  border-block-start: awsui.$border-divider-list-width solid transparent;
+  padding-block: 0;
+  padding-inline: 0;
+  & > .body-cell-content {
+    padding-block-start: $cell-vertical-padding;
+    padding-block-end: $cell-vertical-padding-w-border;
+    padding-inline: $cell-horizontal-padding;
+    border-block-start: awsui.$border-divider-list-width solid transparent;
+  }
   word-wrap: break-word;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
   font-weight: inherit;
@@ -71,7 +81,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   &-content {
     /* used for testing */
   }
-  &:not(.body-cell-wrap) {
+  &:not(.body-cell-wrap) > .body-cell-content {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -81,7 +91,9 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   }
   &:last-child {
     border-inline-end: $border-placeholder;
-    padding-inline-end: $cell-edge-horizontal-padding;
+    & > .body-cell-content {
+      padding-inline-end: $cell-edge-horizontal-padding;
+    }
   }
   &.is-visual-refresh:first-child {
     &:not(.has-striped-rows) {
@@ -139,11 +151,13 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     background-color: awsui.$color-background-item-selected;
     border-block-start: $selected-border;
     border-block-end: $selected-border;
-    padding-block-end: $cell-vertical-padding;
+    & > .body-cell-content {
+      padding-block-end: $cell-vertical-padding;
+    }
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
-    &.body-cell-last-row.is-visual-refresh {
+    &.body-cell-last-row.is-visual-refresh > .body-cell-content {
       padding-block-end: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
     }
 
@@ -206,15 +220,19 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   }
 
   // Use padding as a selected border placeholder to make sure rows don't change height on selection (visual refresh)
-  &-selected:not(:first-child) {
+  &-selected:not(:first-child) > .body-cell-content {
     padding-block-start: $cell-vertical-padding-w-border;
   }
   &:not(.body-cell-selected).body-cell-next-selected {
     border-block-end: 0;
-    padding-block-end: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
+    & > .body-cell-content {
+      padding-block-end: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
+    }
   }
   &-selected.body-cell-prev-selected {
-    padding-block-start: $cell-vertical-padding-w-border;
+    & > .body-cell-content {
+      padding-block-start: $cell-vertical-padding-w-border;
+    }
     border-block-start: $selected-border-placeholder;
   }
   &-selected.body-cell-next-selected {
@@ -235,7 +253,7 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
   }
   // Reset padding for selected rows with no adjacent selected row above it,
   // because rows reuse adjacent selected borders (visual refresh)
-  &-selected:not(.body-cell-prev-selected) {
+  &-selected:not(.body-cell-prev-selected) > .body-cell-content {
     padding-block-start: $cell-vertical-padding;
   }
 

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -122,17 +122,19 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         {...nativeAttributes}
         tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       >
-        {level !== undefined && isExpandable && (
-          <div className={styles['expandable-toggle-wrapper']}>
-            <ExpandToggleButton
-              isExpanded={isExpanded}
-              onExpandableItemToggle={onExpandableItemToggle}
-              expandButtonLabel={expandButtonLabel}
-              collapseButtonLabel={collapseButtonLabel}
-            />
-          </div>
-        )}
-        <span className={styles['body-cell-content']}>{children}</span>
+        <div className={styles['body-cell-content']}>
+          {level !== undefined && isExpandable && (
+            <div className={styles['expandable-toggle-wrapper']}>
+              <ExpandToggleButton
+                isExpanded={isExpanded}
+                onExpandableItemToggle={onExpandableItemToggle}
+                expandButtonLabel={expandButtonLabel}
+                collapseButtonLabel={collapseButtonLabel}
+              />
+            </div>
+          )}
+          {children}
+        </div>
       </Element>
     );
   }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -122,7 +122,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         {...nativeAttributes}
         tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       >
-        <div className={styles['body-cell-content']}>
+        <span className={styles['body-cell-content']}>
           {level !== undefined && isExpandable && (
             <div className={styles['expandable-toggle-wrapper']}>
               <ExpandToggleButton
@@ -134,7 +134,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
             </div>
           )}
           {children}
-        </div>
+        </span>
       </Element>
     );
   }


### PR DESCRIPTION
### Description

A follow up update for https://github.com/cloudscape-design/components/pull/2113.

In this PR the new table cell content wrappers receive paddings and overflow styles. Now, the https://github.com/cloudscape-design/components/pull/2070 is possible as the next step.

### How has this been tested?

* VR and screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
