### PR TITLE
revert: Partially rounded corners for stacked bar charts

### DIFF
--- a/src/mixed-line-bar-chart/__tests__/utils.test.ts
+++ b/src/mixed-line-bar-chart/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { matchesX, calculateStackedBarValues } from '../../../lib/components/mixed-line-bar-chart/utils';
+import { matchesX, calculateOffsetMaps } from '../../../lib/components/mixed-line-bar-chart/utils';
 
 import { barSeries, barSeries2 } from './common';
 
@@ -37,84 +37,78 @@ describe('matchesX', () => {
   });
 });
 
-describe('calculateStackedBarValues', () => {
+describe('calculateOffsetMaps', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   test('without data', () => {
-    expect(calculateStackedBarValues([])).toEqual(new Map());
+    expect(calculateOffsetMaps([])).toEqual([]);
   });
 
   test('with categorical data', () => {
     const data = [barSeries.data, barSeries2.data, barSeries.data];
-    const computed = calculateStackedBarValues(data);
-    expect(computed).toEqual(
-      new Map([
-        [
-          'Potatoes',
-          new Map([
-            [0, 77],
-            [1, 77 + 10],
-            [2, 77 + 10 + 77],
-          ]),
-        ],
-        [
-          'Chocolate',
-          new Map([
-            [0, 546],
-            [1, 546 + 20],
-            [2, 546 + 20 + 546],
-          ]),
-        ],
-        [
-          'Apples',
-          new Map([
-            [0, 52],
-            [2, 52 + 0 + 52],
-          ]),
-        ],
-        [
-          'Oranges',
-          new Map([
-            [0, 47],
-            [1, 47 + 50],
-            [2, 47 + 50 + 47],
-          ]),
-        ],
-      ])
-    );
+
+    const actual = calculateOffsetMaps(data);
+
+    expect(actual).toEqual([
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
+      {
+        positiveOffsets: new Map([
+          ['Potatoes', 77],
+          ['Chocolate', 546],
+          ['Apples', 52],
+          ['Oranges', 47],
+        ]),
+        negativeOffsets: new Map(),
+      },
+      {
+        positiveOffsets: new Map([
+          ['Potatoes', 87],
+          ['Chocolate', 566],
+          ['Apples', 52],
+          ['Oranges', 97],
+        ]),
+        negativeOffsets: new Map(),
+      },
+    ]);
   });
 
   test('with timeseries data', () => {
     const date = new Date('1995-12-17T03:24:00');
     const data = [[{ x: date, y: 1 }], [{ x: date, y: 2 }], [{ x: date, y: 3 }]];
-    const computed = calculateStackedBarValues(data);
-    expect(computed).toEqual(
-      new Map([
-        [
-          date.getTime(),
-          new Map([
-            [0, 1],
-            [1, 1 + 2],
-            [2, 1 + 2 + 3],
-          ]),
-        ],
-      ])
-    );
+
+    const actual = calculateOffsetMaps(data);
+
+    expect(actual).toEqual([
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
+      {
+        positiveOffsets: new Map([[date.getTime(), 1]]),
+        negativeOffsets: new Map(),
+      },
+      {
+        positiveOffsets: new Map([[date.getTime(), 3]]),
+        negativeOffsets: new Map(),
+      },
+    ]);
   });
 
-  test('with numeric data', () => {
+  test('with number data', () => {
     const data = [[{ x: 1, y: 1 }], [{ x: 1, y: 2 }], [{ x: 1, y: 3 }]];
-    const computed = calculateStackedBarValues(data);
-    expect(computed).toEqual(
-      new Map([
-        [
-          1,
-          new Map([
-            [0, 1],
-            [1, 1 + 2],
-            [2, 1 + 2 + 3],
-          ]),
-        ],
-      ])
-    );
+
+    const actual = calculateOffsetMaps(data);
+
+    expect(actual).toEqual([
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
+      {
+        positiveOffsets: new Map([[1, 1]]),
+        negativeOffsets: new Map(),
+      },
+      {
+        positiveOffsets: new Map([[1, 3]]),
+        negativeOffsets: new Map(),
+      },
+    ]);
   });
 
   test('with mixed positive and negative numbers', () => {
@@ -135,34 +129,29 @@ describe('calculateStackedBarValues', () => {
         { x: 3, y: 10 },
       ],
     ];
-    const computed = calculateStackedBarValues(data);
-    expect(computed).toEqual(
-      new Map([
-        [
-          1,
-          new Map([
-            [0, -1],
-            [1, 2],
-            [2, 2 + 2],
-          ]),
-        ],
-        [
-          2,
-          new Map([
-            [0, 3],
-            [1, -3],
-            [2, -3 + -1],
-          ]),
-        ],
-        [
-          3,
-          new Map([
-            [0, -4],
-            [1, -4 + -4],
-            [2, 10],
-          ]),
-        ],
-      ])
-    );
+
+    const actual = calculateOffsetMaps(data);
+
+    expect(actual).toEqual([
+      { positiveOffsets: new Map(), negativeOffsets: new Map() },
+      {
+        positiveOffsets: new Map([[2, 3]]),
+        negativeOffsets: new Map([
+          [1, -1],
+          [3, -4],
+        ]),
+      },
+      {
+        positiveOffsets: new Map([
+          [1, 2],
+          [2, 3],
+        ]),
+        negativeOffsets: new Map([
+          [1, -1],
+          [2, -3],
+          [3, -8],
+        ]),
+      },
+    ]);
   });
 });

--- a/src/mixed-line-bar-chart/data-series.tsx
+++ b/src/mixed-line-bar-chart/data-series.tsx
@@ -10,7 +10,7 @@ import BarSeries from './bar-series';
 import { ChartDataTypes, InternalChartSeries, MixedLineBarChartProps } from './interfaces';
 
 import styles from './styles.css.js';
-import { calculateStackedBarValues } from './utils';
+import { calculateOffsetMaps, StackedOffsets } from './utils';
 
 // Should have the same value as the `border-line-chart-width` token.
 const STROKE_WIDTH = 2;
@@ -49,10 +49,11 @@ export default function DataSeries<T extends ChartDataTypes>({
   // Lines get a small extra space at the top and bottom to account for the strokes when they are at the edge of the graph.
   const lineAreaClipPath = useUniqueId('awsui-line-chart__chart-area-');
 
-  const stackedBarValues = useMemo(() => {
+  const stackedBarOffsetMaps: StackedOffsets[] = useMemo(() => {
     if (!stackedBars) {
-      return undefined;
+      return [];
     }
+
     const barData: Array<readonly MixedLineBarChartProps.Datum<ChartDataTypes>[]> = [];
     visibleSeries.forEach(({ series }) => {
       if (series.type === 'bar') {
@@ -61,7 +62,7 @@ export default function DataSeries<T extends ChartDataTypes>({
         barData.push([]);
       }
     });
-    return calculateStackedBarValues(barData);
+    return calculateOffsetMaps(barData);
   }, [visibleSeries, stackedBars]);
 
   return (
@@ -119,7 +120,7 @@ export default function DataSeries<T extends ChartDataTypes>({
                   highlighted={isHighlighted}
                   dimmed={isDimmed}
                   chartAreaClipPath={chartAreaClipPath}
-                  stackedBarValues={stackedBarValues}
+                  stackedBarOffsets={stackedBarOffsetMaps[index]}
                   highlightedGroupIndex={highlightedGroupIndex}
                 />
               );

--- a/src/mixed-line-bar-chart/utils.ts
+++ b/src/mixed-line-bar-chart/utils.ts
@@ -67,31 +67,47 @@ export const matchesX = <T>(x1: T, x2: T) => {
   return x1 === x2;
 };
 
-export type StackedBarValues = Map<string | number, Map<number, number>>;
+export type OffsetMap = Map<string | number, number>;
 
-// Unlike for regular bars, stacked bar series values depend on the predecessors.
-// The function computes all stacked values grouped by X and series index.
-export function calculateStackedBarValues(
-  dataBySeries: Array<readonly MixedLineBarChartProps.Datum<ChartDataTypes>[]>
-): StackedBarValues {
-  const negativeValues = new Map<string | number, number>();
-  const positiveValues = new Map<string | number, number>();
-  const values = new Map<string | number, Map<number, number>>();
-  for (let seriesIndex = 0; seriesIndex < dataBySeries.length; seriesIndex++) {
-    for (const datum of dataBySeries[seriesIndex]) {
-      const key = getKeyValue(datum.x);
-      if (datum.y < 0) {
-        negativeValues.set(key, (negativeValues.get(key) ?? 0) + datum.y);
-      } else {
-        positiveValues.set(key, (positiveValues.get(key) ?? 0) + datum.y);
-      }
-      const seriesValue = (datum.y < 0 ? negativeValues.get(key) : positiveValues.get(key)) ?? 0;
-      const valuesByIndex = values.get(key) ?? new Map<number, number>();
-      valuesByIndex.set(seriesIndex, seriesValue);
-      values.set(key, valuesByIndex);
+export interface StackedOffsets {
+  positiveOffsets: OffsetMap;
+  negativeOffsets: OffsetMap;
+}
+
+/**
+ * Calculates list of offset maps from all data by accumulating each value
+ */
+export function calculateOffsetMaps(
+  data: Array<readonly MixedLineBarChartProps.Datum<ChartDataTypes>[]>
+): StackedOffsets[] {
+  return data.reduce((acc, curr, idx) => {
+    // First series receives empty offsets map
+    if (idx === 0) {
+      acc.push({ positiveOffsets: new Map(), negativeOffsets: new Map() });
     }
-  }
-  return values;
+    const lastMap = acc[idx];
+    const map: StackedOffsets = lastMap
+      ? { positiveOffsets: new Map(lastMap.positiveOffsets), negativeOffsets: new Map(lastMap.negativeOffsets) }
+      : { positiveOffsets: new Map(), negativeOffsets: new Map() };
+
+    curr.forEach(({ x, y }) => {
+      const key = getKeyValue(x);
+      if (y < 0) {
+        const lastValue = lastMap?.negativeOffsets.get(key) || 0;
+        map.negativeOffsets.set(key, lastValue + y);
+      } else {
+        const lastValue = lastMap?.positiveOffsets.get(key) || 0;
+        map.positiveOffsets.set(key, lastValue + y);
+      }
+    });
+
+    // Ignore last value for map but still run it for logging
+    if (idx < data.length - 1) {
+      acc.push(map);
+    }
+
+    return acc;
+  }, [] as StackedOffsets[]);
 }
 
 /** Returns string or number value for ChartDataTypes key */


### PR DESCRIPTION
### Description

Reverting PR https://github.com/cloudscape-design/components/pull/2171 due to unexpected performance impact.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
