### PR TITLE
feat: support updateDrawer in AppLayout plugins API

### DIFF
--- a/pages/app-layout/runtime-drawers-with-updates.page.tsx
+++ b/pages/app-layout/runtime-drawers-with-updates.page.tsx
@@ -1,0 +1,196 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useState } from 'react';
+import {
+  AppLayout,
+  ContentLayout,
+  Header,
+  HelpPanel,
+  Drawer,
+  Link,
+  SpaceBetween,
+  SplitPanel,
+  Toggle,
+} from '~components';
+import appLayoutLabels from './utils/labels';
+import { AppLayoutProps } from '~components/app-layout';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import './utils/external-widget';
+import AppContext, { AppContextType } from '../app/app-context';
+import awsuiPlugins from '~components/internal/plugins';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    hasTools: boolean | undefined;
+    hasDrawers: boolean | undefined;
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+  }>
+>;
+
+export default function WithDrawers() {
+  const [activeDrawerId, setActiveDrawerId] = useState<string | null>(null);
+  const [helpPathSlug, setHelpPathSlug] = useState<string>('default');
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const hasTools = urlParams.hasTools ?? false;
+  const hasDrawers = urlParams.hasDrawers ?? true;
+  const [isToolsOpen, setIsToolsOpen] = useState(false);
+  const [showBadge, setShowBadge] = useState(false);
+  const [turnOffResizable, setTurnOffResizable] = useState(false);
+
+  const drawersProps: Pick<AppLayoutProps, 'activeDrawerId' | 'onDrawerChange' | 'drawers'> | null = !hasDrawers
+    ? null
+    : {
+        activeDrawerId: activeDrawerId,
+        drawers: [
+          {
+            ariaLabels: {
+              closeButton: 'ProHelp close button',
+              drawerName: 'ProHelp drawer content',
+              triggerButton: 'ProHelp trigger button',
+              resizeHandle: 'ProHelp resize handle',
+            },
+            content: <ProHelp />,
+            id: 'pro-help',
+            trigger: {
+              iconName: 'contact',
+            },
+          },
+        ],
+        onDrawerChange: event => {
+          setActiveDrawerId(event.detail.activeDrawerId);
+        },
+      };
+
+  const onChangeShowBadge = (checked: boolean) => {
+    setShowBadge(checked);
+    awsuiPlugins.appLayout.updateDrawer({
+      id: 'security',
+      badge: checked,
+    });
+  };
+
+  const onChangeTurnOffResize = (checked: boolean) => {
+    setTurnOffResizable(checked);
+    awsuiPlugins.appLayout.updateDrawer({
+      id: 'security',
+      resizable: !checked,
+    });
+  };
+
+  return (
+    <AppLayout
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      content={
+        <ContentLayout
+          disableOverlap={true}
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Sometimes you need custom drawers to get the job done."
+                info={
+                  <Link
+                    data-testid="info-link-header"
+                    variant="info"
+                    onFollow={() => {
+                      setHelpPathSlug('header');
+                      setIsToolsOpen(true);
+                    }}
+                  >
+                    Info
+                  </Link>
+                }
+              >
+                Testing Custom Drawers with update!
+              </Header>
+
+              <SpaceBetween size="xs">
+                <Toggle checked={hasTools} onChange={({ detail }) => setUrlParams({ hasTools: detail.checked })}>
+                  Use Tools
+                </Toggle>
+
+                <Toggle checked={hasDrawers} onChange={({ detail }) => setUrlParams({ hasDrawers: detail.checked })}>
+                  Use Drawers
+                </Toggle>
+
+                <SpaceBetween size="xs">
+                  <h3>Security Drawer Updates</h3>
+                  <Toggle checked={showBadge} onChange={({ detail }) => onChangeShowBadge(detail.checked)}>
+                    Show Badge
+                  </Toggle>
+                  <Toggle
+                    data-testid="turn-off-resize-toggle"
+                    checked={turnOffResizable}
+                    onChange={({ detail }) => onChangeTurnOffResize(detail.checked)}
+                  >
+                    Turn off Resize
+                  </Toggle>
+                </SpaceBetween>
+              </SpaceBetween>
+            </SpaceBetween>
+          }
+        >
+          <Header
+            info={
+              <Link
+                data-testid="info-link-content"
+                variant="info"
+                onFollow={() => {
+                  setHelpPathSlug('content');
+                  setIsToolsOpen(true);
+                }}
+              >
+                Info
+              </Link>
+            }
+          >
+            Content
+          </Header>
+          <Containers />
+        </ContentLayout>
+      }
+      splitPanel={
+        <SplitPanel
+          header="Split panel header"
+          i18nStrings={{
+            preferencesTitle: 'Preferences',
+            preferencesPositionLabel: 'Split panel position',
+            preferencesPositionDescription: 'Choose the default split panel position for the service.',
+            preferencesPositionSide: 'Side',
+            preferencesPositionBottom: 'Bottom',
+            preferencesConfirm: 'Confirm',
+            preferencesCancel: 'Cancel',
+            closeButtonAriaLabel: 'Close panel',
+            openButtonAriaLabel: 'Open panel',
+            resizeHandleAriaLabel: 'Slider',
+          }}
+        >
+          This is the Split Panel!
+        </SplitPanel>
+      }
+      splitPanelPreferences={{
+        position: urlParams.splitPanelPosition,
+      }}
+      onSplitPanelPreferencesChange={event => {
+        const { position } = event.detail;
+        setUrlParams({ splitPanelPosition: position === 'side' ? position : undefined });
+      }}
+      onToolsChange={event => {
+        setIsToolsOpen(event.detail.open);
+      }}
+      tools={<Info helpPathSlug={helpPathSlug} />}
+      toolsOpen={isToolsOpen}
+      toolsHide={!hasTools}
+      {...drawersProps}
+    />
+  );
+}
+
+function Info({ helpPathSlug }: { helpPathSlug: string }) {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you: {helpPathSlug}</HelpPanel>;
+}
+
+function ProHelp() {
+  return <Drawer header={<h2>Pro Help</h2>}>Need some Pro Help? We got you.</Drawer>;
+}

