### PR TITLE
revert: Revert "fix: Full-page table uses container background colours instead of page background colours"

### DIFF
--- a/src/container/internal.tsx
+++ b/src/container/internal.tsx
@@ -143,7 +143,6 @@ export default function InternalContainer({
                   [styles['with-toolbar']]: hasToolbar,
                   [styles['with-hidden-content']]: !children || __hiddenContent,
                   [styles['header-with-media']]: hasMedia,
-                  [styles['header-full-page']]: __fullPage,
                 })}
                 {...stickyStyles}
                 ref={headerMergedRef}

--- a/src/container/styles.scss
+++ b/src/container/styles.scss
@@ -123,9 +123,6 @@
   background-color: awsui.$color-background-container-header;
   border-start-start-radius: awsui.$border-radius-container;
   border-start-end-radius: awsui.$border-radius-container;
-  &.header-full-page {
-    background-color: awsui.$color-background-layout-main;
-  }
 
   &.header-with-media {
     background: none;

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -66,9 +66,6 @@
   &-stuck:not(.header-cell-variant-full-page) {
     border-block-end-color: transparent;
   }
-  &-variant-full-page {
-    background: awsui.$color-background-layout-main;
-  }
   &-variant-full-page.header-cell-hidden {
     border-block-end-color: transparent;
   }

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -156,9 +156,6 @@ filter search icon.
   border-end-start-radius: 0;
   border-end-end-radius: 0;
   background: awsui.$color-background-table-header;
-  &.variant-full-page {
-    background: awsui.$color-background-layout-main;
-  }
   &.variant-stacked,
   &.variant-container {
     & > .table {


### PR DESCRIPTION
Reverts cloudscape-design/components#2398