### PR TITLE
chore: Table cell expand toggle is outside cell content

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -56,21 +56,36 @@ $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
   inset-block: 0;
   display: flex;
   align-items: center;
-  margin-inline-start: calc(-1 * #{$cell-offset});
 }
 
 @mixin cell-padding-inline-start($padding) {
+  $max-nesting-levels: 9;
+  $offset-padding: calc($padding - 1 * awsui.$border-divider-list-width);
+
   > .body-cell-content {
-    padding-inline-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
+    margin-inline-start: $offset-padding;
+  }
+  > .expandable-toggle-wrapper {
+    margin-inline-start: $offset-padding;
   }
 
-  @for $i from 0 through 9 {
-    &.expandable-level-#{$i} > .body-cell-content {
-      padding-inline-start: calc($padding + $i * $cell-offset - 1 * awsui.$border-divider-list-width);
+  @for $i from 0 through $max-nesting-levels {
+    &.expandable-level-#{$i} {
+      > .body-cell-content {
+        margin-inline-start: calc($offset-padding + $i * $cell-offset);
+      }
+      > .expandable-toggle-wrapper {
+        margin-inline-start: calc($offset-padding + ($i - 1) * $cell-offset);
+      }
     }
   }
-  &.expandable-level-next > .body-cell-content {
-    padding-inline-start: calc(#{$padding} + 9 * #{$cell-offset} - 1 * #{awsui.$border-divider-list-width});
+  &.expandable-level-next {
+    > .body-cell-content {
+      margin-inline-start: calc(#{$offset-padding} + #{$max-nesting-levels} * #{$cell-offset});
+    }
+    > .expandable-toggle-wrapper {
+      margin-inline-start: calc(#{$offset-padding} + (#{$max-nesting-levels} - 1) * #{$cell-offset});
+    }
   }
 }
 @mixin cell-padding-inline-end($padding) {

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -122,19 +122,18 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
         {...nativeAttributes}
         tabIndex={cellTabIndex === -1 ? undefined : cellTabIndex}
       >
-        <div className={styles['body-cell-content']}>
-          {level !== undefined && isExpandable && (
-            <div className={styles['expandable-toggle-wrapper']}>
-              <ExpandToggleButton
-                isExpanded={isExpanded}
-                onExpandableItemToggle={onExpandableItemToggle}
-                expandButtonLabel={expandButtonLabel}
-                collapseButtonLabel={collapseButtonLabel}
-              />
-            </div>
-          )}
-          {children}
-        </div>
+        {level !== undefined && isExpandable && (
+          <div className={styles['expandable-toggle-wrapper']}>
+            <ExpandToggleButton
+              isExpanded={isExpanded}
+              onExpandableItemToggle={onExpandableItemToggle}
+              expandButtonLabel={expandButtonLabel}
+              collapseButtonLabel={collapseButtonLabel}
+            />
+          </div>
+        )}
+
+        <div className={styles['body-cell-content']}>{children}</div>
       </Element>
     );
   }


### PR DESCRIPTION
### Description

Update table body cell structure so that expand toggle is outside cell content. That is to support a follow-up change to move cell editing styles to from cell to cell content so that both inline edit trigger and expand toggle can be present in a single cell.

Rel: AWSUI-43194

### How has this been tested?

* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
