### PR TITLE
chore: Refactor app layout test helpers

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout(size => {
+describeEachAppLayout(({ size }) => {
   test('Default state', () => {
     const { wrapper } = renderComponent(<AppLayout />);
 

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { act, fireEvent, screen, within } from '@testing-library/react';
 
 import {
-  describeEachThemeAppLayout,
+  describeEachAppLayout,
   isDrawerClosed,
   renderComponent,
   testDrawer,
@@ -27,7 +27,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [1300, () => {}],
 }));
 
-describeEachThemeAppLayout(false, () => {
+describeEachAppLayout({ sizes: ['desktop'] }, () => {
   test('renders breadcrumbs and notifications inside of the main landmark', () => {
     const { wrapper } = renderComponent(<AppLayout breadcrumbs="breadcrumbs" notifications="notifications" />);
     const mains = document.querySelectorAll('main');

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout(size => {
+describeEachAppLayout(({ size }) => {
   test(`should not render drawer when it is not defined`, () => {
     const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} drawers={[testDrawer]} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { within } from '@testing-library/react';
 import {
-  describeEachThemeAppLayout,
+  describeEachAppLayout,
   isDrawerClosed,
   renderComponent,
   testDrawer,
@@ -50,7 +50,7 @@ function AppLayoutWithControlledNavigation({
   );
 }
 
-describeEachThemeAppLayout(true, theme => {
+describeEachAppLayout({ sizes: ['mobile'] }, ({ theme }) => {
   // In refactored Visual Refresh different styles are used compared to Classic
   const mobileBarClassName = theme === 'refresh' ? testUtilsStyles['mobile-bar'] : toolbarStyles['mobile-bar'];
   const drawerBarClassName =

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -43,7 +43,7 @@ const drawerDefaults: DrawerConfig = {
   unmountContent: () => {},
 };
 
-describeEachAppLayout(size => {
+describeEachAppLayout(({ size }) => {
   test('does not render runtime drawers when it is explicitly disabled', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper } = await renderComponent(<AppLayout {...({ __disableRuntimeDrawers: true } as any)} />);

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -7,7 +7,7 @@ import { AppLayoutProps } from '../../../lib/components/app-layout/interfaces';
 import SplitPanel from '../../../lib/components/split-panel';
 import { KeyCode } from '../../../lib/components/internal/keycode';
 import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
-import { renderComponent, splitPanelI18nStrings } from './utils';
+import { describeEachAppLayout, renderComponent, splitPanelI18nStrings } from './utils';
 import applayoutTools from '../../../lib/components/app-layout/visual-refresh/styles.selectors.js';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 
@@ -63,127 +63,118 @@ afterEach(() => {
   window.getComputedStyle = originalGetComputedStyle;
 });
 
-for (const theme of ['refresh', 'classic']) {
-  describe(`Theme=${theme}`, () => {
-    beforeEach(() => {
-      (useVisualRefresh as jest.Mock).mockReturnValue(theme === 'refresh');
-    });
-    afterEach(() => {
-      (useVisualRefresh as jest.Mock).mockReset();
-    });
+describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
+  test('should render split panel in bottom position', () => {
+    const { wrapper } = renderComponent(
+      <AppLayout
+        splitPanel={defaultSplitPanel}
+        splitPanelOpen={true}
+        onSplitPanelToggle={noop}
+        splitPanelPreferences={{ position: 'bottom' }}
+        onSplitPanelPreferencesChange={noop}
+      />
+    );
+    expect(wrapper.findSplitPanel()!.findOpenPanelBottom()).not.toBeNull();
+  });
 
-    test('should render split panel in bottom position', () => {
+  test('should render split panel in side position', () => {
+    isMocked = true;
+    const { wrapper } = renderComponent(
+      <AppLayout
+        splitPanel={defaultSplitPanel}
+        splitPanelOpen={true}
+        onSplitPanelToggle={noop}
+        splitPanelPreferences={{ position: 'side' }}
+        onSplitPanelPreferencesChange={noop}
+      />
+    );
+    expect(wrapper.findSplitPanel()!.findOpenPanelSide()).not.toBeNull();
+    isMocked = false;
+  });
+
+  (['bottom', 'side'] as const).forEach(position => {
+    test(`split panel can open and close in ${position} position`, () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
-          splitPanelOpen={true}
-          onSplitPanelToggle={noop}
-          splitPanelPreferences={{ position: 'bottom' }}
+          splitPanelPreferences={{ position }}
           onSplitPanelPreferencesChange={noop}
         />
       );
-      expect(wrapper.findSplitPanel()!.findOpenPanelBottom()).not.toBeNull();
+      expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
+      wrapper.findSplitPanelOpenButton()!.click();
+      if (position === 'side' && theme === 'refresh') {
+        expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
+      } else {
+        expect(wrapper.findSplitPanelOpenButton()).toBeNull();
+      }
+      wrapper.findSplitPanel()!.findCloseButton()!.click();
+      expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
     });
 
-    test('should render split panel in side position', () => {
-      isMocked = true;
+    test(`Moves focus to slider when opened in ${position} position`, () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
-          splitPanelOpen={true}
-          onSplitPanelToggle={noop}
-          splitPanelPreferences={{ position: 'side' }}
+          splitPanelPreferences={{ position }}
           onSplitPanelPreferencesChange={noop}
         />
       );
-      expect(wrapper.findSplitPanel()!.findOpenPanelSide()).not.toBeNull();
-      isMocked = false;
+      wrapper.findSplitPanelOpenButton()!.click();
+      expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
     });
 
-    (['bottom', 'side'] as const).forEach(position => {
-      test(`split panel can open and close in ${position} position`, () => {
-        const { wrapper } = renderComponent(
-          <AppLayout
-            splitPanel={defaultSplitPanel}
-            splitPanelPreferences={{ position }}
-            onSplitPanelPreferencesChange={noop}
-          />
-        );
-        expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
-        wrapper.findSplitPanelOpenButton()!.click();
-        if (position === 'side' && theme === 'refresh') {
-          expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
-        } else {
-          expect(wrapper.findSplitPanelOpenButton()).toBeNull();
-        }
-        wrapper.findSplitPanel()!.findCloseButton()!.click();
-        expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
-      });
-
-      test(`Moves focus to slider when opened in ${position} position`, () => {
-        const { wrapper } = renderComponent(
-          <AppLayout
-            splitPanel={defaultSplitPanel}
-            splitPanelPreferences={{ position }}
-            onSplitPanelPreferencesChange={noop}
-          />
-        );
-        wrapper.findSplitPanelOpenButton()!.click();
-        expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
-      });
-
-      test(`Moves focus to open button when closed in ${position} position`, () => {
-        const { wrapper } = renderComponent(
-          <AppLayout
-            splitPanel={defaultSplitPanel}
-            splitPanelPreferences={{ position }}
-            onSplitPanelPreferencesChange={noop}
-          />
-        );
-        wrapper.findSplitPanelOpenButton()!.click();
-        wrapper.findSplitPanel()!.findCloseButton()!.click();
-        expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveFocus();
-      });
-
-      test(`Moves focus to the slider when focusSplitPanel() is called`, () => {
-        const ref: React.MutableRefObject<AppLayoutProps.Ref | null> = React.createRef();
-        const { wrapper } = renderComponent(
-          <AppLayout
-            ref={ref}
-            splitPanel={defaultSplitPanel}
-            splitPanelOpen={true}
-            splitPanelPreferences={{ position }}
-            onSplitPanelPreferencesChange={noop}
-          />
-        );
-        ref.current!.focusSplitPanel();
-        expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
-      });
-
-      test(`Does nothing when focusSplitPanel() is called but split panel is closed`, () => {
-        const ref: React.MutableRefObject<AppLayoutProps.Ref | null> = React.createRef();
-        renderComponent(
-          <AppLayout
-            ref={ref}
-            splitPanel={defaultSplitPanel}
-            splitPanelPreferences={{ position }}
-            onSplitPanelPreferencesChange={noop}
-          />
-        );
-        const previouslyFocusedElement = document.activeElement;
-        ref.current!.focusSplitPanel();
-        expect(previouslyFocusedElement).toHaveFocus();
-      });
+    test(`Moves focus to open button when closed in ${position} position`, () => {
+      const { wrapper } = renderComponent(
+        <AppLayout
+          splitPanel={defaultSplitPanel}
+          splitPanelPreferences={{ position }}
+          onSplitPanelPreferencesChange={noop}
+        />
+      );
+      wrapper.findSplitPanelOpenButton()!.click();
+      wrapper.findSplitPanel()!.findCloseButton()!.click();
+      expect(wrapper.findSplitPanelOpenButton()!.getElement()).toHaveFocus();
     });
 
-    test(`should not render split panel when it is not defined in ${theme}`, () => {
-      const { wrapper, rerender } = renderComponent(<AppLayout splitPanel={defaultSplitPanel} />);
-      expect(wrapper.findSplitPanel()).toBeTruthy();
-      rerender(<AppLayout />);
-      expect(wrapper.findSplitPanel()).toBeFalsy();
+    test(`Moves focus to the slider when focusSplitPanel() is called`, () => {
+      const ref: React.MutableRefObject<AppLayoutProps.Ref | null> = React.createRef();
+      const { wrapper } = renderComponent(
+        <AppLayout
+          ref={ref}
+          splitPanel={defaultSplitPanel}
+          splitPanelOpen={true}
+          splitPanelPreferences={{ position }}
+          onSplitPanelPreferencesChange={noop}
+        />
+      );
+      ref.current!.focusSplitPanel();
+      expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
+    });
+
+    test(`Does nothing when focusSplitPanel() is called but split panel is closed`, () => {
+      const ref: React.MutableRefObject<AppLayoutProps.Ref | null> = React.createRef();
+      renderComponent(
+        <AppLayout
+          ref={ref}
+          splitPanel={defaultSplitPanel}
+          splitPanelPreferences={{ position }}
+          onSplitPanelPreferencesChange={noop}
+        />
+      );
+      const previouslyFocusedElement = document.activeElement;
+      ref.current!.focusSplitPanel();
+      expect(previouslyFocusedElement).toHaveFocus();
     });
   });
-}
+
+  test(`should not render split panel when it is not defined in ${theme}`, () => {
+    const { wrapper, rerender } = renderComponent(<AppLayout splitPanel={defaultSplitPanel} />);
+    expect(wrapper.findSplitPanel()).toBeTruthy();
+    rerender(<AppLayout />);
+    expect(wrapper.findSplitPanel()).toBeFalsy();
+  });
+});
 
 describe('Visual refresh only features', () => {
   beforeEach(() => {


### PR DESCRIPTION
### Description

Merge two very similar helpers `describeEachThemeAppLayout` and `describeEachAppLayout` into one


Related links, issue #, if available: n/a

### How has this been tested?

Test only change. PR build passes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
