### PR TITLE
revert: Align property filter token light height with operation selector

### DIFF
--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -101,9 +101,6 @@
 
 .token-trigger {
   @include styles.text-wrapping;
-
-  // Setting line height to match line height of the Select component used for operation selector.
-  line-height: awsui.$line-height-body-m;
 }
 
 .remove-all,


### PR DESCRIPTION
### Description

This reverts commit 061677bb364056794033239a24e590a56d0cd1d0 which introduced some unexpected visual changes. 

Related links, issue #, if available: n/a

### How has this been tested?

n/a

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
