### PR TITLE
test: Add visual regression coverage for borderless table inside container with paddings

### DIFF
--- a/pages/table/variants.page.tsx
+++ b/pages/table/variants.page.tsx
@@ -53,7 +53,18 @@ export default function () {
             </SpaceBetween>
           </ExpandableSection>
           <div>
-            <Container disableContentPaddings={true} header={<Header>Container with borderless table</Header>}>
+            <Container
+              disableContentPaddings={true}
+              header={<Header>Container (without paddings) with borderless table</Header>}
+            >
+              <BorderlessTable />
+            </Container>
+          </div>
+          <div>
+            <Container
+              disableContentPaddings={false}
+              header={<Header>Container (with paddings) with borderless table</Header>}
+            >
               <BorderlessTable />
             </Container>
           </div>


### PR DESCRIPTION
### Description

Borderless table in Visual Refresh does not include its own internal paddings so the padding needs to be provided by the container, whereas in Classic the padding from the container needs to be removed.

We have visual regression test for a borderless table inside a container with `disableContentPaddings={true}`, which is how it is supposed to be used in Classic, but not inside a container with `disableContentPaddings={false}` (or without `disableContentPaddings` set), which is how it is supposed to be used in Visual Refresh.

### How has this been tested?

Existing visual regression tests in the pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
