### PR TITLE
refactor: activeDrawerSize to return size only when open

### DIFF
--- a/src/app-layout/classic.tsx
+++ b/src/app-layout/classic.tsx
@@ -210,7 +210,7 @@ const ClassicAppLayout = React.forwardRef(
     const effectiveNavigationWidth = navigationHide ? 0 : navigationOpen ? navigationWidth : closedDrawerWidth;
 
     const getEffectiveToolsWidth = () => {
-      if (activeDrawer && activeDrawerSize) {
+      if (activeDrawerSize) {
         return activeDrawerSize;
       }
 

--- a/src/app-layout/utils/use-drawers.ts
+++ b/src/app-layout/utils/use-drawers.ts
@@ -136,7 +136,7 @@ export function useDrawers(
 
   const activeDrawerSize = activeDrawerIdResolved
     ? drawerSizes[activeDrawerIdResolved] ?? activeDrawer?.defaultSize ?? toolsProps.toolsWidth
-    : toolsProps.toolsWidth;
+    : 0;
   const minDrawerSize = Math.min(activeDrawer?.defaultSize ?? 290, 290);
 
   return {


### PR DESCRIPTION
### Description

Change code to ensure `activeDrawerSize` is only set when it is really active

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
