### PR TITLE
feat: Add wrapTriggerText to popover

### DIFF
--- a/pages/popover/text-wrap.page.tsx
+++ b/pages/popover/text-wrap.page.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ScreenshotArea from '../utils/screenshot-area';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
-import { PopoverProps } from '~components/popover';
+import Popover, { PopoverProps } from '~components/popover';
 import PopoverBody, { PopoverBodyProps } from '~components/popover/body';
 
 const noop = () => {};
@@ -15,8 +15,19 @@ const sizeMap: Record<PopoverProps.Size, number> = {
   large: 480,
 };
 
-/* eslint-disable react/jsx-key */
-const permutations = createPermutations<PopoverBodyProps & { size: PopoverProps.Size }>([
+const triggerPermutations = createPermutations<PopoverProps & { size: PopoverProps.Size }>([
+  {
+    size: ['small', 'medium', 'large'],
+    children: [
+      'Hello!',
+      'Really long popover content with a lot of text that will probably overflow the popover trigger',
+      'Reallylongpopovercontentwithalotoftextbutnospacesthatwillprobablyoverflowthepopovertrigger',
+    ],
+    wrapTriggerText: [true, false],
+  },
+]);
+
+const bodyPermutations = createPermutations<PopoverBodyProps & { size: PopoverProps.Size }>([
   {
     size: ['small', 'medium', 'large'],
     header: [
@@ -40,7 +51,6 @@ const permutations = createPermutations<PopoverBodyProps & { size: PopoverProps.
     overflowVisible: ['both'],
   },
 ]);
-/* eslint-enable react/jsx-key */
 
 export default function () {
   return (
@@ -48,7 +58,21 @@ export default function () {
       <h1>Popover text wrapping</h1>
       <ScreenshotArea>
         <PermutationsView
-          permutations={permutations}
+          permutations={triggerPermutations}
+          render={({ size, ...permutation }) => (
+            <div
+              style={{
+                width: sizeMap[size],
+                maxWidth: sizeMap[size],
+              }}
+            >
+              <Popover {...permutation} />
+            </div>
+          )}
+        />
+
+        <PermutationsView
+          permutations={bodyPermutations}
           render={({ size, ...permutation }) => (
             <div
               style={{

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10638,6 +10638,14 @@ that don't have visible text, and to distinguish between multiple triggers with 
       "optional": true,
       "type": "string",
     },
+    Object {
+      "defaultValue": "true",
+      "description": "Specifies if the text trigger content should wrap. If you set it to false, it prevents the text from
+wrapping and truncates it with an ellipsis.",
+      "name": "wrapTriggerText",
+      "optional": true,
+      "type": "boolean",
+    },
   ],
   "regions": Array [
     Object {

--- a/src/popover/index.tsx
+++ b/src/popover/index.tsx
@@ -18,6 +18,7 @@ export default function Popover({
   triggerType = 'text',
   dismissButton = true,
   renderWithPortal = false,
+  wrapTriggerText = true,
   header,
   ...rest
 }: PopoverProps) {
@@ -40,6 +41,7 @@ export default function Popover({
       triggerType={triggerType}
       dismissButton={dismissButton}
       renderWithPortal={renderWithPortal}
+      wrapTriggerText={wrapTriggerText}
       {...externalProps}
       {...baseComponentProps}
     />

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -35,6 +35,12 @@ export interface PopoverProps extends BaseComponentProps {
   triggerAriaLabel?: string;
 
   /**
+   * Specifies if the text trigger content should wrap. If you set it to false, it prevents the text from
+   * wrapping and truncates it with an ellipsis.
+   */
+  wrapTriggerText?: boolean;
+
+  /**
    * Element that triggers the popover when selected by the user.
    * @displayname trigger
    */

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -47,6 +47,7 @@ function InternalPopover(
     content,
     triggerAriaLabel,
 
+    wrapTriggerText = true,
     renderWithPortal = false,
 
     __onOpen,
@@ -187,13 +188,14 @@ function InternalPopover(
       {triggerType === 'text' ? (
         <button
           {...triggerProps}
+          className={clsx(triggerProps.className, wrapTriggerText === false && styles['overflow-ellipsis'])}
           tabIndex={triggerTabIndex}
           type="button"
           aria-haspopup="dialog"
           id={referrerId}
           aria-label={triggerAriaLabel}
         >
-          <span className={styles['trigger-inner-text']}>{children}</span>
+          {children}
         </button>
       ) : (
         <span {...triggerProps} id={referrerId}>

--- a/src/popover/styles.scss
+++ b/src/popover/styles.scss
@@ -24,6 +24,11 @@
   text-align: inherit;
 }
 
+.overflow-ellipsis {
+  @include styles.text-overflow-ellipsis;
+  @include styles.text-wrapping;
+}
+
 .trigger-type-text {
   border-block: 0;
   border-inline: 0;
@@ -42,12 +47,6 @@
 
   @include focus-visible.when-visible {
     @include styles.focus-highlight(1px);
-  }
-
-  // Prevents trigger from shifting on click in IE11.
-  // https://stackoverflow.com/a/32655269
-  > .trigger-inner-text {
-    position: relative;
   }
 }
 


### PR DESCRIPTION
### Description

Added a `wrapTriggerText` property.

Follows the "negative" prop convention we essentially established for button and status indicator components. It has the name `trigger` in it to both follow the pattern with the other props (`triggerType`, `triggerAriaLabel`), and make it clear that this doesn't apply to the body itself. Setting this prop to `false` adds both text wrapping and truncation to the text trigger, and while I messed around with making it default, I've seen enough popovers with "internal" wrapping to realize this is a bad idea (plus it would make it completely unreadable/inaccessible for most cases outside a resizable table).

#### API changes

```typescript
/**
 * Specifies if the text trigger content should wrap. If you set it to false, it prevents the text from
 * wrapping and truncates it with an ellipsis.
 */
wrapTriggerText?: boolean;
```

Copied almost verbatim from the status indicator (except I added the word "trigger").

Related links, issue #, if available: AWSUI-38391

### How has this been tested?

Added permutation tests. Updated snapshots.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
