### PR TITLE
chore: Treat CSS containment as containing block for positioning

### DIFF
--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -63,7 +63,9 @@ export function getContainingBlock(startElement: HTMLElement): HTMLElement | nul
         const computedStyle = getComputedStyle(element);
         return (
           (!!computedStyle.transform && computedStyle.transform !== 'none') ||
-          (!!computedStyle.perspective && computedStyle.perspective !== 'none')
+          (!!computedStyle.perspective && computedStyle.perspective !== 'none') ||
+          (!!computedStyle.containerType && computedStyle.containerType !== 'normal') ||
+          computedStyle.contain.split(' ').some(s => ['layout', 'paint', 'strict', 'content'].includes(s))
         );
       }) as HTMLElement)
     : null;


### PR DESCRIPTION
### Description

Just getting ahead of any possible future need (container queries 😉). Right now, there's no use-case for it directly in the components itself, but it does bring it closer in line with [native browser layout behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block#identifying_the_containing_block), should people end up doing container queries on their end.

Related links, issue #, if available: n/a

### How has this been tested?

No tests, just manual messing around. Just getting ahead of potential future changes where we use container queries ourselves and the popover ends up breaking.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
