### PR TITLE
chore: Do not emit performance marks for buttons inside modals

### DIFF
--- a/pages/button/performance-marks-in-modal.page.tsx
+++ b/pages/button/performance-marks-in-modal.page.tsx
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useEffect, useState } from 'react';
+import Button from '~components/button';
+import Box from '~components/box';
+import Modal from '~components/modal';
+
+export default function ButtonsPerformanceMarkPage() {
+  const marks = usePerformanceMarks();
+
+  return (
+    <Box padding="xxl">
+      <h1>Performance marks in a Modal</h1>
+
+      <Modal
+        visible={true}
+        footer={<Button variant="primary">Button INSIDE modal</Button>}
+        header="Performance marks on this page"
+      >
+        <pre>
+          {marks.map((m, index) => (
+            <React.Fragment key={index}>
+              <b>{m.name}</b>
+              <pre>Details: {JSON.stringify(m.detail, null, 2)}</pre>
+            </React.Fragment>
+          ))}
+        </pre>
+      </Modal>
+
+      <Button variant="primary">Button OUTSIDE modal</Button>
+    </Box>
+  );
+}
+
+function usePerformanceMarks() {
+  const [marks, setMarks] = useState<PerformanceMark[]>([]);
+
+  useEffect(() => {
+    const existingEntries = (performance.getEntriesByType('mark') as PerformanceMark[]).filter(isNotReactDevTools);
+    setMarks(existingEntries);
+
+    const observer = new PerformanceObserver(list => {
+      const newEntries = (list.getEntries() as PerformanceMark[]).filter(isNotReactDevTools);
+      if (newEntries.length > 0) {
+        setMarks(existing => [...existing, ...newEntries]);
+      }
+    });
+
+    observer.observe({ type: 'mark' });
+    return () => observer.disconnect();
+  }, [setMarks]);
+
+  return marks;
+}
+
+// This prevents an infinite rerendering loop.
+const isNotReactDevTools = (m: PerformanceMark) => !m.name.includes('⚛') && m.name !== '__v3';

--- a/src/internal/hooks/use-performance-marks.ts
+++ b/src/internal/hooks/use-performance-marks.ts
@@ -4,6 +4,7 @@
 import { useEffect } from 'react';
 import { useUniqueId } from './use-unique-id';
 import { useEffectOnUpdate } from './use-effect-on-update';
+import { useModalContext } from '../context/modal-context';
 
 export function usePerformanceMarks(
   name: string,
@@ -13,9 +14,10 @@ export function usePerformanceMarks(
   dependencies: React.DependencyList
 ) {
   const id = useUniqueId();
+  const { isInModal } = useModalContext();
 
   useEffect(() => {
-    if (!enabled || !elementRef.current) {
+    if (!enabled || !elementRef.current || isInModal) {
       return;
     }
 
@@ -41,7 +43,7 @@ export function usePerformanceMarks(
   }, []);
 
   useEffectOnUpdate(() => {
-    if (!enabled || !elementRef.current) {
+    if (!enabled || !elementRef.current || isInModal) {
       return;
     }
     const elementVisible =


### PR DESCRIPTION
### Description

This PR updates the logic for emitting performance marks. They will no longer be emitted for components that are located inside Modals.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-44575

### How has this been tested?

Added a unit test, and manually verified in the new dev page

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
