### PR TITLE
chore: Fix app layout + split panel tests structure

### DIFF
--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -92,8 +92,8 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
     isMocked = false;
   });
 
-  (['bottom', 'side'] as const).forEach(position => {
-    test(`split panel can open and close in ${position} position`, () => {
+  describe.each(['bottom', 'side'] as const)('%s position', position => {
+    test('split panel can open and close', () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
@@ -112,7 +112,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
       expect(wrapper.findSplitPanelOpenButton()).not.toBeNull();
     });
 
-    test(`Moves focus to slider when opened in ${position} position`, () => {
+    test('Moves focus to slider when opened', () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
@@ -124,7 +124,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
       expect(wrapper.findSplitPanel()!.findSlider()!.getElement()).toHaveFocus();
     });
 
-    test(`Moves focus to open button when closed in ${position} position`, () => {
+    test('Moves focus to open button when closed', () => {
       const { wrapper } = renderComponent(
         <AppLayout
           splitPanel={defaultSplitPanel}
@@ -168,7 +168,7 @@ describeEachAppLayout({ sizes: ['desktop'] }, ({ theme }) => {
     });
   });
 
-  test(`should not render split panel when it is not defined in ${theme}`, () => {
+  test('should not render split panel when it is not defined', () => {
     const { wrapper, rerender } = renderComponent(<AppLayout splitPanel={defaultSplitPanel} />);
     expect(wrapper.findSplitPanel()).toBeTruthy();
     rerender(<AppLayout />);


### PR DESCRIPTION
### Description

Use `describe.each` instead of manual for-of loop. This makes navigation through the tests easier, as they are logically grouped

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
