### PR TITLE
fix: Problem with hotspot component within annotation context

### DIFF
--- a/pages/annotation-context/with-switching-pages.page.tsx
+++ b/pages/annotation-context/with-switching-pages.page.tsx
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useState } from 'react';
+
+import AnnotationContext from '~components/annotation-context';
+import Button from '~components/button';
+import Hotspot from '~components/hotspot';
+import SpaceBetween from '~components/space-between';
+import Spinner from '~components/spinner';
+
+import { annotationContextStrings } from '../onboarding/i18n';
+import tutorials from '../onboarding/tutorials';
+
+const tutorial = tutorials(() => {})[0];
+const noop = () => {};
+
+export default function AnnotationScroll() {
+  const [currentPage, setCurrentPage] = useState<'1' | '2' | 'loading'>('1');
+
+  return (
+    <>
+      <h1>Annotation Context: with switching pages</h1>
+      <AnnotationContext
+        currentTutorial={tutorial}
+        i18nStrings={annotationContextStrings}
+        onStartTutorial={noop}
+        onExitTutorial={noop}
+      >
+        <div style={{ padding: 20 }}>
+          <SpaceBetween size="l">
+            {currentPage === 'loading' && <Spinner />}
+
+            {currentPage === '1' && (
+              <div>
+                <div style={{ paddingBottom: '200px' }}>
+                  first
+                  <Hotspot hotspotId={tutorial.tasks[0].steps[0].hotspotId} />
+                </div>
+                <Button
+                  onClick={() => {
+                    setCurrentPage('loading');
+                    setTimeout(() => setCurrentPage('2'), 100);
+                  }}
+                  data-testid="next-page"
+                >
+                  to next page
+                </Button>
+              </div>
+            )}
+
+            {currentPage === '2' && (
+              <div data-testid="second-page">
+                <div>
+                  fourth
+                  <Hotspot hotspotId={tutorial.tasks[0].steps[2].hotspotId} />
+                </div>
+              </div>
+            )}
+          </SpaceBetween>
+        </div>
+      </AnnotationContext>
+    </>
+  );
+}

--- a/src/annotation-context/__integ__/switching-pages.test.ts
+++ b/src/annotation-context/__integ__/switching-pages.test.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper();
+const annotationWrapper = wrapper.findAnnotation();
+
+// AWSUI-51612
+test(
+  'should open a next hotspot on a next page after loading',
+  useBrowser(async browser => {
+    await browser.url('#/light/annotation-context/with-switching-pages');
+    const page = new BasePageObject(browser);
+    await page.click(annotationWrapper.findNextButton().toSelector());
+    await page.click('[data-testid="next-page"]');
+    await page.waitForVisible('[data-testid="second-page"]');
+    await expect(page.isDisplayed(wrapper.findAnnotation().toSelector())).resolves.toBe(true);
+  })
+);

--- a/src/annotation-context/index.tsx
+++ b/src/annotation-context/index.tsx
@@ -109,7 +109,7 @@ export default function AnnotationContext({
       setOpen(true);
       fireNonCancelableEvent(onStepChange, { step: newStepIndex, reason: 'auto-fallback' });
     }
-  }, [annotations, isCurrentHotspotAvailable, currentId, currentStepIndex, id2index, onStepChange]);
+  }, [annotations, isCurrentHotspotAvailable, currentId, currentStepIndex, id2index, onStepChange, availableHotspots]);
 
   const onDismiss = useCallback(() => {
     setOpen(false);


### PR DESCRIPTION
### Description

AWSUI-51612

**Problem**
When 2 pages have connected hotspots and loading states for transition between them, after loading a new page, the next hotspot in not automatically shown.

**Root cause**
[useEffect](https://github.com/cloudscape-design/components/blob/main/src/annotation-context/index.tsx#L87) responsible for opening the next hotspot is called before the next hotspot is registered on the page, so [this object](https://github.com/cloudscape-design/components/blob/main/src/annotation-context/index.tsx#L95) would be empty.

**Solution**
Added `availableHotspots` to the `useEffect` dependency array to ensure the useEffect picks up the latest changes from newly registered hotspot. Adding `availableHotspots` to the dependency array does not causing infinite loop, because they are not updating within this `useEffect`



Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
