### PR TITLE
revert: Allow release workflow for dev branch with slashes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - 'dev-v3-**'
+      - 'dev-v3-*'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Reverts cloudscape-design/components#2420

Our release infra does not support slashes