### PR TITLE
fix: Fix markdown format in table docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -13710,20 +13710,20 @@ add a meaningful description to the whole selection.
   The comparator must implement ascending ordering, and the output is inverted automatically in case of descending order.
   If present, the \`sortingField\` property is ignored.
 * \`editConfig\` (EditConfig) - Enables inline editing in column when present. The value is used to configure the editing behavior.
-* * \`editConfig.ariaLabel\` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
-* * \`editConfig.errorIconAriaLabel\` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
-* * \`editConfig.editIconAriaLabel\` (string) - Specifies an alternate text for the edit icon used in column header.
-* * \`editConfig.constraintText\` (string) - Constraint text that is displayed below the edit control.
-* * \`editConfig.disabledReason\` ((item) => string | undefined) - A function that determines whether inline edit for certain items is disabled, and provides a reason why.
+  * \`editConfig.ariaLabel\` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
+  * \`editConfig.errorIconAriaLabel\` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
+  * \`editConfig.editIconAriaLabel\` (string) - Specifies an alternate text for the edit icon used in column header.
+  * \`editConfig.constraintText\` (string) - Constraint text that is displayed below the edit control.
+  * \`editConfig.disabledReason\` ((item) => string | undefined) - A function that determines whether inline edit for certain items is disabled, and provides a reason why.
            Return a string from the function to disable inline edit with a reason. Return \`undefined\` (or no return) from the function allow inline edit.
-* * \`editConfig.validation\` ((item, value) => string) - A function that allows you to validate the value of the edit control.
+  * \`editConfig.validation\` ((item, value) => string) - A function that allows you to validate the value of the edit control.
            Return a string from the function to display an error message. Return \`undefined\` (or no return) from the function to indicate that the value is valid.
-* * \`editConfig.editingCell\` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
+  * \`editConfig.editingCell\` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
        You receive the current table row \`item\` and a \`cellContext\` object as arguments.
        The \`cellContext\` object contains the following properties:
- *  * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
- *  * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
- * \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.",
+    * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
+    * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
+* \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.",
       "name": "columnDefinitions",
       "optional": false,
       "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -91,20 +91,20 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *   The comparator must implement ascending ordering, and the output is inverted automatically in case of descending order.
    *   If present, the `sortingField` property is ignored.
    * * `editConfig` (EditConfig) - Enables inline editing in column when present. The value is used to configure the editing behavior.
-   * * * `editConfig.ariaLabel` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
-   * * * `editConfig.errorIconAriaLabel` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
-   * * * `editConfig.editIconAriaLabel` (string) - Specifies an alternate text for the edit icon used in column header.
-   * * * `editConfig.constraintText` (string) - Constraint text that is displayed below the edit control.
-   * * * `editConfig.disabledReason` ((item) => string | undefined) - A function that determines whether inline edit for certain items is disabled, and provides a reason why.
+   *   * `editConfig.ariaLabel` (string) - Specifies a label for the edit control. Visually hidden but read by screen readers.
+   *   * `editConfig.errorIconAriaLabel` (string) - Specifies an ariaLabel for the error icon that is displayed when the validation fails.
+   *   * `editConfig.editIconAriaLabel` (string) - Specifies an alternate text for the edit icon used in column header.
+   *   * `editConfig.constraintText` (string) - Constraint text that is displayed below the edit control.
+   *   * `editConfig.disabledReason` ((item) => string | undefined) - A function that determines whether inline edit for certain items is disabled, and provides a reason why.
    *            Return a string from the function to disable inline edit with a reason. Return `undefined` (or no return) from the function allow inline edit.
-   * * * `editConfig.validation` ((item, value) => string) - A function that allows you to validate the value of the edit control.
+   *   * `editConfig.validation` ((item, value) => string) - A function that allows you to validate the value of the edit control.
    *            Return a string from the function to display an error message. Return `undefined` (or no return) from the function to indicate that the value is valid.
-   * * * `editConfig.editingCell` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
+   *   * `editConfig.editingCell` ((item, cellContext) => ReactNode) - Determines the display of a cell's content when inline editing is active on a cell;
    *        You receive the current table row `item` and a `cellContext` object as arguments.
    *        The `cellContext` object contains the following properties:
-   *  *  * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
-   *  *  * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
-   *  * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
+   *     * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
+   *     * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
+   * * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
   /**


### PR DESCRIPTION
### Description

Fix markdown formatting so lists are correctly nested

Related links, issue #, if available: n/a

### How has this been tested?

Tested output locally 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
