### PR TITLE
fix: Read-only slider fixes

### DIFF
--- a/src/slider/mixins.scss
+++ b/src/slider/mixins.scss
@@ -61,6 +61,8 @@ $border-radius-slider-thumb: 50%;
 }
 
 @mixin base-thumb-disabled-styles {
+  block-size: $thumb-size;
+  inline-size: $thumb-size;
   background-color: awsui.$color-background-control-disabled;
   border-color: awsui.$color-background-control-disabled;
   box-shadow: none;

--- a/src/slider/styles.scss
+++ b/src/slider/styles.scss
@@ -182,7 +182,7 @@
   &.filled {
     background: awsui.$color-background-slider-handle-default;
 
-    &.readonly:not(.tick-disabled) {
+    &.readonly:not(.disabled) {
       background: awsui.$color-foreground-control-read-only;
     }
   }
@@ -282,21 +282,21 @@
     @include mixins.base-thumb-styles();
   }
 
-  &:not(&.disabled):hover::-webkit-slider-thumb {
+  &:hover::-webkit-slider-thumb {
     @include mixins.base-thumb-hover-styles();
   }
 
-  &:not(&.disabled):hover::-moz-range-thumb {
+  &:hover::-moz-range-thumb {
     @include mixins.base-thumb-hover-styles();
   }
 
-  &:not(&.disabled):focus::-webkit-slider-thumb,
-  &:not(&.disabled):active::-webkit-slider-thumb {
+  &:focus::-webkit-slider-thumb,
+  &:active::-webkit-slider-thumb {
     @include mixins.base-thumb-focus-styles();
   }
 
-  &:not(&.disabled):focus::-moz-range-thumb,
-  &:not(&.disabled):active::-moz-range-thumb {
+  &:focus::-moz-range-thumb,
+  &:active::-moz-range-thumb {
     @include mixins.base-thumb-focus-styles();
   }
 }

--- a/src/slider/styles.scss
+++ b/src/slider/styles.scss
@@ -282,21 +282,21 @@
     @include mixins.base-thumb-styles();
   }
 
-  &:hover::-webkit-slider-thumb {
+  &:not(&.disabled):hover::-webkit-slider-thumb {
     @include mixins.base-thumb-hover-styles();
   }
 
-  &:hover::-moz-range-thumb {
+  &:not(&.disabled):hover::-moz-range-thumb {
     @include mixins.base-thumb-hover-styles();
   }
 
-  &:focus::-webkit-slider-thumb,
-  &:active::-webkit-slider-thumb {
+  &:not(&.disabled):focus::-webkit-slider-thumb,
+  &:not(&.disabled):active::-webkit-slider-thumb {
     @include mixins.base-thumb-focus-styles();
   }
 
-  &:focus::-moz-range-thumb,
-  &:active::-moz-range-thumb {
+  &:not(&.disabled):focus::-moz-range-thumb,
+  &:not(&.disabled):active::-moz-range-thumb {
     @include mixins.base-thumb-focus-styles();
   }
 }

--- a/src/slider/styles.scss
+++ b/src/slider/styles.scss
@@ -31,10 +31,6 @@
     border-end-end-radius: 3px;
     margin-block-start: awsui.$space-xs;
     margin-inline: calc(mixins.$thumb-size / -2);
-
-    &.readonly:not(&.disabled) {
-      margin-inline: calc(mixins.$thumb-readonly-size / -2);
-    }
   }
 
   &-track {
@@ -51,7 +47,6 @@
     &.readonly:not(&.disabled) {
       cursor: default;
       background-color: awsui.$color-background-control-disabled;
-      inline-size: calc(100% + mixins.$thumb-readonly-size);
     }
   }
 


### PR DESCRIPTION
### Description

Follow up the recent release of read-only states.
1. Fix read-only slider size
2. Prevent hover, focus, and active styles from being applied to the disabled state

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
