### PR TITLE
chore: Add skeleton state for breadcrumb group widget

### DIFF
--- a/src/app-layout/__tests__/widgetized-layout.test.tsx
+++ b/src/app-layout/__tests__/widgetized-layout.test.tsx
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
+import { describeWithAppLayoutFeatureFlagEnabled } from '../../internal/widgets/__tests__/utils';
 import { createWidgetizedAppLayout } from '../../../lib/components/app-layout/implementation';
 import { AppLayoutProps, AppLayoutPropsWithDefaults } from '../../../lib/components/app-layout/interfaces';
-import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../../../lib/components/internal/utils/global-flags';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import createWrapper from '../../../lib/components/test-utils/dom';
-
-declare const window: Window & FlagsHolder;
 
 const LoaderSkeleton = React.forwardRef<AppLayoutProps.Ref, AppLayoutPropsWithDefaults>(() => {
   return <div data-testid="loader">Loading...</div>;
@@ -47,20 +45,6 @@ jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
 }));
 
-function describeWithFeatureFlag(tests: () => void) {
-  describe('when feature flag is active', () => {
-    beforeEach(() => {
-      window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
-    });
-
-    afterEach(() => {
-      delete window[awsuiGlobalFlagsSymbol];
-    });
-
-    tests();
-  });
-}
-
 describe('Classic layout', () => {
   beforeEach(() => {
     jest.mocked(useVisualRefresh).mockReturnValue(false);
@@ -72,7 +56,7 @@ describe('Classic layout', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render normal layout', () => {
       const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
       expect(wrapper).toBeTruthy();
@@ -92,7 +76,7 @@ describe('Refresh layout', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render loader', () => {
       const { wrapper, container } = renderComponent(<WidgetizedLayout {...defaultProps} />);
       expect(wrapper).toBeFalsy();

--- a/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
+++ b/src/breadcrumb-group/__tests__/widgetized-breadcrumbs.test.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describeWithAppLayoutFeatureFlagEnabled } from '../../internal/widgets/__tests__/utils';
+import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { createWidgetizedBreadcrumbGroup } from '../../../lib/components/breadcrumb-group/implementation';
+import { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
+import { BreadcrumbGroupSkeleton } from '../../../lib/components/breadcrumb-group/skeleton';
+import { getFunnelNameSelector } from '../../../lib/components/internal/analytics/selectors';
+
+function renderComponent(jsx: React.ReactElement) {
+  const { container } = render(jsx);
+  const wrapper = createWrapper(container).findBreadcrumbGroup();
+
+  return { wrapper, container };
+}
+
+const defaultProps: BreadcrumbGroupProps = {
+  items: [
+    { href: '#', text: 'Root' },
+    { href: '#', text: 'Page name' },
+  ],
+};
+
+const WidgetizedBreadcrumbs = createWidgetizedBreadcrumbGroup(BreadcrumbGroupSkeleton);
+
+function getFunnelNameElement(container: HTMLElement) {
+  return container.querySelector(getFunnelNameSelector());
+}
+
+jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
+  useVisualRefresh: jest.fn().mockReturnValue(false),
+}));
+
+describe('Classic design', () => {
+  beforeEach(() => {
+    jest.mocked(useVisualRefresh).mockReturnValue(false);
+  });
+
+  test('should render normal layout by default', () => {
+    const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
+    expect(wrapper).toBeTruthy();
+    expect(getFunnelNameElement(container)).toHaveTextContent('Page name');
+  });
+});
+
+describe('Refresh design', () => {
+  beforeEach(() => {
+    jest.mocked(useVisualRefresh).mockReturnValue(true);
+  });
+
+  test('should render normal layout by default', () => {
+    const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
+    expect(wrapper).toBeTruthy();
+    expect(getFunnelNameElement(container)).toHaveTextContent('Page name');
+  });
+
+  describeWithAppLayoutFeatureFlagEnabled(() => {
+    test('should render funnel name using loader', () => {
+      const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs {...defaultProps} />);
+      expect(wrapper).toBeFalsy();
+      expect(getFunnelNameElement(container)).toHaveTextContent('Page name');
+    });
+
+    test('should not render funnel name if breadcrumbs list is empty', () => {
+      const { wrapper, container } = renderComponent(<WidgetizedBreadcrumbs items={[]} />);
+      expect(wrapper).toBeFalsy();
+      expect(getFunnelNameElement(container)).toEqual(null);
+    });
+  });
+});

--- a/src/breadcrumb-group/implementation.tsx
+++ b/src/breadcrumb-group/implementation.tsx
@@ -8,11 +8,10 @@ import InternalButtonDropdown from '../button-dropdown/internal';
 import { CustomTriggerProps, LinkItem } from '../button-dropdown/interfaces';
 import { InternalButton } from '../button/internal';
 import { BreadcrumbItem } from './item/item';
-import { BreadcrumbGroupProps, EllipsisDropdownProps } from './interfaces';
+import { BreadcrumbGroupProps, EllipsisDropdownProps, InternalBreadcrumbGroupProps } from './interfaces';
 import { fireCancelableEvent } from '../internal/events';
 import { getBaseProps } from '../internal/base-component';
 import { useMobile } from '../internal/hooks/use-mobile';
-import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../i18n/context';
 import { createWidgetizedComponent } from '../internal/widgets';
@@ -74,9 +73,6 @@ const EllipsisDropdown = ({
     </li>
   );
 };
-
-type InternalBreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item> =
-  BreadcrumbGroupProps<T> & InternalBaseComponentProps;
 
 export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item>({
   items = [],

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -3,6 +3,7 @@
 import { BaseNavigationDetail, CancelableEventHandler } from '../internal/events';
 import { LinkItem } from '../button-dropdown/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 
 export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item>
   extends BaseComponentProps {
@@ -53,6 +54,9 @@ export namespace BreadcrumbGroupProps {
     href: string;
   }
 }
+
+export type InternalBreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item> =
+  BreadcrumbGroupProps<T> & InternalBaseComponentProps;
 
 export interface BreadcrumbItemProps<T extends BreadcrumbGroupProps.Item> {
   item: T;

--- a/src/breadcrumb-group/item/funnel.tsx
+++ b/src/breadcrumb-group/item/funnel.tsx
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../internal/analytics/selectors';
+import styles from './styles.css.js';
+import clsx from 'clsx';
+
+interface FunnelBreadcrumbItemProps {
+  text: string;
+  last: boolean;
+  hidden?: boolean;
+}
+
+export const FunnelBreadcrumbItem = React.forwardRef<HTMLSpanElement, FunnelBreadcrumbItemProps>(
+  ({ text, hidden, last }, ref) => {
+    const funnelAttributes: Record<string, string> = {};
+    if (last) {
+      funnelAttributes[DATA_ATTR_FUNNEL_KEY] = FUNNEL_KEY_FUNNEL_NAME;
+    }
+
+    return (
+      <span {...funnelAttributes} className={clsx(styles.text, hidden && styles['text-hidden'])} ref={ref}>
+        {text}
+      </span>
+    );
+  }
+);

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -7,23 +7,20 @@ import styles from './styles.css.js';
 import clsx from 'clsx';
 import { fireCancelableEvent, isPlainLeftClick } from '../../internal/events';
 
-import { DATA_ATTR_FUNNEL_KEY } from '../../internal/analytics/selectors';
-import { FUNNEL_KEY_FUNNEL_NAME } from '../../internal/analytics/selectors';
 import Tooltip from '../../internal/components/tooltip';
 import { getEventDetail } from '../utils';
+import { FunnelBreadcrumbItem } from './funnel';
 
 type BreadcrumbItemWithPopoverProps<T extends BreadcrumbGroupProps.Item> = React.HTMLAttributes<HTMLElement> & {
   item: T;
   isLast: boolean;
   anchorAttributes: React.AnchorHTMLAttributes<HTMLAnchorElement>;
-  funnelAttributes: Record<string, string>;
 };
 
 const BreadcrumbItemWithPopover = <T extends BreadcrumbGroupProps.Item>({
   item,
   isLast,
   anchorAttributes,
-  funnelAttributes,
   ...itemAttributes
 }: BreadcrumbItemWithPopoverProps<T>) => {
   const [showPopover, setShowPopover] = useState(false);
@@ -73,9 +70,7 @@ const BreadcrumbItemWithPopover = <T extends BreadcrumbGroupProps.Item>({
         onMouseLeave={() => setShowPopover(false)}
         anchorAttributes={anchorAttributes}
       >
-        <span {...funnelAttributes} className={styles.text} ref={textRef}>
-          {item.text}
-        </span>
+        <FunnelBreadcrumbItem ref={textRef} text={item.text} last={isLast} />
         <span className={styles['virtual-item']} ref={virtualTextRef}>
           {item.text}
         </span>
@@ -122,11 +117,6 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
     onClick: isLast ? preventDefault : onClickHandler,
   };
 
-  const funnelAttributes: Record<string, string> = {};
-  if (isLast) {
-    funnelAttributes[DATA_ATTR_FUNNEL_KEY] = FUNNEL_KEY_FUNNEL_NAME;
-  }
-
   return (
     <div className={clsx(styles.breadcrumb, isLast && styles.last)}>
       {isDisplayed && isCompressed ? (
@@ -134,14 +124,11 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
           item={item}
           isLast={isLast}
           anchorAttributes={anchorAttributes}
-          funnelAttributes={funnelAttributes}
           {...itemAttributes}
         />
       ) : (
         <Item isLast={isLast} anchorAttributes={anchorAttributes} {...itemAttributes}>
-          <span {...funnelAttributes} className={styles.text}>
-            {item.text}
-          </span>
+          <FunnelBreadcrumbItem text={item.text} last={isLast} />
         </Item>
       )}
       {!isLast ? (

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -54,3 +54,7 @@
   @include styles.awsui-util-hide;
   visibility: hidden;
 }
+
+.text-hidden {
+  display: none;
+}

--- a/src/breadcrumb-group/skeleton.tsx
+++ b/src/breadcrumb-group/skeleton.tsx
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { FunnelBreadcrumbItem } from './item/funnel';
+import { BreadcrumbGroupProps, InternalBreadcrumbGroupProps } from './interfaces';
+
+export function BreadcrumbGroupSkeleton<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item>({
+  items,
+}: InternalBreadcrumbGroupProps<T>) {
+  const lastItem = items[items.length - 1];
+  if (!lastItem) {
+    return <></>;
+  }
+  return <FunnelBreadcrumbItem hidden={true} last={true} text={lastItem.text} />;
+}

--- a/src/internal/widgets/__tests__/utils.ts
+++ b/src/internal/widgets/__tests__/utils.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { awsuiGlobalFlagsSymbol, FlagsHolder } from '../../../../lib/components/internal/utils/global-flags';
+
+declare const window: Window & FlagsHolder;
+
+export function describeWithAppLayoutFeatureFlagEnabled(tests: () => void) {
+  describe('when feature flag is active', () => {
+    beforeEach(() => {
+      window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
+    });
+
+    afterEach(() => {
+      delete window[awsuiGlobalFlagsSymbol];
+    });
+
+    tests();
+  });
+}

--- a/src/internal/widgets/__tests__/widgets.test.tsx
+++ b/src/internal/widgets/__tests__/widgets.test.tsx
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
-import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../../../../lib/components/internal/utils/global-flags';
 import { useVisualRefresh } from '../../../../lib/components/internal/hooks/use-visual-mode';
 import { createWidgetizedComponent, createWidgetizedForwardRef } from '../../../../lib/components/internal/widgets';
-
-declare const window: Window & FlagsHolder;
+import { describeWithAppLayoutFeatureFlagEnabled } from './utils';
 
 const LoaderSkeleton = () => <div data-testid="loader">Loading...</div>;
 const RealComponent = () => <div data-testid="content">Real content</div>;
@@ -39,20 +37,6 @@ jest.mock('../../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
 }));
 
-function describeWithFeatureFlag(tests: () => void) {
-  describe('when feature flag is active', () => {
-    beforeEach(() => {
-      window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
-    });
-
-    afterEach(() => {
-      delete window[awsuiGlobalFlagsSymbol];
-    });
-
-    tests();
-  });
-}
-
 describe('Classic design', () => {
   beforeEach(() => {
     jest.mocked(useVisualRefresh).mockReturnValue(false);
@@ -64,7 +48,7 @@ describe('Classic design', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render normal layout', () => {
       const { container } = render(<WidgetizedComponent />);
       expect(findContent(container)).toBeTruthy();
@@ -84,7 +68,7 @@ describe('Refresh design', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render loader', () => {
       const { container } = render(<WidgetizedComponent />);
       expect(findContent(container)).toBeFalsy();
@@ -102,7 +86,7 @@ describe('Ref handling', () => {
     expect(ref.current).toHaveTextContent('Real content');
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should forward ref to loader', () => {
       const ref = React.createRef<HTMLDivElement>();
       const { container } = render(<WidgetizedComponentWithRef ref={ref} />);

--- a/src/split-panel/__tests__/widgetized-panel.test.tsx
+++ b/src/split-panel/__tests__/widgetized-panel.test.tsx
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
-import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../../../lib/components/internal/utils/global-flags';
+import { describeWithAppLayoutFeatureFlagEnabled } from '../../internal/widgets/__tests__/utils';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { createWidgetizedSplitPanel } from '../../../lib/components/split-panel/implementation';
 import { SplitPanelProps } from '../../../lib/components/split-panel/interfaces';
 import { SplitPanelContextProvider } from '../../../lib/components/internal/context/split-panel-context';
 import { defaultSplitPanelContextProps } from './helpers';
-
-declare const window: Window & FlagsHolder;
 
 const LoaderSkeleton = React.forwardRef<HTMLElement, SplitPanelProps>(() => {
   return <div data-testid="loader">Loading...</div>;
@@ -42,20 +40,6 @@ jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   useVisualRefresh: jest.fn().mockReturnValue(false),
 }));
 
-function describeWithFeatureFlag(tests: () => void) {
-  describe('when feature flag is active', () => {
-    beforeEach(() => {
-      window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
-    });
-
-    afterEach(() => {
-      delete window[awsuiGlobalFlagsSymbol];
-    });
-
-    tests();
-  });
-}
-
 describe('Classic design', () => {
   beforeEach(() => {
     jest.mocked(useVisualRefresh).mockReturnValue(false);
@@ -67,7 +51,7 @@ describe('Classic design', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render normal layout', () => {
       const { wrapper, container } = renderComponent(<WidgetizedPanel {...defaultProps} />);
       expect(wrapper).toBeTruthy();
@@ -87,7 +71,7 @@ describe('Refresh design', () => {
     expect(findLoader(container)).toBeFalsy();
   });
 
-  describeWithFeatureFlag(() => {
+  describeWithAppLayoutFeatureFlagEnabled(() => {
     test('should render loader', () => {
       const { wrapper, container } = renderComponent(<WidgetizedPanel {...defaultProps} />);
       expect(wrapper).toBeFalsy();


### PR DESCRIPTION
### Description

Render funnel name placeholder while the widget is loading

Related links, issue #, if available: n/a

### How has this been tested?

Added unit tests. Integration tests will be done in the pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
