### PR TITLE
fix: Use consistent link styles when href is present or not

### DIFF
--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -11,7 +11,6 @@ import { KeyCode } from '../internal/keycode';
 import { LinkProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
-import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { useInternalI18n } from '../i18n/context';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
@@ -30,7 +29,7 @@ import { useSingleTabStopNavigation } from '../internal/context/single-tab-stop-
 
 type InternalLinkProps = InternalBaseComponentProps<HTMLAnchorElement> &
   Omit<LinkProps, 'variant'> & {
-    variant?: LinkProps['variant'] | 'top-navigation' | 'link' | 'recovery';
+    variant?: LinkProps['variant'] | 'top-navigation' | 'recovery';
   };
 
 const InternalLink = React.forwardRef(
@@ -57,8 +56,6 @@ const InternalLink = React.forwardRef(
     const isButton = !href;
     const { defaultVariant } = useContext(LinkDefaultVariantContext);
     const variant = providedVariant || defaultVariant;
-    const specialStyles = ['top-navigation', 'link', 'recovery'];
-    const hasSpecialStyle = specialStyles.indexOf(variant) > -1;
 
     const i18n = useInternalI18n('link');
     const baseProps = getBaseProps(props);
@@ -151,11 +148,7 @@ const InternalLink = React.forwardRef(
     };
 
     const linkRef = useRef<HTMLElement>(null);
-    const isVisualRefresh = useVisualRefresh();
     useForwardFocus(ref, linkRef);
-
-    // Visual refresh should only add styles to buttons that don't already have unique styles (e.g. primary/secondary variants)
-    const applyButtonStyles = isButton && isVisualRefresh && !hasSpecialStyle;
 
     const sharedProps = {
       id: linkId,
@@ -165,7 +158,6 @@ const InternalLink = React.forwardRef(
       className: clsx(
         styles.link,
         baseProps.className,
-        applyButtonStyles ? styles.button : null,
         styles[getVariantStyle(variant)],
         styles[getFontSizeStyle(variant, fontSize)],
         styles[getColorStyle(variant, color)]

--- a/src/link/styles.scss
+++ b/src/link/styles.scss
@@ -28,17 +28,11 @@
     }
   }
 
-  &.button {
-    @include styles.font-smoothing;
-    @include styles.link-variant-style(map.get(constants.$link-styles, 'button'));
-  }
-
   &.color-inverted {
     color: awsui.$color-text-notification-default;
-    &:not(.button) {
-      text-decoration-line: underline;
-      text-decoration-color: currentColor;
-    }
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+
     &:hover {
       color: awsui.$color-text-link-inverted-hover;
     }

--- a/src/s3-resource-selector/s3-modal/buckets-table.tsx
+++ b/src/s3-resource-selector/s3-modal/buckets-table.tsx
@@ -83,7 +83,7 @@ export function BucketsTable({
           cell: item => {
             const isClickable = includes(selectableItemsTypes, 'objects') || includes(selectableItemsTypes, 'versions');
             return isClickable ? (
-              <InternalLink onFollow={() => item.Name && onDrilldown(item.Name)} variant="link">
+              <InternalLink onFollow={() => item.Name && onDrilldown(item.Name)} variant="secondary">
                 {item.Name}
               </InternalLink>
             ) : (

--- a/src/s3-resource-selector/s3-modal/objects-table.tsx
+++ b/src/s3-resource-selector/s3-modal/objects-table.tsx
@@ -95,7 +95,7 @@ export function ObjectsTable({
               <>
                 <InternalIcon name={item.IsFolder ? 'folder' : 'file'} />{' '}
                 {isClickable ? (
-                  <InternalLink onFollow={() => item.Key && onDrilldown(item)} variant="link">
+                  <InternalLink onFollow={() => item.Key && onDrilldown(item)} variant="secondary">
                     {item.Key}
                   </InternalLink>
                 ) : (


### PR DESCRIPTION
### Description

Make sure `<Link>` component looks the same whether the `href` is set or not.

For the former `<Link href={undefined}>` styling, use `<Button variant="inline-link">`

Related links, issue #, if available: n/a

### How has this been tested?

* Locally checked pages using the link component
* Screenshot tests in my pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
