### PR TITLE
fix: Apply top header offset only to full-page containers

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -16,6 +16,7 @@ import { useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
 import { useModalContext } from '../internal/context/modal-context';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { ContainerHeaderContextProvider } from '../internal/context/container-header';
+import { getGlobalFlag } from '../internal/utils/global-flags';
 
 export interface InternalContainerProps extends Omit<ContainerProps, 'variant'>, InternalBaseComponentProps {
   __stickyHeader?: boolean;
@@ -120,6 +121,7 @@ export default function InternalContainer({
   const shouldHaveStickyStyles = isSticky && !isMobile;
 
   const hasMedia = !!media?.content;
+  const hasToolbar = getGlobalFlag('appLayoutWidget');
   const mediaPosition = media?.position ?? 'top';
   return (
     <div
@@ -159,6 +161,7 @@ export default function InternalContainer({
                   [styles['header-dynamic-height']]: hasDynamicHeight,
                   [styles['header-stuck']]: isStuck,
                   [styles['with-paddings']]: !disableHeaderPaddings,
+                  [styles['with-toolbar']]: hasToolbar,
                   [styles['with-hidden-content']]: !children || __hiddenContent,
                   [styles['header-with-media']]: hasMedia,
                 })}

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -201,30 +201,36 @@
     }
   }
 
-  &-variant-full-page.header-stuck {
-    box-shadow: none;
-
-    &::before {
-      content: '';
-
-      position: absolute;
-      pointer-events: none;
-      inset-inline-end: 0;
-      inset-inline-start: 0;
-      inset-block-end: 0;
-      inset-block-start: 0;
-      border-block-end: solid awsui.$border-divider-section-width awsui.$color-border-divider-default;
+  &-variant-full-page {
+    &.with-toolbar {
+      padding-block-start: awsui.$space-scaled-s;
     }
 
-    &::after {
-      content: '';
+    &.header-stuck {
+      box-shadow: none;
 
-      position: absolute;
-      inset: 0;
+      &::before {
+        content: '';
 
-      box-shadow: awsui.$shadow-sticky;
-      // This polygon only shows the part of the shadow that is lower than the element itself.
-      clip-path: polygon(-999% 100%, 999% 100%, 999% 999%, -999% 999%);
+        position: absolute;
+        pointer-events: none;
+        inset-inline-end: 0;
+        inset-inline-start: 0;
+        inset-block-end: 0;
+        inset-block-start: 0;
+        border-block-end: solid awsui.$border-divider-section-width awsui.$color-border-divider-default;
+      }
+
+      &::after {
+        content: '';
+
+        position: absolute;
+        inset: 0;
+
+        box-shadow: awsui.$shadow-sticky;
+        // This polygon only shows the part of the shadow that is lower than the element itself.
+        clip-path: polygon(-999% 100%, 999% 100%, 999% 999%, -999% 999%);
+      }
     }
   }
 }

--- a/src/header/internal.tsx
+++ b/src/header/internal.tsx
@@ -15,7 +15,6 @@ import { CollectionLabelContext } from '../internal/context/collection-label-con
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_SUBSTEP_NAME } from '../internal/analytics/selectors';
 import { useContainerHeader } from '../internal/context/container-header';
-import { getGlobalFlag } from '../internal/utils/global-flags';
 
 interface InternalHeaderProps extends SomeRequired<HeaderProps, 'variant'>, InternalBaseComponentProps {
   __disableActionsWrapping?: boolean;
@@ -47,7 +46,6 @@ export default function InternalHeader({
   // If is mobile there is no need to have the dynamic variant because it's scrolled out of view
   const dynamicVariant = !isMobile && isStuck ? 'h2' : 'h1';
   const variantOverride = variant === 'awsui-h1-sticky' ? (isRefresh ? dynamicVariant : 'h2') : variant;
-  const hasToolbarHeader = getGlobalFlag('appLayoutWidget');
 
   return (
     <div
@@ -57,7 +55,6 @@ export default function InternalHeader({
         baseProps.className,
         styles[`root-variant-${variantOverride}`],
         isRefresh && styles.refresh,
-        hasToolbarHeader && styles['root-with-toolbar'],
         !actions && [styles[`root-no-actions`]],
         description && [styles[`root-has-description`]]
       )}

--- a/src/header/styles.scss
+++ b/src/header/styles.scss
@@ -17,9 +17,6 @@
   inline-size: 100%;
   flex-wrap: wrap;
   justify-content: space-between;
-  &-with-toolbar {
-    padding-block-start: awsui.$space-scaled-s;
-  }
 
   &.refresh,
   &:not(.root-no-actions) {


### PR DESCRIPTION
### Description

Revisit implementation from a past PR: https://github.com/cloudscape-design/components/pull/2192#discussion_r1579341752

The change was supposed to work only for full page table and cards, not for all headers. Moved the implementation into container component for more specificity.

Related links, issue #, if available: n/a

### How has this been tested?

* Tests in my dev pipeline
* Not testable in the main pipeline for now, needs this CR-128628624 to take screenshots for feature flag modes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
