### PR TITLE
chore: Improve graceful degradation for CodeEditor in Safari 15.

### DIFF
--- a/src/code-editor/styles.scss
+++ b/src/code-editor/styles.scss
@@ -198,6 +198,16 @@
     }
     /* stylelint-enable plugin/no-unsupported-browser-features */
   }
+
+  @supports not (contain: inline-size) {
+    > .count {
+      display: none;
+    }
+
+    > .text {
+      display: inline;
+    }
+  }
 }
 
 $default-height: 480px;


### PR DESCRIPTION
<img width="981" alt="Screenshot 2024-06-12 at 10 08 22 PM" src="https://github.com/cloudscape-design/components/assets/438181/039dff0f-3a3b-44ab-869f-83a377ccd76e">

The CodeEditor was upgraded to use container queries with an anticipated degraded experience in Safari 15 for the remainder of the support cycle. A duplicate text occurrence of the count appears in the UI only for this browser and version. This PR adds an additional @supports query to remove this.