### PR TITLE
fix: Make inputs inside top navigation programmatically focusable

### DIFF
--- a/pages/autosuggest/simple.page.tsx
+++ b/pages/autosuggest/simple.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
-import Autosuggest from '~components/autosuggest';
+import React, { useRef, useState } from 'react';
+import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
 
 const empty = <span>Nothing found</span>;
 const options = [
@@ -15,11 +15,12 @@ export default function AutosuggestPage() {
   const [value, setValue] = useState('');
   const [readOnly, setReadOnly] = useState(false);
   const [hasOptions, setHasOptions] = useState(true);
-
+  const ref = useRef<AutosuggestProps.Ref>(null);
   return (
     <div style={{ padding: 10 }}>
       <h1>Simple autosuggest</h1>
       <Autosuggest
+        ref={ref}
         value={value}
         readOnly={readOnly}
         options={hasOptions ? options : []}
@@ -36,6 +37,7 @@ export default function AutosuggestPage() {
       <button id="set-read-only" onClick={() => setReadOnly(true)}>
         set read only
       </button>
+      <button onClick={() => ref.current?.focus()}>focus</button>
     </div>
   );
 }

--- a/pages/top-navigation/integ.page.tsx
+++ b/pages/top-navigation/integ.page.tsx
@@ -1,19 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { NonCancelableCustomEvent } from '~components';
 
-import Input from '~components/input';
+import Input, { InputProps } from '~components/input';
 import TopNavigation from '~components/top-navigation';
 import { I18N_STRINGS } from './common';
 
 export default function () {
+  const inputRef = useRef<InputProps.Ref>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const [events, setEvents] = useState<string[]>([]);
   const onUtilityClick = (event: NonCancelableCustomEvent<unknown>) => {
     setEvents(events => [...events, JSON.stringify(event.detail)]);
   };
-
   return (
     <article>
       <h1>TopNavigation Integ Page</h1>
@@ -25,6 +25,7 @@ export default function () {
         }}
         search={
           <Input
+            ref={inputRef}
             type="search"
             placeholder="Search..."
             value={inputValue}
@@ -75,6 +76,9 @@ export default function () {
       </code>
       <button type="button" onClick={() => setEvents([])} id="clear">
         Clear events
+      </button>
+      <button type="button" onClick={() => inputRef.current?.focus()} id="focus-input">
+        Focus input
       </button>
     </article>
   );

--- a/pages/top-navigation/search.page.tsx
+++ b/pages/top-navigation/search.page.tsx
@@ -1,16 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import * as React from 'react';
+import React, { useState, useRef } from 'react';
 
 import TopNavigation from '~components/top-navigation';
-import Input from '~components/input';
-import Autosuggest from '~components/autosuggest';
+import Input, { InputProps } from '~components/input';
+import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
 import logo from './logos/simple-logo.svg';
 import { I18N_STRINGS } from './common';
 
 export default function TopNavigationPage() {
-  const [valueAutosuggest, setValueAutosuggest] = React.useState('');
-  const [valueInput, setValueInput] = React.useState('');
+  const [valueAutosuggest, setValueAutosuggest] = useState('');
+  const [valueInput, setValueInput] = useState('');
+  const inputRef = useRef<InputProps.Ref>(null);
+  const autosuggestRef = useRef<AutosuggestProps.Ref>(null);
   return (
     <article>
       <h1>TopNavigation with search</h1>
@@ -22,7 +24,12 @@ export default function TopNavigationPage() {
           title: 'Input as a search',
         }}
         search={
-          <Input ariaLabel="Input field" value={valueInput} onChange={({ detail }) => setValueInput(detail.value)} />
+          <Input
+            ref={inputRef}
+            ariaLabel="Input field"
+            value={valueInput}
+            onChange={({ detail }) => setValueInput(detail.value)}
+          />
         }
       />
       <br />
@@ -34,6 +41,7 @@ export default function TopNavigationPage() {
         }}
         search={
           <Autosuggest
+            ref={autosuggestRef}
             ariaLabel="Input field"
             onChange={({ detail }) => setValueAutosuggest(detail.value)}
             value={valueAutosuggest}
@@ -49,6 +57,9 @@ export default function TopNavigationPage() {
           />
         }
       />
+      <br />
+      <button onClick={() => inputRef.current?.focus()}>Focus input</button>
+      <button onClick={() => autosuggestRef.current?.focus()}>Focus autosuggest</button>
     </article>
   );
 }

--- a/pages/top-navigation/search.page.tsx
+++ b/pages/top-navigation/search.page.tsx
@@ -1,18 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 
 import TopNavigation from '~components/top-navigation';
-import Input, { InputProps } from '~components/input';
-import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
+import Input from '~components/input';
+import Autosuggest from '~components/autosuggest';
 import logo from './logos/simple-logo.svg';
 import { I18N_STRINGS } from './common';
 
 export default function TopNavigationPage() {
   const [valueAutosuggest, setValueAutosuggest] = useState('');
   const [valueInput, setValueInput] = useState('');
-  const inputRef = useRef<InputProps.Ref>(null);
-  const autosuggestRef = useRef<AutosuggestProps.Ref>(null);
   return (
     <article>
       <h1>TopNavigation with search</h1>
@@ -24,12 +22,7 @@ export default function TopNavigationPage() {
           title: 'Input as a search',
         }}
         search={
-          <Input
-            ref={inputRef}
-            ariaLabel="Input field"
-            value={valueInput}
-            onChange={({ detail }) => setValueInput(detail.value)}
-          />
+          <Input ariaLabel="Input field" value={valueInput} onChange={({ detail }) => setValueInput(detail.value)} />
         }
       />
       <br />
@@ -41,7 +34,6 @@ export default function TopNavigationPage() {
         }}
         search={
           <Autosuggest
-            ref={autosuggestRef}
             ariaLabel="Input field"
             onChange={({ detail }) => setValueAutosuggest(detail.value)}
             value={valueAutosuggest}
@@ -58,8 +50,6 @@ export default function TopNavigationPage() {
         }
       />
       <br />
-      <button onClick={() => inputRef.current?.focus()}>Focus input</button>
-      <button onClick={() => autosuggestRef.current?.focus()}>Focus autosuggest</button>
     </article>
   );
 }

--- a/src/top-navigation/__integ__/top-navigation.test.ts
+++ b/src/top-navigation/__integ__/top-navigation.test.ts
@@ -4,9 +4,9 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
 import '../../../lib/components/test-utils/selectors';
-import TopNavigationWrapper from '../../../lib/components/test-utils/selectors/top-navigation';
+import { createWrapper } from '@cloudscape-design/test-utils-core/selectors';
 
-const wrapper = new TopNavigationWrapper(`.${TopNavigationWrapper.rootSelector}`);
+const wrapper = createWrapper().findTopNavigation();
 
 class TopNavigationPage extends BasePageObject {
   getLocation() {
@@ -222,4 +222,14 @@ describe('Top navigation', () => {
       })
     );
   });
+
+  test(
+    'can focus search input programmatically',
+    setupTest(1000, async page => {
+      const searchInputSelector = wrapper.findSearch()!.findInput().findNativeInput().toSelector();
+
+      await page.click('#focus-input');
+      await expect(page.isFocused(searchInputSelector)).resolves.toBe(true);
+    })
+  );
 });

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -7,7 +7,6 @@ import { InternalBaseComponentProps } from '../internal/hooks/use-base-component
 import { getBaseProps } from '../internal/base-component';
 import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
 import VisualContext from '../internal/components/visual-context';
