### PR TITLE
chore: Remove mentions of high contrast header from descriptions

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -4215,8 +4215,7 @@ It's also used for connecting \`items\` and \`selectedItems\` values when they d
       "defaultValue": "'container'",
       "description": "Specify a cards variant with one of the following:
 * \`container\` - Use this variant to have the cards displayed as a container.
-* \`full-page\` – Use this variant when cards are the entire content of a page. Full page variants
-                implement the high contrast header and content behavior automatically.",
+* \`full-page\` – Use this variant when cards are the entire content of a page.",
       "inlineType": Object {
         "name": "",
         "type": "union",
@@ -14360,8 +14359,7 @@ It's also used to connect \`items\` and \`selectedItems\` or \`expandableRows.ex
                **Deprecated**, replaced by \`borderless\` and \`container\`.
 * \`stacked\` - Use this variant adjacent to other stacked containers (such as a container,
               table).
-* \`full-page\` – Use this variant when the table is the entire content of a page. Full page variants
-                implement the high contrast header and content behavior automatically.",
+* \`full-page\` – Use this variant when the table is the entire content of a page.",
       "inlineType": Object {
         "name": "TableProps.Variant",
         "type": "union",

--- a/src/cards/interfaces.tsx
+++ b/src/cards/interfaces.tsx
@@ -206,8 +206,7 @@ export interface CardsProps<T = any> extends BaseComponentProps {
   /**
    * Specify a cards variant with one of the following:
    * * `container` - Use this variant to have the cards displayed as a container.
-   * * `full-page` – Use this variant when cards are the entire content of a page. Full page variants
-   *                 implement the high contrast header and content behavior automatically.
+   * * `full-page` – Use this variant when cards are the entire content of a page.
    * @visualrefresh `full-page` variant
    */
   variant?: 'container' | 'full-page';

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -292,8 +292,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *                **Deprecated**, replaced by `borderless` and `container`.
    * * `stacked` - Use this variant adjacent to other stacked containers (such as a container,
    *               table).
-   * * `full-page` – Use this variant when the table is the entire content of a page. Full page variants
-   *                 implement the high contrast header and content behavior automatically.
+   * * `full-page` – Use this variant when the table is the entire content of a page.
    * @visualrefresh `embedded`, `stacked`, and `full-page` variants
    */
   variant?: TableProps.Variant;


### PR DESCRIPTION
### Description

There were two descriptions that mention the high-contrast header for Cards and Table, which have been removed.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