--- a/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-controllability.test.ts
@@ -7,7 +7,7 @@ import createWrapper from '../../../lib/components/test-utils/selectors';
 const wrapper = createWrapper().findAppLayout();
 
 for (const visualRefresh of [true, false]) {
-  for (const pageName of ['runtime-drawers', 'runtime-drawers-imperative']) {
+  for (const pageName of ['runtime-drawers', 'runtime-drawers-imperative', 'runtime-drawers-with-updates']) {
     describe(`page=${pageName} visualRefresh=${visualRefresh}`, () => {
       function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
         return useBrowser(async browser => {

--- a/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+import { viewports } from './constants';
+
+const wrapper = createWrapper().findAppLayout();
+
+for (const visualRefresh of [true, false]) {
+  describe(`visualRefresh=${visualRefresh}`, () => {
+    function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+      return useBrowser(async browser => {
+        const page = new BasePageObject(browser);
+
+        await browser.url(
+          `#/light/app-layout/runtime-drawers-with-updates?${new URLSearchParams({
+            hasDrawers: 'false',
+            hasTools: 'true',
+            splitPanelPosition: 'side',
+            visualRefresh: `${visualRefresh}`,
+          }).toString()}`
+        );
+        await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
+        await testFn(page);
+      });
+    }
+
+    test(
+      'should resize equally with tools or drawers',
+      setupTest(async page => {
+        await page.setWindowSize({ ...viewports.desktop, width: 1800 });
+        await page.click(wrapper.findToolsToggle().toSelector());
+        await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+
+        const { width: splitPanelWidthWithTools } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
+
+        await page.click(wrapper.findDrawerTriggerById('circle').toSelector());
+        const { width: splitPanelWidthWithDrawer } = await page.getBoundingBox(wrapper.findSplitPanel().toSelector());
+
+        expect(splitPanelWidthWithTools).toEqual(splitPanelWidthWithDrawer);
+      })
+    );
+
+    test(
+      'renders according to defaultSize property',
+      setupTest(async page => {
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+        // using `clientWidth` to neglect possible border width set on this element
+        const width = await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth');
+        expect(width).toEqual(320);
+      })
+    );
+
+    test(
+      'should call resize handler',
+      setupTest(async page => {
+        // close navigation panel to give drawer more room to resize
+        await page.click(wrapper.findNavigationClose().toSelector());
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: false');
+
+        await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -200);
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
+      })
+    );
+
+    test(
+      'should call update drawer to disable resize',
+      setupTest(async page => {
+        // close navigation panel to give drawer more room to resize
+        await page.click(wrapper.findNavigationClose().toSelector());
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+
+        await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(true);
+
+        await page.click(
+          createWrapper().findToggle('[data-testid="turn-off-resize-toggle"]').findNativeInput().toSelector()
+        );
+
+        await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(false);
+      })
+    );
+  });
+}

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -71,6 +71,31 @@ describeEachAppLayout(({ theme, size }) => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
+  test('update rendered drawers via runtime config', async () => {
+    awsuiPlugins.appLayout.registerDrawer(drawerDefaults);
+    const { wrapper } = await renderComponent(<AppLayout />);
+    // the 2nd trigger is for tools
+    expect(wrapper.findDrawersTriggers()).toHaveLength(2);
+
+    awsuiPlugins.appLayout.updateDrawer({
+      id: 'test',
+      badge: true,
+      ariaLabels: {
+        triggerButton: 'test-trigger-button',
+      },
+    });
+    await delay();
+
+    if (theme !== 'classic' && size === 'desktop') {
+      expect(wrapper.find('[class*=awsui_dot_]')?.getElement()).toBeInTheDocument();
+    }
+
+    expect(wrapper.findDrawerTriggerById(drawerDefaults.id)!.getElement()).toHaveAttribute(
+      'aria-label',
+      'test-trigger-button'
+    );
+  });
+
   test('combines runtime drawers with the tools', async () => {
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, ariaLabels: { triggerButton: 'Runtime drawer' } });
     const { wrapper } = await renderComponent(<AppLayout tools="test" ariaLabels={{ toolsToggle: 'Tools' }} />);

--- a/src/internal/plugins/__tests__/api.test.ts
+++ b/src/internal/plugins/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { loadApi } from '../../../../lib/components/internal/plugins/api';
-import { DrawerConfig } from '../../../../lib/components/internal/plugins/controllers/drawers';
+import { DrawerConfig, UpdateDrawerConfig } from '../../../../lib/components/internal/plugins/controllers/drawers';
 
 function delay() {
   return new Promise(resolve => setTimeout(resolve));
@@ -24,9 +24,14 @@ test('loading api multiple times does not reset the state', async () => {
   onRegister.mockReset();
 
   api = loadApi();
-  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-2' } as DrawerConfig);
+  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-2', badge: false } as DrawerConfig);
   await delay();
-  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2' }]);
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2', badge: false }]);
+  onRegister.mockReset();
+
+  api.awsuiPlugins.appLayout.updateDrawer({ id: 'drawer-2', badge: true } as UpdateDrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2', badge: true }]);
 });
 
 test('partial API can be extended', () => {

--- a/src/internal/plugins/controllers/__tests__/drawers.test.ts
+++ b/src/internal/plugins/controllers/__tests__/drawers.test.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DrawerConfig, DrawersController } from '../../../../../lib/components/internal/plugins/controllers/drawers';
+import {
+  DrawerConfig,
+  DrawersController,
+  UpdateDrawerConfig,
+} from '../../../../../lib/components/internal/plugins/controllers/drawers';
 
 const drawerA = { id: 'drawerA' } as DrawerConfig;
 const drawerB = { id: 'drawerB' } as DrawerConfig;
@@ -50,6 +54,38 @@ test('change listener is not called after cleanup', async () => {
   drawers.registerDrawer(drawerA);
   await delay();
   expect(onDrawersRegistered).not.toHaveBeenCalled();
+});
+
+describe('update drawer', () => {
+  test('notifies about updated drawers', async () => {
+    const onDrawersRegistered = jest.fn();
+    const drawers = new DrawersController();
+    drawers.onDrawersRegistered(onDrawersRegistered);
+    drawers.registerDrawer(drawerA);
+    drawers.registerDrawer(drawerB);
+    expect(onDrawersRegistered).not.toHaveBeenCalled();
+    await delay();
+    expect(onDrawersRegistered).toHaveBeenCalledWith([drawerA, drawerB]);
+    const updatedDrawer = { ...drawerA, badge: true };
+    drawers.updateDrawer(updatedDrawer);
+    await delay();
+    expect(onDrawersRegistered).toHaveBeenLastCalledWith([updatedDrawer, drawerB]);
+  });
+
+  test('throw error if the update drawer is not registered', () => {
+    const drawers = new DrawersController();
+    expect(() => drawers.updateDrawer({ id: 'test-drawer' } as UpdateDrawerConfig)).toThrowError(
+      '[AwsUi] [runtime drawers] drawer with id test-drawer not found'
+    );
+  });
+
+  test('throw error if update drawer overrides register drawer functions', () => {
+    const drawers = new DrawersController();
+    drawers.registerDrawer(drawerA);
+    expect(() => drawers.updateDrawer({ id: 'drawerA', mountContent: () => {} } as any)).toThrowError(
+      '[AwsUi] [runtime drawers] cannot update drawer functions'
+    );
+  });
 });
 
 describe('console warnings', () => {


### PR DESCRIPTION
### Description

Support `updateDrawer` in AppLayout plugins API

Currently, there is only option to register a Drawer, there is no support to update a registered drawer. Such updates includes badge, resizable, orderPriority, and others

Related links, issue #, if available: n/a

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ yes
- _Changes are covered with new/existing integration tests?_ yes
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
