### PR TITLE
feat: Allow multiple app layouts rendered on a page (feature-flag only)

### DIFF
--- a/pages/app-layout/multi-layout-simple.page.tsx
+++ b/pages/app-layout/multi-layout-simple.page.tsx
@@ -7,7 +7,7 @@ import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import { Containers, Navigation, Tools } from './utils/content-blocks';
+import { Breadcrumbs, Containers, Navigation, Tools } from './utils/content-blocks';
 import labels from './utils/labels';
 import * as toolsContent from './utils/tools-content';
 
@@ -24,6 +24,7 @@ export default function () {
           <AppLayout
             data-testid="secondary-layout"
             ariaLabels={labels}
+            breadcrumbs={<Breadcrumbs />}
             navigationHide={true}
             content={
               <SpaceBetween size="s">

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -69,6 +69,13 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
   });
 
+  test('no relocation happens on the initial render', () => {
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+  });
+
   test('renders breadcrumbs adjacent to app layout', async () => {
     await renderAsync(
       <>

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -16,6 +16,13 @@ const defaultBreadcrumbs: Array<BreadcrumbGroupProps.Item> = [
   { text: 'Page', href: '/home/page' },
 ];
 
+const defaultAppLayoutProps = {
+  // Suppress warning in runtime drawers API
+  __disableRuntimeDrawers: true,
+  // Suppress warning about duplicate tools which are rendered by default
+  toolsHide: true,
+};
+
 function findAllBreadcrumbsInstances() {
   return wrapper.findAllByClassName(BreadcrumbGroupWrapper.rootSelector);
 }
@@ -28,10 +35,14 @@ function findRootBreadcrumb() {
   return wrapper.findAppLayout()!.findBreadcrumbs()!.findBreadcrumbGroup()!.findBreadcrumbLink(1)!;
 }
 
-function renderAsync(jsx: React.ReactElement) {
-  render(jsx);
+function delay() {
   // longer than a setTimeout(..., 0) used inside the implementation
   return act(() => new Promise(resolve => setTimeout(resolve, 10)));
+}
+
+function renderAsync(jsx: React.ReactElement) {
+  render(jsx);
+  return delay();
 }
 
 afterEach(() => {
@@ -56,13 +67,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     await renderAsync(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-  });
-
-  test('no relocation happens on the initial render', () => {
-    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-    expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
-    expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
   });
 
   test('renders breadcrumbs adjacent to app layout', async () => {
@@ -122,23 +126,54 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
   });
 
-  test('when multiple app layouts rendered, only the first instance receives breadcrumbs', async () => {
+  test('when multiple app layouts rendered, only the last instance receives breadcrumbs', async () => {
     await renderAsync(
       <>
-        <AppLayout data-testid="first" />
-        <AppLayout data-testid="second" content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />
+        <AppLayout {...defaultAppLayoutProps} data-testid="first" />
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="second"
+          content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+        />
       </>
     );
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.find('[data-testid="first"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
     expect(
       wrapper
-        .find('[data-testid="first"]')!
+        .find('[data-testid="second"]')!
         .findAppLayout()!
         .findBreadcrumbs()!
         .findBreadcrumbGroup()!
         .findBreadcrumbLinks()
     ).toHaveLength(2);
-    expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+  });
+
+  test('when multiple nested app layouts rendered, the inner instance receives breadcrumbs', async () => {
+    await renderAsync(
+      <>
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="first"
+          content={
+            <AppLayout
+              {...defaultAppLayoutProps}
+              data-testid="second"
+              breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+            />
+          }
+        />
+      </>
+    );
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(
+      wrapper
+        .find('[data-testid="second"]')!
+        .findAppLayout()!
+        .findBreadcrumbs()!
+        .findBreadcrumbGroup()!
+        .findBreadcrumbLinks()
+    ).toHaveLength(2);
   });
 
   test('updates when a single breadcrumbs instance changes', async () => {

--- a/src/app-layout/__tests__/multi-layout.test.tsx
+++ b/src/app-layout/__tests__/multi-layout.test.tsx
@@ -1,0 +1,234 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+/* eslint-disable simple-import-sort/imports */
+import React from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+
+import { clearMessageCache } from '@cloudscape-design/component-toolkit/internal';
+
+import { describeEachAppLayout, isDrawerClosed, testDrawer } from './utils';
+
+import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
+import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import SplitPanel from '../../../lib/components/split-panel';
+import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
+
+import appLayoutToolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.css.js';
+
+function findToolbar(wrapper: AppLayoutWrapper) {
+  return wrapper.findByClassName(appLayoutToolbarStyles['universal-toolbar']);
+}
+
+function findAllToolbars() {
+  return createWrapper().findAllByClassName(appLayoutToolbarStyles['universal-toolbar']);
+}
+
+function delay() {
+  // longer than a setTimeout(..., 0) used inside the implementation
+  return act(() => new Promise(resolve => setTimeout(resolve, 10)));
+}
+
+const defaultAppLayoutProps = {
+  // Suppress warning in runtime drawers API
+  __disableRuntimeDrawers: true,
+  // use this content type to make navigation closed initially
+  contentType: 'form',
+} as AppLayoutProps;
+
+async function renderAsync(jsx: React.ReactElement) {
+  render(jsx);
+  await delay();
+  const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
+  const secondLayout = createWrapper().find('[data-testid="second"]')!.findAppLayout()!;
+  expect(findAllToolbars()).toHaveLength(1);
+  expect(findToolbar(secondLayout)).toBeTruthy();
+  return { firstLayout, secondLayout };
+}
+
+describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+  afterEach(() => {
+    // force unmount for all rendered component to run clean state assertions
+    cleanup();
+    const state = awsuiPluginsInternal.appLayoutWidget.getStateForTesting();
+    expect(state).toEqual({
+      registrations: [],
+    });
+  });
+
+  test('merges navigation from two instances', async () => {
+    const { firstLayout, secondLayout } = await renderAsync(
+      <AppLayout
+        {...defaultAppLayoutProps}
+        data-testid="first"
+        navigation="testing nav"
+        toolsHide={true}
+        content={
+          <AppLayout {...defaultAppLayoutProps} data-testid="second" navigationHide={true} tools="testing tools" />
+        }
+      />
+    );
+    expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(true);
+    expect(secondLayout.findNavigation()).toBeFalsy();
+
+    secondLayout.findNavigationToggle().click();
+    expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(false);
+  });
+
+  test('merges tools from two instances', async () => {
+    const { firstLayout, secondLayout } = await renderAsync(
+      <AppLayout
+        {...defaultAppLayoutProps}
+        data-testid="first"
+        toolsHide={true}
+        content={<AppLayout data-testid="second" tools="testing tools" />}
+      />
+    );
+    expect(firstLayout.findTools()).toBeFalsy();
+    expect(secondLayout.findTools()).toBeFalsy();
+
+    secondLayout.findToolsToggle().click();
+    expect(secondLayout.findTools()).toBeTruthy();
+  });
+
+  test('merges split panel from two instances', async () => {
+    const { firstLayout, secondLayout } = await renderAsync(
+      <AppLayout
+        {...defaultAppLayoutProps}
+        data-testid="first"
+        toolsHide={true}
+        splitPanel={<SplitPanel header="Testing">Dummy content</SplitPanel>}
+        content={<AppLayout data-testid="second" />}
+      />
+    );
+    expect(firstLayout.findSplitPanel()).toBeTruthy();
+    expect(secondLayout.findSplitPanel()).toBeFalsy();
+    expect(secondLayout.findSplitPanelOpenButton()).toBeTruthy();
+    expect(firstLayout.findSplitPanel()!.findOpenPanelBottom()).toBeFalsy();
+
+    secondLayout.findSplitPanelOpenButton()!.click();
+    expect(firstLayout.findSplitPanel()!.findOpenPanelBottom()).toBeTruthy();
+  });
+
+  test('merges props across multiple react roots', async () => {
+    render(<AppLayout {...defaultAppLayoutProps} data-testid="first" navigation="testing nav" toolsHide={true} />);
+    render(<AppLayout {...defaultAppLayoutProps} data-testid="second" navigationHide={true} />);
+
+    await delay();
+
+    const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
+    const secondLayout = createWrapper().find('[data-testid="second"]')!.findAppLayout()!;
+    expect(firstLayout.findNavigationToggle()).toBeFalsy();
+    expect(secondLayout.findNavigationToggle()).toBeTruthy();
+  });
+
+  test('merges props from multiple instances', async () => {
+    render(
+      <AppLayout
+        {...defaultAppLayoutProps}
+        data-testid="first"
+        navigation="testing nav"
+        toolsHide={true}
+        content={
+          <AppLayout
+            {...defaultAppLayoutProps}
+            data-testid="second"
+            navigationHide={true}
+            tools="testing tools"
+            content={
+              <AppLayout
+                {...defaultAppLayoutProps}
+                data-testid="third"
+                navigationHide={true}
+                toolsHide={true}
+                splitPanel={<SplitPanel header="Testing">Dummy content</SplitPanel>}
+              />
+            }
+          />
+        }
+      />
+    );
+    await delay();
+
+    const thirdLayout = createWrapper().find('[data-testid="third"]')!.findAppLayout()!;
+    expect(findToolbar(thirdLayout)).toBeTruthy();
+    expect(findAllToolbars()).toHaveLength(1);
+    expect(thirdLayout.findNavigationToggle()).toBeTruthy();
+    expect(thirdLayout.findToolsToggle()).toBeTruthy();
+    expect(thirdLayout.findSplitPanelOpenButton()).toBeTruthy();
+  });
+
+  test('allows manual deduplication control', async () => {
+    render(
+      <AppLayout
+        {...defaultAppLayoutProps}
+        {...{ __forceDeduplicationType: 'primary' }}
+        data-testid="first"
+        navigationHide={true}
+        toolsHide={true}
+        content={
+          <AppLayout
+            {...defaultAppLayoutProps}
+            {...{ __forceDeduplicationType: 'secondary' }}
+            data-testid="second"
+            navigation="testing nav"
+          />
+        }
+      />
+    );
+    await delay();
+
+    const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
+    const secondLayout = createWrapper().find('[data-testid="second"]')!.findAppLayout()!;
+    expect(findToolbar(firstLayout)).toBeTruthy();
+    expect(findToolbar(secondLayout)).toBeFalsy();
+    expect(findAllToolbars()).toHaveLength(1);
+    expect(firstLayout.findNavigationToggle()).toBeTruthy();
+    expect(secondLayout.findNavigationToggle()).toBeFalsy();
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation();
+    });
+    afterEach(() => {
+      clearMessageCache();
+      jest.restoreAllMocks();
+    });
+
+    test('ignores duplicate properties and prints a warning', async () => {
+      const { secondLayout } = await renderAsync(
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="first"
+          navigation="first navigation"
+          toolsHide={true}
+          content={<AppLayout {...defaultAppLayoutProps} data-testid="second" navigation="second navigation" />}
+        />
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Another app layout instance on this page already defines navigation property')
+      );
+      secondLayout.findNavigationToggle().click();
+      expect(isDrawerClosed(secondLayout.findNavigation())).toEqual(false);
+    });
+
+    test('deduplicates tools and drawers in a single entity', async () => {
+      const { secondLayout } = await renderAsync(
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="first"
+          drawers={[testDrawer]}
+          content={<AppLayout {...defaultAppLayoutProps} data-testid="second" tools="second tools" />}
+        />
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Another app layout instance on this page already defines tools or drawers property')
+      );
+      expect(secondLayout.findDrawersTriggers()).toHaveLength(0);
+      expect(secondLayout.findTools()).toBeFalsy();
+
+      secondLayout.findToolsToggle().click();
+      expect(secondLayout.findTools()).toBeTruthy();
+    });
+  });
+});

--- a/src/app-layout/visual-refresh-toolbar/compute-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/compute-layout.ts
@@ -50,7 +50,7 @@ export function computeHorizontalLayout({
 
 interface VerticalLayoutInput {
   topOffset: number;
-  hasToolbar: boolean;
+  hasVisibleToolbar: boolean;
   toolbarHeight: number;
   stickyNotifications: boolean;
   notificationsHeight: number;
@@ -64,14 +64,14 @@ export interface VerticalLayoutOutput {
 
 export function computeVerticalLayout({
   topOffset,
-  hasToolbar,
+  hasVisibleToolbar,
   toolbarHeight,
   stickyNotifications,
   notificationsHeight,
 }: VerticalLayoutInput): VerticalLayoutOutput {
   const toolbar = topOffset;
   let notifications = topOffset;
-  if (hasToolbar) {
+  if (hasVisibleToolbar) {
     notifications += toolbarHeight;
   }
   let header = notifications;

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -294,6 +294,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
             )
           }
           contentHeader={contentHeader}
+          // delay rendering the content until registration of this instance is complete
           content={registered ? content : null}
           navigation={resolvedNavigation && <AppLayoutNavigation appLayoutInternals={appLayoutInternals} />}
           navigationOpen={navigationOpen}

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useImperativeHandle, useState } from 'react';
 
+import ScreenreaderOnly from '../../internal/components/screenreader-only';
 import { SplitPanelSideToggleProps } from '../../internal/context/split-panel-context';
 import { fireNonCancelableEvent } from '../../internal/events';
 import { useControllable } from '../../internal/hooks/use-controllable';
@@ -25,9 +26,10 @@ import {
   AppLayoutSplitPanelSide,
   AppLayoutToolbar,
 } from './internal';
+import { useMultiAppLayout } from './multi-layout';
 import { SkeletonLayout } from './skeleton';
 
-const AppLayoutVisualRefreshToolbar = React.forwardRef(
+const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLayoutPropsWithDefaults>(
   (
     {
       ariaLabels,
@@ -60,11 +62,11 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef(
       maxContentWidth,
       placement,
       ...rest
-    }: AppLayoutPropsWithDefaults,
-    forwardRef: React.Ref<AppLayoutProps.Ref>
+    },
+    forwardRef
   ) => {
     const isMobile = useMobile();
-    const embeddedViewMode = (rest as any).__embeddedViewMode;
+    const { __embeddedViewMode: embeddedViewMode, __forceDeduplicationType: forceDeduplicationType } = rest as any;
     const splitPanelControlId = useUniqueId('split-panel');
     const [toolbarState, setToolbarState] = useState<'show' | 'hide'>('show');
     const [toolbarHeight, setToolbarHeight] = useState(0);
@@ -178,20 +180,36 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef(
       splitPanelPosition: splitPanelPreferences?.position,
     });
 
-    const discoveredBreadcrumbs = useGetGlobalBreadcrumbs();
+    const { registered, toolbarProps } = useMultiAppLayout({
+      forceDeduplicationType,
+      ariaLabels: ariaLabelsWithDrawers,
+      navigation,
+      navigationOpen,
+      onNavigationToggle,
+      navigationFocusRef: navigationFocusControl.refs.toggle,
+      breadcrumbs,
+      activeDrawerId: activeDrawer?.id ?? null,
+      // only pass it down if there are non-empty drawers or tools
+      drawers: drawers?.length || !toolsHide ? drawers : undefined,
+      onActiveDrawerChange,
+      drawersFocusRef: drawersFocusControl.refs.toggle,
+      splitPanel,
+      splitPanelToggleProps: {
+        ...splitPanelToggleConfig,
+        active: splitPanelOpen,
+        controlId: splitPanelControlId,
+        position: splitPanelPosition,
+      },
+      splitPanelFocusRef: splitPanelFocusControl.refs.toggle,
+      onSplitPanelToggle: onSplitPanelToggleHandler,
+    });
 
-    const hasToolbar = Boolean(
-      !embeddedViewMode &&
-        (resolvedNavigation ||
-          breadcrumbs ||
-          discoveredBreadcrumbs ||
-          splitPanelToggleConfig.displayed ||
-          drawers!.length > 0)
-    );
+    const hasToolbar = !embeddedViewMode && !!toolbarProps;
+    const discoveredBreadcrumbs = useGetGlobalBreadcrumbs(hasToolbar);
 
     const verticalOffsets = computeVerticalLayout({
       topOffset: placement.insetBlockStart,
-      hasToolbar: hasToolbar && toolbarState !== 'hide',
+      hasVisibleToolbar: hasToolbar && toolbarState !== 'hide',
       notificationsHeight: notificationsHeight ?? 0,
       toolbarHeight: toolbarHeight ?? 0,
       stickyNotifications: !!stickyNotifications,
@@ -258,50 +276,59 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef(
     };
 
     return (
-      <SkeletonLayout
-        style={{
-          [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,
-          [globalVars.stickyVerticalBottomOffset]: `${placement.insetBlockEnd}px`,
-          paddingBlockEnd: splitPanelOpen ? splitPanelReportedSize : '',
-        }}
-        toolbar={hasToolbar && <AppLayoutToolbar appLayoutInternals={appLayoutInternals} />}
-        notifications={
-          notifications && (
-            <AppLayoutNotifications appLayoutInternals={appLayoutInternals}>{notifications}</AppLayoutNotifications>
-          )
-        }
-        contentHeader={contentHeader}
-        content={content}
-        navigation={resolvedNavigation && <AppLayoutNavigation appLayoutInternals={appLayoutInternals} />}
-        navigationOpen={navigationOpen}
-        navigationWidth={navigationWidth}
-        tools={activeDrawer && <AppLayoutDrawer appLayoutInternals={appLayoutInternals} />}
-        toolsOpen={!!activeDrawer}
-        toolsWidth={activeDrawerSize}
-        sideSplitPanel={
-          splitPanelPosition === 'side' &&
-          splitPanel && (
-            <AppLayoutSplitPanelSide appLayoutInternals={appLayoutInternals} splitPanelInternals={splitPanelInternals}>
-              {splitPanel}
-            </AppLayoutSplitPanelSide>
-          )
-        }
-        bottomSplitPanel={
-          splitPanelPosition === 'bottom' && (
-            <AppLayoutSplitPanelBottom
-              appLayoutInternals={appLayoutInternals}
-              splitPanelInternals={splitPanelInternals}
-            >
-              {splitPanel}
-            </AppLayoutSplitPanelBottom>
-          )
-        }
-        splitPanelOpen={splitPanelOpen}
-        placement={placement}
-        contentType={contentType}
-        maxContentWidth={maxContentWidth}
-        disableContentPaddings={disableContentPaddings}
-      />
+      <>
+        {/* Rendering a hidden copy of breadcrumbs to trigger their deduplication */}
+        {!hasToolbar && breadcrumbs ? <ScreenreaderOnly>{breadcrumbs}</ScreenreaderOnly> : null}
+        <SkeletonLayout
+          style={{
+            [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,
+            [globalVars.stickyVerticalBottomOffset]: `${placement.insetBlockEnd}px`,
+            paddingBlockEnd: splitPanelOpen ? splitPanelReportedSize : '',
+          }}
+          toolbar={
+            hasToolbar && <AppLayoutToolbar appLayoutInternals={appLayoutInternals} toolbarProps={toolbarProps} />
+          }
+          notifications={
+            notifications && (
+              <AppLayoutNotifications appLayoutInternals={appLayoutInternals}>{notifications}</AppLayoutNotifications>
+            )
+          }
+          contentHeader={contentHeader}
+          content={registered ? content : null}
+          navigation={resolvedNavigation && <AppLayoutNavigation appLayoutInternals={appLayoutInternals} />}
+          navigationOpen={navigationOpen}
+          navigationWidth={navigationWidth}
+          tools={activeDrawer && <AppLayoutDrawer appLayoutInternals={appLayoutInternals} />}
+          toolsOpen={!!activeDrawer}
+          toolsWidth={activeDrawerSize}
+          sideSplitPanel={
+            splitPanelPosition === 'side' &&
+            splitPanel && (
+              <AppLayoutSplitPanelSide
+                appLayoutInternals={appLayoutInternals}
+                splitPanelInternals={splitPanelInternals}
+              >
+                {splitPanel}
+              </AppLayoutSplitPanelSide>
+            )
+          }
+          bottomSplitPanel={
+            splitPanelPosition === 'bottom' && (
+              <AppLayoutSplitPanelBottom
+                appLayoutInternals={appLayoutInternals}
+                splitPanelInternals={splitPanelInternals}
+              >
+                {splitPanel}
+              </AppLayoutSplitPanelBottom>
+            )
+          }
+          splitPanelOpen={splitPanelOpen}
+          placement={placement}
+          contentType={contentType}
+          maxContentWidth={maxContentWidth}
+          disableContentPaddings={disableContentPaddings}
+        />
+      </>
     );
   }
 );

--- a/src/app-layout/visual-refresh-toolbar/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/multi-layout.ts
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useLayoutEffect, useState } from 'react';
+
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
+
+import { awsuiPluginsInternal } from '../../internal/plugins/api';
+import { RegistrationState } from '../../internal/plugins/controllers/app-layout-widget';
+import { AppLayoutProps } from '../interfaces';
+import { Focusable } from '../utils/use-focus-control';
+import { SplitPanelToggleProps, ToolbarProps } from './toolbar';
+
+interface SharedProps {
+  forceDeduplicationType?: 'primary' | 'secondary';
+  ariaLabels: AppLayoutProps.Labels | undefined;
+  navigation: React.ReactNode;
+  navigationOpen: boolean;
+  onNavigationToggle: (open: boolean) => void;
+  navigationFocusRef: React.Ref<Focusable> | undefined;
+  breadcrumbs: React.ReactNode;
+  activeDrawerId: string | null;
+  drawers: ReadonlyArray<AppLayoutProps.Drawer> | undefined;
+  onActiveDrawerChange: ((drawerId: string | null) => void) | undefined;
+  drawersFocusRef: React.Ref<Focusable> | undefined;
+  splitPanel: React.ReactNode;
+  splitPanelToggleProps: SplitPanelToggleProps;
+  splitPanelFocusRef: React.Ref<Focusable> | undefined;
+  onSplitPanelToggle: () => void;
+}
+
+function checkAlreadyExists(value: boolean, propName: string) {
+  if (value) {
+    warnOnce(
+      'AppLayout',
+      `Another app layout instance on this page already defines ${propName} property. This instance will be ignored.`
+    );
+    return true;
+  }
+  return false;
+}
+
+function mergeProps(ownProps: SharedProps, additionalProps: ReadonlyArray<Partial<SharedProps>>): ToolbarProps | null {
+  const toolbar: ToolbarProps = {};
+  for (const props of [ownProps, ...additionalProps]) {
+    toolbar.ariaLabels = Object.assign(toolbar.ariaLabels ?? {}, props.ariaLabels);
+    if (props.drawers && !checkAlreadyExists(!!toolbar.drawers, 'tools or drawers')) {
+      toolbar.drawers = props.drawers;
+      toolbar.activeDrawerId = props.activeDrawerId;
+      toolbar.drawersFocusRef = props.drawersFocusRef;
+      toolbar.onActiveDrawerChange = props.onActiveDrawerChange;
+    }
+    if (props.navigation && !checkAlreadyExists(!!toolbar.hasNavigation, 'navigation')) {
+      toolbar.hasNavigation = true;
+      toolbar.navigationOpen = props.navigationOpen;
+      toolbar.navigationFocusRef = props.navigationFocusRef;
+      toolbar.onNavigationToggle = props.onNavigationToggle;
+    }
+    if (props.splitPanel && !checkAlreadyExists(!!toolbar.hasSplitPanel, 'splitPanel')) {
+      toolbar.hasSplitPanel = true;
+      toolbar.splitPanelFocusRef = props.splitPanelFocusRef;
+      toolbar.splitPanelToggleProps = props.splitPanelToggleProps;
+      toolbar.onSplitPanelToggle = props.onSplitPanelToggle;
+    }
+  }
+  return Object.keys(toolbar).length > 0 ? toolbar : null;
+}
+
+export function useMultiAppLayout(props: SharedProps) {
+  const [registration, setRegistration] = useState<RegistrationState<SharedProps> | null>(null);
+  const { forceDeduplicationType } = props;
+
+  useLayoutEffect(() => {
+    return awsuiPluginsInternal.appLayoutWidget.register(forceDeduplicationType, props =>
+      setRegistration(props as RegistrationState<SharedProps>)
+    );
+  }, [forceDeduplicationType]);
+
+  useLayoutEffect(() => {
+    if (registration?.type === 'secondary') {
+      registration.update(props);
+    }
+  });
+
+  return {
+    registered: !!registration?.type,
+    toolbarProps: registration?.type === 'primary' ? mergeProps(props, registration.discoveredProps) : null,
+  };
+}

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -37,6 +37,7 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
         styles.navigation,
         {
           [styles['is-navigation-open']]: navigationOpen,
+          [testutilStyles['drawer-closed']]: !navigationOpen,
         },
         testutilStyles.navigation
       )}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -17,24 +17,25 @@ import splitPanelTestUtilStyles from '../../../split-panel/test-classes/styles.c
 import testutilStyles from '../../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
+export interface SplitPanelToggleProps {
+  displayed: boolean;
+  ariaLabel: string | undefined;
+  controlId: string | undefined;
+  active: boolean;
+  position: AppLayoutProps.SplitPanelPosition;
+}
+
 interface DrawerTriggersProps {
   ariaLabels: AppLayoutPropsWithDefaults['ariaLabels'];
 
   activeDrawerId: string | null;
-  drawersFocusRef: React.Ref<Focusable>;
+  drawersFocusRef: React.Ref<Focusable> | undefined;
   drawers: ReadonlyArray<AppLayoutProps.Drawer>;
-  onActiveDrawerChange: (drawerId: string | null) => void;
+  onActiveDrawerChange: ((drawerId: string | null) => void) | undefined;
 
-  splitPanelToggleProps:
-    | undefined
-    | {
-        ariaLabel: string | undefined;
-        controlId: string | undefined;
-        active: boolean;
-        position: AppLayoutProps.SplitPanelPosition;
-      };
-  splitPanelFocusRef: React.Ref<Focusable>;
-  onSplitPanelToggle: () => void;
+  splitPanelToggleProps: SplitPanelToggleProps | undefined;
+  splitPanelFocusRef: React.Ref<Focusable> | undefined;
+  onSplitPanelToggle: (() => void) | undefined;
 }
 
 export function DrawerTriggers({
@@ -108,7 +109,7 @@ export function DrawerTriggers({
             ariaExpanded={splitPanelToggleProps.active}
             className={clsx(styles['drawers-trigger'], splitPanelTestUtilStyles['open-button'])}
             iconName={splitPanelToggleProps.position === 'side' ? 'view-vertical' : 'view-horizontal'}
-            onClick={() => onSplitPanelToggle()}
+            onClick={() => onSplitPanelToggle?.()}
             selected={splitPanelToggleProps.active}
             ref={splitPanelFocusRef}
           />
@@ -127,7 +128,7 @@ export function DrawerTriggers({
               iconName={item.trigger.iconName}
               iconSvg={item.trigger.iconSvg}
               key={item.id}
-              onClick={() => onActiveDrawerChange(activeDrawerId !== item.id ? item.id : null)}
+              onClick={() => onActiveDrawerChange?.(activeDrawerId !== item.id ? item.id : null)}
               ref={item.id === previousActiveDrawerId.current ? drawersFocusRef : undefined}
               selected={item.id === activeDrawerId}
               badge={item.badge}
@@ -150,7 +151,7 @@ export function DrawerTriggers({
                 onClick={onClick}
               />
             )}
-            onItemClick={event => onActiveDrawerChange(event.detail.id)}
+            onItemClick={event => onActiveDrawerChange?.(event.detail.id)}
           />
         )}
       </div>

--- a/src/internal/plugins/api.ts
+++ b/src/internal/plugins/api.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BreadcrumbGroupProps } from '../../breadcrumb-group/interfaces';
 import { ActionButtonsController, ActionsApiInternal, ActionsApiPublic } from './controllers/action-buttons';
+import { AppLayoutWidgetApiInternal, AppLayoutWidgetController } from './controllers/app-layout-widget';
 import { BreadcrumbsApiInternal, BreadcrumbsController } from './controllers/breadcrumbs';
 import { DrawersApiInternal, DrawersApiPublic, DrawersController } from './controllers/drawers';
 
@@ -15,6 +16,7 @@ interface AwsuiApi {
   };
   awsuiPluginsInternal: {
     appLayout: DrawersApiInternal;
+    appLayoutWidget: AppLayoutWidgetApiInternal;
     alert: ActionsApiInternal;
     flashbar: ActionsApiInternal;
     breadcrumbs: BreadcrumbsApiInternal<BreadcrumbGroupProps>;
@@ -64,6 +66,11 @@ function installApi(api: DeepPartial<AwsuiApi>): AwsuiApi {
   const appLayoutDrawers = new DrawersController();
   api.awsuiPlugins.appLayout = appLayoutDrawers.installPublic(api.awsuiPlugins.appLayout);
   api.awsuiPluginsInternal.appLayout = appLayoutDrawers.installInternal(api.awsuiPluginsInternal.appLayout);
+
+  const appLayoutController = new AppLayoutWidgetController();
+  api.awsuiPluginsInternal.appLayoutWidget = appLayoutController.installInternal(
+    api.awsuiPluginsInternal.appLayoutWidget
+  );
 
   const alertActions = new ActionButtonsController();
   api.awsuiPlugins.alert = alertActions.installPublic(api.awsuiPlugins.alert);

--- a/src/internal/plugins/controllers/__tests__/app-layout-widget.test.ts
+++ b/src/internal/plugins/controllers/__tests__/app-layout-widget.test.ts
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AppLayoutWidgetController } from '../../../../../lib/components/internal/plugins/controllers/app-layout-widget';
+
+function delay() {
+  return new Promise(resolve => setTimeout(resolve));
+}
+
+test('registers and unregisters a single instance', () => {
+  const onRegister = jest.fn();
+  const controller = new AppLayoutWidgetController();
+  const cleanup = controller.register(undefined, onRegister);
+  expect(controller.getStateForTesting().registrations).toHaveLength(1);
+  expect(onRegister).toHaveBeenCalledWith({ type: 'primary', discoveredProps: [] });
+
+  cleanup();
+  expect(controller.getStateForTesting().registrations).toHaveLength(0);
+});
+
+test('registers and unregisters multiple instances', async () => {
+  const onRegisterFirst = jest.fn();
+  const onRegisterSecond = jest.fn();
+  const controller = new AppLayoutWidgetController();
+  const cleanupFirst = controller.register(undefined, onRegisterFirst);
+  expect(onRegisterFirst).toHaveBeenCalledTimes(1);
+  expect(onRegisterFirst).toHaveBeenCalledWith({ type: 'primary', discoveredProps: [] });
+  onRegisterFirst.mockClear();
+  const cleanupSecond = controller.register(undefined, onRegisterSecond);
+  expect(controller.getStateForTesting().registrations).toHaveLength(2);
+  expect(onRegisterFirst).toHaveBeenCalledTimes(1);
+  expect(onRegisterFirst).toHaveBeenCalledWith({ type: 'secondary', update: expect.any(Function) });
+  expect(onRegisterSecond).toHaveBeenCalledTimes(1);
+  expect(onRegisterSecond).toHaveBeenCalledWith({ type: 'primary', discoveredProps: [{}] });
+
+  onRegisterFirst.mockClear();
+  onRegisterSecond.mockClear();
+  cleanupFirst();
+  cleanupSecond();
+  expect(controller.getStateForTesting().registrations).toHaveLength(0);
+
+  await delay();
+
+  expect(onRegisterFirst).toHaveBeenCalledTimes(0);
+  expect(onRegisterSecond).toHaveBeenCalledTimes(0);
+});
+
+test('delivers property updates from secondary to primary instance', async () => {
+  const onRegisterFirst = jest.fn();
+  const onRegisterSecond = jest.fn();
+  const controller = new AppLayoutWidgetController();
+  controller.register(undefined, onRegisterFirst);
+  controller.register(undefined, onRegisterSecond);
+  onRegisterSecond.mockClear();
+
+  onRegisterFirst.mock.lastCall[0].update({ foo: '123' });
+  await delay();
+
+  expect(onRegisterSecond).toHaveBeenCalledTimes(1);
+  expect(onRegisterSecond).toHaveBeenCalledWith({ type: 'primary', discoveredProps: [{ foo: '123' }] });
+});
+
+test('delivers property updates from multiple secondary instances', async () => {
+  let stateFirst: any;
+  let stateSecond: any;
+  let stateThird: any;
+  const controller = new AppLayoutWidgetController();
+  controller.register(undefined, state => (stateFirst = state));
+  controller.register(undefined, state => (stateSecond = state));
+  controller.register(undefined, state => (stateThird = state));
+
+  expect(stateFirst.type).toEqual('secondary');
+  expect(stateSecond.type).toEqual('secondary');
+  expect(stateThird.type).toEqual('primary');
+
+  stateFirst.update({ foo: '123' });
+  stateSecond.update({ bar: '456' });
+  await delay();
+
+  expect(stateThird).toEqual({ type: 'primary', discoveredProps: [{ foo: '123' }, { bar: '456' }] });
+});
+
+test('when primary instance is unregistered, the next becomes primary', async () => {
+  let stateFirst: any;
+  let stateSecond: any;
+  let stateThird: any;
+  const controller = new AppLayoutWidgetController();
+  controller.register(undefined, state => (stateFirst = state));
+  controller.register(undefined, state => (stateSecond = state));
+  const cleanupLast = controller.register(undefined, state => (stateThird = state));
+
+  expect(stateThird.type).toEqual('primary');
+
+  cleanupLast();
+  expect(stateSecond.type).toEqual('secondary');
+
+  await delay();
+  expect(stateSecond.type).toEqual('primary');
+  expect(stateFirst.type).toEqual('secondary');
+});
+
+test('supports forced primary registration', () => {
+  let stateFirst: any;
+  let stateSecond: any;
+  const controller = new AppLayoutWidgetController();
+  controller.register('primary', state => (stateFirst = state));
+  controller.register(undefined, state => (stateSecond = state));
+  expect(stateFirst.type).toEqual('primary');
+  expect(stateSecond.type).toEqual('secondary');
+});
+
+test('throws an error when multiple forced primary registration are attempted', () => {
+  const controller = new AppLayoutWidgetController();
+  controller.register('primary', () => {});
+  expect(() => controller.register('primary', () => {})).toThrow('Double primary registration attempt');
+});
+
+test('supports forced secondary registration', () => {
+  let stateFirst: any;
+  let stateSecond: any;
+  let stateThird: any;
+  let stateForth: any;
+  const controller = new AppLayoutWidgetController();
+  controller.register('secondary', state => (stateFirst = state));
+  controller.register('secondary', state => (stateSecond = state));
+  expect(stateFirst.type).toEqual('secondary');
+  expect(stateSecond.type).toEqual('secondary');
+
+  controller.register(undefined, state => (stateThird = state));
+  expect(stateFirst.type).toEqual('secondary');
+  expect(stateSecond.type).toEqual('secondary');
+  expect(stateThird.type).toEqual('primary');
+
+  controller.register('secondary', state => (stateForth = state));
+  expect(stateFirst.type).toEqual('secondary');
+  expect(stateSecond.type).toEqual('secondary');
+  expect(stateThird.type).toEqual('primary');
+  expect(stateForth.type).toEqual('secondary');
+});

--- a/src/internal/plugins/controllers/app-layout-widget.ts
+++ b/src/internal/plugins/controllers/app-layout-widget.ts
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import debounce from '../../debounce';
+
+interface PrimaryRegistration<Props> {
+  type: 'primary';
+  discoveredProps: Array<Props>;
+}
+
+interface SecondaryRegistration<Props> {
+  type: 'secondary';
+  update: (props: Props) => void;
+}
+
+export type RegistrationState<Props> = PrimaryRegistration<Props> | SecondaryRegistration<Props>;
+export type RegistrationType = RegistrationState<unknown>['type'];
+
+type RegistrationChangeHandler<Props> = (
+  registration: PrimaryRegistration<Props> | SecondaryRegistration<Props>
+) => void;
+
+interface RegistrationInternal<Props> {
+  forceType: RegistrationType | undefined;
+  props: Props;
+  secondaryInstance: SecondaryRegistration<Props>;
+  onChange: (registration: PrimaryRegistration<Props> | SecondaryRegistration<Props>) => void;
+}
+
+export interface AppLayoutWidgetApiInternal<Props = unknown> {
+  register(
+    forceDeduplicationType: RegistrationType | undefined,
+    onPropsChange: RegistrationChangeHandler<Props>
+  ): () => void;
+}
+
+export class AppLayoutWidgetController<Props = unknown> {
+  #registrations: Array<RegistrationInternal<Props>> = [];
+
+  #findPrimary = () => {
+    const forcedPrimary = this.#registrations.some(registration => registration.forceType === 'primary');
+    if (forcedPrimary) {
+      return forcedPrimary;
+    }
+    for (const registration of this.#registrations.slice().reverse()) {
+      if (registration.forceType !== 'secondary') {
+        return registration;
+      }
+    }
+    return undefined;
+  };
+
+  #update = () => {
+    const primary = this.#findPrimary();
+    const discoveredProps = this.#registrations
+      .filter(registration => registration !== primary)
+      .map(registration => registration.props);
+    for (const registration of this.#registrations) {
+      if (registration === primary) {
+        registration.onChange({
+          type: 'primary',
+          discoveredProps,
+        });
+      } else {
+        registration.onChange(registration.secondaryInstance);
+      }
+    }
+  };
+
+  #scheduleUpdate = debounce(() => this.#update(), 0);
+
+  register = (
+    forceType: RegistrationType | undefined,
+    onRegistrationChange: RegistrationChangeHandler<Props>
+  ): (() => void) => {
+    const registration: RegistrationInternal<Props> = {
+      forceType,
+      onChange: onRegistrationChange,
+      props: {} as Props,
+      secondaryInstance: {
+        type: 'secondary',
+        update: props => {
+          registration.props = props;
+          this.#scheduleUpdate();
+        },
+      },
+    };
+    const hasForcedPrimary = this.#registrations.some(instance => instance.forceType === 'primary');
+    if (forceType === 'primary' && hasForcedPrimary) {
+      throw new Error('Double primary registration attempt');
+    }
+    this.#registrations.push(registration);
+
+    this.#update();
+
+    return () => {
+      this.#registrations.splice(this.#registrations.indexOf(registration), 1);
+      this.#scheduleUpdate();
+    };
+  };
+
+  installInternal = (
+    internalApi: Partial<AppLayoutWidgetApiInternal<Props>> = {}
+  ): AppLayoutWidgetApiInternal<Props> => {
+    internalApi.register ??= this.register;
+    return internalApi as AppLayoutWidgetApiInternal<Props>;
+  };
+}

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -40,14 +40,17 @@ export function useSetGlobalBreadcrumbs<T extends BreadcrumbGroupProps.Item>(pro
   return useSetGlobalBreadcrumbsImplementation(props);
 }
 
-export function useGetGlobalBreadcrumbs() {
+export function useGetGlobalBreadcrumbs(enabled: boolean) {
   const [discoveredBreadcrumbs, setDiscoveredBreadcrumbs] = useState<BreadcrumbGroupProps<any> | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     return awsuiPluginsInternal.breadcrumbs.registerAppLayout(breadcrumbs => {
       setDiscoveredBreadcrumbs(breadcrumbs);
     });
-  }, []);
+  }, [enabled]);
 
   return discoveredBreadcrumbs;
 }


### PR DESCRIPTION
### Description

Allow multiple app layouts to collaborate and render a single UI

Related links, issue #, if available: n/a

### How has this been tested?

1. Added unit tests
2. Integration tests are done on these dev pages: https://github.com/cloudscape-design/components/pull/2486

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
