### PR TITLE
refactor: use shared widget utility in app layout

### DIFF
--- a/src/app-layout/implementation.tsx
+++ b/src/app-layout/implementation.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
+import { createWidgetizedForwardRef } from '../internal/widgets';
 import ClassicAppLayout from './classic';
 import RefreshedAppLayout from './visual-refresh';
 import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
@@ -12,3 +13,9 @@ export const AppLayoutImplementation = React.forwardRef<AppLayoutProps.Ref, AppL
     return isRefresh ? <RefreshedAppLayout ref={ref} {...props} /> : <ClassicAppLayout ref={ref} {...props} />;
   }
 );
+
+export const createWidgetizedAppLayout = createWidgetizedForwardRef<
+  AppLayoutPropsWithDefaults,
+  AppLayoutProps.Ref,
+  typeof AppLayoutImplementation
+>(AppLayoutImplementation);

--- a/src/app-layout/widget.tsx
+++ b/src/app-layout/widget.tsx
@@ -1,22 +1,3 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
-import { getGlobalFlag } from '../internal/utils/global-flags';
-import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
-import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
-import { AppLayoutImplementation } from './implementation';
-
-type AppLayoutType = React.ForwardRefExoticComponent<
-  AppLayoutPropsWithDefaults & React.RefAttributes<AppLayoutProps.Ref>
->;
-
-export function createWidgetizedAppLayout(AppLayoutLoader?: AppLayoutType): AppLayoutType {
-  return React.forwardRef((props, ref) => {
-    const isRefresh = useVisualRefresh();
-    if (isRefresh && getGlobalFlag('appLayoutWidget') && AppLayoutLoader) {
-      return <AppLayoutLoader ref={ref} {...props} />;
-    }
-
-    return <AppLayoutImplementation ref={ref} {...props} />;
-  });
-}
+export { createWidgetizedAppLayout } from './implementation';


### PR DESCRIPTION
### Description

I added a shared utility for repetitive code in a past PR: https://github.com/cloudscape-design/components/pull/2234

Now I retroactively apply it to app layout component, to remove duplicate code. Utility does exactly the same code, but reusable.

Related links, issue #, if available: n/a

### How has this been tested?

PR build. There is [a test](https://github.com/cloudscape-design/components/blob/main/src/app-layout/__tests__/widgetized-layout.test.tsx) to ensure everything works

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
