### PR TITLE
feat: Add focus() method to popover ref

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10778,7 +10778,7 @@ Object {
   "events": Array [],
   "functions": Array [
     Object {
-      "description": "Sets focus on the popover's text trigger button.",
+      "description": "Sets focus on the popover's trigger.",
       "name": "focus",
       "parameters": Array [],
       "returnType": "void",

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10776,7 +10776,14 @@ Make sure you update the \`data\` property when any of your custom filters chang
 exports[`Documenter definition for popover matches the snapshot: popover 1`] = `
 Object {
   "events": Array [],
-  "functions": Array [],
+  "functions": Array [
+    Object {
+      "description": "Sets focus on the popover's text trigger button.",
+      "name": "focus",
+      "parameters": Array [],
+      "returnType": "void",
+    },
+  ],
   "name": "Popover",
   "properties": Array [
     Object {
@@ -10822,7 +10829,7 @@ For example, use it when you need to place a column layout in the popover conten
       "type": "string",
     },
     Object {
-      "defaultValue": "\\"right\\"",
+      "defaultValue": "'right'",
       "description": "Determines where the popover is displayed when opened, relative to the trigger.
 If the popover doesn't have enough space to open in this direction, it
 automatically chooses a better direction based on available space.",
@@ -10854,7 +10861,7 @@ Note: Using popover rendered with portal within a Modal is not supported.
       "type": "boolean",
     },
     Object {
-      "defaultValue": "\\"medium\\"",
+      "defaultValue": "'medium'",
       "description": "Determines the maximum width for the popover.",
       "inlineType": Object {
         "name": "PopoverProps.Size",
@@ -10877,7 +10884,7 @@ that don't have visible text, and to distinguish between multiple triggers with 
       "type": "string",
     },
     Object {
-      "defaultValue": "\\"text\\"",
+      "defaultValue": "'text'",
       "description": "Specifies the type of content inside the trigger region. The following types are available:
 - \`text\` - Use for inline text triggers.
 - \`custom\` - Use for the [button](/components/button/) component.",

--- a/src/popover/__tests__/popover.test.tsx
+++ b/src/popover/__tests__/popover.test.tsx
@@ -42,7 +42,7 @@ class PopoverInternalWrapper extends PopoverWrapper {
   }
 }
 
-function renderPopover(props: PopoverProps) {
+function renderPopover(props: PopoverProps & { ref?: React.Ref<PopoverProps.Ref> }) {
   const { container } = render(<Popover {...props} />);
   return new PopoverInternalWrapper(container);
 }
@@ -373,5 +373,37 @@ describe('table grid navigation support', () => {
     );
     setCurrentTarget(getTrigger());
     expect(getTrigger()).not.toHaveAttribute('tabIndex');
+  });
+});
+
+describe('ref support', () => {
+  test('focuses when focus() is called on the ref', () => {
+    const ref: React.RefObject<PopoverProps.Ref> = { current: null };
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', ref });
+    ref.current?.focus();
+    expect(document.activeElement).toBe(wrapper.findTrigger().getElement());
+    expect(wrapper.findContent()?.getElement()).toBeFalsy();
+  });
+
+  test('focuses the first interactive element when focus() is called with a custom trigger', () => {
+    const ref: React.RefObject<PopoverProps.Ref> = { current: null };
+    const wrapper = renderPopover({
+      triggerType: 'custom',
+      children: <button id="test">Custom</button>,
+      content: 'Popover',
+      ref,
+    });
+    ref.current?.focus();
+    expect(document.activeElement).toBe(document.getElementById('test'));
+    expect(wrapper.findContent()?.getElement()).toBeFalsy();
+  });
+
+  test('closes an open popover when focus() is called on the ref', () => {
+    const ref: React.RefObject<PopoverProps.Ref> = { current: null };
+    const wrapper = renderPopover({ children: 'Trigger', content: 'Popover', ref });
+    wrapper.findTrigger().getElement().click();
+    expect(wrapper.findContent()?.getElement()).toBeInTheDocument();
+    ref.current?.focus();
+    expect(wrapper.findContent()?.getElement()).toBeFalsy();
   });
 });

--- a/src/popover/index.tsx
+++ b/src/popover/index.tsx
@@ -1,51 +1,63 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
-import InternalPopover from './internal';
+import React, { useRef } from 'react';
+import InternalPopover, { InternalPopoverRef } from './internal';
 import { getExternalProps } from '../internal/utils/external-props';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { isDevelopment } from '../internal/is-development';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { PopoverProps } from './interfaces';
+import useForwardFocus from '../internal/hooks/forward-focus';
 
 export { PopoverProps };
 
-export default function Popover({
-  position = 'right',
-  size = 'medium',
-  fixedWidth = false,
-  triggerType = 'text',
-  dismissButton = true,
-  renderWithPortal = false,
-  wrapTriggerText = true,
-  header,
-  ...rest
-}: PopoverProps) {
-  if (isDevelopment) {
-    if (dismissButton && !header) {
-      warnOnce('Popover', `You should provide a \`header\` when \`dismissButton\` is true.`);
+const Popover = React.forwardRef(
+  (
+    {
+      position = 'right',
+      size = 'medium',
+      fixedWidth = false,
+      triggerType = 'text',
+      dismissButton = true,
+      renderWithPortal = false,
+      wrapTriggerText = true,
+      header,
+      ...rest
+    }: PopoverProps,
+    ref: React.Ref<PopoverProps.Ref>
+  ) => {
+    if (isDevelopment) {
+      if (dismissButton && !header) {
+        warnOnce('Popover', `You should provide a \`header\` when \`dismissButton\` is true.`);
+      }
     }
-  }
 
-  const baseComponentProps = useBaseComponent('Popover', {
-    props: { dismissButton, fixedWidth, position, renderWithPortal, size, triggerType },
-  });
-  const externalProps = getExternalProps(rest);
-  return (
-    <InternalPopover
-      header={header}
-      position={position}
-      size={size}
-      fixedWidth={fixedWidth}
-      triggerType={triggerType}
-      dismissButton={dismissButton}
-      renderWithPortal={renderWithPortal}
-      wrapTriggerText={wrapTriggerText}
-      {...externalProps}
-      {...baseComponentProps}
-    />
-  );
-}
+    const baseComponentProps = useBaseComponent('Popover', {
+      props: { dismissButton, fixedWidth, position, renderWithPortal, size, triggerType },
+    });
+    const externalProps = getExternalProps(rest);
+
+    const internalRef = useRef<InternalPopoverRef | null>(null);
+    useForwardFocus(ref, internalRef);
+
+    return (
+      <InternalPopover
+        ref={internalRef}
+        header={header}
+        position={position}
+        size={size}
+        fixedWidth={fixedWidth}
+        triggerType={triggerType}
+        dismissButton={dismissButton}
+        renderWithPortal={renderWithPortal}
+        wrapTriggerText={wrapTriggerText}
+        {...externalProps}
+        {...baseComponentProps}
+      />
+    );
+  }
+);
 
 applyDisplayName(Popover, 'Popover');
+export default Popover;

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -110,4 +110,11 @@ export namespace PopoverProps {
   export type Position = 'top' | 'right' | 'bottom' | 'left';
   export type Size = 'small' | 'medium' | 'large';
   export type TriggerType = 'text' | 'custom';
+
+  export interface Ref {
+    /**
+     * Sets focus on the popover's text trigger button.
+     */
+    focus(): void;
+  }
 }

--- a/src/popover/interfaces.ts
+++ b/src/popover/interfaces.ts
@@ -113,7 +113,7 @@ export namespace PopoverProps {
 
   export interface Ref {
     /**
-     * Sets focus on the popover's text trigger button.
+     * Sets focus on the popover's trigger.
      */
     focus(): void;
   }

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -30,6 +30,7 @@ export interface InternalPopoverProps extends PopoverProps, InternalBaseComponen
 
 export interface InternalPopoverRef {
   dismissPopover: () => void;
+  focus: HTMLElement['focus'];
 }
 
 export default React.forwardRef(InternalPopover);
@@ -100,6 +101,10 @@ function InternalPopover(
 
   useImperativeHandle(ref, () => ({
     dismissPopover: onDismiss,
+    focus: () => {
+      setVisible(false);
+      focusTrigger();
+    },
   }));
 
   useEffect(() => {


### PR DESCRIPTION
### Description

As part of the effort to improve accessibility on the [loading and refreshing](https://cloudscape.design/patterns/general/loading-and-refreshing/) pattern. When the status indicator popover gets added dynamically, we should move focus to the trigger so that assistive technology users are aware.

Related links, issue #, if available: n/a

### How has this been tested?

Unit tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
