### PR TITLE
chore: Update tooltip to accept html attributes

### DIFF
--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -5,8 +5,12 @@ import { render } from '@testing-library/react';
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
 import createWrapper, { ElementWrapper, PopoverWrapper } from '../../../../../lib/components/test-utils/dom';
 import styles from '../../../../../lib/components/popover/styles.selectors.js';
+import tooltipStyles from '../../../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 class TooltipInternalWrapper extends PopoverWrapper {
+  findTooltip(): ElementWrapper | null {
+    return createWrapper().findByClassName(tooltipStyles.root);
+  }
   findContent(): ElementWrapper | null {
     return createWrapper().findByClassName(styles.content);
   }
@@ -20,7 +24,9 @@ class TooltipInternalWrapper extends PopoverWrapper {
 
 const dummyRef = { current: null };
 function renderTooltip(props: Partial<TooltipProps>) {
-  const { container } = render(<Tooltip trackRef={dummyRef} value={props.value ?? ''} />);
+  const { container } = render(
+    <Tooltip trackRef={dummyRef} value={props.value ?? ''} contentAttributes={props.contentAttributes} />
+  );
   return new TooltipInternalWrapper(container);
 }
 
@@ -41,5 +47,11 @@ describe('Tooltip', () => {
     const wrapper = renderTooltip({ value: 'Value' });
 
     expect(wrapper.findHeader()).toBeNull();
+  });
+
+  it('contentAttributes work as expected', () => {
+    const wrapper = renderTooltip({ value: 'Value', contentAttributes: { title: 'test' } });
+
+    expect(wrapper.findTooltip()?.getElement()).toHaveAttribute('title', 'test');
   });
 });

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -13,12 +13,13 @@ import styles from './styles.css.js';
 export interface TooltipProps {
   value: number | string;
   trackRef: React.RefObject<HTMLElement | SVGElement>;
+  contentAttributes?: React.HTMLAttributes<HTMLDivElement>;
 }
 
-export default function Tooltip({ value, trackRef }: TooltipProps) {
+export default function Tooltip({ value, trackRef, contentAttributes = {} }: TooltipProps) {
   return (
     <Portal>
-      <div className={styles.root}>
+      <div className={styles.root} {...contentAttributes}>
         <Transition in={true}>
           {() => (
             <PopoverContainer


### PR DESCRIPTION
### Description

Update tooltip to accept html attributes. Avatar will use it to close the tooltip when tooltip is clicked to have consistency across other tooltip usages (slider, breadcrumb, etc.).

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
