### PR TITLE
feat: Adds verticalAlign property to table cells

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -64,7 +64,7 @@ const VERTICAL_ALIGN_COLUMNS: TableProps.ColumnDefinition<any>[] = [
   {
     id: 'variable',
     header: 'Property',
-    cell: item => <Input readOnly={true} value={item.number} />,
+    cell: item => <Input ariaLabel="vertical align input" readOnly={true} value={item.number} />,
     verticalAlign: 'top',
   },
   {
@@ -72,7 +72,7 @@ const VERTICAL_ALIGN_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     header: 'Type',
     cell: item => (
       <FormField errorText={`${item.text} error text`}>
-        <Input readOnly={true} value={item.text} />
+        <Input ariaLabel="vertical align error input" readOnly={true} value={item.text} />
       </FormField>
     ),
     verticalAlign: 'top',

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -3,7 +3,9 @@
 import React from 'react';
 import range from 'lodash/range';
 
+import FormField from '~components/form-field';
 import Header from '~components/header';
+import Input from '~components/input';
 import Link from '~components/link';
 import PropertyFilter from '~components/property-filter';
 import Table, { TableProps } from '~components/table';
@@ -55,6 +57,31 @@ const PROPERTY_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     id: 'value',
     header: 'Value',
     cell: item => item.value,
+  },
+];
+
+const VERTICAL_ALIGN_COLUMNS: TableProps.ColumnDefinition<any>[] = [
+  {
+    id: 'variable',
+    header: 'Property',
+    cell: item => <Input readOnly={true} value={item.number} />,
+    verticalAlign: 'top',
+  },
+  {
+    id: 'type',
+    header: 'Type',
+    cell: item => (
+      <FormField errorText={`${item.text} error text`}>
+        <Input readOnly={true} value={item.text} />
+      </FormField>
+    ),
+    verticalAlign: 'top',
+  },
+  {
+    id: 'type',
+    header: 'Type',
+    cell: item => item.text,
+    verticalAlign: 'top',
   },
 ];
 
