### PR TITLE
feat: add generateThemeStylesheet API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 node_modules
 coverage
 backstop/report
+.idea
 # build output
 lib
 # generated sources

--- a/pages/theming/integration.page.tsx
+++ b/pages/theming/integration.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
 import { Button, Link, SpaceBetween } from '~components';
-import { Theme, applyTheme } from '~components/theming';
+import { Theme, applyTheme, generateThemeStylesheet } from '~components/theming';
 import * as Tokens from '~design-tokens';
 import ScreenshotArea from '../utils/screenshot-area';
 
@@ -35,15 +35,31 @@ const theme: Theme = {
 export default function () {
   const [themed, setThemed] = useState<boolean>(false);
   const [secondaryTheme, setSecondaryTheme] = useState<boolean>(false);
+  const [themeMethod, setThemeMethod] = useState<'applyTheme' | 'generateThemeStylesheet'>('applyTheme');
 
   useEffect(() => {
     let reset: () => void = () => {};
     if (themed) {
-      const result = applyTheme({ theme, baseThemeId: secondaryTheme ? 'visual-refresh' : undefined });
-      reset = result.reset;
+      if (themeMethod === 'applyTheme') {
+        const result = applyTheme({ theme, baseThemeId: secondaryTheme ? 'visual-refresh' : undefined });
+        reset = result.reset;
+      } else {
+        const stylesheet = generateThemeStylesheet({
+          theme,
+          baseThemeId: secondaryTheme ? 'visual-refresh' : undefined,
+        });
+
+        const styleNode = document.createElement('style');
+        styleNode.appendChild(document.createTextNode(stylesheet));
+        document.head.appendChild(styleNode);
+
+        reset = () => {
+          styleNode.remove();
+        };
+      }
     }
     return reset;
-  }, [themed, secondaryTheme]);
+  }, [themed, secondaryTheme, themeMethod]);
   return (
     <div style={{ padding: 15 }}>
       <h1>Theming Integration Page</h1>
@@ -66,6 +82,16 @@ export default function () {
           onChange={evt => setSecondaryTheme(evt.currentTarget.checked)}
         />
         <span style={{ marginLeft: 5 }}>Secondary theme</span>
+      </label>
+      <label>
+        <input
+          style={{ marginLeft: 15 }}
+          type="checkbox"
+          data-testid="change-theme-method"
+          checked={themeMethod === 'applyTheme'}
+          onChange={evt => setThemeMethod(evt.currentTarget.checked ? 'applyTheme' : 'generateThemeStylesheet')}
+        />
+        <span style={{ marginLeft: 5 }}>Use applyTheme</span>
       </label>
       <ScreenshotArea>
         <SpaceBetween direction="vertical" size="m">

--- a/pages/theming/tokens.page.tsx
+++ b/pages/theming/tokens.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useEffect, useState } from 'react';
-import { Theme, applyTheme } from '~components/theming';
+import { Theme, applyTheme, generateThemeStylesheet } from '~components/theming';
 import * as Tokens from '~design-tokens';
 import { preset } from '~components/internal/generated/theming';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -26,15 +26,29 @@ const tiles: Tile[] = themeableColorTokens
 export default function () {
   const [themed, setThemed] = useState<boolean>(false);
   const [secondaryTheme, setSecondaryTheme] = useState<boolean>(false);
+  const [themeMethod, setThemeMethod] = useState<'applyTheme' | 'generateThemeStylesheet'>('applyTheme');
 
   useEffect(() => {
     let reset: () => void = () => {};
-    if (themed) {
+    if (themeMethod === 'applyTheme') {
       const result = applyTheme({ theme, baseThemeId: secondaryTheme ? 'visual-refresh' : undefined });
       reset = result.reset;
+    } else {
+      const stylesheet = generateThemeStylesheet({
+        theme,
+        baseThemeId: secondaryTheme ? 'visual-refresh' : undefined,
+      });
+
+      const styleNode = document.createElement('style');
+      styleNode.appendChild(document.createTextNode(stylesheet));
+      document.head.appendChild(styleNode);
+
+      reset = () => {
+        styleNode.remove();
+      };
     }
     return reset;
-  }, [themed, secondaryTheme]);
+  }, [themed, secondaryTheme, themeMethod]);
   return (
     <div style={{ padding: 15, backgroundColor: 'white' }}>
       <h1 className={styles.title}>Color Token Mosaik</h1>
@@ -56,6 +70,16 @@ export default function () {
           onChange={evt => setSecondaryTheme(evt.currentTarget.checked)}
         />
         <span style={{ marginLeft: 5 }}>Secondary theme</span>
+      </label>
+      <label>
+        <input
+          style={{ marginLeft: 15 }}
+          type="checkbox"
+          data-testid="change-theme-method"
+          checked={themeMethod === 'applyTheme'}
+          onChange={evt => setThemeMethod(evt.currentTarget.checked ? 'applyTheme' : 'generateThemeStylesheet')}
+        />
+        <span style={{ marginLeft: 5 }}>Use applyTheme</span>
       </label>
       <ScreenshotArea>
         <Mosaik tiles={tiles} />

--- a/src/theming/__integ__/index.test.ts
+++ b/src/theming/__integ__/index.test.ts
@@ -10,6 +10,9 @@ class ThemingPage extends BasePageObject {
   switchTheme() {
     return this.click('[data-testid="change-theme"]');
   }
+  switchThemeMethod() {
+    return this.click('[data-testid="change-theme-method"]');
+  }
   toggleDarkMode() {
     return this.click('#mode-toggle');
   }
@@ -55,11 +58,16 @@ const linkTextColor = {
   test(
     `applies theme to components${vr ? ' in Visual Refresh' : ''}`,
     setupTest(async page => {
-      // Using a component is not ideal. Changes to the component will effect this test case.
+      // Using a component is not ideal. Changes to the component will affect this test case.
       await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.light);
       await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.light);
 
       await page.switchTheme();
+
+      await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.light);
+      await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.light);
+
+      await page.switchThemeMethod();
 
       await expect(page.getButtonBackgroundColor()).resolves.toBe(buttonBackgroundColor.light);
       await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.light);
@@ -70,6 +78,11 @@ const linkTextColor = {
       await expect(page.getLinkTextColor()).resolves.toBe(linkTextColor.dark);
 
       await page.switchTheme();
+
+      await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.dark);
+      await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
+
+      await page.switchThemeMethod();
 
       await expect(page.getButtonBackgroundColor()).resolves.not.toBe(buttonBackgroundColor.dark);
       await expect(page.getLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
@@ -85,11 +98,19 @@ const linkTextColor = {
 
       await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.light);
 
+      await page.switchThemeMethod();
+
+      await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.light);
+
       await page.toggleDarkMode();
 
       await expect(page.getFakeLinkTextColor()).resolves.toBe(linkTextColor.dark);
 
       await page.switchTheme();
+
+      await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
+
+      await page.switchThemeMethod();
 
       await expect(page.getFakeLinkTextColor()).resolves.not.toBe(linkTextColor.dark);
     }, vr)

--- a/src/theming/__integ__/tokens.test.ts
+++ b/src/theming/__integ__/tokens.test.ts
@@ -24,6 +24,9 @@ class ColorTokensMosaikPage extends BasePageObject {
   switchTheme() {
     return this.click('[data-testid="change-theme"]');
   }
+  switchThemeMethod() {
+    return this.click('[data-testid="change-theme-method"]');
+  }
   setSecondaryTheme() {
     return this.click('[data-testid="set-secondary"]');
   }
@@ -38,11 +41,16 @@ class ColorTokensMosaikPage extends BasePageObject {
   }
 }
 
-const setupTest = (testFn: (page: ColorTokensMosaikPage) => Promise<void>, vr?: boolean) => {
+type ThemeMethod = 'applyTheme' | 'generateThemeStylesheet';
+
+const setupTest = (testFn: (page: ColorTokensMosaikPage) => Promise<void>, vr: boolean, themeMethod: ThemeMethod) => {
   return useBrowser(async browser => {
     const page = new ColorTokensMosaikPage(browser);
     await browser.url(`#/light/theming/tokens${!vr ? '?visualRefresh=false' : ''}`);
     await page.switchTheme();
+    if (themeMethod === 'generateThemeStylesheet') {
+      await page.switchThemeMethod();
+    }
     if (vr) {
       await page.setSecondaryTheme();
     }
@@ -64,81 +72,115 @@ const darkMap = colorTokens.reduce((acc, current) => {
   return acc;
 }, {} as Record<string, string>);
 
-test(
-  'applies theming in default',
-  setupTest(async page => {
-    const actual = await page.getCustomPropertyMap();
+describe.each<[ThemeMethod]>([['applyTheme'], ['generateThemeStylesheet']])('using %s', (themeMethod: ThemeMethod) => {
+  test(
+    'applies theming in default',
+    setupTest(
+      async page => {
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(defaultMap);
-  })
-);
-test(
-  'applies theming in compact density',
-  setupTest(async page => {
-    await page.toggleCompactDensity();
+        expect(actual).toMatchObject(defaultMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in compact density',
+    setupTest(
+      async page => {
+        await page.toggleCompactDensity();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(defaultMap);
-  })
-);
-test(
-  'applies theming in disabled motion',
-  setupTest(async page => {
-    await page.toggleDisabledMotion();
+        expect(actual).toMatchObject(defaultMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in disabled motion',
+    setupTest(
+      async page => {
+        await page.toggleDisabledMotion();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(defaultMap);
-  })
-);
-test(
-  'applies theming in dark mode',
-  setupTest(async page => {
-    await page.toggleDarkMode();
+        expect(actual).toMatchObject(defaultMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in dark mode',
+    setupTest(
+      async page => {
+        await page.toggleDarkMode();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(darkMap);
-  })
-);
-test(
-  'applies theming in dark mode + compact mode',
-  setupTest(async page => {
-    await page.toggleDarkMode();
-    await page.toggleCompactDensity();
+        expect(actual).toMatchObject(darkMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in dark mode + compact mode',
+    setupTest(
+      async page => {
+        await page.toggleDarkMode();
+        await page.toggleCompactDensity();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(darkMap);
-  })
-);
-test(
-  'applies theming in dark mode + reduced motion',
-  setupTest(async page => {
-    await page.toggleDarkMode();
-    await page.toggleDisabledMotion();
+        expect(actual).toMatchObject(darkMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in dark mode + reduced motion',
+    setupTest(
+      async page => {
+        await page.toggleDarkMode();
+        await page.toggleDisabledMotion();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(darkMap);
-  })
-);
-test(
-  'applies theming in visual refresh',
-  setupTest(async page => {
-    const actual = await page.getCustomPropertyMap();
+        expect(actual).toMatchObject(darkMap);
+      },
+      false,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in visual refresh',
+    setupTest(
+      async page => {
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(defaultMap);
-  }, true)
-);
-test(
-  'applies theming in dark mode + visual refresh',
-  setupTest(async page => {
-    await page.toggleDarkMode();
+        expect(actual).toMatchObject(defaultMap);
+      },
+      true,
+      themeMethod
+    )
+  );
+  test(
+    'applies theming in dark mode + visual refresh',
+    setupTest(
+      async page => {
+        await page.toggleDarkMode();
 
-    const actual = await page.getCustomPropertyMap();
+        const actual = await page.getCustomPropertyMap();
 
-    expect(actual).toMatchObject(darkMap);
-  }, true)
-);
+        expect(actual).toMatchObject(darkMap);
+      },
+      true,
+      themeMethod
+    )
+  );
+});

--- a/src/theming/__tests__/index.test.ts
+++ b/src/theming/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Theme, applyTheme } from '../../../lib/components/theming';
+import { Theme, applyTheme, generateThemeStylesheet } from '../../../lib/components/theming';
 
 const findStyleNode = () => document.head.querySelector('style');
 const attachNonceMetaElement = (nonce: string) => {
@@ -36,4 +36,8 @@ test('applyTheme respects nonce meta elements', () => {
   applyTheme({ theme });
 
   expect(findStyleNode()).toHaveAttribute('nonce', nonce);
+});
+
+test('generateThemeStylesheet returns the theme override stylesheet as a string', () => {
+  expect(generateThemeStylesheet({ theme })).toEqual(expect.any(String));
 });

--- a/src/theming/index.ts
+++ b/src/theming/index.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { applyTheme as coreApplyTheme } from '@cloudscape-design/theming-runtime';
+import {
+  applyTheme as coreApplyTheme,
+  generateThemeStylesheet as coreGenerateThemeStylesheet,
+} from '@cloudscape-design/theming-runtime';
 import { preset, TypedOverride } from '../internal/generated/theming';
 
 export type Theme = TypedOverride;
@@ -15,6 +18,19 @@ export interface ApplyThemeResult {
 
 export function applyTheme({ theme, baseThemeId }: ApplyThemeParams): ApplyThemeResult {
   return coreApplyTheme({
+    override: theme,
+    preset,
+    baseThemeId,
+  });
+}
+
+export interface GenerateThemeStylesheetParams {
+  theme: Theme;
+  baseThemeId?: string;
+}
+
+export function generateThemeStylesheet({ theme, baseThemeId }: GenerateThemeStylesheetParams): string {
+  return coreGenerateThemeStylesheet({
     override: theme,
     preset,
     baseThemeId,


### PR DESCRIPTION
### Description
Expose `generateThemeStylesheet` API added to `@cloudscape-design/theming-core`:

Related links, issue #, if available:
* https://github.com/cloudscape-design/theming-core/pull/75
* https://github.com/cloudscape-design/theming-core/pull/77

### How has this been tested?
I've tested this API with my application which consumes it, and I've added unit & integration tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
