### PR TITLE
chore: Replace data-x/y attributes with getBBox

### DIFF
--- a/src/pie-chart/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/src/pie-chart/__tests__/__snapshots__/utils.test.tsx.snap
@@ -3,8 +3,6 @@
 exports[`balanceLabelNodes changes xOffset if vertical overlap 1`] = `
 NodeList [
   <g
-    data-x="20"
-    data-y="-50"
     transform=""
   >
     <text
@@ -15,8 +13,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="20"
-    data-y="-49"
     transform="translate(79.67948635501689 25)"
   >
     <text
@@ -27,8 +23,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-20"
-    data-y="21"
     transform="translate(-68.79189152169245 25)"
   >
     <text
@@ -39,8 +33,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-20"
-    data-y="20"
     transform=""
   >
     <text
@@ -56,8 +48,6 @@ NodeList [
 exports[`balanceLabelNodes does not change xOffset if no vertical overlap 1`] = `
 NodeList [
   <g
-    data-x="20"
-    data-y="-50"
     transform=""
   >
     <text
@@ -68,8 +58,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="20"
-    data-y="-20"
     transform=""
   >
     <text
@@ -80,8 +68,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-20"
-    data-y="50"
     transform=""
   >
     <text
@@ -92,8 +78,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-20"
-    data-y="20"
     transform=""
   >
     <text
@@ -111,8 +95,6 @@ exports[`balanceLabelNodes empty 1`] = `NodeList []`;
 exports[`balanceLabelNodes heavy overlap on both sides 1`] = `
 NodeList [
   <g
-    data-x="125"
-    data-y="-120"
     transform=""
   >
     <text
@@ -123,8 +105,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-116"
     transform="translate(0 22)"
   >
     <text
@@ -135,8 +115,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-109"
     transform="translate(0 41)"
   >
     <text
@@ -147,8 +125,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="120"
     transform=""
   >
     <text
@@ -159,8 +135,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-109"
     transform="translate(0 41)"
   >
     <rect
@@ -171,8 +145,6 @@ NodeList [
     </rect>
   </g>,
   <g
-    data-x="-125"
-    data-y="-118"
     transform="translate(0 24)"
   >
     <text
@@ -183,8 +155,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-120"
     transform=""
   >
     <text
@@ -200,8 +170,6 @@ NodeList [
 exports[`balanceLabelNodes heavy overlap on the left side 1`] = `
 NodeList [
   <g
-    data-x="125"
-    data-y="111"
     transform=""
   >
     <text
@@ -212,8 +180,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-92"
     transform="translate(0 102)"
   >
     <text
@@ -224,8 +190,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-100"
     transform="translate(0 84)"
   >
     <text
@@ -236,8 +200,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-108"
     transform="translate(0 66)"
   >
     <text
@@ -248,8 +210,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-114"
     transform="translate(0 46)"
   >
     <rect
@@ -260,8 +220,6 @@ NodeList [
     </rect>
   </g>,
   <g
-    data-x="-125"
-    data-y="-118"
     transform="translate(0 24)"
   >
     <text
@@ -272,8 +230,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-120"
     transform=""
   >
     <text
@@ -289,8 +245,6 @@ NodeList [
 exports[`balanceLabelNodes heavy overlap on the right side 1`] = `
 NodeList [
   <g
-    data-x="125"
-    data-y="-119"
     transform=""
   >
     <text
@@ -301,8 +255,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-117"
     transform="translate(0 24)"
   >
     <text
@@ -313,8 +265,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-113"
     transform="translate(0 46)"
   >
     <text
@@ -325,8 +275,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-108"
     transform="translate(0 67)"
   >
     <text
@@ -337,8 +285,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="125"
-    data-y="-100"
     transform="translate(0 85)"
   >
     <rect
@@ -349,8 +295,6 @@ NodeList [
     </rect>
   </g>,
   <g
-    data-x="125"
-    data-y="-92"
     transform="translate(0 103)"
   >
     <text
@@ -361,8 +305,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="111"
     transform=""
   >
     <text
@@ -378,8 +320,6 @@ NodeList [
 exports[`balanceLabelNodes one segment 1`] = `
 NodeList [
   <g
-    data-x="-125"
-    data-y="120"
     transform=""
   >
     <text
@@ -395,8 +335,6 @@ NodeList [
 exports[`balanceLabelNodes overlap on the left, but not all labels need to be moved 1`] = `
 NodeList [
   <g
-    data-x="125"
-    data-y="45"
     transform=""
   >
     <text
@@ -407,8 +345,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="45"
     transform=""
   >
     <text
@@ -419,8 +355,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-45"
     transform=""
   >
     <text
@@ -431,8 +365,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-113"
     transform="translate(0 20)"
   >
     <text
@@ -443,8 +375,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="-119"
     transform=""
   >
     <rect
@@ -460,8 +390,6 @@ NodeList [
 exports[`balanceLabelNodes two equal segments 1`] = `
 NodeList [
   <g
-    data-x="125"
-    data-y="0"
     transform=""
   >
     <text
@@ -472,8 +400,6 @@ NodeList [
     </text>
   </g>,
   <g
-    data-x="-125"
-    data-y="0"
     transform=""
   >
     <text

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -61,6 +61,13 @@ const dataWithZero: Array<PieChartProps.Datum> = [
 const originalCSS = window.CSS;
 beforeEach(() => {
   window.CSS.supports = () => true;
+  Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+    writable: true,
+    value: jest.fn().mockReturnValue({
+      x: 0,
+      y: 0,
+    }),
+  });
 });
 afterEach(() => {
   window.CSS = originalCSS;

--- a/src/pie-chart/__tests__/utils.test.tsx
+++ b/src/pie-chart/__tests__/utils.test.tsx
@@ -27,7 +27,7 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="-125" data-y="120">
+        <g>
           <text x="-125" y="120">
             Test
           </text>
@@ -42,12 +42,12 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="125" data-y="0">
+        <g>
           <text x="125" y="0">
             Test
           </text>
         </g>
-        <g data-x="-125" data-y="0">
+        <g>
           <text x="-125" y="0">
             Test
           </text>
@@ -65,37 +65,37 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="125" data-y="-119">
+        <g>
           <text x="125" y="-119">
             Segment 1
           </text>
         </g>
-        <g data-x="125" data-y="-117">
+        <g>
           <text x="125" y="-117">
             Segment 2
           </text>
         </g>
-        <g data-x="125" data-y="-113">
+        <g>
           <text x="125" y="-113">
             Segment 3
           </text>
         </g>
-        <g data-x="125" data-y="-108">
+        <g>
           <text x="125" y="-108">
             Segment 4
           </text>
         </g>
-        <g data-x="125" data-y="-100">
+        <g>
           <rect x="125" y="-100">
             Segment 5
           </rect>
         </g>
-        <g data-x="125" data-y="-92">
+        <g>
           <text x="125" y="-92">
             Segment 6
           </text>
         </g>
-        <g data-x="-125" data-y="111">
+        <g>
           <text x="-125" y="111">
             Segment 7
           </text>
@@ -118,37 +118,37 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="125" data-y="111">
+        <g>
           <text x="125" y="111">
             Segment 1
           </text>
         </g>
-        <g data-x="-125" data-y="-92">
+        <g>
           <text x="-125" y="-92">
             Segment 2
           </text>
         </g>
-        <g data-x="-125" data-y="-100">
+        <g>
           <text x="-125" y="-100">
             Segment 3
           </text>
         </g>
-        <g data-x="-125" data-y="-108">
+        <g>
           <text x="-125" y="-108">
             Segment 4
           </text>
         </g>
-        <g data-x="-125" data-y="-114">
+        <g>
           <rect x="-125" y="-114">
             Segment 5
           </rect>
         </g>
-        <g data-x="-125" data-y="-118">
+        <g>
           <text x="-125" y="-118">
             Segment 6
           </text>
         </g>
-        <g data-x="-125" data-y="-120">
+        <g>
           <text x="-125" y="-120">
             Segment 7
           </text>
@@ -171,37 +171,37 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="125" data-y="-120">
+        <g>
           <text x="125" y="-120">
             Segment 1
           </text>
         </g>
-        <g data-x="125" data-y="-116">
+        <g>
           <text x="125" y="-116">
             Segment 2
           </text>
         </g>
-        <g data-x="125" data-y="-109">
+        <g>
           <text x="125" y="-109">
             Segment 3
           </text>
         </g>
-        <g data-x="125" data-y="120">
+        <g>
           <text x="125" y="120">
             Segment 4
           </text>
         </g>
-        <g data-x="-125" data-y="-109">
+        <g>
           <rect x="-125" y="-109">
             Segment 5
           </rect>
         </g>
-        <g data-x="-125" data-y="-118">
+        <g>
           <text x="-125" y="-118">
             Segment 6
           </text>
         </g>
-        <g data-x="-125" data-y="-120">
+        <g>
           <text x="-125" y="-120">
             Segment 7
           </text>
@@ -224,27 +224,27 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="125" data-y="45">
+        <g>
           <text x="125" y="45">
             Segment 1
           </text>
         </g>
-        <g data-x="-125" data-y="45">
+        <g>
           <text x="-125" y="45">
             Segment 2
           </text>
         </g>
-        <g data-x="-125" data-y="-45">
+        <g>
           <text x="-125" y="-45">
             Segment 3
           </text>
         </g>
-        <g data-x="-125" data-y="-113">
+        <g>
           <text x="-125" y="-113">
             Segment 4
           </text>
         </g>
-        <g data-x="-125" data-y="-119">
+        <g>
           <rect x="-125" y="-119">
             Segment 5
           </rect>
@@ -265,22 +265,22 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="20" data-y="-50">
+        <g>
           <text x="20" y="-50">
             Segment 1
           </text>
         </g>
-        <g data-x="20" data-y="-20">
+        <g>
           <text x="20" y="-20">
             Segment 2
           </text>
         </g>
-        <g data-x="-20" data-y="50">
+        <g>
           <text x="-20" y="50">
             Segment 3
           </text>
         </g>
-        <g data-x="-20" data-y="20">
+        <g>
           <text x="-20" y="20">
             Segment 4
           </text>
@@ -300,22 +300,22 @@ const testCases = [
     height: 300,
     nodes: (
       <>
-        <g data-x="20" data-y="-50">
+        <g>
           <text x="20" y="-50">
             Segment 1
           </text>
         </g>
-        <g data-x="20" data-y="-49">
+        <g>
           <text x="20" y="-49">
             Segment 2
           </text>
         </g>
-        <g data-x="-20" data-y="21">
+        <g>
           <text x="-20" y="21">
             Segment 3
           </text>
         </g>
-        <g data-x="-20" data-y="20">
+        <g>
           <text x="-20" y="20">
             Segment 4
           </text>
@@ -348,6 +348,20 @@ describe('balanceLabelNodes', () => {
       bottom: 0,
       right: 0,
       toJSON: () => {},
+    });
+    // getBBox does not work by default in jest env
+    // introduced the hacky way to make it work and return proper coordinates
+    // otherwise, it won't be possible to test this behaviour
+    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+      writable: true,
+      value: function () {
+        const childProps = this[Object.keys(this)[0]].child.pendingProps;
+
+        return {
+          x: parseFloat(childProps?.x || '0') || 0,
+          y: parseFloat(childProps?.y || '0') || 0,
+        };
+      },
     });
   });
   afterAll(() => {

--- a/src/pie-chart/labels.tsx
+++ b/src/pie-chart/labels.tsx
@@ -44,9 +44,7 @@ function LabelElement({
   containerBoundaries,
 }: LabelElementProps) {
   return (
-    // Reset the transform property to prepare for `balanceLabelNodes`.
-    // The dataset attributes are also needed in the function for IE11 support.
-    <g className={styles['label-text']} transform="" data-x={x} data-y={y}>
+    <g className={styles['label-text']} transform="">
       {!hideTitles && (
         <ResponsiveText x={x} y={y} rightSide={rightSide} containerBoundaries={containerBoundaries}>
           {title}

--- a/src/pie-chart/utils.ts
+++ b/src/pie-chart/utils.ts
@@ -131,12 +131,7 @@ export const balanceLabelNodes = (
   while ((leftSide && i >= 0) || (!leftSide && i < nodes.length)) {
     const node = nodes[i];
 
-    // Currently using dataset attributes to determine the base position.
-    // This implementation can be changed back to using `getBBox` when we drop IE11 support.
-    // Unfortunately, there is no good alternative for `getBBox` that is supported by IE11.
-    // `getBoundingClientRect` works for width and height calculations in SVG, but the x/y positions are inaccurate.
-    const x = parseFloat(node.getAttribute('data-x') || '0');
-    const y = parseFloat(node.getAttribute('data-y') || '0');
+    const { x, y } = node.getBBox();
     const box = {
       x,
       y,


### PR DESCRIPTION
### Description

Replaced data-x/y attributes with `getBBox` (not supported by IE11) in `balanceLabelNodes` for pie-chart, because we dropped IE11 support.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
