### PR TITLE
refactor: Reorganise and document code in table use-selection util

### DIFF
--- a/src/table/selection/use-selection.ts
+++ b/src/table/selection/use-selection.ts
@@ -29,92 +29,85 @@ export function useSelection<T>({
   | 'onSelectionChange'
   | 'loading'
 >) {
-  const [shiftPressed, setShiftPressed] = useState(false);
-  const [lastClickedItem, setLastClickedItem] = useState<T | null>(null);
-  const selectionName = useUniqueId();
+  // The name assigned to all radio- controls to combine them in a single group.
+  const selectionControlName = useUniqueId();
+
+  // Selection state for individual items.
   const finalSelectedItems = selectionType === 'single' ? selectedItems.slice(0, 1) : selectedItems;
   const selectedSet = new ItemSet(trackBy, finalSelectedItems);
-  const itemIndexesMap = new Map();
-  items.forEach((item, i) => itemIndexesMap.set(getTrackableValue(trackBy, item), i));
   const isItemSelected = selectedSet.has.bind(selectedSet);
-  const getItemState = (item: T) => ({
-    disabled: isItemDisabled(item),
-    selected: isItemSelected(item),
-  });
-  const [allDisabled, allEnabledSelected] = selectionType
-    ? items.reduce(
-        ([allDisabled, allEnabledSelected], item) => {
-          const { disabled, selected } = getItemState(item);
-          return [
-            // all items are disabled (or none are present)
-            allDisabled && disabled,
-            // all enabled items are selected (or none are present)
-            allEnabledSelected && (selected || disabled),
-          ];
-        },
-        [true, true]
-      )
-    : [true, true];
 
-  // the page has at least one selected item
-  const hasSelected = finalSelectedItems.length > 0;
-
-  const handleToggleAll = () => {
-    const requestedItems = new ItemSet(trackBy, items);
-    const newSelectedItems = allEnabledSelected ? deselectItems(requestedItems) : selectItems(requestedItems);
-    fireNonCancelableEvent(onSelectionChange, { selectedItems: newSelectedItems });
-  };
-
-  const getRequestedItems = (item: T) => {
-    const requestedItems = new ItemSet(trackBy, [item]);
-    let lastClickedItemIndex = lastClickedItem ? itemIndexesMap.get(getTrackableValue(trackBy, lastClickedItem)) : -1;
-    if (lastClickedItemIndex === undefined) {
-      lastClickedItemIndex = -1;
+  // Derived selection state for all-items checkbox.
+  let allItemsDisabled = true;
+  let allEnabledItemsSelected = true;
+  if (selectionType === 'multi') {
+    for (const item of items) {
+      allItemsDisabled = allItemsDisabled && isItemDisabled(item);
+      allEnabledItemsSelected = allEnabledItemsSelected && (isItemSelected(item) || isItemDisabled(item));
     }
-    // we use lastClickedItemIndex to determine if filtering/sorting/pagination
-    // made previously selected item invisible, therefore we reset state for shift-select
-    if (shiftPressed && lastClickedItemIndex !== -1) {
-      // item is always in items
-      const currentItemIndex = itemIndexesMap.get(getTrackableValue(trackBy, item)) as number;
+  }
+  const allItemsCheckboxSelected = finalSelectedItems.length > 0 && allEnabledItemsSelected;
+  const allItemsCheckboxIndeterminate = finalSelectedItems.length > 0 && !allEnabledItemsSelected;
+
+  // Shift-selection helpers.
+  const [shiftPressed, setShiftPressed] = useState(false);
+  const [lastClickedItem, setLastClickedItem] = useState<null | T>(null);
+  const itemIndexesMap = new Map<T, number>();
+  items.forEach((item, i) => itemIndexesMap.set(getTrackableValue(trackBy, item), i));
+  const getShiftSelectedItems = (item: T): T[] => {
+    const lastClickedItemIndex = lastClickedItem
+      ? itemIndexesMap.get(getTrackableValue(trackBy, lastClickedItem))
+      : undefined;
+    // We use lastClickedItemIndex to determine if filtering/sorting/pagination
+    // made previously selected item invisible, therefore we reset state for shift-select.
+    if (lastClickedItemIndex !== undefined) {
+      const currentItemIndex = itemIndexesMap.get(getTrackableValue(trackBy, item))!;
       const start = Math.min(currentItemIndex, lastClickedItemIndex);
       const end = Math.max(currentItemIndex, lastClickedItemIndex);
-      items.slice(start, end + 1).forEach(item => requestedItems.put(item));
+      return items.slice(start, end + 1);
     }
-    return requestedItems;
+    return [item];
   };
 
-  const deselectItems = (requestedItems: ItemSet<T>) => {
-    const newSelectedItems: Array<T> = [];
-    selectedItems.forEach(selectedItem => {
-      const toUnselect = requestedItems.has(selectedItem);
-      if (!toUnselect || isItemDisabled(selectedItem)) {
-        newSelectedItems.push(selectedItem);
-      }
-    });
-    return newSelectedItems;
-  };
-
-  const selectItems = (requestedItems: ItemSet<T>) => {
+  // Select items that are not already selected or disabled.
+  const selectItems = (requestedItems: readonly T[]) => {
     const newSelectedItems = [...selectedItems];
     requestedItems.forEach(newItem => {
-      const { selected, disabled } = getItemState(newItem);
-      if (!selected && !disabled) {
+      if (!isItemSelected(newItem) && !isItemDisabled(newItem)) {
         newSelectedItems.push(newItem);
       }
     });
     return newSelectedItems;
   };
 
-  const handleToggleItem = (item: T) => () => {
-    const { disabled, selected } = getItemState(item);
-    if (disabled || (selectionType === 'single' && selected)) {
+  // Unselect items unless they are disabled.
+  const deselectItems = (requestedItems: readonly T[]) => {
+    const requestedItemsSet = new ItemSet(trackBy, requestedItems);
+    const newSelectedItems: Array<T> = [];
+    selectedItems.forEach(selectedItem => {
+      const shouldUnselect = requestedItemsSet.has(selectedItem);
+      if (!shouldUnselect || isItemDisabled(selectedItem)) {
+        newSelectedItems.push(selectedItem);
+      }
+    });
+    return newSelectedItems;
+  };
+
+  const handleToggleAll = () => {
+    const newSelectedItems = allEnabledItemsSelected ? deselectItems(items) : selectItems(items);
+    fireNonCancelableEvent(onSelectionChange, { selectedItems: newSelectedItems });
+  };
+
+  const handleToggleItem = (item: T) => {
+    if (isItemDisabled(item)) {
       return;
     }
-    if (selectionType === 'single') {
+    if (selectionType === 'single' && !isItemSelected(item)) {
       fireNonCancelableEvent(onSelectionChange, { selectedItems: [item] });
-    } else {
-      const requestedItems = getRequestedItems(item);
-      const selectedItems = selected ? deselectItems(requestedItems) : selectItems(requestedItems);
+    }
+    if (selectionType === 'multi') {
+      const requestedItems = shiftPressed ? getShiftSelectedItems(item) : [item];
+      const selectedItems = isItemSelected(item) ? deselectItems(requestedItems) : selectItems(requestedItems);
       fireNonCancelableEvent(onSelectionChange, { selectedItems });
       setLastClickedItem(item);
     }
@@ -127,11 +120,11 @@ export function useSelection<T>({
         throw new Error('Invariant violation: calling selection props with missing selection type.');
       }
       return {
-        name: selectionName,
-        disabled: allDisabled || !!loading,
+        name: selectionControlName,
         selectionType: selectionType,
-        indeterminate: hasSelected && !allEnabledSelected,
-        checked: hasSelected && allEnabledSelected,
+        disabled: allItemsDisabled || !!loading,
+        checked: allItemsCheckboxSelected,
+        indeterminate: allItemsCheckboxIndeterminate,
         onChange: handleToggleAll,
         ariaLabel: joinStrings(
           ariaLabels?.selectionGroupLabel,
@@ -144,15 +137,16 @@ export function useSelection<T>({
         throw new Error('Invariant violation: calling selection props with missing selection type.');
       }
       return {
-        name: selectionName,
+        name: selectionControlName,
         selectionType: selectionType,
+        disabled: isItemDisabled(item),
+        checked: isItemSelected(item),
+        indeterminate: false,
+        onChange: () => handleToggleItem(item),
         ariaLabel: joinStrings(
           ariaLabels?.selectionGroupLabel,
           ariaLabels?.itemSelectionLabel?.({ selectedItems }, item)
         ),
-        onChange: handleToggleItem(item),
-        checked: isItemSelected(item),
-        disabled: isItemDisabled(item),
       };
     },
     updateShiftToggle: (value: boolean) => {


### PR DESCRIPTION
### Description

The refactoring is done to facilitate future planned support for grouped selection so that when a parent row is selected (in table with expandable rows) all child rows are automatically selected too. That different selection mechanism requires a different computation which can be substituted to the useSelection.

### How has this been tested?

Existing tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
