### PR TITLE
chore: Fix flaky code-editor screenshot test

### DIFF
--- a/backstop.config.js
+++ b/backstop.config.js
@@ -15,6 +15,8 @@ const scenarios = findAllPages()
   .filter(pageName => pageName.indexOf('permutations') !== -1 && skippedTests.indexOf(pageName) === -1)
   .map(pageName => ({
     label: pageName,
+    // wait until code-editor is fully loaded and rendered error state
+    readySelector: pageName === 'code-editor/permutations' ? '.ace_error' : undefined,
     url: `http://localhost:8080/#/light/${pageName}`,
     delay: 1000,
   }));


### PR DESCRIPTION
### Description

Wait for code-editor error state before taking a screenshot.

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
