### PR TITLE
fix: Do not return tools drawer in findDrawersTriggers test-util

### DIFF
--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -53,29 +53,26 @@ describeEachAppLayout(({ size }) => {
   test('runtime drawers integration can be dynamically enabled and disabled', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout />);
-    // the 2nd trigger is for tools
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     rerender(<AppLayout {...({ __disableRuntimeDrawers: true } as any)} />);
     await delay();
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     rerender(<AppLayout />);
     await delay();
-    // the 2nd trigger is for tools
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
   test('renders drawers via runtime config', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper } = await renderComponent(<AppLayout />);
-    // the 2nd trigger is for tools
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
   test('combines runtime drawers with the tools', async () => {
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, ariaLabels: { triggerButton: 'Runtime drawer' } });
     const { wrapper } = await renderComponent(<AppLayout tools="test" ariaLabels={{ toolsToggle: 'Tools' }} />);
+    expect(wrapper.findToolsToggle().getElement()).toHaveAttribute('aria-label', 'Tools');
     expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
-      'Tools',
       'Runtime drawer',
     ]);
   });
@@ -187,12 +184,7 @@ describeEachAppLayout(({ size }) => {
 
   test('does not open defaultActive drawer if the tools are already open', async () => {
     const { wrapper } = await renderComponent(
-      <AppLayout
-        toolsOpen={true}
-        tools="Tools content"
-        ariaLabels={{ toolsToggle: 'tools toggle' }}
-        onToolsChange={() => {}}
-      />
+      <AppLayout toolsOpen={true} tools="Tools content" onToolsChange={() => {}} />
     );
     expect(wrapper.findDrawersTriggers()).toHaveLength(0);
     expect(wrapper.findActiveDrawer()).toBeFalsy();
@@ -208,7 +200,7 @@ describeEachAppLayout(({ size }) => {
     const { wrapper, rerender } = await renderComponent(
       <AppLayout tools="Tools content" toolsOpen={false} onToolsChange={event => onToolsChange(event.detail)} />
     );
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     expect(wrapper.findTools()).toBeFalsy();
     expect(onToolsChange).not.toHaveBeenCalled();
 
@@ -458,10 +450,10 @@ describeEachAppLayout(({ size }) => {
   test('persists drawer config between mounts/unmounts', async () => {
     awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
     const { wrapper, rerender } = await renderComponent(<AppLayout key="first" />);
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
     rerender(<AppLayout key="second" />);
     await delay();
-    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+    expect(wrapper.findDrawersTriggers()).toHaveLength(1);
   });
 
   test('drawer content lifecycle', async () => {
@@ -488,9 +480,8 @@ describeEachAppLayout(({ size }) => {
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'bbb', ariaLabels: { triggerButton: 'bbb' } });
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'aaa', ariaLabels: { triggerButton: 'aaa' } });
       awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, id: 'ccc', ariaLabels: { triggerButton: 'ccc' } });
-      const { wrapper } = await renderComponent(<AppLayout ariaLabels={{ toolsToggle: 'tools toggle' }} />);
+      const { wrapper } = await renderComponent(<AppLayout />);
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
-        'tools toggle',
         'aaa',
         'bbb',
         'ccc',
@@ -512,9 +503,8 @@ describeEachAppLayout(({ size }) => {
         ariaLabels: { triggerButton: 'ccc' },
         orderPriority: 10,
       });
-      const { wrapper } = await renderComponent(<AppLayout ariaLabels={{ toolsToggle: 'tools toggle' }} />);
+      const { wrapper } = await renderComponent(<AppLayout />);
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([
-        'tools toggle',
         'ccc',
         'aaa',
         'bbb',
@@ -539,7 +529,6 @@ describeEachAppLayout(({ size }) => {
       const { wrapper } = await renderComponent(
         <AppLayout
           drawers={[{ id: 'ddd', trigger: {}, content: null, ariaLabels: { triggerButton: 'ddd', drawerName: 'ddd' } }]}
-          ariaLabels={{ toolsToggle: 'tools toggle' }}
         />
       );
       expect(wrapper.findDrawersTriggers().map(trigger => trigger.getElement().getAttribute('aria-label'))).toEqual([

--- a/src/app-layout/__tests__/use-drawers.test.tsx
+++ b/src/app-layout/__tests__/use-drawers.test.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { TOOLS_DRAWER_ID, useDrawers } from '../../../lib/components/app-layout/utils/use-drawers';
+import { AppLayoutProps } from '../../../lib/components/app-layout';
+import { fireNonCancelableEvent } from '../../../lib/components/internal/events';
+import { testDrawer } from './utils';
+import { awsuiPlugins, awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import { DrawerConfig } from '../../../lib/components/internal/plugins/controllers/drawers';
+
+const someDrawers = [
+  { ...testDrawer, id: 'one' },
+  { ...testDrawer, id: 'two' },
+];
+
+function delay() {
+  return act(() => new Promise(resolve => setTimeout(resolve)));
+}
+
+function TestComponent({
+  ariaLabels,
+  tools,
+  toolsOpen,
+  toolsHide,
+  toolsWidth,
+  onToolsChange,
+  ...rest
+}: AppLayoutProps) {
+  const { drawers } = useDrawers(rest, ariaLabels, {
+    ariaLabels,
+    tools,
+    toolsOpen,
+    toolsHide,
+    toolsWidth: toolsWidth ?? 0,
+    onToolsToggle: open => fireNonCancelableEvent(onToolsChange, { open }),
+  });
+
+  return <ul data-testid="drawers-list">{drawers?.map((drawer, index) => <li key={index}>{drawer.id}</li>)}</ul>;
+}
+
+function findDrawerIds() {
+  return Array.from(document.querySelectorAll('[data-testid="drawers-list"] > li')).map(item => item.textContent);
+}
+
+test('should render own drawers when they are provided', () => {
+  render(<TestComponent drawers={someDrawers} />);
+  expect(findDrawerIds()).toEqual(['one', 'two']);
+});
+
+test('should render nothing by default', () => {
+  render(<TestComponent />);
+  expect(findDrawerIds()).toEqual([]);
+});
+
+test('should render nothing if only tools exist', () => {
+  render(<TestComponent tools="testing" />);
+  expect(findDrawerIds()).toEqual([]);
+});
+
+test('when both tools and drawers are defined, only drawers are used', () => {
+  render(<TestComponent drawers={someDrawers} tools="testing" />);
+  expect(findDrawerIds()).toEqual(['one', 'two']);
+});
+
+describe('when runtime drawers exist', () => {
+  beforeEach(() => {
+    const runtimeDrawerConfig: DrawerConfig = {
+      id: 'test',
+      ariaLabels: {},
+      trigger: { iconSvg: '' },
+      mountContent: () => {},
+      unmountContent: () => {},
+    };
+    awsuiPlugins.appLayout.registerDrawer({ ...runtimeDrawerConfig, id: 'runtime-before', orderPriority: 1 });
+    awsuiPlugins.appLayout.registerDrawer({ ...runtimeDrawerConfig, id: 'runtime-after', orderPriority: -1 });
+  });
+
+  afterEach(() => {
+    awsuiPluginsInternal.appLayout.clearRegisteredDrawers();
+  });
+
+  test('should merge with own drawers', async () => {
+    render(<TestComponent drawers={someDrawers} />);
+    await delay();
+    expect(findDrawerIds()).toEqual(['runtime-before', 'one', 'two', 'runtime-after']);
+  });
+
+  test('should merge with tools', async () => {
+    render(<TestComponent tools="testing" />);
+    await delay();
+    expect(findDrawerIds()).toEqual([TOOLS_DRAWER_ID, 'runtime-before', 'runtime-after']);
+  });
+
+  test('should render standalone', async () => {
+    render(<TestComponent toolsHide={true} />);
+    await delay();
+    expect(findDrawerIds()).toEqual(['runtime-before', 'runtime-after']);
+  });
+});

--- a/src/test-utils/dom/app-layout/index.ts
+++ b/src/test-utils/dom/app-layout/index.ts
@@ -62,7 +62,9 @@ export default class AppLayoutWrapper extends ComponentWrapper {
   }
 
   findDrawersTriggers(): ElementWrapper<HTMLButtonElement>[] {
-    return this.findAllByClassName<HTMLButtonElement>(testutilStyles['drawers-trigger']);
+    return this.findAll<HTMLButtonElement>(
+      `.${testutilStyles['drawers-trigger']}:not([data-testid="awsui-app-layout-trigger-awsui-internal-tools"])`
+    );
   }
 
   findDrawerTriggerById(id: string): ElementWrapper<HTMLButtonElement> | null {


### PR DESCRIPTION
### Description

Preparing test utils for future changes

Related links, issue #, if available: n/a

### How has this been tested?

* PR build
* Did usage assessment, found no one relying on tools drawer to be present in that list

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
