### PR TITLE
fix: Fix table grid navigation for React 18

### DIFF
--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useLayoutEffect, useState } from 'react';
 
 export type FocusableChangeHandler = (isFocusable: boolean) => void;
 
@@ -32,7 +32,7 @@ export function useSingleTabStopNavigation(
   const navigationDisabled = options?.tabIndex && options?.tabIndex < 0;
   const navigationActive = contextNavigationActive && !navigationDisabled;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (navigationActive && focusable && focusable.current) {
       const unregister = registerFocusable(focusable.current, isFocusable => setFocusTargetActive(isFocusable));
       return () => unregister();

--- a/src/table/table-role/utils.ts
+++ b/src/table/table-role/utils.ts
@@ -96,8 +96,14 @@ export function isTableCell(element: Element) {
 
 export function focusNextElement(element: null | HTMLElement) {
   if (element) {
+    // Table cells are not focusable by default (tabIndex=undefined) and cell.focus() is ignored.
+    // To force focusing we have to imperatively set tabIndex to -1. When focused, the grid navigation
+    // will update the tabIndex to 0 if the cell gets focused or set it to undefined if the cell content
+    // gets focused instead.
+    // We cannot make cells have tabIndex=-1 by default due to an associated bug with text selection,
+    // see: https://github.com/cloudscape-design/components/pull/2158.
     if (isTableCell(element)) {
-      element.tabIndex = 0;
+      element.tabIndex = -1;
     }
     element.focus();
   }


### PR DESCRIPTION
### Description

In a recent bugfix (https://github.com/cloudscape-design/components/pull/2294) to table keyboard navigation for Firefox and Safari the focus lost detection transitioned from listening to focusout event to monitoring focusable element unmounts. That introduced problems in React 18 because there the unmount events come after the focus transition occurred so the check `nodeBelongs(focusable, document.activeElement)` no longer works. This is fixed by updating the single tab stop navigation context subscription to use layout effect instead of effect.

### How has this been tested?

* Manual testing in Chrome, Firefox, and Safari in React 16 and 18;
* Existing unit- and integration tests run with React 16 and 18;
* New behaviour test for Firefox and Safari (React 16, CR-129786127);
* New e2e test for examples/demos (React 18, CR-129785894);
* Existing screenshot and lighthouse tests (no regression in screenshot and lighthouse tests).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
