### PR TITLE
fix: Fix table cell focus outline

### DIFF
--- a/src/internal/styles/forms/mixins.scss
+++ b/src/internal/styles/forms/mixins.scss
@@ -50,6 +50,19 @@
     $gutter-vertical: map.get($gutter, 'vertical');
     $gutter-horizontal: map.get($gutter, 'horizontal');
   }
+  $gutter-top: $gutter-vertical;
+  $gutter-bottom: $gutter-vertical;
+  @if type-of($gutter-vertical) == 'map' {
+    $gutter-top: map.get($gutter-vertical, 'top');
+    $gutter-bottom: map.get($gutter-vertical, 'bottom');
+  }
+  $gutter-left: $gutter-horizontal;
+  $gutter-right: $gutter-horizontal;
+  @if type-of($gutter-horizontal) == 'map' {
+    $gutter-left: map.get($gutter-horizontal, 'left');
+    $gutter-right: map.get($gutter-horizontal, 'right');
+  }
+
   position: relative;
   // Add a special outline for Window High Contrast Mode.
   // This mode will remove all box shadows from the side and can only use outline
@@ -58,7 +71,7 @@
   // are transparent.
   & {
     outline: 2px dotted transparent;
-    outline-offset: calc(#{$gutter-horizontal} - 1px);
+    outline-offset: calc(#{$gutter-left} - 1px);
   }
 
   // Regular rounded outline for all other browsers and modes
@@ -66,10 +79,10 @@
     content: ' ';
     display: block;
     position: absolute;
-    inset-inline-start: calc(-1 * #{$gutter-horizontal});
-    inset-block-start: calc(-1 * #{$gutter-vertical});
-    inline-size: calc(100% + 2 * #{$gutter-horizontal});
-    block-size: calc(100% + 2 * #{$gutter-vertical});
+    inset-inline-start: calc(-1 * #{$gutter-left});
+    inset-block-start: calc(-1 * #{$gutter-top});
+    inline-size: calc(100% + #{$gutter-left} + #{$gutter-right});
+    block-size: calc(100% + #{$gutter-top} + #{$gutter-bottom});
     border-start-start-radius: $border-radius;
     border-start-end-radius: $border-radius;
     border-end-start-radius: $border-radius;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -105,7 +105,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   text-align: start;
 
   &-content {
-    /* used for testing */
+    box-sizing: border-box;
   }
   &:not(.body-cell-wrap) > .body-cell-content {
     white-space: nowrap;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -59,14 +59,16 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 }
 
 @mixin cell-padding-inline-start($padding) {
-  padding-inline-start: $padding;
+  > .body-cell-content {
+    padding-inline-start: $padding;
+  }
 
   @for $i from 0 through 9 {
-    &.expandable-level-#{$i} {
+    &.expandable-level-#{$i} > .body-cell-content {
       padding-inline-start: calc($padding + $i * (#{awsui.$space-m} + #{awsui.$space-xs}));
     }
   }
-  &.expandable-level-next {
+  &.expandable-level-next > .body-cell-content {
     padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
   }
 }

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -29,6 +29,20 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
 @mixin cell-focus-outline {
   @include styles.focus-highlight(calc(-1 * #{awsui.$space-scaled-xxs}));
+
+  // Give extra space on the left (inline start) to compensate for missing body cell padding.
+  &.is-visual-refresh:first-child {
+    @include styles.focus-highlight(
+      (
+        'vertical': calc(-1 * #{awsui.$space-scaled-xxs}),
+        'horizontal': (
+          'left': calc(1 * #{awsui.$space-scaled-xxs}),
+          'right': calc(-1 * #{awsui.$space-scaled-xxs}),
+        ),
+      )
+    );
+  }
+
   // @mixin focus-highlight sets cell's position to "relative".
   // Reinforcing sticky position for it to take precedence.
   &.sticky-cell {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -56,27 +56,32 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
   }
 }
-@mixin content-padding-block($padding) {
+@mixin cell-padding-block($padding) {
   > .body-cell-content {
     padding-block: $padding;
   }
 }
-@mixin content-padding-block-start($padding) {
+@mixin cell-padding-block-start($padding) {
   > .body-cell-content {
     padding-block-start: $padding;
   }
 }
-@mixin content-padding-block-end($padding) {
+@mixin cell-padding-block-end($padding) {
   > .body-cell-content {
     padding-block-end: $padding;
+  }
+}
+@mixin cell-padding-inline-end($padding) {
+  > .body-cell-content {
+    padding-inline-end: $padding;
   }
 }
 
 .body-cell {
   box-sizing: border-box;
-  @include content-padding-block-start($cell-vertical-padding);
-  @include content-padding-block-end($cell-vertical-padding-w-border);
-  padding-inline-end: $cell-horizontal-padding;
+  @include cell-padding-block-start($cell-vertical-padding);
+  @include cell-padding-block-end($cell-vertical-padding-w-border);
+  @include cell-padding-inline-end($cell-horizontal-padding);
   border-block-start: awsui.$border-divider-list-width solid transparent;
   word-wrap: break-word;
   border-block-end: awsui.$border-divider-list-width solid awsui.$color-border-divider-secondary;
@@ -97,7 +102,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   }
   &:last-child {
     border-inline-end: $border-placeholder;
-    padding-inline-end: $cell-edge-horizontal-padding;
+    @include cell-padding-inline-end($cell-edge-horizontal-padding);
   }
   &.is-visual-refresh:first-child {
     &:not(.has-striped-rows) {
@@ -155,12 +160,12 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     background-color: awsui.$color-background-item-selected;
     border-block-start: $selected-border;
     border-block-end: $selected-border;
-    @include content-padding-block-end($cell-vertical-padding);
+    @include cell-padding-block-end($cell-vertical-padding);
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
     &.body-cell-last-row.is-visual-refresh {
-      @include content-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
+      @include cell-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
     }
 
     &:first-child {
@@ -240,14 +245,14 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
   // Use padding as a selected border placeholder to make sure rows don't change height on selection (visual refresh)
   &-selected:not(:first-child) {
-    @include content-padding-block-start($cell-vertical-padding-w-border);
+    @include cell-padding-block-start($cell-vertical-padding-w-border);
   }
   &:not(.body-cell-selected).body-cell-next-selected {
     border-block-end: 0;
-    @include content-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
+    @include cell-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
   }
   &-selected.body-cell-prev-selected {
-    @include content-padding-block-start($cell-vertical-padding-w-border);
+    @include cell-padding-block-start($cell-vertical-padding-w-border);
     border-block-start: $selected-border-placeholder;
   }
   &-selected.body-cell-next-selected {
@@ -269,7 +274,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   // Reset padding for selected rows with no adjacent selected row above it,
   // because rows reuse adjacent selected borders (visual refresh)
   &-selected:not(.body-cell-prev-selected) {
-    @include content-padding-block-start($cell-vertical-padding);
+    @include cell-padding-block-start($cell-vertical-padding);
   }
 
   &-editor-wrapper {
@@ -378,12 +383,12 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
         // Include interactive padding even when a cell is not hovered to prevent jittering when resizableColumns=false.
         &:not(.resizable-columns) {
-          padding-inline-end: $interactive-column-padding-inline-end;
+          @include cell-padding-inline-end($interactive-column-padding-inline-end);
         }
       }
 
       @mixin focused-editor-styles {
-        padding-inline-end: $interactive-column-padding-inline-end;
+        @include cell-padding-inline-end($interactive-column-padding-inline-end);
         & > .body-cell-editor-wrapper,
         & > .expandable-cell-content > .body-cell-editor-wrapper {
           opacity: 1;
@@ -418,7 +423,9 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
       &.body-cell-edit-disabled-popover {
         &.body-cell-has-success {
           // After a successful edit, we display the success icon next to the edit button and need additional padding to not let the text overflow the success icon.
-          padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l} + #{$icon-width-with-spacing});
+          @include cell-padding-inline-end(
+            calc(#{$cell-horizontal-padding} + #{awsui.$space-l} + #{$icon-width-with-spacing})
+          );
         }
         @include focused-editor-styles;
         &.sticky-cell {
@@ -439,25 +446,27 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
         & > .body-cell-editor-wrapper,
         & > .expandable-cell-content > .body-cell-editor-wrapper {
-          padding-inline-end: calc(#{$edit-button-padding-right} - (2 * #{awsui.$border-divider-list-width}));
+          @include cell-padding-inline-end(
+            calc(#{$edit-button-padding-right} - (2 * #{awsui.$border-divider-list-width}))
+          );
         }
         & > .body-cell-success {
           // Update padding to avoid a jumping icon because of the additional borders added when hovering an editable cell.
-          padding-inline-end: calc(#{$success-icon-padding-right} - (2 * #{awsui.$border-divider-list-width}));
+          @include cell-padding-inline-end(
+            calc(#{$success-icon-padding-right} - (2 * #{awsui.$border-divider-list-width}))
+          );
         }
         &.body-cell-last-row.body-cell-selected,
         &.body-cell-next-selected {
-          @include content-padding-block(
-            calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2))
-          );
+          @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2)));
         }
         &.body-cell-last-row:not(.body-cell-selected) {
-          @include content-padding-block-start(
+          @include cell-padding-block-start(
             calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
           );
         }
         &.body-cell-first-row:not(.body-cell-selected) {
-          @include content-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width})));
+          @include cell-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width})));
         }
         &.sticky-cell {
           position: sticky;
@@ -478,7 +487,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     &.body-cell-first-row > .body-cell-success,
     &.body-cell-first-row > .body-cell-editor-wrapper,
     &.body-cell-first-row > .expandable-cell-content > .body-cell-editor-wrapper {
-      @include content-padding-block-start(awsui.$border-divider-list-width);
+      @include cell-padding-block-start(awsui.$border-divider-list-width);
     }
   }
   @include cell-offset($cell-horizontal-padding);

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -60,7 +60,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
 @mixin cell-padding-inline-start($padding) {
   > .body-cell-content {
-    padding-inline-start: $padding;
+    padding-inline-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
   }
 
   @for $i from 0 through 9 {
@@ -74,7 +74,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 }
 @mixin cell-padding-inline-end($padding) {
   > .body-cell-content {
-    padding-inline-end: $padding;
+    padding-inline-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
   }
 }
 @mixin cell-padding-block($padding) {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -56,11 +56,26 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
   }
 }
+@mixin content-padding-block($padding) {
+  > .body-cell-content {
+    padding-block: $padding;
+  }
+}
+@mixin content-padding-block-start($padding) {
+  > .body-cell-content {
+    padding-block-start: $padding;
+  }
+}
+@mixin content-padding-block-end($padding) {
+  > .body-cell-content {
+    padding-block-end: $padding;
+  }
+}
 
 .body-cell {
   box-sizing: border-box;
-  padding-block-start: $cell-vertical-padding;
-  padding-block-end: $cell-vertical-padding-w-border;
+  @include content-padding-block-start($cell-vertical-padding);
+  @include content-padding-block-end($cell-vertical-padding-w-border);
   padding-inline-end: $cell-horizontal-padding;
   border-block-start: awsui.$border-divider-list-width solid transparent;
   word-wrap: break-word;
@@ -72,7 +87,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   &-content {
     /* used for testing */
   }
-  &:not(.body-cell-wrap) {
+  &:not(.body-cell-wrap) > .body-cell-content {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -140,12 +155,12 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     background-color: awsui.$color-background-item-selected;
     border-block-start: $selected-border;
     border-block-end: $selected-border;
-    padding-block-end: $cell-vertical-padding;
+    @include content-padding-block-end($cell-vertical-padding);
 
     // Last selected row has a fixed border-bottom width which do not change on selection in visual refresh.
     // Adjust padding-bottom prevents a slight jump in the table height.
     &.body-cell-last-row.is-visual-refresh {
-      padding-block-end: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
+      @include content-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
     }
 
     &:first-child {
@@ -225,14 +240,14 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
   // Use padding as a selected border placeholder to make sure rows don't change height on selection (visual refresh)
   &-selected:not(:first-child) {
-    padding-block-start: $cell-vertical-padding-w-border;
+    @include content-padding-block-start($cell-vertical-padding-w-border);
   }
   &:not(.body-cell-selected).body-cell-next-selected {
     border-block-end: 0;
-    padding-block-end: calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width});
+    @include content-padding-block-end(calc(#{$cell-vertical-padding} + #{awsui.$border-divider-list-width}));
   }
   &-selected.body-cell-prev-selected {
-    padding-block-start: $cell-vertical-padding-w-border;
+    @include content-padding-block-start($cell-vertical-padding-w-border);
     border-block-start: $selected-border-placeholder;
   }
   &-selected.body-cell-next-selected {
@@ -254,7 +269,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   // Reset padding for selected rows with no adjacent selected row above it,
   // because rows reuse adjacent selected borders (visual refresh)
   &-selected:not(.body-cell-prev-selected) {
-    padding-block-start: $cell-vertical-padding;
+    @include content-padding-block-start($cell-vertical-padding);
   }
 
   &-editor-wrapper {
@@ -349,7 +364,9 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     }
 
     &.body-cell-edit-active {
-      overflow: visible;
+      > .body-cell-content {
+        overflow: visible;
+      }
       &.sticky-cell {
         position: sticky;
       }
@@ -430,13 +447,17 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
         }
         &.body-cell-last-row.body-cell-selected,
         &.body-cell-next-selected {
-          padding-block: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2));
+          @include content-padding-block(
+            calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width} / 2))
+          );
         }
         &.body-cell-last-row:not(.body-cell-selected) {
-          padding-block-start: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+          @include content-padding-block-start(
+            calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}))
+          );
         }
         &.body-cell-first-row:not(.body-cell-selected) {
-          padding-block: calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width}));
+          @include content-padding-block(calc(#{$cell-vertical-padding} - calc(#{awsui.$border-divider-list-width})));
         }
         &.sticky-cell {
           position: sticky;
@@ -457,7 +478,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     &.body-cell-first-row > .body-cell-success,
     &.body-cell-first-row > .body-cell-editor-wrapper,
     &.body-cell-first-row > .expandable-cell-content > .body-cell-editor-wrapper {
-      padding-block-start: awsui.$border-divider-list-width;
+      @include content-padding-block-start(awsui.$border-divider-list-width);
     }
   }
   @include cell-offset($cell-horizontal-padding);

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -147,6 +147,13 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     &:not(.has-selection):not(.body-cell-editable) {
       border-inline-start: none;
     }
+
+    // Give extra space on the edge to allow slight content overflow.
+    // That is to prevent focus outline on cell content from being cut out.
+    > .body-cell-content {
+      padding-inline-start: awsui.$space-scaled-xxs;
+      margin-inline-start: calc(-1 * #{awsui.$space-scaled-xxs});
+    }
   }
   &:first-child:not(.is-visual-refresh) {
     @include cell-padding-inline-start($cell-edge-horizontal-padding);

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -79,17 +79,17 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 }
 @mixin cell-padding-block($padding) {
   > .body-cell-content {
-    padding-block: $padding;
+    padding-block: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
   }
 }
 @mixin cell-padding-block-start($padding) {
   > .body-cell-content {
-    padding-block-start: $padding;
+    padding-block-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
   }
 }
 @mixin cell-padding-block-end($padding) {
   > .body-cell-content {
-    padding-block-end: $padding;
+    padding-block-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
   }
 }
 
@@ -153,8 +153,8 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     // Give extra space on the edge to allow slight content overflow.
     // That is to prevent focus outline on cell content from being cut out.
     > .body-cell-content {
-      padding-inline-start: awsui.$space-scaled-xxs;
-      margin-inline-start: calc(-1 * #{awsui.$space-scaled-xxs});
+      padding-inline-start: awsui.$border-divider-list-width;
+      margin-inline-start: calc(-1 * #{awsui.$border-divider-list-width});
     }
   }
   &:first-child:not(.is-visual-refresh) {

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -44,7 +44,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   margin-inline-start: calc(-1 * (#{awsui.$space-m} + #{awsui.$space-xs}));
 }
 
-@mixin cell-offset($padding) {
+@mixin cell-padding-inline-start($padding) {
   padding-inline-start: $padding;
 
   @for $i from 0 through 9 {
@@ -54,6 +54,11 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   }
   &.expandable-level-next {
     padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
+  }
+}
+@mixin cell-padding-inline-end($padding) {
+  > .body-cell-content {
+    padding-inline-end: $padding;
   }
 }
 @mixin cell-padding-block($padding) {
@@ -71,14 +76,10 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     padding-block-end: $padding;
   }
 }
-@mixin cell-padding-inline-end($padding) {
-  > .body-cell-content {
-    padding-inline-end: $padding;
-  }
-}
 
 .body-cell {
   box-sizing: border-box;
+  @include cell-padding-inline-start($cell-horizontal-padding);
   @include cell-padding-block-start($cell-vertical-padding);
   @include cell-padding-block-end($cell-vertical-padding-w-border);
   @include cell-padding-inline-end($cell-horizontal-padding);
@@ -106,9 +107,9 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   }
   &.is-visual-refresh:first-child {
     &:not(.has-striped-rows) {
-      @include cell-offset(awsui.$space-xxxs);
+      @include cell-padding-inline-start(awsui.$space-xxxs);
       &:not(.body-cell-edit-active).body-cell-interactive.body-cell-editable:hover {
-        @include cell-offset(calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width}));
+        @include cell-padding-inline-start(calc(#{awsui.$space-xxxs} + #{awsui.$border-divider-list-width}));
       }
     }
 
@@ -118,9 +119,9 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
       to the table edge.
       */
     &:first-child.has-striped-rows {
-      @include cell-offset(awsui.$space-xxs);
+      @include cell-padding-inline-start(awsui.$space-xxs);
       &-sticky-cell-pad-inline-start {
-        @include cell-offset(awsui.$space-table-horizontal);
+        @include cell-padding-inline-start(awsui.$space-table-horizontal);
       }
     }
 
@@ -134,7 +135,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     }
   }
   &:first-child:not(.is-visual-refresh) {
-    @include cell-offset($cell-edge-horizontal-padding);
+    @include cell-padding-inline-start($cell-edge-horizontal-padding);
   }
   &-first-row {
     border-block-start: $border-placeholder;
@@ -189,7 +190,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
     background: awsui.$color-background-container-content;
     z-index: 798; // Our sticky elements should have z-index in the range of 800-850, this value needs to be lower
     &-pad-left:not(.has-selection):not(.is-visual-refresh.body-cell:first-child.has-striped-rows) {
-      @include cell-offset(awsui.$space-table-horizontal);
+      @include cell-padding-inline-start(awsui.$space-table-horizontal);
     }
     &.body-cell-shaded {
       background: awsui.$color-background-cell-shaded;
@@ -490,7 +491,6 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
       @include cell-padding-block-start(awsui.$border-divider-list-width);
     }
   }
-  @include cell-offset($cell-horizontal-padding);
 
   @include focus-visible.when-visible {
     @include cell-focus-outline;

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -26,6 +26,7 @@ $edit-button-padding-right: calc(
 ); // Cell vertical padding + xxs space that would normally come from the button.
 $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-with-spacing});
 $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
+$cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
 
 @mixin cell-focus-outline {
   @include styles.focus-highlight(calc(-1 * #{awsui.$space-scaled-xxs}));
@@ -55,7 +56,7 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
   inset-block: 0;
   display: flex;
   align-items: center;
-  margin-inline-start: calc(-1 * (#{awsui.$space-m} + #{awsui.$space-xs}));
+  margin-inline-start: calc(-1 * #{$cell-offset});
 }
 
 @mixin cell-padding-inline-start($padding) {
@@ -65,11 +66,11 @@ $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{aws
 
   @for $i from 0 through 9 {
     &.expandable-level-#{$i} > .body-cell-content {
-      padding-inline-start: calc($padding + $i * (#{awsui.$space-m} + #{awsui.$space-xs}));
+      padding-inline-start: calc($padding + $i * $cell-offset - 1 * awsui.$border-divider-list-width);
     }
   }
   &.expandable-level-next > .body-cell-content {
-    padding-inline-start: calc($padding + 9 * (#{awsui.$space-m} + #{awsui.$space-xs}));
+    padding-inline-start: calc(#{$padding} + 9 * #{$cell-offset} - 1 * #{awsui.$border-divider-list-width});
   }
 }
 @mixin cell-padding-inline-end($padding) {

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -122,17 +122,19 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         {...nativeAttributes}
         tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       >
-        {level !== undefined && isExpandable && (
-          <div className={styles['expandable-toggle-wrapper']}>
-            <ExpandToggleButton
-              isExpanded={isExpanded}
-              onExpandableItemToggle={onExpandableItemToggle}
-              expandButtonLabel={expandButtonLabel}
-              collapseButtonLabel={collapseButtonLabel}
-            />
-          </div>
-        )}
-        <div className={styles['body-cell-content']}>{children}</div>
+        <div className={styles['body-cell-content']}>
+          {level !== undefined && isExpandable && (
+            <div className={styles['expandable-toggle-wrapper']}>
+              <ExpandToggleButton
+                isExpanded={isExpanded}
+                onExpandableItemToggle={onExpandableItemToggle}
+                expandButtonLabel={expandButtonLabel}
+                collapseButtonLabel={collapseButtonLabel}
+              />
+            </div>
+          )}
+          {children}
+        </div>
       </Element>
     );
   }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -132,7 +132,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
             />
           </div>
         )}
-        <span className={styles['body-cell-content']}>{children}</span>
+        <div className={styles['body-cell-content']}>{children}</div>
       </Element>
     );
   }

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -23,6 +23,21 @@
   }
 }
 
+@mixin header-cell-focus-outline-first($gutter) {
+  @include when-focus-visible-or-fake {
+    // Give extra space on the left (inline start) to compensate for missing header cell padding.
+    @include styles.focus-highlight(
+      (
+        'vertical': calc(-1 * #{$gutter}),
+        'horizontal': (
+          'left': calc(-1 * #{$gutter} + #{awsui.$space-scaled-xxs}),
+          'right': calc(-1 * #{$gutter}),
+        ),
+      )
+    );
+  }
+}
+
 @mixin cell-offset($padding) {
   padding-inline-start: $padding;
 
@@ -176,6 +191,14 @@ settings icon in the pagination slot.
 }
 
 .header-cell.is-visual-refresh {
+  &:first-child {
+    @include header-cell-focus-outline-first(awsui.$space-scaled-xxs);
+  }
+  &:first-child > .header-cell-content {
+    @include cell-offset(0px);
+    @include header-cell-focus-outline-first(awsui.$space-table-header-focus-outline-gutter);
+  }
+
   &:first-child:not(.has-striped-rows) {
     @include cell-offset(awsui.$space-xxxs);
     &.sticky-cell-pad-inline-start {
@@ -190,10 +213,6 @@ settings icon in the pagination slot.
   */
   &:first-child.has-striped-rows {
     @include cell-offset(awsui.$space-xxs);
-  }
-
-  &:first-child > .header-cell-content {
-    @include cell-offset(0px);
   }
 
   &:last-child.header-cell-sortable {


### PR DESCRIPTION
### Description

This PR mainly changes how paddings are applied to table cells. Previously the paddings were applied to the cell directly (TD or TH element) and now all paddings are applied to the nested content element (the DIV element). The content element also receives the `overflow: none` from the cell. This way, the content DIV does not allow for the content to overflow but the cell element does. As result, we can render the cell focus outline which exceeds the dimensions of the cell on the left.

Because the borders are still applied to the cells and not the content, there is a 1px difference in cell size compared to the previous version. That difference is compensated by subtracting border width from padding, but due to conditional padding application in certain cases there is a small pixel shift in some table screenshots.

Rel: AWSUI-36760

### How has this been tested?

* Existing unit- and integration tests;
* VR tests;
* Screenshot tests and Lighthouse tests (run accfb3a0-c67a-47a5-8381-2925dc27e2a7);
* Dry-tun to live (build 6888143054).

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
