### PR TITLE
feat: support updateDrawer in AppLayout plugins API

### DIFF
--- a/pages/app-layout/runtime-drawers-with-updates.page.tsx
+++ b/pages/app-layout/runtime-drawers-with-updates.page.tsx
@@ -1,13 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useContext, useEffect, useState } from 'react';
+
 import { AppLayout, ContentLayout, Header, HelpPanel, Link, SpaceBetween, Toggle } from '~components';
-import appLayoutLabels from './utils/labels';
 import { AppLayoutProps } from '~components/app-layout';
-import { Breadcrumbs, Containers } from './utils/content-blocks';
+import awsuiPlugins from '~components/internal/plugins';
+
 import './utils/external-widget';
 import AppContext, { AppContextType } from '../app/app-context';
-import awsuiPlugins from '~components/internal/plugins';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import appLayoutLabels from './utils/labels';
 
 type DemoContext = React.Context<
   AppContextType<{
@@ -67,30 +69,28 @@ export default function WithDrawers() {
                   Use Tools
                 </Toggle>
 
-                <SpaceBetween size="xs">
-                  <Header variant="h2">Security Drawer Updates</Header>
-                  <Toggle
-                    data-testid="show-badge-toggle"
-                    checked={showBadge}
-                    onChange={({ detail }) => setUrlParams({ showBadge: detail.checked })}
-                  >
-                    Show Badge
-                  </Toggle>
-                  <Toggle
-                    data-testid="turn-off-resize-toggle"
-                    checked={turnOffResizable}
-                    onChange={({ detail }) => setUrlParams({ turnOffResizable: detail.checked })}
-                  >
-                    Turn off Resize
-                  </Toggle>
-                  <Toggle
-                    data-testid="increase-drawer-size-toggle"
-                    checked={increaseDrawerSize}
-                    onChange={({ detail }) => setUrlParams({ increaseDrawerSize: detail.checked })}
-                  >
-                    Increase Drawer Size
-                  </Toggle>
-                </SpaceBetween>
+                <Header variant="h2">Security Drawer Updates</Header>
+                <Toggle
+                  data-testid="show-badge-toggle"
+                  checked={showBadge}
+                  onChange={({ detail }) => setUrlParams({ showBadge: detail.checked })}
+                >
+                  Show Badge
+                </Toggle>
+                <Toggle
+                  data-testid="turn-off-resize-toggle"
+                  checked={turnOffResizable}
+                  onChange={({ detail }) => setUrlParams({ turnOffResizable: detail.checked })}
+                >
+                  Turn off Resize
+                </Toggle>
+                <Toggle
+                  data-testid="increase-drawer-size-toggle"
+                  checked={increaseDrawerSize}
+                  onChange={({ detail }) => setUrlParams({ increaseDrawerSize: detail.checked })}
+                >
+                  Increase Drawer Size
+                </Toggle>
               </SpaceBetween>
             </SpaceBetween>
           }

--- a/pages/app-layout/runtime-drawers-with-updates.page.tsx
+++ b/pages/app-layout/runtime-drawers-with-updates.page.tsx
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useEffect, useState } from 'react';
+import { AppLayout, ContentLayout, Header, HelpPanel, Link, SpaceBetween, Toggle } from '~components';
+import appLayoutLabels from './utils/labels';
+import { AppLayoutProps } from '~components/app-layout';
+import { Breadcrumbs, Containers } from './utils/content-blocks';
+import './utils/external-widget';
+import AppContext, { AppContextType } from '../app/app-context';
+import awsuiPlugins from '~components/internal/plugins';
+
+type DemoContext = React.Context<
+  AppContextType<{
+    hasTools: boolean | undefined;
+    showBadge: boolean | undefined;
+    turnOffResizable: boolean | undefined;
+    increaseDrawerSize: boolean | undefined;
+    splitPanelPosition: AppLayoutProps.SplitPanelPreferences['position'];
+  }>
+>;
+
+export default function WithDrawers() {
+  const [helpPathSlug, setHelpPathSlug] = useState<string>('default');
+  const { urlParams, setUrlParams } = useContext(AppContext as DemoContext);
+  const { increaseDrawerSize = false, hasTools = false, showBadge = false, turnOffResizable = false } = urlParams;
+  const [isToolsOpen, setIsToolsOpen] = useState(false);
+
+  useEffect(() => {
+    awsuiPlugins.appLayout.updateDrawer({
+      id: 'security',
+      badge: showBadge,
+      resizable: !turnOffResizable,
+      defaultSize: increaseDrawerSize ? 440 : 320,
+    });
+  }, [showBadge, turnOffResizable, increaseDrawerSize]);
+
+  return (
+    <AppLayout
+      ariaLabels={appLayoutLabels}
+      breadcrumbs={<Breadcrumbs />}
+      content={
+        <ContentLayout
+          disableOverlap={true}
+          header={
+            <SpaceBetween size="m">
+              <Header
+                variant="h1"
+                description="Sometimes you need custom drawers to get the job done."
+                info={
+                  <Link
+                    data-testid="info-link-header"
+                    variant="info"
+                    onFollow={() => {
+                      setHelpPathSlug('header');
+                      setIsToolsOpen(true);
+                    }}
+                  >
+                    Info
+                  </Link>
+                }
+              >
+                Testing Custom Drawers with updates!
+              </Header>
+
+              <SpaceBetween size="xs">
+                <Toggle checked={hasTools} onChange={({ detail }) => setUrlParams({ hasTools: detail.checked })}>
+                  Use Tools
+                </Toggle>
+
+                <SpaceBetween size="xs">
+                  <Header variant="h2">Security Drawer Updates</Header>
+                  <Toggle
+                    data-testid="show-badge-toggle"
+                    checked={showBadge}
+                    onChange={({ detail }) => setUrlParams({ showBadge: detail.checked })}
+                  >
+                    Show Badge
+                  </Toggle>
+                  <Toggle
+                    data-testid="turn-off-resize-toggle"
+                    checked={turnOffResizable}
+                    onChange={({ detail }) => setUrlParams({ turnOffResizable: detail.checked })}
+                  >
+                    Turn off Resize
+                  </Toggle>
+                  <Toggle
+                    data-testid="increase-drawer-size-toggle"
+                    checked={increaseDrawerSize}
+                    onChange={({ detail }) => setUrlParams({ increaseDrawerSize: detail.checked })}
+                  >
+                    Increase Drawer Size
+                  </Toggle>
+                </SpaceBetween>
+              </SpaceBetween>
+            </SpaceBetween>
+          }
+        >
+          <Header
+            info={
+              <Link
+                data-testid="info-link-content"
+                variant="info"
+                onFollow={() => {
+                  setHelpPathSlug('content');
+                  setIsToolsOpen(true);
+                }}
+              >
+                Info
+              </Link>
+            }
+          >
+            Content
+          </Header>
+          <Containers />
+        </ContentLayout>
+      }
+      onToolsChange={event => {
+        setIsToolsOpen(event.detail.open);
+      }}
+      tools={<Info helpPathSlug={helpPathSlug} />}
+      toolsOpen={isToolsOpen}
+      toolsHide={!hasTools}
+    />
+  );
+}
+
+function Info({ helpPathSlug }: { helpPathSlug: string }) {
+  return <HelpPanel header={<h2>Info</h2>}>Here is some info for you: {helpPathSlug}</HelpPanel>;
+}

