### PR TITLE
fix: Improve progress bar color contrast in warning flash message

### DIFF
--- a/pages/progress-bar/permutations-flash.page.tsx
+++ b/pages/progress-bar/permutations-flash.page.tsx
@@ -18,6 +18,14 @@ export default function ProgressBarPermutations() {
             statusIconAriaLabel: 'info',
           }))}
         />
+        <Flashbar
+          items={permutations.map(permutation => ({
+            type: 'warning',
+            content: <ProgressBar {...permutation} variant="flash" />,
+            buttonText: permutation.resultButtonText,
+            statusIconAriaLabel: 'warning',
+          }))}
+        />
       </ScreenshotArea>
     </article>
   );

--- a/src/progress-bar/styles.scss
+++ b/src/progress-bar/styles.scss
@@ -37,7 +37,7 @@
 
 .label {
   &-flash {
-    color: 'inherit';
+    color: inherit;
     font-weight: styles.$font-weight-bold;
   }
   &-key-value {
@@ -94,14 +94,11 @@ $background-color-in-flash: awsui.$color-background-progress-bar-layout-in-flash
 $bar-color: awsui.$color-background-progress-bar-content-default;
 $bar-color-in-flash: awsui.$color-background-progress-bar-content-in-flash;
 
-// Current version of Edge has a known bug with CSS variables used in pseudo elements.
-$bar-color-edge: #0073bb;
-$bar-color-edge-in-flash: rgba(255, 255, 255, 0.7);
-
 .progress {
   inline-size: 100%;
   margin-inline-end: awsui.$space-s;
   min-inline-size: 0;
+
   @include general-progress-background-style;
   background-color: $background-color;
 
@@ -110,7 +107,8 @@ $bar-color-edge-in-flash: rgba(255, 255, 255, 0.7);
     background-color: $background-color;
   }
 
-  &::-webkit-progress-value {
+  &::-webkit-progress-value,
+  &::-moz-progress-bar {
     @include general-progress-bar-style;
     background-color: $bar-color;
   }
@@ -122,42 +120,17 @@ $bar-color-edge-in-flash: rgba(255, 255, 255, 0.7);
     border-end-end-radius: 10px;
   }
 
-  &::-moz-progress-bar {
-    @include general-progress-bar-style;
-    background-color: $bar-color;
-  }
-
-  &::-ms-fill {
-    @include general-progress-bar-style;
-    background-color: $bar-color-edge;
-    border-block: none;
-    border-inline: none;
-  }
-
-  &.complete::-ms-fill {
-    border-start-start-radius: 10px;
-    border-start-end-radius: 10px;
-    border-end-start-radius: 10px;
-    border-end-end-radius: 10px;
-  }
-
   &.progress-in-flash {
     background-color: $background-color-in-flash;
-
-    &::-webkit-progress-bar {
-      background-color: $background-color-in-flash;
-    }
-
-    &::-webkit-progress-value {
-      background-color: $bar-color-in-flash;
-    }
-
     &::-moz-progress-bar {
       background-color: $bar-color-in-flash;
     }
 
-    &::-ms-fill {
-      background-color: $bar-color-edge-in-flash;
+    &::-webkit-progress-bar {
+      background-color: $background-color-in-flash;
+    }
+    &::-webkit-progress-value {
+      background-color: $bar-color-in-flash;
     }
   }
 }

--- a/style-dictionary/utils/token-names.ts
+++ b/style-dictionary/utils/token-names.ts
@@ -211,6 +211,7 @@ export type ColorChartsTokenName =
   | 'colorChartsPaletteCategorical49'
   | 'colorChartsPaletteCategorical50';
 export type ColorsTokenName =
+  | 'colorGreyOpaque15'
   | 'colorGreyOpaque25'
   | 'colorGreyOpaque40'
   | 'colorGreyOpaque50'

--- a/style-dictionary/visual-refresh/colors.ts
+++ b/style-dictionary/visual-refresh/colors.ts
@@ -5,6 +5,7 @@ import { StyleDictionary } from '../utils/interfaces';
 import { expandColorDictionary } from '../utils';
 
 const tokens: StyleDictionary.ColorsDictionary = {
+  colorGreyOpaque15: 'rgba(22, 25, 31, 0.15)',
   colorGreyOpaque25: 'rgba(255, 255, 255, 0.25)',
   colorGreyOpaque40: 'rgba(0, 0, 0, 0.4)',
   colorGreyOpaque50: 'rgba(0, 0, 0, 0.5)',

--- a/style-dictionary/visual-refresh/contexts/flashbar-warning.ts
+++ b/style-dictionary/visual-refresh/contexts/flashbar-warning.ts
@@ -20,6 +20,10 @@ export const sharedTokens: StyleDictionary.ColorsDictionary = {
   colorTextInteractiveInvertedDefault: '{colorGrey600}',
   colorTextInteractiveInvertedHover: '{colorGrey900}',
 
+  // Progress bar should be using variant="flash", but this makes them use a white background.
+  colorBackgroundProgressBarContentInFlash: '{colorGrey900}',
+  colorBackgroundProgressBarLayoutInFlash: '{colorGreyOpaque15}',
+
   // Expandable sections
   colorTextExpandableSectionDefault: '{colorTextNotificationYellow}',
   colorTextExpandableSectionHover: '{colorTextNotificationYellow}',


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
