### PR TITLE
chore: Add RTL support for pie chart

### DIFF
--- a/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
+++ b/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
@@ -4,15 +4,21 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ResponsiveText from '../../../../../lib/components/internal/components/responsive-text';
 import { getTextWidth } from '../../../../../lib/components/internal/components/responsive-text/responsive-text-utils';
+import { isRtl } from '../../../../../lib/components/internal/direction';
 
 jest.mock('../../../../../lib/components/internal/components/responsive-text/responsive-text-utils', () => ({
   ...jest.requireActual('../../../../../lib/components/internal/components/responsive-text/responsive-text-utils'),
   getTextWidth: jest.fn().mockReturnValue(0),
 }));
 
+jest.mock('../../../../../lib/components/internal/direction', () => ({
+  isRtl: jest.fn().mockReturnValue(false),
+}));
+
 describe('responsive SVG text tests', () => {
-  test('renders full text', () => {
+  test.each([false, true])('renders full text', rtl => {
     jest.mocked(getTextWidth).mockReturnValueOnce(100);
+    (isRtl as jest.Mock).mockReturnValue(rtl);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -25,6 +31,7 @@ describe('responsive SVG text tests', () => {
 
   test('renders truncated text', () => {
     jest.mocked(getTextWidth).mockReturnValueOnce(101);
+    (isRtl as jest.Mock).mockReturnValue(false);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -33,5 +40,18 @@ describe('responsive SVG text tests', () => {
     );
 
     expect(container).toHaveTextContent('Long tex…');
+  });
+
+  test('renders truncated text RTL', () => {
+    jest.mocked(getTextWidth).mockReturnValueOnce(101);
+    (isRtl as jest.Mock).mockReturnValue(true);
+
+    const { container } = render(
+      <ResponsiveText x={0} y={0} maxWidth={100}>
+        Long text
+      </ResponsiveText>
+    );
+
+    expect(container).toHaveTextContent('ong text…');
   });
 });

--- a/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
+++ b/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import ResponsiveText from '../../../../../lib/components/internal/components/responsive-text';
 import { getTextWidth } from '../../../../../lib/components/internal/components/responsive-text/responsive-text-utils';
-import { isRtl } from '../../../../../lib/components/internal/direction';
+import { getIsRtl } from '../../../../../lib/components/internal/direction';
 
 jest.mock('../../../../../lib/components/internal/components/responsive-text/responsive-text-utils', () => ({
   ...jest.requireActual('../../../../../lib/components/internal/components/responsive-text/responsive-text-utils'),
@@ -19,7 +19,7 @@ jest.mock('../../../../../lib/components/internal/direction', () => ({
 describe('responsive SVG text tests', () => {
   test.each([{ rtl: false }, { rtl: true }])('renders full text, rtl="$rtl"', ({ rtl }) => {
     jest.mocked(getTextWidth).mockReturnValueOnce(100);
-    jest.mocked(isRtl).mockReturnValue(rtl);
+    jest.mocked(getIsRtl).mockReturnValue(rtl);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -32,7 +32,7 @@ describe('responsive SVG text tests', () => {
 
   test('renders truncated text', () => {
     jest.mocked(getTextWidth).mockReturnValueOnce(101);
-    jest.mocked(isRtl).mockReturnValue(false);
+    jest.mocked(getIsRtl).mockReturnValue(false);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -45,7 +45,7 @@ describe('responsive SVG text tests', () => {
 
   test('renders truncated text RTL', () => {
     jest.mocked(getTextWidth).mockReturnValueOnce(101);
-    jest.mocked(isRtl).mockReturnValue(true);
+    jest.mocked(getIsRtl).mockReturnValue(true);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>

--- a/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
+++ b/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
@@ -19,7 +19,7 @@ jest.mock('../../../../../lib/components/internal/direction', () => ({
 describe('responsive SVG text tests', () => {
   test.each([{ rtl: false }, { rtl: true }])('renders full text, rtl="$rtl"', ({ rtl }) => {
     jest.mocked(getTextWidth).mockReturnValueOnce(100);
-    (isRtl as jest.Mock).mockReturnValue(rtl);
+    jest.mocked(isRtl).mockReturnValue(rtl);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -32,7 +32,7 @@ describe('responsive SVG text tests', () => {
 
   test('renders truncated text', () => {
     jest.mocked(getTextWidth).mockReturnValueOnce(101);
-    (isRtl as jest.Mock).mockReturnValue(false);
+    jest.mocked(isRtl).mockReturnValue(false);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>
@@ -45,7 +45,7 @@ describe('responsive SVG text tests', () => {
 
   test('renders truncated text RTL', () => {
     jest.mocked(getTextWidth).mockReturnValueOnce(101);
-    (isRtl as jest.Mock).mockReturnValue(true);
+    jest.mocked(isRtl).mockReturnValue(true);
 
     const { container } = render(
       <ResponsiveText x={0} y={0} maxWidth={100}>

--- a/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
+++ b/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
@@ -12,11 +12,12 @@ jest.mock('../../../../../lib/components/internal/components/responsive-text/res
 }));
 
 jest.mock('../../../../../lib/components/internal/direction', () => ({
+  ...jest.requireActual('../../../../../lib/components/internal/direction'),
   isRtl: jest.fn().mockReturnValue(false),
 }));
 
 describe('responsive SVG text tests', () => {
-  test.each([false, true])('renders full text', rtl => {
+  test.each([{ rtl: false }, { rtl: true }])('renders full text, rtl="$rtl"', ({ rtl }) => {
     jest.mocked(getTextWidth).mockReturnValueOnce(100);
     (isRtl as jest.Mock).mockReturnValue(rtl);
 

--- a/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
+++ b/src/internal/components/responsive-text/__tests__/responsive-text.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../../../../../lib/components/internal/components/responsive-text/res
 
 jest.mock('../../../../../lib/components/internal/direction', () => ({
   ...jest.requireActual('../../../../../lib/components/internal/direction'),
-  isRtl: jest.fn().mockReturnValue(false),
+  getIsRtl: jest.fn().mockReturnValue(false),
 }));
 
 describe('responsive SVG text tests', () => {

--- a/src/internal/components/responsive-text/index.tsx
+++ b/src/internal/components/responsive-text/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { memo, useEffect, useRef } from 'react';
 import { getTextWidth } from './responsive-text-utils';
-import { isRtl as getIsRtl } from '../../direction';
+import { getIsRtl } from '../../direction';
 
 interface ResponsiveTextProps {
   x: number;

--- a/src/internal/components/responsive-text/index.tsx
+++ b/src/internal/components/responsive-text/index.tsx
@@ -16,12 +16,12 @@ export default memo(ResponsiveText);
 
 function ResponsiveText({ x, y, className, children, maxWidth }: ResponsiveTextProps) {
   const textRef = useRef<SVGTextElement>(null);
-  const isRtl = textRef.current ? getIsRtl(textRef.current) : false;
 
   // Determine the visible width of the text and if necessary truncate it until it fits.
   useEffect(() => {
+    const isRtl = getIsRtl(textRef.current!);
     renderTextContent(textRef.current!, children, maxWidth, isRtl);
-  }, [maxWidth, children, isRtl]);
+  }, [maxWidth, children]);
 
   return (
     <text ref={textRef} x={x} y={y} style={{ textAnchor: 'end' }} className={className}>

--- a/src/internal/components/responsive-text/index.tsx
+++ b/src/internal/components/responsive-text/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { memo, useEffect, useRef } from 'react';
 import { getTextWidth } from './responsive-text-utils';
+import { isRtl as getIsRtl } from '../../direction';
 
 interface ResponsiveTextProps {
   x: number;
@@ -15,11 +16,12 @@ export default memo(ResponsiveText);
 
 function ResponsiveText({ x, y, className, children, maxWidth }: ResponsiveTextProps) {
   const textRef = useRef<SVGTextElement>(null);
+  const isRtl = textRef.current ? getIsRtl(textRef.current) : false;
 
   // Determine the visible width of the text and if necessary truncate it until it fits.
   useEffect(() => {
-    renderTextContent(textRef.current!, children, maxWidth);
-  }, [maxWidth, children]);
+    renderTextContent(textRef.current!, children, maxWidth, isRtl);
+  }, [maxWidth, children, isRtl]);
 
   return (
     <text ref={textRef} x={x} y={y} style={{ textAnchor: 'end' }} className={className}>
@@ -28,10 +30,10 @@ function ResponsiveText({ x, y, className, children, maxWidth }: ResponsiveTextP
   );
 }
 
-export function renderTextContent(textNode: SVGTextElement, text: string, maxWidth: number) {
+export function renderTextContent(textNode: SVGTextElement, text: string, maxWidth: number, isRtl: boolean) {
   let visibleLength = text.length;
   while (visibleLength >= 0) {
-    textNode.textContent = truncateText(text, visibleLength);
+    textNode.textContent = truncateText(text, visibleLength, isRtl);
 
     if (getTextWidth(textNode) <= maxWidth) {
       return;
@@ -41,9 +43,12 @@ export function renderTextContent(textNode: SVGTextElement, text: string, maxWid
   }
 }
 
-function truncateText(text: string, maxLength: number) {
+function truncateText(text: string, maxLength: number, isRtl: boolean) {
   if (text.length === maxLength) {
     return text;
+  }
+  if (isRtl) {
+    return text.slice(text.length - maxLength) + '…';
   }
   return text.slice(0, maxLength) + '…';
 }

--- a/src/pie-chart/__tests__/responsive-text.test.tsx
+++ b/src/pie-chart/__tests__/responsive-text.test.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import ResponsiveText from '../../../lib/components/pie-chart/responsive-text';
+import { renderTextContent } from '../../../lib/components/internal/components/responsive-text/index';
+import { isRtl } from '../../..//lib/components/internal/direction';
+
+jest.mock('../../../lib/components/internal/components/responsive-text/index', () => ({
+  ...jest.requireActual('../../../lib/components/internal/components/responsive-text/index'),
+  renderTextContent: jest.fn(),
+}));
+
+jest.mock('../../../lib/components/internal/direction', () => ({
+  ...jest.requireActual('../../../lib/components/internal/direction'),
+  isRtl: jest.fn().mockReturnValue(false),
+}));
+
+afterEach(() => {
+  jest.mocked(renderTextContent).mockReset();
+  jest.mocked(isRtl).mockReset();
+});
+
+test.each([{ rtl: false }, { rtl: true }])('provides rtl="$rtl" to renderTextContent', async ({ rtl }) => {
+  jest.mocked(isRtl).mockReturnValue(rtl);
+
+  render(
+    <ResponsiveText x={0} y={0} containerBoundaries={null}>
+      Text
+    </ResponsiveText>
+  );
+
+  await waitFor(() => {
+    expect(renderTextContent).toHaveBeenCalledTimes(1);
+    expect(renderTextContent).toHaveBeenCalledWith(expect.anything(), 'Text', 0, rtl);
+  });
+});

--- a/src/pie-chart/__tests__/responsive-text.test.tsx
+++ b/src/pie-chart/__tests__/responsive-text.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import ResponsiveText from '../../../lib/components/pie-chart/responsive-text';
 import { renderTextContent } from '../../../lib/components/internal/components/responsive-text/index';
-import { getIsRtl } from '../../..//lib/components/internal/direction';
+import { getIsRtl } from '../../../lib/components/internal/direction';
 
 jest.mock('../../../lib/components/internal/components/responsive-text/index', () => ({
   ...jest.requireActual('../../../lib/components/internal/components/responsive-text/index'),
@@ -13,7 +13,7 @@ jest.mock('../../../lib/components/internal/components/responsive-text/index', (
 
 jest.mock('../../../lib/components/internal/direction', () => ({
   ...jest.requireActual('../../../lib/components/internal/direction'),
-  isRtl: jest.fn().mockReturnValue(false),
+  getIsRtl: jest.fn().mockReturnValue(false),
 }));
 
 afterEach(() => {

--- a/src/pie-chart/__tests__/responsive-text.test.tsx
+++ b/src/pie-chart/__tests__/responsive-text.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import ResponsiveText from '../../../lib/components/pie-chart/responsive-text';
 import { renderTextContent } from '../../../lib/components/internal/components/responsive-text/index';
-import { isRtl } from '../../..//lib/components/internal/direction';
+import { getIsRtl } from '../../..//lib/components/internal/direction';
 
 jest.mock('../../../lib/components/internal/components/responsive-text/index', () => ({
   ...jest.requireActual('../../../lib/components/internal/components/responsive-text/index'),
@@ -18,11 +18,11 @@ jest.mock('../../../lib/components/internal/direction', () => ({
 
 afterEach(() => {
   jest.mocked(renderTextContent).mockReset();
-  jest.mocked(isRtl).mockReset();
+  jest.mocked(getIsRtl).mockReset();
 });
 
 test.each([{ rtl: false }, { rtl: true }])('provides rtl="$rtl" to renderTextContent', async ({ rtl }) => {
-  jest.mocked(isRtl).mockReturnValue(rtl);
+  jest.mocked(getIsRtl).mockReturnValue(rtl);
 
   render(
     <ResponsiveText x={0} y={0} containerBoundaries={null}>

--- a/src/pie-chart/responsive-text.tsx
+++ b/src/pie-chart/responsive-text.tsx
@@ -26,6 +26,7 @@ function ResponsiveText({ x, y, rightSide, className, children, containerBoundar
   useEffect(() => {
     // The debouncing is necessary for visual smoothness.
     const timeoutId = setTimeout(() => {
+      const isRtl = getIsRtl(virtualRef.current!);
       const groupRect = virtualRef.current!.getBoundingClientRect();
       const visibleWidth = containerBoundaries ? getVisibleWidth(groupRect, containerBoundaries) : 0;
       renderTextContent(actualRef.current!, children, visibleWidth, isRtl);
@@ -56,6 +57,7 @@ function ResponsiveText({ x, y, rightSide, className, children, containerBoundar
 }
 
 function getVisibleWidth(element: { left: number; right: number }, container: { left: number; right: number }): number {
+  console.log('getVisibleWidth', element, container);
   if (element.left < container.left) {
     return element.right - container.left;
   } else if (element.right > container.right) {

--- a/src/pie-chart/responsive-text.tsx
+++ b/src/pie-chart/responsive-text.tsx
@@ -57,7 +57,6 @@ function ResponsiveText({ x, y, rightSide, className, children, containerBoundar
 }
 
 function getVisibleWidth(element: { left: number; right: number }, container: { left: number; right: number }): number {
-  console.log('getVisibleWidth', element, container);
   if (element.left < container.left) {
     return element.right - container.left;
   } else if (element.right > container.right) {

--- a/src/pie-chart/responsive-text.tsx
+++ b/src/pie-chart/responsive-text.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { memo, useEffect, useRef } from 'react';
 import { renderTextContent } from '../internal/components/responsive-text';
-import { isRtl as getIsRtl } from '../internal/direction';
+import { getIsRtl } from '../internal/direction';
 
 interface ResponsiveTextProps {
   x: number;

--- a/src/pie-chart/responsive-text.tsx
+++ b/src/pie-chart/responsive-text.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { memo, useEffect, useRef } from 'react';
 import { renderTextContent } from '../internal/components/responsive-text';
+import { isRtl as getIsRtl } from '../internal/direction';
 
 interface ResponsiveTextProps {
   x: number;
@@ -18,13 +19,16 @@ function ResponsiveText({ x, y, rightSide, className, children, containerBoundar
   const actualRef = useRef<SVGTextElement>(null);
   const virtualRef = useRef<SVGTextElement>(null);
 
+  const isRtl = actualRef.current ? getIsRtl(actualRef.current) : false;
+  rightSide = !isRtl ? rightSide : !rightSide;
+
   // Determine the visible width of the text and if necessary truncate it until it fits.
   useEffect(() => {
     // The debouncing is necessary for visual smoothness.
     const timeoutId = setTimeout(() => {
       const groupRect = virtualRef.current!.getBoundingClientRect();
       const visibleWidth = containerBoundaries ? getVisibleWidth(groupRect, containerBoundaries) : 0;
-      renderTextContent(actualRef.current!, children, visibleWidth);
+      renderTextContent(actualRef.current!, children, visibleWidth, isRtl);
     }, 25);
     return () => clearTimeout(timeoutId);
   });


### PR DESCRIPTION
### Description

Fix pie charts rendering issues when page direction is RTL:
* Align the labels to the correct side;
* Make labels truncation reversed.

<img width="375" alt="Screenshot 2024-04-23 at 11 12 26" src="https://github.com/cloudscape-design/components/assets/20790937/ee41e7ce-dc32-49fb-8838-75571de55073">



### How has this been tested?

* New unit test for truncation;
* Manual testing;
* Screenshot testing.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
