### PR TITLE
chore: Add app layout skeleton internal component

### DIFF
--- a/pages/app-layout/skeleton.page.tsx
+++ b/pages/app-layout/skeleton.page.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext } from 'react';
+
+import BreadcrumbGroup from '~components/breadcrumb-group';
+import Container from '~components/container';
+import Drawer from '~components/drawer';
+import Header from '~components/header';
+import Toggle from '~components/toggle';
+
+import SpaceBetween from '~components/space-between';
+import { SkeletonLayout } from './utils/skeleton-layout';
+import AppContext, { AppContextType } from '../app/app-context';
+import { Notifications } from './utils/content-blocks';
+
+type PageConfigurationContext = React.Context<
+  AppContextType<{
+    navigationOpen?: boolean;
+    toolsOpen?: boolean;
+    hideContentHeader?: boolean;
+    maxContentWidth?: boolean;
+    disableContentPaddings?: boolean;
+  }>
+>;
+
+export default function () {
+  const { urlParams } = useContext(AppContext as PageConfigurationContext);
+  return (
+    <SkeletonLayout
+      navigationOpen={urlParams.navigationOpen}
+      navigation={<Drawer header={<h2>Navigation</h2>}>Nav content</Drawer>}
+      toolsOpen={urlParams.toolsOpen}
+      tools={<Drawer header={<h2>Tools</h2>}>Tools content</Drawer>}
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Home', href: '#' },
+            { text: 'Skeleton page', href: '' },
+          ]}
+        />
+      }
+      maxContentWidth={urlParams.maxContentWidth ? Number.MAX_VALUE : undefined}
+      notifications={<Notifications />}
+      disableContentPaddings={urlParams.disableContentPaddings}
+      contentHeader={
+        !urlParams.hideContentHeader && (
+          <Header variant="h1" description="Basic demo">
+            Demo page
+          </Header>
+        )
+      }
+      content={<Configurator />}
+    />
+  );
+}
+
+function Configurator() {
+  const { urlParams, setUrlParams } = useContext(AppContext as PageConfigurationContext);
+
+  return (
+    <Container header={<Header description="Skeleton can only be controlled programmatically">Configurator</Header>}>
+      <SpaceBetween size="m">
+        <Toggle
+          checked={urlParams.navigationOpen ?? false}
+          onChange={event => setUrlParams({ navigationOpen: event.detail.checked })}
+        >
+          Navigation open
+        </Toggle>
+        <Toggle
+          checked={urlParams.toolsOpen ?? false}
+          onChange={event => setUrlParams({ toolsOpen: event.detail.checked })}
+        >
+          Tools open
+        </Toggle>
+        <Toggle
+          checked={urlParams.hideContentHeader ?? false}
+          onChange={event => setUrlParams({ hideContentHeader: event.detail.checked })}
+        >
+          Hide content header
+        </Toggle>
+        <Toggle
+          checked={urlParams.maxContentWidth ?? false}
+          onChange={event => setUrlParams({ maxContentWidth: event.detail.checked })}
+        >
+          Activate max content width
+        </Toggle>
+        <Toggle
+          checked={urlParams.disableContentPaddings ?? false}
+          onChange={event => setUrlParams({ disableContentPaddings: event.detail.checked })}
+        >
+          Disable content paddings
+        </Toggle>
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/pages/app-layout/utils/skeleton-layout.tsx
+++ b/pages/app-layout/utils/skeleton-layout.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AppLayoutProps } from '~components';
+import { useAppLayoutPlacement } from '~components/app-layout/utils/use-app-layout-placement';
+import { applyDefaults } from '~components/app-layout/defaults';
+import React from 'react';
+import { AppLayoutSkeleton } from '~components/app-layout/skeleton';
+
+// Allow to render app layout in forced skeleton mode for development and testing
+export function SkeletonLayout({
+  contentType = 'default',
+  toolsWidth = 290,
+  navigationWidth = 280,
+  navigationOpen,
+  onNavigationChange = () => {},
+  minContentWidth,
+  maxContentWidth,
+  ...rest
+}: AppLayoutProps) {
+  const [rootRef, placement] = useAppLayoutPlacement('#h', '#f');
+  const defaults = applyDefaults(contentType, { maxContentWidth, minContentWidth }, true);
+  return (
+    <div ref={rootRef as React.Ref<any>}>
+      <AppLayoutSkeleton
+        {...rest}
+        {...defaults}
+        placement={placement}
+        contentType={contentType}
+        navigationOpen={!!navigationOpen}
+        navigationWidth={navigationWidth}
+        onNavigationChange={onNavigationChange}
+        toolsWidth={toolsWidth}
+      />
+    </div>
+  );
+}

--- a/src/app-layout/skeleton/index.tsx
+++ b/src/app-layout/skeleton/index.tsx
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { AppLayoutPropsWithDefaults } from '../interfaces';
+import { SkeletonLayout } from './layout';
+
+export function AppLayoutSkeleton({
+  notifications,
+  contentHeader,
+  content,
+
+  navigation,
+  navigationHide,
+  navigationOpen,
+  navigationWidth,
+  tools,
+  toolsHide,
+  toolsOpen,
+  toolsWidth,
+
+  placement,
+  contentType,
+  maxContentWidth,
+  minContentWidth,
+  disableContentPaddings,
+}: AppLayoutPropsWithDefaults) {
+  // render nothing in the skeleton state
+  const placeholder = <></>;
+  return (
+    <SkeletonLayout
+      topBar={placeholder}
+      notifications={notifications}
+      contentHeader={contentHeader}
+      content={content}
+      navigation={!navigationHide && navigationOpen && navigation && placeholder}
+      navigationWidth={navigationWidth}
+      tools={!toolsHide && toolsOpen && tools && placeholder}
+      toolsWidth={toolsWidth}
+      placement={placement}
+      contentType={contentType}
+      maxContentWidth={maxContentWidth}
+      minContentWidth={minContentWidth}
+      disableContentPaddings={disableContentPaddings}
+    />
+  );
+}

--- a/src/app-layout/skeleton/layout.tsx
+++ b/src/app-layout/skeleton/layout.tsx
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { AppLayoutPropsWithDefaults } from '../interfaces';
+import styles from './styles.css.js';
+import customCssProps from '../../internal/generated/custom-css-properties';
+import clsx from 'clsx';
+
+const contentTypeCustomWidths: Array<string | undefined> = ['dashboard', 'cards', 'table'];
+
+interface SkeletonLayoutProps
+  extends Pick<
+    AppLayoutPropsWithDefaults,
+    | 'notifications'
+    | 'contentHeader'
+    | 'content'
+    | 'contentType'
+    | 'minContentWidth'
+    | 'maxContentWidth'
+    | 'disableContentPaddings'
+    | 'navigation'
+    | 'navigationWidth'
+    | 'tools'
+    | 'toolsWidth'
+    | 'placement'
+  > {
+  topBar?: React.ReactNode;
+}
+
+export function SkeletonLayout({
+  notifications,
+  contentHeader,
+  content,
+  navigation,
+  navigationWidth,
+  tools,
+  toolsWidth,
+  topBar,
+  placement,
+  contentType,
+  maxContentWidth,
+  minContentWidth,
+  disableContentPaddings,
+}: SkeletonLayoutProps) {
+  const isMaxWidth = maxContentWidth === Number.MAX_VALUE || maxContentWidth === Number.MAX_SAFE_INTEGER;
+  return (
+    <div
+      className={clsx(styles.root, {
+        [styles['has-adaptive-widths-default']]: !contentTypeCustomWidths.includes(contentType),
+        [styles['has-adaptive-widths-dashboard']]: contentType === 'dashboard',
+      })}
+      style={{
+        minBlockSize: `calc(100vh - ${placement.insetBlockStart}px - ${placement.insetBlockEnd}px)`,
+        [customCssProps.maxContentWidth]: isMaxWidth ? '100%' : maxContentWidth ? `${maxContentWidth}px` : '',
+        [customCssProps.minContentWidth]: `${minContentWidth}px`,
+      }}
+    >
+      <section className={styles['top-bar']}>{topBar}</section>
+      {navigation && (
+        <div className={styles.navigation} style={{ inlineSize: navigationWidth }}>
+          {navigation}
+        </div>
+      )}
+      <main className={styles['main-landmark']}>
+        {notifications && <div className={styles.notifications}>{notifications}</div>}
+        <div className={clsx(styles.main, { [styles['main-disable-paddings']]: disableContentPaddings })}>
+          {contentHeader && <div className={styles['content-header']}>{contentHeader}</div>}
+          <div>{content}</div>
+        </div>
+      </main>
+      {tools && (
+        <div className={styles.tools} style={{ inlineSize: toolsWidth }}>
+          {tools}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app-layout/skeleton/styles.scss
+++ b/src/app-layout/skeleton/styles.scss
@@ -1,0 +1,82 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use '../../internal/styles' as styles;
+@use '../../internal/styles/tokens' as awsui;
+@use '../../internal/generated/custom-css-properties/index.scss' as custom-props;
+@use '../constants' as constants;
+
+.root {
+  #{custom-props.$maxContentWidth}: 100%;
+  display: grid;
+  grid-template-areas:
+    'navigation topBar       topBar        topBar    tools'
+    'navigation .         notifications    .         tools'
+    'navigation .             main         .         tools';
+  grid-template-columns:
+    min-content
+    minmax(#{awsui.$space-layout-content-horizontal}, 1fr)
+    minmax(var(#{custom-props.$minContentWidth}), var(#{custom-props.$maxContentWidth}))
+    minmax(#{awsui.$space-layout-content-horizontal}, 1fr)
+    min-content;
+  grid-template-rows: min-content min-content 1fr min-content;
+
+  &.has-adaptive-widths-default {
+    @each $breakpoint, $width in constants.$adaptive-content-widths {
+      @include styles.media-breakpoint-up($breakpoint) {
+        #{custom-props.$maxContentWidth}: $width;
+      }
+    }
+  }
+
+  &.has-adaptive-widths-dashboard {
+    @each $breakpoint, $width in constants.$dashboard-content-widths {
+      @include styles.media-breakpoint-up($breakpoint) {
+        #{custom-props.$maxContentWidth}: $width;
+      }
+    }
+  }
+}
+
+.main-landmark {
+  // does not participate in the layout, rendered for accessibility grouping
+  display: contents;
+}
+
+.navigation {
+  grid-area: navigation;
+  border-inline-end: 1px solid awsui.$color-border-divider-panel-side;
+}
+
+.tools {
+  grid-area: tools;
+  border-inline-start: 1px solid awsui.$color-border-divider-panel-side;
+}
+
+.top-bar {
+  grid-area: topBar;
+  block-size: 48px;
+  border-block-end: 1px solid awsui.$color-border-divider-panel-bottom;
+}
+
+.notifications {
+  grid-area: notifications;
+  &:not(:empty) {
+    padding-block-start: awsui.$space-scaled-xs;
+  }
+}
+
+.main {
+  grid-area: main;
+  margin-block-start: awsui.$space-scaled-s;
+  margin-block-end: awsui.$space-layout-content-bottom;
+  &-disable-paddings {
+    grid-column: 2 / span 3;
+    margin-block: 0;
+  }
+}
+
+.content-header {
+  margin-block-end: awsui.$space-content-header-padding-bottom;
+}

--- a/src/internal/generated/custom-css-properties/list.js
+++ b/src/internal/generated/custom-css-properties/list.js
@@ -5,7 +5,10 @@
  * This file is only needed to generate the proper js ans scss files at build step generateCustomCssPropertiesMap
  */
 const customCssPropertiesList = [
-  // AppLayout Custom Properties
+  // AppLayout Custom Properties,
+  'maxContentWidth',
+  'minContentWidth',
+  // AppLayout Custom Properties (deprecated)
   'breadcrumbsGap',
   'contentGapLeft',
   'contentGapRight',
@@ -20,8 +23,6 @@ const customCssPropertiesList = [
   'mainGap',
   'mainOffsetLeft',
   'mainTemplateRows',
-  'maxContentWidth',
-  'minContentWidth',
   'mobileBarHeight',
   'notificationsGap',
   'notificationsHeight',


### PR DESCRIPTION
### Description

Part of a bigger project to refactor app layout and make it lazy loadable

Related links, issue #, if available: n/a

### How has this been tested?

Added a new dev page. [Click here to preview](https://d21d5uik3ws71m.cloudfront.net/components/0e4d1e6c26686e1e6277556dd28413a9438056a1/dev-pages/index.html#/light/app-layout/skeleton)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
