### PR TITLE
fix: Fix select overflow when using in table inline editing

### DIFF
--- a/pages/table/editable-data.ts
+++ b/pages/table/editable-data.ts
@@ -29,6 +29,7 @@ export const tlsVersions = [
   { label: 'TLS 1.1', value: 'TLS 1.1' },
   { label: 'TLS 1.2', value: 'TLS 1.2' },
   { label: 'TLS 1.3', value: 'TLS 1.3' },
+  { label: 'TLS 1.4 (The newest and the greatest of them all)', value: 'TLS 1.4' },
 ];
 
 export const tagOptions = [

--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { TableBodyCell } from '~components/table/body-cell';
-import { TableProps } from '~components/table';
-import Input from '~components/input';
-import Multiselect from '~components/multiselect';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 import { useStickyColumns } from '~components/table/sticky-columns';
-import { Box } from '~components';
+import { Box, Select, Multiselect, Input, TableProps } from '~components';
 
 const baseColumnDefinition = {
   cell: () => 'Editable cell content shown inline when not editing',
@@ -17,6 +14,12 @@ const baseColumnDefinition = {
 };
 
 const options = ['A', 'B', 'C', 'D', 'E', 'F'].map(value => ({ value, label: `Option ${value}` }));
+
+const unevenOptions = [
+  { value: 'A', label: 'A' },
+  { value: 'B', label: 'B' },
+  { value: 'C', label: 'C (this option label is very long and can cause an overflow)' },
+];
 
 interface PermutationProps extends TableProps.EditConfig<unknown> {
   isEditing: boolean;
@@ -67,6 +70,20 @@ const editPermutations = createPermutations<PermutationProps>([
     isEditing: [false],
     interactiveCell: [false, true],
     disabledReason: [() => 'Disabled reason popover content'],
+  },
+  // Select overflow permutation
+  {
+    ariaLabel: ['Editable column'],
+    editIconAriaLabel: ['editable'],
+    errorIconAriaLabel: ['Error'],
+    editingCell: [
+      () => <Select options={unevenOptions} selectedOption={unevenOptions[2]} placeholder="Choose an option" />,
+      () => <Multiselect options={unevenOptions} selectedOptions={[unevenOptions[2]]} placeholder="Choose an option" />,
+    ],
+    constraintText: [undefined],
+    validation: [undefined],
+    isEditing: [true],
+    interactiveCell: [false],
   },
 ]);
 

--- a/pages/table/inline-editor.permutations.page.tsx
+++ b/pages/table/inline-editor.permutations.page.tsx
@@ -78,7 +78,14 @@ const editPermutations = createPermutations<PermutationProps>([
     errorIconAriaLabel: ['Error'],
     editingCell: [
       () => <Select options={unevenOptions} selectedOption={unevenOptions[2]} placeholder="Choose an option" />,
-      () => <Multiselect options={unevenOptions} selectedOptions={[unevenOptions[2]]} placeholder="Choose an option" />,
+      () => (
+        <Multiselect
+          options={unevenOptions}
+          selectedOptions={[unevenOptions[2]]}
+          placeholder="Choose an option"
+          deselectAriaLabel={() => 'Dismiss'}
+        />
+      ),
     ],
     constraintText: [undefined],
     validation: [undefined],

--- a/src/table/body-cell/inline-editor.tsx
+++ b/src/table/body-cell/inline-editor.tsx
@@ -123,7 +123,7 @@ export function InlineEditor<ItemType>({
             errorText={validation(item, currentEditValue)}
           >
             <div className={styles['body-cell-editor-row']}>
-              {editingCell(item, cellContext)}
+              <div className={styles['body-cell-editor-row-editor']}>{editingCell(item, cellContext)}</div>
               <span className={styles['body-cell-editor-controls']}>
                 <SpaceBetween direction="horizontal" size="xxs">
                   {!currentEditLoading ? (

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -332,7 +332,8 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
       flex-shrink: 0;
     }
     &-row-editor {
-      max-inline-size: calc(100% - 6 * #{awsui.$space-xxxs} - 2 * #{awsui.$size-icon-normal});
+      // 6 space-xxs: 2 * icon left padding + 2 * icon right padding + space between icons + space between icons and editor
+      max-inline-size: calc(100% - 6 * #{awsui.$space-xxs} - 2 * #{awsui.$size-icon-normal});
     }
   }
 

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -331,6 +331,9 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     &-controls {
       flex-shrink: 0;
     }
+    &-row-editor {
+      max-inline-size: calc(100% - 6 * #{awsui.$space-xxxs} - 2 * #{awsui.$size-icon-normal});
+    }
   }
 
   &.body-cell-expandable {


### PR DESCRIPTION
### Description

When using select component with very long option labels in table with inline editing the component expands beyond cell borders.

https://github.com/cloudscape-design/components/assets/20790937/53bc2866-9d01-428c-a700-ec93bc01dfce


Rel: AWSUI-42444

### How has this been tested?

* Updated permutations, the issue is now captured by VR and screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
