### PR TITLE
fix: Associate description and additionalInfo with <progress> element

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10785,6 +10785,12 @@ Use the \`buttonText\` property and the \`onButtonClick\` event listener of the 
   "name": "ProgressBar",
   "properties": Array [
     Object {
+      "description": "Adds \`aria-describedby\` to the progress bar.",
+      "name": "ariaDescribedby",
+      "optional": true,
+      "type": "string",
+    },
+    Object {
       "description": "Adds an \`aria-label\` to the progress bar.",
       "name": "ariaLabel",
       "optional": true,

--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ProgressBarWrapper from '../../../lib/components/test-utils/dom/progress-bar';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import ProgressBar, { ProgressBarProps } from '../../../lib/components/progress-bar';
@@ -106,6 +106,51 @@ allVariants.forEach(variant => {
       test('ignores aria-labelledby if aria-label is provided', () => {
         const wrapper = renderProgressBar({ variant, value: 100, ariaLabelledby: 'testid', ariaLabel: 'hello' });
         expect(wrapper.find('progress')!.getElement()).not.toHaveAttribute('aria-labelledby');
+      });
+
+      describe('aria-describedby', () => {
+        test('associate progress element with description prop', () => {
+          const wrapper = renderProgressBar({ variant, description: 'dummy description' });
+          const descriptionId = screen.queryByText('dummy description')!.id;
+          expect(wrapper.find('progress')!.getElement()).toHaveAttribute('aria-describedby', descriptionId);
+        });
+
+        test('associate progress element with additionalInfo prop', () => {
+          const wrapper = renderProgressBar({ variant, additionalInfo: 'dummy additional info' });
+          const additionalInfoId = screen.queryByText('dummy additional info')!.id;
+          expect(wrapper.find('progress')!.getElement()).toHaveAttribute('aria-describedby', additionalInfoId);
+        });
+
+        test('associate progress element with ariaDescribedby prop', () => {
+          const wrapper = renderProgressBar({
+            variant,
+            ariaDescribedby: 'dummy-reference-element-id',
+          });
+          expect(wrapper.find('progress')!.getElement()).toHaveAttribute(
+            'aria-describedby',
+            'dummy-reference-element-id'
+          );
+        });
+
+        test('associate progress element with description, additionalInfo and ariaDescribedby props', () => {
+          const wrapper = renderProgressBar({
+            variant,
+            description: 'dummy description',
+            additionalInfo: 'dummy additional info',
+            ariaDescribedby: 'dummy-reference-element-id',
+          });
+          const descriptionId = screen.queryByText('dummy description')!.id;
+          const additionalInfoId = screen.queryByText('dummy additional info')!.id;
+          const ariaDescribedByValue = wrapper.find('progress')!.getElement().getAttribute('aria-describedby');
+          expect(ariaDescribedByValue).toContain(descriptionId);
+          expect(ariaDescribedByValue).toContain(additionalInfoId);
+          expect(ariaDescribedByValue).toContain('dummy-reference-element-id');
+        });
+
+        test('is ignored when additionalInfo, description and ariaDescribedby props are not present', () => {
+          const wrapper = renderProgressBar({ variant, value: 100 });
+          expect(wrapper.find('progress')!.getElement()).not.toHaveAttribute('aria-describedby');
+        });
       });
     });
   });

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -28,6 +28,7 @@ export default function ProgressBar({
   label,
   ariaLabel,
   ariaLabelledby,
+  ariaDescribedby,
   description,
   additionalInfo,
   resultText,
@@ -43,6 +44,9 @@ export default function ProgressBar({
   const labelId = `${generatedName}-label`;
   const isInFlash = variant === 'flash';
   const isInProgressState = status === 'in-progress';
+
+  const descriptionId = useUniqueId('progressbar-description-');
+  const additionalInfoId = useUniqueId('progressbar-additional-info-');
 
   const [announcedValue, setAnnouncedValue] = useState('');
   const throttledAssertion = useMemo(() => {
@@ -72,7 +76,11 @@ export default function ProgressBar({
         <div className={clsx(styles['word-wrap'], styles[`label-${variant}`])} id={labelId}>
           {label}
         </div>
-        {description && <SmallText color={isInFlash ? 'inherit' : undefined}>{description}</SmallText>}
+        {description && (
+          <SmallText color={isInFlash ? 'inherit' : undefined} id={descriptionId}>
+            {description}
+          </SmallText>
+        )}
         <div>
           {isInProgressState ? (
             <>
@@ -80,6 +88,11 @@ export default function ProgressBar({
                 value={value}
                 ariaLabel={ariaLabel}
                 ariaLabelledby={joinStrings(labelId, ariaLabelledby)}
+                ariaDescribedby={joinStrings(
+                  description ? descriptionId : undefined,
+                  additionalInfo ? additionalInfoId : undefined,
+                  ariaDescribedby
+                )}
                 isInFlash={isInFlash}
               />
               <LiveRegion delay={0}>
@@ -102,7 +115,11 @@ export default function ProgressBar({
         </div>
       </div>
       {additionalInfo && (
-        <SmallText className={styles['additional-info']} color={isInFlash ? 'inherit' : undefined}>
+        <SmallText
+          className={styles['additional-info']}
+          color={isInFlash ? 'inherit' : undefined}
+          id={additionalInfoId}
+        >
           {additionalInfo}
         </SmallText>
       )}

--- a/src/progress-bar/interfaces.ts
+++ b/src/progress-bar/interfaces.ts
@@ -49,6 +49,11 @@ export interface ProgressBarProps extends BaseComponentProps {
   ariaLabelledby?: string;
 
   /**
+   * Adds `aria-describedby` to the progress bar.
+   */
+  ariaDescribedby?: string;
+
+  /**
    * Short description of the operation that appears at the top of the component.
    *
    * Make sure that you always provide a label for accessibility.

--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -22,8 +22,9 @@ interface ProgressProps {
   isInFlash: boolean;
   ariaLabel?: string;
   ariaLabelledby?: string;
+  ariaDescribedby?: string;
 }
-export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: ProgressProps) => {
+export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby, ariaDescribedby }: ProgressProps) => {
   const roundedValue = Math.round(value);
   const progressValue = clamp(roundedValue, 0, MAX_VALUE);
 
@@ -40,6 +41,7 @@ export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: Progre
         aria-label={ariaLabel}
         // Ensures aria-label takes precedence over aria-labelledby
         aria-labelledby={!ariaLabel ? ariaLabelledby : undefined}
+        aria-describedby={ariaDescribedby}
       />
       <span aria-hidden="true" className={styles['percentage-container']}>
         <InternalBox className={styles.percentage} variant="small" color={isInFlash ? 'inherit' : undefined}>
@@ -52,13 +54,14 @@ export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: Progre
 
 interface SmallTextProps {
   color?: BoxProps.Color;
+  id?: string;
   children: React.ReactNode;
   className?: string;
 }
 
-export const SmallText = ({ color, children, className }: SmallTextProps) => {
+export const SmallText = ({ color, children, className, id }: SmallTextProps) => {
   return (
-    <InternalBox className={clsx(styles['word-wrap'], className)} variant="small" display="block" color={color}>
+    <InternalBox className={clsx(styles['word-wrap'], className)} variant="small" display="block" color={color} id={id}>
       {children}
     </InternalBox>
   );


### PR DESCRIPTION
### Description

Before this change screen reader users had difficulty determining which constraints correspond with which field. This change associates the `description`, `additionalInfo` and `ariaDescribedby` with the `<progress />` element if provided. The `ariaDescribedby` property got exposed which allows customization if needed. 

Related links, issue #, if available: AWSUI-40665

### How has this been tested?

- added additional unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
