### PR TITLE
feat: Add onClick event for Link component

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -8871,6 +8871,43 @@ exports[`Documenter definition for link matches the snapshot: link 1`] = `
 Object {
   "events": Array [
     Object {
+      "cancelable": false,
+      "description": "Called when the user clicks on the link. Do not use this handler for navigation, use the \`onFollow\` event instead.",
+      "detailInlineType": Object {
+        "name": "ClickDetail",
+        "properties": Array [
+          Object {
+            "name": "altKey",
+            "optional": false,
+            "type": "boolean",
+          },
+          Object {
+            "name": "button",
+            "optional": false,
+            "type": "number",
+          },
+          Object {
+            "name": "ctrlKey",
+            "optional": false,
+            "type": "boolean",
+          },
+          Object {
+            "name": "metaKey",
+            "optional": false,
+            "type": "boolean",
+          },
+          Object {
+            "name": "shiftKey",
+            "optional": false,
+            "type": "boolean",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "ClickDetail",
+      "name": "onClick",
+    },
+    Object {
       "cancelable": true,
       "description": "Called when a link is clicked without any modifier keys. If the link has no \`href\` provided, it will be called on
 all clicks.

--- a/src/link/__integ__/link.test.ts
+++ b/src/link/__integ__/link.test.ts
@@ -41,7 +41,7 @@ describe('Link', () => {
     );
   });
 
-  describe('role="button"', () => {
+  describe('Button Link', () => {
     test(
       'enter key and space key trigger link',
       useBrowser(async browser => {

--- a/src/link/__tests__/index.test.tsx
+++ b/src/link/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ import { FunnelMetrics } from '../../../lib/components/internal/analytics';
 
 import { mockedFunnelInteractionId, mockFunnelMetrics } from '../../internal/analytics/__tests__/mocks';
 import { renderWithSingleTabStopNavigation } from '../../internal/context/__tests__/utils';
+import { KeyCode } from '@cloudscape-design/test-utils-core/dist/utils.js';
 
 function renderLink(props: LinkProps = {}) {
   const renderResult = render(<Link {...props} />);
@@ -301,5 +302,77 @@ describe('table grid navigation support', () => {
     setCurrentTarget(getLink('#link1'));
     expect(getLink('#link1')).toHaveAttribute('tabIndex', '0');
     expect(getLink('#link2')).toHaveAttribute('tabIndex', '-1');
+  });
+});
+
+describe('"onClick" event', () => {
+  test('call onClick without modifiers when the anchor is normally clicked', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ href: '#', onClick: onClickSpy });
+    wrapper.click();
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: false, shiftKey: false, altKey: false, metaKey: false },
+      })
+    );
+  });
+
+  test('calls onClick with modifiers when the anchor is clicked with modifiers', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ href: '#', onClick: onClickSpy });
+    wrapper.click({ button: 0, ctrlKey: true, shiftKey: true, altKey: true, metaKey: true });
+
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: true, shiftKey: true, altKey: true, metaKey: true },
+      })
+    );
+  });
+
+  test('call onClick without metakey when the button is normally clicked', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ onClick: onClickSpy });
+    wrapper.click();
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: false, shiftKey: false, altKey: false, metaKey: false },
+      })
+    );
+  });
+
+  test('calls onClick with modifiers when the button is clicked with modifiers', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ onClick: onClickSpy });
+    wrapper.click({ button: 0, ctrlKey: true, shiftKey: true, altKey: true, metaKey: true });
+
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: true, shiftKey: true, altKey: true, metaKey: true },
+      })
+    );
+  });
+
+  test('calls onClick with keyboard Enter', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ onClick: onClickSpy });
+    wrapper.keydown(KeyCode.enter);
+
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: false, shiftKey: false, altKey: false, metaKey: false },
+      })
+    );
+  });
+
+  test('calls onClick with keyboard Space', () => {
+    const onClickSpy = jest.fn();
+    const wrapper = renderLink({ onClick: onClickSpy });
+    wrapper.keydown(KeyCode.space);
+
+    expect(onClickSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { button: 0, ctrlKey: false, shiftKey: false, altKey: false, metaKey: false },
+      })
+    );
   });
 });

--- a/src/link/interfaces.ts
+++ b/src/link/interfaces.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BaseComponentProps } from '../internal/base-component';
 import React from 'react';
-import { BaseNavigationDetail, CancelableEventHandler } from '../internal/events';
+import {
+  BaseNavigationDetail,
+  CancelableEventHandler,
+  NonCancelableEventHandler,
+  ClickDetail as _ClickDetail,
+} from '../internal/events';
 
 export interface LinkProps extends BaseComponentProps {
   /**
@@ -91,6 +96,11 @@ export interface LinkProps extends BaseComponentProps {
   onFollow?: CancelableEventHandler<LinkProps.FollowDetail>;
 
   /**
+   * Called when the user clicks on the link. Do not use this handler for navigation, use the `onFollow` event instead.
+   */
+  onClick?: NonCancelableEventHandler<LinkProps.ClickDetail>;
+
+  /**
    * Adds a `rel` attribute to the link. If the `rel` property is provided, it overrides the default behaviour.
    * By default, the component sets the `rel` attribute to "noopener noreferrer" when `external` is `true` or `target` is `"_blank"`.
    */
@@ -119,4 +129,6 @@ export namespace LinkProps {
      */
     focus(): void;
   }
+
+  export type ClickDetail = _ClickDetail;
 }

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import InternalIcon from '../icon/internal';
 import styles from './styles.css.js';
 import { getBaseProps } from '../internal/base-component';
-import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
+import { fireCancelableEvent, fireNonCancelableEvent, isPlainLeftClick } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import { KeyCode } from '../internal/keycode';
 import { LinkProps } from './interfaces';
@@ -46,6 +46,7 @@ const InternalLink = React.forwardRef(
       ariaLabel,
       externalIconAriaLabel,
       onFollow,
+      onClick,
       children,
       __internalRootRef = null,
       ...props
@@ -121,20 +122,31 @@ const InternalLink = React.forwardRef(
       fireCancelableEvent(onFollow, { href, external, target: anchorTarget }, event);
     };
 
+    const fireClickEvent = (event: React.MouseEvent | React.KeyboardEvent) => {
+      const { altKey, ctrlKey, metaKey, shiftKey } = event;
+      const button = 'button' in event ? event.button : 0;
+      // make onClick non-cancelable to prevent it from being used to block full page reload
+      // for navigation use `onFollow` event instead
+      fireNonCancelableEvent(onClick, { altKey, button, ctrlKey, metaKey, shiftKey });
+    };
+
     const handleLinkClick = (event: React.MouseEvent) => {
       if (isPlainLeftClick(event)) {
         fireFollowEvent(event);
       }
+      fireClickEvent(event);
     };
 
     const handleButtonClick = (event: React.MouseEvent) => {
       fireFollowEvent(event);
+      fireClickEvent(event);
     };
 
     const handleButtonKeyDown = (event: React.KeyboardEvent) => {
       if (event.keyCode === KeyCode.space || event.keyCode === KeyCode.enter) {
         event.preventDefault();
         fireFollowEvent(event);
+        fireClickEvent(event);
       }
     };
 


### PR DESCRIPTION
### Description

Add onClick event for Link component. 

Currently Link has one event: onFollow, which is called when the Link is called without modifier key. Our customer needs an event calls for every onClick to collect metrics. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? --> Add unit tests 

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
