### PR TITLE
fix: Hide resize handler icon SVG from screen readers

### DIFF
--- a/src/split-panel/icons/resize-handler.tsx
+++ b/src/split-panel/icons/resize-handler.tsx
@@ -10,6 +10,7 @@ const ResizeHandler = ({ className }: { className?: string }) => (
     width="16"
     height="16"
     viewBox="0 0 16 16"
+    aria-hidden={true}
   >
     <line strokeWidth="2" x1="2" y1="5" x2="14" y2="5" />
     <line strokeWidth="2" x1="14" y1="10" x2="2" y2="10" />


### PR DESCRIPTION
### Description

Hide the SVG from being treated as a graphic by screen readers so that they don't call this out as an unlabeled image. In every context that it's used, it's wrapped by a `role="slider"` with a label, so a label on the icon itself is irrelevant. But if we don't remove from the accessibility tree, it's treated as an unlabeled image by automated testing tools.

We do this in the icon component by default but we're not using the icon component here, so it was missed.

Related links, issue #, if available: AWSUI-42858

### How has this been tested?

No new tests here. Adding a test for checking a fixed property feels silly.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
