### PR TITLE
fix: Fix popover in split panel leaking outside of the split panel container

### DIFF
--- a/pages/app-layout/with-split-panel.page.tsx
+++ b/pages/app-layout/with-split-panel.page.tsx
@@ -5,6 +5,7 @@ import AppLayout, { AppLayoutProps } from '~components/app-layout';
 import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
+import Popover from '~components/popover';
 import Toggle from '~components/toggle';
 import AppContext, { AppContextType } from '../app/app-context';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -22,6 +23,12 @@ type SplitPanelDemoContext = React.Context<
 
 const DEMO_CONTENT = (
   <div>
+    <Popover
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+    magna aliqua. Augue neque gravida in fermentum."
+    >
+      Launch popover
+    </Popover>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
       magna aliqua. Augue neque gravida in fermentum. Suspendisse sed nisi lacus sed viverra tellus in hac. Nec sagittis
@@ -29,6 +36,7 @@ const DEMO_CONTENT = (
       magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
       Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
     </p>
+    <div data-testid="scroll-me">The end</div>
     <p>
       Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
       vulputate eu scelerisque felis imperdiet proin fermentum.
@@ -39,6 +47,18 @@ const DEMO_CONTENT = (
       integer malesuada nunc. Sem et tortor consequat id porta nibh. Semper auctor neque vitae tempus quam pellentesque.
     </p>
     <p>Ante in nibh mauris cursus mattis molestie.</p>
+    <p>
+      Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
+      eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi vitae
+      suscipit tellus mauris a diam. Diam donec adipiscing tristique risus nec feugiat in. Arcu felis bibendum ut
+      tristique et egestas quis. Nulla porttitor massa id neque aliquam vestibulum morbi blandit. In hac habitasse
+      platea dictumst quisque sagittis. Sollicitudin tempor id eu nisl nunc mi ipsum. Ornare aenean euismod elementum
+      nisi quis. Elementum curabitur vitae nunc sed velit dignissim sodales. Amet tellus cras adipiscing enim eu. Id
+      interdum velit laoreet id donec ultrices tincidunt. Ullamcorper eget nulla facilisi etiam. Sodales neque sodales
+      ut etiam sit amet nisl purus. Auctor urna nunc id cursus metus aliquam eleifend mi in. Urna condimentum mattis
+      pellentesque id. Porta lorem mollis aliquam ut porttitor leo a. Lectus quam id leo in vitae turpis massa sed.
+      Pharetra pharetra massa massa ultricies mi.
+    </p>
     <p>
       Pharetra et ultrices neque ornare. Bibendum neque egestas congue quisque egestas diam in arcu cursus. Porttitor
       eget dolor morbi non arcu risus quis. Integer quis auctor elit sed vulputate mi sit. Mauris nunc congue nisi vitae

--- a/pages/app-layout/with-table-and-split-panel.page.tsx
+++ b/pages/app-layout/with-table-and-split-panel.page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import AppLayout from '~components/app-layout';
 import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
+import Popover from '~components/popover';
 import { Navigation, Tools, Breadcrumbs, Footer } from './utils/content-blocks';
 import * as toolsContent from './utils/tools-content';
 import labels from './utils/labels';
@@ -24,6 +25,12 @@ const DEMO_CONTENT = (
       magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
       Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
     </p>
+    <Popover
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. Augue neque gravida in fermentum."
+    >
+      Show me a popover
+    </Popover>
     <p>
       Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
       vulputate eu scelerisque felis imperdiet proin fermentum.

--- a/pages/app-layout/with-table-and-split-panel.page.tsx
+++ b/pages/app-layout/with-table-and-split-panel.page.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import AppLayout from '~components/app-layout';
 import SplitPanel from '~components/split-panel';
 import Header from '~components/header';
-import Popover from '~components/popover';
 import { Navigation, Tools, Breadcrumbs, Footer } from './utils/content-blocks';
 import * as toolsContent from './utils/tools-content';
 import labels from './utils/labels';
@@ -25,12 +24,6 @@ const DEMO_CONTENT = (
       magnis dis parturient montes nascetur ridiculus mus mauris. Nisi porta lorem mollis aliquam ut porttitor leo a.
       Facilisi morbi tempus iaculis urna. Odio tempor orci dapibus ultrices in iaculis nunc.
     </p>
-    <Popover
-      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Augue neque gravida in fermentum."
-    >
-      Show me a popover
-    </Popover>
     <p>
       Ut diam quam nulla porttitor massa id neque. Duis at tellus at urna condimentum mattis pellentesque id nibh. Metus
       vulputate eu scelerisque felis imperdiet proin fermentum.

--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -110,7 +110,7 @@ function setupTest(
             async page => {
               await page.setWindowSize({ width: 1000, height: 800 });
               await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-              await page.keys(['Tab', 'Tab', 'Tab', 'Enter']);
+              await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
               await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
             },
             { pageName: 'with-split-panel', visualRefresh, mobile, splitPanelPosition: 'side' }

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -63,6 +63,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
     overflow-y: auto;
     position: absolute;
     inset: 0;
+    // Make sure that fixed position elements like popovers don't leak out
     clip-path: border-box;
   }
 }

--- a/src/split-panel/styles.scss
+++ b/src/split-panel/styles.scss
@@ -63,6 +63,7 @@ $app-layout-drawer-width: calc(#{awsui.$space-layout-toggle-diameter} + 2 * #{aw
     overflow-y: auto;
     position: absolute;
     inset: 0;
+    clip-path: border-box;
   }
 }
 


### PR DESCRIPTION
### Description
Currently, fixed position elements like an open Popover can "leak" out of a split panel when scrolling (see screenshot). While there is no technical defect, this can be very jarring and users might find it looks broken.

To fix this issue, we're introducing a `clip-path` to the split panel bottom drawer.

![Screenshot 2024-05-13 at 12 25 15](https://github.com/cloudscape-design/components/assets/2446349/6ed62bc9-7581-4cf3-9544-8fd908d9c58b)


Related links, issue #, if available: AWSUI-24345, `CR-126847853`

### How has this been tested?
Tested locally, added a new screenshot test, and tested in a prod environment.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
