### PR TITLE
fix: Form field has padding even when no label is present

### DIFF
--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -218,7 +218,7 @@ export default function InternalFormField({
       ref={__internalRootRef}
       {...analyticsAttributes}
     >
-      <div className={clsx(__hideLabel && styles['visually-hidden'])}>
+      <div className={clsx(styles['label-wrapper'], __hideLabel && styles['visually-hidden'])}>
         {label && (
           <label className={styles.label} id={slotIds.label} htmlFor={generatedControlId}>
             {label}

--- a/src/form-field/styles.scss
+++ b/src/form-field/styles.scss
@@ -47,6 +47,10 @@
   &:not(.label-hidden) {
     padding-block-start: awsui.$space-xxs;
   }
+
+  .label-wrapper:empty + & {
+    padding-block-start: 0;
+  }
 }
 
 .control {


### PR DESCRIPTION
### Description

This PR removes the top padding from the form field when there is no label present. 
![padding](https://github.com/cloudscape-design/components/assets/9086585/44a018d7-3168-498f-8e06-4a8baa484cc7)

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-43667

### How has this been tested?
Tested manually in the dev pages by removing the label from a form field and inspecting the layout with the dev tools.

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
