### PR TITLE
chore: Make notification grey token public

### DIFF
--- a/src/__tests__/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/__snapshots__/design-tokens.test.ts.snap
@@ -300,6 +300,13 @@ Object {
             "light": "#1d8102",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#687078",
+            "light": "#545b64",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -2649,6 +2656,13 @@ Object {
           "$value": Object {
             "dark": "#1d8102",
             "light": "#1d8102",
+          },
+        },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#687078",
+            "light": "#545b64",
           },
         },
         "color-background-notification-red": Object {
@@ -5002,6 +5016,13 @@ Object {
             "light": "#1d8102",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#687078",
+            "light": "#545b64",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -7351,6 +7372,13 @@ Object {
           "$value": Object {
             "dark": "#1d8102",
             "light": "#1d8102",
+          },
+        },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#687078",
+            "light": "#545b64",
           },
         },
         "color-background-notification-red": Object {
@@ -9704,6 +9732,13 @@ Object {
             "light": "#1d8102",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#687078",
+            "light": "#687078",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -12053,6 +12088,13 @@ Object {
       "$value": Object {
         "dark": "#1d8102",
         "light": "#1d8102",
+      },
+    },
+    "color-background-notification-grey": Object {
+      "$description": "Background color for grey notifications. For example: grey badges.",
+      "$value": Object {
+        "dark": "#687078",
+        "light": "#545b64",
       },
     },
     "color-background-notification-red": Object {
@@ -14411,6 +14453,13 @@ Object {
             "light": "#037f0c",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#414d5c",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -16760,6 +16809,13 @@ Object {
           "$value": Object {
             "dark": "#037f0c",
             "light": "#037f0c",
+          },
+        },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#5f6b7a",
           },
         },
         "color-background-notification-red": Object {
@@ -19113,6 +19169,13 @@ Object {
             "light": "#037f0c",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#414d5c",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -21462,6 +21525,13 @@ Object {
           "$value": Object {
             "dark": "#037f0c",
             "light": "#037f0c",
+          },
+        },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#414d5c",
           },
         },
         "color-background-notification-red": Object {
@@ -23815,6 +23885,13 @@ Object {
             "light": "#037f0c",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#414d5c",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -26164,6 +26241,13 @@ Object {
           "$value": Object {
             "dark": "#037f0c",
             "light": "#037f0c",
+          },
+        },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#5f6b7a",
           },
         },
         "color-background-notification-red": Object {
@@ -28517,6 +28601,13 @@ Object {
             "light": "#037f0c",
           },
         },
+        "color-background-notification-grey": Object {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": Object {
+            "dark": "#5f6b7a",
+            "light": "#5f6b7a",
+          },
+        },
         "color-background-notification-red": Object {
           "$description": "Background color for red notifications. For example: red badges and error flash messages.",
           "$value": Object {
@@ -30866,6 +30957,13 @@ Object {
       "$value": Object {
         "dark": "#037f0c",
         "light": "#037f0c",
+      },
+    },
+    "color-background-notification-grey": Object {
+      "$description": "Background color for grey notifications. For example: grey badges.",
+      "$value": Object {
+        "dark": "#5f6b7a",
+        "light": "#414d5c",
       },
     },
     "color-background-notification-red": Object {

--- a/style-dictionary/visual-refresh/metadata/colors.ts
+++ b/style-dictionary/visual-refresh/metadata/colors.ts
@@ -182,6 +182,11 @@ const metadata: StyleDictionary.MetadataIndex = {
     public: true,
     themeable: true,
   },
+  colorBackgroundNotificationGrey: {
+    description: 'Background color for grey notifications. For example: grey badges.',
+    public: true,
+    themeable: true,
+  },
   colorBackgroundPopover: {
     description: 'Background color for the popover container.',
     public: true,


### PR DESCRIPTION
### Description

Making the notification grey design token public.
Related links, issue #, if available:

AWSUI-48766

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
