### PR TITLE
chore: Remove usage of overlap hook in container

### DIFF
--- a/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
+++ b/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
@@ -34,17 +34,15 @@ function setupTest({ viewport = viewports.desktop, url = '' }, testFn: (page: Ap
 }
 
 test(
-  'keeps consistent spacing between sticky notifications and table header in visual refresh',
+  'correctly stacks table header below notifications in visual refresh',
   setupTest({ url: '#/light/app-layout/with-sticky-notifications-and-header?visualRefresh=true' }, async page => {
     await page.windowScrollTo({ top: viewports.desktop.height });
 
-    const { bottom: firstNotificationBottom } = await page.getBoundingBox(page.findNotificationByIndex(1).toSelector());
-    const { top: secondNotificationTop, bottom: secondNotificationBottom } = await page.getBoundingBox(
+    const { bottom: secondNotificationBottom } = await page.getBoundingBox(
       page.findNotificationByIndex(2).toSelector()
     );
     const { top: tableHeaderTop } = await page.getBoundingBox(page.findStickyTableHeader().toSelector());
-    const expected = secondNotificationTop - firstNotificationBottom;
-    expect(tableHeaderTop - secondNotificationBottom).toEqual(expected);
+    expect(tableHeaderTop - secondNotificationBottom).toEqual(0);
   })
 );
 

--- a/src/app-layout/__tests__/sticky-offset.test.ts
+++ b/src/app-layout/__tests__/sticky-offset.test.ts
@@ -11,43 +11,36 @@ const MOBILE_BAR = '28px';
 describe('computes vertical offsets', () => {
   test('header and footer only', () => {
     expect(getStickyOffsetVars(HEADER, FOOTER, '0px', '0px', false, false)).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + 0px + 0px)`,
+      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + 0px)`,
       [globalVars.stickyVerticalBottomOffset]: `${FOOTER}px`,
     });
   });
 
   test('with sticky notifications on desktop', () => {
     expect(getStickyOffsetVars(HEADER, FOOTER, NOTIFICATIONS, MOBILE_BAR, false, false)).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + ${NOTIFICATIONS} + 0px)`,
+      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + ${NOTIFICATIONS})`,
       [globalVars.stickyVerticalBottomOffset]: `${FOOTER}px`,
     });
   });
 
   test('with sticky notifications on mobile', () => {
     expect(getStickyOffsetVars(HEADER, FOOTER, NOTIFICATIONS, MOBILE_BAR, false, true)).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + ${MOBILE_BAR} + 0px)`,
+      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + ${MOBILE_BAR})`,
       [globalVars.stickyVerticalBottomOffset]: `${FOOTER}px`,
     });
   });
 
   test('disableBodyScroll mode on desktop', () => {
     expect(getStickyOffsetVars(HEADER, FOOTER, NOTIFICATIONS, MOBILE_BAR, true, false)).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(0px + ${NOTIFICATIONS} + 0px)`,
+      [globalVars.stickyVerticalTopOffset]: `calc(0px + ${NOTIFICATIONS})`,
       [globalVars.stickyVerticalBottomOffset]: '0px',
     });
   });
 
   test('disableBodyScroll mode on mobile', () => {
     expect(getStickyOffsetVars(HEADER, FOOTER, NOTIFICATIONS, MOBILE_BAR, true, true)).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(0px + ${MOBILE_BAR} + 0px)`,
+      [globalVars.stickyVerticalTopOffset]: `calc(0px + ${MOBILE_BAR})`,
       [globalVars.stickyVerticalBottomOffset]: '0px',
-    });
-  });
-
-  test('supports extra top offset', () => {
-    expect(getStickyOffsetVars(HEADER, FOOTER, '0px', '0px', false, false, '322px')).toEqual({
-      [globalVars.stickyVerticalTopOffset]: `calc(${HEADER}px + 0px + 322px)`,
-      [globalVars.stickyVerticalBottomOffset]: `${FOOTER}px`,
     });
   });
 });

