### PR TITLE
chore: Fix type definitions for custom css prop names generator

### DIFF
--- a/build-tools/tasks/generate-custom-css-properties.js
+++ b/build-tools/tasks/generate-custom-css-properties.js
@@ -18,7 +18,7 @@ function writeJsFile() {
   writeFile(
     filepath,
     `
-      const customCSSPropertiesMap: Record<string,string> = {
+      const customCSSPropertiesMap = {
         ${customCssPropertiesList.map(property => `"${property}": "${getHashedProperty(property)}",`).join('\n')}
       };
       export default customCSSPropertiesMap;


### PR DESCRIPTION
### Description

```js
import customCssProps from '../../../lib/components/internal/generated/custom-css-properties';

customCssProps.whateverRandom;
// before: no type error
// after: Property whateverRandom does not exist on type ...
```

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
