### PR TITLE
fix: Styles for ButtonDropdown and Button API description

### DIFF
--- a/pages/button-dropdown/disabled-reason.page.tsx
+++ b/pages/button-dropdown/disabled-reason.page.tsx
@@ -99,6 +99,31 @@ const actionsItems: ButtonDropdownProps.Items = [
   { text: 'Monitor and troubleshoot', items: [{ id: 'system-log', text: 'Get System log' }] },
 ];
 
+export const selectableGroupItems: ButtonDropdownProps.Items = [
+  {
+    text: 'Settings group',
+    id: 'setting-group',
+    items: [
+      {
+        text: 'Setting',
+        id: 'setting',
+        itemType: 'checkbox',
+        checked: true,
+        disabled: false,
+      },
+      {
+        text: 'Disabled setting',
+        id: 'setting',
+        itemType: 'checkbox',
+        checked: true,
+        disabled: true,
+        disabledReason: 'disabled reason',
+      },
+    ],
+  },
+  { text: 'Action', id: 'action', disabled: false },
+];
+
 export default function DescriptionPage() {
   const [isRightAligned, setIsRightAligned] = useState(false);
   return (
@@ -131,6 +156,11 @@ export default function DescriptionPage() {
             mainAction={{ text: 'Launch instance', disabled: true, disabledReason: 'disabled reason' }}
             variant="primary"
           />
+        </div>
+        <div style={{ float: isRightAligned ? 'right' : undefined, marginBottom: '100px' }}>
+          <ButtonDropdown items={selectableGroupItems} data-testid="buttonDropdownSelectableItems">
+            Selectable example
+          </ButtonDropdown>
         </div>
       </ScreenshotArea>
     </>

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3106,7 +3106,7 @@ The text will also be added to the \`title\` attribute of the button.",
     Object {
       "description": "Provides a reason why the button is disabled (only when \`disabled\` is \`true\`).
 If provided, the button becomes focusable.
-Applicable for all button variants, except link.",
+Applicable for all button variants, except link and icon.",
       "name": "disabledReason",
       "optional": true,
       "type": "string",

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -121,7 +121,7 @@ function MenuItem({ item, disabled, highlighted }: MenuItemProps) {
   const { position } = useDropdownContext();
   const tooltipPosition = position === 'bottom-left' || position === 'top-left' ? 'left' : 'right';
   return isDisabledWithReason ? (
-    <Tooltip content={item.disabledReason} position={tooltipPosition}>
+    <Tooltip content={item.disabledReason} position={tooltipPosition} className={styles['item-tooltip-wrapper']}>
       {menuItem}
       {descriptionEl}
     </Tooltip>

--- a/src/button-dropdown/item-element/styles.scss
+++ b/src/button-dropdown/item-element/styles.scss
@@ -67,6 +67,7 @@
 
   /* stylelint-disable selector-max-type */
   .has-category-header > &,
+  .has-category-header > .item-tooltip-wrapper > &,
   .has-category-header:not(.has-checkmark) > span > & {
     padding-inline-start: calc(#{awsui.$space-xs} + #{awsui.$space-l});
   }

--- a/src/button-dropdown/tooltip.tsx
+++ b/src/button-dropdown/tooltip.tsx
@@ -13,18 +13,19 @@ export interface TooltipProps {
   children?: React.ReactNode;
   content?: React.ReactNode;
   position?: 'top' | 'right' | 'bottom' | 'left';
+  className?: string;
 }
 
 const DEFAULT_OPEN_TIMEOUT_IN_MS = 120;
 
-export default function Tooltip({ children, content, position = 'right' }: TooltipProps) {
+export default function Tooltip({ children, content, position = 'right', className }: TooltipProps) {
   const ref = useRef<HTMLSpanElement | null>(null);
   const isReducedMotion = useReducedMotion(ref);
   const { open, triggerProps } = useTooltipOpen(isReducedMotion ? 0 : DEFAULT_OPEN_TIMEOUT_IN_MS);
   const portalClasses = usePortalModeClasses(ref);
 
   return (
-    <span ref={ref} {...triggerProps}>
+    <span ref={ref} {...triggerProps} className={className}>
       {children}
       {open && (
         <Portal>

--- a/src/button/interfaces.ts
+++ b/src/button/interfaces.ts
@@ -13,7 +13,7 @@ export interface ButtonProps extends BaseComponentProps {
   /**
    * Provides a reason why the button is disabled (only when `disabled` is `true`).
    * If provided, the button becomes focusable.
-   * Applicable for all button variants, except link.
+   * Applicable for all button variants, except link and icon.
    */
   disabledReason?: string;
   /**


### PR DESCRIPTION
### Description

Fixed styles for ButtonDropdown selectable items when disabledReason is present. Updated API description for Button interfaces.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
