### PR TITLE
refactor: Move transition handling to shared chart popover component

### DIFF
--- a/src/area-chart/__tests__/area-chart-initial-state.test.tsx
+++ b/src/area-chart/__tests__/area-chart-initial-state.test.tsx
@@ -329,7 +329,7 @@ test('popover size is assigned', () => {
     // Show popover for the first data point.
     wrapper.findApplication()!.focus();
 
-    expect(wrapper.findByClassName(popoverStyles[`container-body-size-${size}`])).not.toBe(null);
+    expect(wrapper.findDetailPopover()!.findByClassName(popoverStyles[`container-body-size-${size}`])).not.toBe(null);
   }
 });
 

--- a/src/area-chart/elements/chart-popover.tsx
+++ b/src/area-chart/elements/chart-popover.tsx
@@ -26,31 +26,28 @@ export default function AreaChartPopover<T extends AreaChartProps.DataTypes>({
   size?: 'small' | 'medium' | 'large';
   onBlur?: (event: React.FocusEvent) => void;
 }) {
-  if (!highlightDetails) {
-    return null;
-  }
-
-  const popoverProps = {
-    title: highlightDetails.formattedX,
-    trackRef: model.refs.verticalMarker,
-    trackKey: highlightDetails.highlightIndex,
-    dismissButton: highlightDetails.isPopoverPinned,
-    onDismiss: model.handlers.onPopoverDismiss,
-    onMouseLeave: model.handlers.onPopoverLeave,
-    ref: model.refs.popoverRef,
-  };
-
   return (
     <ChartPopover
-      {...popoverProps}
+      isOpen={!!highlightDetails}
+      ref={model.refs.popoverRef}
+      title={highlightDetails?.formattedX}
+      trackRef={model.refs.verticalMarker}
+      trackKey={highlightDetails?.highlightIndex}
+      dismissButton={highlightDetails?.isPopoverPinned}
+      onDismiss={model.handlers.onPopoverDismiss}
+      onMouseLeave={model.handlers.onPopoverLeave}
       container={model.refs.container.current}
       dismissAriaLabel={dismissAriaLabel}
       size={size}
       onBlur={onBlur}
     >
-      <ChartSeriesDetails details={highlightDetails.seriesDetails} />
-      <div className={styles['popover-divider']} />
-      <ChartSeriesDetails details={highlightDetails.totalDetails} />
+      {highlightDetails && (
+        <>
+          <ChartSeriesDetails details={highlightDetails.seriesDetails} />
+          <div className={styles['popover-divider']} />
+          <ChartSeriesDetails details={highlightDetails.totalDetails} />
+        </>
+      )}
       {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
     </ChartPopover>
   );

--- a/src/internal/components/chart-popover/index.tsx
+++ b/src/internal/components/chart-popover/index.tsx
@@ -14,13 +14,14 @@ import { useMergeRefs } from '../../hooks/use-merge-refs';
 
 import styles from './styles.css.js';
 import { nodeBelongs } from '../../utils/node-belongs';
+import { Transition } from '../transition';
 
 export interface ChartPopoverProps extends PopoverProps {
   /** Title of the popover */
   title?: React.ReactNode;
 
   /** References the element the container is positioned against. */
-  trackRef: React.RefObject<HTMLElement | SVGElement>;
+  trackRef: React.RefObject<HTMLElement | SVGElement> | undefined;
   /**
     Used to update the container position in case track or track position changes:
     
@@ -31,6 +32,9 @@ export interface ChartPopoverProps extends PopoverProps {
     </>)
   */
   trackKey?: string | number;
+
+  /** whether the popover is open */
+  isOpen: boolean;
 
   /** Optional container element that prevents any clicks in there from dismissing the popover */
   container: Element | null;
@@ -54,6 +58,7 @@ export default React.forwardRef(ChartPopover);
 
 function ChartPopover(
   {
+    isOpen,
     position = 'right',
     size = 'medium',
     fixedWidth = false,
@@ -102,46 +107,54 @@ function ChartPopover(
   const isPinned = dismissButton;
 
   return (
-    <div
-      {...baseProps}
-      className={clsx(popoverStyles.root, styles.root, baseProps.className)}
-      ref={popoverRef}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      onBlur={onBlur}
-      // The tabIndex makes it so that clicking inside popover assigns this element as blur target.
-      // That is necessary in charts to ensure the blur target is within the chart and no cleanup is needed.
-      tabIndex={-1}
-    >
-      <PopoverContainer
-        size={size}
-        fixedWidth={fixedWidth}
-        position={position}
-        trackRef={trackRef}
-        trackKey={trackKey}
-        arrow={position => (
-          <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
-            <div className={popoverStyles['arrow-outer']} />
-            <div className={popoverStyles['arrow-inner']} />
-          </div>
-        )}
-        keepPosition={true}
-        allowVerticalOverflow={true}
-        allowScrollToFit={isPinned}
-      >
-        <div className={styles['hover-area']}>
-          <PopoverBody
-            dismissButton={dismissButton}
-            dismissAriaLabel={dismissAriaLabel}
-            header={title}
-            onDismiss={onDismiss}
-            overflowVisible="content"
-            className={styles['popover-body']}
-          >
-            {children}
-          </PopoverBody>
+    <Transition in={isOpen}>
+      {(state, ref) => (
+        <div ref={ref} className={clsx(state === 'exiting' && styles.exiting)}>
+          {isOpen && trackRef && (
+            <div
+              {...baseProps}
+              className={clsx(popoverStyles.root, styles.root, baseProps.className)}
+              ref={popoverRef}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
+              onBlur={onBlur}
+              // The tabIndex makes it so that clicking inside popover assigns this element as blur target.
+              // That is necessary in charts to ensure the blur target is within the chart and no cleanup is needed.
+              tabIndex={-1}
+            >
+              <PopoverContainer
+                size={size}
+                fixedWidth={fixedWidth}
+                position={position}
+                trackRef={trackRef}
+                trackKey={trackKey}
+                arrow={position => (
+                  <div className={clsx(popoverStyles.arrow, popoverStyles[`arrow-position-${position}`])}>
+                    <div className={popoverStyles['arrow-outer']} />
+                    <div className={popoverStyles['arrow-inner']} />
+                  </div>
+                )}
+                keepPosition={true}
+                allowVerticalOverflow={true}
+                allowScrollToFit={isPinned}
+              >
+                <div className={styles['hover-area']}>
+                  <PopoverBody
+                    dismissButton={dismissButton}
+                    dismissAriaLabel={dismissAriaLabel}
+                    header={title}
+                    onDismiss={onDismiss}
+                    overflowVisible="content"
+                    className={styles['popover-body']}
+                  >
+                    {children}
+                  </PopoverBody>
+                </div>
+              </PopoverContainer>
+            </div>
+          )}
         </div>
-      </PopoverContainer>
-    </div>
+      )}
+    </Transition>
   );
 }

--- a/src/internal/components/chart-popover/motion.scss
+++ b/src/internal/components/chart-popover/motion.scss
@@ -1,0 +1,14 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+@use '../../styles' as styles;
+@use '../../styles/tokens' as awsui;
+
+.exiting {
+  @include styles.with-motion {
+    @include styles.animation-fade-out-0;
+    animation: awsui-motion-fade-out-0 awsui.$motion-duration-refresh-only-fast awsui.$motion-easing-refresh-only-b;
+  }
+}

--- a/src/internal/components/chart-popover/styles.scss
+++ b/src/internal/components/chart-popover/styles.scss
@@ -5,6 +5,7 @@
 
 @use '../../styles' as styles;
 @use '../../styles/tokens' as awsui;
+@use './motion';
 
 .root {
   @include styles.styles-reset;

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -965,17 +965,16 @@ describe('Details popover', () => {
 
     // Should be visible but unpinned first
     expect(wrapper.findDetailPopover()).not.toBeNull();
-    expect(wrapper.findDetailPopover()?.findDismissButton()).toBeNull();
+    expect(wrapper.findDetailPopover()!.findDismissButton()).toBeNull();
 
     // Can be pinned
     wrapper.findChart()!.click();
 
-    expect(wrapper.findDetailPopover()?.findDismissButton()).not.toBeNull();
-    expect(wrapper.findByClassName(styles.exiting)).toBeNull();
+    expect(wrapper.findDetailPopover()!.findDismissButton()).not.toBeNull();
 
     // Can be unpinned
-    wrapper.findDetailPopover()?.findDismissButton()?.click();
-    expect(wrapper.findByClassName(styles.exiting)).not.toBeNull();
+    wrapper.findDetailPopover()!.findDismissButton()?.click();
+    expect(wrapper.findDetailPopover()).toBeNull();
   });
 
   test('delegates focus back to chart when unpinned in a non-grouped chart', async () => {

--- a/src/mixed-line-bar-chart/chart-popover.tsx
+++ b/src/mixed-line-bar-chart/chart-popover.tsx
@@ -1,14 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useState } from 'react';
-import clsx from 'clsx';
 
 import ChartPopover from '../internal/components/chart-popover';
 import ChartSeriesDetails, { ExpandedSeries } from '../internal/components/chart-series-details';
 import { ChartDataTypes, MixedLineBarChartProps } from './interfaces';
 
-import styles from './styles.css.js';
-import { Transition } from '../internal/components/transition';
 import { HighlightDetails } from './format-highlighted';
 import ChartPopoverFooter from '../internal/components/chart-popover-footer';
 
@@ -50,49 +47,44 @@ function MixedChartPopover<T extends ChartDataTypes>(
 ) {
   const [expandedSeries, setExpandedSeries] = useState<Record<string, ExpandedSeries>>({});
   return (
-    <Transition in={isOpen}>
-      {(state, ref) => (
-        <div ref={ref} className={clsx(state === 'exiting' && styles.exiting)}>
-          {(isOpen || state !== 'exited') && highlightDetails && (
-            <ChartPopover
-              ref={popoverRef}
-              title={highlightDetails.position}
-              trackRef={trackRef}
-              trackKey={highlightDetails.position}
-              dismissButton={isPinned}
-              dismissAriaLabel={dismissAriaLabel}
-              onDismiss={onDismiss}
-              container={containerRef.current}
-              size={size}
-              onMouseEnter={onMouseEnter}
-              onMouseLeave={onMouseLeave}
-              onBlur={onBlur}
-            >
-              <ChartSeriesDetails
-                key={highlightDetails.position}
-                details={highlightDetails.details}
-                setPopoverText={setPopoverText}
-                expandedSeries={expandedSeries[highlightDetails.position]}
-                setExpandedState={(id, isExpanded) =>
-                  setExpandedSeries(oldState => {
-                    const expandedSeriesInCurrentCoordinate = new Set(oldState[highlightDetails.position]);
-                    if (isExpanded) {
-                      expandedSeriesInCurrentCoordinate.add(id);
-                    } else {
-                      expandedSeriesInCurrentCoordinate.delete(id);
-                    }
-                    return {
-                      ...oldState,
-                      [highlightDetails.position]: expandedSeriesInCurrentCoordinate,
-                    };
-                  })
-                }
-              />
-              {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
-            </ChartPopover>
-          )}
-        </div>
+    <ChartPopover
+      isOpen={isOpen && !!highlightDetails}
+      ref={popoverRef}
+      title={highlightDetails?.position}
+      trackRef={trackRef}
+      trackKey={highlightDetails?.position}
+      dismissButton={isPinned}
+      dismissAriaLabel={dismissAriaLabel}
+      onDismiss={onDismiss}
+      container={containerRef.current}
+      size={size}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onBlur={onBlur}
+    >
+      {highlightDetails && (
+        <ChartSeriesDetails
+          key={highlightDetails.position}
+          details={highlightDetails.details}
+          setPopoverText={setPopoverText}
+          expandedSeries={expandedSeries[highlightDetails.position]}
+          setExpandedState={(id, isExpanded) =>
+            setExpandedSeries(oldState => {
+              const expandedSeriesInCurrentCoordinate = new Set(oldState[highlightDetails.position]);
+              if (isExpanded) {
+                expandedSeriesInCurrentCoordinate.add(id);
+              } else {
+                expandedSeriesInCurrentCoordinate.delete(id);
+              }
+              return {
+                ...oldState,
+                [highlightDetails.position]: expandedSeriesInCurrentCoordinate,
+              };
+            })
+          }
+        />
       )}
-    </Transition>
+      {footer && <ChartPopoverFooter>{footer}</ChartPopoverFooter>}
+    </ChartPopover>
   );
 }

--- a/src/mixed-line-bar-chart/motion.scss
+++ b/src/mixed-line-bar-chart/motion.scss
@@ -12,10 +12,3 @@
     transition: opacity awsui.$motion-duration-transition-quick awsui.$motion-easing-transition-quick;
   }
 }
-
-.exiting {
-  @include styles.with-motion {
-    @include styles.animation-fade-out-0;
-    animation: awsui-motion-fade-out-0 awsui.$motion-duration-refresh-only-fast awsui.$motion-easing-refresh-only-b;
-  }
-}

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -364,31 +364,30 @@ export default <T extends PieChartProps.Datum>({
           )}
         </div>
       )}
-      {isPopoverOpen && popoverData && (
-        <ChartPopover
-          ref={popoverRef}
-          title={
-            popoverData.series && (
-              <InternalBox className={styles['popover-header']} variant="strong">
-                <SeriesMarker color={popoverData.series.color} type={popoverData.series.markerType} />{' '}
-                {popoverData.series.label}
-              </InternalBox>
-            )
-          }
-          trackRef={popoverData.trackRef}
-          trackKey={popoverData.series.index}
-          dismissButton={pinnedSegment !== null}
-          dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
-          onDismiss={onPopoverDismiss}
-          container={plotRef.current?.svg || null}
-          size={detailPopoverSize}
-          onMouseLeave={checkMouseLeave}
-          onBlur={onApplicationBlur}
-        >
-          {popoverContent}
-          {detailPopoverFooterContent && <ChartPopoverFooter>{detailPopoverFooterContent}</ChartPopoverFooter>}
-        </ChartPopover>
-      )}
+      <ChartPopover
+        ref={popoverRef}
+        isOpen={isPopoverOpen && !!popoverData}
+        title={
+          popoverData?.series && (
+            <InternalBox className={styles['popover-header']} variant="strong">
+              <SeriesMarker color={popoverData.series.color} type={popoverData.series.markerType} />{' '}
+              {popoverData.series.label}
+            </InternalBox>
+          )
+        }
+        trackRef={popoverData?.trackRef}
+        trackKey={popoverData?.series.index}
+        dismissButton={pinnedSegment !== null}
+        dismissAriaLabel={i18nStrings.detailPopoverDismissAriaLabel}
+        onDismiss={onPopoverDismiss}
+        container={plotRef.current?.svg || null}
+        size={detailPopoverSize}
+        onMouseLeave={checkMouseLeave}
+        onBlur={onApplicationBlur}
+      >
+        {popoverContent}
+        {detailPopoverFooterContent && <ChartPopoverFooter>{detailPopoverFooterContent}</ChartPopoverFooter>}
+      </ChartPopover>
       <LiveRegion source={[popoverContentRef]} />
     </div>
   );


### PR DESCRIPTION
### Description

Improve code reuse between chart instances and apply the same transition treatment to all popovers used there

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Locally, ensured transition works on all chart instances

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