--- a/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
 import createWrapper from '../../../lib/components/test-utils/selectors';
 
 const wrapper = createWrapper().findAppLayout();

--- a/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
+++ b/src/app-layout/__integ__/runtime-drawers-with-updates.test.ts
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper().findAppLayout();
+
+for (const visualRefresh of [true, false]) {
+  describe(`visualRefresh=${visualRefresh}`, () => {
+    function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+      return useBrowser(async browser => {
+        const page = new BasePageObject(browser);
+
+        await browser.url(
+          `#/light/app-layout/runtime-drawers-with-updates?${new URLSearchParams({
+            hasTools: 'true',
+            visualRefresh: `${visualRefresh}`,
+          }).toString()}`
+        );
+        await page.waitForVisible(wrapper.findDrawerTriggerById('security').toSelector(), true);
+        await testFn(page);
+      });
+    }
+
+    test(
+      'should update the drawer default size',
+      setupTest(async page => {
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+        // using `clientWidth` to neglect possible border width set on this element
+        expect(await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth')).toEqual(320);
+
+        await page.click(
+          createWrapper().findToggle('[data-testid="increase-drawer-size-toggle"]').findNativeInput().toSelector()
+        );
+
+        expect(await page.getElementProperty(wrapper.findActiveDrawer().toSelector(), 'clientWidth')).toEqual(440);
+      })
+    );
+
+    test(
+      'should call update drawer to disable resize',
+      setupTest(async page => {
+        // close navigation panel to give drawer more room to resize
+        await page.click(wrapper.findNavigationClose().toSelector());
+        await page.click(wrapper.findDrawerTriggerById('security').toSelector());
+
+        await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(true);
+
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: false');
+
+        await page.dragAndDrop(wrapper.findActiveDrawerResizeHandle().toSelector(), -200);
+        await expect(page.getText('[data-testid="current-size"]')).resolves.toEqual('resized: true');
+
+        await page.click(
+          createWrapper().findToggle('[data-testid="turn-off-resize-toggle"]').findNativeInput().toSelector()
+        );
+
+        await expect(page.isExisting(wrapper.findActiveDrawerResizeHandle().toSelector())).resolves.toBe(false);
+      })
+    );
+  });
+}

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -75,7 +75,7 @@ describeEachAppLayout(({ theme, size }) => {
     expect(wrapper.findDrawersTriggers()).toHaveLength(2);
   });
 
