### PR TITLE
chore: Fix content area styles

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -84,7 +84,7 @@ export function SkeletonLayout({
         {notifications}
         <div className={clsx(styles.main, { [styles['main-disable-paddings']]: disableContentPaddings })} style={style}>
           {contentHeader && <div className={styles['content-header']}>{contentHeader}</div>}
-          <div className={testutilStyles.content}>{content}</div>
+          <div className={clsx(styles.content, testutilStyles.content)}>{content}</div>
         </div>
         {bottomSplitPanel && (
           <div

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -146,6 +146,10 @@
   margin-block-end: awsui.$space-content-header-padding-bottom;
 }
 
+.content {
+  display: contents;
+}
+
 /* stylelint-disable-next-line selector-combinator-disallowed-list, selector-max-universal */
 .unfocusable-mobile * {
   visibility: hidden;


### PR DESCRIPTION
### Description

Fixing a use-case from this page: https://github.com/cloudscape-design/components/blob/main/pages/app-layout/fill-content-area.page.tsx

it works in old app layout, but broke in the new `visual-refresh-toolbar` mode

Related links, issue #, if available: n/a

### How has this been tested?

Tested using that dev page. No visual regression tests for that mode yet

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
