### PR TITLE
fix: Change test selector from data-testid to className for findAddit…

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -403,6 +403,7 @@ Object {
     "awsui_trigger_xjuzf",
   ],
   "progress-bar": Array [
+    "awsui_additional-info_11huc",
     "awsui_percentage_11huc",
     "awsui_result-button_11huc",
     "awsui_result-container-error_11huc",

--- a/src/progress-bar/index.tsx
+++ b/src/progress-bar/index.tsx
@@ -102,7 +102,7 @@ export default function ProgressBar({
         </div>
       </div>
       {additionalInfo && (
-        <SmallText testId="additional-info" color={isInFlash ? 'inherit' : undefined}>
+        <SmallText className={styles['additional-info']} color={isInFlash ? 'inherit' : undefined}>
           {additionalInfo}
         </SmallText>
       )}

--- a/src/progress-bar/internal.tsx
+++ b/src/progress-bar/internal.tsx
@@ -53,12 +53,12 @@ export const Progress = ({ value, isInFlash, ariaLabel, ariaLabelledby }: Progre
 interface SmallTextProps {
   color?: BoxProps.Color;
   children: React.ReactNode;
-  testId?: string;
+  className?: string;
 }
 
-export const SmallText = ({ color, children, testId }: SmallTextProps) => {
+export const SmallText = ({ color, children, className }: SmallTextProps) => {
   return (
-    <InternalBox className={styles['word-wrap']} variant="small" display="block" color={color} data-testid={testId}>
+    <InternalBox className={clsx(styles['word-wrap'], className)} variant="small" display="block" color={color}>
       {children}
     </InternalBox>
   );

--- a/src/progress-bar/styles.scss
+++ b/src/progress-bar/styles.scss
@@ -161,3 +161,7 @@ $bar-color-edge-in-flash: rgba(255, 255, 255, 0.7);
     }
   }
 }
+
+.additional-info {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/progress-bar/index.ts
+++ b/src/test-utils/dom/progress-bar/index.ts
@@ -29,6 +29,6 @@ export default class ProgressBarWrapper extends ComponentWrapper {
   }
 
   findAdditionalInfo(): ElementWrapper | null {
-    return this.find(`[data-testid="additional-info"]`);
+    return this.findByClassName(styles['additional-info']);
   }
 }


### PR DESCRIPTION
…ionalInfo method in progress bar test utils

### Description

Changed `data-testid` selector by `className` in `findAdditionalInfo` which was introduced in [the PR](https://github.com/cloudscape-design/components/pull/2268) to align with [dev conventions](https://quip-amazon.com/i0b0A07hAfPB/v3-development-conventions#JHL9CAMslgw)

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
