### PR TITLE
chore: Deprecate variant property in form component

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -7353,9 +7353,10 @@ Object {
     },
     Object {
       "defaultValue": "\\"full-page\\"",
+      "deprecatedTag": "You can safely remove this property as there is no longer any visual difference between \`full-page\` and \`embedded\` variants.",
       "description": "Specify a form variant with one of the following:
-* \`full-page\` - Use this variant when the form contains the entire content of the page. Full page variants implement the high contrast header and content behavior automatically.
-* \`embedded\` - Use this variant when the form doesn't occupy the full page. This variant doesn't use a high contrast header.",
+* \`full-page\` - Use this variant when the form contains the entire content of the page.
+* \`embedded\` - Use this variant when the form doesn't occupy the full page.",
       "inlineType": Object {
         "name": "",
         "type": "union",
@@ -7367,7 +7368,6 @@ Object {
       "name": "variant",
       "optional": true,
       "type": "string",
-      "visualRefreshTag": "",
     },
   ],
   "regions": Array [

--- a/src/form/__tests__/form.test.tsx
+++ b/src/form/__tests__/form.test.tsx
@@ -19,24 +19,6 @@ describe('Form Component', () => {
       expect(wrapper.findHeader()).toBeNull();
     });
 
-    it('does not use content layout when no header is set', () => {
-      const { container } = render(<Form />);
-      const wrapper = createWrapper(container);
-      expect(wrapper.findContentLayout()).toBeNull();
-    });
-
-    it('does not use content layout in embedded variant', () => {
-      const { container } = render(<Form variant="embedded" />);
-      const wrapper = createWrapper(container);
-      expect(wrapper.findContentLayout()).toBeNull();
-    });
-
-    it('uses content layout by default when header is present', () => {
-      const { container } = render(<Form header={<h1>Form header</h1>} />);
-      const wrapper = createWrapper(container);
-      expect(wrapper.findContentLayout()).not.toBeNull();
-    });
-
     it('displays header - custom html', () => {
       const wrapper = renderForm({ header: <h1>Form header</h1> });
       expect(wrapper.findHeader()!.getElement()).toHaveTextContent('Form header');

--- a/src/form/interfaces.ts
+++ b/src/form/interfaces.ts
@@ -37,15 +37,9 @@ export interface FormProps extends BaseComponentProps {
 
   /**
    * Specify a form variant with one of the following:
-   * * `full-page` - Use this variant when the form contains the entire content of the page. Full page variants implement the high contrast header and content behavior automatically.
-   * * `embedded` - Use this variant when the form doesn't occupy the full page. This variant doesn't use a high contrast header.
-   * @visualrefresh
+   * * `full-page` - Use this variant when the form contains the entire content of the page.
+   * * `embedded` - Use this variant when the form doesn't occupy the full page.
+   * @deprecated You can safely remove this property as there is no longer any visual difference between `full-page` and `embedded` variants.
    */
   variant?: 'full-page' | 'embedded';
-}
-
-export interface FormLayoutProps {
-  children?: React.ReactNode;
-  header?: React.ReactNode;
-  variant: FormProps['variant'];
 }

--- a/src/form/internal.tsx
+++ b/src/form/internal.tsx
@@ -5,9 +5,8 @@ import clsx from 'clsx';
 import { getBaseProps } from '../internal/base-component';
 import InternalAlert from '../alert/internal';
 import InternalBox from '../box/internal';
-import InternalContentLayout from '../content-layout/internal';
 import styles from './styles.css.js';
-import { FormLayoutProps, FormProps } from './interfaces';
+import { FormProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import LiveRegion from '../internal/components/live-region';
 import { useInternalI18n } from '../i18n/context';
@@ -21,7 +20,6 @@ export default function InternalForm({
   errorIconAriaLabel: errorIconAriaLabelOverride,
   actions,
   secondaryActions,
-  variant,
   __internalRootRef,
   ...props
 }: InternalFormProps) {
@@ -31,45 +29,28 @@ export default function InternalForm({
 
   return (
     <div {...baseProps} ref={__internalRootRef} className={clsx(styles.root, baseProps.className)}>
-      <FormLayout
-        header={
-          header && <div className={clsx(styles.header, variant === 'full-page' && styles['full-page'])}>{header}</div>
-        }
-        variant={variant}
-      >
-        {children && <div className={styles.content}>{children}</div>}
-        {errorText && (
-          <InternalBox margin={{ top: 'l' }}>
-            <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
-              <div className={styles.error}>{errorText}</div>
-            </InternalAlert>
-          </InternalBox>
-        )}
-        {(actions || secondaryActions) && (
-          <div className={styles.footer}>
-            <div className={styles['actions-section']}>
-              {actions && <div className={styles.actions}>{actions}</div>}
-              {secondaryActions && <div className={styles['secondary-actions']}>{secondaryActions}</div>}
-            </div>
+      {header && <div className={styles.header}>{header}</div>}
+      {children && <div className={styles.content}>{children}</div>}
+      {errorText && (
+        <InternalBox margin={{ top: 'l' }}>
+          <InternalAlert type="error" statusIconAriaLabel={errorIconAriaLabel}>
+            <div className={styles.error}>{errorText}</div>
+          </InternalAlert>
+        </InternalBox>
+      )}
+      {(actions || secondaryActions) && (
+        <div className={styles.footer}>
+          <div className={styles['actions-section']}>
+            {actions && <div className={styles.actions}>{actions}</div>}
+            {secondaryActions && <div className={styles['secondary-actions']}>{secondaryActions}</div>}
           </div>
-        )}
-        {errorText && (
-          <LiveRegion assertive={true}>
-            {errorIconAriaLabel}, {errorText}
-          </LiveRegion>
-        )}
-      </FormLayout>
+        </div>
+      )}
+      {errorText && (
+        <LiveRegion assertive={true}>
+          {errorIconAriaLabel}, {errorText}
+        </LiveRegion>
+      )}
     </div>
-  );
-}
-
-function FormLayout({ children, header, variant }: FormLayoutProps) {
-  return variant === 'full-page' && header ? (
-    <InternalContentLayout header={header}>{children}</InternalContentLayout>
-  ) : (
-    <>
-      {header}
-      {children}
-    </>
   );
 }

--- a/src/form/styles.scss
+++ b/src/form/styles.scss
@@ -10,7 +10,7 @@
   @include styles.styles-reset;
 }
 
-.header:not(.full-page) {
+.header {
   margin-block-end: awsui.$space-scaled-m;
 }
 


### PR DESCRIPTION
### Description

With the removal of high-contrast header, the form variant property is no longer needed


### How has this been tested?

dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ Y
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes, existing
- _Changes are covered with new/existing integration tests?_ Yes, existing
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
