### PR TITLE
chore: Add additional metadata metrics to table and collection preferences

### DIFF
--- a/src/collection-preferences/index.tsx
+++ b/src/collection-preferences/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
@@ -10,6 +10,7 @@ import { ButtonProps } from '../button/interfaces';
 import { InternalButton } from '../button/internal';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
+import { CollectionPreferencesMetadata } from '../internal/context/collection-preferences-metadata-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import checkControlled from '../internal/hooks/check-controlled';
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -58,7 +59,18 @@ export default function CollectionPreferences({
   removeModalRoot,
   ...rest
 }: CollectionPreferencesProps) {
-  const { __internalRootRef } = useBaseComponent('CollectionPreferences');
+  const parentMetadata = useContext(CollectionPreferencesMetadata);
+  const { __internalRootRef } = useBaseComponent('CollectionPreferences', {
+    props: {},
+    metadata: {
+      ...parentMetadata,
+      hasStripedRowsPreference: !!stripedRowsPreference,
+      hasVisibleContentPreference: !!visibleContentPreference,
+      hasContentDisplayPreference: !!contentDisplayPreference,
+      hasContentDensityPreference: !!contentDensityPreference,
+      hasStickyColumnsPreference: !!stickyColumnsPreference,
+    },
+  });
   checkControlled('CollectionPreferences', 'preferences', preferences, 'onConfirm', onConfirm);
 
   const i18n = useInternalI18n('collection-preferences');

--- a/src/internal/context/collection-preferences-metadata-context.ts
+++ b/src/internal/context/collection-preferences-metadata-context.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createContext } from 'react';
+
+interface CollectionPreferencesMetadataInterface {
+  tableHasStripedRows?: boolean;
+  tableHasHiddenColumns?: boolean;
+  tableHasStickyColumns?: boolean;
+  tableContentDensity?: string;
+}
+
+export const CollectionPreferencesMetadata = createContext<CollectionPreferencesMetadataInterface>({});

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -47,7 +47,7 @@ const Table = React.forwardRef(
         hasStickyColumns,
         hasFilterSlot: !!props.filter,
         hasPaginationSlot: !!props.pagination,
-        itemCount: items.length,
+        itemCount: props.totalItemsCount ?? items.length,
       },
     });
 

--- a/src/table/index.tsx
+++ b/src/table/index.tsx
@@ -36,6 +36,7 @@ const Table = React.forwardRef(
         variant,
         wrapLines: props.wrapLines,
         enableKeyboardNavigation: props.enableKeyboardNavigation,
+        totalItemsCount: props.totalItemsCount,
       },
       metadata: {
         expandableRows: !!props.expandableRows,
@@ -47,7 +48,7 @@ const Table = React.forwardRef(
         hasStickyColumns,
         hasFilterSlot: !!props.filter,
         hasPaginationSlot: !!props.pagination,
-        itemCount: props.totalItemsCount ?? items.length,
+        itemsCount: items.length,
       },
     });
 


### PR DESCRIPTION
### Description

Supporting an automated internal use of the component metrics. We can use these metrics to find more complex components/patterns that don't match up with our usage guidelines and UX best practices (like uses of sticky headers, or not allowing disabling table features enabled by default). Keeping details out of this public PR, but feel free to reach out. Adding another context felt safe because it's only used internally, there isn't a wide gap between the components (as in, unlikely to be split across bundles), and it doesn't break any end-user experience if it doesn't match up. Maybe long-term, this could be "generified" into a linting context or something, but not for now.

Related links, issue #, if available: n/a

### How has this been tested?

No coded test, just manually made sure the shape/values align with expectations.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
