### PR TITLE
fix: Chart testing util `.findYTicks` returns empty array when `fitHeight` is `true` 

### DIFF
--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -598,6 +598,22 @@ describe('Axes', () => {
     expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('40.00');
   });
 
+  test('can have tick formatter for y axis when fitHeight is true', () => {
+    const { wrapper } = renderMixedChart(
+      <MixedLineBarChart
+        series={[lineSeries]}
+        fitHeight={true}
+        xDomain={[0, 12]}
+        yDomain={[0, 100]}
+        i18nStrings={{ yTickFormatter: (value: number) => value.toFixed(2) }}
+      />
+    );
+
+    expect(wrapper.findYTicks()[0].getElement()).toHaveTextContent('0.00');
+    expect(wrapper.findYTicks()[1].getElement()).toHaveTextContent('10.00');
+    expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('20.00');
+  });
+
   describe('can have tick formatter for x axis', () => {
     test('numeric axis', () => {
       const { wrapper } = renderMixedChart(

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -587,6 +587,7 @@ describe('Axes', () => {
       <MixedLineBarChart
         series={[lineSeries]}
         fitHeight={fitHeight}
+        height={250}
         xDomain={[0, 12]}
         yDomain={[0, 100]}
         i18nStrings={{ yTickFormatter: (value: number) => value.toFixed(2) }}
@@ -594,8 +595,8 @@ describe('Axes', () => {
     );
 
     expect(wrapper.findYTicks()[0].getElement()).toHaveTextContent('0.00');
-    expect(wrapper.findYTicks()[1].getElement()).toHaveTextContent('10.00');
-    expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('20.00');
+    expect(wrapper.findYTicks()[1].getElement()).toHaveTextContent('20.00');
+    expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('40.00');
   });
 
   describe('can have tick formatter for x axis', () => {

--- a/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
+++ b/src/mixed-line-bar-chart/__tests__/mixed-chart.test.tsx
@@ -582,27 +582,11 @@ describe('Axes', () => {
     expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('10000');
   });
 
-  test('can have tick formatter for y axis', () => {
+  test.each([false, true])('can have tick formatter for y axis when fitHeight is %s', fitHeight => {
     const { wrapper } = renderMixedChart(
       <MixedLineBarChart
         series={[lineSeries]}
-        height={250}
-        xDomain={[0, 12]}
-        yDomain={[0, 100]}
-        i18nStrings={{ yTickFormatter: (value: number) => value.toFixed(2) }}
-      />
-    );
-
-    expect(wrapper.findYTicks()[0].getElement()).toHaveTextContent('0.00');
-    expect(wrapper.findYTicks()[1].getElement()).toHaveTextContent('20.00');
-    expect(wrapper.findYTicks()[2].getElement()).toHaveTextContent('40.00');
-  });
-
-  test('can have tick formatter for y axis when fitHeight is true', () => {
-    const { wrapper } = renderMixedChart(
-      <MixedLineBarChart
-        series={[lineSeries]}
-        fitHeight={true}
+        fitHeight={fitHeight}
         xDomain={[0, 12]}
         yDomain={[0, 100]}
         i18nStrings={{ yTickFormatter: (value: number) => value.toFixed(2) }}

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -197,7 +197,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
 
   const plotMeasureRef = useRef<SVGLineElement>(null);
   const measuredHeight = useHeightMeasure(() => plotMeasureRef.current, !fitHeight);
-  const plotHeight = fitHeight ? measuredHeight ?? 0 : explicitPlotHeight;
+  const plotHeight = fitHeight ? (measuredHeight || explicitPlotHeight) ?? 0 : explicitPlotHeight;
 
   const leftAxisProps = !horizontalBars
     ? getYAxisProps(plotHeight, [plotHeight, 0])


### PR DESCRIPTION
### Description

Default chart height `explicitPlotHeight` if resize observer returns 0 (not a case in browser environment, but in JSDOM)

Related links, issue #, if available: AWSUI-46382

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
