### PR TITLE
chore: Add RTL support for area chart

### DIFF
--- a/src/area-chart/__integ__/page-objects/area-chart-page.ts
+++ b/src/area-chart/__integ__/page-objects/area-chart-page.ts
@@ -106,9 +106,9 @@ export default class AreaChartPageObject extends BasePageObject {
   }
 
   async getPointOffset(serialIndex: number, totalPoints: number) {
-    const valueLabelsSelector = this.chart.findByClassName(cartesianChartStyles['labels-left']).toSelector();
+    const inlineStartLabelsSelector = this.chart.findByClassName(cartesianChartStyles['labels-left']).toSelector();
     const chartWidth = (await this.getBoundingBox(this.chart.toSelector())).width;
-    const labelsWidth = (await this.getBoundingBox(valueLabelsSelector)).width;
+    const labelsWidth = (await this.getBoundingBox(inlineStartLabelsSelector)).width;
     const distanceBetweenPoints = (chartWidth - labelsWidth) / totalPoints;
     return labelsWidth + distanceBetweenPoints * serialIndex;
   }

--- a/src/area-chart/__integ__/page-objects/area-chart-page.ts
+++ b/src/area-chart/__integ__/page-objects/area-chart-page.ts
@@ -106,9 +106,9 @@ export default class AreaChartPageObject extends BasePageObject {
   }
 
   async getPointOffset(serialIndex: number, totalPoints: number) {
-    const leftLabelsSelector = this.chart.findByClassName(cartesianChartStyles['labels-left']).toSelector();
+    const valueLabelsSelector = this.chart.findByClassName(cartesianChartStyles['labels-left']).toSelector();
     const chartWidth = (await this.getBoundingBox(this.chart.toSelector())).width;
-    const labelsWidth = (await this.getBoundingBox(leftLabelsSelector)).width;
+    const labelsWidth = (await this.getBoundingBox(valueLabelsSelector)).width;
     const distanceBetweenPoints = (chartWidth - labelsWidth) / totalPoints;
     return labelsWidth + distanceBetweenPoints * serialIndex;
   }

--- a/src/area-chart/__integ__/page-objects/area-chart-page.ts
+++ b/src/area-chart/__integ__/page-objects/area-chart-page.ts
@@ -106,7 +106,9 @@ export default class AreaChartPageObject extends BasePageObject {
   }
 
   async getPointOffset(serialIndex: number, totalPoints: number) {
-    const inlineStartLabelsSelector = this.chart.findByClassName(cartesianChartStyles['labels-left']).toSelector();
+    const inlineStartLabelsSelector = this.chart
+      .findByClassName(cartesianChartStyles['labels-inline-start'])
+      .toSelector();
     const chartWidth = (await this.getBoundingBox(this.chart.toSelector())).width;
     const labelsWidth = (await this.getBoundingBox(inlineStartLabelsSelector)).width;
     const distanceBetweenPoints = (chartWidth - labelsWidth) / totalPoints;

--- a/src/area-chart/__tests__/area-chart-model-utils.test.ts
+++ b/src/area-chart/__tests__/area-chart-model-utils.test.ts
@@ -10,6 +10,7 @@ import {
   circleIndex,
   isSeriesValid,
 } from '../../../lib/components/area-chart/model/utils';
+import computeChartProps from '../../../lib/components/area-chart/model/compute-chart-props';
 
 function getPointIndices(matrix: ChartModel.PlotPoint<number>[][]) {
   const indices = [];
@@ -359,5 +360,75 @@ describe('AreaChart isSeriesValid', () => {
         },
       ])
     ).toBe(false);
