### PR TITLE
feat: add loading a11y to s3 selectors for screen readers

### DIFF
--- a/pages/s3-resource-selector/data/i18n-strings.ts
+++ b/pages/s3-resource-selector/data/i18n-strings.ts
@@ -17,6 +17,7 @@ export const i18nStrings: S3ResourceSelectorProps.I18nStrings = {
   modalCancelButton: 'Cancel',
   modalSubmitButton: 'Choose',
   modalBreadcrumbRootItem: 'S3 buckets',
+  modalLastUpdatedText: 'Last updated',
 
   selectionBuckets: 'Buckets',
   selectionObjects: 'Objects',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12860,6 +12860,11 @@ The function will be called when a user clicks on the trigger button.",
             "type": "string",
           },
           Object {
+            "name": "modalLastUpdatedText",
+            "optional": true,
+            "type": "string",
+          },
+          Object {
             "name": "modalSubmitButton",
             "optional": true,
             "type": "string",

--- a/src/s3-resource-selector/__tests__/fixtures.ts
+++ b/src/s3-resource-selector/__tests__/fixtures.ts
@@ -23,6 +23,7 @@ export const i18nStrings: S3ResourceSelectorProps.I18nStrings = {
   modalCancelButton: 'Cancel',
   modalSubmitButton: 'Choose',
   modalBreadcrumbRootItem: 'S3 buckets',
+  modalLastUpdatedText: 'Last updated',
 
   selectionBuckets: 'Buckets',
   selectionObjects: 'Objects',

--- a/src/s3-resource-selector/__tests__/main.test.tsx
+++ b/src/s3-resource-selector/__tests__/main.test.tsx
@@ -9,6 +9,8 @@ import S3ResourceSelector, { S3ResourceSelectorProps } from '../../../lib/compon
 import createWrapper, { S3ResourceSelectorWrapper } from '../../../lib/components/test-utils/dom';
 import { buckets, i18nStrings, objects, versions, waitForFetch } from './fixtures';
 
+import styles from '../../../lib/components/s3-resource-selector/s3-modal/styles.css.js';
+
 jest.setTimeout(10_000);
 
 const defaultProps = {
@@ -209,6 +211,7 @@ describe('i18n', () => {
             'i18nStrings.modalCancelButton': 'Custom cancel',
             'i18nStrings.modalSubmitButton': 'Custom submit',
             'i18nStrings.modalBreadcrumbRootItem': 'Custom root',
+            'i18nStrings.modalLastUpdatedText': 'Custom last updated',
             'i18nStrings.selectionBuckets': 'Custom buckets',
             'i18nStrings.labelRefresh': 'Custom refresh',
             'i18nStrings.selectionBucketsSearchPlaceholder': 'Custom find buckets',
@@ -225,6 +228,7 @@ describe('i18n', () => {
       </TestI18nProvider>
     );
     await openBrowseDialog(wrapper);
+    await waitForFetch();
     expect(wrapper.findModal()!.findHeader().getElement()).toHaveTextContent('Custom modal title');
     expect(
       wrapper.findModal()!.findFooter()!.findSpaceBetween()!.find(':nth-child(1)')!.findButton()!.getElement()
@@ -236,10 +240,8 @@ describe('i18n', () => {
     expect(modalContent.findBreadcrumbGroup()!.getElement()).toHaveTextContent('Custom root');
     const table = modalContent.findTable()!;
     expect(table.findHeaderSlot()!.findHeader()!.findHeadingText().getElement()).toHaveTextContent('Custom buckets');
-    expect(table.findHeaderSlot()!.findHeader()!.findActions()!.findButton()!.getElement()).toHaveAttribute(
-      'aria-label',
-      'Custom refresh'
-    );
+    const refreshButton = table.findHeaderSlot()!.findHeader()!.findActions()!.findButton();
+    expect(refreshButton!.getElement()).toHaveAttribute('aria-label', 'Custom refresh');
     expect(table.findHeaderSlot()!.findTextFilter()!.findInput()!.findNativeInput()!.getElement()).toHaveAttribute(
       'placeholder',
       'Custom find buckets'
@@ -265,6 +267,12 @@ describe('i18n', () => {
     expect(table.findColumnSortingArea(2)!.getElement()).toHaveAttribute(
       'aria-label',
       'Custom Custom name sorted descending'
+    );
+
+    refreshButton?.click();
+    await waitForFetch();
+    expect(table.findHeaderSlot()!.findByClassName(styles['last-updated-caption'])!.getElement()).toHaveTextContent(
+      /^Custom last updated.+$/
     );
   });
 });

--- a/src/s3-resource-selector/interfaces.ts
+++ b/src/s3-resource-selector/interfaces.ts
@@ -218,6 +218,7 @@ export namespace S3ResourceSelectorProps {
     modalCancelButton?: string;
     modalSubmitButton?: string;
     modalBreadcrumbRootItem?: string;
+    modalLastUpdatedText?: string;
 
     selectionBuckets?: string;
     selectionObjects?: string;

--- a/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
+++ b/src/s3-resource-selector/s3-modal/__tests__/fetching.test.tsx
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import { S3Modal } from '../../../../lib/components/s3-resource-selector/s3-modal';
 import createWrapper, { ElementWrapper } from '../../../../lib/components/test-utils/dom';
-import { buckets, objects, versions, waitForFetch } from '../../__tests__/fixtures';
+import { buckets, i18nStrings, objects, versions, waitForFetch } from '../../__tests__/fixtures';
 import { getElementsText, modalDefaultProps, navigateToTableItem } from './utils';
+
+import styles from '../../../../lib/components/s3-resource-selector/s3-modal/styles.css.js';
 
 jest.setTimeout(30_000);
 
@@ -19,6 +21,11 @@ async function renderModal(jsx: React.ReactElement) {
 
 function getBreadcrumbsText(wrapper: ElementWrapper<Element>) {
   return getElementsText(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks());
+}
+
+async function clickRefreshAndWaitForFetch() {
+  screen.getByRole('button', { name: i18nStrings.labelRefresh }).click();
+  await waitForFetch();
 }
 
 test('updating breadcrumbs and header text when navigating the bucket contents', async () => {
@@ -125,4 +132,62 @@ test('dives into folders containing slashes in names', async () => {
   fetchObjectsSpy.mockClear();
   await navigateToTableItem(wrapper, 1);
   expect(fetchObjectsSpy).toHaveBeenCalledWith('bucket-laborum', 'folder/folder///final');
+});
+
+describe('last updated status text', () => {
+  beforeEach(() => {
+    const lastUpdatedDate = new Date('2024-01-02T10:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(lastUpdatedDate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('does not show the last updated once the initial fetch is done', async () => {
+    const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
+    const lastUpdated = wrapper.findByClassName(styles['last-updated-caption']);
+
+    expect(lastUpdated).toBeFalsy();
+  });
+
+  test('renders the last updated time within the aria-live region', async () => {
+    const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
+    await clickRefreshAndWaitForFetch();
+
+    const lastUpdated = wrapper.findByClassName(styles['last-updated-caption'])!.find('[aria-live]')!.getElement();
+    await waitFor(() => {
+      /**
+       * <LiveRegion /> component is using innerText for setting the span element's text content.
+       * To populate the textContent from innerText, layout engine is required which JSDom doesn't have.
+       * So falling back to assert against innerText rather than the textContent.
+       */
+      expect(lastUpdated.innerText).toBe('Last updated January 2, 2024, 10:00:00 (UTC)');
+    });
+  });
+
+  test('updates the "last updated" once the refresh button is clicked and the request is settled', async () => {
+    const wrapper = await renderModal(<S3Modal {...modalDefaultProps} />);
+    await waitForFetch();
+
+    const refreshFetchDate = new Date('2024-01-02T11:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(refreshFetchDate);
+    await clickRefreshAndWaitForFetch();
+
+    const lastUpdated = wrapper.findByClassName(styles['last-updated-caption'])!.getElement();
+    expect(lastUpdated).toHaveTextContent('Last updatedJanuary 2, 2024, 11:00:00 (UTC)');
+  });
+
+  test('does not render "Last updated" when the i18n label is not specified', async () => {
+    const wrapper = await renderModal(
+      <S3Modal
+        {...modalDefaultProps}
+        i18nStrings={{ ...modalDefaultProps.i18nStrings, modalLastUpdatedText: undefined }}
+      />
+    );
+    await clickRefreshAndWaitForFetch();
+
+    const lastUpdated = wrapper.findByClassName(styles['last-updated-caption']);
+    expect(lastUpdated).toBeFalsy();
+  });
 });

--- a/src/s3-resource-selector/s3-modal/styles.scss
+++ b/src/s3-resource-selector/s3-modal/styles.scss
@@ -2,6 +2,8 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use '../../internal/styles/tokens.scss' as awsui;
+@use '../../internal/styles' as styles;
 
 .modal-actions {
   justify-content: flex-end;
@@ -9,4 +11,11 @@
 
 .submit-button {
   /* used in test-utils */
+}
+
+.last-updated-caption {
+  @include styles.font-body-s;
+
+  text-align: end;
+  color: awsui.$color-text-status-inactive;
 }


### PR DESCRIPTION
### Description

Adds `Last Updated` to the S3 resource selector modal.
The addition of this text should help the screen readers to inform the users once the fetch process is finished.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-41521

### How has this been tested?

<!-- How did you test to verify your changes? -->

Manually tested on Chrome, Firefox & Safari.
Automated testing _in progress_.

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
