### PR TITLE
feat: Decorate button component with analytics metadata

### DIFF
--- a/src/button/__tests__/analytics-metadata.test.tsx
+++ b/src/button/__tests__/analytics-metadata.test.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
+import {
+  activateAnalyticsMetadata,
+  GeneratedAnalyticsMetadataFragment,
+} from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import Button, { ButtonProps } from '../../../lib/components/button';
+import InternalButton from '../../../lib/components/button/internal';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
+import labels from '../../../lib/components/button/analytics-metadata/styles.css.js';
+
+function renderButton(props: ButtonProps = {}) {
+  const renderResult = render(<Button {...props} />);
+  return createWrapper(renderResult.container).findButton()!;
+}
+
+const getMetadata = (label: string, variant: string, disabled?: boolean) => {
+  const metadata: GeneratedAnalyticsMetadataFragment = {
+    contexts: [
+      {
+        type: 'component',
+        detail: {
+          name: 'awsui.Button',
+          label,
+          properties: {
+            variant,
+            disabled: disabled ? 'true' : 'false',
+          },
+        },
+      },
+    ],
+  };
+  if (!disabled) {
+    metadata.action = 'click';
+    metadata.detail = { label };
+  }
+  return metadata;
+};
+
+beforeAll(() => {
+  activateAnalyticsMetadata(true);
+});
+describe('Button renders correct analytics metadata', () => {
+  test('when it is empty and with no aria label', () => {
+    const wrapper = renderButton();
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('', 'normal'));
+  });
+  test('when it is empty and has aria label', () => {
+    const wrapper = renderButton({ variant: 'primary', ariaLabel: 'button text', disabled: true });
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('button text', 'primary', true));
+  });
+  test('when it has text content', () => {
+    const wrapper = renderButton({ children: 'inline button text', disabled: true, disabledReason: 'reason' });
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(
+      getMetadata('inline button text', 'normal', true)
+    );
+  });
+  test('when it has text content and aria label', () => {
+    const wrapper = renderButton({ children: 'inline button text', ariaLabel: 'button text aria' });
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('inline button text', 'normal'));
+  });
+  test('when it has icon variant', () => {
+    const wrapper = renderButton({ ariaLabel: 'button text aria', variant: 'inline-icon' });
+    validateComponentNameAndLabels(wrapper.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual(getMetadata('button text aria', 'inline-icon'));
+  });
+});
+
+test('Internal Button does not render "component" metadata', () => {
+  const renderResult = render(<InternalButton>inline button text</InternalButton>);
+  const wrapper = createWrapper(renderResult.container).findButton()!;
+  validateComponentNameAndLabels(wrapper.getElement(), labels);
+  expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
+    action: 'click',
+    detail: {
+      label: 'inline button text',
+    },
+  });
+});

