### PR TITLE
fix: Better support for decimal steps in slider

### DIFF
--- a/src/slider/__tests__/utils.test.tsx
+++ b/src/slider/__tests__/utils.test.tsx
@@ -20,6 +20,12 @@ describe('getStepArray', () => {
   test('works with negative numbers', () => {
     expect(getStepArray(5, [-10, 10])).toEqual([-10, -5, 0, 5, 10]);
   });
+
+  test('works with decimals', () => {
+    expect(getStepArray(0.1, [0, 1])).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
+    expect(getStepArray(0.1, [-1, -0.5])).toEqual([-1, -0.9, -0.8, -0.7, -0.6, -0.5]);
+    expect(getStepArray(0.000000001, [0, 5e-9])).toEqual([0, 1e-9, 2e-9, 3e-9, 4e-9, 5e-9]);
+  });
 });
 
 describe('findLowerAndHigherValues', () => {

--- a/src/slider/utils.ts
+++ b/src/slider/utils.ts
@@ -14,10 +14,8 @@ function countDecimals(value: number) {
   // very small numbers, e.g. 1e-9
   if (str.indexOf('-') !== -1) {
     return parseInt(str.split('-')[1], 10) || 0;
-  } else if (str.indexOf('.') !== -1) {
-    return str.split('.')[1].length || 0;
   }
-  return 0;
+  return str.split('.')[1]?.length || 0;
 }
 
 export const getStepArray = (step: number, [min, max]: [min: number, max: number]) => {

--- a/src/slider/utils.ts
+++ b/src/slider/utils.ts
@@ -4,12 +4,39 @@
 export function getPercent(value: number, range: [min: number, max: number]) {
   return ((value - range[0]) / (range[1] - range[0])) * 100;
 }
-export const getStepArray = (step: number, range: [min: number, max: number]) => {
-  const steps = [];
 
-  for (let i = range[0]; i <= range[1]; i = i + step) {
-    steps.push(i);
+function countDecimals(value: number) {
+  if (Math.floor(value) === value) {
+    return 0;
   }
+
+  const str = Math.abs(value).toString();
+  // very small numbers, e.g. 1e-9
+  if (str.indexOf('-') !== -1) {
+    return parseInt(str.split('-')[1], 10) || 0;
+  } else if (str.indexOf('.') !== -1) {
+    return str.split('.')[1].length || 0;
+  }
+  return 0;
+}
+
+export const getStepArray = (step: number, [min, max]: [min: number, max: number]) => {
+  const steps = [min];
+  let stepNumber = 1;
+
+  // JS struggles with rounding errors when using decimals, so include a multiplier
+  // to make step calculations integer-based
+  const multiplier = Math.pow(10, countDecimals(step));
+
+  while (steps[steps.length - 1] < max) {
+    steps.push((min * multiplier + stepNumber * multiplier * step) / multiplier);
+    stepNumber++;
+  }
+
+  if (steps[steps.length - 1] > max) {
+    steps.pop();
+  }
+
   return steps;
 };
 

--- a/src/slider/utils.ts
+++ b/src/slider/utils.ts
@@ -22,19 +22,18 @@ function countDecimals(value: number) {
 
 export const getStepArray = (step: number, [min, max]: [min: number, max: number]) => {
   const steps = [min];
-  let stepNumber = 1;
 
   // JS struggles with rounding errors when using decimals, so include a multiplier
   // to make step calculations integer-based
   const multiplier = Math.pow(10, countDecimals(step));
 
-  while (steps[steps.length - 1] < max) {
-    steps.push((min * multiplier + stepNumber * multiplier * step) / multiplier);
-    stepNumber++;
-  }
+  let currentStep = min;
 
-  if (steps[steps.length - 1] > max) {
-    steps.pop();
+  while (currentStep < max) {
+    currentStep = (multiplier * currentStep + multiplier * step) / multiplier;
+    if (currentStep <= max) {
+      steps.push(currentStep);
+    }
   }
 
   return steps;


### PR DESCRIPTION
### Description

Fix JS rounding issues when using decimal values for slider `step`

Related links, issue #, if available: AWSUI-42557

### How has this been tested?

Updated unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