-  test.only('update rendered drawers via runtime config', async () => {
+  test('update rendered drawers via runtime config', async () => {
     awsuiPlugins.appLayout.registerDrawer({ ...drawerDefaults, resizable: true });
     const { wrapper } = await renderComponent(<AppLayout />);
     // the 2nd trigger is for tools
@@ -90,14 +90,14 @@ describeEachAppLayout(({ theme, size }) => {
       badge: true,
     });
     await delay();
-    const selector =
+    const badgeSelector =
       theme === 'refresh-toolbar'
         ? toolbarTriggerStyles.badge
         : theme === 'refresh' && size === 'desktop'
           ? triggerStyles.badge
           : iconStyles.badge;
 
-    expect(triggerParentWrapper?.findByClassName(selector)?.getElement()).toBeInTheDocument();
+    expect(triggerParentWrapper!.findByClassName(badgeSelector)!.getElement()).toBeInTheDocument();
 
     awsuiPlugins.appLayout.updateDrawer({
       id: drawerDefaults.id,
@@ -106,7 +106,7 @@ describeEachAppLayout(({ theme, size }) => {
     await delay();
 
     // re-querying the dot element
-    expect(triggerParentWrapper?.findByClassName(selector)?.getElement()).toBeUndefined();
+    expect(triggerParentWrapper!.findByClassName(badgeSelector)).toBeNull();
   });
 
   (size === 'desktop' ? test : test.skip)('update runtime drawers config resizable validation', async () => {

--- a/src/internal/plugins/__tests__/api.test.ts
+++ b/src/internal/plugins/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { loadApi } from '../../../../lib/components/internal/plugins/api';
-import { DrawerConfig } from '../../../../lib/components/internal/plugins/controllers/drawers';
+import { DrawerConfig, UpdateDrawerConfig } from '../../../../lib/components/internal/plugins/controllers/drawers';
 
 function delay() {
   return new Promise(resolve => setTimeout(resolve));
@@ -27,6 +27,27 @@ test('loading api multiple times does not reset the state', async () => {
   api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-2' } as DrawerConfig);
   await delay();
   expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2' }]);
+});
+
+test('triggering update drawer multiple times does not reset the state', async () => {
+  const api = loadApi();
+  const onRegister = jest.fn();
+  api.awsuiPluginsInternal.appLayout.onDrawersRegistered(onRegister);
+  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-1' } as DrawerConfig);
+  api.awsuiPlugins.appLayout.registerDrawer({ id: 'drawer-2', badge: false } as DrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2', badge: false }]);
+
+  api.awsuiPlugins.appLayout.updateDrawer({ id: 'drawer-2', badge: true } as UpdateDrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([{ id: 'drawer-1' }, { id: 'drawer-2', badge: true }]);
+
+  api.awsuiPlugins.appLayout.updateDrawer({ id: 'drawer-1', defaultSize: 400, resizable: true } as UpdateDrawerConfig);
+  await delay();
+  expect(onRegister).toHaveBeenCalledWith([
+    { id: 'drawer-1', defaultSize: 400, resizable: true },
+    { id: 'drawer-2', badge: true },
+  ]);
 });
 
 test('partial API can be extended', () => {

--- a/src/internal/plugins/controllers/__tests__/drawers.test.ts
+++ b/src/internal/plugins/controllers/__tests__/drawers.test.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DrawerConfig, DrawersController } from '../../../../../lib/components/internal/plugins/controllers/drawers';
+import {
+  DrawerConfig,
+  DrawersController,
+  UpdateDrawerConfig,
+} from '../../../../../lib/components/internal/plugins/controllers/drawers';
 
 const drawerA = { id: 'drawerA' } as DrawerConfig;
 const drawerB = { id: 'drawerB' } as DrawerConfig;
@@ -50,6 +54,30 @@ test('change listener is not called after cleanup', async () => {
   drawers.registerDrawer(drawerA);
   await delay();
   expect(onDrawersRegistered).not.toHaveBeenCalled();
+});
+
+describe('update drawer', () => {
+  test('notifies about updated drawers', async () => {
+    const onDrawersRegistered = jest.fn();
+    const drawers = new DrawersController();
+    drawers.onDrawersRegistered(onDrawersRegistered);
+    drawers.registerDrawer(drawerA);
+    drawers.registerDrawer(drawerB);
+    expect(onDrawersRegistered).not.toHaveBeenCalled();
+    await delay();
+    expect(onDrawersRegistered).toHaveBeenCalledWith([drawerA, drawerB]);
+    const updatedDrawer = { ...drawerA, badge: true };
+    drawers.updateDrawer(updatedDrawer);
+    await delay();
+    expect(onDrawersRegistered).toHaveBeenLastCalledWith([updatedDrawer, drawerB]);
+  });
+
+  test('throw error if the update drawer is not registered', () => {
+    const drawers = new DrawersController();
+    expect(() => drawers.updateDrawer({ id: 'test-drawer' } as UpdateDrawerConfig)).toThrowError(
+      '[AwsUi] [runtime drawers] drawer with id test-drawer not found'
+    );
+  });
 });
 
 describe('console warnings', () => {


### PR DESCRIPTION
### Description

Support `updateDrawer` in AppLayout plugins API

Currently, there is only option to register a Drawer, there is no support to update a registered drawer. Such updates includes badge, resizable, orderPriority, and others

Related links
- Linked to previous [pull request](https://github.com/cloudscape-design/components/pull/2476).

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ yes
- _Changes are covered with new/existing integration tests?_ yes
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
