### PR TITLE
feat: Constraint text for Property Filter

### DIFF
--- a/pages/property-filter/permutations.page.tsx
+++ b/pages/property-filter/permutations.page.tsx
@@ -110,6 +110,24 @@ const permutations = createPermutations<Partial<PropertyFilterProps>>([
       <ButtonDropdown key={0} mainAction={{ text: 'Clear filters' }} items={[]} ariaLabel="Filter actions" />,
     ],
   },
+  {
+    query: [
+      { tokens: [], operation: 'and' },
+      {
+        tokens: [
+          { value: '123', operator: ':' },
+          { value: '234', operator: '!:' },
+          { propertyKey: 'instanceid', value: '345', operator: '=' },
+        ],
+        operation: 'and',
+      },
+    ],
+    filteringConstraintText: [
+      <div key={0}>
+        Some <b>bold</b> constraint text
+      </div>,
+    ],
+  },
 ]);
 
 export default function () {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11450,6 +11450,12 @@ When using this slot, make sure to still provide a mechanism to clear all filter
       "name": "customFilterActions",
     },
     Object {
+      "description": "Constraint text that's displayed below the filtering input.
+Use this to provide additional information about supported filters.",
+      "isDefault": false,
+      "name": "filteringConstraintText",
+    },
+    Object {
       "description": "Displayed when there are no options to display.
 This is only shown when \`statusType\` is set to \`finished\` or not set at all.",
       "isDefault": false,

--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -411,6 +411,7 @@ Object {
     "awsui_root_11huc",
   ],
   "property-filter": Array [
+    "awsui_constraint_1wzqe",
     "awsui_custom-control_1wzqe",
     "awsui_custom-filter-actions_1wzqe",
     "awsui_remove-all_1wzqe",

--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -464,6 +464,34 @@ describe('property filter parts', () => {
     });
   });
 
+  describe('constraint text', () => {
+    test('is not displayed when constraint text is empty', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringConstraintText: '',
+        query: { tokens: [{ propertyKey: 'string', value: 'first', operator: ':' }], operation: 'or' },
+      });
+      expect(wrapper.findConstraint()).toBe(null);
+    });
+    test('is visible when the constraint text is not empty', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        filteringConstraintText: <div>This is my constraint</div>,
+        query: { tokens: [{ propertyKey: 'string', value: 'first', operator: ':' }], operation: 'or' },
+      });
+      expect(wrapper.findConstraint()!.getElement()).toHaveTextContent('This is my constraint');
+    });
+    test('is used as ARIA description for the autosuggest input', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        ariaDescribedby: 'my-custom-description',
+        filteringConstraintText: <div>This is my constraint</div>,
+        query: { tokens: [{ propertyKey: 'string', value: 'first', operator: ':' }], operation: 'or' },
+      });
+      expect(wrapper.findNativeInput().getElement()).toHaveAttribute(
+        'aria-describedby',
+        'my-custom-description' + ' ' + wrapper.findConstraint()!.getElement().id
+      );
+    });
+  });
+
   describe('filtering  tokens', () => {
     describe('content', () => {
       test('free text token', () => {

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -37,6 +37,7 @@ import { PropertyFilterOperator } from '@cloudscape-design/collection-hooks';
 import { useInternalI18n } from '../i18n/context';
 import TokenList from '../internal/components/token-list';
 import { SearchResults } from '../text-filter/search-results';
+import { joinStrings } from '../internal/utils/strings';
 
 export { PropertyFilterProps };
 
@@ -94,6 +95,7 @@ const PropertyFilter = React.forwardRef(
       filteringFinishedText,
       filteringErrorText,
       filteringRecoveryText,
+      filteringConstraintText,
       filteringStatusType,
       asyncProperties,
       tokenLimit,
@@ -349,6 +351,10 @@ const PropertyFilter = React.forwardRef(
       parsedText.step === 'property' && parsedText.property.getValueFormRenderer(parsedText.operator);
 
     const searchResultsId = useUniqueId('property-filter-search-results');
+    const constraintTextId = useUniqueId('property-filter-constraint');
+    const textboxAriaDescribedBy = filteringConstraintText
+      ? joinStrings(rest.ariaDescribedby, constraintTextId)
+      : rest.ariaDescribedby;
 
     return (
       <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
@@ -361,7 +367,7 @@ const PropertyFilter = React.forwardRef(
             ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
             placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
             ariaLabelledby={rest.ariaLabelledby}
-            ariaDescribedby={rest.ariaDescribedby}
+            ariaDescribedby={textboxAriaDescribedBy}
             controlId={rest.controlId}
             value={filteringText}
             disabled={disabled}
@@ -404,6 +410,11 @@ const PropertyFilter = React.forwardRef(
             </div>
           ) : null}
         </div>
+        {filteringConstraintText && (
+          <div id={constraintTextId} className={styles.constraint}>
+            {filteringConstraintText}
+          </div>
+        )}
         {internalQuery.tokens && internalQuery.tokens.length > 0 && (
           <div className={styles.tokens}>
             <InternalSpaceBetween size="xs" direction="horizontal">

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -185,6 +185,11 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    **/
   filteringRecoveryText?: string;
   /**
+   * Constraint text that's displayed below the filtering input.
+   * Use this to provide additional information about supported filters.
+   */
+  filteringConstraintText?: React.ReactNode;
+  /**
    * Specifies the current status of loading more options.
    * * `pending` - Indicates that no request in progress, but more options may be loaded.
    * * `loading` - Indicates that data fetching is in progress.

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -109,3 +109,8 @@
 .custom-filter-actions {
   /* used in test-utils */
 }
+
+.constraint {
+  padding-block-start: awsui.$space-xxs;
+  @include styles.form-control-description;
+}

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -48,4 +48,11 @@ export default class PropertyFilterWrapper extends AutosuggestWrapper {
   findCustomFilterActions(): ElementWrapper | null {
     return this.findByClassName(styles['custom-filter-actions']);
   }
+
+  /**
+   * Returns the element containing the `filteringConstraintText` slot.
+   */
+  findConstraint(): ElementWrapper | null {
+    return this.findByClassName(styles.constraint);
+  }
 }


### PR DESCRIPTION
### Description

This CR adds the ability to display a constraint text for the Property Filter. This can be used for server-side collections when the capabilities of the Search API do not allow every combination of filters offered by Property Filter: limited number of filter tokens, incompatible tokens, etc.

This change includes a new method to the `PropertyFilterWrapper` test utility, to find the new slot container for the constraint text.

See: mMxbAEGGaa5a

### How has this been tested?

1. Tested by updating the permutations page to display constraint text with and without tokens:

<img width="726" alt="Screenshot 2024-05-13 at 17 12 10" src="https://github.com/cloudscape-design/components/assets/4647197/50352a4f-986a-4d36-a3b1-135e9b11e7cd">

2. Updated unit tests with a straightforward test to confirm the new test utility works and that the constraint text is correctly slotted.
3. Ran all unit, integ, a11y and motion tests. Updated documentation snapshots.
4. Ran visual regression testing. Since I updated the Property Filter permutations, the tests for that page failed and the snapshots will need to be updated. Before/after on the page:

https://github.com/cloudscape-design/components/assets/4647197/26b2a1d1-05df-42eb-a30c-214e0361850c

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
