### PR TITLE
fix: Clean up icons content

### DIFF
--- a/themes/icons/drag-indicator.svg
+++ b/themes/icons/drag-indicator.svg
@@ -1,6 +1,5 @@
 <svg
   viewBox="0 0 16 16"
-  fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
   <circle
@@ -8,41 +7,35 @@
     cy="2.5"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
   <circle
     cx="5.5"
     cy="13.5"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
   <circle
     cx="5.5"
     cy="8"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
   <circle
     cx="10.5"
     cy="2.5"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
   <circle
     cx="10.5"
     cy="13.5"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
   <circle
     cx="10.5"
     cy="8"
     r="0.5"
     class="filled"
-    stroke-width="2"
   />
 </svg>

--- a/themes/icons/resize-area.svg
+++ b/themes/icons/resize-area.svg
@@ -1,14 +1,11 @@
 <svg
   viewBox="0 0 16 16"
-  fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
     d="M9.5 14.5L14.5 9.5"
-    stroke-width="2"
   />
   <path
     d="M4 14.5L14.5 4"
-    stroke-width="2"
   />
 </svg>

--- a/themes/icons/send.svg
+++ b/themes/icons/send.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
-  <path d="M1.00053 1.00103L14.9995 8.00537L1.00053 14.999L3.69265 8.00537L1.00053 1.00103Z" stroke="#555C65" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M3.69266 8.00537H13.9641" stroke="#555C65" stroke-width="2" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M1.00053 1.00103L14.9995 8.00537L1.00053 14.999L3.69265 8.00537L1.00053 1.00103Z" class="stroke-linejoin-round" />
+  <path d="M3.69266 8.00537H13.9641" class="stroke-linejoin-round" />
 </svg>

--- a/themes/icons/subtract-minus.svg
+++ b/themes/icons/subtract-minus.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 	<path d="M1 8H15" />
 </svg>


### PR DESCRIPTION
### Description

Clean up icons from inline attributes because they conflict with our CSS we apply to the icons: https://github.com/cloudscape-design/components/blob/af1a976051f9de50675d30004475bbe0e3847ffa/src/icon/mixins.scss#L98-L120

Related links, issue #, if available: n/a

### How has this been tested?

Screenshot tests in my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
