### PR TITLE
fix: CopyToClipboard is stuck in insecure contexts

### DIFF
--- a/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
+++ b/src/copy-to-clipboard/__tests__/copy-to-clipboard.test.tsx
@@ -84,4 +84,19 @@ describe('CopyToClipboard', () => {
     wrapper.findCopyButton().click();
     await waitFor(() => expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard'));
   });
+
+  describe('when the clipboard API is not available', () => {
+    beforeEach(() => Object.assign(global.navigator, { clipboard: undefined }));
+    afterEach(() => Object.assign(global.navigator, { clipboard: originalNavigatorClipboard }));
+
+    test('fails to copy to clipboard and shows error message', async () => {
+      const { container } = render(<CopyToClipboard {...defaultProps} textToCopy="Text to copy with error" />);
+      const wrapper = createWrapper(container).findCopyToClipboard()!;
+
+      wrapper.findCopyButton().click();
+      await waitFor(() =>
+        expect(wrapper.findStatusText()!.getElement().textContent).toBe('Failed to copy to clipboard')
+      );
+    });
+  });
 });

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -29,20 +29,25 @@ export default function InternalCopyToClipboard({
 
   const baseProps = getBaseProps(restProps);
   const onClick = () => {
-    if (navigator.clipboard) {
-      setStatus('pending');
-      setStatusText('');
-      navigator.clipboard
-        .writeText(textToCopy)
-        .then(() => {
-          setStatus('success');
-          setStatusText(copySuccessText);
-        })
-        .catch(() => {
-          setStatus('error');
-          setStatusText(copyErrorText);
-        });
+    if (!navigator.clipboard) {
+      // The clipboard API is not available in insecure contexts.
+      setStatus('error');
+      setStatusText(copyErrorText);
+      return;
     }
+
+    setStatus('pending');
+    setStatusText('');
+    navigator.clipboard
+      .writeText(textToCopy)
+      .then(() => {
+        setStatus('success');
+        setStatusText(copySuccessText);
+      })
+      .catch(() => {
+        setStatus('error');
+        setStatusText(copyErrorText);
+      });
   };
 
   const triggerVariant = (


### PR DESCRIPTION
### Description

When a page runs in an insecure context (e.g. plain HTTP), the browser's clipboard API is not available. In this case, the CopyToClipboard component used to get stuck in the pending state. With this change, the component shows the error state instead.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
