### PR TITLE
fix: Automatically label table's scrollable region using header

### DIFF
--- a/pages/table/full-page-variant.page.tsx
+++ b/pages/table/full-page-variant.page.tsx
@@ -16,7 +16,6 @@ export default function App() {
       variant="full-page"
       columnDefinitions={columnsConfig}
       items={items}
-      ariaLabels={{ tableLabel: 'Full-page table' }}
     />
   );
 }

--- a/src/table/__integ__/table.test.ts
+++ b/src/table/__integ__/table.test.ts
@@ -62,25 +62,25 @@ test(
   'sets role=region and aria-label on scrollable wrapper when overflowing',
   useBrowser(async browser => {
     const tableWrapper = createWrapper().findTable();
-    const tableLabel = 'Full-page table';
+    const tableHeading = 'Full-page table';
     await browser.url('#/light/table/full-page-variant?visualRefresh=true');
     const page = new BasePageObject(browser);
 
     // Find the scrollable wrapper element
     const scrollableWrapperSelector = tableWrapper.findByClassName(styles.wrapper).toSelector();
 
-    let role, ariaLabel;
     // Get the 'role' and 'aria-label' attributes of the scrollable wrapper
-    role = await page.getElementAttribute(scrollableWrapperSelector, 'role');
-    ariaLabel = await page.getElementAttribute(scrollableWrapperSelector, 'aria-label');
+    let role = await page.getElementAttribute(scrollableWrapperSelector, 'role');
+    let ariaLabelledby = await page.getElementAttribute(scrollableWrapperSelector, 'aria-labelledby');
 
     // Verify that the 'role' and 'aria-label' attributes are set correctly
-    await expect(role).toBeNull();
-    await expect(ariaLabel).toBeNull();
+    expect(role).toBeNull();
+    expect(ariaLabelledby).toBeNull();
     await page.setWindowSize({ width: 400, height: 800 });
     role = await page.getElementAttribute(scrollableWrapperSelector, 'role');
-    ariaLabel = await page.getElementAttribute(scrollableWrapperSelector, 'aria-label');
-    await expect(role).toEqual('region');
-    await expect(ariaLabel).toEqual(tableLabel);
+    ariaLabelledby = await page.getElementAttribute(scrollableWrapperSelector, 'aria-labelledby');
+    expect(role).toEqual('region');
+    expect(ariaLabelledby).not.toBeFalsy();
+    await expect(page.getElementsText(`#${ariaLabelledby}`)).resolves.toEqual([tableHeading]);
   })
 );

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -242,6 +242,7 @@ const InternalTable = React.forwardRef(
 
     const headerIdRef = useRef<string | undefined>(undefined);
     const isLabelledByHeader = !ariaLabels?.tableLabel && !!header;
+    const ariaLabelledby = isLabelledByHeader && headerIdRef.current ? headerIdRef.current : undefined;
     const setHeaderRef = useCallback((id: string) => {
       headerIdRef.current = id;
     }, []);
@@ -314,6 +315,7 @@ const InternalTable = React.forwardRef(
       tableRole,
       isScrollable: !!(tableWidth && containerWidth && tableWidth > containerWidth),
       ariaLabel: ariaLabels?.tableLabel,
+      ariaLabelledby,
     });
 
     const getMouseDownTarget = useMouseDownTarget();
@@ -443,7 +445,7 @@ const InternalTable = React.forwardRef(
                     totalItemsCount,
                     totalColumnsCount: totalColumnsCount,
                     ariaLabel: ariaLabels?.tableLabel,
-                    ariaLabelledBy: isLabelledByHeader && headerIdRef.current ? headerIdRef.current : undefined,
+                    ariaLabelledby,
                   })}
                 >
                   <Thead

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -19,7 +19,7 @@ const getAriaSort = (sortingState: SortingStatus) => stateToAriaSort[sortingStat
 export function getTableRoleProps(options: {
   tableRole: TableRole;
   ariaLabel?: string;
-  ariaLabelledBy?: string;
+  ariaLabelledby?: string;
   totalItemsCount?: number;
   totalColumnsCount?: number;
 }): React.TableHTMLAttributes<HTMLTableElement> {
@@ -30,7 +30,7 @@ export function getTableRoleProps(options: {
   nativeProps.role = options.tableRole === 'grid-default' ? 'grid' : options.tableRole;
 
   nativeProps['aria-label'] = options.ariaLabel;
-  nativeProps['aria-labelledby'] = options.ariaLabelledBy;
+  nativeProps['aria-labelledby'] = options.ariaLabelledby;
 
   // Incrementing the total count by one to account for the header row.
   nativeProps['aria-rowcount'] = options.totalItemsCount ? options.totalItemsCount + 1 : -1;
@@ -47,7 +47,12 @@ export function getTableRoleProps(options: {
   return nativeProps;
 }
 
-export function getTableWrapperRoleProps(options: { tableRole: TableRole; isScrollable: boolean; ariaLabel?: string }) {
+export function getTableWrapperRoleProps(options: {
+  tableRole: TableRole;
+  isScrollable: boolean;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}) {
   const nativeProps: React.HTMLAttributes<HTMLDivElement> = {};
 
   // When the table is scrollable, the wrapper is made focusable so that keyboard users can scroll it horizontally with arrow keys.
@@ -55,6 +60,7 @@ export function getTableWrapperRoleProps(options: { tableRole: TableRole; isScro
     nativeProps.role = 'region';
     nativeProps.tabIndex = 0;
     nativeProps['aria-label'] = options.ariaLabel;
+    nativeProps['aria-labelledby'] = options.ariaLabelledby;
   }
 
   return nativeProps;


### PR DESCRIPTION
### Description

Found in Slack and I'm following up with a quick fix, so no ticket. There are two things here that need to be labelled - the table itself (if there are multiple tables) and the focusable scroll wrapper (if the table is horizontally scrollable). Previously, we used to "auto-label" the former from the header slot, but not the latter.

Related links, issue #, if available: n/a

### How has this been tested?

Removed a manual label from a test page and the test should continue to pass. No unit test changes because we can't reliably make the scrollable wrapper show up on unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
