### PR TITLE
fix: Ensure chart announcements track focus state correctly

### DIFF
--- a/src/mixed-line-bar-chart/__integ__/announcements.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/announcements.test.ts
@@ -75,3 +75,27 @@ describe('Popover content is announced as plain text on hover', () => {
     );
   });
 });
+
+describe('Application aria label', () => {
+  const chartWrapper = createWrapper().findMixedLineBarChart('#chart');
+  test(
+    'is updated when navigating in a bar chart with keyboard',
+    setupTest('#/light/bar-chart/test', async page => {
+      // Hover over first group in the first chart
+      await page.click('#focus-target');
+      await page.keys(['Tab', 'Tab', 'ArrowRight']);
+      await page.waitForAssertion(async () => {
+        await expect(page.getElementAttribute(chartWrapper.findApplication().toSelector(), 'aria-label')).resolves.toBe(
+          'Potatoes, Calories 77'
+        );
+      });
+
+      await page.keys(['ArrowRight']);
+      await page.waitForAssertion(async () => {
+        await expect(page.getElementAttribute(chartWrapper.findApplication().toSelector(), 'aria-label')).resolves.toBe(
+          'Chocolate, Calories 546'
+        );
+      });
+    })
+  );
+});

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -531,10 +531,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
           ariaRoleDescription={i18nStrings?.chartAriaRoleDescription}
           ariaLiveRegion={activeLiveRegion}
           activeElementRef={highlightedElementRef}
-          activeElementKey={
-            highlightedGroupIndex?.toString() ??
-            (isLineXKeyboardFocused ? `point-index-${handlers.xIndex}` : point?.key)
-          }
+          activeElementKey={activeAriaLabel}
           activeElementFocusOffset={isGroupNavigation ? 0 : isLineXKeyboardFocused ? { x: 8, y: 0 } : 3}
           onMouseMove={onSVGMouseMove}
           onMouseOut={onSVGMouseOut}


### PR DESCRIPTION
### Description

Ensure chart announcements track focus state correctly: previously they would lag one action behind the active selection.

Related links, issue #, if available: AWSUI-42778

### How has this been tested?

Updated integ tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
