### PR TITLE
fix: Exclude backslash from the list of allowed characters in tag editor

### DIFF
--- a/src/tag-editor/__tests__/validation.test.ts
+++ b/src/tag-editor/__tests__/validation.test.ts
@@ -262,6 +262,12 @@ describe('invalidCharCheck', () => {
 
     const stringContainingEmojis = '💩';
     expect(invalidCharCheck(stringContainingEmojis)).toBe(true);
+
+    // generateStringOfInvalidCharacters method generates invalid characters as a negation of valid ones.
+    // That implies that we have a correct regex in the first place.
+    // However, it's easy to miss backslash, so we test it explicitly
+    const backslash = '\\';
+    expect(invalidCharCheck(backslash)).toBe(true);
   });
 });
 
@@ -277,6 +283,7 @@ function generateStringOfValidCharacters() {
   return [numbers, lowerCaseLetters, upperCaseLetters, specialCharacters, unicodeCharacters].join('');
 }
 
+// currently generates string with following characters: !"#$%&'()*,;<>?[\]^`{|}~
 function generateStringOfInvalidCharacters() {
   const validCharacterSet = new Set(generateStringOfValidCharacters().split(''));
   return Array(128)

--- a/src/tag-editor/validation.ts
+++ b/src/tag-editor/validation.ts
@@ -3,7 +3,7 @@
 import { ComponentFormatFunction } from '../i18n/context';
 import { TagEditorProps } from './interfaces';
 
-const DEFAULT_CHAR_REGEX = /^([\p{L}\p{Z}\p{N}_.:/=+\\@-]*)$/u;
+const DEFAULT_CHAR_REGEX = /^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$/u;
 
 const SYSTEM_TAG_PREFIX = 'aws:';
 const MAX_KEY_LENGTH = 128;


### PR DESCRIPTION
### Description

TagEditor allows only for the following characters: `+ - = . _ : / @`. However, our validation allowed for backslash. 
We checked with Tagris team and confirmed with them that backslash is not allowed.

So we're updating the regex.

Related links, issue #, if available: AWSUI-42153

### How has this been tested?

Added a new test to explicitly test for backslash

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
