### PR TITLE
fix: Full-page table uses container background colours instead of page background colours

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -143,6 +143,7 @@ export default function InternalContainer({
                   [styles['with-toolbar']]: hasToolbar,
                   [styles['with-hidden-content']]: !children || __hiddenContent,
                   [styles['header-with-media']]: hasMedia,
+                  [styles['header-full-page']]: __fullPage,
                 })}
                 {...stickyStyles}
                 ref={headerMergedRef}

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -123,6 +123,9 @@
   background-color: awsui.$color-background-container-header;
   border-start-start-radius: awsui.$border-radius-container;
   border-start-end-radius: awsui.$border-radius-container;
+  &.header-full-page {
+    background-color: awsui.$color-background-layout-main;
+  }
 
   &.header-with-media {
     background: none;

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -66,6 +66,9 @@
   &-stuck:not(.header-cell-variant-full-page) {
     border-block-end-color: transparent;
   }
+  &-variant-full-page {
+    background: awsui.$color-background-layout-main;
+  }
   &-variant-full-page.header-cell-hidden {
     border-block-end-color: transparent;
   }

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -156,6 +156,9 @@ filter search icon.
   border-end-start-radius: 0;
   border-end-end-radius: 0;
   background: awsui.$color-background-table-header;
+  &.variant-full-page {
+    background: awsui.$color-background-layout-main;
+  }
   &.variant-stacked,
   &.variant-container {
     & > .table {


### PR DESCRIPTION
### Description

This PR updates the colour tokens used for the Table header background. It used to use the Container tokens, even if the table was in the `full-page` variant, which does not have a (visible) container. After this PR, the table uses the page-level colour tokens when it is in the `full-page` variant.

#### Screenshots


Before
![themed before](https://github.com/cloudscape-design/components/assets/9086585/b652c75c-5a1b-4ccb-8d52-1a1a3467d4e7)

After
![themed-after](https://github.com/cloudscape-design/components/assets/9086585/fdf3a544-9f10-4a6a-b809-ae7fa0bfee2d)

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?


Manual testing in the dev pages


<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
