### PR TITLE
refactor: Single tab stop navigation simpler unregistering

### DIFF
--- a/src/internal/context/single-tab-stop-navigation-context.tsx
+++ b/src/internal/context/single-tab-stop-navigation-context.tsx
@@ -10,6 +10,7 @@ import React, {
   useImperativeHandle,
   forwardRef,
 } from 'react';
+import { nodeBelongs } from '../utils/node-belongs';
 
 export type FocusableChangeHandler = (isFocusable: boolean) => void;
 
@@ -61,7 +62,7 @@ export interface SingleTabStopNavigationProviderProps {
   getNextFocusTarget: () => null | HTMLElement;
   isElementSuppressed?(focusableElement: Element): boolean;
   onRegisterFocusable?(focusableElement: Element): void;
-  onUnregisterFocusable?(focusableElement: Element): void;
+  onUnregisterActive?(focusableElement: Element): void;
 }
 
 export interface SingleTabStopNavigationAPI {
@@ -78,7 +79,7 @@ export const SingleTabStopNavigationProvider = forwardRef(
       getNextFocusTarget,
       isElementSuppressed,
       onRegisterFocusable,
-      onUnregisterFocusable,
+      onUnregisterActive,
     }: SingleTabStopNavigationProviderProps,
     ref: React.Ref<SingleTabStopNavigationAPI>
   ) => {
@@ -90,6 +91,14 @@ export const SingleTabStopNavigationProvider = forwardRef(
     const focusablesState = useRef(new WeakMap<Element, boolean>());
     // A reference to the currently focused element.
     const focusTarget = useRef<null | HTMLElement>(null);
+
+    function onUnregisterFocusable(focusableElement: Element) {
+      const isUnregisteringFocusedNode = nodeBelongs(focusableElement, document.activeElement);
+      if (isUnregisteringFocusedNode) {
+        // Wait for unmounted node to get removed from the DOM.
+        requestAnimationFrame(() => onUnregisterActive?.(focusableElement));
+      }
+    }
 
     // Register a focusable element to allow navigating into it.
     // The focusable element tabIndex is only set to 0 if the element matches the focus target.

--- a/src/table/table-role/grid-navigation.tsx
+++ b/src/table/table-role/grid-navigation.tsx
@@ -61,7 +61,7 @@ export function GridNavigationProvider({ keyboardNavigation, pageSize, getTable,
       getNextFocusTarget={gridNavigation.getNextFocusTarget}
       isElementSuppressed={gridNavigation.isElementSuppressed}
       onRegisterFocusable={gridNavigation.onRegisterFocusable}
-      onUnregisterFocusable={gridNavigation.onUnregisterFocusable}
+      onUnregisterActive={gridNavigation.onUnregisterActive}
     >
       {children}
     </SingleTabStopNavigationProvider>
@@ -128,17 +128,11 @@ class GridNavigationProcessor {
     }
   };
 
-  public onUnregisterFocusable = (focusable: Element) => {
-    const isUnregisteringFocusedNode = nodeBelongs(focusable, document.activeElement);
-    if (isUnregisteringFocusedNode) {
-      // Wait for unmounted node to get removed from the DOM.
-      setTimeout(() => {
-        // If the focused cell appears to be no longer attached to the table we need to re-apply
-        // focus to a cell with the same or closest position.
-        if (this.focusedCell && !nodeBelongs(this.table, this.focusedCell.element)) {
-          this.moveFocusBy(this.focusedCell, { x: 0, y: 0 });
-        }
-      }, 0);
+  public onUnregisterActive = () => {
+    // If the focused cell appears to be no longer attached to the table we need to re-apply
+    // focus to a cell with the same or closest position.
+    if (this.focusedCell && !nodeBelongs(this.table, this.focusedCell.element)) {
+      this.moveFocusBy(this.focusedCell, { x: 0, y: 0 });
     }
   };
 

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -27,7 +27,6 @@ import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { getAllFocusables } from '../internal/components/focus-lock/utils';
 import useHiddenDescription from '../internal/hooks/use-hidden-description';
 import Tooltip from '../internal/components/tooltip';
-import { nodeBelongs } from '../internal/utils/node-belongs';
 import { ButtonProps } from '../button/interfaces';
 import { circleIndex } from '../internal/utils/circle-index';
 
@@ -183,16 +182,12 @@ export function TabHeaderBar({
     return tabElements.find(tab => tab.matches(focusedTabSelector)) ?? tabElements.find(tab => !tab.disabled) ?? null;
   }
 
-  function onUnregisterFocusable(focusableElement: HTMLElement) {
-    const isUnregisteringFocusedNode = nodeBelongs(focusableElement, document.activeElement);
+  function onUnregisterActive(focusableElement: HTMLElement) {
     const isFocusableActionOrDismissible = !focusableElement.classList.contains(styles['tabs-tab-link']);
-    if (isUnregisteringFocusedNode && !isFocusableActionOrDismissible) {
-      // Wait for unmounted node to get removed from the DOM.
-      requestAnimationFrame(() => {
-        const nextFocusTarget = navigationAPI.current?.getFocusTarget();
-        const tabLinkButton = nextFocusTarget?.querySelector(`.${styles['tabs-tab-link']}`) as HTMLElement;
-        tabLinkButton?.focus();
-      });
+    if (!isFocusableActionOrDismissible) {
+      const nextFocusTarget = navigationAPI.current?.getFocusTarget();
+      const tabLinkButton = nextFocusTarget?.querySelector(`.${styles['tabs-tab-link']}`) as HTMLElement;
+      tabLinkButton?.focus();
     }
   }
 
@@ -294,7 +289,7 @@ export function TabHeaderBar({
         ref={navigationAPI}
         navigationActive={true}
         getNextFocusTarget={getNextFocusTarget}
-        onUnregisterFocusable={onUnregisterFocusable}
+        onUnregisterActive={onUnregisterActive}
       >
         <TabList
           {...tabActionAttributes}


### PR DESCRIPTION
### Description

A small improvement for single tab stop navigation context. To be also consumed here by the new button group component: https://github.com/cloudscape-design/components/pull/2469

Related links, issue #, if available: n/a

### How has this been tested?

* Existing unit- and integration tests
* Manual tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
