### PR TITLE
chore: Fixes tab divider height regression in VR compact mode

### DIFF
--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -147,15 +147,16 @@ $label-horizontal-spacing: awsui.$space-xs;
 .tabs-tab:not(:last-child) {
   & > .tabs-tab-header-container {
     margin-inline-end: calc(-1 * #{awsui.$border-divider-section-width});
+    // This is the divider for the tab
     &:before {
       content: '';
       position: absolute;
       border-inline-end: awsui.$border-divider-section-width solid $separator-color;
-      inset: calc(#{awsui.$space-scaled-s}) 0;
+      inset: awsui.$space-scaled-s 0;
       opacity: 1;
     }
 
-    &.refresh:before {
+    &.refresh:not(.compact):before {
       inset: calc(#{awsui.$space-scaled-s} - #{awsui.$border-active-width}) 0;
     }
   }

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -156,8 +156,8 @@ $label-horizontal-spacing: awsui.$space-xs;
       opacity: 1;
     }
 
-    &.refresh:not(.compact):before {
-      inset: calc(#{awsui.$space-scaled-s} - #{awsui.$border-active-width}) 0;
+    &.refresh:before {
+      inset: calc(#{awsui.$space-static-s} - #{awsui.$border-active-width}) 0;
     }
   }
 }

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -27,7 +27,6 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { getAllFocusables } from '../internal/components/focus-lock/utils';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ButtonProps } from '../button/interfaces';
-import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 
 const tabSelector = `.${styles['tabs-tab-link']}`;
 
@@ -80,7 +79,6 @@ export function TabHeaderBar({
   const [widthChange, containerMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
   const containerRef = useMergeRefs(containerObjectRef, containerMeasureRef);
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map());
-  const isCompactMode = useDensityMode(headerBarRef as any) === 'compact';
   const [horizontalOverflow, setHorizontalOverflow] = useState(false);
   const [inlineStartOverflow, setInlineStartOverflow] = useState(false);
   const [inlineEndOverflow, setInlineEndOverflow] = useState(false);
@@ -364,7 +362,6 @@ export function TabHeaderBar({
     const tabHeaderContainerClasses = clsx({
       [styles['tabs-tab-header-container']]: true,
       [styles.refresh]: isVisualRefresh,
-      [styles.compact]: isCompactMode,
       [styles['tabs-tab-active']]: isActive,
       [styles['tabs-tab-disabled']]: tab.disabled,
     });

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -27,6 +27,7 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { getAllFocusables } from '../internal/components/focus-lock/utils';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ButtonProps } from '../button/interfaces';
+import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 
 const tabSelector = `.${styles['tabs-tab-link']}`;
 
@@ -79,6 +80,7 @@ export function TabHeaderBar({
   const [widthChange, containerMeasureRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
   const containerRef = useMergeRefs(containerObjectRef, containerMeasureRef);
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const isCompactMode = useDensityMode(headerBarRef as any) === 'compact';
   const [horizontalOverflow, setHorizontalOverflow] = useState(false);
   const [inlineStartOverflow, setInlineStartOverflow] = useState(false);
   const [inlineEndOverflow, setInlineEndOverflow] = useState(false);
@@ -362,6 +364,7 @@ export function TabHeaderBar({
     const tabHeaderContainerClasses = clsx({
       [styles['tabs-tab-header-container']]: true,
       [styles.refresh]: isVisualRefresh,
+      [styles.compact]: isCompactMode,
       [styles['tabs-tab-active']]: isActive,
       [styles['tabs-tab-disabled']]: tab.disabled,
     });


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

Undoes regression introduced into VR compact mode in #2435

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