@@ -281,6 +308,11 @@ const permutations = createPermutations<TableProps>([
     ],
     preferences: ['preferences'],
     items: [createSimpleItems(3)],
+  },
+  {
+    columnDefinitions: [VERTICAL_ALIGN_COLUMNS],
+    items: [createSimpleItems(3)],
+    variant: [undefined, 'full-page'],
   },
 ]);
 /* eslint-enable react/jsx-key */

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -78,8 +78,8 @@ const VERTICAL_ALIGN_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     verticalAlign: 'top',
   },
   {
-    id: 'type',
-    header: 'Type',
+    id: 'type-2',
+    header: 'Value',
     cell: item => item.text,
     verticalAlign: 'top',
   },

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -71,7 +71,7 @@ const VERTICAL_ALIGN_COLUMNS: TableProps.ColumnDefinition<any>[] = [
     id: 'type',
     header: 'Type',
     cell: item => (
-      <FormField errorText={`${item.text} error text`}>
+      <FormField errorText={`${item.text} error text`} i18nStrings={{ errorIconAriaLabel: 'Error' }}>
         <Input ariaLabel="vertical align error input" readOnly={true} value={item.text} />
       </FormField>
     ),

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14708,7 +14708,8 @@ add a meaningful description to the whole selection.
        The \`cellContext\` object contains the following properties:
     * \`cellContext.currentValue\` - State to keep track of a value in input fields while editing.
     * \`cellContext.setValue\` - Function to update \`currentValue\`. This should be called when the value in input field changes.
-* \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.",
+* \`isRowHeader\` (boolean) - Specifies that cells in this column should be used as row headers.
+* \`verticalAlign\` ('middle' | 'top') - Determines the alignment of the content in the table cell.",
       "name": "columnDefinitions",
       "optional": false,
       "type": "ReadonlyArray<TableProps.ColumnDefinition<T>>",

--- a/src/table/__tests__/body-cell.test.tsx
+++ b/src/table/__tests__/body-cell.test.tsx
@@ -350,4 +350,17 @@ describe('TableBodyCell', () => {
     setCurrentTarget(null);
     expect(tableCell).not.toHaveAttribute('tabIndex');
   });
+
+  describe('vertical align', () => {
+    const verticalAlignTopClass = `.${styles['body-cell-align-top']}`;
+    test('verticalAlign style is not present by default', () => {
+      const { container } = render(<TestComponent />);
+      expect(container.querySelector(verticalAlignTopClass)!).not.toBeInTheDocument();
+    });
+
+    test('verticalAlign style works as expected when defined', () => {
+      const { container } = render(<TestComponent verticalAlign="top" />);
+      expect(container.querySelector(verticalAlignTopClass)!).toBeInTheDocument();
+    });
+  });
 });

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -176,6 +176,9 @@ $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
   &:first-child:not(.is-visual-refresh) {
     @include cell-padding-inline-start($cell-edge-horizontal-padding);
   }
+  &-align-top {
+    vertical-align: top;
+  }
   &-first-row {
     border-block-start: $border-placeholder;
   }

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -9,6 +9,7 @@ import { ExpandToggleButton } from '../expandable-rows/expand-toggle-button';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { getTableCellRoleProps, TableRole } from '../table-role';
 import { getStickyClassNames } from '../utils';
+import { TableProps } from '../interfaces.js';
 
 import styles from './styles.css.js';
 
@@ -45,6 +46,7 @@ export interface TableTdElementProps {
   onExpandableItemToggle?: () => void;
   expandButtonLabel?: string;
   collapseButtonLabel?: string;
+  verticalAlign?: TableProps.VerticalAlignType;
 }
 
 export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElementProps>(
@@ -79,6 +81,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
       onExpandableItemToggle,
       expandButtonLabel,
       collapseButtonLabel,
+      verticalAlign,
     },
     ref
   ) => {
@@ -115,6 +118,7 @@ export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElem
           hasFooter && styles['has-footer'],
           level !== undefined && styles['body-cell-expandable'],
           level !== undefined && styles[`expandable-level-${getLevelClassSuffix(level)}`],
+          verticalAlign === 'top' && styles['body-cell-align-top'],
           stickyStyles.className
         )}
         onClick={onClick}

--- a/src/table/body-cell/td-element.tsx
+++ b/src/table/body-cell/td-element.tsx
@@ -6,10 +6,10 @@ import clsx from 'clsx';
 import { useSingleTabStopNavigation } from '../../internal/context/single-tab-stop-navigation-context';
 import { useMergeRefs } from '../../internal/hooks/use-merge-refs';
 import { ExpandToggleButton } from '../expandable-rows/expand-toggle-button';
+import { TableProps } from '../interfaces.js';
 import { StickyColumnsModel, useStickyCellStyles } from '../sticky-columns';
 import { getTableCellRoleProps, TableRole } from '../table-role';
 import { getStickyClassNames } from '../utils';
-import { TableProps } from '../interfaces.js';
 
 import styles from './styles.css.js';
 
@@ -46,7 +46,7 @@ export interface TableTdElementProps {
   onExpandableItemToggle?: () => void;
   expandButtonLabel?: string;
   collapseButtonLabel?: string;
-  verticalAlign?: TableProps.VerticalAlignType;
+  verticalAlign?: TableProps.VerticalAlign;
 }
 
 export const TableTdElement = React.forwardRef<HTMLTableCellElement, TableTdElementProps>(

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -106,6 +106,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
    *     * `cellContext.currentValue` - State to keep track of a value in input fields while editing.
    *     * `cellContext.setValue` - Function to update `currentValue`. This should be called when the value in input field changes.
    * * `isRowHeader` (boolean) - Specifies that cells in this column should be used as row headers.
+   * * `verticalAlign` ('middle' | 'top') - Determines the alignment of the content in the table cell.
    */
   columnDefinitions: ReadonlyArray<TableProps.ColumnDefinition<T>>;
   /**
@@ -436,7 +437,7 @@ export namespace TableProps {
     last?: number;
   }
 
-  export type VerticalAlignType = 'center' | 'top';
+  export type VerticalAlignType = 'middle' | 'top';
   export type SelectionType = 'single' | 'multi';
   export type Variant = 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page';
   export interface SelectionState<T> {

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -427,6 +427,7 @@ export namespace TableProps {
     maxWidth?: number | string;
     editConfig?: EditConfig<ItemType>;
     isRowHeader?: boolean;
+    verticalAlign?: VerticalAlignType;
     cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 
@@ -435,6 +436,7 @@ export namespace TableProps {
     last?: number;
   }
 
+  export type VerticalAlignType = 'center' | 'top';
   export type SelectionType = 'single' | 'multi';
   export type Variant = 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page';
   export interface SelectionState<T> {

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -428,7 +428,7 @@ export namespace TableProps {
     maxWidth?: number | string;
     editConfig?: EditConfig<ItemType>;
     isRowHeader?: boolean;
-    verticalAlign?: VerticalAlignType;
+    verticalAlign?: VerticalAlign;
     cell(item: ItemType): React.ReactNode;
   } & SortingColumn<ItemType>;
 
@@ -437,7 +437,7 @@ export namespace TableProps {
     last?: number;
   }
 
-  export type VerticalAlignType = 'middle' | 'top';
+  export type VerticalAlign = 'middle' | 'top';
   export type SelectionType = 'single' | 'multi';
   export type Variant = 'container' | 'embedded' | 'borderless' | 'stacked' | 'full-page';
   export interface SelectionState<T> {

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -579,6 +579,7 @@ const InternalTable = React.forwardRef(
                                     submitEdit={cellEditing.submitEdit}
                                     columnId={column.id ?? colIndex}
                                     colIndex={colIndex + colIndexOffset}
+                                    verticalAlign={column.verticalAlign}
                                     {...cellExpandableProps}
                                   />
                                 );


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->
This PR adds a small property to table cells that allows the content to be aligned vertically.
<img width="1700" alt="image" src="https://github.com/user-attachments/assets/7b1cfb97-f181-407d-bf80-5116dc9697d6">

Part of the track two tickets for the P&C squad in Q3.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
