### PR TITLE
chore: Set dir attribute to ltr for email input type.

### DIFF
--- a/src/input/internal.tsx
+++ b/src/input/internal.tsx
@@ -173,7 +173,12 @@ function InternalInput(
   }
 
   return (
-    <div {...baseProps} className={clsx(baseProps.className, styles['input-container'])} ref={__internalRootRef}>
+    <div
+      {...baseProps}
+      className={clsx(baseProps.className, styles['input-container'])}
+      ref={__internalRootRef}
+      dir={type === 'email' ? 'ltr' : undefined}
+    >
       {__leftIcon && (
         <span onClick={__onLeftIconClick} className={styles['input-icon-left']}>
           <InternalIcon name={__leftIcon} variant={disabled || readOnly ? 'disabled' : __leftIconVariant} />


### PR DESCRIPTION
Email input types should always use dir='ltr' regardless of the inherited document direction. This PR updates the attribute accordingly.