### PR TITLE
fix: drawers overflow too soon

### DIFF
--- a/src/app-layout/visual-refresh/universal-toolbar.scss
+++ b/src/app-layout/visual-refresh/universal-toolbar.scss
@@ -37,17 +37,25 @@ section.universal-toolbar {
   > .toolbar-container {
     block-size: 48px;
     align-items: center;
-    justify-content: space-between;
-    display: flex;
+    display: grid;
     column-gap: awsui.$space-static-xs;
+    inline-size: 100%;
+    grid-template-columns: min-content auto minmax(140px, 1fr);
+    grid-template-rows: var(#{custom-props.$toolbarHeight});
+
+    > .universal-toolbar-nav {
+      grid-column: 1;
+      padding-inline-end: awsui.$space-static-xxs;
+    }
 
     > .universal-toolbar-breadcrumbs {
-      padding-inline-start: awsui.$space-static-xxs;
+      grid-column: 2;
       background-color: transparent;
       flex: 1 0;
     }
 
     > .universal-toolbar-drawers {
+      grid-column: 3;
       column-gap: awsui.$space-static-xs;
       display: flex;
       justify-content: flex-end;


### PR DESCRIPTION
### Description

Fix drawers from collapsing when they still have room next to breadcrumbs.

Related links, issue #, if available: follow up from  [#2204](https://github.com/cloudscape-design/components/pull/2204)

### How has this been tested?


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
