### PR TITLE
feat: Report bundle size for every commit in main

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions:
   statuses: write

--- a/.github/workflows/bundle-size/build.js
+++ b/.github/workflows/bundle-size/build.js
@@ -1,11 +1,21 @@
 import { build } from 'esbuild';
 import { gzip } from 'node:zlib';
 import { promisify } from 'node:util';
-import { unlinkSync, writeFileSync } from 'node:fs';
+import { unlinkSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
 const compress = promisify(gzip);
 
 function concatFiles(files) {
   return files.reduce((total, current) => total + current.text ?? '', '');
+}
+
+function getInstalledVersions(projectRoot) {
+  const packageLock = JSON.parse(readFileSync(path.join(projectRoot, 'package-lock.json'), 'utf-8'));
+  const entries = Object.entries(packageLock.packages)
+    .filter(([pkg]) => pkg.includes('@cloudscape-design'))
+    .map(([pkg, details]) => [pkg.replace(/^node_modules\//, ''), details.version]);
+  return Object.fromEntries(entries);
 }
 
 async function main() {
@@ -35,6 +45,7 @@ async function main() {
     cssCompressedSize: await getCompressedSize(cssContent),
     jsSize: jsContent.length,
     jsCompressedSize: await getCompressedSize(jsContent),
+    versions: getInstalledVersions('../components'),
   };
 }
 

--- a/.github/workflows/bundle-size/status-report.js
+++ b/.github/workflows/bundle-size/status-report.js
@@ -26,7 +26,7 @@ function getStatusMetadata(context) {
   return {
     owner: context.repo.owner,
     repo: context.repo.repo,
-    sha: context.payload.pull_request.head.sha,
+    sha: context.sha,
     context: 'Bundle size',
     state: 'pending',
     target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,


### PR DESCRIPTION
### Description

- Report bundle size on push (not just on pull request). This is so that reports can be associated with commits.
- Extend bundle size report to include dependency versions taken from `packagelock.json`, as `@cloudscape-design` dependencies are not pinned in `package.json`

### How has this been tested?

See:
- [Report on this PR](https://github.com/cloudscape-design/components/actions/runs/9129222860/job/25103251099?pr=2266) (PR workflow)
- [Report on dev branch](https://github.com/cloudscape-design/components/actions/runs/9129510421) (push workflow)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
