### PR TITLE
fix: Do not apply global sticky offset when local value is defined

### DIFF
--- a/src/container/__tests__/sticky-offset.test.ts
+++ b/src/container/__tests__/sticky-offset.test.ts
@@ -4,15 +4,35 @@ import { computeOffset } from '../../../lib/components/container/use-sticky-head
 import globalVars from '../../../lib/components/internal/styles/global-vars';
 
 describe('computeOffset', () => {
-  test('should calculate offset for mobile', () => {
+  test('should calculate offset for mobile outside overflow parent', () => {
     const result = computeOffset({
       isMobile: true,
-      __stickyOffset: 0,
       __mobileStickyOffset: 10,
       hasInnerOverflowParents: false,
     });
 
     expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + -10px)`);
+  });
+
+  test('should calculate offset for mobile inside overflow parent', () => {
+    const result = computeOffset({
+      isMobile: true,
+      __mobileStickyOffset: 10,
+      hasInnerOverflowParents: true,
+    });
+
+    expect(result).toBe('-10px');
+  });
+
+  test('should apply explicit sticky offset inside overflow parent', () => {
+    const result = computeOffset({
+      isMobile: true,
+      __stickyOffset: 30,
+      __mobileStickyOffset: 10,
+      hasInnerOverflowParents: true,
+    });
+
+    expect(result).toBe('20px');
   });
 
   test('should calculate offset for non-mobile without inner overflow parents', () => {
@@ -53,6 +73,16 @@ describe('computeOffset', () => {
       hasInnerOverflowParents: false,
     });
 
-    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + 60px)`);
+    expect(result).toBe('60px');
+  });
+
+  test('should apply zero sticky offset value', () => {
+    const result = computeOffset({
+      isMobile: false,
+      __stickyOffset: 0,
+      hasInnerOverflowParents: false,
+    });
+
+    expect(result).toBe('0px');
   });
 });

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -24,7 +24,7 @@ export function computeOffset({
   hasInnerOverflowParents,
 }: ComputeOffsetProps): string {
   const localOffset = isMobile ? (__stickyOffset ?? 0) - (__mobileStickyOffset ?? 0) : __stickyOffset ?? 0;
-  if (hasInnerOverflowParents) {
+  if (hasInnerOverflowParents || __stickyOffset !== undefined) {
     return `${localOffset}px`;
   }
   const globalOffset = `var(${globalVars.stickyVerticalTopOffset}, 0px)`;


### PR DESCRIPTION
### Description

Fixing an issue when `<Table stickyHeaderVerticalOffset={123}>` is used

Related links, issue #, if available: n/a

### How has this been tested?

Added more unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
