### PR TITLE
chore: Property filter custom forms input dropdown

### DIFF
--- a/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
+++ b/src/property-filter/__tests__/property-filter-extended-operators.test.tsx
@@ -3,8 +3,13 @@
 
 import React from 'react';
 import { act, render } from '@testing-library/react';
-import createWrapper, { PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
+import createWrapper, {
+  ElementWrapper,
+  FormFieldWrapper,
+  PropertyFilterWrapper,
+} from '../../../lib/components/test-utils/dom';
 import PropertyFilter from '../../../lib/components/property-filter';
+import DropdownWrapper from '../../../lib/components/test-utils/dom/internal/dropdown';
 import styles from '../../../lib/components/property-filter/styles.selectors.js';
 import { FilteringProperty, PropertyFilterProps, Ref } from '../../../lib/components/property-filter/interfaces.js';
 import { createDefaultProps } from './common';
@@ -28,6 +33,14 @@ function openTokenEditor(wrapper: PropertyFilterWrapper, index = 0) {
   act(() => popoverWrapper.findTrigger().click());
   const contentWrapper = popoverWrapper.findContent()!;
   return [contentWrapper, popoverWrapper] as const;
+}
+
+function findTokenSubmitButton(wrapper: ElementWrapper) {
+  return wrapper.findButton(`.${styles['token-editor-submit']}`)!;
+}
+
+function findPropertySubmitButton(wrapper: ElementWrapper) {
+  return wrapper.findButton(`.${styles['property-editor-submit']}`)!;
 }
 
 describe('extended operators', () => {
@@ -65,19 +78,50 @@ describe('extended operators', () => {
   });
 
   test('property filter uses operator form in the token editor', () => {
+    const onChange = jest.fn();
     const { propertyFilterWrapper: wrapper } = renderComponent({
       ...extendedOperatorProps,
       query: {
+        operation: 'and',
         tokens: [
           { propertyKey: 'index', value: 1, operator: '>' },
           { propertyKey: 'index', value: 2, operator: '<' },
         ],
-        operation: 'and',
       },
+      onChange,
     });
+
+    // Ensure token editors have respective custom forms
     expect(wrapper.findTokens()).toHaveLength(2);
-    expect(openTokenEditor(wrapper, 0)[0].find('[data-testid="change+"]')).not.toBe(null);
-    expect(openTokenEditor(wrapper, 1)[0].find('[data-testid="change-"]')).not.toBe(null);
+    const [editorPlus, editorMinus] = [openTokenEditor(wrapper, 0)[0], openTokenEditor(wrapper, 1)[0]];
+    expect(editorPlus.find('[data-testid="change+"]')).not.toBe(null);
+    expect(editorMinus.find('[data-testid="change-"]')).not.toBe(null);
+
+    // Click on value field.
+    const valueFormField = editorPlus.findAllByClassName(FormFieldWrapper.rootSelector)[2];
+    valueFormField.find('button')!.click();
+
+    // Click change+ button
+    const valueDropdown = new DropdownWrapper(valueFormField.find(`.${DropdownWrapper.rootSelector}`)!.getElement());
+    valueDropdown.findOpenDropdown()!.find('button[data-testid="change+"]')!.click();
+
+    // Click value apply button
+    findPropertySubmitButton(valueDropdown.findOpenDropdown()!).click();
+
+    // Click token editor apply button
+    findTokenSubmitButton(editorPlus).click();
+
+    expect(onChange).toBeCalledWith(
+      expect.objectContaining({
+        detail: {
+          operation: 'and',
+          tokens: [
+            { propertyKey: 'index', value: 2, operator: '>' },
+            { propertyKey: 'index', value: 2, operator: '<' },
+          ],
+        },
+      })
+    );
   });
 
   test('extended operator form takes value/onChange state', () => {

--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -17,6 +17,15 @@ interface PropertyEditorProps<TokenValue> {
   i18nStrings: I18nStrings;
 }
 
+interface PropertyEditorFormProps<TokenValue> {
+  property: InternalFilteringProperty;
+  value?: null | TokenValue;
+  customForm: (value: null | TokenValue, onChange: (value: TokenValue) => void) => React.ReactNode;
+  onCancel: () => void;
+  onSubmit: (value: null | TokenValue) => void;
+  i18nStrings: I18nStrings;
+}
+
 export function PropertyEditor<TokenValue = any>({
   property,
   operator,
@@ -26,21 +35,38 @@ export function PropertyEditor<TokenValue = any>({
   onSubmit,
   i18nStrings,
 }: PropertyEditorProps<TokenValue>) {
-  const [value, onChange] = useState<null | TokenValue>(null);
-  const submitToken = () => onSubmit({ propertyKey: property.propertyKey, operator, value });
+  return (
+    <PropertyEditorForm
+      property={property}
+      customForm={(value, onChange) => operatorForm({ value, onChange, operator, filter })}
+      onCancel={onCancel}
+      onSubmit={value => onSubmit({ propertyKey: property.propertyKey, operator, value })}
+      i18nStrings={i18nStrings}
+    />
+  );
+}
+
+export function PropertyEditorForm<TokenValue = any>({
+  property,
+  value,
+  customForm,
+  onCancel,
+  onSubmit,
+  i18nStrings,
+}: PropertyEditorFormProps<TokenValue>) {
+  const [tempValue, onTempValueChange] = useState<null | TokenValue>(value ?? null);
+  const onChange = (value: TokenValue) => onTempValueChange(value);
   return (
     <div className={styles['property-editor']}>
       <div className={styles['property-editor-form']}>
-        <InternalFormField label={property.groupValuesLabel}>
-          {operatorForm({ value, onChange, operator, filter })}
-        </InternalFormField>
+        <InternalFormField label={property.groupValuesLabel}>{customForm(tempValue, onChange)}</InternalFormField>
       </div>
 
       <div className={styles['property-editor-actions']}>
         <InternalButton variant="link" className={styles['property-editor-cancel']} onClick={onCancel}>
           {i18nStrings.cancelActionText}
         </InternalButton>
-        <InternalButton className={styles['property-editor-submit']} onClick={submitToken}>
+        <InternalButton className={styles['property-editor-submit']} onClick={() => onSubmit(tempValue)}>
           {i18nStrings.applyActionText}
         </InternalButton>
       </div>

--- a/src/property-filter/property-filter-autosuggest.tsx
+++ b/src/property-filter/property-filter-autosuggest.tsx
@@ -30,9 +30,7 @@ import clsx from 'clsx';
 import { getFirstFocusable } from '../internal/components/focus-lock/utils';
 import { filterOptions } from './filter-options';
 import { joinStrings } from '../internal/utils/strings';
-
-const DROPDOWN_WIDTH_OPTIONS_LIST = 300;
-const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
+import { DROPDOWN_WIDTH_CUSTOM_FORM, DROPDOWN_WIDTH_OPTIONS_LIST } from './utils';
 
 export interface PropertyFilterAutosuggestProps
   extends Omit<AutosuggestProps, 'filteringResultsText'>,

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -25,12 +25,15 @@ import { NonCancelableEventHandler } from '../internal/events';
 import { DropdownStatusProps } from '../internal/components/dropdown-status/interfaces';
 import InternalButton from '../button/internal';
 import InternalFormField from '../form-field/internal';
-import { matchTokenValue } from './utils';
 import clsx from 'clsx';
+import { DROPDOWN_WIDTH_CUSTOM_FORM, matchTokenValue } from './utils';
 import ButtonTrigger from '../internal/components/button-trigger';
 import Dropdown from '../internal/components/dropdown';
 import { useFormFieldContext } from '../contexts/form-field';
 import { PropertyEditorForm } from './property-editor';
+import ScreenreaderOnly from '../internal/components/screenreader-only';
+import { useUniqueId } from '../internal/hooks/use-unique-id';
+import { joinStrings } from '../internal/utils/strings';
 
 interface PropertyInputProps {
   asyncProps: null | DropdownStatusProps;
@@ -159,23 +162,26 @@ function ValueInput({
   const formattedValue = property?.getValueFormatter(operator)?.(value) ?? value;
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const formFieldProps = useFormFieldContext({});
+  const valueId = useUniqueId();
 
   return OperatorForm ? (
     <Dropdown
-      minWidth={200}
+      minWidth={DROPDOWN_WIDTH_CUSTOM_FORM}
       stretchBeyondTriggerWidth={true}
       open={isDropdownOpen}
       onDropdownClose={() => setDropdownOpen(false)}
       trigger={
-        <ButtonTrigger
-          hideCaret={true}
-          onClick={() => setDropdownOpen(true)}
-          ariaHasPopup="dialog"
-          pressed={isDropdownOpen}
-          ariaLabelledby={formFieldProps.ariaLabelledby}
-        >
-          {typeof formattedValue === 'string' ? formattedValue : ''}
-        </ButtonTrigger>
+        <>
+          <ButtonTrigger
+            onClick={() => setDropdownOpen(true)}
+            ariaHasPopup="dialog"
+            pressed={isDropdownOpen}
+            ariaLabelledby={joinStrings(formFieldProps.ariaLabelledby, formattedValue ? valueId : undefined)}
+          >
+            {typeof formattedValue === 'string' ? formattedValue : ''}
+          </ButtonTrigger>
+          <ScreenreaderOnly id={valueId}>{formattedValue}</ScreenreaderOnly>
+        </>
       }
     >
       <PropertyEditorForm

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -34,6 +34,7 @@ import { PropertyEditorForm } from './property-editor';
 import ScreenreaderOnly from '../internal/components/screenreader-only';
 import { useUniqueId } from '../internal/hooks/use-unique-id';
 import { joinStrings } from '../internal/utils/strings';
+import FocusLock from '../internal/components/focus-lock';
 
 interface PropertyInputProps {
   asyncProps: null | DropdownStatusProps;
@@ -188,17 +189,19 @@ function ValueInput({
         </>
       }
     >
-      <PropertyEditorForm
-        value={value}
-        property={property}
-        customForm={(value, onChange) => <OperatorForm value={value} onChange={onChange} operator={operator} />}
-        onCancel={onDropdownClose}
-        onSubmit={value => {
-          onChangeValue(value);
-          onDropdownClose();
-        }}
-        i18nStrings={i18nStrings}
-      />
+      <FocusLock className={styles['focus-lock']} autoFocus={true}>
+        <PropertyEditorForm
+          value={value}
+          property={property}
+          customForm={(value, onChange) => <OperatorForm value={value} onChange={onChange} operator={operator} />}
+          onCancel={onDropdownClose}
+          onSubmit={value => {
+            onChangeValue(value);
+            onDropdownClose();
+          }}
+          i18nStrings={i18nStrings}
+        />
+      </FocusLock>
     </Dropdown>
   ) : (
     <InternalAutosuggest

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -189,7 +189,7 @@ function ValueInput({
         </>
       }
     >
-      <FocusLock className={styles['focus-lock']} autoFocus={true}>
+      <FocusLock autoFocus={true}>
         <PropertyEditorForm
           value={value}
           property={property}

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -161,6 +161,7 @@ function ValueInput({
   const OperatorForm = property?.propertyKey && operator && property?.getValueFormRenderer(operator);
   const formattedValue = property?.getValueFormatter(operator)?.(value) ?? value;
   const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const onDropdownClose = () => setDropdownOpen(false);
   const formFieldProps = useFormFieldContext({});
   const valueId = useUniqueId();
 
@@ -169,7 +170,7 @@ function ValueInput({
       minWidth={DROPDOWN_WIDTH_CUSTOM_FORM}
       stretchBeyondTriggerWidth={true}
       open={isDropdownOpen}
-      onDropdownClose={() => setDropdownOpen(false)}
+      onDropdownClose={onDropdownClose}
       trigger={
         <>
           <ButtonTrigger
@@ -188,10 +189,10 @@ function ValueInput({
         value={value}
         property={property}
         customForm={(value, onChange) => <OperatorForm value={value} onChange={onChange} operator={operator} />}
-        onCancel={() => setDropdownOpen(false)}
+        onCancel={onDropdownClose}
         onSubmit={value => {
           onChangeValue(value);
-          setDropdownOpen(false);
+          onDropdownClose();
         }}
         i18nStrings={i18nStrings}
       />

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -164,6 +164,7 @@ function ValueInput({
   const onDropdownClose = () => setDropdownOpen(false);
   const formFieldProps = useFormFieldContext({});
   const valueId = useUniqueId();
+  const ariaLabelledby = joinStrings(formFieldProps.ariaLabelledby, formattedValue ? valueId : undefined);
 
   return OperatorForm ? (
     <Dropdown
@@ -171,13 +172,15 @@ function ValueInput({
       stretchBeyondTriggerWidth={true}
       open={isDropdownOpen}
       onDropdownClose={onDropdownClose}
+      dropdownContentRole="dialog"
+      ariaLabelledby={ariaLabelledby}
       trigger={
         <>
           <ButtonTrigger
             onClick={() => setDropdownOpen(true)}
             ariaHasPopup="dialog"
             pressed={isDropdownOpen}
-            ariaLabelledby={joinStrings(formFieldProps.ariaLabelledby, formattedValue ? valueId : undefined)}
+            ariaLabelledby={ariaLabelledby}
           >
             {typeof formattedValue === 'string' ? formattedValue : ''}
           </ButtonTrigger>

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -9,6 +9,9 @@ import {
   Token,
 } from './interfaces';
 
+export const DROPDOWN_WIDTH_OPTIONS_LIST = 300;
+export const DROPDOWN_WIDTH_CUSTOM_FORM = 200;
+
 // Finds the longest property the filtering text starts from.
 export function matchFilteringProperty(
   filteringProperties: readonly InternalFilteringProperty[],


### PR DESCRIPTION
### Description

Updates property filter so that tokens with custom forms have their value editable with a custom input dropdown to ensure the value input takes less space.

Rel: Nu26A4Kr5E80

### How has this been tested?

* Unit tests and manual testing
* Consultation with accessibility team

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
