### PR TITLE
chore: Pass analytics instance identifier for parents down to methods

### DIFF
--- a/pages/funnel-analytics/mock-funnel.ts
+++ b/pages/funnel-analytics/mock-funnel.ts
@@ -34,34 +34,34 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   funnelStepStart(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepStart', props, resolvedProps: { stepName } });
   },
 
   funnelStepComplete(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepComplete', props, resolvedProps: { stepName } });
   },
 
   funnelStepNavigation(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     // const subStepAllElements = document.querySelectorAll(props.subStepAllSelector); // TODO: Does not work
 
     funnelMetricsLog.push({ action: 'funnelStepNavigation', props, resolvedProps: { stepName } });
   },
 
   funnelStepError(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepError', props, resolvedProps: { stepName } });
   },
 
   funnelStepChange(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     funnelMetricsLog.push({ action: 'funnelStepChange', props, resolvedProps: { stepName } });
   },
 
   funnelSubStepStart(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
     const subStepElement = document.querySelector(props.subStepSelector);
@@ -74,7 +74,7 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   funnelSubStepComplete(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
     const subStepElement = document.querySelector(props.subStepSelector);
@@ -87,7 +87,7 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   funnelSubStepError(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const fieldLabel = document.querySelector(props.fieldLabelSelector!)?.innerHTML;
     const fieldError = document.querySelector(props.fieldErrorSelector!)?.innerHTML;
@@ -100,7 +100,7 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   helpPanelInteracted(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepElement = document.querySelectorAll(props.subStepSelector);
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);
@@ -114,7 +114,7 @@ export const MockedFunnelMetrics: IFunnelMetrics = {
   },
 
   externalLinkInteracted(props): void {
-    const stepName = document.querySelector(props.stepNameSelector)?.innerHTML;
+    const stepName = document.querySelector(props.stepNameSelector!)?.innerHTML;
     const subStepName = document.querySelector(props.subStepNameSelector)?.innerHTML;
     const subStepElement = document.querySelectorAll(props.subStepSelector);
     const subStepAllElements = document.querySelectorAll(props.subStepAllSelector);

--- a/pages/funnel-analytics/static-multi-page-flow.page.tsx
+++ b/pages/funnel-analytics/static-multi-page-flow.page.tsx
@@ -40,7 +40,10 @@ export default function MultiPageCreate() {
         <SpaceBetween size="s">
           <Container
             header={<Header>Container 1 - header</Header>}
-            {...getAnalyticsProps({ instanceIdentifier: 'step1-container1' })}
+            {...getAnalyticsProps({
+              instanceIdentifier: 'step1-container1',
+              errorContext: value === 'error' ? 'errors.fields' : undefined,
+            })}
           >
             <SpaceBetween size="s">
               <FormField
@@ -51,6 +54,10 @@ export default function MultiPageCreate() {
                 }
                 errorText={value === 'error' ? 'Trigger error' : ''}
                 label="Field 1"
+                {...getAnalyticsProps({
+                  instanceIdentifier: 'field1',
+                  errorContext: value === 'error' ? 'errors.triggered' : undefined,
+                })}
               >
                 <Input
                   data-testid="field1"
@@ -114,7 +121,7 @@ export default function MultiPageCreate() {
     {
       title: 'Step 3',
       info: <Link variant="info">Info</Link>,
-      errorText,
+      errorText: 'Simulated final step error',
       content: (
         <div className={styles['step-content']}>
           {Array.from(Array(15).keys()).map(key => (
@@ -124,7 +131,7 @@ export default function MultiPageCreate() {
           ))}
         </div>
       ),
-      ...getAnalyticsProps({ instanceIdentifier: 'step-3' }),
+      ...getAnalyticsProps({ instanceIdentifier: 'step-3', errorContext: 'errors.validation' }),
     },
   ];
 
@@ -147,7 +154,7 @@ export default function MultiPageCreate() {
       {mounted && (
         <Wizard
           {...getAnalyticsProps({
-            instanceIdentifier: 'multi-page',
+            instanceIdentifier: 'multi-page-demo',
             flowType: 'create',
           })}
           i18nStrings={i18nStrings}

--- a/pages/funnel-analytics/static-single-page-flow.page.tsx
+++ b/pages/funnel-analytics/static-single-page-flow.page.tsx
@@ -85,8 +85,9 @@ export default function StaticSinglePageCreatePage() {
       {mounted && (
         <Form
           {...getAnalyticsProps({
-            instanceIdentifier: 'single-page',
+            instanceIdentifier: 'single-page-demo',
             flowType: 'create',
+            ...(errorText ? { errorContext: 'errors.validation' } : {}),
           })}
           errorText={errorText}
           actions={
@@ -136,6 +137,7 @@ export default function StaticSinglePageCreatePage() {
               }
               {...getAnalyticsProps({
                 instanceIdentifier: 'container-1',
+                errorContext: value === 'error' ? 'errors.fields' : undefined,
               })}
             >
               <SpaceBetween size="s">
@@ -147,6 +149,10 @@ export default function StaticSinglePageCreatePage() {
                   }
                   errorText={value === 'error' ? 'Trigger error' : ''}
                   label="This is an ordinary text field"
+                  {...getAnalyticsProps({
+                    instanceIdentifier: 'field1',
+                    errorContext: value === 'error' ? 'errors.triggered' : undefined,
+                  })}
                 >
                   <Input
                     data-testid="field1"

--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -23,9 +23,10 @@ const Alert = React.forwardRef(
       analyticsMetadata
     );
 
-    const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
-    const { stepNumber, stepNameSelector } = useFunnelStep();
-    const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
+    const { funnelIdentifier, funnelInteractionId, funnelErrorContext, submissionAttempt, funnelState, errorCount } =
+      useFunnel();
+    const { stepNumber, stepNameSelector, stepIdentifier } = useFunnelStep();
+    const { subStepSelector, subStepNameSelector, subStepIdentifier, subStepErrorContext } = useFunnelSubStep();
 
     useEffect(() => {
       if (funnelInteractionId && visible && type === 'error' && funnelState.current !== 'complete') {
@@ -41,6 +42,8 @@ const Alert = React.forwardRef(
           if (subStepSelector) {
             FunnelMetrics.funnelSubStepError({
               funnelInteractionId,
+              funnelIdentifier,
+              stepIdentifier,
               subStepSelector,
               subStepName,
               subStepNameSelector,
@@ -48,12 +51,14 @@ const Alert = React.forwardRef(
               stepName,
               stepNameSelector,
               subStepAllSelector: getSubStepAllSelector(),
-              instanceIdentifier: analyticsMetadata?.instanceIdentifier,
-              errorContext: analyticsMetadata?.errorContext,
+              subStepIdentifier,
+              subStepErrorContext,
             });
           } else {
             FunnelMetrics.funnelError({
+              funnelIdentifier,
               funnelInteractionId,
+              funnelErrorContext,
             });
           }
         }

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -30,8 +30,8 @@ export default function Container({
 
   return (
     <AnalyticsFunnelSubStep
-      instanceIdentifier={analyticsMetadata?.instanceIdentifier}
-      errorContext={analyticsMetadata?.errorContext}
+      subStepIdentifier={analyticsMetadata?.instanceIdentifier}
+      subStepErrorContext={analyticsMetadata?.errorContext}
     >
       <InternalContainerAsSubstep
         variant={variant}

--- a/src/form-field/index.tsx
+++ b/src/form-field/index.tsx
@@ -11,12 +11,18 @@ import { FormFieldProps } from './interfaces';
 export { FormFieldProps };
 
 export default function FormField({ stretch = false, ...props }: FormFieldProps) {
-  const baseComponentProps = useBaseComponent(
-    'FormField',
-    { props: { stretch } },
-    getAnalyticsMetadataProps(props as BasePropsWithAnalyticsMetadata)
+  const analyticsMetadata = getAnalyticsMetadataProps(props as BasePropsWithAnalyticsMetadata);
+  const baseComponentProps = useBaseComponent('FormField', { props: { stretch } }, analyticsMetadata);
+
+  return (
+    <InternalFormField
+      stretch={stretch}
+      {...props}
+      __hideLabel={false}
+      __analyticsMetadata={analyticsMetadata}
+      {...baseComponentProps}
+    />
   );
-  return <InternalFormField stretch={stretch} {...props} __hideLabel={false} {...baseComponentProps} />;
 }
 
 applyDisplayName(FormField, 'FormField');

--- a/src/form-field/interfaces.ts
+++ b/src/form-field/interfaces.ts
@@ -3,6 +3,7 @@
 import { BaseComponentProps } from '../internal/base-component';
 import React from 'react';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { AnalyticsMetadata } from '../internal/analytics/interfaces';
 
 export interface FormFieldProps extends BaseComponentProps {
   /**
@@ -92,4 +93,5 @@ export interface InternalFormFieldProps extends FormFieldProps, InternalBaseComp
    * Disable the gutter applied by default.
    */
   __disableGutters?: boolean;
+  __analyticsMetadata?: AnalyticsMetadata;
 }

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -91,6 +91,7 @@ export default function InternalFormField({
   __hideLabel,
   __internalRootRef = null,
   __disableGutters = false,
+  __analyticsMetadata = undefined,
   ...rest
 }: InternalFormFieldProps) {
   const baseProps = getBaseProps(rest);
@@ -100,9 +101,9 @@ export default function InternalFormField({
   const generatedControlId = controlId || instanceUniqueId;
   const formFieldId = controlId || generatedControlId;
 
-  const { funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
-  const { stepNumber, stepNameSelector } = useFunnelStep();
-  const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
+  const { funnelIdentifier, funnelInteractionId, submissionAttempt, funnelState, errorCount } = useFunnel();
+  const { stepIdentifier, stepNumber, stepNameSelector } = useFunnelStep();
+  const { subStepErrorContext, subStepIdentifier, subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
   const slotIds = getSlotIds(formFieldId, label, description, constraintText, errorText);
 
@@ -140,15 +141,21 @@ export default function InternalFormField({
       if (errorIsVisible) {
         FunnelMetrics.funnelSubStepError({
           funnelInteractionId,
+          funnelIdentifier,
           subStepSelector,
           subStepName,
           subStepNameSelector,
+          subStepIdentifier,
           stepNumber,
           stepName,
           stepNameSelector,
+          stepIdentifier,
+          subStepErrorContext,
           fieldErrorSelector: `${getFieldSlotSeletor(slotIds.error)} .${styles.error__message}`,
           fieldLabelSelector: getFieldSlotSeletor(slotIds.label),
           subStepAllSelector: getSubStepAllSelector(),
+          fieldIdentifier: __analyticsMetadata?.instanceIdentifier,
+          fieldErrorContext: __analyticsMetadata?.errorContext,
         });
       }
 

--- a/src/form/__tests__/analytics.test.tsx
+++ b/src/form/__tests__/analytics.test.tsx
@@ -51,7 +51,7 @@ describe('Form Analytics', () => {
         funnelNameSelector: `.${headerStyles['heading-text']}`,
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
-        theme: expect.any(String),
+        componentTheme: expect.any(String),
         stepConfiguration: [{ isOptional: false, name: 'My funnel', number: 1 }],
       })
     );

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import { getBaseProps } from '../internal/base-component';
 import InternalAlert from '../alert/internal';
@@ -11,9 +11,6 @@ import { FormLayoutProps, FormProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import LiveRegion from '../internal/components/live-region';
 import { useInternalI18n } from '../i18n/context';
-
-import { useFunnel } from '../internal/analytics/hooks/use-funnel';
-import { FunnelMetrics } from '../internal/analytics';
 
 type InternalFormProps = FormProps & InternalBaseComponentProps;
 
@@ -31,19 +28,6 @@ export default function InternalForm({
   const baseProps = getBaseProps(props);
   const i18n = useInternalI18n('form');
   const errorIconAriaLabel = i18n('errorIconAriaLabel', errorIconAriaLabelOverride);
-
-  const { funnelInteractionId, submissionAttempt, errorCount } = useFunnel();
-
-  useEffect(() => {
-    if (funnelInteractionId && errorText) {
-      errorCount.current++;
-      FunnelMetrics.funnelError({ funnelInteractionId });
-      return () => {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        errorCount.current--;
-      };
-    }
-  }, [funnelInteractionId, errorText, submissionAttempt, errorCount]);
 
   return (
     <div {...baseProps} ref={__internalRootRef} className={clsx(styles.root, baseProps.className)}>

--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -12,6 +12,7 @@ declare const window: ExtendedWindow;
 
 const wrapper = createWrapper();
 const FUNNEL_INTERACTION_ID = 'mocked-funnel-id';
+const FUNNEL_IDENTIFIER = 'multi-page-demo';
 
 class MultiPageCreate extends BasePageObject {
   async getFunnelLog() {
@@ -49,27 +50,30 @@ describe('Multi-page create', () => {
         componentVersion: expect.any(String),
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         flowType: 'create',
         funnelType: 'multi-page',
         optionalStepNumbers: [2],
-        theme: 'vr',
+        componentTheme: 'vr',
         totalFunnelSteps: 3,
         stepConfiguration: [
           {
             name: 'Step 1',
             number: 1,
             isOptional: false,
+            stepIdentifier: 'step-1',
           },
           {
             name: 'Step 2',
             number: 2,
             isOptional: true,
+            stepIdentifier: 'step-2',
           },
           {
             name: 'Step 3',
             number: 3,
             isOptional: false,
+            stepIdentifier: 'step-3',
           },
         ],
       });
@@ -82,16 +86,19 @@ describe('Multi-page create', () => {
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: 'step-1',
         stepName: 'Step 1',
         subStepConfiguration: [
           {
             name: 'Container 1 - header',
             number: 1,
+            subStepIdentifier: 'step1-container1',
           },
           {
             name: 'Container 2 - header',
             number: 2,
+            subStepIdentifier: 'step1-container2',
           },
         ],
         stepNumber: 1,
@@ -123,11 +130,13 @@ describe('Multi-page create', () => {
         subStepAllSelector: expect.any(String),
         subStepNameSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepIdentifier: 'step-1',
         stepName: 'Step 1',
         subStepName: 'Container 1 - header',
         subStepNumber: 1,
+        subStepIdentifier: 'step1-container1',
         stepNumber: 1,
       });
       expect(funnelSubStep1StartEvent.resolvedProps).toEqual({
@@ -143,11 +152,13 @@ describe('Multi-page create', () => {
         subStepAllSelector: expect.any(String),
         subStepNameSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepIdentifier: 'step-1',
         stepName: 'Step 1',
         subStepName: 'Container 1 - header',
         subStepNumber: 1,
+        subStepIdentifier: 'step1-container1',
         stepNumber: 1,
       });
       expect(funnelSubStep1CompleteEvent.resolvedProps).toEqual({
@@ -162,12 +173,14 @@ describe('Multi-page create', () => {
         subStepAllSelector: expect.any(String),
         subStepNameSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        stepIdentifier: 'step-1',
         stepName: 'Step 1',
         subStepName: 'Container 2 - header',
         subStepNumber: 2,
         stepNumber: 1,
+        subStepIdentifier: 'step1-container2',
       });
       expect(funnelSubStep2StartEvent.resolvedProps).toEqual({
         subStepElement: expect.any(Object),
@@ -237,28 +250,18 @@ describe('Multi-page create', () => {
       await page.click(primaryButton); // Create
 
       const { funnelLog, actions } = await page.getFunnelLog();
-      expect(actions).toEqual([
-        'funnelStart',
-        'funnelStepStart', // Step 1 - Start
-        'funnelStepNavigation', // Navigate to Step 2
-        'funnelStepComplete', // Step 1 - Complete
-        'funnelStepStart', // Step 2 - Start
-        'funnelStepNavigation', // Navigate to Step 3
-        'funnelStepComplete', // Step 2 - Complete
-        'funnelStepStart', // Step 3 - Start
-        'funnelComplete',
-        'funnelSuccessful',
-        'funnelStepComplete', // TODO: This is the current order, it needs work :(
-      ]);
 
-      const funnelCompleteEvent = funnelLog[8];
-      const funnelSuccessfulEvent = funnelLog[9];
-
+      const funnelCompleteEventIndex = actions.findIndex(action => action === 'funnelComplete');
+      const funnelCompleteEvent = funnelLog[funnelCompleteEventIndex];
       expect(funnelCompleteEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
 
+      const funnelSucessEventIndex = actions.findIndex(action => action === 'funnelSuccessful');
+      const funnelSuccessfulEvent = funnelLog[funnelSucessEventIndex];
       expect(funnelSuccessfulEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
     })
@@ -281,6 +284,7 @@ describe('Multi-page create', () => {
       ]);
       const funnelCancelledEvent = funnelLog[5];
       expect(funnelCancelledEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
     })
@@ -295,6 +299,7 @@ describe('Multi-page create', () => {
 
       const funnelCancelledEvent = funnelLog[2];
       expect(funnelCancelledEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
     })
@@ -317,9 +322,15 @@ describe('Multi-page create', () => {
         subStepSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: 'step-1',
         stepName: 'Step 1',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
+        subStepIdentifier: 'step1-container1',
+        fieldErrorContext: 'errors.triggered',
+        fieldIdentifier: 'field1',
+        subStepErrorContext: 'errors.fields',
       });
 
       expect(funnelSubStepErrorEvent.resolvedProps).toEqual({
@@ -332,26 +343,19 @@ describe('Multi-page create', () => {
   );
 
   test(
-    'Wizard error',
+    'Emits a funnelError when an error is shown on the last step',
     setupTest(async page => {
-      await page.click('[data-testid=field1]');
-      await page.setValue(wrapper.findInput('[data-testid=field1]').findNativeInput().toSelector(), 'error');
-      await page.click(wrapper.findWizard().findPrimaryButton().toSelector());
+      const nextButton = wrapper.findWizard().findPrimaryButton().toSelector();
+      await page.click(nextButton); // Step 1 -> Step 2
+      await page.click(nextButton); // Step 2 -> Step 3 (Last step)
 
       const { funnelLog, actions } = await page.getFunnelLog();
-      expect(actions).toEqual([
-        'funnelStart',
-        'funnelStepStart',
-        'funnelSubStepStart',
-        'funnelSubStepError',
-        'funnelStepNavigation', // Navigation "attempt"
-        'funnelSubStepError', // FIXME: Should be a funnelStepError with error message
-        'funnelError',
-        'funnelSubStepComplete',
-      ]);
-      const funnelErrorEvent = funnelLog[6];
+      const funnelErrorIndex = actions.findIndex(entry => entry === 'funnelError');
+      const funnelErrorEvent = funnelLog[funnelErrorIndex];
       expect(funnelErrorEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelErrorContext: 'errors.validation',
       });
     })
   );

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -11,6 +11,8 @@ declare const window: ExtendedWindow;
 
 const wrapper = createWrapper();
 const FUNNEL_INTERACTION_ID = 'mocked-funnel-id';
+const FUNNEL_IDENTIFIER = 'single-page-demo';
+const STEP_IDENTIFIER = FUNNEL_IDENTIFIER;
 
 class SinglePageCreate extends BasePageObject {
   getFormAttribute(attribute: string) {
@@ -48,17 +50,18 @@ describe('Single-page create', () => {
         componentVersion: expect.any(String),
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         flowType: 'create',
         funnelType: 'single-page',
         optionalStepNumbers: [],
-        theme: 'vr',
+        componentTheme: 'vr',
         totalFunnelSteps: 1,
         stepConfiguration: [
           {
             name: 'Form Header',
             isOptional: false,
             number: 1,
+            stepIdentifier: FUNNEL_IDENTIFIER,
           },
         ],
       });
@@ -69,12 +72,13 @@ describe('Single-page create', () => {
       expect(funnelStepStartEvent.props).toEqual({
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
         stepName: 'Form Header',
         subStepConfiguration: [
-          { name: 'Container 1 - header', number: 1 },
-          { name: 'Container 2 - header', number: 2 },
+          { name: 'Container 1 - header', number: 1, subStepIdentifier: 'container-1' },
+          { name: 'Container 2 - header', number: 2, subStepIdentifier: 'container-2' },
         ],
         stepNumber: 1,
         totalSubSteps: 2,
@@ -106,8 +110,10 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-1',
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
@@ -127,8 +133,10 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-1',
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
@@ -148,8 +156,10 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-2',
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 2 - header',
@@ -169,8 +179,10 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         subStepSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-2',
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 2 - header',
@@ -201,17 +213,20 @@ describe('Single-page create', () => {
 
       const [, , funnelCompleteEvent, funnelSuccessfulEvent, funnelStepCompleteEvent] = funnelLog;
       expect(funnelCompleteEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
       expect(funnelSuccessfulEvent.props).toEqual({
+        funnelIdentifier: FUNNEL_IDENTIFIER,
         funnelInteractionId: FUNNEL_INTERACTION_ID,
       });
 
       expect(funnelStepCompleteEvent.props).toEqual({
         stepNameSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
-        instanceIdentifier: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
         stepName: 'Form Header',
         stepNumber: 1,
         totalSubSteps: 2,
@@ -232,6 +247,7 @@ describe('Single-page create', () => {
       const funnelCancelledEvent = funnelLog[2];
       expect(funnelCancelledEvent.props).toEqual({
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
       });
     })
   );
@@ -246,6 +262,7 @@ describe('Single-page create', () => {
       const [, , funnelCancelledEvent] = funnelLog;
       expect(funnelCancelledEvent.props).toEqual({
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
       });
     })
   );
@@ -267,9 +284,15 @@ describe('Single-page create', () => {
         subStepSelector: expect.any(String),
         subStepAllSelector: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-1',
         stepName: 'Form Header',
         stepNumber: 1,
         subStepName: 'Container 1 - header',
+        fieldErrorContext: 'errors.triggered',
+        fieldIdentifier: 'field1',
+        subStepErrorContext: 'errors.fields',
       });
 
       expect(funnelSubStepErrorEvent.resolvedProps).toEqual({
@@ -301,6 +324,8 @@ describe('Single-page create', () => {
       const funnelErrorEvent = funnelLog[5];
       expect(funnelErrorEvent.props).toEqual({
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        funnelErrorContext: 'errors.validation',
       });
     })
   );
@@ -320,6 +345,9 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepSelector: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-1',
         stepName: 'Form Header',
         subStepName: 'Container 1 - header',
         stepNumber: 1,
@@ -349,6 +377,9 @@ describe('Single-page create', () => {
         subStepNameSelector: expect.any(String),
         subStepSelector: expect.any(String),
         funnelInteractionId: FUNNEL_INTERACTION_ID,
+        funnelIdentifier: FUNNEL_IDENTIFIER,
+        stepIdentifier: STEP_IDENTIFIER,
+        subStepIdentifier: 'container-2',
         stepName: 'Form Header',
         subStepName: 'Container 2 - header',
         stepNumber: 1,
@@ -391,7 +422,7 @@ describe('Embedded Form', () => {
         funnelVersion: expect.any(String),
         funnelType: 'single-page',
         optionalStepNumbers: [],
-        theme: 'vr',
+        componentTheme: 'vr',
         totalFunnelSteps: 1,
         stepConfiguration: [
           {

--- a/src/internal/analytics/context/analytics-context.ts
+++ b/src/internal/analytics/context/analytics-context.ts
@@ -8,6 +8,9 @@ export type FunnelState = 'default' | 'validating' | 'complete' | 'cancelled';
 
 export interface FunnelContextValue {
   funnelInteractionId: string | undefined;
+  funnelIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  funnelErrorContext?: AnalyticsMetadata['errorContext'];
+  funnelFlowType?: AnalyticsMetadata['flowType'];
   funnelType: FunnelType;
   funnelNameSelector: string;
   optionalStepNumbers: number[];
@@ -26,7 +29,8 @@ export interface FunnelContextValue {
 }
 
 export interface FunnelStepContextValue {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  stepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  stepErrorContext?: AnalyticsMetadata['errorContext'];
   stepNameSelector: string;
   stepNumber: number;
   funnelStepProps?: Record<string, string | number | boolean | undefined>;
@@ -39,7 +43,8 @@ export interface FunnelStepContextValue {
 }
 
 export interface FunnelSubStepContextValue {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  subStepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  subStepErrorContext?: AnalyticsMetadata['errorContext'];
   subStepId: string;
   subStepSelector: string;
   subStepNameSelector: string;

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -29,11 +29,11 @@ import { nodeBelongs } from '../../utils/node-belongs';
  */
 export const useFunnelSubStep = () => {
   const context = useContext(FunnelSubStepContext);
-  const { funnelInteractionId, funnelState, latestFocusCleanupFunction } = useFunnel();
-  const { stepNumber, stepNameSelector, subStepConfiguration } = useFunnelStep();
+  const { funnelInteractionId, funnelIdentifier, funnelState, latestFocusCleanupFunction } = useFunnel();
+  const { stepNumber, stepIdentifier, stepNameSelector, subStepConfiguration } = useFunnelStep();
 
   const {
-    instanceIdentifier,
+    subStepIdentifier,
     subStepId,
     subStepSelector,
     subStepNameSelector,
@@ -74,12 +74,14 @@ export const useFunnelSubStep = () => {
         ?.get(stepNumber)
         ?.find(step => step.name === subStepName)?.number;
       FunnelMetrics.funnelSubStepStart({
-        instanceIdentifier,
+        funnelIdentifier,
         funnelInteractionId,
+        subStepIdentifier,
         subStepSelector,
         subStepNameSelector,
         subStepName,
         subStepNumber,
+        stepIdentifier,
         stepNumber,
         stepName,
         stepNameSelector,
@@ -107,12 +109,14 @@ export const useFunnelSubStep = () => {
 
         if (funnelState.current !== 'cancelled') {
           FunnelMetrics.funnelSubStepComplete({
-            instanceIdentifier,
+            funnelIdentifier,
             funnelInteractionId,
+            subStepIdentifier,
             subStepSelector,
             subStepNameSelector,
             subStepName,
             subStepNumber,
+            stepIdentifier,
             stepNumber,
             stepName,
             stepNameSelector,

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -1,31 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: Replace with correct type from component-toolkit
+export type FunnelType = 'single-page' | 'multi-page';
 export interface AnalyticsMetadata {
   instanceIdentifier?: string;
   flowType?: 'create' | 'edit';
   errorContext?: string;
 }
 
-export type FunnelType = 'single-page' | 'multi-page';
-
 // Common properties for all funnels
 export interface BaseFunnelProps {
+  funnelIdentifier?: AnalyticsMetadata['instanceIdentifier'];
   funnelInteractionId: string;
+  currentDocument?: Document;
 }
 
-export interface FunnelProps extends BaseFunnelProps {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
-  flowType?: AnalyticsMetadata['flowType'];
-  totalFunnelSteps: number;
-  optionalStepNumbers: number[];
-  funnelType: FunnelType;
-  funnelNameSelector?: string;
+export interface FunnelErrorProps extends BaseFunnelProps {
+  funnelErrorContext?: AnalyticsMetadata['errorContext'];
 }
 
-export interface FunnelStartProps {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+export interface FunnelStartProps extends Omit<BaseFunnelProps, 'funnelInteractionId'> {
   flowType?: AnalyticsMetadata['flowType'];
   funnelNameSelector: string;
   totalFunnelSteps: number;
@@ -34,7 +28,8 @@ export interface FunnelStartProps {
   funnelType: FunnelType;
   funnelVersion: string;
   componentVersion: string;
-  theme: string;
+  componentTheme: string;
+  funnelInteractionId?: string;
 }
 
 // A function type for a generic funnel method
@@ -45,19 +40,13 @@ export type FunnelStartMethod = (props: FunnelStartProps) => string;
 
 // Define individual method props by extending the base
 export interface FunnelStepProps extends BaseFunnelProps {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  stepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
   stepNumber: number;
   stepName?: string | undefined;
-  stepNameSelector: string;
+  stepNameSelector?: string;
   subStepAllSelector: string;
-}
-
-export interface FunnelStepStartProps extends FunnelStepProps {
   totalSubSteps?: number;
   subStepConfiguration?: SubStepConfiguration[];
-}
-export interface FunnelStepCompleteProps extends FunnelStepProps {
-  totalSubSteps?: number;
 }
 
 export interface FunnelStepNavigationProps extends FunnelStepProps {
@@ -67,12 +56,12 @@ export interface FunnelStepNavigationProps extends FunnelStepProps {
 }
 
 export interface FunnelStepErrorProps extends FunnelStepProps {
+  stepErrorContext?: AnalyticsMetadata['errorContext'];
   stepErrorSelector: string;
-  errorContext?: AnalyticsMetadata['errorContext'];
 }
 
 export interface FunnelSubStepProps extends FunnelStepProps {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  subStepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
   subStepSelector: string;
   subStepName?: string | undefined;
   subStepNameSelector: string;
@@ -80,15 +69,19 @@ export interface FunnelSubStepProps extends FunnelStepProps {
 }
 
 export interface FunnelSubStepErrorProps extends FunnelSubStepProps {
+  subStepErrorContext?: AnalyticsMetadata['errorContext'];
+  fieldIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  fieldErrorContext?: AnalyticsMetadata['errorContext'];
   fieldLabelSelector: string;
   fieldErrorSelector: string;
-  errorContext?: AnalyticsMetadata['errorContext'];
 }
 
 export interface OptionalFunnelSubStepErrorProps extends FunnelSubStepProps {
+  subStepErrorContext?: AnalyticsMetadata['errorContext'];
+  fieldIdentifier?: AnalyticsMetadata['instanceIdentifier'];
+  fieldErrorContext?: AnalyticsMetadata['errorContext'];
   fieldLabelSelector?: string;
   fieldErrorSelector?: string;
-  errorContext?: AnalyticsMetadata['errorContext'];
 }
 
 export interface FunnelLinkInteractionProps extends FunnelSubStepProps {
@@ -99,29 +92,17 @@ export interface FunnelChangeProps extends BaseFunnelProps {
   stepConfiguration: StepConfiguration[];
 }
 
-export interface FunnelStepChangeProps extends BaseFunnelProps {
-  instanceIdentifier?: AnalyticsMetadata['instanceIdentifier'];
-  stepNumber: number;
-  stepName: string;
-  stepNameSelector: string;
-  subStepAllSelector: string;
-  totalSubSteps: number;
-  subStepConfiguration: SubStepConfiguration[];
-}
-
 export interface StepConfiguration {
   number: number;
   name: string;
   isOptional: boolean;
+  stepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
 }
 
 export interface SubStepConfiguration {
   number: number;
   name: string;
-}
-
-export interface FunnelErrorProps extends BaseFunnelProps {
-  errorContext?: AnalyticsMetadata['errorContext'];
+  subStepIdentifier?: AnalyticsMetadata['instanceIdentifier'];
 }
 
 // Define the interface using the method type
@@ -133,11 +114,11 @@ export interface IFunnelMetrics {
   funnelCancelled: FunnelMethod<BaseFunnelProps>;
   funnelChange: FunnelMethod<FunnelChangeProps>;
 
-  funnelStepStart: FunnelMethod<FunnelStepStartProps>;
-  funnelStepComplete: FunnelMethod<FunnelStepCompleteProps>;
+  funnelStepStart: FunnelMethod<FunnelStepProps>;
+  funnelStepComplete: FunnelMethod<FunnelStepProps>;
   funnelStepNavigation: FunnelMethod<FunnelStepNavigationProps>;
   funnelStepError: FunnelMethod<FunnelStepErrorProps>;
-  funnelStepChange: FunnelMethod<FunnelStepChangeProps>;
+  funnelStepChange: FunnelMethod<FunnelStepProps>;
 
   funnelSubStepStart: FunnelMethod<FunnelSubStepProps>;
   funnelSubStepComplete: FunnelMethod<FunnelSubStepProps>;

--- a/src/internal/base-component/index.ts
+++ b/src/internal/base-component/index.ts
@@ -40,6 +40,6 @@ export interface BasePropsWithAnalyticsMetadata {
   __analyticsMetadata?: AnalyticsMetadata;
 }
 
-export function getAnalyticsMetadataProps(props: BasePropsWithAnalyticsMetadata) {
-  return props.__analyticsMetadata;
+export function getAnalyticsMetadataProps(props?: BasePropsWithAnalyticsMetadata) {
+  return props?.__analyticsMetadata;
 }

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -69,9 +69,9 @@ const InternalLink = React.forwardRef(
 
     const infoLinkLabelFromContext = useContext(InfoLinkLabelContext);
 
-    const { funnelInteractionId } = useFunnel();
-    const { stepNumber, stepNameSelector } = useFunnelStep();
-    const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
+    const { funnelIdentifier, funnelInteractionId } = useFunnel();
+    const { stepIdentifier, stepNumber, stepNameSelector } = useFunnelStep();
+    const { subStepIdentifier, subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
     const fireFunnelEvent = (funnelInteractionId: string) => {
       if (variant === 'info') {
@@ -79,9 +79,12 @@ const InternalLink = React.forwardRef(
         const subStepName = getNameFromSelector(subStepNameSelector);
 
         FunnelMetrics.helpPanelInteracted({
+          funnelIdentifier,
           funnelInteractionId,
+          stepIdentifier,
           stepNumber,
           stepName,
+          subStepIdentifier,
           stepNameSelector,
           subStepSelector,
           subStepName,
@@ -94,10 +97,13 @@ const InternalLink = React.forwardRef(
         const subStepName = getNameFromSelector(subStepNameSelector);
 
         FunnelMetrics.externalLinkInteracted({
+          funnelIdentifier,
           funnelInteractionId,
+          stepIdentifier,
           stepNumber,
           stepName,
           stepNameSelector,
+          subStepIdentifier,
           subStepSelector,
           subStepName,
           subStepNameSelector,

--- a/src/wizard/__tests__/analytics.test.tsx
+++ b/src/wizard/__tests__/analytics.test.tsx
@@ -63,7 +63,7 @@ describe('Wizard Analytics', () => {
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
-        theme: expect.any(String),
+        componentTheme: expect.any(String),
         stepConfiguration: [
           { isOptional: false, name: 'Step 1', number: 1 },
           { isOptional: true, name: 'Step 2', number: 2 },
@@ -372,7 +372,7 @@ describe('Wizard Analytics', () => {
         funnelNameSelector: expect.any(String),
         funnelVersion: expect.any(String),
         componentVersion: expect.any(String),
-        theme: expect.any(String),
+        componentTheme: expect.any(String),
         stepConfiguration: [
           { isOptional: false, name: 'Step 1', number: 1 },
           { isOptional: true, name: 'Step 2', number: 2 },

--- a/src/wizard/analytics.ts
+++ b/src/wizard/analytics.ts
@@ -4,8 +4,13 @@
 import { useRef, useEffect } from 'react';
 import { FunnelMetrics } from '../internal/analytics';
 import { WizardProps } from './interfaces';
+import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
 
-export function useFunnelChangeEvent(funnelInteractionId: string | undefined, steps: WizardProps['steps']) {
+export function useFunnelChangeEvent(
+  funnelInteractionId: string | undefined,
+  funnelIdentifier: string | undefined,
+  steps: WizardProps['steps']
+) {
   const listenForStepChanges = useRef(false);
 
   useEffect(() => {
@@ -26,6 +31,7 @@ export function useFunnelChangeEvent(funnelInteractionId: string | undefined, st
 
     FunnelMetrics.funnelChange({
       funnelInteractionId,
+      funnelIdentifier,
       stepConfiguration: getStepConfiguration(steps),
     });
 
@@ -37,9 +43,14 @@ export function useFunnelChangeEvent(funnelInteractionId: string | undefined, st
 }
 
 export function getStepConfiguration(steps: WizardProps['steps']) {
-  return steps.map((step, index) => ({
-    name: step.title,
-    number: index + 1,
-    isOptional: step.isOptional ?? false,
-  }));
+  return steps.map((step, index) => {
+    const stepAnalyticsMetadata = getAnalyticsMetadataProps(step as BasePropsWithAnalyticsMetadata);
+
+    return {
+      name: step.title,
+      number: index + 1,
+      isOptional: step.isOptional ?? false,
+      stepIdentifier: stepAnalyticsMetadata?.instanceIdentifier,
+    };
+  });
 }

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -27,9 +27,9 @@ function Wizard({ isLoadingNextStep = false, allowSkipTo = false, ...props }: Wi
 
   return (
     <AnalyticsFunnel
-      instanceIdentifier={analyticsMetadata?.instanceIdentifier}
-      flowType={analyticsMetadata?.flowType}
-      errorContext={analyticsMetadata?.errorContext}
+      funnelIdentifier={analyticsMetadata?.instanceIdentifier}
+      funnelFlowType={analyticsMetadata?.flowType}
+      funnelErrorContext={analyticsMetadata?.errorContext}
       funnelType="multi-page"
       optionalStepNumbers={props.steps
         .map((step, index) => (step.isOptional ? index + 1 : -1))

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -56,7 +56,8 @@ export default function InternalWizard({
     controlledProp: 'activeStepIndex',
     changeHandler: 'onNavigate',
   });
-  const { funnelInteractionId, funnelSubmit, funnelCancel, funnelProps, funnelNextOrSubmitAttempt } = useFunnel();
+  const { funnelIdentifier, funnelInteractionId, funnelSubmit, funnelCancel, funnelProps, funnelNextOrSubmitAttempt } =
+    useFunnel();
   const actualActiveStepIndex = activeStepIndex ? Math.min(activeStepIndex, steps.length - 1) : 0;
 
   const farthestStepIndex = useRef<number>(actualActiveStepIndex);
@@ -101,7 +102,7 @@ export default function InternalWizard({
     }
   };
 
-  useFunnelChangeEvent(funnelInteractionId, steps);
+  useFunnelChangeEvent(funnelInteractionId, funnelIdentifier, steps);
 
   const i18n = useInternalI18n('wizard');
   const skipToButtonLabel = i18n(


### PR DESCRIPTION
### Description

This separates instance identifiers between funnel, steps and substeps to allow them to be passed in separately in the funnel event functions.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
