### PR TITLE
fix: Correctly pass ariaLabel from code editor to underlying ace editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@juggle/resize-observer": "^3.3.1",
-        "ace-builds": "^1.32.6",
+        "ace-builds": "^1.34.0",
         "balanced-match": "^1.0.2",
         "clsx": "^1.1.0",
         "d3-shape": "^1.3.7",
@@ -4211,9 +4211,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.6.tgz",
-      "integrity": "sha512-dO5BnyDOhCnznhOpILzXq4jqkbhRXxNkf3BuVTmyxGyRLrhddfdyk6xXgy+7A8LENrcYoFi/sIxMuH3qjNUN4w=="
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.34.0.tgz",
+      "integrity": "sha512-ZQqoV76wl4guDE5zvEnxCDrvy9gzLAwu7eD4ikYj/Gdlb4+qRLbb+aOFVnweZZRsHh089V0WVaw2NMNuiiEdTw=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@dnd-kit/utilities": "^3.2.1",
     "@juggle/resize-observer": "^3.3.1",
-    "ace-builds": "^1.32.6",
+    "ace-builds": "^1.34.0",
     "balanced-match": "^1.0.2",
     "clsx": "^1.1.0",
     "d3-shape": "^1.3.7",

--- a/src/code-editor/__tests__/code-editor.test.tsx
+++ b/src/code-editor/__tests__/code-editor.test.tsx
@@ -233,7 +233,7 @@ describe('Code editor component', () => {
     editorMock.on.mockRestore();
   });
 
-  it('provides ariaLabel to the underlying textarea', () => {
+  it('provides ariaLabel to the underlying textarea (before v1.34.0)', () => {
     const textarea = editorMock.renderer.textarea;
     editorMock.renderer.textarea = null as any;
 
@@ -243,6 +243,12 @@ describe('Code editor component', () => {
 
     renderCodeEditor({ ariaLabel: 'test aria label' });
     expect(editorMock.renderer.textarea).toHaveAttribute('aria-label', 'test aria label');
+  });
+
+  it('provides ariaLabel to the the ace editor (after v1.34.0)', () => {
+    editorMock.getOption.mockImplementation(key => (key === 'textInputAriaLabel' ? '' : undefined));
+    renderCodeEditor({ ariaLabel: 'test aria label' });
+    expect(editorMock.setOption).toHaveBeenCalledWith('textInputAriaLabel', 'test aria label');
   });
 
   describe('onDelayedChange', () => {

--- a/src/code-editor/__tests__/util.tsx
+++ b/src/code-editor/__tests__/util.tsx
@@ -41,6 +41,8 @@ export const editorMock = {
     setAnnotations: jest.fn(),
     clearAnnotations: jest.fn(),
   },
+  getOption: jest.fn(),
+  setOption: jest.fn(),
   setOptions: jest.fn(),
   setAutoScrollEditorIntoView: jest.fn(),
   setHighlightActiveLine: jest.fn(),

--- a/src/code-editor/use-editor.tsx
+++ b/src/code-editor/use-editor.tsx
@@ -42,16 +42,33 @@ export function useSyncEditorLabels(
     if (!editor) {
       return;
     }
+
     const { textarea } = editor.renderer as unknown as { textarea: HTMLTextAreaElement };
     if (!textarea) {
       return;
     }
-    const updateAttribute = (attribute: string, value: string | undefined) =>
-      value ? textarea.setAttribute(attribute, value) : textarea.removeAttribute(attribute);
+
+    // Update attributes on the textarea element manually. This is fine as long as ace
+    // doesn't touch these attributes as well.
+    const updateAttribute = (attribute: string, value: string | undefined) => {
+      if (value) {
+        textarea.setAttribute(attribute, value);
+      } else {
+        textarea.removeAttribute(attribute);
+      }
+    };
     updateAttribute('id', controlId);
-    updateAttribute('aria-label', ariaLabel);
     updateAttribute('aria-labelledby', ariaLabelledby);
     updateAttribute('aria-describedby', ariaDescribedby);
+
+    // Ace (starting from v1.34.0) has a built-in setting to provide an aria-label.
+    // For older versions (before aria-label was managed by ace), we still use the
+    // attribute method.
+    if (typeof editor.getOption('textInputAriaLabel') === 'string') {
+      editor.setOption('textInputAriaLabel', ariaLabel ?? '');
+    } else {
+      updateAttribute('aria-label', ariaLabel);
+    }
   }, [ariaLabel, ariaDescribedby, ariaLabelledby, controlId, editor]);
 }
 


### PR DESCRIPTION
Un-reverts cloudscape-design/components#2288 (when it's time)