### PR TITLE
fix: Fix chart popovers rendering under sticky headers

### DIFF
--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -329,7 +329,7 @@ test('popover size is assigned', () => {
     // Show popover for the first data point.
     wrapper.findApplication()!.focus();
 
-    expect(wrapper.findByClassName(popoverStyles[`container-body-size-${size}`])).not.toBe(null);
+    expect(wrapper.findDetailPopover()!.findByClassName(popoverStyles[`container-body-size-${size}`])).not.toBe(null);
   }
 });
 

--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -20,6 +20,7 @@ import useHighlightDetails from './elements/use-highlight-details';
 import useContainerWidth from '../internal/utils/use-container-width';
 import { useSelector } from './async-store';
 import { CartesianChartContainer } from '../internal/components/cartesian-chart/chart-container';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 const DEFAULT_CHART_WIDTH = 500;
 const INLINE_START_LABELS_MARGIN = 16;
@@ -76,6 +77,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   yTickFormatter = deprecatedYTickFormatter,
   detailTotalFormatter = deprecatedDetailTotalFormatter,
 }: ChartContainerProps<T>) {
+  const chartId = useUniqueId();
   const [inlineStartLabelsWidth, setInlineStartLabelsWidth] = useState(0);
   const [containerWidth, containerWidthRef] = useContainerWidth(DEFAULT_CHART_WIDTH);
   const maxInlineStartLabelsWidth = Math.round(containerWidth / 2);
@@ -132,6 +134,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
       chartPlot={
         <ChartPlot
           ref={model.refs.plot}
+          id={chartId}
           width="100%"
           height={fitHeight ? `calc(100% - ${blockEndLabelsProps.height}px)` : model.height}
           offsetBottom={blockEndLabelsProps.height}
@@ -194,6 +197,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
       }
       popover={
         <AreaChartPopover
+          popoverId={chartId}
           model={model}
           highlightDetails={highlightDetails}
           dismissAriaLabel={detailPopoverDismissAriaLabel}

--- a/src/area-chart/elements/chart-popover.tsx
+++ b/src/area-chart/elements/chart-popover.tsx
@@ -12,6 +12,7 @@ import { HighlightDetails } from './use-highlight-details';
 import ChartPopoverFooter from '../../internal/components/chart-popover-footer';
 
 export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
+  popoverId,
   model,
   highlightDetails,
   dismissAriaLabel,
@@ -19,6 +20,7 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
   size,
   onBlur,
 }: {
+  popoverId: string;
   model: ChartModel<T>;
   highlightDetails: null | HighlightDetails;
   dismissAriaLabel?: string;
@@ -26,31 +28,29 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
   size?: 'small' | 'medium' | 'large';
   onBlur?: (event: React.FocusEvent) => void;
 }) {
-  if (!highlightDetails) {
-    return null;
-  }
-
-  const popoverProps = {
-    title: highlightDetails.formattedX,
-    trackRef: model.refs.verticalMarker,
-    trackKey: highlightDetails.highlightIndex,
-    dismissButton: highlightDetails.isPopoverPinned,
-    onDismiss: model.handlers.onPopoverDismiss,
-    onMouseLeave: model.handlers.onPopoverLeave,
-    ref: model.refs.popoverRef,
-  };
-
   return (
     <ChartPopover
-      {...popoverProps}
+      popoverId={popoverId}
+      isOpen={!!highlightDetails}
+      ref={model.refs.popoverRef}
+      title={highlightDetails?.formattedX}
+      trackRef={model.refs.verticalMarker}
+      trackKey={highlightDetails?.highlightIndex}
+      dismissButton={highlightDetails?.isPopoverPinned}
+      onDismiss={model.handlers.onPopoverDismiss}
+      onMouseLeave={model.handlers.onPopoverLeave}
       container={model.refs.container.current}
       dismissAriaLabel={dismissAriaLabel}
       size={size}
       onBlur={onBlur}
     >
-      <ChartSeriesDetails details={highlightDetails.seriesDetails} />
-      <div className={styles['popover-divider']} />
-      <ChartSeriesDetails details={highlightDetails.totalDetails} />
+      {highlightDetails && (
+        <>
+          <ChartSeriesDetails details={highlightDetails.seriesDetails} />
+          <div className={styles['popover-divider']} />
+          <ChartSeriesDetails details={highlightDetails.totalDetails} />
+        </>
+      )}
       {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
     </ChartPopover>
   );

--- a/src/internal/components/chart-plot/index.tsx
+++ b/src/internal/components/chart-plot/index.tsx
@@ -23,6 +23,7 @@ export interface ChartPlotRef {
 }
 
 export interface ChartPlotProps {
+  id?: string;
   width: number | string;
   height: number | string;
   transform?: string;
@@ -65,6 +66,7 @@ export default forwardRef(ChartPlot);
 
 function ChartPlot(
   {
+    id,
     width,
     height,
     transform,
@@ -169,6 +171,7 @@ function ChartPlot(
   return (
     <>
       <svg
+        id={id}
         onMouseMove={onMouseMove}
         onMouseOut={onMouseOut}
         focusable={plotFocusable}

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -14,13 +14,15 @@ import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import styles from './styles.css.js';
 import { nodeBelongs } from '../../utils/node-belongs';
+import { Transition } from '../transition';
+import Portal from '../portal';
 
 export interface ChartPopoverProps extends PopoverProps {
   /** Title of the popover */
   title?: React.ReactNode;
 
   /** References the element the container is positioned against. */
-  trackRef: React.RefObject<HTMLElement | SVGElement>;
+  trackRef: React.RefObject<HTMLElement | SVGElement> | undefined;
   /**
     Used to update the container position in case track or track position changes:
     
@@ -31,6 +33,12 @@ export interface ChartPopoverProps extends PopoverProps {
     </>)
   */
   trackKey?: string | number;
+
+  /** whether the popover is open */
+  isOpen: boolean;
+
+  /** unique identifier to track cross-portal interactions */
+  popoverId: string;
 
   /** Optional container element that prevents any clicks in there from dismissing the popover */
   container: Element | null;
@@ -54,6 +62,8 @@ export default React.forwardRef(ChartPopover);
 
 function ChartPopover(
   {
+    isOpen,
+    popoverId,
     position = 'right',
     size = 'medium',
     fixedWidth = false,
@@ -102,46 +112,56 @@ function ChartPopover(
   const isPinned = dismissButton;
 
   return (
-    <div
-      {...baseProps}
-      className={clsx(popoverStyles.root, styles.root, baseProps.className)}
-      ref={popoverRef}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      onBlur={onBlur}
-      // The tabIndex makes it so that clicking inside popover assigns this element as blur target.
-      // That is necessary in charts to ensure the blur target is within the chart and no cleanup is needed.
-      tabIndex={-1}
-    >
-      <PopoverContainer
-        size={size}
-        fixedWidth={fixedWidth}
-        position={position}
-        trackRef={trackRef}
-        trackKey={trackKey}
-        arrow={position => (
-          <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
-            <div className={popoverStyles['arrow-outer']} />
-            <div className={popoverStyles['arrow-inner']} />
+    <Portal>
+      <Transition in={isOpen}>
+        {(state, ref) => (
+          <div data-awsui-referrer-id={popoverId} ref={ref} className={clsx(state === 'exiting' && styles.exiting)}>
+            {isOpen && trackRef && (
+              <div
+                {...baseProps}
+                className={clsx(popoverStyles.root, styles.root, baseProps.className)}
+                ref={popoverRef}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                onBlur={onBlur}
+                // The tabIndex makes it so that clicking inside popover assigns this element as blur target.
+                // That is necessary in charts to ensure the blur target is within the chart and no cleanup is needed.
+                tabIndex={-1}
+              >
+                <PopoverContainer
+                  size={size}
+                  fixedWidth={fixedWidth}
+                  position={position}
+                  trackRef={trackRef}
+                  trackKey={trackKey}
+                  arrow={position => (
+                    <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
+                      <div className={popoverStyles['arrow-outer']} />
+                      <div className={popoverStyles['arrow-inner']} />
+                    </div>
+                  )}
+                  keepPosition={true}
+                  allowVerticalOverflow={true}
+                  allowScrollToFit={isPinned}
+                >
+                  <div className={styles['hover-area']}>
+                    <PopoverBody
+                      dismissButton={dismissButton}
+                      dismissAriaLabel={dismissAriaLabel}
+                      header={title}
+                      onDismiss={onDismiss}
+                      overflowVisible="content"
+                      className={styles['popover-body']}
+                    >
+                      {children}
+                    </PopoverBody>
+                  </div>
+                </PopoverContainer>
+              </div>
+            )}
           </div>
         )}
-        keepPosition={true}
-        allowVerticalOverflow={true}
-        allowScrollToFit={isPinned}
-      >
-        <div className={styles['hover-area']}>
-          <PopoverBody
-            dismissButton={dismissButton}
-            dismissAriaLabel={dismissAriaLabel}
-            header={title}
-            onDismiss={onDismiss}
-            overflowVisible="content"
-            className={styles['popover-body']}
-          >
-            {children}
-          </PopoverBody>
-        </div>
-      </PopoverContainer>
-    </div>
+      </Transition>
+    </Portal>
   );
 }

--- a/src/internal/components/chart-popover/motion.scss
+++ b/src/internal/components/chart-popover/motion.scss
@@ -1,0 +1,14 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../styles' as styles;
+@use '../../styles/tokens' as awsui;
+
+.exiting {
+  @include styles.with-motion {
+    @include styles.animation-fade-out-0;
+    animation: awsui-motion-fade-out-0 awsui.$motion-duration-refresh-only-fast awsui.$motion-easing-refresh-only-b;
+  }
+}

--- a/src/internal/components/chart-popover/styles.scss
+++ b/src/internal/components/chart-popover/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
+@use './motion';
 
 .root {
   @include styles.styles-reset;

--- a/src/mixed-line-bar-chart/__tests__/chart-popover.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/chart-popover.test.tsx
@@ -3,14 +3,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import createWrapper from '../../../lib/components/test-utils/dom';
 import ChartPopoverWrapper from '../../../lib/components/test-utils/dom/internal/chart-popover';
 import MixedChartPopover, { MixedChartPopoverProps } from '../../../lib/components/mixed-line-bar-chart/chart-popover';
 import { ChartDataTypes } from '../../../lib/components/mixed-line-bar-chart/interfaces';
 
 const dummyRef = { current: null };
 function renderChart<T extends ChartDataTypes>(props: Partial<MixedChartPopoverProps<T>>) {
-  const { container } = render(
+  render(
     <MixedChartPopover
+      popoverId={''}
       isOpen={props.isOpen ?? false}
       isPinned={props.isPinned ?? false}
       highlightDetails={props.highlightDetails ?? null}
@@ -22,13 +24,14 @@ function renderChart<T extends ChartDataTypes>(props: Partial<MixedChartPopoverP
       setPopoverText={() => null}
     />
   );
-  return new ChartPopoverWrapper(container);
+  const root = createWrapper().findByClassName(ChartPopoverWrapper.rootSelector);
+  return root ? new ChartPopoverWrapper(root.getElement()) : null;
 }
 
 test('not rendered when no position', () => {
   const wrapper = renderChart({ isOpen: true, highlightDetails: null });
 
-  expect(wrapper.findHeader()).toBeNull();
+  expect(wrapper).toBeNull();
 });
 
 test('not rendered when not open', () => {
@@ -37,7 +40,7 @@ test('not rendered when not open', () => {
     highlightDetails: { position: '1', details: [] },
   });
 
-  expect(wrapper.findHeader()).toBeNull();
+  expect(wrapper).toBeNull();
 });
 
 test('contains series details', () => {
@@ -54,8 +57,8 @@ test('contains series details', () => {
     },
   });
 
-  expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Potatoes');
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('Series123');
+  expect(wrapper!.findHeader()!.getElement()).toHaveTextContent('Potatoes');
+  expect(wrapper!.findContent()!.getElement()).toHaveTextContent('Series123');
 });
 
 test('can contain custom footer content', () => {
@@ -73,5 +76,5 @@ test('can contain custom footer content', () => {
     footer: 'My custom footer',
   });
 
-  expect(wrapper.findContent()!.getElement()).toHaveTextContent('My custom footer');
+  expect(wrapper!.findContent()!.getElement()).toHaveTextContent('My custom footer');
 });

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -949,17 +949,16 @@ describe('Details popover', () => {
 
     // Should be visible but unpinned first
     expect(wrapper.findDetailPopover()).not.toBeNull();
-    expect(wrapper.findDetailPopover()?.findDismissButton()).toBeNull();
+    expect(wrapper.findDetailPopover()!.findDismissButton()).toBeNull();
 
     // Can be pinned
     wrapper.findChart()!.click();
 
-    expect(wrapper.findDetailPopover()?.findDismissButton()).not.toBeNull();
-    expect(wrapper.findByClassName(styles.exiting)).toBeNull();
+    expect(wrapper.findDetailPopover()!.findDismissButton()).not.toBeNull();
 
     // Can be unpinned
-    wrapper.findDetailPopover()?.findDismissButton()?.click();
-    expect(wrapper.findByClassName(styles.exiting)).not.toBeNull();
+    wrapper.findDetailPopover()!.findDismissButton()?.click();
+    expect(wrapper.findDetailPopover()).toBeNull();
   });
 
   test('delegates focus back to chart when unpinned in a non-grouped chart', async () => {

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -35,6 +35,7 @@ import { nodeBelongs } from '../internal/utils/node-belongs';
 import { CartesianChartContainer } from '../internal/components/cartesian-chart/chart-container';
 import { useHeightMeasure } from '../internal/hooks/container-queries/use-height-measure';
 import { getIsRtl } from '../internal/direction';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
 
 const INLINE_START_LABELS_MARGIN = 16;
 const BLOCK_END_LABELS_OFFSET = 12;
@@ -131,6 +132,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
   detailPopoverSeriesContent,
   ...props
 }: ChartContainerProps<T>) {
+  const chartId = useUniqueId();
   const plotRef = useRef<ChartPlotRef>(null);
   const verticalMarkerRef = useRef<SVGLineElement>(null);
 
@@ -519,6 +521,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
       bottomAxisLabel={<AxisLabel axis={x} position="bottom" title={bottomAxisProps.title} />}
       chartPlot={
         <ChartPlot
+          id={chartId}
           ref={plotRef}
           width="100%"
           height={fitHeight ? `calc(100% - ${blockEndLabelsProps.height}px)` : plotHeight}
@@ -637,6 +640,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
       popover={
         <MixedChartPopover
           ref={popoverRef}
+          popoverId={chartId}
           containerRef={containerRefObject}
           trackRef={highlightedElementRef}
           isOpen={isPopoverOpen}

--- a/src/mixed-line-bar-chart/chart-popover.tsx
+++ b/src/mixed-line-bar-chart/chart-popover.tsx
@@ -1,18 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import clsx from 'clsx';
 
 import ChartPopover from '../internal/components/chart-popover';
 import ChartSeriesDetails, { ExpandedSeries } from '../internal/components/chart-series-details';
 import { ChartDataTypes, MixedLineBarChartProps } from './interfaces';
 
-import styles from './styles.css.js';
-import { Transition } from '../internal/components/transition';
 import { HighlightDetails } from './format-highlighted';
 import ChartPopoverFooter from '../internal/components/chart-popover-footer';
 
 export interface MixedChartPopoverProps<T extends ChartDataTypes> {
+  popoverId: string;
   containerRef: React.RefObject<HTMLDivElement>;
   trackRef: React.RefObject<SVGElement>;
   isOpen: boolean;
@@ -32,6 +30,7 @@ export default React.forwardRef(MixedChartPopover);
 
 function MixedChartPopover<T extends ChartDataTypes>(
   {
+    popoverId,
     containerRef,
     trackRef,
     isOpen,
@@ -50,49 +49,45 @@ function MixedChartPopover<T extends ChartDataTypes>(
 ) {
   const [expandedSeries, setExpandedSeries] = useState<Record<string, ExpandedSeries>>({});
   return (
-    <Transition in={isOpen}>
-      {(state, ref) => (
-        <div ref={ref} className={clsx(state === 'exiting' && styles.exiting)}>
-          {(isOpen || state !== 'exited') && highlightDetails && (
-            <ChartPopover
-              ref={popoverRef}
-              title={highlightDetails.position}
-              trackRef={trackRef}
-              trackKey={highlightDetails.position}
-              dismissButton={isPinned}
-              dismissAriaLabel={dismissAriaLabel}
-              onDismiss={onDismiss}
-              container={containerRef.current}
-              size={size}
-              onMouseEnter={onMouseEnter}
-              onMouseLeave={onMouseLeave}
-              onBlur={onBlur}
-            >
-              <ChartSeriesDetails
-                key={highlightDetails.position}
-                details={highlightDetails.details}
-                setPopoverText={setPopoverText}
-                expandedSeries={expandedSeries[highlightDetails.position]}
-                setExpandedState={(id, isExpanded) =>
-                  setExpandedSeries(oldState => {
-                    const expandedSeriesInCurrentCoordinate = new Set(oldState[highlightDetails.position]);
-                    if (isExpanded) {
-                      expandedSeriesInCurrentCoordinate.add(id);
-                    } else {
-                      expandedSeriesInCurrentCoordinate.delete(id);
-                    }
-                    return {
-                      ...oldState,
-                      [highlightDetails.position]: expandedSeriesInCurrentCoordinate,
-                    };
-                  })
-                }
-              />
-              {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
-            </ChartPopover>
-          )}
-        </div>
+    <ChartPopover
+      popoverId={popoverId}
+      isOpen={isOpen && !!highlightDetails}
+      ref={popoverRef}
+      title={highlightDetails?.position}
+      trackRef={trackRef}
+      trackKey={highlightDetails?.position}
+      dismissButton={isPinned}
+      dismissAriaLabel={dismissAriaLabel}
+      onDismiss={onDismiss}
+      container={containerRef.current}
+      size={size}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onBlur={onBlur}
+    >
+      {highlightDetails && (
+        <ChartSeriesDetails
+          key={highlightDetails.position}
+          details={highlightDetails.details}
+          setPopoverText={setPopoverText}
+          expandedSeries={expandedSeries[highlightDetails.position]}
+          setExpandedState={(id, isExpanded) =>
+            setExpandedSeries(oldState => {
+              const expandedSeriesInCurrentCoordinate = new Set(oldState[highlightDetails.position]);
+              if (isExpanded) {
+                expandedSeriesInCurrentCoordinate.add(id);
+              } else {
+                expandedSeriesInCurrentCoordinate.delete(id);
+              }
+              return {
+                ...oldState,
+                [highlightDetails.position]: expandedSeriesInCurrentCoordinate,
+              };
+            })
+          }
+        />
       )}
-    </Transition>
+      {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
+    </ChartPopover>
   );
 }

--- a/src/mixed-line-bar-chart/hooks/use-popover.ts
+++ b/src/mixed-line-bar-chart/hooks/use-popover.ts
@@ -10,7 +10,9 @@ export function usePopover() {
 
   const showPopover = useCallback(() => setState('open'), []);
   const pinPopover = useCallback(() => setState('pinned'), []);
-  const dismissPopover = useCallback(() => setState('closed'), []);
+  const dismissPopover = useCallback(() => {
+    setState('closed');
+  }, []);
 
   return { isPopoverOpen, isPopoverPinned, showPopover, pinPopover, dismissPopover };
 }

--- a/src/mixed-line-bar-chart/motion.scss
+++ b/src/mixed-line-bar-chart/motion.scss
@@ -12,10 +12,3 @@
     transition: opacity awsui.$motion-duration-transition-quick awsui.$motion-easing-transition-quick;
   }
 }
-
-.exiting {
-  @include styles.with-motion {
-    @include styles.animation-fade-out-0;
-    animation: awsui-motion-fade-out-0 awsui.$motion-duration-refresh-only-fast awsui.$motion-easing-refresh-only-b;
-  }
-}

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -85,6 +85,7 @@ export default <T extends PieChartProps.Datum>({
   const focusedSegmentRef = useRef<SVGGElement>(null);
   const popoverTrackRef = useRef<SVGCircleElement>(null);
   const popoverRef = useRef<HTMLElement | null>(null);
+  const chartId = useUniqueId();
 
   const hasLabels = !(hideTitles && hideDescriptions);
   const isRefresh = useVisualRefresh();
@@ -301,6 +302,7 @@ export default <T extends PieChartProps.Datum>({
         )}
       >
         <ChartPlot
+          id={chartId}
           ref={plotRef}
           width="100%"
           height={fitHeight ? '100%' : height}
@@ -364,31 +366,31 @@ export default <T extends PieChartProps.Datum>({
           )}
         </div>
       )}
-      {isPopoverOpen && popoverData && (
-        <ChartPopover
-          ref={popoverRef}
-          title={
-            popoverData.series && (
-              <InternalBox className={styles['popover-header']} variant="strong">
-                <SeriesMarker color={popoverData.series.color} type={popoverData.series.markerType} />{' '}
-                {popoverData.series.label}
-              </InternalBox>
-            )
-          }
-          trackRef={popoverData.trackRef}
-          trackKey={popoverData.series.index}
-          dismissButton={pinnedSegment !== null}
-          dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
-          onDismiss={onPopoverDismiss}
-          container={plotRef.current?.svg || null}
-          size={detailPopoverSize}
-          onMouseLeave={checkMouseLeave}
-          onBlur={onApplicationBlur}
-        >
-          {popoverContent}
-          {detailPopoverFooterContent && <ChartPopoverFooter>{detailPopoverFooterContent}</ChartPopoverFooter>}
-        </ChartPopover>
-      )}
+      <ChartPopover
+        ref={popoverRef}
+        popoverId={chartId}
+        isOpen={isPopoverOpen && !!popoverData}
+        title={
+          popoverData?.series && (
+            <InternalBox className={styles['popover-header']} variant="strong">
+              <SeriesMarker color={popoverData.series.color} type={popoverData.series.markerType} />{' '}
+              {popoverData.series.label}
+            </InternalBox>
+          )
+        }
+        trackRef={popoverData?.trackRef}
+        trackKey={popoverData?.series.index}
+        dismissButton={pinnedSegment !== null}
+        dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
+        onDismiss={onPopoverDismiss}
+        container={plotRef.current?.svg || null}
+        size={detailPopoverSize}
+        onMouseLeave={checkMouseLeave}
+        onBlur={onApplicationBlur}
+      >
+        {popoverContent}
+        {detailPopoverFooterContent && <ChartPopoverFooter>{detailPopoverFooterContent}</ChartPopoverFooter>}
+      </ChartPopover>
       <LiveRegion source={[popoverContentRef]} />
     </div>
   );

--- a/src/test-utils/dom/internal/charts.ts
+++ b/src/test-utils/dom/internal/charts.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
+import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 import ChartLegendWrapper from './chart-legend';
 import ChartFilterWrapper from './chart-filter';
 import ChartPopoverWrapper from './chart-popover';
@@ -23,6 +23,6 @@ export default class CommonChartWrapper extends ComponentWrapper {
   }
 
   findDetailPopover(): ChartPopoverWrapper | null {
-    return this.findComponent(`.${popoverStyles.root}`, ChartPopoverWrapper);
+    return createWrapper().findComponent(`.${popoverStyles.root}`, ChartPopoverWrapper);
   }
 }


### PR DESCRIPTION
### Description

Fix AWSUI-43021

Related links, issue #, if available: n/a

### How has this been tested?

* Regression testing done in my dev-pipeline
* For the change, reproduced the issue locally and tested there. Not included into the PR because automated testing for this issue is hard to do. Let's assume as long as we use `<Portal>` util there, we are safe

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
