### PR TITLE
chore: Tabs use single tab stop navigation mechanism

### DIFF
--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -268,7 +268,7 @@ describe('Tabs', () => {
       expect(changeSpy).not.toHaveBeenCalled();
     });
 
-    test('fires a change event on right and left arrow key press', () => {
+    test('fires a change event on right arrow key press', () => {
       const changeSpy = jest.fn();
       const wrapper = renderTabs(<Tabs tabs={defaultTabs} activeTabId="first" onChange={changeSpy} />).wrapper;
       expect(changeSpy).not.toHaveBeenCalled();
@@ -284,10 +284,16 @@ describe('Tabs', () => {
           },
         })
       );
+    });
+
+    test('fires a change event on left arrow key press', () => {
+      const changeSpy = jest.fn();
+      const wrapper = renderTabs(<Tabs tabs={defaultTabs} activeTabId="first" onChange={changeSpy} />).wrapper;
+      expect(changeSpy).not.toHaveBeenCalled();
 
       pressLeft(wrapper);
 
-      expect(changeSpy).toHaveBeenCalledTimes(2);
+      expect(changeSpy).toHaveBeenCalledTimes(1);
       expect(changeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           detail: {

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -335,41 +335,32 @@ export function TabHeaderBar({
       tabRefs.current.set(tab.id, tabElement as HTMLElement);
     };
 
-    let trigger = null;
-    if (tab.href) {
-      const anchorProps = commonProps as JSX.IntrinsicElements['a'];
-      anchorProps.href = tab.href;
-      trigger = <AnchorTrigger {...anchorProps} ref={setElement} />;
-    } else {
-      const buttonProps = commonProps as JSX.IntrinsicElements['button'];
-      buttonProps.type = 'button';
-      if (tab.disabled) {
-        buttonProps.disabled = true;
-      }
-      trigger = <ButtonTrigger {...buttonProps} ref={setElement} />;
-    }
-
     return (
       <li className={styles['tabs-tab']} role="presentation" key={tab.id}>
-        {trigger}
+        <TabTrigger ref={setElement} tab={tab} elementProps={commonProps} />
       </li>
     );
   }
 }
 
-const AnchorTrigger = forwardRef((props: React.HTMLAttributes<HTMLAnchorElement>, ref: React.Ref<HTMLElement>) => {
-  const refObject = useRef<HTMLAnchorElement>(null);
-  const mergedRef = useMergeRefs(refObject, ref);
-  const { tabIndex } = useSingleTabStopNavigation(refObject);
-  return <a ref={mergedRef} {...props} tabIndex={tabIndex} />;
-});
-
-const ButtonTrigger = forwardRef((props: React.HTMLAttributes<HTMLButtonElement>, ref: React.Ref<HTMLElement>) => {
-  const refObject = useRef<HTMLAnchorElement>(null);
-  const mergedRef = useMergeRefs(refObject, ref);
-  const { tabIndex } = useSingleTabStopNavigation(refObject);
-  return <button ref={mergedRef} {...props} tabIndex={tabIndex} />;
-});
+const TabTrigger = forwardRef(
+  (
+    {
+      tab,
+      elementProps,
+    }: { tab: TabsProps.Tab; elementProps: React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement> },
+    ref: React.Ref<HTMLElement>
+  ) => {
+    const refObject = useRef<HTMLElement>(null);
+    const mergedRef = useMergeRefs(refObject, ref);
+    const { tabIndex } = useSingleTabStopNavigation(refObject);
+    return tab.href ? (
+      <a {...elementProps} href={tab.href} ref={mergedRef} tabIndex={tabIndex} />
+    ) : (
+      <button {...elementProps} type="button" disabled={tab.disabled} ref={mergedRef} tabIndex={tabIndex} />
+    );
+  }
+);
 
 export function getTabElementId({ namespace, tabId }: { namespace: string; tabId: string }) {
   return namespace + '-' + tabId;


### PR DESCRIPTION
### Description

Updated keyboard navigation logic in Tabs to use single-tab-stop context.

So far there is a lot of similarities with src/table/table-role/grid-navigation.ts. There is an opportunity to reuse the parts of code that define focusables, focusableHandles, and focusablesState state, but I would prefer to do it in a separate follow-up PR to keep the diff manageable.

The change is supposed to introduce no difference to the current Tabs UX. We do it to support the upcoming feature: https://github.com/cloudscape-design/components/pull/2173 (actions in tabs). The update is proven to work with actions: https://github.com/cloudscape-design/components/pull/2325.

### How has this been tested?

* Existing unit- and integration tests;
* Screenshot tests;
* Dry-run;
* Manual tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