-import Portal from '../internal/components/portal';
 import { useEffectOnUpdate } from '../internal/hooks/use-effect-on-update';
 
 import { TopNavigationProps } from './interfaces';
@@ -229,8 +228,11 @@ export default function InternalTopNavigation({
   return (
     <div {...baseProps} ref={__internalRootRef}>
       <VisualContext contextName="top-navigation">
+        {/* Render virtual content first to ensure React refs for content will be assigned on the actual nodes. */}
+        {content(true)}
+
         {content(false)}
-        <Portal>{content(true)}</Portal>
+
         {menuTriggerVisible && overflowMenuOpen && (
           <div className={styles['overflow-menu-drawer']}>
             <OverflowMenu


### PR DESCRIPTION
### Description

In Top navigation all content is rendered twice. The second time the content is rendered as "virtual" - it is invisible and is used to measure content elements widths. That creates potential problems, for example, using the `id` attribute on a content node would result in duplicate IDs present in the DOM. A similar issue was with React refs. The ref callback is called twice and the actual node it gets assigned is the one which comes from the callback executed the last. That means the virtual content must come before the actual content and it can't be rendered in our Portal because the portal content is rendered with a delay.

Rel: AWSUI-42554, https://github.com/cloudscape-design/components/issues/2181

### How has this been tested?

* New integration test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
