### PR TITLE
fix: Fixed cells jittering in tables with inline editing and non-resizable columns

### DIFF
--- a/pages/table/editable.page.tsx
+++ b/pages/table/editable.page.tsx
@@ -16,6 +16,7 @@ import AppContext, { AppContextType } from '../app/app-context';
 
 type PageContext = React.Context<
   AppContextType<{
+    resizableColumns: boolean;
     enableKeyboardNavigation: boolean;
   }>
 >;
@@ -218,7 +219,9 @@ const Demo = forwardRef(
     tableRef: ForwardedRef<TableProps.Ref>
   ) => {
     const [items, setItems] = useState(initialItems);
-    const { urlParams } = useContext(AppContext as PageContext);
+    const {
+      urlParams: { resizableColumns = true, enableKeyboardNavigation = false },
+    } = useContext(AppContext as PageContext);
 
     const handleSubmit: TableProps.SubmitEditFunction<DistributionInfo> = async (currentItem, column, newValue) => {
       let value = newValue;
@@ -264,17 +267,20 @@ const Demo = forwardRef(
         }}
         columnDefinitions={columns}
         items={items}
-        resizableColumns={true}
         ariaLabels={ariaLabels}
         stickyHeader={true}
-        enableKeyboardNavigation={urlParams.enableKeyboardNavigation}
+        resizableColumns={resizableColumns}
+        enableKeyboardNavigation={enableKeyboardNavigation}
       />
     );
   }
 );
 
 export default function () {
-  const { urlParams, setUrlParams } = useContext(AppContext as PageContext);
+  const {
+    urlParams: { resizableColumns = true, enableKeyboardNavigation = false },
+    setUrlParams,
+  } = useContext(AppContext as PageContext);
   const [modalVisible, setModalVisible] = useState(false);
   const tableRef = useRef<TableProps.Ref>(null);
 
@@ -293,15 +299,27 @@ export default function () {
   return (
     <Box margin="s">
       <SpaceBetween size="s">
-        <Checkbox
-          checked={urlParams.enableKeyboardNavigation}
-          onChange={event => {
-            setUrlParams({ enableKeyboardNavigation: event.detail.checked });
-            window.location.reload();
-          }}
-        >
-          Keyboard navigation
-        </Checkbox>
+        <SpaceBetween size="s" direction="horizontal">
+          <Checkbox
+            checked={resizableColumns}
+            onChange={event => {
+              setUrlParams({ resizableColumns: event.detail.checked });
+              window.location.reload();
+            }}
+          >
+            Resizable columns
+          </Checkbox>
+
+          <Checkbox
+            checked={enableKeyboardNavigation}
+            onChange={event => {
+              setUrlParams({ enableKeyboardNavigation: event.detail.checked });
+              window.location.reload();
+            }}
+          >
+            Keyboard navigation
+          </Checkbox>
+        </SpaceBetween>
 
         <input data-testid="focus" aria-label="focus input" />
       </SpaceBetween>

--- a/src/table/body-cell/index.tsx
+++ b/src/table/body-cell/index.tsx
@@ -21,6 +21,7 @@ export interface TableBodyCellProps<ItemType> extends TableTdElementProps {
   column: TableProps.ColumnDefinition<ItemType>;
   item: ItemType;
   isEditing: boolean;
+  resizableColumns?: boolean;
   successfulEdit?: boolean;
   onEditStart: () => void;
   onEditEnd: (cancelled: boolean) => void;
@@ -39,6 +40,7 @@ function TableCellEditable<ItemType>({
   submitEdit,
   ariaLabels,
   isVisualRefresh,
+  resizableColumns = false,
   successfulEdit = false,
   interactiveCell = true,
   ...rest
@@ -87,6 +89,7 @@ function TableCellEditable<ItemType>({
         className,
         styles['body-cell-editable'],
         interactiveCell && styles['body-cell-interactive'],
+        resizableColumns && styles['resizable-columns'],
         isEditing && styles['body-cell-edit-active'],
         showSuccessIcon && showIcon && styles['body-cell-has-success'],
         isVisualRefresh && styles['is-visual-refresh']

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -25,6 +25,7 @@ $edit-button-padding-right: calc(
   #{awsui.$space-xs} + #{awsui.$space-xxs}
 ); // Cell vertical padding + xxs space that would normally come from the button.
 $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-with-spacing});
+$interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
 
 @mixin cell-focus-outline {
   @include styles.focus-highlight(calc(-1 * #{awsui.$space-scaled-xxs}));
@@ -357,10 +358,15 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
     &:not(.body-cell-edit-active) {
       &.body-cell-interactive {
         cursor: pointer;
+
+        // Include interactive padding even when a cell is not hovered to prevent jittering when resizableColumns=false.
+        &:not(.resizable-columns) {
+          padding-inline-end: $interactive-column-padding-inline-end;
+        }
       }
 
       @mixin focused-editor-styles {
-        padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
+        padding-inline-end: $interactive-column-padding-inline-end;
         & > .body-cell-editor-wrapper,
         & > .expandable-cell-content > .body-cell-editor-wrapper {
           opacity: 1;
@@ -393,7 +399,6 @@ $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-
       &:not(.body-cell-interactive),
       &:focus-within:focus-within,
       &.body-cell-edit-disabled-popover {
-        padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
         &.body-cell-has-success {
           // After a successful edit, we display the success icon next to the edit button and need additional padding to not let the text overflow the success icon.
           padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l} + #{$icon-width-with-spacing});

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -526,6 +526,7 @@ const InternalTable = React.forwardRef(
                                   isEditable={isEditable}
                                   isEditing={isEditing}
                                   isRowHeader={column.isRowHeader}
+                                  resizableColumns={resizableColumns}
                                   successfulEdit={successfulEdit}
                                   onEditStart={() => cellEditing.startEdit({ rowIndex, colIndex })}
                                   onEditEnd={editCancelled =>


### PR DESCRIPTION
### Description

When inline editing is used in tables without resizable columns hovering on cells causes columns to change width.

Before:

https://github.com/cloudscape-design/components/assets/20790937/c7cd8383-853c-49c4-bdbc-c57faa071306

After:

https://github.com/cloudscape-design/components/assets/20790937/2a26608f-64a8-4bfe-b6f2-482333f32076

### How has this been tested?

* Existing and new screenshot tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