--- a/src/app-layout/utils/sticky-offsets.ts
+++ b/src/app-layout/utils/sticky-offsets.ts
@@ -9,13 +9,12 @@ export function getStickyOffsetVars(
   stickyNotificationsHeight: string,
   mobileToolbarHeight: string,
   disableBodyScroll: boolean,
-  isMobile: boolean,
-  extraTopOffset?: string
+  isMobile: boolean
 ) {
   return {
     [globalVars.stickyVerticalTopOffset]: `calc(${!disableBodyScroll ? headerHeight : 0}px + ${
       isMobile ? mobileToolbarHeight : stickyNotificationsHeight
-    } + ${extraTopOffset ?? '0px'})`,
+    })`,
     [globalVars.stickyVerticalBottomOffset]: `${!disableBodyScroll ? footerHeight : 0}px`,
   };
 }

--- a/src/app-layout/visual-refresh/layout.scss
+++ b/src/app-layout/visual-refresh/layout.scss
@@ -169,11 +169,6 @@ explicitly set in script.
     #{custom-props.$contentGapRight}: #{awsui.$space-l};
   }
 
-  // Vertically align the notifications with the trigger buttons
-  &.content-first-child-notifications {
-    #{custom-props.$notificationsGap}: #{awsui.$space-xs};
-  }
-
   // Vertically align the breadcrumbs with the trigger buttons
   &.has-breadcrumbs {
     #{custom-props.$breadcrumbsGap}: #{awsui.$space-scaled-m};
@@ -218,10 +213,6 @@ explicitly set in script.
   components for mobile viewports.
   */
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
-    &.content-first-child-notifications {
-      #{custom-props.$notificationsGap}: #{awsui.$space-scaled-s};
-    }
-
     &.content-first-child-header {
       #{custom-props.$headerGap}: #{awsui.$space-scaled-s};
     }

--- a/src/app-layout/visual-refresh/main.tsx
+++ b/src/app-layout/visual-refresh/main.tsx
@@ -18,7 +18,6 @@ export default function Main() {
     hasDrawerViewportOverlay,
     navigationOpen,
     placement,
-    hasBackgroundOverlap,
     isMobile,
     isSplitPanelOpen,
     isToolsOpen,
@@ -29,7 +28,6 @@ export default function Main() {
     splitPanelDisplayed,
     splitPanelPosition,
     activeDrawerId,
-    hasStickyBackground,
   } = useAppLayoutInternals();
 
   const splitPanelHeight = offsetBottom - footerHeight;
@@ -56,13 +54,10 @@ export default function Main() {
         ...getStickyOffsetVars(
           placement.insetBlockStart,
           offsetBottom,
-          stickyNotifications && notificationsHeight > 0
-            ? `${tokens.spaceXs} + ${notificationsHeight}px + ${!hasBackgroundOverlap ? tokens.spaceXxxs : '0px'}`
-            : '0px',
+          stickyNotifications && notificationsHeight > 0 ? `${tokens.spaceXs} + ${notificationsHeight}px` : '0px',
           `var(${customCssProps.mobileBarHeight})`,
           !!disableBodyScroll,
-          isMobile,
-          hasBackgroundOverlap && hasStickyBackground && !isMobile ? tokens.spaceScaledS : '0px'
+          isMobile
         ),
       }}
     >

--- a/src/app-layout/visual-refresh/notifications.scss
+++ b/src/app-layout/visual-refresh/notifications.scss
@@ -12,11 +12,21 @@
   grid-area: notifications;
   z-index: 850;
 
+  &.has-notification-content {
+    padding-block-start: awsui.$space-scaled-s;
+  }
+
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     &.sticky-notifications {
       #{custom-props.$flashbarStickyBottomMargin}: #{awsui.$space-xxl};
       position: sticky;
-      inset-block-start: calc(var(#{custom-props.$offsetTop}) + #{awsui.$space-xs});
+      inset-block-start: var(#{custom-props.$offsetTop});
+      &:not(.high-contrast) {
+        background-color: awsui.$color-background-layout-main;
+      }
+    }
+    &.has-notification-content {
+      padding-block-start: awsui.$space-xs;
     }
   }
 }

--- a/src/app-layout/visual-refresh/notifications.tsx
+++ b/src/app-layout/visual-refresh/notifications.tsx
@@ -15,6 +15,7 @@ export default function Notifications() {
     notificationsElement,
     stickyNotifications,
     headerVariant,
+    hasNotificationsContent,
   } = useAppLayoutInternals();
 
   if (!notifications) {
@@ -33,8 +34,10 @@ export default function Notifications() {
         styles.notifications,
         {
           [styles['sticky-notifications']]: stickyNotifications,
+          [styles['has-notification-content']]: hasNotificationsContent,
           [styles.unfocusable]: hasDrawerViewportOverlay,
           [highContrastHeaderClassName]: headerVariant === 'high-contrast',
+          [styles['high-contrast']]: headerVariant === 'high-contrast',
         },
         testutilStyles.notifications
       )}

--- a/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
+++ b/src/container/__integ__/awsui-legacy-applayout-sticky.test.ts
@@ -13,19 +13,13 @@ const containerHeaderSelector = containerWrapper.findHeader().toSelector();
 const flashBarSelector = createWrapper().findFlashbar().toSelector();
 const demoHeaderSelector = '#h';
 
-const CLASSIC_STICKY_OFFSET_SPACE = 0; // No borders on flashbars or additional padding below
-const VISUAL_REFRESH_STICKY_OFFSET_SPACE = 2; // space-xxxs - from $offsetTopWithNotifications additional padding
-
 class AppLayoutLegacyStickyPage extends BasePageObject {
   scrollTo(params: { top?: number; left?: number }) {
     return this.elementScrollTo(`.${appLayoutSelectors['disable-body-scroll-root']}`, params);
   }
 }
 
-describe.each([
-  ['classic', CLASSIC_STICKY_OFFSET_SPACE],
-  ['visualRefresh', VISUAL_REFRESH_STICKY_OFFSET_SPACE],
-])('In %s', (type, stickyOffset) => {
+describe.each(['classic', 'visualRefresh'])('In %s', type => {
   function setupTest({ viewport = viewports.desktop }, testFn: (page: AppLayoutLegacyStickyPage) => Promise<void>) {
     return useBrowser(async browser => {
       const page = new AppLayoutLegacyStickyPage(browser);
@@ -47,7 +41,7 @@ describe.each([
       await page.scrollTo({ top: 400 });
       const { top: containerTopAfter } = await page.getBoundingBox(containerHeaderSelector);
       const { bottom: flashBarBottomAfter } = await page.getBoundingBox(flashBarSelector);
-      expect(containerTopAfter).toEqual(flashBarBottomAfter + stickyOffset);
+      expect(containerTopAfter).toEqual(flashBarBottomAfter);
     })
   );
 

--- a/src/container/__integ__/header-cover.test.ts
+++ b/src/container/__integ__/header-cover.test.ts
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from '../../app-layout/__integ__/constants';
+import styles from '../../../lib/components/container/styles.selectors.js';
+
+const tableWrapper = createWrapper().findTable();
+
+class ContainerStickyPage extends BasePageObject {
+  async hasHeaderCover() {
+    const elements = await this.browser.$$(tableWrapper.findByClassName(styles['header-cover']).toSelector());
+    if (elements.length === 0) {
+      return false;
+    }
+    return true;
+  }
+}
+
+function setupTest(
+  { viewport = viewports.desktop, search = '', visualRefresh = true },
+  testFn: (page: ContainerStickyPage) => Promise<void>
+) {
+  return useBrowser(async browser => {
+    const page = new ContainerStickyPage(browser);
+    await page.setWindowSize(viewport);
+    await browser.url(`#/light/container/sticky-permutations?visualRefresh=${visualRefresh}&${search}`);
+    await page.waitForVisible(tableWrapper.findBodyCell(1, 1).toSelector());
+    await testFn(page);
+  });
+}
+
+test(
+  'Header cover is displayed in full-page variant',
+  setupTest({}, async page => {
+    await page.windowScrollTo({ top: 300 });
+    expect(page.hasHeaderCover()).resolves.toBe(true);
+  })
+);
+
+test(
+  'Header cover is not displayed in container variant',
+  setupTest({ search: 'tableVariant=container' }, async page => {
+    await page.windowScrollTo({ top: 300 });
+    expect(page.hasHeaderCover()).resolves.toBe(false);
+  })
+);
+
+test(
+  'Header cover is not displayed in mobile',
+  setupTest({ viewport: viewports.mobile }, async page => {
+    await page.windowScrollTo({ top: 300 });
+    expect(page.hasHeaderCover()).resolves.toBe(false);
+  })
+);
+
+test(
+  'Header cover is removed upon scrolling up',
+  setupTest({}, async page => {
+    await page.windowScrollTo({ top: 300 });
+    await page.windowScrollTo({ top: 0 });
+    expect(page.hasHeaderCover()).resolves.toBe(false);
+  })
+);
+
+test(
+  'Header cover is not displayed in classic',
+  setupTest({ visualRefresh: false }, async page => {
+    await page.windowScrollTo({ top: 300 });
+    expect(page.hasHeaderCover()).resolves.toBe(false);
+  })
+);

