### PR TITLE
chore: Rename bundle size output file

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -71,14 +71,13 @@ jobs:
           cd ../bundle-size
           npm run build
 
-          mv output.json output-pr.json
-          cat output-pr.json
+          cat output.json
 
       - name: Upload size report artifact
         uses: actions/upload-artifact@v4
         with:
           name: size-report
-          path: bundle-size/output-pr.json
+          path: bundle-size/output.json
 
       - name: Update the commit status with calculated results
         uses: actions/github-script@v7

--- a/.github/workflows/bundle-size/status-report.js
+++ b/.github/workflows/bundle-size/status-report.js
@@ -47,7 +47,7 @@ export async function statusReportFailure({ github, context }) {
 
 export async function statusReportSuccess({ github, context }) {
   const basebranch = readJson('./bundle-size/output-basebranch.json');
-  const pr = readJson('./bundle-size/output-pr.json');
+  const pr = readJson('./bundle-size/output.json');
 
   console.log('Base branch:', basebranch);
   console.log('This PR:', pr);


### PR DESCRIPTION
### Description

The bundle size is calculated for PR commits but also once a commit is merged to main. Thus, rename the output file to not be refer to "pr" and be more generic instead.

Related links, issue #, if available: n/a

### How has this been tested?

Result of PR workflow can be seen in the checks below.

Result of merging to main will be seen once this PR is merged.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