+  });
+});
+
+describe('AreaChart computeChartProps', () => {
+  it('returns the unmodified series in ltr', () => {
+    const computed = computeChartProps({
+      isRtl: false,
+      series: [
+        {
+          type: 'area',
+          title: 'A1x',
+          data: [
+            { x: 1, y: 1 },
+            { x: 2, y: 2 },
+            { x: 3, y: 3 },
+          ],
+        },
+        {
+          type: 'area',
+          title: 'A2x',
+          data: [
+            { x: 1, y: 2 },
+            { x: 2, y: 4 },
+            { x: 3, y: 6 },
+          ],
+        },
+      ],
+      xDomain: [1, 2, 3, 4, 5],
+      yDomain: [1, 2, 3, 4, 5],
+      xScaleType: 'linear',
+      yScaleType: 'linear',
+      height: 400,
+      width: 400,
+    });
+
+    expect(computed.xDomain).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('returns a reversed series in rtl', () => {
+    const computed = computeChartProps({
+      isRtl: true,
+      series: [
+        {
+          type: 'area',
+          title: 'A1x',
+          data: [
+            { x: 1, y: 1 },
+            { x: 2, y: 2 },
+            { x: 3, y: 3 },
+          ],
+        },
+        {
+          type: 'area',
+          title: 'A2x',
+          data: [
+            { x: 1, y: 2 },
+            { x: 2, y: 4 },
+            { x: 3, y: 6 },
+          ],
+        },
+      ],
+      xDomain: [1, 2, 3, 4, 5],
+      yDomain: [1, 2, 3, 4, 5],
+      xScaleType: 'linear',
+      yScaleType: 'linear',
+      height: 400,
+      width: 400,
+    });
+
+    expect(computed.xDomain).toEqual([5, 4, 3, 2, 1]);
   });
 });

--- a/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
+++ b/src/area-chart/__tests__/area-chart-use-chart-model.test.tsx
@@ -167,7 +167,7 @@ describe('useChartModel', () => {
       expect(wrapper.findHighlightedPoint()?.getElement()).toBeEmptyDOMElement();
     });
 
-    describe('navigation across X axis', () => {
+    describe('navigation across X axis, ltr', () => {
       it('highlights next or previous point in the data series when a series is focused', () => {
         const { wrapper } = renderChartModelHook({
           height: 0,
@@ -189,6 +189,16 @@ describe('useChartModel', () => {
 
         act(() => wrapper.keydown(KeyCode.right));
         expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
+
+        act(() => wrapper.keydown(KeyCode.right));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('2,6');
+
+        act(() => wrapper.keydown(KeyCode.left));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
+
+        act(() => wrapper.keydown(KeyCode.down));
+        act(() => wrapper.keydown(KeyCode.up));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
       });
 
       it('highlights next or previous X when no series is focused', () => {
@@ -209,6 +219,67 @@ describe('useChartModel', () => {
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('0');
 
         act(() => wrapper.keydown(KeyCode.right));
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
+      });
+    });
+
+    describe('navigation across X axis, rtl', () => {
+      it('highlights next or previous point in the data series when a series is focused', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+        act(() => wrapper.focus());
+
+        wrapper.getElement().style.direction = 'rtl';
+
+        act(() => wrapper.keydown(KeyCode.down));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('0,2');
+
+        act(() => wrapper.keydown(KeyCode.left));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
+
+        act(() => wrapper.keydown(KeyCode.left));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('2,6');
+
+        act(() => wrapper.keydown(KeyCode.right));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
+
+        act(() => wrapper.keydown(KeyCode.down));
+        act(() => wrapper.keydown(KeyCode.up));
+        expect(wrapper.findHighlightedPoint()?.getElement()).toHaveTextContent('1,4');
+      });
+
+      it('highlights next or previous X when no series is focused', () => {
+        const { wrapper } = renderChartModelHook({
+          height: 0,
+          highlightedSeries: null,
+          setHighlightedSeries: (_series: AreaChartProps.Series<ChartDataTypes> | null) => _series,
+          setVisibleSeries: (_series: readonly AreaChartProps.Series<ChartDataTypes>[]) => _series,
+          width: 0,
+          xDomain: undefined,
+          xScaleType: 'linear',
+          yScaleType: 'linear',
+          externalSeries: series,
+          visibleSeries: series,
+          popoverRef: { current: null },
+        });
+        act(() => wrapper.focus());
+
+        wrapper.getElement().style.direction = 'rtl';
+
+        expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('0');
+
+        act(() => wrapper.keydown(KeyCode.left));
         expect(wrapper.findHighlightedX()?.getElement()).toHaveTextContent('1');
       });
     });

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -6,8 +6,8 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import ChartPlot from '../internal/components/chart-plot';
 import AxisLabel from '../internal/components/cartesian-chart/axis-label';
 import LabelsMeasure from '../internal/components/cartesian-chart/labels-measure';
-import ValueLabels from '../internal/components/cartesian-chart/value-labels';
-import BottomLabels, { useBottomLabels } from '../internal/components/cartesian-chart/bottom-labels';
+import InlineStartLabels from '../internal/components/cartesian-chart/inline-start-labels';
+import BlockEndLabels, { useBLockEndLabels } from '../internal/components/cartesian-chart/block-end-labels';
 import EmphasizedBaseline from '../internal/components/cartesian-chart/emphasized-baseline';
 import { AreaChartProps } from './interfaces';
 import { ChartModel } from './model';
@@ -22,8 +22,8 @@ import { useSelector } from './async-store';
 import { CartesianChartContainer } from '../internal/components/cartesian-chart/chart-container';
 
 const DEFAULT_CHART_WIDTH = 500;
-const LEFT_LABELS_MARGIN = 16;
-const BOTTOM_LABELS_OFFSET = 12;
+const INLINE_START_LABELS_MARGIN = 16;
+const BLOCK_END_LABELS_OFFSET = 12;
 
 type TickFormatter = undefined | ((value: AreaChartProps.DataTypes) => string);
 
@@ -76,18 +76,18 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   yTickFormatter = deprecatedYTickFormatter,
   detailTotalFormatter = deprecatedDetailTotalFormatter,
 }: ChartContainerProps<T>) {
-  const [valueLabelsWidth, setValueLabelsWidth] = useState(0);
+  const [inlineStartLabelsWidth, setInlineStartLabelsWidth] = useState(0);
   const [containerWidth, containerWidthRef] = useContainerWidth(DEFAULT_CHART_WIDTH);
-  const maxValueLabelsWidth = Math.round(containerWidth / 2);
+  const maxInlineStartLabelsWidth = Math.round(containerWidth / 2);
 
-  const bottomLabelsProps = useBottomLabels({
+  const blockEndLabelsProps = useBLockEndLabels({
     ticks: model.computed.xTicks,
     scale: model.computed.xScale,
     tickFormatter: xTickFormatter as TickFormatter,
   });
 
   // Calculate the width of the plot area and tell it to the parent.
-  const plotWidth = Math.max(0, containerWidth - valueLabelsWidth - LEFT_LABELS_MARGIN);
+  const plotWidth = Math.max(0, containerWidth - inlineStartLabelsWidth - INLINE_START_LABELS_MARGIN);
   useEffect(() => {
     autoWidth(plotWidth);
   }, [autoWidth, plotWidth]);
@@ -116,7 +116,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   return (
     <CartesianChartContainer
       ref={mergedRef}
-      minHeight={minHeight + bottomLabelsProps.height}
+      minHeight={minHeight + blockEndLabelsProps.height}
       fitHeight={!!fitHeight}
       leftAxisLabel={<AxisLabel axis="y" position="left" title={yTitle} />}
       leftAxisLabelMeasure={
@@ -124,8 +124,8 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
           scale={model.computed.yScale}
           ticks={model.computed.yTicks}
           tickFormatter={yTickFormatter as TickFormatter}
-          autoWidth={setValueLabelsWidth}
-          maxLabelsWidth={maxValueLabelsWidth}
+          autoWidth={setInlineStartLabelsWidth}
+          maxLabelsWidth={maxInlineStartLabelsWidth}
         />
       }
       bottomAxisLabel={<AxisLabel axis="x" position="bottom" title={xTitle} />}
@@ -133,8 +133,8 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
         <ChartPlot
           ref={model.refs.plot}
           width="100%"
-          height={fitHeight ? `calc(100% - ${bottomLabelsProps.height}px)` : model.height}
-          offsetBottom={bottomLabelsProps.height}
+          height={fitHeight ? `calc(100% - ${blockEndLabelsProps.height}px)` : model.height}
+          offsetBottom={blockEndLabelsProps.height}
           ariaLabel={ariaLabel}
           ariaLabelledby={ariaLabelledby}
           ariaDescription={ariaDescription}
@@ -161,7 +161,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             style={{ pointerEvents: 'none' }}
           />
 
-          <ValueLabels
+          <InlineStartLabels
             plotWidth={model.width}
             plotHeight={model.height}
             scale={model.computed.yScale}
@@ -169,20 +169,20 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             tickFormatter={yTickFormatter}
             title={yTitle}
             ariaRoleDescription={yAxisAriaRoleDescription}
-            maxLabelsWidth={maxValueLabelsWidth}
+            maxLabelsWidth={maxInlineStartLabelsWidth}
           />
 
           <AreaDataSeries model={model} />
 
-          <BottomLabels
-            {...bottomLabelsProps}
+          <BlockEndLabels
+            {...blockEndLabelsProps}
             width={model.width}
             height={model.height}
             scale={model.computed.xScale}
             title={xTitle}
             ariaRoleDescription={xAxisAriaRoleDescription}
-            offsetLeft={valueLabelsWidth + BOTTOM_LABELS_OFFSET}
-            offsetRight={BOTTOM_LABELS_OFFSET}
+            offsetLeft={inlineStartLabelsWidth + BLOCK_END_LABELS_OFFSET}
+            offsetRight={BLOCK_END_LABELS_OFFSET}
           />
 
           <EmphasizedBaseline width={model.width} height={model.height} scale={model.computed.yScale} />

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -6,7 +6,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import ChartPlot from '../internal/components/chart-plot';
 import AxisLabel from '../internal/components/cartesian-chart/axis-label';
 import LabelsMeasure from '../internal/components/cartesian-chart/labels-measure';
-import LeftLabels from '../internal/components/cartesian-chart/left-labels';
+import ValueLabels from '../internal/components/cartesian-chart/value-labels';
 import BottomLabels, { useBottomLabels } from '../internal/components/cartesian-chart/bottom-labels';
 import EmphasizedBaseline from '../internal/components/cartesian-chart/emphasized-baseline';
 import { AreaChartProps } from './interfaces';
@@ -76,9 +76,9 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   yTickFormatter = deprecatedYTickFormatter,
   detailTotalFormatter = deprecatedDetailTotalFormatter,
 }: ChartContainerProps<T>) {
-  const [leftLabelsWidth, setLeftLabelsWidth] = useState(0);
+  const [valueLabelsWidth, setValueLabelsWidth] = useState(0);
   const [containerWidth, containerWidthRef] = useContainerWidth(DEFAULT_CHART_WIDTH);
-  const maxLeftLabelsWidth = Math.round(containerWidth / 2);
+  const maxValueLabelsWidth = Math.round(containerWidth / 2);
 
   const bottomLabelsProps = useBottomLabels({
     ticks: model.computed.xTicks,
@@ -87,7 +87,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   });
 
   // Calculate the width of the plot area and tell it to the parent.
-  const plotWidth = Math.max(0, containerWidth - leftLabelsWidth - LEFT_LABELS_MARGIN);
+  const plotWidth = Math.max(0, containerWidth - valueLabelsWidth - LEFT_LABELS_MARGIN);
   useEffect(() => {
     autoWidth(plotWidth);
   }, [autoWidth, plotWidth]);
@@ -124,8 +124,8 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
           scale={model.computed.yScale}
           ticks={model.computed.yTicks}
           tickFormatter={yTickFormatter as TickFormatter}
-          autoWidth={setLeftLabelsWidth}
-          maxLabelsWidth={maxLeftLabelsWidth}
+          autoWidth={setValueLabelsWidth}
+          maxLabelsWidth={maxValueLabelsWidth}
         />
       }
       bottomAxisLabel={<AxisLabel axis="x" position="bottom" title={xTitle} />}
@@ -161,7 +161,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             style={{ pointerEvents: 'none' }}
           />
 
-          <LeftLabels
+          <ValueLabels
             plotWidth={model.width}
             plotHeight={model.height}
             scale={model.computed.yScale}
@@ -169,7 +169,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             tickFormatter={yTickFormatter}
             title={yTitle}
             ariaRoleDescription={yAxisAriaRoleDescription}
-            maxLabelsWidth={maxLeftLabelsWidth}
+            maxLabelsWidth={maxValueLabelsWidth}
           />
 
           <AreaDataSeries model={model} />
@@ -181,7 +181,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             scale={model.computed.xScale}
             title={xTitle}
             ariaRoleDescription={xAxisAriaRoleDescription}
-            offsetLeft={leftLabelsWidth + BOTTOM_LABELS_OFFSET}
+            offsetLeft={valueLabelsWidth + BOTTOM_LABELS_OFFSET}
             offsetRight={BOTTOM_LABELS_OFFSET}
           />
 

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -22,7 +22,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ChartWrapper } from '../internal/components/chart-wrapper';
-import { isRtl as getIsRtl } from '../internal/direction';
+import { getIsRtl } from '../internal/direction';
 
 type InternalAreaChartProps<T extends AreaChartProps.DataTypes> = SomeRequired<
   AreaChartProps<T>,

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -22,6 +22,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { SomeRequired } from '../internal/types';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ChartWrapper } from '../internal/components/chart-wrapper';
+import { isRtl as getIsRtl } from '../internal/direction';
 
 type InternalAreaChartProps<T extends AreaChartProps.DataTypes> = SomeRequired<
   AreaChartProps<T>,
@@ -94,7 +95,9 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
     controlledHighlightedSeries,
     controlledOnHighlightChange
   );
+  const isRtl = containerRef.current ? getIsRtl(containerRef.current) : false;
   const model = useChartModel({
+    isRtl,
     fitHeight,
     externalSeries,
     visibleSeries,

--- a/src/area-chart/model/compute-chart-props.ts
+++ b/src/area-chart/model/compute-chart-props.ts
@@ -3,7 +3,13 @@
 import { AreaChartProps } from '../interfaces';
 import { computePlotPoints, computeDomainX, computeDomainY } from './utils';
 
-import { XDomain, XScaleType, YDomain, YScaleType } from '../../internal/components/cartesian-chart/interfaces';
+import {
+  ChartDomain,
+  XDomain,
+  XScaleType,
+  YDomain,
+  YScaleType,
+} from '../../internal/components/cartesian-chart/interfaces';
 import {
   createXTicks,
   createYTicks,
@@ -13,6 +19,7 @@ import {
 import { ChartScale, NumericChartScale } from '../../internal/components/cartesian-chart/scales';
 
 export default function computeChartProps<T extends AreaChartProps.DataTypes>({
+  isRtl,
   series,
   xDomain: externalXDomain,
   yDomain: externalYDomain,
@@ -21,6 +28,7 @@ export default function computeChartProps<T extends AreaChartProps.DataTypes>({
   height,
   width,
 }: {
+  isRtl?: boolean;
   series: readonly AreaChartProps.Series<T>[];
   xDomain?: XDomain<T>;
   yDomain?: YDomain;
@@ -29,7 +37,11 @@ export default function computeChartProps<T extends AreaChartProps.DataTypes>({
   height: number;
   width: number;
 }) {
-  const xDomain = externalXDomain || computeDomainX(series);
+  const xDomain = externalXDomain ? ([...externalXDomain] as unknown as ChartDomain<T>) : computeDomainX(series);
+  if (isRtl && Array.isArray(xDomain)) {
+    xDomain.reverse();
+  }
+
   const xTickCount = getXTickCount(width);
   const xScale = new ChartScale(xScaleType, xDomain, [0, width]);
   const xTicks = xScale.domain.length > 0 ? createXTicks(xScale, xTickCount) : [];

--- a/src/area-chart/model/index.ts
+++ b/src/area-chart/model/index.ts
@@ -19,7 +19,7 @@ export interface ChartModel<T extends AreaChartProps.DataTypes> {
     onSVGMouseMove: (event: React.MouseEvent<SVGElement>) => void;
     onSVGMouseOut: (event: React.MouseEvent<SVGElement>) => void;
     onSVGMouseDown: (event: React.MouseEvent<SVGSVGElement>) => void;
-    onSVGKeyDown: (event: React.KeyboardEvent<SVGElement>) => void;
+    onSVGKeyDown: (event: React.KeyboardEvent<HTMLElement | SVGElement>) => void;
     onApplicationFocus: (event: React.FocusEvent<Element>, trigger: 'mouse' | 'keyboard') => void;
     onApplicationBlur: (event: React.FocusEvent<Element>) => void;
     onFilterSeries: (series: readonly AreaChartProps.Series<T>[]) => void;

--- a/src/area-chart/model/index.ts
+++ b/src/area-chart/model/index.ts
@@ -19,7 +19,7 @@ export interface ChartModel<T extends AreaChartProps.DataTypes> {
     onSVGMouseMove: (event: React.MouseEvent<SVGElement>) => void;
     onSVGMouseOut: (event: React.MouseEvent<SVGElement>) => void;
     onSVGMouseDown: (event: React.MouseEvent<SVGSVGElement>) => void;
-    onSVGKeyDown: (event: React.KeyboardEvent) => void;
+    onSVGKeyDown: (event: React.KeyboardEvent<SVGElement>) => void;
     onApplicationFocus: (event: React.FocusEvent<Element>, trigger: 'mouse' | 'keyboard') => void;
     onApplicationBlur: (event: React.FocusEvent<Element>) => void;
     onFilterSeries: (series: readonly AreaChartProps.Series<T>[]) => void;

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -225,7 +225,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
     };
 
     // A callback for svg keydown to enable motions and popover pin with the keyboard.
-    const onSVGKeyDown = (event: React.KeyboardEvent<SVGElement>) => {
+    const onSVGKeyDown = (event: React.KeyboardEvent<HTMLElement | SVGElement>) => {
       const keyCode = event.keyCode;
       if (
         keyCode !== KeyCode.up &&

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -23,6 +23,7 @@ const SVG_HOVER_THROTTLE = 25;
 const POPOVER_DEADZONE = 12;
 
 export interface UseChartModelProps<T extends AreaChartProps.DataTypes> {
+  isRtl?: boolean;
   fitHeight?: boolean;
   externalSeries: readonly AreaChartProps.Series<T>[];
   visibleSeries: readonly AreaChartProps.Series<T>[];
@@ -40,6 +41,7 @@ export interface UseChartModelProps<T extends AreaChartProps.DataTypes> {
 
 // Represents the core the chart logic, including the model of all allowed user interactions.
 export default function useChartModel<T extends AreaChartProps.DataTypes>({
+  isRtl,
   fitHeight,
   externalSeries: allSeries,
   visibleSeries: series,
@@ -68,6 +70,7 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
   const model = useMemo(() => {
     // Compute scales, ticks and two-dimensional plots.
     const computed = computeChartProps({
+      isRtl,
       series,
       xDomain,
       yDomain,
@@ -174,6 +177,8 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
 
     // A helper function to highlight the next or previous point within selected series.
     const moveWithinSeries = (direction: -1 | 1) => {
+      direction = (!isRtl ? direction : -direction) as -1 | 1;
+
       // Can only use motion when a particular point is highlighted.
       const point = interactions.get().highlightedPoint;
       if (!point) {
@@ -355,7 +360,19 @@ export default function useChartModel<T extends AreaChartProps.DataTypes>({
         popoverRef,
       },
     };
-  }, [allSeries, series, xDomain, yDomain, xScaleType, yScaleType, height, width, stableSetVisibleSeries, popoverRef]);
+  }, [
+    allSeries,
+    series,
+    xDomain,
+    yDomain,
+    xScaleType,
+    yScaleType,
+    height,
+    width,
+    stableSetVisibleSeries,
+    popoverRef,
+    isRtl,
+  ]);
 
   // Notify client when series highlight change.
   useReaction(model.interactions, state => state.highlightedSeries, setHighlightedSeries);

--- a/src/internal/components/cartesian-chart/__tests__/value-labels.test.tsx
+++ b/src/internal/components/cartesian-chart/__tests__/value-labels.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
-import LeftLabels from '../../../../../lib/components/internal/components/cartesian-chart/left-labels';
+import ValueLabels from '../../../../../lib/components/internal/components/cartesian-chart/value-labels';
 import {
   getVisibleTicks,
   getSVGTextSize,
@@ -34,7 +34,7 @@ describe('cartesian chart left labels', () => {
     ]);
 
     const { container } = render(
-      <LeftLabels
+      <ValueLabels
         axis="x"
         plotWidth={500}
         plotHeight={300}
@@ -62,7 +62,7 @@ describe('cartesian chart left labels', () => {
       .mockReturnValueOnce({ width: 250, height: 20 });
 
     const { container } = render(
-      <LeftLabels
+      <ValueLabels
         axis="x"
         plotWidth={500}
         plotHeight={300}

--- a/src/internal/components/cartesian-chart/__tests__/value-labels.test.tsx
+++ b/src/internal/components/cartesian-chart/__tests__/value-labels.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
-import ValueLabels from '../../../../../lib/components/internal/components/cartesian-chart/value-labels';
+import InlineStartLabels from '../../../../../lib/components/internal/components/cartesian-chart/inline-start-labels';
 import {
   getVisibleTicks,
   getSVGTextSize,
@@ -34,7 +34,7 @@ describe('cartesian chart left labels', () => {
     ]);
 
     const { container } = render(
-      <ValueLabels
+      <InlineStartLabels
         axis="x"
         plotWidth={500}
         plotHeight={300}
@@ -62,7 +62,7 @@ describe('cartesian chart left labels', () => {
       .mockReturnValueOnce({ width: 250, height: 20 });
 
     const { container } = render(
-      <ValueLabels
+      <InlineStartLabels
         axis="x"
         plotWidth={500}
         plotHeight={300}

--- a/src/internal/components/cartesian-chart/block-end-labels.tsx
+++ b/src/internal/components/cartesian-chart/block-end-labels.tsx
@@ -89,7 +89,7 @@ function BlockEndLabels({
   return (
     <g
       transform={`translate(0,${height})`}
-      className={styles['labels-bottom']}
+      className={styles['labels-block-end']}
       aria-label={title}
       role="list"
       aria-roledescription={i18n('i18nStrings.chartAriaRoleDescription', ariaRoleDescription)}

--- a/src/internal/components/cartesian-chart/block-end-labels.tsx
+++ b/src/internal/components/cartesian-chart/block-end-labels.tsx
@@ -11,7 +11,7 @@ import styles from './styles.css.js';
 import { formatTicks, getVisibleTicks, FormattedTick } from './label-utils';
 import { useInternalI18n } from '../../../i18n/context';
 
-interface BottomLabelsProps {
+interface BlockEndLabelsProps {
   axis?: 'x' | 'y';
   width: number;
   height: number;
@@ -24,7 +24,7 @@ interface BottomLabelsProps {
   formattedTicks: readonly FormattedTick[];
 }
 
-export function useBottomLabels({
+export function useBLockEndLabels({
   ticks,
   scale,
   tickFormatter,
@@ -62,10 +62,10 @@ export function useBottomLabels({
   return { virtualTextRef, formattedTicks, height };
 }
 
-export default memo(BottomLabels) as typeof BottomLabels;
+export default memo(BlockEndLabels) as typeof BlockEndLabels;
 
 // Renders the visible tick labels on the bottom axis, as well as their grid lines.
-function BottomLabels({
+function BlockEndLabels({
   axis = 'x',
   width,
   height,
@@ -76,7 +76,7 @@ function BottomLabels({
   offsetRight = 0,
   virtualTextRef,
   formattedTicks,
-}: BottomLabelsProps) {
+}: BlockEndLabelsProps) {
   const i18n = useInternalI18n('[charts]');
 
   const xOffset = scale.isCategorical() && axis === 'x' ? Math.max(0, scale.d3Scale.bandwidth() - 1) / 2 : 0;

--- a/src/internal/components/cartesian-chart/inline-start-labels.tsx
+++ b/src/internal/components/cartesian-chart/inline-start-labels.tsx
@@ -72,7 +72,7 @@ function InlineStartLabels({
 
   return (
     <g
-      className={clsx(styles['labels-left'])}
+      className={clsx(styles['labels-inline-start'])}
       aria-label={title}
       role="list"
       aria-roledescription={i18n('i18nStrings.chartAriaRoleDescription', ariaRoleDescription)}

--- a/src/internal/components/cartesian-chart/inline-start-labels.tsx
+++ b/src/internal/components/cartesian-chart/inline-start-labels.tsx
@@ -11,7 +11,7 @@ import { formatTicks, getSVGTextSize, getVisibleTicks } from './label-utils';
 import { ChartDataTypes } from '../../../mixed-line-bar-chart/interfaces';
 import { useInternalI18n } from '../../../i18n/context';
 import ResponsiveText from '../responsive-text';
-import { isRtl as getIsRtl } from '../../direction';
+import { getIsRtl } from '../../direction';
 
 const OFFSET_PX = 12;
 

--- a/src/internal/components/cartesian-chart/inline-start-labels.tsx
+++ b/src/internal/components/cartesian-chart/inline-start-labels.tsx
@@ -15,7 +15,7 @@ import { isRtl as getIsRtl } from '../../direction';
 
 const OFFSET_PX = 12;
 
-interface ValueLabelsProps {
+interface InlineStartLabelsProps {
   axis?: 'x' | 'y';
   plotWidth: number;
   plotHeight: number;
@@ -27,10 +27,10 @@ interface ValueLabelsProps {
   ariaRoleDescription?: string;
 }
 
-export default memo(ValueLabels) as typeof ValueLabels;
+export default memo(InlineStartLabels) as typeof InlineStartLabels;
 
 // Renders the visible tick labels on the value axis, as well as their grid lines.
-function ValueLabels({
+function InlineStartLabels({
   axis = 'y',
   plotWidth,
   plotHeight,
@@ -40,7 +40,7 @@ function ValueLabels({
   tickFormatter,
   title,
   ariaRoleDescription,
-}: ValueLabelsProps) {
+}: InlineStartLabelsProps) {
   const i18n = useInternalI18n('[charts]');
   const virtualTextRef = useRef<SVGTextElement>(null);
 

--- a/src/internal/components/cartesian-chart/labels-measure.tsx
+++ b/src/internal/components/cartesian-chart/labels-measure.tsx
@@ -40,7 +40,7 @@ function LabelsMeasure({ scale, ticks, tickFormatter, autoWidth, maxLabelsWidth 
     return (
       <Fragment key={`${value}`}>
         {lines.map((line, lineIndex) => (
-          <div key={lineIndex} className={styles['labels-left__label']} aria-hidden="true">
+          <div key={lineIndex} className={styles['labels-inline-start__label']} aria-hidden="true">
             {line}
           </div>
         ))}
@@ -51,7 +51,7 @@ function LabelsMeasure({ scale, ticks, tickFormatter, autoWidth, maxLabelsWidth 
   return (
     <div
       ref={ref}
-      className={clsx(styles['labels-left'], styles['labels-left--hidden'])}
+      className={clsx(styles['labels-inline-start'], styles['labels-inline-start--hidden'])}
       style={{ maxWidth: maxLabelsWidth }}
     >
       {ticks.map(labelMapper)}

--- a/src/internal/components/cartesian-chart/styles.scss
+++ b/src/internal/components/cartesian-chart/styles.scss
@@ -50,12 +50,12 @@
   dominant-baseline: hanging;
 }
 
-.labels-left > .ticks > .ticks__text {
+.labels-inline-start > .ticks > .ticks__text {
   text-anchor: end;
   dominant-baseline: central;
 }
 
-.labels-left {
+.labels-inline-start {
   position: relative;
   margin-inline-end: 12px;
 
@@ -66,20 +66,20 @@
   }
 }
 
-.labels-left__label {
+.labels-inline-start__label {
   position: absolute;
 }
 
-.labels-left--hidden {
+.labels-inline-start--hidden {
   visibility: hidden;
 
-  > .labels-left__label {
+  > .labels-inline-start__label {
     position: relative;
     white-space: nowrap;
   }
 }
 
-.labels-bottom {
+.labels-block-end {
   position: relative;
   display: block;
   inline-size: 100%;

--- a/src/internal/components/cartesian-chart/value-labels.tsx
+++ b/src/internal/components/cartesian-chart/value-labels.tsx
@@ -11,10 +11,11 @@ import { formatTicks, getSVGTextSize, getVisibleTicks } from './label-utils';
 import { ChartDataTypes } from '../../../mixed-line-bar-chart/interfaces';
 import { useInternalI18n } from '../../../i18n/context';
 import ResponsiveText from '../responsive-text';
+import { isRtl as getIsRtl } from '../../direction';
 
 const OFFSET_PX = 12;
 
-interface LeftLabelsProps {
+interface ValueLabelsProps {
   axis?: 'x' | 'y';
   plotWidth: number;
   plotHeight: number;
@@ -26,10 +27,10 @@ interface LeftLabelsProps {
   ariaRoleDescription?: string;
 }
 
-export default memo(LeftLabels) as typeof LeftLabels;
+export default memo(ValueLabels) as typeof ValueLabels;
 
-// Renders the visible tick labels on the left axis, as well as their grid lines.
-function LeftLabels({
+// Renders the visible tick labels on the value axis, as well as their grid lines.
+function ValueLabels({
   axis = 'y',
   plotWidth,
   plotHeight,
@@ -39,7 +40,7 @@ function LeftLabels({
   tickFormatter,
   title,
   ariaRoleDescription,
-}: LeftLabelsProps) {
+}: ValueLabelsProps) {
   const i18n = useInternalI18n('[charts]');
   const virtualTextRef = useRef<SVGTextElement>(null);
 
@@ -66,6 +67,8 @@ function LeftLabels({
   const from = 0 - OFFSET_PX - yOffset;
   const until = plotHeight + OFFSET_PX - yOffset;
   const visibleTicks = getVisibleTicks(formattedTicks, from, until);
+
+  const isRtl = virtualTextRef.current ? getIsRtl(virtualTextRef.current) : false;
 
   return (
     <g
@@ -96,8 +99,9 @@ function LeftLabels({
               )}
 
               {lines.map((line, lineIndex) => {
+                const x = -(TICK_LENGTH + TICK_MARGIN);
                 const lineTextProps = {
-                  x: -(TICK_LENGTH + TICK_MARGIN),
+                  x: !isRtl ? x : plotWidth - x,
                   y: (lineIndex - (lines.length - 1) * 0.5) * TICK_LINE_HEIGHT,
                   className: styles.ticks__text,
                   children: line,

--- a/src/internal/components/chart-legend/index.tsx
+++ b/src/internal/components/chart-legend/index.tsx
@@ -8,6 +8,7 @@ import { KeyCode } from '../../keycode';
 import SeriesMarker, { ChartSeriesMarkerType } from '../chart-series-marker';
 import styles from './styles.css.js';
 import { useInternalI18n } from '../../../i18n/context';
+import handleKey from '../../utils/handle-key';
 
 export interface ChartLegendItem<T> {
   label: string;
@@ -41,33 +42,27 @@ function ChartLegend<T>({
 
   const highlightedSeriesIndex = findSeriesIndex(series, highlightedSeries);
 
-  const highlightLeft = () => {
+  const highlightInlineStart = () => {
     const currentIndex = highlightedSeriesIndex ?? 0;
     const nextIndex = currentIndex - 1 >= 0 ? currentIndex - 1 : series.length - 1;
     segmentsRef.current[nextIndex]?.focus();
   };
 
-  const highlightRight = () => {
+  const highlightInlineEnd = () => {
     const currentIndex = highlightedSeriesIndex ?? 0;
     const nextIndex = currentIndex + 1 < series.length ? currentIndex + 1 : 0;
     segmentsRef.current[nextIndex]?.focus();
   };
 
-  const handleKeyPress = (event: React.KeyboardEvent) => {
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLElement>) => {
     if (event.keyCode === KeyCode.right || event.keyCode === KeyCode.left) {
       // Preventing default fixes an issue in Safari+VO when VO additionally interprets arrow keys as its commands.
       event.preventDefault();
 
-      switch (event.keyCode) {
-        case KeyCode.left:
-          return highlightLeft();
-
-        case KeyCode.right:
-          return highlightRight();
-
-        default:
-          return;
-      }
+      handleKey(event, {
+        onInlineStart: () => highlightInlineStart(),
+        onInlineEnd: () => highlightInlineEnd(),
+      });
     }
   };
 

--- a/src/internal/utils/handle-key.ts
+++ b/src/internal/utils/handle-key.ts
@@ -4,12 +4,12 @@ import { KeyCode } from '../keycode';
 import { getIsRtl } from '../direction';
 
 export function isEventLike(event: any): event is EventLike {
-  return event.currentTarget instanceof HTMLElement;
+  return event.currentTarget instanceof HTMLElement || event.currentTarget instanceof SVGElement;
 }
 
 export interface EventLike {
   keyCode: number;
-  currentTarget: HTMLElement;
+  currentTarget: HTMLElement | SVGElement;
 }
 
 export default function handleKey(

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -8,7 +8,7 @@ import { getXTickCount, getYTickCount, createXTicks, createYTicks } from '../int
 import ChartPlot, { ChartPlotRef } from '../internal/components/chart-plot';
 import AxisLabel from '../internal/components/cartesian-chart/axis-label';
 import LabelsMeasure from '../internal/components/cartesian-chart/labels-measure';
-import LeftLabels from '../internal/components/cartesian-chart/left-labels';
+import ValueLabels from '../internal/components/cartesian-chart/value-labels';
 import BottomLabels, { useBottomLabels } from '../internal/components/cartesian-chart/bottom-labels';
 import VerticalGridLines from '../internal/components/cartesian-chart/vertical-grid-lines';
 import EmphasizedBaseline from '../internal/components/cartesian-chart/emphasized-baseline';
@@ -133,14 +133,14 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const plotRef = useRef<ChartPlotRef>(null);
   const verticalMarkerRef = useRef<SVGLineElement>(null);
 
-  const [leftLabelsWidth, setLeftLabelsWidth] = useState(0);
+  const [valueLabelsWidth, setValueLabelsWidth] = useState(0);
   const [verticalMarkerX, setVerticalMarkerX] = useState<VerticalMarkerX<T> | null>(null);
   const [detailsPopoverText, setDetailsPopoverText] = useState('');
   const [containerWidth, containerMeasureRef] = useContainerWidth(fallbackContainerWidth);
-  const maxLeftLabelsWidth = Math.round(containerWidth / 2);
+  const maxValueLabelsWidth = Math.round(containerWidth / 2);
   const plotWidth = containerWidth
-    ? // Calculate the minimum between leftLabelsWidth and maxLeftLabelsWidth for extra safety because leftLabelsWidth could be out of date
-      Math.max(0, containerWidth - Math.min(leftLabelsWidth, maxLeftLabelsWidth) - LEFT_LABELS_MARGIN)
+    ? // Calculate the minimum between valueLabelsWidth and maxValueLabelsWidth for extra safety because valueLabelsWidth could be out of date
+      Math.max(0, containerWidth - Math.min(valueLabelsWidth, maxValueLabelsWidth) - LEFT_LABELS_MARGIN)
     : fallbackContainerWidth;
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
@@ -506,8 +506,8 @@ export default function ChartContainer<T extends ChartDataTypes>({
           ticks={leftAxisProps.ticks}
           scale={leftAxisProps.scale}
           tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
-          autoWidth={setLeftLabelsWidth}
-          maxLabelsWidth={maxLeftLabelsWidth}
+          autoWidth={setValueLabelsWidth}
+          maxLabelsWidth={maxValueLabelsWidth}
         />
       }
       bottomAxisLabel={<AxisLabel axis={x} position="bottom" title={bottomAxisProps.title} />}
@@ -547,14 +547,14 @@ export default function ChartContainer<T extends ChartDataTypes>({
             style={{ pointerEvents: 'none' }}
           />
 
-          <LeftLabels
+          <ValueLabels
             axis={y}
             ticks={leftAxisProps.ticks}
             scale={leftAxisProps.scale}
             tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
             title={leftAxisProps.title}
             ariaRoleDescription={leftAxisProps.ariaRoleDescription}
-            maxLabelsWidth={maxLeftLabelsWidth}
+            maxLabelsWidth={maxValueLabelsWidth}
             plotWidth={plotWidth}
             plotHeight={plotHeight}
           />
@@ -623,7 +623,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
             ariaRoleDescription={bottomAxisProps.ariaRoleDescription}
             height={plotHeight}
             width={plotWidth}
-            offsetLeft={leftLabelsWidth + BOTTOM_LABELS_OFFSET}
+            offsetLeft={valueLabelsWidth + BOTTOM_LABELS_OFFSET}
             offsetRight={BOTTOM_LABELS_OFFSET}
           />
         </ChartPlot>

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -8,8 +8,8 @@ import { getXTickCount, getYTickCount, createXTicks, createYTicks } from '../int
 import ChartPlot, { ChartPlotRef } from '../internal/components/chart-plot';
 import AxisLabel from '../internal/components/cartesian-chart/axis-label';
 import LabelsMeasure from '../internal/components/cartesian-chart/labels-measure';
-import ValueLabels from '../internal/components/cartesian-chart/value-labels';
-import BottomLabels, { useBottomLabels } from '../internal/components/cartesian-chart/bottom-labels';
+import InlineStartLabels from '../internal/components/cartesian-chart/inline-start-labels';
+import BlockEndLabels, { useBLockEndLabels } from '../internal/components/cartesian-chart/block-end-labels';
 import VerticalGridLines from '../internal/components/cartesian-chart/vertical-grid-lines';
 import EmphasizedBaseline from '../internal/components/cartesian-chart/emphasized-baseline';
 import HighlightedPoint from '../internal/components/cartesian-chart/highlighted-point';
@@ -35,8 +35,8 @@ import { nodeBelongs } from '../internal/utils/node-belongs';
 import { CartesianChartContainer } from '../internal/components/cartesian-chart/chart-container';
 import { useHeightMeasure } from '../internal/hooks/container-queries/use-height-measure';
 
-const LEFT_LABELS_MARGIN = 16;
-const BOTTOM_LABELS_OFFSET = 12;
+const INLINE_START_LABELS_MARGIN = 16;
+const BLOCK_END_LABELS_OFFSET = 12;
 
 type TickFormatter = undefined | ((value: ChartDataTypes) => string);
 
@@ -133,14 +133,17 @@ export default function ChartContainer<T extends ChartDataTypes>({
   const plotRef = useRef<ChartPlotRef>(null);
   const verticalMarkerRef = useRef<SVGLineElement>(null);
 
-  const [valueLabelsWidth, setValueLabelsWidth] = useState(0);
+  const [inlineStartLabelsWidth, setInlineStartLabelsWidth] = useState(0);
   const [verticalMarkerX, setVerticalMarkerX] = useState<VerticalMarkerX<T> | null>(null);
   const [detailsPopoverText, setDetailsPopoverText] = useState('');
   const [containerWidth, containerMeasureRef] = useContainerWidth(fallbackContainerWidth);
-  const maxValueLabelsWidth = Math.round(containerWidth / 2);
+  const maxInlineStartLabelsWidth = Math.round(containerWidth / 2);
   const plotWidth = containerWidth
-    ? // Calculate the minimum between valueLabelsWidth and maxValueLabelsWidth for extra safety because valueLabelsWidth could be out of date
-      Math.max(0, containerWidth - Math.min(valueLabelsWidth, maxValueLabelsWidth) - LEFT_LABELS_MARGIN)
+    ? // Calculate the minimum between inlineStartLabelsWidth and maxInlineStartLabelsWidth for extra safety because inlineStarteLabelsWidth could be out of date
+      Math.max(
+        0,
+        containerWidth - Math.min(inlineStartLabelsWidth, maxInlineStartLabelsWidth) - INLINE_START_LABELS_MARGIN
+      )
     : fallbackContainerWidth;
   const containerRefObject = useRef(null);
   const containerRef = useMergeRefs(containerMeasureRef, containerRefObject);
@@ -188,7 +191,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
     ? getXAxisProps(plotWidth, [0, plotWidth])
     : getYAxisProps(plotWidth, [0, plotWidth]);
 
-  const bottomLabelsProps = useBottomLabels({ ...bottomAxisProps });
+  const blockEndLabelsProps = useBLockEndLabels({ ...bottomAxisProps });
 
   const plotMeasureRef = useRef<SVGLineElement>(null);
   const measuredHeight = useHeightMeasure(() => plotMeasureRef.current, !fitHeight);
@@ -498,7 +501,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
   return (
     <CartesianChartContainer
       ref={containerRef}
-      minHeight={explicitPlotHeight + bottomLabelsProps.height}
+      minHeight={explicitPlotHeight + blockEndLabelsProps.height}
       fitHeight={!!fitHeight}
       leftAxisLabel={<AxisLabel axis={y} position="left" title={leftAxisProps.title} />}
       leftAxisLabelMeasure={
@@ -506,8 +509,8 @@ export default function ChartContainer<T extends ChartDataTypes>({
           ticks={leftAxisProps.ticks}
           scale={leftAxisProps.scale}
           tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
-          autoWidth={setValueLabelsWidth}
-          maxLabelsWidth={maxValueLabelsWidth}
+          autoWidth={setInlineStartLabelsWidth}
+          maxLabelsWidth={maxInlineStartLabelsWidth}
         />
       }
       bottomAxisLabel={<AxisLabel axis={x} position="bottom" title={bottomAxisProps.title} />}
@@ -515,8 +518,8 @@ export default function ChartContainer<T extends ChartDataTypes>({
         <ChartPlot
           ref={plotRef}
           width="100%"
-          height={fitHeight ? `calc(100% - ${bottomLabelsProps.height}px)` : plotHeight}
-          offsetBottom={bottomLabelsProps.height}
+          height={fitHeight ? `calc(100% - ${blockEndLabelsProps.height}px)` : plotHeight}
+          offsetBottom={blockEndLabelsProps.height}
           isClickable={isPopoverOpen && !isPopoverPinned}
           ariaLabel={ariaLabel}
           ariaLabelledby={ariaLabelledby}
@@ -547,14 +550,14 @@ export default function ChartContainer<T extends ChartDataTypes>({
             style={{ pointerEvents: 'none' }}
           />
 
-          <ValueLabels
+          <InlineStartLabels
             axis={y}
             ticks={leftAxisProps.ticks}
             scale={leftAxisProps.scale}
             tickFormatter={leftAxisProps.tickFormatter as TickFormatter}
             title={leftAxisProps.title}
             ariaRoleDescription={leftAxisProps.ariaRoleDescription}
-            maxLabelsWidth={maxValueLabelsWidth}
+            maxLabelsWidth={maxInlineStartLabelsWidth}
             plotWidth={plotWidth}
             plotHeight={plotHeight}
           />
@@ -615,16 +618,16 @@ export default function ChartContainer<T extends ChartDataTypes>({
             />
           )}
 
-          <BottomLabels
-            {...bottomLabelsProps}
+          <BlockEndLabels
+            {...blockEndLabelsProps}
             axis={x}
             scale={bottomAxisProps.scale}
             title={bottomAxisProps.title}
             ariaRoleDescription={bottomAxisProps.ariaRoleDescription}
             height={plotHeight}
             width={plotWidth}
-            offsetLeft={valueLabelsWidth + BOTTOM_LABELS_OFFSET}
-            offsetRight={BOTTOM_LABELS_OFFSET}
+            offsetLeft={inlineStartLabelsWidth + BLOCK_END_LABELS_OFFSET}
+            offsetRight={BLOCK_END_LABELS_OFFSET}
           />
         </ChartPlot>
       }


### PR DESCRIPTION
### Description

Fix area charts rendering issues when page direction is RTL:
* Inverting X domain when RTL;
* Inverting horizontal move direction with keyboard when RTL;
* Alternative X position for value axis.

<img width="1412" alt="Screenshot 2024-04-23 at 11 35 14" src="https://github.com/cloudscape-design/components/assets/20790937/32aae10d-31a4-4780-bc61-a70a26babbc1">

### How has this been tested?

* Manual testing;
* Screenshot testing.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
