### PR TITLE
refactor: Shared circleIndex util

### DIFF
--- a/src/area-chart/__tests__/area-chart-model-utils.test.ts
+++ b/src/area-chart/__tests__/area-chart-model-utils.test.ts
@@ -7,7 +7,6 @@ import {
   computeDomainY,
   computePlotPoints,
   findClosest,
-  circleIndex,
   isSeriesValid,
 } from '../../../lib/components/area-chart/model/utils';
 
@@ -241,18 +240,6 @@ describe('AreaChart findClosest', () => {
   it('finds closest in an desc sorted array', () => {
     const closest = findClosest([6, 5, 3.5, 3, 2, 1], 4, x => x);
     expect(closest).toBe(3.5);
-  });
-});
-
-describe('AreaChart circleIndex', () => {
-  it('returns same index if in range', () => {
-    expect(circleIndex(1, [1, 5])).toBe(1);
-    expect(circleIndex(5, [1, 5])).toBe(5);
-  });
-
-  it('returns opposite boundary if not in range', () => {
-    expect(circleIndex(0, [1, 5])).toBe(5);
-    expect(circleIndex(6, [1, 5])).toBe(1);
   });
 });
 

--- a/src/area-chart/model/use-chart-model.ts
+++ b/src/area-chart/model/use-chart-model.ts
@@ -3,7 +3,7 @@
 import { AreaChartProps } from '../interfaces';
 import React, { useEffect, useMemo, useRef, RefObject, MouseEvent } from 'react';
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
-import { findClosest, circleIndex } from './utils';
+import { findClosest } from './utils';
 
 import { KeyCode } from '../../internal/keycode';
 import { XDomain, XScaleType, YDomain, YScaleType } from '../../internal/components/cartesian-chart/interfaces';
@@ -18,6 +18,7 @@ import { useHeightMeasure } from '../../internal/hooks/container-queries/use-hei
 import { useStableCallback } from '@cloudscape-design/component-toolkit/internal';
 import { nodeBelongs } from '../../internal/utils/node-belongs';
 import handleKey from '../../internal/utils/handle-key';
+import { circleIndex } from '../../internal/utils/circle-index';
 
 const MAX_HOVER_MARGIN = 6;
 const SVG_HOVER_THROTTLE = 25;

--- a/src/area-chart/model/utils.ts
+++ b/src/area-chart/model/utils.ts
@@ -169,17 +169,6 @@ export function findClosest<T>(sortedArray: readonly T[], target: number, getter
   return delta(sortedArray[lo]) < delta(sortedArray[hi]) ? sortedArray[lo] : sortedArray[hi];
 }
 
-// Returns given index if it is in range or the opposite range boundary otherwise.
-export function circleIndex(index: number, [from, to]: [number, number]): number {
-  if (index < from) {
-    return to;
-  }
-  if (index > to) {
-    return from;
-  }
-  return index;
-}
-
 // Compares all x-values between series to ensure they are consistent.
 export function isSeriesValid<T>(series: readonly AreaChartProps.Series<T>[]) {
   const sampleXValues = getXValues(series);

--- a/src/internal/utils/__tests__/circle-index.test.ts
+++ b/src/internal/utils/__tests__/circle-index.test.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { circleIndex } from '../../../../lib/components/internal/utils/circle-index';
+
+it('returns same index if in range', () => {
+  expect(circleIndex(1, [1, 5])).toBe(1);
+  expect(circleIndex(5, [1, 5])).toBe(5);
+});
+
+it('returns opposite boundary if not in range', () => {
+  expect(circleIndex(0, [1, 5])).toBe(5);
+  expect(circleIndex(6, [1, 5])).toBe(1);
+});

--- a/src/internal/utils/circle-index.ts
+++ b/src/internal/utils/circle-index.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Returns given index if it is in range or the opposite range boundary otherwise.
+export function circleIndex(index: number, [from, to]: [number, number]): number {
+  if (index < from) {
+    return to;
+  }
+  if (index > to) {
+    return from;
+  }
+  return index;
+}

--- a/src/mixed-line-bar-chart/hooks/use-navigation.ts
+++ b/src/mixed-line-bar-chart/hooks/use-navigation.ts
@@ -8,6 +8,7 @@ import { ChartScale, NumericChartScale } from '../../internal/components/cartesi
 import { findNavigableSeries, isXThreshold, isYThreshold, nextValidDomainIndex } from '../utils';
 import { ScaledPoint } from '../make-scaled-series';
 import { ScaledBarGroup } from '../make-scaled-bar-groups';
+import { circleIndex } from '../../internal/utils/circle-index';
 
 export type UseNavigationProps<T extends ChartDataTypes> = Pick<
   ChartContainerProps<T>,
@@ -295,15 +296,4 @@ export function useNavigation<T extends ChartDataTypes>({
   );
 
   return { isGroupNavigation, onFocus, onKeyDown, xIndex };
-}
-
-// Returns given index if it is in range or the opposite range boundary otherwise.
-function circleIndex(index: number, [from, to]: [number, number]): number {
-  if (index < from) {
-    return to;
-  }
-  if (index > to) {
-    return from;
-  }
-  return index;
 }

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -29,6 +29,7 @@ import useHiddenDescription from '../internal/hooks/use-hidden-description';
 import Tooltip from '../internal/components/tooltip';
 import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ButtonProps } from '../button/interfaces';
+import { circleIndex } from '../internal/utils/circle-index';
 
 const tabSelector = `.${styles['tabs-tab-link']}`;
 const focusedTabSelector = `[role="tab"].${styles['tabs-tab-focused']}`;
@@ -525,14 +526,4 @@ const TabTrigger = forwardRef(
 
 export function getTabElementId({ namespace, tabId }: { namespace: string; tabId: string }) {
   return namespace + '-' + tabId;
-}
-
-function circleIndex(index: number, [from, to]: [number, number]): number {
-  if (index < from) {
-    return to;
-  }
-  if (index > to) {
-    return from;
-  }
-  return index;
 }


### PR DESCRIPTION
### Description

Reduce code duplication by sharing circle-index util from area chart.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
