### PR TITLE
feat: support for React.ReactNode values in the internal tooltip

### DIFF
--- a/src/internal/components/tooltip/__tests__/tooltip.test.tsx
+++ b/src/internal/components/tooltip/__tests__/tooltip.test.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Tooltip, { TooltipProps } from '../../../../../lib/components/internal/components/tooltip';
+import StatusIndicator from '../../../../../lib/components/status-indicator';
 import createWrapper, { ElementWrapper, PopoverWrapper } from '../../../../../lib/components/test-utils/dom';
 import styles from '../../../../../lib/components/popover/styles.selectors.js';
 import tooltipStyles from '../../../../../lib/components/internal/components/tooltip/styles.selectors.js';
@@ -25,7 +26,12 @@ class TooltipInternalWrapper extends PopoverWrapper {
 const dummyRef = { current: null };
 function renderTooltip(props: Partial<TooltipProps>) {
   const { container } = render(
-    <Tooltip trackRef={dummyRef} value={props.value ?? ''} contentAttributes={props.contentAttributes} />
+    <Tooltip
+      trackRef={dummyRef}
+      trackKey={props.trackKey}
+      value={props.value ?? ''}
+      contentAttributes={props.contentAttributes}
+    />
   );
   return new TooltipInternalWrapper(container);
 }
@@ -35,6 +41,13 @@ describe('Tooltip', () => {
     const wrapper = renderTooltip({ value: 'Value' });
 
     expect(wrapper.findContent()!.getElement()).toHaveTextContent('Value');
+  });
+
+  it('renders node correctly', () => {
+    const wrapper = renderTooltip({ value: <StatusIndicator type="success">Success</StatusIndicator> });
+    const statusIndicatorWrapper = createWrapper(wrapper.findContent()!.getElement()).findStatusIndicator()!;
+
+    expect(statusIndicatorWrapper.getElement()).toHaveTextContent('Success');
   });
 
   it('renders arrow', () => {
@@ -53,5 +66,18 @@ describe('Tooltip', () => {
     const wrapper = renderTooltip({ value: 'Value', contentAttributes: { title: 'test' } });
 
     expect(wrapper.findTooltip()?.getElement()).toHaveAttribute('title', 'test');
+  });
+
+  it('trackKey is set correctly for strings', () => {
+    const wrapper = renderTooltip({ value: 'Value' });
+
+    expect(wrapper.findTooltip()?.getElement()).toHaveAttribute('data-testid', 'Value');
+  });
+
+  it('trackKey is set correctly for explicit value', () => {
+    const trackKey = 'test-track-key';
+    const wrapper = renderTooltip({ value: 'Value', trackKey });
+
+    expect(wrapper.findTooltip()?.getElement()).toHaveAttribute('data-testid', trackKey);
   });
 });

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -11,8 +11,9 @@ import popoverStyles from '../../../popover/styles.css.js';
 import styles from './styles.css.js';
 
 export interface TooltipProps {
-  value: number | string;
+  value: React.ReactNode;
   trackRef: React.RefObject<HTMLElement | SVGElement>;
+  trackKey?: string | number;
   position?: 'top' | 'right' | 'bottom' | 'left';
   className?: string;
   contentAttributes?: React.HTMLAttributes<HTMLDivElement>;
@@ -21,18 +22,23 @@ export interface TooltipProps {
 export default function Tooltip({
   value,
   trackRef,
+  trackKey,
   className,
   contentAttributes = {},
   position = 'top',
 }: TooltipProps) {
+  if (!trackKey && (typeof value === 'string' || typeof value === 'number')) {
+    trackKey = value;
+  }
+
   return (
     <Portal>
-      <div className={clsx(styles.root, className)} {...contentAttributes}>
+      <div className={clsx(styles.root, className)} {...contentAttributes} data-testid={trackKey}>
         <Transition in={true}>
           {() => (
             <PopoverContainer
               trackRef={trackRef}
-              trackKey={value}
+              trackKey={trackKey}
               size="small"
               fixedWidth={false}
               position={position}


### PR DESCRIPTION
### Description

Added support for arbitrary React nodes in the internal Tooltip. Previously, it only accepted string and number values. It is now possible to distplay tooltips with components like StatusIndicator inside. 

Related links, issue #, if available: n/a

### How has this been tested?

I've added tests to verify that components are displayed in the Tooltip and that the trackKey is set correctly

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
