### PR TITLE
feat: Support breadcrumb instances deduplication

### DIFF
--- a/pages/app-layout/global-breadcrumbs.page.tsx
+++ b/pages/app-layout/global-breadcrumbs.page.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import AppLayout from '~components/app-layout';
+import SpaceBetween from '~components/space-between';
+import labels from './utils/labels';
+import BreadcrumbGroup from '~components/breadcrumb-group';
+
+export default function () {
+  const [extraBreadcrumb, setExtraBreadcrumb] = useState(false);
+  return (
+    <AppLayout
+      ariaLabels={labels}
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: 'Default', href: '#' },
+            { text: 'one', href: '#' },
+          ]}
+        />
+      }
+      content={
+        <SpaceBetween size="m">
+          <h1>Page with additional breadcrumbs</h1>
+          <label>
+            <input
+              type="checkbox"
+              data-testid="toggle-extra-breadcrumb"
+              onChange={event => setExtraBreadcrumb(event.target.checked)}
+            />{' '}
+            Extra breadcrumb
+          </label>
+          {extraBreadcrumb && (
+            <BreadcrumbGroup
+              items={[
+                { text: 'Dynamic', href: '#' },
+                { text: 'instance', href: '#' },
+              ]}
+            />
+          )}
+        </SpaceBetween>
+      }
+    />
+  );
+}

