### PR TITLE
fix: Correctly pass ariaLabel from code editor to underlying ace editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.32.6",
+        "ace-builds": "^1.34.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -3460,9 +3460,10 @@
       "license": "MIT"
     },
     "node_modules/@types/pngjs": {
-      "version": "6.0.1",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4210,9 +4211,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.6.tgz",
-      "integrity": "sha512-dO5BnyDOhCnznhOpILzXq4jqkbhRXxNkf3BuVTmyxGyRLrhddfdyk6xXgy+7A8LENrcYoFi/sIxMuH3qjNUN4w=="
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.0.tgz",
+      "integrity": "sha512-ZQqoV76wl4guDE5zvEnxCDrvy9gzLAwu7eD4ikYj/Gdlb4+qRLbb+aOFVnweZZRsHh089V0WVaw2NMNuiiEdTw=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.32.6",
+    "ace-builds": "^1.34.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -233,7 +233,7 @@ describe('Code editor component', () => {
     editorMock.on.mockRestore();
   });
 
-  it('provides ariaLabel to the underlying textarea', () => {
+  it('provides ariaLabel to the underlying textarea (before v1.34.0)', () => {
     const textarea = editorMock.renderer.textarea;
     editorMock.renderer.textarea = null as any;
 
@@ -243,6 +243,12 @@ describe('Code editor component', () => {
 
     renderCodeEditor({ ariaLabel: 'test aria label' });
     expect(editorMock.renderer.textarea).toHaveAttribute('aria-label', 'test aria label');
+  });
+
+  it('provides ariaLabel to the the ace editor (after v1.34.0)', () => {
+    editorMock.getOption.mockImplementation(key => (key === 'textInputAriaLabel' ? '' : undefined));
+    renderCodeEditor({ ariaLabel: 'test aria label' });
+    expect(editorMock.setOption).toHaveBeenCalledWith('textInputAriaLabel', 'test aria label');
   });
 
   describe('onDelayedChange', () => {

--- a/src/code-editor/__tests__/util.tsx
+++ b/src/code-editor/__tests__/util.tsx
@@ -41,6 +41,8 @@ export const editorMock = {
     setAnnotations: jest.fn(),
     clearAnnotations: jest.fn(),
   },
+  getOption: jest.fn(),
+  setOption: jest.fn(),
   setOptions: jest.fn(),
   setAutoScrollEditorIntoView: jest.fn(),
   setHighlightActiveLine: jest.fn(),

--- a/src/code-editor/use-editor.tsx
+++ b/src/code-editor/use-editor.tsx
@@ -42,16 +42,33 @@ export function useSyncEditorLabels(
     if (!editor) {
       return;
     }
+
     const { textarea } = editor.renderer as unknown as { textarea: HTMLTextAreaElement };
     if (!textarea) {
       return;
     }
-    const updateAttribute = (attribute: string, value: string | undefined) =>
-      value ? textarea.setAttribute(attribute, value) : textarea.removeAttribute(attribute);
+
+    // Update attributes on the textarea element manually. This is fine as long as ace
+    // doesn't touch these attributes as well.
+    const updateAttribute = (attribute: string, value: string | undefined) => {
+      if (value) {
+        textarea.setAttribute(attribute, value);
+      } else {
+        textarea.removeAttribute(attribute);
+      }
+    };
     updateAttribute('id', controlId);
-    updateAttribute('aria-label', ariaLabel);
     updateAttribute('aria-labelledby', ariaLabelledby);
     updateAttribute('aria-describedby', ariaDescribedby);
+
+    // Ace (starting from v1.34.0) has a built-in setting to provide an aria-label.
+    // For older versions (before aria-label was managed by ace), we still use the
+    // attribute method.
+    if (typeof editor.getOption('textInputAriaLabel') === 'string') {
+      editor.setOption('textInputAriaLabel', ariaLabel ?? '');
+    } else {
+      updateAttribute('aria-label', ariaLabel);
+    }
   }, [ariaLabel, ariaDescribedby, ariaLabelledby, controlId, editor]);
 }
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
