### PR TITLE
refactor: Refactor single tab stop context

### DIFF
--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -1,7 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, useContext, useLayoutEffect, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
 
 export type FocusableChangeHandler = (isFocusable: boolean) => void;
 
@@ -46,3 +54,88 @@ export function useSingleTabStopNavigation(
 
   return { navigationActive, tabIndex };
 }
+
+export interface SingleTabStopNavigationProviderProps {
+  navigationActive: boolean;
+  children: React.ReactNode;
+  getNextFocusTarget: () => null | HTMLElement;
+  onRegisterFocusable?(focusableElement: Element): void;
+  onUnregisterFocusable?(focusableElement: Element): void;
+}
+
+export interface SingleTabStopNavigationAPI {
+  updateFocusTarget(): void;
+  getFocusTarget(): null | HTMLElement;
+  isRegistered(element: Element): boolean;
+}
+
+export const SingleTabStopNavigationProvider = forwardRef(
+  (
+    {
+      navigationActive,
+      children,
+      getNextFocusTarget,
+      onRegisterFocusable,
+      onUnregisterFocusable,
+    }: SingleTabStopNavigationProviderProps,
+    ref: React.Ref<SingleTabStopNavigationAPI>
+  ) => {
+    // A set of registered focusable elements that can use keyboard navigation.
+    const focusables = useRef(new Set<Element>());
+    // A map of registered focusable element handlers to update the respective tab indices.
+    const focusHandlers = useRef(new Map<Element, FocusableChangeHandler>());
+    // A map of focusable element states to avoid issuing unnecessary updates to registered elements.
+    const focusablesState = useRef(new WeakMap<Element, boolean>());
+    // A reference to the currently focused element.
+    const focusTarget = useRef<null | HTMLElement>(null);
+
+    // Register a focusable element to allow navigating into it.
+    // The focusable element tabIndex is only set to 0 if the element matches the focus target.
+    function registerFocusable(focusableElement: Element, changeHandler: FocusableChangeHandler) {
+      focusables.current.add(focusableElement);
+      focusHandlers.current.set(focusableElement, changeHandler);
+      const isFocusable = !!focusablesState.current.get(focusableElement);
+      const newIsFocusable = focusTarget.current === focusableElement;
+      if (newIsFocusable !== isFocusable) {
+        focusablesState.current.set(focusableElement, newIsFocusable);
+        changeHandler(newIsFocusable);
+      }
+      onRegisterFocusable?.(focusableElement);
+      return () => unregisterFocusable(focusableElement);
+    }
+    function unregisterFocusable(focusableElement: Element) {
+      focusables.current.delete(focusableElement);
+      focusHandlers.current.delete(focusableElement);
+      onUnregisterFocusable?.(focusableElement);
+    }
+
+    // Update focus target with next single focusable element and notify all registered focusables of a change.
+    function updateFocusTarget() {
+      focusTarget.current = getNextFocusTarget();
+      for (const focusableElement of focusables.current) {
+        const isFocusable = focusablesState.current.get(focusableElement) ?? false;
+        const newIsFocusable = focusTarget.current === focusableElement;
+        if (newIsFocusable !== isFocusable) {
+          focusablesState.current.set(focusableElement, newIsFocusable);
+          focusHandlers.current.get(focusableElement)!(newIsFocusable);
+        }
+      }
+    }
+
+    function getFocusTarget() {
+      return focusTarget.current;
+    }
+
+    function isRegistered(element: Element) {
+      return focusables.current.has(element);
+    }
+
+    useImperativeHandle(ref, () => ({ updateFocusTarget, getFocusTarget, isRegistered }));
+
+    return (
+      <SingleTabStopNavigationContext.Provider value={{ navigationActive, registerFocusable }}>
+        {children}
+      </SingleTabStopNavigationContext.Provider>
+    );
+  }
+);

--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -59,6 +59,7 @@ export interface SingleTabStopNavigationProviderProps {
   navigationActive: boolean;
   children: React.ReactNode;
   getNextFocusTarget: () => null | HTMLElement;
+  isElementSuppressed?(focusableElement: Element): boolean;
   onRegisterFocusable?(focusableElement: Element): void;
   onUnregisterFocusable?(focusableElement: Element): void;
 }
@@ -75,6 +76,7 @@ export const SingleTabStopNavigationProvider = forwardRef(
       navigationActive,
       children,
       getNextFocusTarget,
+      isElementSuppressed,
       onRegisterFocusable,
       onUnregisterFocusable,
     }: SingleTabStopNavigationProviderProps,
