### PR TITLE
fix: Support dropping files to FileUpload in Safari

### DIFF
--- a/src/file-upload/__tests__/file-upload-dropzone.test.tsx
+++ b/src/file-upload/__tests__/file-upload-dropzone.test.tsx
@@ -49,13 +49,13 @@ describe('File upload dropzone', () => {
     expect(screen.getByText('visible')).toBeDefined();
   });
 
-  test('Dropzone does not show if multiple files dragged into non-multiple zone', () => {
+  test('Dropzone shows if multiple files dragged into non-multiple zone', () => {
     render(<TestDropzoneVisible />);
     expect(screen.getByText('hidden')).toBeDefined();
 
     fireEvent(document, createDragEvent('dragover', [file1, file2]));
 
-    expect(screen.getByText('hidden')).toBeDefined();
+    expect(screen.getByText('visible')).toBeDefined();
   });
 
   test('Dropzone shows if multiple files dragged into multiple zone', () => {

--- a/src/file-upload/dropzone/index.tsx
+++ b/src/file-upload/dropzone/index.tsx
@@ -24,11 +24,12 @@ export function useDropzoneVisible(multiple: boolean) {
       event.preventDefault();
 
       let files = 0;
-      for (let item = 0; item < (event.dataTransfer?.items.length || 0); item++) {
-        if (event.dataTransfer?.items[item].kind === 'file') {
+      for (let item = 0; item < (event.dataTransfer?.types.length || 0); item++) {
+        if (event.dataTransfer?.types[item] === 'Files') {
           files++;
         }
       }
+
       if (files > 0 && (multiple || files === 1)) {
         setDropzoneVisible(true);
         dragTimer && clearTimeout(dragTimer);


### PR DESCRIPTION
### Description

As reported in https://github.com/cloudscape-design/components/issues/2427:
Previously, the drop area was only displayed if `DataTransfer.items`contained a file of kind 'file'. This worked in Chrome, Edge, and Firefox, however it did not work on Safari, because `DataTransfer.files` is in protected mode during the `dragover` event ([HTML specs reference](https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files)).

This change now checks `DataTransfer.types` ([HTML spec reference](https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types)) for the presence of the 'Files' type to display the drop area, ensuring compatibility across all browsers.

⚠️ Changes: With this change, it's now possible to drag multiple files in a non-multiple zone. When doing so, we already log a `warnOnce` to let the builder know about ([link to source](https://github.com/cloudscape-design/components/blob/58c799066a5868867fc4b9ff2a518bfa740fcbd7/src/file-upload/internal.tsx#L68-L70)).

Related links, issue #, if available: n/a

### How has this been tested?

- manually tested on Safari, Chrome, Edge and Firefox
- open the FileUpload demo from this PR and compare it with the one from a previous PR.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
