### PR TITLE
fix: Keep padding when opening dropdown on right or left

### DIFF
--- a/src/internal/components/dropdown/styles.scss
+++ b/src/internal/components/dropdown/styles.scss
@@ -67,17 +67,9 @@
   }
   &-drop-left {
     inset-inline-end: 0;
-
-    @include styles.with-direction('rtl') {
-      inset-inline-end: unset;
-    }
   }
   &-drop-right {
     inset-inline-start: 0;
-
-    @include styles.with-direction('rtl') {
-      inset-inline-start: unset;
-    }
   }
   &.occupy-entire-width {
     min-inline-size: 100%;


### PR DESCRIPTION
### Description

Remove `unset` of paddings to drop down left and right positioning between directions.

this `unset` is causing the dropdown to go out of page boundaries in RTL

to reproduce: open top left or bottom left dropdown in the following links

#### before: https://d21d5uik3ws71m.cloudfront.net/components/e8f018c6088071c30c23b29a21070840db5932b2/dev-pages/index.html#/light/button-dropdown/scenarios-expandable?direction=rtl

#### after:  https://d21d5uik3ws71m.cloudfront.net/components/eed4703446ffa7edd3875825b62d076542b94c5e/dev-pages/index.html#/light/button-dropdown/scenarios-positioning?direction=rtl

Related links, issue #, if available: AWSUI-50831

### How has this been tested?

tested with screenshot tests, the issue currently exist after the change the issue is resolved. 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