@@ -95,7 +97,7 @@ export const SingleTabStopNavigationProvider = forwardRef(
       focusables.current.add(focusableElement);
       focusHandlers.current.set(focusableElement, changeHandler);
       const isFocusable = !!focusablesState.current.get(focusableElement);
-      const newIsFocusable = focusTarget.current === focusableElement;
+      const newIsFocusable = focusTarget.current === focusableElement || !!isElementSuppressed?.(focusableElement);
       if (newIsFocusable !== isFocusable) {
         focusablesState.current.set(focusableElement, newIsFocusable);
         changeHandler(newIsFocusable);
@@ -114,7 +116,7 @@ export const SingleTabStopNavigationProvider = forwardRef(
       focusTarget.current = getNextFocusTarget();
       for (const focusableElement of focusables.current) {
         const isFocusable = focusablesState.current.get(focusableElement) ?? false;
-        const newIsFocusable = focusTarget.current === focusableElement;
+        const newIsFocusable = focusTarget.current === focusableElement || !!isElementSuppressed?.(focusableElement);
         if (newIsFocusable !== isFocusable) {
           focusablesState.current.set(focusableElement, newIsFocusable);
           focusHandlers.current.get(focusableElement)!(newIsFocusable);

--- a/src/table/table-role/__tests__/grid-navigation.test.tsx
+++ b/src/table/table-role/__tests__/grid-navigation.test.tsx
@@ -21,9 +21,9 @@ function formatElement(element: Element) {
   return `${tagName}[${text}]`;
 }
 
-test('updates interactive elements tab indices', () => {
+test('updates interactive elements tab indices', async () => {
   render(<TestTable columns={[nameColumn, valueColumn]} items={items} />);
-  expect(readFocusableElements()).toEqual(['BUTTON[Sort by name]']);
+  await waitFor(() => expect(readFocusableElements()).toEqual(['BUTTON[Sort by name]']));
 });
 
 test.each([0, 5])('supports arrow keys navigation for startIndex=%s', startIndex => {
@@ -243,10 +243,10 @@ test('restores focus when the node gets removed', async () => {
   await waitFor(() => expect(editButtonCell).toHaveFocus());
 });
 
-test('all elements focus is restored if table changes role after being rendered as grid', () => {
+test('all elements focus is restored if table changes role after being rendered as grid', async () => {
   const { rerender } = render(<TestTable columns={[valueColumn, idColumn]} items={items} />);
 
-  expect(readFocusableElements()).toEqual(['BUTTON[Sort by value]']);
+  await waitFor(() => expect(readFocusableElements()).toEqual(['BUTTON[Sort by value]']));
 
   rerender(<TestTable keyboardNavigation={false} columns={[valueColumn, idColumn]} items={items} />);
 

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -136,7 +136,7 @@ export function TabHeaderBar({
     [styles['pagination-button-right-scrollable']]: inlineEndOverflow,
   });
 
-  const singleTabStopNavigationAPI = useRef<SingleTabStopNavigationAPI>(null);
+  const navigationAPI = useRef<SingleTabStopNavigationAPI>(null);
 
   function getNextFocusTarget(): null | HTMLElement {
     if (!containerObjectRef.current) {
@@ -147,17 +147,17 @@ export function TabHeaderBar({
   }
 
   useEffect(() => {
-    singleTabStopNavigationAPI.current?.updateFocusTarget();
+    navigationAPI.current?.updateFocusTarget();
   });
   function onFocus() {
-    singleTabStopNavigationAPI.current?.updateFocusTarget();
+    navigationAPI.current?.updateFocusTarget();
   }
   function onBlur() {
-    singleTabStopNavigationAPI.current?.updateFocusTarget();
+    navigationAPI.current?.updateFocusTarget();
   }
 
   function onKeyDown(event: React.KeyboardEvent) {
-    const focusTarget = singleTabStopNavigationAPI.current?.getFocusTarget();
+    const focusTarget = navigationAPI.current?.getFocusTarget();
     const specialKeys = [KeyCode.right, KeyCode.left, KeyCode.end, KeyCode.home, KeyCode.pageUp, KeyCode.pageDown];
     if (hasModifierKeys(event) || specialKeys.indexOf(event.keyCode) === -1) {
       return;
@@ -192,7 +192,7 @@ export function TabHeaderBar({
   // List all non-disabled and registered focusables: those are eligible for keyboard navigation.
   function getFocusablesFrom(target: HTMLElement) {
     function isElementRegistered(element: HTMLElement) {
-      return singleTabStopNavigationAPI.current?.isRegistered(element) ?? false;
+      return navigationAPI.current?.isRegistered(element) ?? false;
     }
     function isElementDisabled(element: HTMLElement) {
       if (element instanceof HTMLButtonElement) {
@@ -220,7 +220,7 @@ export function TabHeaderBar({
         </span>
       )}
       <SingleTabStopNavigationProvider
-        ref={singleTabStopNavigationAPI}
+        ref={navigationAPI}
         navigationActive={true}
         getNextFocusTarget={getNextFocusTarget}
       >


### PR DESCRIPTION
### Description

Reused code between Tabs and Table that now both use single tab stop navigation context.

This change is a follow-up for https://github.com/cloudscape-design/components/pull/2330.

### How has this been tested?

* Existing unit- and integration tests;
* Screenshot and lighthouse tests;
* Dry run to live.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
