### PR TITLE
Feat: support typed select values (Proof of Concept)

### DIFF
--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -9,8 +9,8 @@ export interface BaseOption {
   disabled?: boolean;
 }
 
-export interface OptionDefinition extends BaseOption {
-  value?: string;
+export interface OptionDefinition<ValueType extends string = string> extends BaseOption {
+  value?: ValueType;
   lang?: string;
   labelTag?: string;
   description?: string;
@@ -27,8 +27,8 @@ export interface InternalOptionDefinition extends OptionDefinition {
   __customIcon?: React.ReactNode;
 }
 
-export interface OptionGroup extends BaseOption {
-  options: ReadonlyArray<OptionDefinition>;
+export interface OptionGroup<ValueType extends string = string> extends BaseOption {
+  options: ReadonlyArray<OptionDefinition<ValueType>>;
 }
 
 export interface DropdownOption {

--- a/src/internal/components/screenreader-only/index.tsx
+++ b/src/internal/components/screenreader-only/index.tsx
@@ -13,7 +13,7 @@ export interface ScreenreaderOnlyProps {
 
 /**
  * Makes content now shown on a screen but still announced by screen-reader users.
- * The component is suitable when the aria-label cannot be used, e.g. to avoid elemnts being announced as "blank".
+ * The component is suitable when the aria-label cannot be used, e.g. to avoid elements being announced as "blank".
  *
  * To exclude screenreader-only content use `:not(.${screenreaderOnlyStyles.root})` selector, for example:
  *

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -24,8 +24,17 @@ beforeEach(() => {
   (warnOnce as any).mockClear();
 });
 
+export declare const SelectValues: {
+  readonly FIRST: '1';
+  readonly SECOND: '2';
+  readonly THIRD: '3';
+  readonly FORTH: 'Option 4, test"2';
+};
+
+export type EnumStringType = (typeof SelectValues)[keyof typeof SelectValues];
+
 const VALUE_WITH_SPECIAL_CHARS = 'Option 4, test"2';
-const defaultOptions: SelectProps.Options = [
+const defaultOptions: SelectProps.Options<EnumStringType> = [
   { label: 'First', value: '1' },
   { label: 'Second', value: '2' },
   {
@@ -60,7 +69,7 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
   }
 
   test('renders selected option', () => {
-    const { wrapper } = renderSelect({ selectedOption: { label: 'First', value: '1' } });
+    const { wrapper } = renderSelect({ selectedOption: { label: 'First', value: '10' } });
     expect(wrapper.findTrigger().getElement().textContent).toBe('First');
   });
 

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -170,9 +170,9 @@ export namespace SelectProps {
   export type FilteringType = OptionsFilteringType;
   export type TriggerVariant = 'label' | 'option';
 
-  export type Option = OptionDefinition;
-  export type OptionGroup = OptionGroupDefinition;
-  export type Options = ReadonlyArray<Option | OptionGroup>;
+  export type Option<ValueType extends string = string> = OptionDefinition<ValueType>;
+  export type OptionGroup<ValueType extends string = string> = OptionGroupDefinition<ValueType>;
+  export type Options<ValueType extends string = string> = ReadonlyArray<Option<ValueType> | OptionGroup<ValueType>>;
 
   export type LoadItemsDetail = OptionsLoadItemsDetail;
 


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Whenever we code select we pass in Enum Strings that match our API 1:1. 
Since Cloudscape Select Components Option & OptionDefinition has value typed as a string.

We end up needing to type cast the output (when onChange event occurs)

It would be nice if cloudscape components supported a generic that let you scope down further than just string (specifically string enums).

I included an example using the existing tests 

```
export declare const SelectValues: {
  readonly FIRST: '1';
  readonly SECOND: '2';
  readonly THIRD: '3';
  readonly FORTH: 'Option 4, test"2';
};

export type EnumStringType = (typeof SelectValues)[keyof typeof SelectValues];
```

The way this has been implemented, it defaults to `string` if you don't pass a type.

Behaviour will be unchanged if you don't pass a type, and if you do pass a type that type still needs to extend a string.



<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

Easiest way to test it, is to pull this and play around with it.

I'm making this PR, so I can play around and test this a bit more extensively. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
