### PR TITLE
fix: Form field live region error icon aria label

### DIFF
--- a/src/form-field/__tests__/form-field-rendering.test.tsx
+++ b/src/form-field/__tests__/form-field-rendering.test.tsx
@@ -124,6 +124,8 @@ describe('FormField component', () => {
         i18nStrings: { errorIconAriaLabel },
       });
 
+      // Since live region in this componennt uses 'source' prop
+      // it is too complex to successfully assert the aria live message
       expect(wrapper.findByClassName(liveRegionStyles.root)?.getElement()).toBeInTheDocument();
     });
   });

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -38,16 +38,13 @@ interface FormFieldErrorProps {
 export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldErrorProps) {
   const i18n = useInternalI18n('form-field');
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const i18nErrorIconAriaLabel = i18n('i18nStrings.errorIconAriaLabel', errorIconAriaLabel);
 
   return (
     <>
       <div id={id} className={styles.error}>
         <div className={styles['error-icon-shake-wrapper']}>
-          <div
-            role="img"
-            aria-label={i18n('i18nStrings.errorIconAriaLabel', errorIconAriaLabel)}
-            className={styles['error-icon-scale-wrapper']}
-          >
+          <div role="img" aria-label={i18nErrorIconAriaLabel} className={styles['error-icon-scale-wrapper']}>
             <InternalIcon name="status-warning" size="small" />
           </div>
         </div>
@@ -56,7 +53,7 @@ export function FormFieldError({ id, children, errorIconAriaLabel }: FormFieldEr
         </span>
       </div>
 
-      <LiveRegion assertive={true} source={[errorIconAriaLabel, contentRef]} />
+      <LiveRegion assertive={true} source={[i18nErrorIconAriaLabel, contentRef]} />
     </>
   );
 }


### PR DESCRIPTION
### Description

Fixed the issue where error icon aria label wasn't being announced unless i18n strings were defined specifically

Related links, issue #, if available: AWSUI-41861

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
