### PR TITLE
fix: Button group tooltip fix for items w/o popover, loading and disabled items

### DIFF
--- a/pages/button-group/item-permutations.page.tsx
+++ b/pages/button-group/item-permutations.page.tsx
@@ -1,10 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
-import ScreenshotArea from '../utils/screenshot-area';
-import PermutationsView from '../utils/permutations-view';
-import createPermutations from '../utils/permutations';
+
 import { ButtonGroup, ButtonGroupProps, SpaceBetween, StatusIndicator } from '~components';
+
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
 
 const itemPermutations = createPermutations<ButtonGroupProps.IconButton>([
   // Undefined icon

--- a/pages/button-group/permutations.page.tsx
+++ b/pages/button-group/permutations.page.tsx
@@ -1,10 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
-import ScreenshotArea from '../utils/screenshot-area';
-import PermutationsView from '../utils/permutations-view';
-import createPermutations from '../utils/permutations';
+
 import { ButtonGroup, ButtonGroupProps } from '~components';
+
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
 
 const feedbackGroup: ButtonGroupProps.Group = {
   type: 'group',

--- a/pages/button-group/test.page.tsx
+++ b/pages/button-group/test.page.tsx
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import React, { useContext, useState } from 'react';
-import ButtonGroup, { ButtonGroupProps } from '~components/button-group';
+
 import { Box, Button, SpaceBetween, StatusIndicator } from '~components';
+import ButtonGroup, { ButtonGroupProps } from '~components/button-group';
+
 import AppContext, { AppContextType } from '../app/app-context';
 
 type PageContext = React.Context<
@@ -50,11 +53,25 @@ const addButton: ButtonGroupProps.Item = {
   disabled: true,
 };
 
+const sendButton: ButtonGroupProps.Item = {
+  type: 'icon-button',
+  id: 'send',
+  iconName: 'send',
+  text: 'Send',
+};
+
 const removeButton: ButtonGroupProps.Item = {
   type: 'icon-button',
   id: 'remove',
   iconName: 'remove',
   text: 'Remove',
+};
+
+const redoButton: ButtonGroupProps.Item = {
+  type: 'icon-button',
+  id: 'redo',
+  iconName: 'redo',
+  text: 'Redo',
 };
 
 const moreActionsMenu: ButtonGroupProps.MenuDropdown = {
@@ -85,36 +102,37 @@ const moreActionsMenu: ButtonGroupProps.MenuDropdown = {
   ],
 };
 
-const moreActionsMenu2: ButtonGroupProps.MenuDropdown = {
-  type: 'menu-dropdown',
-  id: 'more-actions2',
-  text: 'More actions',
-  items: [
-    {
-      id: 'cut',
-      iconName: 'delete-marker',
-      text: 'Cut',
-    },
-  ],
-};
-
-const actionsGroup: ButtonGroupProps.Group = {
-  type: 'group',
-  text: 'Actions',
-  items: [addButton, removeButton, moreActionsMenu, moreActionsMenu2],
-};
-
 export default function ButtonGroupPage() {
   const {
     urlParams: { dropdownExpandToViewport = true },
   } = useContext(AppContext as PageContext);
   const ref = React.useRef<ButtonGroupProps.Ref>(null);
 
+  const [items, setItems] = useState([
+    feedbackGroup,
+    copyButton,
+    addButton,
+    sendButton,
+    redoButton,
+    removeButton,
+    moreActionsMenu,
+  ]);
+
   const onItemClick: ButtonGroupProps['onItemClick'] = event => {
     document.querySelector('#last-clicked')!.textContent = event.detail.id;
 
     if (event.detail.id === 'dislike') {
-      setItems([copyButton, actionsGroup]);
+      setItems(prev => prev.filter(item => item.type !== 'group'));
+    }
+    if (event.detail.id === 'redo') {
+      setItems(prev =>
+        prev.map(item => (item.type === 'icon-button' && item.id === 'redo' ? { ...item, disabled: true } : item))
+      );
+    }
+    if (event.detail.id === 'remove') {
+      setItems(prev =>
+        prev.map(item => (item.type === 'icon-button' && item.id === 'remove' ? { ...item, loading: true } : item))
+      );
     }
   };
 
@@ -125,8 +143,6 @@ export default function ButtonGroupPage() {
   const onFocusOnMoreActionsButtonClick = () => {
     ref.current?.focus('more-actions');
   };
-
-  const [items, setItems] = useState([feedbackGroup, copyButton, actionsGroup]);
 
   return (
     <Box margin="m">

--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -9,6 +9,7 @@ const buttonGroup = createWrapper().findButtonGroup();
 const likeButton = buttonGroup.findButtonById('like');
 const dislikeButton = buttonGroup.findButtonById('dislike');
 const copyButton = buttonGroup.findButtonById('copy');
+const sendButton = buttonGroup.findButtonById('send');
 const actionsMenu = buttonGroup.findMenuById('more-actions');
 
 function setup(options: { dropdownExpandToViewport?: boolean }, testFn: (page: BasePageObject) => Promise<void>) {
@@ -50,7 +51,7 @@ test.each([false, true])(
       await page.keys(['Tab']);
       await expect(page.isFocused(likeButton.toSelector())).resolves.toBe(true);
 
-      await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
+      await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight', 'ArrowRight']);
       await expect(page.isFocused(actionsMenu.find('button').toSelector())).resolves.toBe(true);
 
       await page.keys(['Enter']);
@@ -125,10 +126,21 @@ test(
 
     await page.keys(['ArrowRight']);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
-    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Remove');
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
 
-    await page.keys(['ArrowRight']);
+    await page.keys(['ArrowRight', 'ArrowRight', 'ArrowRight']);
     await expect(page.getElementsCount(buttonGroup.findTooltip().toSelector())).resolves.toBe(1);
     await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('More actions');
+  })
+);
+
+test(
+  'keeps showing tooltip after clicking on a button with no popover feedback',
+  setup({}, async page => {
+    await page.hoverElement(sendButton.toSelector());
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
+
+    await page.click(sendButton.toSelector());
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('Send');
   })
 );

--- a/src/button-group/icon-button-item.tsx
+++ b/src/button-group/icon-button-item.tsx
@@ -56,7 +56,7 @@ const IconButtonItem = forwardRef(
         >
           {item.text}
         </InternalButton>
-        {showTooltip && !item.disabled && (!showFeedback || item.popoverFeedback) && (
+        {showTooltip && !item.disabled && !item.loading && (!showFeedback || item.popoverFeedback) && (
           <Tooltip
             trackRef={containerRef}
             trackKey={item.id}

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -83,8 +83,6 @@ const ItemElement = forwardRef(
 
       if (popoverFeedback) {
         setTooltip({ item: item.id, feedback: true });
-      } else {
-        setTooltip(null);
       }
 
       fireCancelableEvent(onItemClick, { id: 'id' in event.detail ? event.detail.id : item.id }, event);

--- a/src/button-group/menu-dropdown-item.tsx
+++ b/src/button-group/menu-dropdown-item.tsx
@@ -48,7 +48,7 @@ const MenuDropdownItem = React.forwardRef(
         data-testid={item.id}
         customTriggerBuilder={({ onClick, isOpen, triggerRef, ariaLabel, ariaExpanded, testUtilsClass }) => (
           <div ref={containerRef}>
-            {!isOpen && showTooltip && (
+            {!isOpen && showTooltip && !item.disabled && !item.loading && (
               <Tooltip
                 trackRef={containerRef}
                 trackKey={item.id}


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
