### PR TITLE
fix: Ensure 'contain' is provided in getComputedStyle before relying on it

### DIFF
--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -31,7 +31,7 @@ export function getContainingBlock(startElement: HTMLElement): HTMLElement | nul
       (!!computedStyle.transform && computedStyle.transform !== 'none') ||
       (!!computedStyle.perspective && computedStyle.perspective !== 'none') ||
       (!!computedStyle.containerType && computedStyle.containerType !== 'normal') ||
-      computedStyle.contain.split(' ').some(s => ['layout', 'paint', 'strict', 'content'].includes(s))
+      computedStyle.contain?.split(' ').some(s => ['layout', 'paint', 'strict', 'content'].includes(s))
     );
   }) as HTMLElement;
 }


### PR DESCRIPTION
### Description

My guess on what's happening here is that CSS [contain](https://caniuse.com/mdn-css_properties_contain) isn't supported on Safari 15.0, 15.1, and 15.3, so calling a property on it causes an error to throw. Treating this as a hotfix for now, but I don't know how best to address this in the long term. Either an audit on whether properties we're calling on `getComputedStyle` exist, or some kind of CSS-like browser-support check?

Related links, issue #, if available: AWSUI-45436

### How has this been tested?

See above.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
