### PR TITLE
chore: Add stickyHeaderVerticalOffset use-case for screenshot testing

### DIFF
--- a/pages/app-layout/with-table-and-sticky-offset.page.tsx
+++ b/pages/app-layout/with-table-and-sticky-offset.page.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+import AppLayout from '~components/app-layout';
+import Header from '~components/header';
+import Table from '~components/table';
+import ScreenshotArea from '../utils/screenshot-area';
+import { generateItems, Instance } from '../table/generate-data';
+import { columnsConfig } from '../table/shared-configs';
+import { Breadcrumbs } from './utils/content-blocks';
+import labels from './utils/labels';
+import AppContext from '../app/app-context';
+
+const items = generateItems(20);
+
+export default function () {
+  const { urlParams } = useContext(AppContext);
+  return (
+    <ScreenshotArea gutters={false}>
+      <AppLayout
+        ariaLabels={labels}
+        breadcrumbs={<Breadcrumbs />}
+        navigationHide={true}
+        toolsHide={true}
+        contentType="table"
+        content={
+          <Table<Instance>
+            header={<Header variant="awsui-h1-sticky">Sticky Scrollbar Example</Header>}
+            // manually set vertical offset to test this feature
+            stickyHeaderVerticalOffset={urlParams.visualRefresh ? 57 : 45}
+            stickyHeader={true}
+            variant="full-page"
+            columnDefinitions={columnsConfig}
+            items={items}
+          />
+        }
+      />
+    </ScreenshotArea>
+  );
+}


### PR DESCRIPTION
### Description

Follow up for https://github.com/cloudscape-design/components/pull/2213 to add a screenshot test. We need to have an AppLayout + stickyHeaderVerticalOffset combination to test

Related links, issue #, if available: n/a

### How has this been tested?

This change is testing

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
