### PR TITLE
fix: Removed gap from the normal variant of the button-dropdown

### DIFF
--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -195,7 +195,13 @@ const InternalButtonDropdown = React.forwardRef(
       trigger = (
         <div role="group" aria-label={ariaLabel} className={styles['split-trigger-wrapper']}>
           <div
-            className={clsx(styles['trigger-item'], styles['split-trigger'])}
+            className={clsx(
+              styles['trigger-item'],
+              styles['split-trigger'],
+              styles[`variant-${variant}`],
+              mainActionProps.disabled && styles.disabled,
+              mainActionProps.loading && styles.loading
+            )}
             // Close dropdown upon main action click unless event is cancelled.
             onClick={closeDropdown}
             // Prevent keyboard events from propagation to the button dropdown handler.
@@ -218,7 +224,10 @@ const InternalButtonDropdown = React.forwardRef(
             className={clsx(
               styles['trigger-item'],
               styles['dropdown-trigger'],
-              isVisualRefresh && styles['visual-refresh']
+              isVisualRefresh && styles['visual-refresh'],
+              styles[`variant-${variant}`],
+              baseTriggerProps.disabled && styles.disabled,
+              baseTriggerProps.loading && styles.loading
             )}
           >
             <InternalButton ref={triggerRef} {...baseTriggerProps} />

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -58,7 +58,8 @@ $dropdown-trigger-icon-offset: 2px;
   display: flex;
 
   & > .trigger-item {
-    & > button:focus {
+    & > .trigger-button:focus,
+    & > .trigger-button:hover {
       z-index: 1;
     }
   }
@@ -83,6 +84,23 @@ $dropdown-trigger-icon-offset: 2px;
       & > .trigger-button {
         padding-inline-end: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
       }
+    }
+  }
+
+  & > .trigger-item.disabled,
+  & > .trigger-item.loading {
+    & > .trigger-button:not(:focus) {
+      z-index: -1;
+    }
+  }
+
+  & > .trigger-item.variant-normal {
+    &:not(:last-child) > .trigger-button {
+      margin-inline-end: 0;
+    }
+
+    &:not(:first-child) > .trigger-button {
+      margin-inline-start: calc(#{styles.$control-border-width} * -1);
     }
   }
 }


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
There was an unwanted gap in drop down button which was only visible in "normal" variant.
**This PR removes the gap.**

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-48343

### How has this been tested?

<!-- How did you test to verify your changes? -->

Tested and verified using the dev run with Chrome, Firefox and Safari.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
