### PR TITLE
chore: remove reportSize from split panel context

### DIFF
--- a/src/app-layout/split-panel/provider.tsx
+++ b/src/app-layout/split-panel/provider.tsx
@@ -7,6 +7,7 @@ import { SPLIT_PANEL_MIN_HEIGHT, SPLIT_PANEL_MIN_WIDTH } from './constants';
 
 export interface SplitPanelProviderProps extends SplitPanelContextBaseProps {
   maxWidth: number;
+  reportSize: (size: number) => void;
   getMaxHeight: () => number;
   children?: React.ReactNode;
 }
@@ -16,10 +17,11 @@ export function SplitPanelProvider({
   size,
   getMaxHeight,
   maxWidth,
+  reportSize,
   onResize,
   ...rest
 }: SplitPanelProviderProps) {
-  const { position, reportSize, isOpen } = rest;
+  const { position, isOpen } = rest;
   const [maxHeight, setMaxHeight] = useState(size);
   const minSize = position === 'bottom' ? SPLIT_PANEL_MIN_HEIGHT : SPLIT_PANEL_MIN_WIDTH;
   const maxSize = position === 'bottom' ? maxHeight : maxWidth;

--- a/src/internal/context/split-panel-context.ts
+++ b/src/internal/context/split-panel-context.ts
@@ -26,7 +26,6 @@ export interface SplitPanelContextBaseProps {
   onResize: (newSize: number) => void;
   onToggle: () => void;
   onPreferencesChange: (detail: { position: 'side' | 'bottom' }) => void;
-  reportSize: (pixels: number) => void;
   reportHeaderHeight: (pixels: number) => void;
   setSplitPanelToggle: (config: SplitPanelSideToggleProps) => void;
   refs: SplitPanelFocusControlRefs;

--- a/src/split-panel/__tests__/helpers.ts
+++ b/src/split-panel/__tests__/helpers.ts
@@ -15,7 +15,6 @@ export const defaultSplitPanelContextProps: SplitPanelContextProps = {
   onResize: jest.fn(),
   onToggle: jest.fn(),
   onPreferencesChange: jest.fn(),
-  reportSize: jest.fn(),
   reportHeaderHeight: jest.fn(),
   setSplitPanelToggle: jest.fn(),
   refs: {


### PR DESCRIPTION
### Description

Since https://github.com/cloudscape-design/components/pull/1612 this value is not used inside split panel context

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
