### PR TITLE
fix: Fix filtering token alignment

### DIFF
--- a/src/internal/components/filtering-token/styles.scss
+++ b/src/internal/components/filtering-token/styles.scss
@@ -14,6 +14,7 @@
 }
 
 .token {
+  flex-grow: 1;
   border-block: awsui.$border-field-width solid constants.$token-border-color;
   border-inline: awsui.$border-field-width solid constants.$token-border-color;
   display: flex;
@@ -24,7 +25,6 @@
   border-end-start-radius: awsui.$border-radius-token;
   border-end-end-radius: awsui.$border-radius-token;
   color: awsui.$color-text-body-default;
-  block-size: 100%;
   box-sizing: border-box;
 }
 

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -101,9 +101,6 @@
 
 .token-trigger {
   @include styles.text-wrapping;
-
-  // Setting line height to match line height of the Select component used for operation selector.
-  line-height: awsui.$line-height-body-m;
 }
 
 .remove-all,


### PR DESCRIPTION
### Description

The fix addresses the issue introduced in https://github.com/cloudscape-design/components/pull/2443. The consistent line height while makes the token size aligned also increases the space between the token text and the popover underline which is unwanted.

A different mitigation is to use the flex stretch alignment. The root container of the filtering token uses items stretch but that can only work if there is no block size. In that particular case the block size 100% does not work well for different zoom levels.

Related links, issue #, if available: n/a

### How has this been tested?

* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
