### PR TITLE
fix: Provide aria-rowcount to table even when totalItemsCount is 0

### DIFF
--- a/src/table/__tests__/a11y.test.tsx
+++ b/src/table/__tests__/a11y.test.tsx
@@ -119,6 +119,11 @@ describe('labels', () => {
       expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('301');
     });
 
+    test('aria-rowcount should be set even if totalItemsCount is 0', () => {
+      const wrapper = renderTableWrapper({ totalItemsCount: 0 });
+      expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('1');
+    });
+
     test('aria-rowcount should be -1 if totalItemsCount is undefined', () => {
       const wrapper = renderTableWrapper({});
       expect(wrapper.find('[role=table]')!.getElement().getAttribute('aria-rowcount')).toEqual('-1');

--- a/src/table/table-role/table-role-helper.ts
+++ b/src/table/table-role/table-role-helper.ts
@@ -33,7 +33,7 @@ export function getTableRoleProps(options: {
   nativeProps['aria-labelledby'] = options.ariaLabelledby;
 
   // Incrementing the total count by one to account for the header row.
-  nativeProps['aria-rowcount'] = options.totalItemsCount ? options.totalItemsCount + 1 : -1;
+  nativeProps['aria-rowcount'] = typeof options.totalItemsCount === 'number' ? options.totalItemsCount + 1 : -1;
 
   if (options.tableRole === 'grid' || options.tableRole === 'treegrid') {
     nativeProps['aria-colcount'] = options.totalColumnsCount;


### PR DESCRIPTION
### Description

Valid falsy values strike again! `aria-rowcount` was being set to `-1` (indeterminate), even though the items were very determinately 0.

Related links, issue #, if available: AWSUI-48116

### How has this been tested?

Unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
