### PR TITLE
feat: Add loop arrow key navigation in autosuggest

### DIFF
--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -15,6 +15,10 @@ const defaultOptions: AutosuggestProps.Options = [
   { value: '1', label: 'One' },
   { value: '2', lang: 'fr' },
 ];
+const groupOptions: AutosuggestProps.Options = [
+  { label: 'Group 1', options: [{ value: '1' }, { value: '2' }] },
+  { label: 'Group 2', options: [{ value: '3' }] },
+];
 const defaultProps: AutosuggestProps = {
   enteredTextLabel: () => 'Use value',
   value: '',
@@ -396,6 +400,44 @@ describe('keyboard interactions', () => {
     expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
     expect(onChange).toBeCalledTimes(1);
   });
+
+  test('ArrowUp key on first option should highlight last option', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
+
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('One');
+    wrapper.findNativeInput().keydown(KeyCode.up);
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('2');
+  });
+
+  test('ArrowUp key on first option should highlight last option (options with groups)', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} options={groupOptions} />);
+
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
+
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('1');
+    wrapper.findNativeInput().keydown(KeyCode.up);
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('3');
+  });
+
+  test('ArrowDown key on last option should highlight first option', () => {
+    const { wrapper } = renderAutosuggest(<Autosuggest {...defaultProps} />);
+
+    expect(wrapper.findDropdown()!.findOpenDropdown()).toBe(null);
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown()!.findOpenDropdown()).not.toBe(null);
+
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('One');
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('2');
+    wrapper.findNativeInput().keydown(KeyCode.down);
+    expect(wrapper.findDropdown().findHighlightedOption()!.getElement()).toHaveTextContent('One');
+  });
 });
 
 describe('Check if should render dropdown', () => {
@@ -474,15 +516,7 @@ describe('Ref', () => {
 
 test('findOptionInGroup', () => {
   const { container } = render(
-    <Autosuggest
-      value=""
-      onChange={() => {}}
-      enteredTextLabel={() => 'Use value'}
-      options={[
-        { label: 'Group 1', options: [{ value: '1' }, { value: '2' }] },
-        { label: 'Group 2', options: [{ value: '3' }] },
-      ]}
-    />
+    <Autosuggest value="" onChange={() => {}} enteredTextLabel={() => 'Use value'} options={groupOptions} />
   );
   const wrapper = createWrapper(container).findAutosuggest()!;
   wrapper.findNativeInput().focus();

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -139,10 +139,23 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   };
 
   const handlePressArrowDown = () => {
+    if (autosuggestItemsState.items.length - 1 === autosuggestItemsState.highlightedIndex) {
+      autosuggestItemsHandlers.goHomeWithKeyboard();
+      return;
+    }
+
     autosuggestItemsHandlers.moveHighlightWithKeyboard(1);
   };
 
   const handlePressArrowUp = () => {
+    if (
+      (autosuggestItemsState.highlightedOption?.type === 'child' && autosuggestItemsState.highlightedIndex === 1) ||
+      autosuggestItemsState.highlightedIndex === 0
+    ) {
+      autosuggestItemsHandlers.goEndWithKeyboard();
+      return;
+    }
+
     autosuggestItemsHandlers.moveHighlightWithKeyboard(-1);
   };
 


### PR DESCRIPTION
### Description

Currently, users can navigate through suggestion list using the keyboard up/down arrow keys. However, when they reach the last position in the suggestion list, pressing the down arrow key does not loop to the first position of the list (and vice versa). Users must repeatedly press the arrow keys to return to the top of the list. This PR addressed this problem.

Related links, issue #, if available: n/a

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
