### PR TITLE
chore: Rename isRtl utility function to getIsRtl.

### DIFF
--- a/pages/app-layout/fill-content-area.page.tsx
+++ b/pages/app-layout/fill-content-area.page.tsx
@@ -8,7 +8,7 @@ import { Navigation, Tools, Breadcrumbs } from './utils/content-blocks';
 import * as toolsContent from './utils/tools-content';
 import labels from './utils/labels';
 import Box from '~components/box';
-import { isRtl } from '~components/internal/direction';
+import { getIsRtl } from '~components/internal/direction';
 
 export default function () {
   return (
@@ -35,7 +35,7 @@ function ContentFilling() {
           position: 'absolute',
           insetBlockStart: '50%',
           insetInlineStart: '50%',
-          transform: isRtl(document.body) ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
+          transform: getIsRtl(document.body) ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
         }}
       >
         <Box fontSize="heading-m">

--- a/pages/popover/container-test.page.tsx
+++ b/pages/popover/container-test.page.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import ScreenshotArea from '../utils/screenshot-area';
 import PopoverContainer from '~components/popover/container';
-import { isRtl } from '~components/internal/direction';
+import { getIsRtl } from '~components/internal/direction';
 import clsx from 'clsx';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -34,7 +34,11 @@ export default function () {
     <article>
       <h1>Popover container test</h1>
       <ScreenshotArea>
-        <svg width={500} height={500} style={{ margin: '20px', transform: isRtl(document.body) ? 'scaleX(-1)' : '' }}>
+        <svg
+          width={500}
+          height={500}
+          style={{ margin: '20px', transform: getIsRtl(document.body) ? 'scaleX(-1)' : '' }}
+        >
           {points.map(point => (
             <circle
               key={point.id}

--- a/src/app-layout/utils/use-pointer-events.ts
+++ b/src/app-layout/utils/use-pointer-events.ts
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import styles from '../styles.css.js';
 import { SizeControlProps } from './interfaces';
-import { isRtl, getLogicalClientX, getLogicalBoundingClientRect } from '../../internal/direction.js';
+import { getIsRtl, getLogicalClientX, getLogicalBoundingClientRect } from '../../internal/direction.js';
 
 export const usePointerEvents = ({
   position,
@@ -21,7 +21,7 @@ export const usePointerEvents = ({
       panelRef.current.classList.remove(styles['with-motion']);
 
       if (position === 'side') {
-        const mouseClientX = getLogicalClientX(event, isRtl(panelRef.current)) || 0;
+        const mouseClientX = getLogicalClientX(event, getIsRtl(panelRef.current)) || 0;
 
         // The handle offset aligns the cursor with the middle of the resize handle.
         const handleOffset = getLogicalBoundingClientRect(handleRef.current).inlineSize / 2;

--- a/src/internal/direction.ts
+++ b/src/internal/direction.ts
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export function isRtl(element: HTMLElement | SVGElement) {
+export function getIsRtl(element: HTMLElement | SVGElement) {
   return getComputedStyle(element).direction === 'rtl';
 }
 
 export function getOffsetInlineStart(element: HTMLElement) {
   const offsetParentWidth = element.offsetParent?.clientWidth ?? 0;
-  return isRtl(element) ? offsetParentWidth - element.offsetWidth - element.offsetLeft : element.offsetLeft;
+  return getIsRtl(element) ? offsetParentWidth - element.offsetWidth - element.offsetLeft : element.offsetLeft;
 }
 
 /**
@@ -17,7 +17,7 @@ export function getOffsetInlineStart(element: HTMLElement) {
  * systems using display scaling requiring the floor and ceiling calls.
  */
 export function getScrollInlineStart(element: HTMLElement) {
-  return isRtl(element) ? Math.floor(element.scrollLeft) * -1 : Math.ceil(element.scrollLeft);
+  return getIsRtl(element) ? Math.floor(element.scrollLeft) * -1 : Math.ceil(element.scrollLeft);
 }
 
 /**
@@ -42,7 +42,7 @@ export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) 
   const inlineSize = boundingClientRect.width;
   const insetBlockStart = boundingClientRect.top;
   const insetBlockEnd = boundingClientRect.bottom;
-  const insetInlineStart = isRtl(element)
+  const insetInlineStart = getIsRtl(element)
     ? document.documentElement.clientWidth - boundingClientRect.right
     : boundingClientRect.left;
   const insetInlineEnd = insetInlineStart + inlineSize;
@@ -63,7 +63,7 @@ export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) 
  * element directions.
  */
 export function getLogicalPageX(event: MouseEvent) {
-  return event.target instanceof HTMLElement && isRtl(event.target)
+  return event.target instanceof HTMLElement && getIsRtl(event.target)
     ? document.documentElement.clientWidth - event.pageX
     : event.pageX;
 }

--- a/src/internal/utils/handle-key.ts
+++ b/src/internal/utils/handle-key.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { KeyCode } from '../keycode';
-import { isRtl } from '../direction';
+import { getIsRtl } from '../direction';
 
 export function isEventLike(event: any): event is EventLike {
   return event.currentTarget instanceof HTMLElement;
@@ -58,7 +58,7 @@ export default function handleKey(
       onHome?.();
       break;
     case KeyCode.left:
-      isRtl(event.currentTarget) ? onInlineEnd?.() : onInlineStart?.();
+      getIsRtl(event.currentTarget) ? onInlineEnd?.() : onInlineStart?.();
       break;
     case KeyCode.pageDown:
       onPageDown?.();
@@ -67,7 +67,7 @@ export default function handleKey(
       onPageUp?.();
       break;
     case KeyCode.right:
-      isRtl(event.currentTarget) ? onInlineStart?.() : onInlineEnd?.();
+      getIsRtl(event.currentTarget) ? onInlineStart?.() : onInlineEnd?.();
       break;
     case KeyCode.up:
       onBlockStart?.();

--- a/src/table/resizer/index.tsx
+++ b/src/table/resizer/index.tsx
@@ -9,7 +9,7 @@ import { useStableCallback } from '@cloudscape-design/component-toolkit/internal
 import { useUniqueId } from '../../internal/hooks/use-unique-id';
 import { getHeaderWidth, getResizerElements } from './resizer-lookup';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context.js';
-import { isRtl, getLogicalBoundingClientRect, getLogicalPageX } from '../../internal/direction.js';
+import { getIsRtl, getLogicalBoundingClientRect, getLogicalPageX } from '../../internal/direction.js';
 import handleKey, { isEventLike } from '../../internal/utils/handle-key';
 
 interface ResizerProps {
@@ -101,7 +101,7 @@ export function Resizer({
       autoGrowTimeout.current = setTimeout(onAutoGrow, AUTO_GROW_INTERVAL);
       // callbacks must be the last calls in the handler, because they may cause an extra update
       updateColumnWidth(inlineSize + AUTO_GROW_INCREMENT);
-      elements.scrollParent.scrollLeft += AUTO_GROW_INCREMENT * (isRtl(elements.scrollParent) ? -1 : 1);
+      elements.scrollParent.scrollLeft += AUTO_GROW_INCREMENT * (getIsRtl(elements.scrollParent) ? -1 : 1);
     };
 
     const onMouseMove = (event: MouseEvent) => {

--- a/src/tabs/scroll-utils.ts
+++ b/src/tabs/scroll-utils.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import smoothScroll from './smooth-scroll';
-import { isRtl, getScrollInlineStart } from '../internal/direction';
+import { getIsRtl, getScrollInlineStart } from '../internal/direction';
 
 export const onPaginationClick = (
   headerBarRef: React.RefObject<HTMLUListElement>,
@@ -22,7 +22,7 @@ export const onPaginationClick = (
       : Math.max(Math.abs(scrollLeft) - paginatedSectionSize, 0);
 
   // scroll destination needs to be a negative number if the direction is RTL
-  const scrollTo = isRtl(element) ? scrollDistance * -1 : scrollDistance;
+  const scrollTo = getIsRtl(element) ? scrollDistance * -1 : scrollDistance;
 
   smoothScroll(element, scrollTo);
 };


### PR DESCRIPTION
This is a minor name change to remove conflicts with instances of `isRtl` as a boolean parameter or the necessity to import `isRtl` as `getIsRtl` in functions where the value assignment is used in multiple places.