### PR TITLE
fix: Allow controlled state to be resolved asynchronously

### DIFF
--- a/src/internal/hooks/use-controllable/__tests__/use-controllable.test.tsx
+++ b/src/internal/hooks/use-controllable/__tests__/use-controllable.test.tsx
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useImperativeHandle } from 'react';
-import { render, act } from '@testing-library/react';
-import { useControllable } from '../index';
+import { render, act, screen } from '@testing-library/react';
+import { clearMessageCache } from '@cloudscape-design/component-toolkit/internal';
+import { useControllable } from '../../../../../lib/components/internal/hooks/use-controllable';
 
 interface Props {
-  value: string | undefined;
+  value?: string;
   defaultValue: string;
   onChange?: () => void;
 }
@@ -25,26 +26,41 @@ const Component = React.forwardRef(({ value, defaultValue, onChange }: Props, re
     setHookValue,
   }));
 
-  return <span>{hookValue}</span>;
+  return <span data-testid="hook-value">{hookValue}</span>;
 });
 
-let consoleWarnSpy: jest.SpyInstance;
-afterEach(() => {
-  consoleWarnSpy?.mockRestore();
-});
+function getHookValue() {
+  return screen.getByTestId('hook-value').textContent;
+}
 
 describe('useControllable', () => {
-  test('only prints a warning if the property switches from controlled to uncontrolled', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+  beforeEach(() => {
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const onChange = () => void 0;
-    const { container, rerender } = render(
-      <Component value="a value" defaultValue="the default value" onChange={onChange} />
+  });
+
+  afterEach(() => {
+    // ensure there is no any unexpected warnings
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    clearMessageCache();
+  });
+
+  test('prints a warning if the property switches from controlled to uncontrolled only in event handler', () => {
+    const ref = React.createRef<Ref>();
+    const { rerender } = render(
+      <Component ref={ref} value="a value" defaultValue="the default value" onChange={() => {}} />
     );
+    act(() => ref.current!.setHookValue('first change'));
     expect(console.warn).not.toHaveBeenCalled();
 
-    rerender(<Component value={undefined} defaultValue="the default value" onChange={onChange} />);
-    expect(container).toHaveTextContent('');
+    rerender(<Component ref={ref} defaultValue="the default value" />);
+    expect(console.warn).not.toHaveBeenCalled();
 
+    act(() => ref.current!.setHookValue('second change'));
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
       "[AwsUi] [MyComponent] A component tried to change controlled 'value' property to be uncontrolled. " +
@@ -52,16 +68,19 @@ describe('useControllable', () => {
         'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
         'More info: https://fb.me/react-controlled-components'
     );
+    consoleWarnSpy.mockClear();
   });
 
-  test('only prints a warning if the property switches from uncontrolled to controlled', () => {
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const { container, rerender } = render(<Component value={undefined} defaultValue="the default value" />);
+  test('prints a warning if the property switches from uncontrolled to controlled only in event handler', () => {
+    const ref = React.createRef<Ref>();
+    const { rerender } = render(<Component ref={ref} defaultValue="the default value" />);
+    act(() => ref.current!.setHookValue('first change'));
     expect(console.warn).not.toHaveBeenCalled();
 
-    rerender(<Component value="a value" defaultValue="the default value" />);
-    expect(container).toHaveTextContent('the default value');
+    rerender(<Component ref={ref} value="a value" defaultValue="the default value" onChange={() => {}} />);
+    expect(console.warn).not.toHaveBeenCalled();
 
+    act(() => ref.current!.setHookValue('second change'));
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
       "[AwsUi] [MyComponent] A component tried to change uncontrolled 'value' property to be controlled. " +
@@ -69,59 +88,100 @@ describe('useControllable', () => {
         'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
         'More info: https://fb.me/react-controlled-components'
     );
+    consoleWarnSpy.mockClear();
   });
 
   test('prints a warning if the onChange handler is missing', () => {
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     render(<Component value="any value" defaultValue="the default value" />);
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
       '[AwsUi] [MyComponent] You provided a `value` prop without an `onChange` handler. This will render a non-interactive component.'
     );
+    consoleWarnSpy.mockClear();
   });
 
   test('tracks the defaultValue if and only if the component is uncontrolled and unchanged', () => {
     const ref = React.createRef<Ref>();
 
-    const { container, rerender } = render(<Component value={undefined} defaultValue="the default value" ref={ref} />);
-    expect(container).toHaveTextContent('the default value');
+    const { rerender } = render(<Component value={undefined} defaultValue="the default value" ref={ref} />);
+    expect(getHookValue()).toEqual('the default value');
 
     rerender(<Component value={undefined} defaultValue="a different default value" ref={ref} />);
-    expect(container).toHaveTextContent('a different default value');
+    expect(getHookValue()).toEqual('a different default value');
 
     act(() => ref.current!.setHookValue('a value set inside the component'));
-    expect(container).toHaveTextContent('a value set inside the component');
+    expect(getHookValue()).toEqual('a value set inside the component');
 
     rerender(<Component value={undefined} defaultValue="another different default value" />);
-    expect(container).toHaveTextContent('a value set inside the component');
+    expect(getHookValue()).toEqual('a value set inside the component');
   });
 
   test('if property is provided, the component is controlled', () => {
     const ref = React.createRef<Ref>();
 
-    const { container, rerender } = render(<Component value="value one" defaultValue="the default value" ref={ref} />);
-    expect(container).toHaveTextContent('value one');
+    const { rerender } = render(
+      <Component ref={ref} value="value one" defaultValue="the default value" onChange={() => {}} />
+    );
+    expect(getHookValue()).toEqual('value one');
 
-    rerender(<Component value="value two" defaultValue="the default value" ref={ref} />);
-    expect(container).toHaveTextContent('value two');
+    rerender(<Component ref={ref} value="value two" defaultValue="the default value" onChange={() => {}} />);
+    expect(getHookValue()).toEqual('value two');
 
     act(() => ref.current!.setHookValue('a value set from inside the component'));
-    expect(container).toHaveTextContent('value two');
+    expect(getHookValue()).toEqual('value two');
   });
 
-  test('if property is not provided, the component is uncontrolled', () => {
+  test('if property and change handler are not provided, the component is uncontrolled', () => {
     const ref = React.createRef<Ref>();
-    const { container } = render(<Component value={undefined} defaultValue="the default value" ref={ref} />);
-    expect(container).toHaveTextContent('the default value');
+    render(<Component ref={ref} defaultValue="the default value" />);
+    expect(getHookValue()).toEqual('the default value');
 
     act(() => ref.current!.setHookValue('another value'));
-    expect(container).toHaveTextContent('another value');
+    expect(getHookValue()).toEqual('another value');
 
     act(() => ref.current!.setHookValue(oldState => oldState + ' but modified'));
-    expect(container).toHaveTextContent('another value but modified');
+    expect(getHookValue()).toEqual('another value but modified');
 
     act(() => ref.current!.setHookValue(undefined!));
-    expect(container).toHaveTextContent('');
+    expect(getHookValue()).toEqual('');
+  });
+
+  test('if only change handler is provided, the component is uncontrolled', () => {
+    const ref = React.createRef<Ref>();
+    render(<Component ref={ref} defaultValue="the default value" onChange={() => {}} />);
+    expect(getHookValue()).toEqual('the default value');
+
+    act(() => ref.current!.setHookValue('another value'));
+    expect(getHookValue()).toEqual('another value');
+
+    act(() => ref.current!.setHookValue(undefined!));
+    expect(getHookValue()).toEqual('');
+  });
+
+  test('allow async switch to controlled mode', () => {
+    const ref = React.createRef<Ref>();
+    const { rerender } = render(<Component ref={ref} defaultValue="the default value" />);
+    expect(getHookValue()).toEqual('the default value');
+
+    rerender(<Component ref={ref} value="any value" defaultValue="the default value" onChange={() => {}} />);
+    expect(getHookValue()).toEqual('any value');
+
+    act(() => ref.current!.setHookValue('uncontrolled value'));
+    expect(getHookValue()).toEqual('any value');
+  });
+
+  test('allow async switch to uncontrolled mode', () => {
+    const ref = React.createRef<Ref>();
+    const { rerender } = render(
+      <Component ref={ref} value="any value" defaultValue="the default value" onChange={() => {}} />
+    );
+    expect(getHookValue()).toEqual('any value');
+
+    act(() => ref.current!.setHookValue('uncontrolled value'));
+    expect(getHookValue()).toEqual('any value');
+
+    rerender(<Component ref={ref} defaultValue="the default value" />);
+    expect(getHookValue()).toEqual('uncontrolled value');
   });
 });


### PR DESCRIPTION
### Description

Makes this use-case possible

```js
// undefined on initial render
const [navigationOpen, setNavigationOpen] = useState();

useEffect(() => {
   // load preference asynchronously
   fetchNavigationOpenPreference().then(preference => setNavigationOpen(preference));
}, []);

<AppLayout navigationOpen={navigationOpen} onChange={event => setNavigationOpen(event.detail.open)} />
```

Before the change it printed a warning, "A component tried to change uncontrolled 'navigationOpen' property to be controlled". After the change, it is no warning, unless user interacted with the navigation.

Related links, issue #, if available: n/a

### How has this been tested?

Updated unit tests for the new behavior.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
