### PR TITLE
chore: Make deprecation of i18nStrings.filtering* in property filter clearer in the docs

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -11450,7 +11450,10 @@ operations are communicated to the user in another way.",
       "type": "boolean",
     },
     Object {
-      "description": "An object containing all the necessary localized strings required by the component.",
+      "description": "An object containing all the necessary localized strings required by the component.
+The properties \`filteringAriaLabel\` and \`filteringPlaceholder\` on \`i18nStrings\` are deprecated.
+Provide these properties at the top-level instead.
+",
       "i18nTag": true,
       "inlineType": Object {
         "name": "PropertyFilterProps.I18nStrings",

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -30,6 +30,10 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   disabled?: boolean;
   /**
    * An object containing all the necessary localized strings required by the component.
+   *
+   * The properties `filteringAriaLabel` and `filteringPlaceholder` on `i18nStrings` are deprecated.
+   * Provide these properties at the top-level instead.
+   *
    * @i18n
    */
   i18nStrings?: PropertyFilterProps.I18nStrings;


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