--- a/src/app-layout/__integ__/global-breadcrumbs.test.ts
+++ b/src/app-layout/__integ__/global-breadcrumbs.test.ts
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper();
+
+class GlobalBreadcrumbsPage extends BasePageObject {
+  getBreadcrumbsCount() {
+    return this.getElementsCount(wrapper.findBreadcrumbGroup().toSelector());
+  }
+
+  getRootBreadcrumbText() {
+    return this.getText(
+      wrapper.findAppLayout().findBreadcrumbs().findBreadcrumbGroup().findBreadcrumbLink(1).toSelector()
+    );
+  }
+
+  async toggleExtraBreadcrumb() {
+    await this.click('[data-testid="toggle-extra-breadcrumb"]');
+  }
+}
+
+describe.each(['classic', 'visual-refresh'])('%s', theme => {
+  test(
+    'does not work in this design',
+    useBrowser(async browser => {
+      const page = new GlobalBreadcrumbsPage(browser);
+      await browser.url(
+        `#/light/app-layout/global-breadcrumbs/?visualRefresh=${theme === 'visual-refresh' ? 'true' : 'false'}`
+      );
+      await expect(page.getRootBreadcrumbText()).resolves.toEqual('Default');
+      await expect(page.getBreadcrumbsCount()).resolves.toEqual(1);
+
+      await page.toggleExtraBreadcrumb();
+      await expect(page.getRootBreadcrumbText()).resolves.toEqual('Default');
+      await expect(page.getBreadcrumbsCount()).resolves.toEqual(2);
+    })
+  );
+});
+
+describe('visual-refresh-toolbar', () => {
+  test(
+    'deduplicates breadcrumbs',
+    useBrowser(async browser => {
+      const page = new GlobalBreadcrumbsPage(browser);
+      await browser.url(`#/light/app-layout/global-breadcrumbs/?visualRefresh=true&appLayoutWidget=true`);
+      await expect(page.getRootBreadcrumbText()).resolves.toEqual('Default');
+      await expect(page.getBreadcrumbsCount()).resolves.toEqual(1);
+
+      await page.toggleExtraBreadcrumb();
+      await expect(page.getRootBreadcrumbText()).resolves.toEqual('Dynamic');
+      await expect(page.getBreadcrumbsCount()).resolves.toEqual(1);
+
+      await page.toggleExtraBreadcrumb();
+      await expect(page.getRootBreadcrumbText()).resolves.toEqual('Default');
+      await expect(page.getBreadcrumbsCount()).resolves.toEqual(1);
+    })
+  );
+});

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -1,0 +1,217 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+import { act, render, cleanup, waitFor } from '@testing-library/react';
+import { describeEachAppLayout } from './utils';
+import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
+import AppLayout from '../../../lib/components/app-layout';
+import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
+import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+
+const wrapper = createWrapper();
+
+const defaultBreadcrumbs: Array<BreadcrumbGroupProps.Item> = [
+  { text: 'Home', href: '/home' },
+  { text: 'Page', href: '/home/page' },
+];
+
+function findAllBreadcrumbsInstances() {
+  return wrapper.findAllByClassName(BreadcrumbGroupWrapper.rootSelector);
+}
+
+function findAppLayoutBreadcrumbItems() {
+  return wrapper.findAppLayout()!.findBreadcrumbs()!.findBreadcrumbGroup()!.findBreadcrumbLinks();
+}
+
+function findRootBreadcrumb() {
+  return wrapper.findAppLayout()!.findBreadcrumbs()!.findBreadcrumbGroup()!.findBreadcrumbLink(1)!;
+}
+
+function renderAsync(jsx: React.ReactElement) {
+  render(jsx);
+  // longer than a setTimeout(..., 0) used inside the implementation
+  return act(() => new Promise(resolve => setTimeout(resolve, 10)));
+}
+
+afterEach(() => {
+  // force unmount for all rendered component to run clean state assertions
+  cleanup();
+  const state = awsuiPluginsInternal.breadcrumbs.getStateForTesting();
+  expect(state).toEqual({
+    appLayoutUpdateCallback: null,
+    breadcrumbInstances: [],
+    breadcrumbRegistrations: [],
+  });
+});
+
+describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+  test('renders normal breadcrumbs when no app layout is present', async () => {
+    await renderAsync(<BreadcrumbGroup items={defaultBreadcrumbs} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
+  });
+
+  test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
+    await renderAsync(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+  });
+
+  test('no relocation happens on the initial render', () => {
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+  });
+
+  test('renders breadcrumbs adjacent to app layout', async () => {
+    await renderAsync(
+      <>
+        <AppLayout />
+        <BreadcrumbGroup items={defaultBreadcrumbs} />
+      </>
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+  });
+
+  test('renders breadcrumbs inside app layout content slot', async () => {
+    await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+  });
+
+  test('event handlers work for relocated breadcrumbs', async () => {
+    const onFollow = jest.fn(event => event.preventDefault());
+    await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
+    findRootBreadcrumb().click();
+    expect(onFollow).toHaveBeenCalledTimes(1);
+    expect(onFollow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ href: '/home', text: 'Home' }),
+      })
+    );
+  });
+
+  test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
+    await renderAsync(
+      <AppLayout
+        breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
+        content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
+      />
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+    expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+  });
+
+  test('when multiple breadcrumbs instances are present the latest is applied', async () => {
+    await renderAsync(
+      <AppLayout
+        content={
+          <>
+            <BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />
+            <BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />
+          </>
+        }
+      />
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+    expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+  });
+
+  test('when multiple app layouts rendered, only the first instance receives breadcrumbs', async () => {
+    await renderAsync(
+      <>
+        <AppLayout data-testid="first" />
+        <AppLayout data-testid="second" content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />
+      </>
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(
+      wrapper
+        .find('[data-testid="first"]')!
+        .findAppLayout()!
+        .findBreadcrumbs()!
+        .findBreadcrumbGroup()!
+        .findBreadcrumbLinks()
+    ).toHaveLength(2);
+    expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+  });
+
+  test('updates when a single breadcrumbs instance changes', async () => {
+    function DynamicBreadcrumb() {
+      const [changed, setChanged] = useState(false);
+      return (
+        <>
+          <button data-testid="change-button" onClick={() => setChanged(true)}>
+            Change
+          </button>
+          <BreadcrumbGroup items={[{ text: changed ? 'Changed' : 'Original', href: '/home' }]} />
+        </>
+      );
+    }
+    await renderAsync(<AppLayout content={<DynamicBreadcrumb />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
+
+    wrapper.find('[data-testid="change-button"]')!.click();
+    await waitFor(() => {
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Changed');
+    });
+  });
+
+  test('updates when a new breadcrumb instance mounts and unmounts', async () => {
+    function ConditionalBreadcrumb() {
+      const [rendered, setRendered] = useState(false);
+      return (
+        <>
+          <label>
+            <input
+              data-testid="render-toggle"
+              type="checkbox"
+              checked={rendered}
+              onChange={event => setRendered(event.target.checked)}
+            />
+            Render
+          </label>
+          {rendered ? <BreadcrumbGroup items={[{ text: 'Conditional', href: '/home' }]} /> : null}
+        </>
+      );
+    }
+    await renderAsync(
+      <AppLayout
+        content={
+          <>
+            <BreadcrumbGroup items={[{ text: 'Static', href: '/home' }]} />
+            <ConditionalBreadcrumb />
+          </>
+        }
+      />
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+
+    wrapper.find('[data-testid="render-toggle"]')!.click();
+    await waitFor(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Conditional');
+    });
+
+    wrapper.find('[data-testid="render-toggle"]')!.click();
+    await waitFor(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+    });
+  });
+});
+
+describe('without feature flag', () => {
+  test('breadcrumbs are not globalized', async () => {
+    await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -24,6 +24,7 @@ import {
   AppLayoutToolbar,
 } from './internal';
 import { AppLayoutInternals } from './interfaces';
+import { useGetGlobalBreadcrumbs } from '../../internal/plugins/helpers/use-global-breadcrumbs';
 
 const AppLayoutVisualRefreshToolbar = React.forwardRef(
   (
@@ -176,9 +177,16 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef(
       splitPanelPosition: splitPanelPreferences?.position,
     });
 
-    const hasToolbar =
+    const discoveredBreadcrumbs = useGetGlobalBreadcrumbs();
+
+    const hasToolbar = Boolean(
       !embeddedViewMode &&
-      (!!resolvedNavigation || !!breadcrumbs || splitPanelToggleConfig.displayed || drawers!.length > 0);
+        (resolvedNavigation ||
+          breadcrumbs ||
+          discoveredBreadcrumbs ||
+          splitPanelToggleConfig.displayed ||
+          drawers!.length > 0)
+    );
 
     const verticalOffsets = computeVerticalLayout({
       topOffset: placement.insetBlockStart,
@@ -193,6 +201,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef(
       headerVariant,
       isMobile,
       breadcrumbs,
+      discoveredBreadcrumbs,
       stickyNotifications,
       navigationOpen,
       navigation: resolvedNavigation,

--- a/src/app-layout/visual-refresh-toolbar/interfaces.ts
+++ b/src/app-layout/visual-refresh-toolbar/interfaces.ts
@@ -6,6 +6,7 @@ import { AppLayoutProps, AppLayoutPropsWithDefaults } from '../interfaces';
 import { FocusControlState } from '../utils/use-focus-control';
 import { SplitPanelFocusControlState } from '../utils/use-split-panel-focus-control';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
+import { BreadcrumbGroupProps } from '../../breadcrumb-group/interfaces';
 import { VerticalLayoutOutput } from './compute-layout';
 
 // Widgetization notice: structures in this file are shared multiple app layout instances, possibly different minor versions.
@@ -31,6 +32,7 @@ export interface AppLayoutInternals {
   drawersFocusControl: FocusControlState;
   stickyNotifications: AppLayoutPropsWithDefaults['stickyNotifications'];
   breadcrumbs: React.ReactNode;
+  discoveredBreadcrumbs: BreadcrumbGroupProps | null;
   toolbarState: 'show' | 'hide';
   setToolbarState: (state: 'show' | 'hide') => void;
   verticalOffsets: VerticalLayoutOutput;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -10,6 +10,7 @@ import { ToolbarSlot } from '../skeleton/slot-wrappers';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutInternals } from '../interfaces';
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
+import { InternalBreadcrumbGroup } from '../../../breadcrumb-group/internal';
 
 interface AppLayoutToolbarImplementationProps {
   appLayoutInternals: AppLayoutInternals;
@@ -19,6 +20,7 @@ export function AppLayoutToolbarImplementation({ appLayoutInternals }: AppLayout
   const {
     ariaLabels,
     breadcrumbs,
+    discoveredBreadcrumbs,
     activeDrawer,
     drawers,
     drawersFocusControl,
@@ -106,8 +108,11 @@ export function AppLayoutToolbarImplementation({ appLayoutInternals }: AppLayout
             />
           </nav>
         )}
-        {breadcrumbs && (
-          <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>{breadcrumbs}</div>
+        {(breadcrumbs || discoveredBreadcrumbs) && (
+          <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
+            {breadcrumbs}
+            {discoveredBreadcrumbs && <InternalBreadcrumbGroup {...discoveredBreadcrumbs} />}
+          </div>
         )}
         {(drawers.length > 0 || splitPanelToggleConfig.displayed) && (
           <span className={clsx(styles['universal-toolbar-drawers'])}>

--- a/src/breadcrumb-group/index.tsx
+++ b/src/breadcrumb-group/index.tsx
@@ -5,6 +5,7 @@ import { BreadcrumbGroupProps } from './interfaces';
 import { applyDisplayName } from '../internal/utils/apply-display-name.js';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { InternalBreadcrumbGroup } from './internal';
+import { useSetGlobalBreadcrumbs } from '../internal/plugins/helpers/use-global-breadcrumbs';
 
 export { BreadcrumbGroupProps };
 
@@ -12,7 +13,13 @@ export default function BreadcrumbGroup<T extends BreadcrumbGroupProps.Item = Br
   items = [],
   ...props
 }: BreadcrumbGroupProps<T>) {
+  const registeredGlobally = useSetGlobalBreadcrumbs({ items, ...props });
   const baseComponentProps = useBaseComponent('BreadcrumbGroup');
+
+  if (registeredGlobally) {
+    return <></>;
+  }
+
   return <InternalBreadcrumbGroup items={items} {...props} {...baseComponentProps} />;
 }
 

--- a/src/internal/plugins/api.ts
+++ b/src/internal/plugins/api.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { DrawersApiInternal, DrawersApiPublic, DrawersController } from './controllers/drawers';
 import { ActionsApiInternal, ActionsApiPublic, ActionButtonsController } from './controllers/action-buttons';
+import { BreadcrumbsApiInternal, BreadcrumbsController } from './controllers/breadcrumbs';
+import { BreadcrumbGroupProps } from '../../breadcrumb-group/interfaces';
 
 const storageKey = Symbol.for('awsui-plugin-api');
 
@@ -15,6 +17,7 @@ interface AwsuiApi {
     appLayout: DrawersApiInternal;
     alert: ActionsApiInternal;
     flashbar: ActionsApiInternal;
+    breadcrumbs: BreadcrumbsApiInternal<BreadcrumbGroupProps>;
   };
 }
 
@@ -69,6 +72,9 @@ function installApi(api: DeepPartial<AwsuiApi>): AwsuiApi {
   const flashbarActions = new ActionButtonsController();
   api.awsuiPlugins.flashbar = flashbarActions.installPublic(api.awsuiPlugins.flashbar);
   api.awsuiPluginsInternal.flashbar = flashbarActions.installInternal(api.awsuiPluginsInternal.flashbar);
+
+  const breadcrumbs = new BreadcrumbsController<BreadcrumbGroupProps>();
+  api.awsuiPluginsInternal.breadcrumbs = breadcrumbs.installInternal(api.awsuiPluginsInternal.breadcrumbs);
 
   return api as AwsuiApi;
 }

--- a/src/internal/plugins/controllers/breadcrumbs.ts
+++ b/src/internal/plugins/controllers/breadcrumbs.ts
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import debounce from '../../debounce';
+
+type ChangeCallback<T> = (props: T | null) => void;
+
+export interface BreadcrumbsGlobalRegistration<T> {
+  update(props: T): void;
+  cleanup(): void;
+}
+
+export interface BreadcrumbsApiInternal<T> {
+  registerAppLayout: (changeCallback: ChangeCallback<T>) => (() => void) | void;
+  registerBreadcrumbs: (props: T, onRegistered: () => void) => BreadcrumbsGlobalRegistration<T>;
+  getStateForTesting: () => {
+    appLayoutUpdateCallback: ChangeCallback<T> | null;
+    breadcrumbInstances: Array<{ props: T }>;
+    breadcrumbRegistrations: Array<() => void>;
+  };
+}
+
+export class BreadcrumbsController<T> {
+  #appLayoutUpdateCallback: ChangeCallback<T> | null = null;
+  #breadcrumbInstances: Array<{ props: T }> = [];
+  #breadcrumbRegistrations: Array<() => void> = [];
+
+  #notifyAppLayout = debounce(() => {
+    if (!this.#appLayoutUpdateCallback) {
+      return;
+    }
+    const latestBreadcrumb = this.#breadcrumbInstances[this.#breadcrumbInstances.length - 1];
+    this.#appLayoutUpdateCallback(latestBreadcrumb?.props ?? null);
+  }, 0);
+
+  #notifyBreadcrumbs = debounce(() => {
+    if (!this.#appLayoutUpdateCallback) {
+      return;
+    }
+    this.#breadcrumbRegistrations.forEach(listener => listener());
+  }, 0);
+
+  registerAppLayout = (changeCallback: ChangeCallback<T>) => {
+    if (this.#appLayoutUpdateCallback) {
+      return;
+    }
+    this.#appLayoutUpdateCallback = changeCallback;
+    this.#notifyBreadcrumbs();
+    return () => {
+      this.#appLayoutUpdateCallback = null;
+    };
+  };
+
+  registerBreadcrumbs = (props: T, onRegistered: () => void): BreadcrumbsGlobalRegistration<T> => {
+    const instance = { props: props };
+    this.#breadcrumbInstances.push(instance);
+    this.#breadcrumbRegistrations.push(onRegistered);
+    this.#notifyBreadcrumbs();
+    this.#notifyAppLayout();
+    return {
+      update: props => {
+        instance.props = props;
+        this.#notifyAppLayout();
+      },
+      cleanup: () => {
+        this.#breadcrumbInstances.splice(this.#breadcrumbInstances.indexOf(instance), 1);
+        this.#breadcrumbRegistrations.splice(this.#breadcrumbRegistrations.indexOf(onRegistered), 1);
+        this.#notifyAppLayout();
+      },
+    };
+  };
+
+  getStateForTesting = () => {
+    return {
+      appLayoutUpdateCallback: this.#appLayoutUpdateCallback,
+      breadcrumbInstances: this.#breadcrumbInstances,
+      breadcrumbRegistrations: this.#breadcrumbRegistrations,
+    };
+  };
+
+  installInternal(internalApi: Partial<BreadcrumbsApiInternal<T>> = {}): BreadcrumbsApiInternal<T> {
+    internalApi.registerBreadcrumbs ??= this.registerBreadcrumbs;
+    internalApi.registerAppLayout ??= this.registerAppLayout;
+    internalApi.getStateForTesting ??= this.getStateForTesting;
+
+    return internalApi as BreadcrumbsApiInternal<T>;
+  }
+}

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { awsuiPluginsInternal } from '../api';
+import { getGlobalFlag } from '../../utils/global-flags';
+import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
+import { BreadcrumbsGlobalRegistration } from '../controllers/breadcrumbs';
+
+function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>) {
+  const registrationRef = useRef<BreadcrumbsGlobalRegistration<BreadcrumbGroupProps> | null>();
+  const [registered, setRegistered] = useState(false);
+
+  useEffect(() => {
+    const registration = awsuiPluginsInternal.breadcrumbs.registerBreadcrumbs(props, () => setRegistered(true));
+    registrationRef.current = registration;
+
+    return () => {
+      registration.cleanup();
+    };
+    // subsequent prop changes are handled by another effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useLayoutEffect(() => {
+    registrationRef.current?.update(props);
+  });
+
+  return registered;
+}
+
+export function useSetGlobalBreadcrumbs<T extends BreadcrumbGroupProps.Item>(props: BreadcrumbGroupProps<T>) {
+  // avoid additional side effects when this feature is not active
+  if (!getGlobalFlag('appLayoutWidget')) {
+    return false;
+  }
+  // getGlobalFlag() value does not change without full page reload
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useSetGlobalBreadcrumbsImplementation(props);
+}
+
+export function useGetGlobalBreadcrumbs() {
+  const [discoveredBreadcrumbs, setDiscoveredBreadcrumbs] = useState<BreadcrumbGroupProps<any> | null>(null);
+
+  useEffect(() => {
+    return awsuiPluginsInternal.breadcrumbs.registerAppLayout(breadcrumbs => {
+      setDiscoveredBreadcrumbs(breadcrumbs);
+    });
+  }, []);
+
+  return discoveredBreadcrumbs;
+}


### PR DESCRIPTION
### Description

Deduplicate multiple `BreadcrumbGroup` instances across the page and render only one inside the respective app layout slot. Only behind `appLayoutWidget` feature flag, not for production use.

```js
<AppLayout
   breadcrumbs={null}
   content={<>
       <BreadcrumbGroup /> // this one will be rendered in the intended place, even if it did not use the slot
   </>}
/>
```

See the tests for more details about order resolution and other corner-cases.

Related links, issue #, if available: n/a

### How has this been tested?

Added unit and integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
