### PR TITLE
feat: findAdditionalInfo method for progress bar test utils

### DIFF
--- a/src/progress-bar/__tests__/progress-bar.test.tsx
+++ b/src/progress-bar/__tests__/progress-bar.test.tsx
@@ -223,4 +223,10 @@ describe('Progress updates', () => {
     });
     expect(wrapper.find(`.${liveRegionStyles.root}`)?.getElement().textContent).toBe('Text-optional: 10%');
   });
+
+  test('renders additional info correctly', () => {
+    const wrapper = renderProgressBar({ additionalInfo: 'additional info' });
+
+    expect(wrapper.findAdditionalInfo()!.getElement().textContent).toBe('additional info');
+  });
 });

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -101,7 +101,11 @@ export default function ProgressBar({
           )}
         </div>
       </div>
-      {additionalInfo && <SmallText color={isInFlash ? 'inherit' : undefined}>{additionalInfo}</SmallText>}
+      {additionalInfo && (
+        <SmallText testId="additional-info" color={isInFlash ? 'inherit' : undefined}>
+          {additionalInfo}
+        </SmallText>
+      )}
     </div>
   );
 }

--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -53,11 +53,12 @@ export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: Progre
 interface SmallTextProps {
   color?: BoxProps.Color;
   children: React.ReactNode;
+  testId?: string;
 }
 
-export const SmallText = ({ color, children }: SmallTextProps) => {
+export const SmallText = ({ color, children, testId }: SmallTextProps) => {
   return (
-    <InternalBox className={styles['word-wrap']} variant="small" display="block" color={color}>
+    <InternalBox className={styles['word-wrap']} variant="small" display="block" color={color} data-testid={testId}>
       {children}
     </InternalBox>
   );

--- a/src/test-utils/dom/progress-bar/index.ts
+++ b/src/test-utils/dom/progress-bar/index.ts
@@ -27,4 +27,8 @@ export default class ProgressBarWrapper extends ComponentWrapper {
     const statusClassName = status ? `.${styles[`result-container-${status}`]} ` : '';
     return this.find(`${statusClassName}.${styles['result-text']}`);
   }
+
+  findAdditionalInfo(): ElementWrapper | null {
+    return this.find(`[data-testid="additional-info"]`);
+  }
 }


### PR DESCRIPTION
### Description

Introduced `findAdditionalInfo` method for progress bar test utils.

The test utils for the ProgressBar component do not provide a way to get the additionalInfo slot. In v2, customers worked around this by searching for a hardcoded class name, which does not work anymore in v3.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
