### PR TITLE
chore: Migrate CodeEditor to native CSS container queries.

### DIFF
--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -66,7 +66,7 @@ export function StatusBar({
         <span className={styles['status-bar__language-mode']}>{languageLabel}</span>
         <span className={styles['status-bar__cursor-position']}>{cursorPosition}</span>
 
-        <div role="tablist">
+        <div className={styles['tab-list']} role="tablist">
           <TabButton
             id={errorButtonId}
             count={errorCount}
@@ -83,6 +83,8 @@ export function StatusBar({
             paneId={paneId}
             isRefresh={isRefresh}
           />
+
+          <span className={styles['tab-button--divider']}></span>
 
           <TabButton
             id={warningButtonId}

--- a/src/code-editor/status-bar.tsx
+++ b/src/code-editor/status-bar.tsx
@@ -69,8 +69,8 @@ export function StatusBar({
         <div role="tablist">
           <TabButton
             id={errorButtonId}
+            count={errorCount}
             text={errorText}
-            // text={minifyCounters ? ` ${errorCount}` : errorText}
             className={styles['tab-button--errors']}
             iconName="status-negative"
             disabled={errorCount === 0}
@@ -83,11 +83,11 @@ export function StatusBar({
             paneId={paneId}
             isRefresh={isRefresh}
           />
-          <span className={styles['tab-button--divider']}></span>
+
           <TabButton
             id={warningButtonId}
+            count={warningCount}
             text={warningText}
-            // text={minifyCounters ? ` ${warningCount}` : warningText}
             className={styles['tab-button--warnings']}
             iconName="status-warning"
             disabled={warningCount === 0}

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -79,6 +79,11 @@
   }
 }
 
+.tab-list {
+  align-items: center;
+  display: inline-flex;
+}
+
 .tab-button {
   position: relative;
   display: inline-flex;
@@ -159,13 +164,21 @@
     @include styles.focus-highlight(awsui.$space-code-editor-status-focus-outline-gutter);
   }
 
+  &--divider {
+    display: inline-block;
+    block-size: awsui.$line-height-body-m;
+    inline-size: awsui.$border-code-editor-status-divider-width;
+    background: awsui.$color-border-tabs-divider;
+    vertical-align: middle;
+  }
+
   &--errors {
     /* used in test-utils */
   }
 
   /* stylelint-disable plugin/no-unsupported-browser-features */
   @supports (contain: inline-size) {
-    @container code-editor (min-width: 501px) {
+    @container code-editor not (max-width: 500px) {
       > .count {
         display: none;
       }

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -59,11 +59,6 @@
     border-inline-end: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   }
 
-  &__left-virtual {
-    flex-wrap: nowrap;
-    white-space: nowrap;
-  }
-
   &__right {
     display: flex;
     align-items: center;
@@ -81,10 +76,6 @@
     padding-block: calc(#{awsui.$space-scaled-xxs} - 1px);
     padding-inline: calc(#{awsui.$space-xs} - 2px);
   }
-}
-
-.status-bar-virtual {
-  @include styles.awsui-util-hide;
 }
 
 .tab-button {

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -12,6 +12,8 @@
 
 .code-editor {
   @include styles.styles-reset;
+  container-type: inline-size;
+  container-name: code-editor;
   display: inline-block;
   border-block: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-inline: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
@@ -41,7 +43,6 @@
 .status-bar {
   display: flex;
   vertical-align: middle;
-
   border-block-start: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   background-color: awsui.$color-background-code-editor-status-bar;
   &-with-hidden-pane {
@@ -80,7 +81,8 @@
 
 .tab-button {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  gap: #{awsui.$space-scaled-xxs};
   padding-block: awsui.$space-scaled-xs;
   padding-inline: awsui.$space-s;
   line-height: inherit;
@@ -157,17 +159,33 @@
     @include styles.focus-highlight(awsui.$space-code-editor-status-focus-outline-gutter);
   }
 
-  &--divider {
-    display: inline-block;
-    block-size: awsui.$line-height-body-m;
-    inline-size: awsui.$border-code-editor-status-divider-width;
-    background: awsui.$color-border-tabs-divider;
-    vertical-align: middle;
-  }
-
   &--errors {
     /* used in test-utils */
   }
+
+  /* stylelint-disable plugin/no-unsupported-browser-features */
+  @supports (contain: inline-size) {
+    @container code-editor (min-width: 501px) {
+      > .count {
+        display: none;
+      }
+
+      > .text {
+        display: inline;
+      }
+    }
+
+    @container code-editor (max-width: 500px) {
+      > .count {
+        display: inline;
+      }
+
+      > .text {
+        display: none;
+      }
+    }
+  }
+  /* stylelint-enable plugin/no-unsupported-browser-features */
 }
 
 $default-height: 480px;

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -175,8 +175,8 @@
     /* used in test-utils */
   }
 
-  /* stylelint-disable plugin/no-unsupported-browser-features */
   @supports (contain: inline-size) {
+    /* stylelint-disable plugin/no-unsupported-browser-features */
     @container not (max-width: 500px) {
       > .count {
         display: none;
@@ -196,9 +196,9 @@
         display: none;
       }
     }
+    /* stylelint-enable plugin/no-unsupported-browser-features */
   }
 }
-/* stylelint-enable plugin/no-unsupported-browser-features */
 
 $default-height: 480px;
 .loading-screen,

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -13,7 +13,6 @@
 .code-editor {
   @include styles.styles-reset;
   container-type: inline-size;
-  container-name: code-editor;
   display: block;
   border-block: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-inline: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
@@ -178,7 +177,7 @@
 
   /* stylelint-disable plugin/no-unsupported-browser-features */
   @supports (contain: inline-size) {
-    @container code-editor not (max-width: 500px) {
+    @container not (max-width: 500px) {
       > .count {
         display: none;
       }
@@ -188,7 +187,7 @@
       }
     }
 
-    @container code-editor (max-width: 500px) {
+    @container (max-width: 500px) {
       > .count {
         display: inline;
       }
@@ -198,8 +197,8 @@
       }
     }
   }
-  /* stylelint-enable plugin/no-unsupported-browser-features */
 }
+/* stylelint-enable plugin/no-unsupported-browser-features */
 
 $default-height: 480px;
 .loading-screen,

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -12,7 +12,6 @@
 
 .code-editor {
   @include styles.styles-reset;
-  container-type: inline-size;
   display: block;
   border-block: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-inline: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
@@ -40,6 +39,7 @@
 }
 
 .status-bar {
+  container-type: inline-size;
   display: flex;
   vertical-align: middle;
   border-block-start: awsui.$border-item-width solid awsui.$color-border-code-editor-default;

--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -14,7 +14,7 @@
   @include styles.styles-reset;
   container-type: inline-size;
   container-name: code-editor;
-  display: inline-block;
+  display: block;
   border-block: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-inline: awsui.$border-item-width solid awsui.$color-border-code-editor-default;
   border-start-start-radius: awsui.$border-radius-code-editor;
@@ -87,7 +87,7 @@
 .tab-button {
   position: relative;
   display: inline-flex;
-  gap: #{awsui.$space-scaled-xxs};
+  gap: #{awsui.$space-xxs};
   padding-block: awsui.$space-scaled-xs;
   padding-inline: awsui.$space-s;
   line-height: inherit;

--- a/src/code-editor/tab-button.tsx
+++ b/src/code-editor/tab-button.tsx
@@ -9,6 +9,7 @@ import InternalIcon from '../icon/internal';
 import styles from './styles.css.js';
 
 interface TabButtonProps {
+  count: number;
   text: string;
   iconName: IconProps.Name;
   active: boolean;
@@ -41,6 +42,7 @@ export const TabButton = React.forwardRef(
       ariaLabel,
       paneId,
       isRefresh,
+      count,
       text,
       className,
       id,
@@ -68,7 +70,9 @@ export const TabButton = React.forwardRef(
         aria-hidden={ariaHidden}
         aria-label={ariaLabel}
       >
-        <InternalIcon name={iconName} /> {text}
+        <InternalIcon name={iconName} />
+        <span className={styles.count}>{count}</span>
+        <span className={styles.text}>{text}</span>
       </button>
     );
   }


### PR DESCRIPTION
This PR migrates the CodeEditor component to using native CSS container queries and removes the need for a virtual status bar measurment.