### PR TITLE
fix: Updates indents in button dropdowns

### DIFF
--- a/pages/button-dropdown/checkboxes.page.tsx
+++ b/pages/button-dropdown/checkboxes.page.tsx
@@ -78,7 +78,16 @@ function ButtonDropdownComponent({ variant }: { variant: 'normal' | 'nested' | '
       items={
         variant === 'normal'
           ? getItems(firstChecked, secondChecked, thirdChecked, fourthChecked)
-          : [{ items: getItems(firstChecked, secondChecked, thirdChecked, fourthChecked), text: 'Category' }]
+          : [
+              { items: getItems(firstChecked, secondChecked, thirdChecked, fourthChecked), text: 'Category' },
+              {
+                text: 'Non selectable category',
+                items: [
+                  { text: 'Option 1', id: 'option-1' },
+                  { text: 'Option 2', id: 'option-2' },
+                ],
+              },
+            ]
       }
       onItemClick={onClick}
       expandableGroups={variant === 'expandable'}

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -68,13 +68,13 @@
   /* stylelint-disable selector-max-type */
   .has-category-header:not(.has-checkmark) > &,
   .has-category-header:not(.has-checkmark) > span > & {
-    padding-inline-start: calc(#{awsui.$space-s} + #{awsui.$space-l});
+    padding-inline-start: calc(#{awsui.$space-xs} + #{awsui.$space-l});
   }
   /* stylelint-enable selector-max-type */
 }
 
 .icon {
-  padding-inline-end: awsui.$space-xs;
+  padding-inline-end: awsui.$space-xxs;
   flex-shrink: 0;
 
   &.checkmark {

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -66,8 +66,8 @@
   }
 
   /* stylelint-disable selector-max-type */
-  .has-category-header:not(.has-checkmark) > &,
-  .has-category-header:not(.has-checkmark) > span > & {
+  .has-category-header > &,
+  .has-category-header > span > & {
     padding-inline-start: calc(#{awsui.$space-xs} + #{awsui.$space-l});
   }
   /* stylelint-enable selector-max-type */

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -67,7 +67,7 @@
 
   /* stylelint-disable selector-max-type */
   .has-category-header > &,
-  .has-category-header > span > & {
+  .has-category-header:not(.has-checkmark) > span > & {
     padding-inline-start: calc(#{awsui.$space-xs} + #{awsui.$space-l});
   }
   /* stylelint-enable selector-max-type */


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Updating the indentation of the button dropdown items based on a design review with visual design. Originally part of the button checkbox project, but separated due to a contributor owning that part.

Changes:
- Indent with icons: 8px -> 4px
- Indent inside a category: 32px -> 28px
- Indent of checkbox items in a category: 20px -> 28px

Previous:
<img width="372" alt="image" src="https://github.com/cloudscape-design/components/assets/9701338/3ba29b4e-2a56-4032-bf6e-571fd552dab0">

New:
<img width="362" alt="image" src="https://github.com/cloudscape-design/components/assets/9701338/9a04ea75-de73-4779-ac63-7d431f11fc3d">


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
