### PR TITLE
chore: Connect performance marks to DOM elements

### DIFF
--- a/src/button/__integ__/performance-marks.test.ts
+++ b/src/button/__integ__/performance-marks.test.ts
@@ -18,7 +18,7 @@ function setupTest(
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-marker="${id}"]`);
+    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-mark="${id}"]`);
 
     await testFn({ page, getMarks, getElementByPerformanceMark });
   });

--- a/src/button/__integ__/performance-marks.test.ts
+++ b/src/button/__integ__/performance-marks.test.ts
@@ -5,7 +5,11 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 
 function setupTest(
   pageName: string,
-  testFn: (page: BasePageObject, getMarks: () => Promise<PerformanceMark[]>) => Promise<void>
+  testFn: (parameters: {
+    page: BasePageObject;
+    getMarks: () => Promise<PerformanceMark[]>;
+    getElementByPerformanceMark: (id: string) => Promise<WebdriverIO.Element>;
+  }) => Promise<void>
 ) {
   return useBrowser(async browser => {
     const page = new BasePageObject(browser);
@@ -14,14 +18,16 @@ function setupTest(
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    await testFn(page, getMarks);
+    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-marker="${id}"]`);
+
+    await testFn({ page, getMarks, getElementByPerformanceMark });
   });
 }
 
 describe('Button', () => {
   test(
     'Emits a mark only for primary visible buttons',
-    setupTest('performance-marks', async (_, getMarks) => {
+    setupTest('performance-marks', async ({ getMarks, getElementByPerformanceMark }) => {
       const marks = await getMarks();
 
       expect(marks).toHaveLength(1);
@@ -33,12 +39,16 @@ describe('Button', () => {
         disabled: false,
         text: 'Primary button',
       });
+
+      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'Primary button'
+      );
     })
   );
 
   test(
     'Emits a mark when properties change',
-    setupTest('performance-marks', async (page, getMarks) => {
+    setupTest('performance-marks', async ({ page, getMarks, getElementByPerformanceMark }) => {
       await page.click('#disabled');
       await page.click('#loading');
       const marks = await getMarks();
@@ -52,6 +62,11 @@ describe('Button', () => {
         disabled: true,
         text: 'Primary button',
       });
+
+      expect(await getElementByPerformanceMark(marks[1].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'Primary button'
+      );
+
       expect(marks[2].name).toBe('primaryButtonUpdated');
       expect(marks[2].detail).toMatchObject({
         source: 'awsui',
@@ -60,18 +75,25 @@ describe('Button', () => {
         disabled: true,
         text: 'Primary button',
       });
+
+      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'Primary button'
+      );
     })
   );
 
   test(
     'Does not emit a mark when inside a modal',
-    setupTest('performance-marks-in-modal', async (page, getMarks) => {
+    setupTest('performance-marks-in-modal', async ({ getMarks, getElementByPerformanceMark }) => {
       const marks = await getMarks();
 
       expect(marks).toHaveLength(1);
       expect(marks[0].detail).toMatchObject({
         text: 'Button OUTSIDE modal',
       });
+      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'Button OUTSIDE modal'
+      );
     })
   );
 });

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -86,7 +86,7 @@ export const InternalButton = React.forwardRef(
     const { stepNumber, stepNameSelector } = useFunnelStep();
     const { subStepSelector, subStepNameSelector } = useFunnelSubStep();
 
-    usePerformanceMarks(
+    const performanceMarkAttributes = usePerformanceMarks(
       'primaryButton',
       variant === 'primary',
       buttonRef,
@@ -145,6 +145,7 @@ export const InternalButton = React.forwardRef(
     const buttonProps = {
       ...props,
       ...__nativeAttributes,
+      ...performanceMarkAttributes,
       tabIndex,
       // https://github.com/microsoft/TypeScript/issues/36659
       ref: useMergeRefs(buttonRef, __internalRootRef),

--- a/src/internal/hooks/use-performance-marks/__tests__/use-performance-marks.test.tsx
+++ b/src/internal/hooks/use-performance-marks/__tests__/use-performance-marks.test.tsx
@@ -15,19 +15,19 @@ describe('Data attribute', () => {
   test('the attribute should be present after the first render', () => {
     const { getByTestId } = render(<Demo />);
 
-    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-marker');
+    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-mark');
   });
 
   test('the attribute should be present after re-rendering', () => {
     const { getByTestId, rerender } = render(<Demo />);
 
-    const attributeValueBefore = getByTestId('element').getAttribute('data-analytics-performance-marker');
+    const attributeValueBefore = getByTestId('element').getAttribute('data-analytics-performance-mark');
 
     rerender(<Demo />);
 
-    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-marker');
+    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-mark');
 
-    const attributeValueAfter = getByTestId('element').getAttribute('data-analytics-performance-marker');
+    const attributeValueAfter = getByTestId('element').getAttribute('data-analytics-performance-mark');
 
     expect(attributeValueAfter).toBe(attributeValueBefore);
   });

--- a/src/internal/hooks/use-performance-marks/__tests__/use-performance-marks.test.tsx
+++ b/src/internal/hooks/use-performance-marks/__tests__/use-performance-marks.test.tsx
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useRef } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { render } from '@testing-library/react';
+import { usePerformanceMarks } from '../index';
+
+function Demo() {
+  const ref = useRef<HTMLDivElement>(null);
+  const attributes = usePerformanceMarks('test-component', true, ref, () => ({}), []);
+  return <div {...attributes} ref={ref} data-testid="element" />;
+}
+
+describe('Data attribute', () => {
+  test('the attribute should be present after the first render', () => {
+    const { getByTestId } = render(<Demo />);
+
+    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-marker');
+  });
+
+  test('the attribute should be present after re-rendering', () => {
+    const { getByTestId, rerender } = render(<Demo />);
+
+    const attributeValueBefore = getByTestId('element').getAttribute('data-analytics-performance-marker');
+
+    rerender(<Demo />);
+
+    expect(getByTestId('element')).toHaveAttribute('data-analytics-performance-marker');
+
+    const attributeValueAfter = getByTestId('element').getAttribute('data-analytics-performance-marker');
+
+    expect(attributeValueAfter).toBe(attributeValueBefore);
+  });
+
+  test('should not render the attribute during server-side rendering', () => {
+    const markup = renderToStaticMarkup(<Demo />);
+
+    expect(markup).toBe('<div data-testid="element"></div>');
+  });
+});

--- a/src/internal/hooks/use-performance-marks/index.ts
+++ b/src/internal/hooks/use-performance-marks/index.ts
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef } from 'react';
-import { useIdFallback } from '../use-unique-id';
+import { useRandomId } from '../use-unique-id';
 import { useEffectOnUpdate } from '../use-effect-on-update';
 import { useModalContext } from '../../context/modal-context';
 
 /*
 This hook allows setting an HTML attribute after the first render, without rerendering the component.
 */
-function useAttributeWithoutRerendering(elementRef: React.RefObject<HTMLElement>, value: string) {
+function usePerformanceMarkAttribute(elementRef: React.RefObject<HTMLElement>, value: string) {
   const attributeName = 'data-analytics-performance-mark';
 
   const attributeValueRef = useRef<string | undefined>();
 
   useEffect(() => {
+    // With this effect, we apply the attribute only on the client, to avoid hydration errors.
     attributeValueRef.current = value;
     elementRef.current?.setAttribute(attributeName, value);
   }, [value, elementRef]);
@@ -36,9 +37,9 @@ export function usePerformanceMarks(
   getDetails: () => Record<string, string | boolean | number | undefined>,
   dependencies: React.DependencyList
 ) {
-  const id = useIdFallback();
+  const id = useRandomId();
   const { isInModal } = useModalContext();
-  const attributes = useAttributeWithoutRerendering(elementRef, id);
+  const attributes = usePerformanceMarkAttribute(elementRef, id);
 
   useEffect(() => {
     if (!enabled || !elementRef.current || isInModal) {

--- a/src/internal/hooks/use-performance-marks/index.ts
+++ b/src/internal/hooks/use-performance-marks/index.ts
@@ -1,11 +1,34 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
-import { useUniqueId } from './use-unique-id';
-import { useEffectOnUpdate } from './use-effect-on-update';
-import { useModalContext } from '../context/modal-context';
+import { useEffect, useRef } from 'react';
+import { useIdFallback } from '../use-unique-id';
+import { useEffectOnUpdate } from '../use-effect-on-update';
+import { useModalContext } from '../../context/modal-context';
 
+/*
+This hook allows setting an HTML attribute after the first render, without rerendering the component.
+*/
+function useAttributeWithoutRerendering(elementRef: React.RefObject<HTMLElement>, value: string) {
+  const attributeName = 'data-analytics-performance-mark';
+
+  const attributeValueRef = useRef<string | undefined>();
+
+  useEffect(() => {
+    attributeValueRef.current = value;
+    elementRef.current?.setAttribute(attributeName, value);
+  }, [value, elementRef]);
+
+  return {
+    [attributeName]: attributeValueRef.current,
+  };
+}
+
+/**
+ * This function returns an object that needs to be spread onto the same
+ * element as the `elementRef`, so that the data attribute is applied
+ * correctly.
+ */
 export function usePerformanceMarks(
   name: string,
   enabled: boolean,
@@ -13,8 +36,9 @@ export function usePerformanceMarks(
   getDetails: () => Record<string, string | boolean | number | undefined>,
   dependencies: React.DependencyList
 ) {
-  const id = useUniqueId();
+  const id = useIdFallback();
   const { isInModal } = useModalContext();
+  const attributes = useAttributeWithoutRerendering(elementRef, id);
 
   useEffect(() => {
     if (!enabled || !elementRef.current || isInModal) {
@@ -66,4 +90,6 @@ export function usePerformanceMarks(
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies);
+
+  return attributes;
 }

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -3,7 +3,7 @@
 import React, { useRef } from 'react';
 
 let counter = 0;
-const useIdFallback = () => {
+export const useIdFallback = () => {
   const idRef = useRef<string | null>(null);
   if (!idRef.current) {
     idRef.current = `${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;

--- a/src/internal/hooks/use-unique-id/index.ts
+++ b/src/internal/hooks/use-unique-id/index.ts
@@ -3,7 +3,7 @@
 import React, { useRef } from 'react';
 
 let counter = 0;
-export const useIdFallback = () => {
+export const useRandomId = () => {
   const idRef = useRef<string | null>(null);
   if (!idRef.current) {
     idRef.current = `${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
@@ -11,7 +11,7 @@ export const useIdFallback = () => {
   return idRef.current;
 };
 
-const useId: typeof useIdFallback = (React as any).useId ?? useIdFallback;
+const useId: typeof useRandomId = (React as any).useId ?? useRandomId;
 
 export function useUniqueId(prefix?: string) {
   return `${prefix ? prefix : ''}` + useId();

--- a/src/table/__integ__/performance-marks.test.ts
+++ b/src/table/__integ__/performance-marks.test.ts
@@ -17,7 +17,7 @@ function setupTest(
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-marker="${id}"]`);
+    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-mark="${id}"]`);
 
     await testFn({ page, getMarks, getElementByPerformanceMark });
   });
@@ -48,9 +48,7 @@ describe('Table', () => {
 
       expect(marks[0].detail.instanceIdentifier).not.toEqual(marks[1].detail.instanceIdentifier);
 
-      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier).then(e => e.getText())).toBe(
-        'This is my table'
-      );
+      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier)).toBeTruthy();
     })
   );
 
@@ -68,9 +66,7 @@ describe('Table', () => {
         loading: false,
         header: 'This is my table',
       });
-      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier).then(e => e.getText())).toBe(
-        'This is my table'
-      );
+      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier)).toBeTruthy();
 
       await page.click('#loading');
 
@@ -83,9 +79,7 @@ describe('Table', () => {
         loading: true,
         header: 'This is my table',
       });
-      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier).then(e => e.getText())).toBe(
-        'This is my table'
-      );
+      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier)).toBeTruthy();
     })
   );
 });

--- a/src/table/__integ__/performance-marks.test.ts
+++ b/src/table/__integ__/performance-marks.test.ts
@@ -3,7 +3,13 @@
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
-function setupTest(testFn: (page: BasePageObject, getMarks: () => Promise<PerformanceMark[]>) => Promise<void>) {
+function setupTest(
+  testFn: (parameters: {
+    page: BasePageObject;
+    getMarks: () => Promise<PerformanceMark[]>;
+    getElementByPerformanceMark: (id: string) => Promise<WebdriverIO.Element>;
+  }) => Promise<void>
+) {
   return useBrowser(async browser => {
     const page = new BasePageObject(browser);
     await browser.url('#/light/table/performance-marks');
@@ -11,14 +17,16 @@ function setupTest(testFn: (page: BasePageObject, getMarks: () => Promise<Perfor
       const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
       return marks.filter(m => m.detail?.source === 'awsui');
     };
-    await testFn(page, getMarks);
+    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-marker="${id}"]`);
+
+    await testFn({ page, getMarks, getElementByPerformanceMark });
   });
 }
 
 describe('Table', () => {
   test(
     'Emits a mark only for visible tables',
-    setupTest(async (_, getMarks) => {
+    setupTest(async ({ getMarks, getElementByPerformanceMark }) => {
       const marks = await getMarks();
 
       expect(marks).toHaveLength(2);
@@ -39,12 +47,16 @@ describe('Table', () => {
       });
 
       expect(marks[0].detail.instanceIdentifier).not.toEqual(marks[1].detail.instanceIdentifier);
+
+      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'This is my table'
+      );
     })
   );
 
   test(
     'Emits a mark when properties change',
-    setupTest(async (page, getMarks) => {
+    setupTest(async ({ page, getMarks, getElementByPerformanceMark }) => {
       await page.click('#loading');
       let marks = await getMarks();
 
@@ -56,6 +68,9 @@ describe('Table', () => {
         loading: false,
         header: 'This is my table',
       });
+      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'This is my table'
+      );
 
       await page.click('#loading');
 
@@ -68,6 +83,9 @@ describe('Table', () => {
         loading: true,
         header: 'This is my table',
       });
+      expect(await getElementByPerformanceMark(marks[2].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'This is my table'
+      );
     })
   );
 });

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -175,7 +175,7 @@ const InternalTable = React.forwardRef(
       toolsHeaderPerformanceMarkRef.current?.querySelector<HTMLElement>(`.${headerStyles['heading-text']}`)
         ?.innerText ?? toolsHeaderPerformanceMarkRef.current?.innerText;
 
-    usePerformanceMarks(
+    const performanceMarkAttributes = usePerformanceMarks(
       'table',
       true,
       tableRefObject,
@@ -442,6 +442,7 @@ const InternalTable = React.forwardRef(
                 getTable={() => tableRefObject.current}
               >
                 <table
+                  {...performanceMarkAttributes}
                   ref={tableRef}
                   className={clsx(
                     styles.table,


### PR DESCRIPTION
### Description

This PR extends the existing performance mark mechanism with a mechanism to identify the corresponding DOM element. Each performance mark already contains an ID (in `detail.instanceIdentifier`) that is tied to the lifetime of the component.

With this PR, this same ID is now attached to a DOM element inside the component (not necessarily the _root_ element), in the data attribute `data-analytics-performance-mark`. Thus, the elements for each performance mark can be found like this:
```js
performance
  .getEntriesByType('mark')
  .filter(mark => mark.detail?.source === 'awsui')
  .map(mark => ({
    mark,
    element: document.querySelector(
      `[data-analytics-performance-mark="${mark.detail.instanceIdentifier}"]`
    ),
  }));


```


<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
