### PR TITLE
fix: Prevent checkbox items from rendering in top navigation

### DIFF
--- a/pages/top-navigation/utilities.page.tsx
+++ b/pages/top-navigation/utilities.page.tsx
@@ -6,7 +6,7 @@ import Input from '~components/input';
 import TopNavigation from '~components/top-navigation';
 import { I18N_STRINGS } from './common';
 import AppContext, { AppContextType } from '../app/app-context';
-import { Box, Checkbox } from '~components';
+import { Box, ButtonDropdownProps, Checkbox } from '~components';
 
 type PageContext = React.Context<
   AppContextType<{
@@ -14,12 +14,13 @@ type PageContext = React.Context<
   }>
 >;
 
-const profileActions = [
-  { type: 'button', id: 'profile', text: 'Profile' },
-  { type: 'button', id: 'preferences', text: 'Preferences' },
-  { type: 'button', id: 'security', text: 'Security' },
+const profileActions: ButtonDropdownProps.ItemOrGroup[] = [
+  { id: 'profile', text: 'Profile' },
+  { id: 'preferences', text: 'Preferences' },
+  { id: 'security', text: 'Security' },
+  { itemType: 'checkbox', id: 'security-checkbox', text: 'Security [Checkbox]', checked: true },
   {
-    type: 'menu-dropdown',
+    itemType: 'group',
     id: 'support-group',
     text: 'Support',
     items: [
@@ -32,9 +33,10 @@ const profileActions = [
       },
       { id: 'feedback', text: 'Feedback', href: '#', external: true, externalIconAriaLabel: ' (opens in new tab)' },
       { id: 'support', text: 'Customer support' },
+      { itemType: 'checkbox', id: 'support-checkbox', text: 'Support [Checkbox]', checked: true },
     ],
   },
-  { type: 'button', id: 'signout', text: 'Sign out' },
+  { id: 'signout', text: 'Sign out' },
 ];
 
 const notificationActions = [
@@ -93,7 +95,7 @@ export default function TopNavigationPage() {
         i18nStrings={I18N_STRINGS}
         identity={{
           href: '#',
-          title: 'Title with an href',
+          title: 'Title with an href that is longer',
         }}
         utilities={[
           {

--- a/src/top-navigation/internal.tsx
+++ b/src/top-navigation/internal.tsx
@@ -20,6 +20,7 @@ import { checkSafeUrl } from '../internal/utils/check-safe-url';
 import { SomeRequired } from '../internal/types';
 import { useInternalI18n } from '../i18n/context';
 import { isDevelopment, warnOnce } from '@cloudscape-design/component-toolkit/internal';
+import { hasCheckboxItems } from '../button-dropdown/utils/utils';
 
 export type InternalTopNavigationProps = SomeRequired<TopNavigationProps, 'utilities'> & InternalBaseComponentProps;
 
@@ -46,12 +47,10 @@ export default function InternalTopNavigation({
   // ButtonDropdown supports checkbox items but we don't support these in TopNavigation. Shown an error in development mode
   // to alert users of this and that it might change in the future.
   if (isDevelopment) {
-    if (
-      utilities.some(item => item.type === 'menu-dropdown' && item.items.some(item => item.itemType === 'checkbox'))
-    ) {
+    if (utilities.some(item => item.type === 'menu-dropdown' && hasCheckboxItems(item.items))) {
       warnOnce(
         'TopNavigation',
-        'The TopNavigation component does not support menu-dropdown items with `itemType` equal to `checkbox`, this might change in the future.'
+        'The TopNavigation component does not support menu-dropdown items with `itemType` equal to `checkbox`.'
       );
     }
   }

--- a/src/top-navigation/parts/utility.tsx
+++ b/src/top-navigation/parts/utility.tsx
@@ -111,11 +111,14 @@ export default function Utility({ hideText, definition, offsetRight }: UtilityPr
     const title = definition.title || definition.text;
     const shouldShowTitle = shouldHideText || !definition.text;
 
+    const items = excludeCheckboxes(definition.items);
+
     checkSafeUrlRecursively(definition.items);
 
     return (
       <MenuDropdown
         {...definition}
+        items={items}
         title={shouldShowTitle ? title : ''}
         ariaLabel={ariaLabel}
         offsetRight={offsetRight}
@@ -138,4 +141,21 @@ function checkSafeUrlRecursively(itemOrGroup: MenuDropdownProps['items']) {
       checkSafeUrlRecursively(item.items);
     }
   }
+}
+
+function excludeCheckboxes(items: MenuDropdownProps['items']): MenuDropdownProps['items'] {
+  return items
+    .map(item => {
+      if (item.itemType === 'checkbox') {
+        return null;
+      }
+      if ('items' in item) {
+        return {
+          ...item,
+          items: excludeCheckboxes(item.items),
+        };
+      }
+      return item;
+    })
+    .filter(item => item !== null) as MenuDropdownProps['items'];
 }


### PR DESCRIPTION
### Description

Prevent checkbox items from rendering in top navigation. They weren't supposed to be supported, and aren't supported in all variants of top navigation (i.e. not in the mobile version) so it's safer to prevent them from working at all.

Related links, issue #, if available: n/a

### How has this been tested?

Local testing, unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