--- a/src/container/__tests__/sticky-header.test.tsx
+++ b/src/container/__tests__/sticky-header.test.tsx
@@ -25,17 +25,16 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-test('should report sticky background in full-page variant', () => {
+test('should not report sticky background in full-page variant', () => {
   const setHasStickyBackground = jest.fn();
   const { rerender } = render(
     <AppLayoutContext.Provider value={{ setHasStickyBackground }}>
       <InternalContainer variant="full-page">test content</InternalContainer>
     </AppLayoutContext.Provider>
   );
-  expect(setHasStickyBackground).toHaveBeenCalledWith(true);
-  setHasStickyBackground.mockReset();
+  expect(setHasStickyBackground).not.toHaveBeenCalledWith(true);
   rerender(<></>);
-  expect(setHasStickyBackground).toHaveBeenCalledWith(false);
+  expect(setHasStickyBackground).not.toHaveBeenCalledWith(false);
 });
 
 test('should not report sticky state in default variant', () => {

--- a/src/container/__tests__/sticky-offset.test.ts
+++ b/src/container/__tests__/sticky-offset.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { computeOffset } from '../../../lib/components/container/use-sticky-header';
 import globalVars from '../../../lib/components/internal/styles/global-vars';
+import * as tokens from '../../../lib/components/internal/generated/styles/tokens';
 
 describe('computeOffset', () => {
   test('should calculate offset for mobile outside overflow parent', () => {
@@ -11,7 +12,7 @@ describe('computeOffset', () => {
       hasInnerOverflowParents: false,
     });
 
-    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + -10px)`);
+    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + -10px + 0px)`);
   });
 
   test('should calculate offset for mobile inside overflow parent', () => {
@@ -42,7 +43,18 @@ describe('computeOffset', () => {
       hasInnerOverflowParents: false,
     });
 
-    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + 0px)`);
+    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + 0px + 0px)`);
+  });
+
+  test('should calculate include additional offset', () => {
+    const result = computeOffset({
+      isMobile: false,
+      __mobileStickyOffset: 10,
+      hasInnerOverflowParents: false,
+      __additionalOffset: true,
+    });
+
+    expect(result).toBe(`calc(var(${globalVars.stickyVerticalTopOffset}, 0px) + 0px + ${tokens.spaceScaledS})`);
   });
 
   test('should calculate offset for non-mobile with inner overflow parents', () => {

--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from 'clsx';
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { ContainerProps } from './interfaces';
 import { getBaseProps } from '../internal/base-component';
-import { useAppLayoutContext } from '../internal/context/app-layout-context';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { StickyHeaderContext, useStickyHeader } from './use-sticky-header';
-import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useMobile } from '../internal/hooks/use-mobile';
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
@@ -77,6 +75,7 @@ export default function InternalContainer({
   ...restProps
 }: InternalContainerProps) {
   const isMobile = useMobile();
+  const isRefresh = useVisualRefresh();
   const baseProps = getBaseProps(restProps);
   const rootRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -86,35 +85,15 @@ export default function InternalContainer({
     __stickyHeader,
     __stickyOffset,
     __mobileStickyOffset,
-    __disableStickyMobile
+    __disableStickyMobile,
+    __fullPage && isRefresh && !isMobile
   );
   const contentId = useUniqueId();
-  const { setHasStickyBackground } = useAppLayoutContext();
-  const isRefresh = useVisualRefresh();
 
   const hasDynamicHeight = isRefresh && variant === 'full-page';
-  const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight || !__fullPage });
 
   const mergedRef = useMergeRefs(rootRef, __internalRootRef);
-  const headerMergedRef = useMergeRefs(headerRef, overlapElement, __headerRef);
-
-  /**
-   * The visual refresh AppLayout component needs to know if a child component
-   * has a high contrast sticky header. This is to make sure the background element
-   * stays in the same vertical position as the header content.
-   */
-  useEffect(() => {
-    const shouldUpdateStickyBackground = isSticky && variant === 'full-page' && setHasStickyBackground;
-    if (shouldUpdateStickyBackground) {
-      setHasStickyBackground(true);
-    }
-
-    return () => {
-      if (shouldUpdateStickyBackground) {
-        setHasStickyBackground(false);
-      }
-    };
-  }, [isSticky, setHasStickyBackground, variant]);
+  const headerMergedRef = useMergeRefs(headerRef, __headerRef);
 
   // The container is only sticky on mobile if it is the header for the table.
   // In this case we don't want the container to have sticky styles, as only the table header row will show as stuck on scroll.
@@ -168,6 +147,7 @@ export default function InternalContainer({
                 {...stickyStyles}
                 ref={headerMergedRef}
               >
+                {isStuck && !isMobile && isRefresh && __fullPage && <div className={styles['header-cover']}></div>}
                 {header}
               </div>
             </StickyHeaderContext.Provider>

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -209,6 +209,14 @@
     &.header-stuck {
       box-shadow: none;
 
+      > .header-cover {
+        background-color: awsui.$color-background-layout-main;
+        inline-size: 100%;
+        position: absolute;
+        block-size: awsui.$space-scaled-s;
+        inset-block-start: calc(-1 * awsui.$space-scaled-s);
+      }
+
       &::before {
         content: '';
 

--- a/src/container/use-sticky-header.ts
+++ b/src/container/use-sticky-header.ts
@@ -5,6 +5,7 @@ import { findUpUntil } from '../internal/utils/dom';
 import { getOverflowParents } from '../internal/utils/scrollable-containers';
 import { useMobile } from '../internal/hooks/use-mobile';
 import globalVars from '../internal/styles/global-vars';
+import * as tokens from '../internal/generated/styles/tokens';
 
 interface StickyHeaderContextProps {
   isStuck: boolean;
@@ -15,6 +16,7 @@ interface ComputeOffsetProps {
   __stickyOffset?: number;
   __mobileStickyOffset?: number;
   hasInnerOverflowParents: boolean;
+  __additionalOffset?: boolean;
 }
 
 export function computeOffset({
@@ -22,6 +24,7 @@ export function computeOffset({
   __stickyOffset,
   __mobileStickyOffset,
   hasInnerOverflowParents,
+  __additionalOffset,
 }: ComputeOffsetProps): string {
   const localOffset = isMobile ? (__stickyOffset ?? 0) - (__mobileStickyOffset ?? 0) : __stickyOffset ?? 0;
   if (hasInnerOverflowParents || __stickyOffset !== undefined) {
@@ -29,7 +32,7 @@ export function computeOffset({
   }
   const globalOffset = `var(${globalVars.stickyVerticalTopOffset}, 0px)`;
 
-  return `calc(${globalOffset} + ${localOffset}px)`;
+  return `calc(${globalOffset} + ${localOffset}px + ${__additionalOffset ? tokens.spaceScaledS : '0px'})`;
 }
 
 export const StickyHeaderContext = createContext<StickyHeaderContextProps>({
@@ -42,7 +45,8 @@ export const useStickyHeader = (
   __stickyHeader?: boolean,
   __stickyOffset?: number,
   __mobileStickyOffset?: number,
-  __disableMobile = true
+  __disableMobile?: boolean,
+  __additionalOffset = false
 ) => {
   const isMobile = useMobile();
   const disableSticky = isMobile && __disableMobile;
@@ -68,6 +72,7 @@ export const useStickyHeader = (
     __stickyOffset,
     __mobileStickyOffset,
     hasInnerOverflowParents,
+    __additionalOffset,
   });
 
   const stickyStyles = isSticky

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -24,7 +24,6 @@ import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import StickyHeader, { StickyHeaderRef } from './sticky-header';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
-import { useDynamicOverlap } from '../internal/hooks/use-dynamic-overlap';
 import LiveRegion from '../internal/components/live-region';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { SomeRequired } from '../internal/types';
@@ -319,8 +318,6 @@ const InternalTable = React.forwardRef(
 
     const getMouseDownTarget = useMouseDownTarget();
 
-    const hasDynamicHeight = computedVariant === 'full-page';
-    const overlapElement = useDynamicOverlap({ disabled: !hasDynamicHeight });
     useTableFocusNavigation({
       enableKeyboardNavigation,
       selectionType,
@@ -348,10 +345,11 @@ const InternalTable = React.forwardRef(
             __internalRootRef={__internalRootRef}
             className={clsx(baseProps.className, styles.root)}
             __funnelSubStepProps={__funnelSubStepProps}
+            __fullPage={variant === 'full-page'}
             header={
               <>
                 {hasHeader && (
-                  <div ref={overlapElement}>
+                  <div>
                     <div
                       ref={toolsHeaderWrapper}
                       className={clsx(styles['header-controls'], styles[`variant-${computedVariant}`])}


### PR DESCRIPTION
### Description

No longer needed after the removal of high-contrast header in these components

Related links, issue #, if available: n/a

### How has this been tested?

dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Y
- _Changes are covered with new/existing integration tests?_ Y
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