--- a/src/button/analytics-metadata/interfaces.ts
+++ b/src/button/analytics-metadata/interfaces.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+interface GeneratedAnalyticsMetadataButtonClick {
+  action: 'click';
+  detail: {
+    label: string;
+  };
+}
+
+interface GeneratedAnalyticsMetadataButtonComponent {
+  name: 'awsui.Button';
+  label: string;
+  properties: {
+    variant: string;
+    disabled: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataButtonFragment extends Partial<GeneratedAnalyticsMetadataButtonClick> {
+  component?: GeneratedAnalyticsMetadataButtonComponent;
+}

--- a/src/button/analytics-metadata/styles.scss
+++ b/src/button/analytics-metadata/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.label {
+  /* used in analytics metadata */
+}

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -74,6 +74,7 @@ const Button = React.forwardRef(
         ariaControls={ariaControls}
         fullWidth={fullWidth}
         form={form}
+        __injectAnalyticsComponentMetadata={true}
       >
         {children}
       </InternalButton>

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -6,6 +6,7 @@ import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
+import analyticsLabels from './analytics-metadata/styles.css.js';
 import { ButtonIconProps, LeftIcon, RightIcon } from './icon-helper';
 import { ButtonProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -26,6 +27,11 @@ import { usePerformanceMarks } from '../internal/hooks/use-performance-marks';
 import { useSingleTabStopNavigation } from '../internal/context/single-tab-stop-navigation-context';
 import Tooltip from '../internal/components/tooltip/index.js';
 import useHiddenDescription from '../internal/hooks/use-hidden-description';
+import {
+  getAnalyticsMetadataAttribute,
+  getAnalyticsLabelAttribute,
+} from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import { GeneratedAnalyticsMetadataButtonFragment } from './analytics-metadata/interfaces';
 
 export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   variant?: ButtonProps['variant'] | 'flashbar-icon' | 'breadcrumb-group' | 'menu-trigger' | 'modal-dismiss';
@@ -35,6 +41,7 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
     | Record<`data-${string}`, string>;
   __iconClass?: string;
   __focusable?: boolean;
+  __injectAnalyticsComponentMetadata?: boolean;
 } & InternalBaseComponentProps<HTMLAnchorElement | HTMLButtonElement>;
 
 export const InternalButton = React.forwardRef(
@@ -69,6 +76,7 @@ export const InternalButton = React.forwardRef(
       __nativeAttributes,
       __internalRootRef = null,
       __focusable = false,
+      __injectAnalyticsComponentMetadata = false,
       ...props
     }: InternalButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -152,6 +160,20 @@ export const InternalButton = React.forwardRef(
       tabIndex: isAnchor && isNotInteractive ? -1 : explicitTabIndex,
     });
 
+    const analyticsMetadata: GeneratedAnalyticsMetadataButtonFragment = disabled
+      ? {}
+      : {
+          action: 'click',
+          detail: { label: '' },
+        };
+    if (__injectAnalyticsComponentMetadata) {
+      analyticsMetadata.component = {
+        name: 'awsui.Button',
+        label: '',
+        properties: { variant, disabled: `${disabled}` },
+      };
+    }
+
     const buttonProps = {
       ...props,
       ...__nativeAttributes,
@@ -168,6 +190,8 @@ export const InternalButton = React.forwardRef(
       className: buttonClass,
       onClick: handleClick,
       [DATA_ATTR_FUNNEL_VALUE]: uniqueId,
+      ...getAnalyticsMetadataAttribute(analyticsMetadata),
+      ...getAnalyticsLabelAttribute(children ? `.${analyticsLabels.label}` : ''),
     } as const;
 
     const iconProps: ButtonIconProps = {
@@ -185,7 +209,7 @@ export const InternalButton = React.forwardRef(
     const buttonContent = (
       <>
         <LeftIcon {...iconProps} />
-        {shouldHaveContent && <span className={styles.content}>{children}</span>}
+        {shouldHaveContent && <span className={clsx(styles.content, analyticsLabels.label)}>{children}</span>}
         <RightIcon {...iconProps} />
       </>
     );

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -6,7 +6,7 @@ import { fireCancelableEvent, isPlainLeftClick } from '../internal/events';
 import useForwardFocus from '../internal/hooks/forward-focus';
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
-import analyticsLabels from './analytics-metadata/styles.css.js';
+import analyticsSelectors from './analytics-metadata/styles.css.js';
 import { ButtonIconProps, LeftIcon, RightIcon } from './icon-helper';
 import { ButtonProps } from './interfaces';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -191,7 +191,7 @@ export const InternalButton = React.forwardRef(
       onClick: handleClick,
       [DATA_ATTR_FUNNEL_VALUE]: uniqueId,
       ...getAnalyticsMetadataAttribute(analyticsMetadata),
-      ...getAnalyticsLabelAttribute(children ? `.${analyticsLabels.label}` : ''),
+      ...getAnalyticsLabelAttribute(children ? `.${analyticsSelectors.label}` : ''),
     } as const;
 
     const iconProps: ButtonIconProps = {
@@ -209,7 +209,7 @@ export const InternalButton = React.forwardRef(
     const buttonContent = (
       <>
         <LeftIcon {...iconProps} />
-        {shouldHaveContent && <span className={clsx(styles.content, analyticsLabels.label)}>{children}</span>}
+        {shouldHaveContent && <span className={clsx(styles.content, analyticsSelectors.label)}>{children}</span>}
         <RightIcon {...iconProps} />
       </>
     );

--- a/src/internal/__tests__/analytics-metadata-test-utils.ts
+++ b/src/internal/__tests__/analytics-metadata-test-utils.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { GeneratedAnalyticsMetadataFragment } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import { getRawAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
+
+export const validateComponentNameAndLabels = (element: HTMLElement, labelsClassNames: Record<string, string>) => {
+  const { metadata, labelSelectors } = getRawAnalyticsMetadata(element);
+  validateComponentName(metadata);
+  validateLabels(labelSelectors, labelsClassNames);
+};
+
+const validateComponentName = (metadata: Array<GeneratedAnalyticsMetadataFragment>) => {
+  const componentNames = metadata
+    .filter(md => !!md.component && !!md.component.name)
+    .map(md => md.component!.name)
+    .filter(name => !name?.startsWith('awsui.'));
+  if (componentNames.length > 0) {
+    throw new Error(`Components names ${componentNames.join(' ,')} should start with "awsui."`);
+  }
+};
+
+const validateLabels = (labelSelectors: Array<string>, labelsClassNames: Record<string, string>) => {
+  const allowedClassNames = Object.values(labelsClassNames);
+  const classNames = labelSelectors.reduce((acc: Array<string>, current) => {
+    const parts = current.split(/\s+/);
+    parts.forEach(part => {
+      const classes = part.split('.').filter(className => !!className);
+      acc = [...acc, ...classes];
+    });
+    return acc;
+  }, []);
+  const wrongClassNames = classNames.filter(className => !allowedClassNames.includes(className));
+  if (wrongClassNames.length > 0) {
+    throw new Error(`ClassNames ${wrongClassNames.join(' ,')} are not stable.`);
+  }
+};


### PR DESCRIPTION
### Description

First implementation of analytics instrumentation

### How has this been tested?

Added unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ N/A
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ N/A
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_ Yes
- _Changes are covered with new/existing integration tests?_ N/A
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
