### PR TITLE
fix: Improve touch handling in pie-chart

### DIFF
--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -637,7 +637,7 @@ describe('Details popover', () => {
 
   test('artificial mouseover event during touch does not open popover', () => {
     const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
-    const element = wrapper.findSegmentLabels()[1].getElement();
+    const element = wrapper.findSegments()[1].getElement();
     element.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
     element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     expect(wrapper.findDetailPopover()?.findContent()).toBeFalsy();

--- a/src/pie-chart/__tests__/pie-chart.test.tsx
+++ b/src/pie-chart/__tests__/pie-chart.test.tsx
@@ -635,6 +635,14 @@ describe('Details popover', () => {
     expect(createWrapper(wrapper.getElement()).findPopover()?.findDismissButton()).not.toBeNull();
   });
 
+  test('artificial mouseover event during touch does not open popover', () => {
+    const { wrapper } = renderPieChart(<PieChart data={defaultData} />);
+    const element = wrapper.findSegmentLabels()[1].getElement();
+    element.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
+    element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    expect(wrapper.findDetailPopover()?.findContent()).toBeFalsy();
+  });
+
   test('details popover can be customized', () => {
     const { wrapper } = renderPieChart(
       <PieChart

--- a/src/pie-chart/pie-chart.tsx
+++ b/src/pie-chart/pie-chart.tsx
@@ -129,6 +129,7 @@ export default <T extends PieChartProps.Datum>({
 
   const popoverDismissedRecently = useRef(false);
   const escapePressed = useRef(false);
+  const duringTouch = useRef(false);
 
   const highlightSegment = useCallback(
     (internalDatum: InternalChartDatum<T>) => {
@@ -203,6 +204,10 @@ export default <T extends PieChartProps.Datum>({
         escapePressed.current = false;
         return;
       }
+      if (duringTouch.current) {
+        duringTouch.current = false;
+        return;
+      }
       if (pinnedSegment !== null) {
         return;
       }
@@ -210,6 +215,9 @@ export default <T extends PieChartProps.Datum>({
     },
     [pinnedSegment, highlightSegment]
   );
+  const onTouchStart = useCallback(() => {
+    duringTouch.current = true;
+  }, []);
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -327,6 +335,7 @@ export default <T extends PieChartProps.Datum>({
             segmentAriaRoleDescription={i18nStrings?.segmentAriaRoleDescription}
             onMouseDown={onMouseDown}
             onMouseOver={onMouseOver}
+            onTouchStart={onTouchStart}
           />
           {hasLabels && (
             <Labels

--- a/src/pie-chart/segments.tsx
+++ b/src/pie-chart/segments.tsx
@@ -21,6 +21,7 @@ interface SegmentsProps<T> {
   segmentAriaRoleDescription?: string;
   onMouseDown: (datum: InternalChartDatum<T>) => void;
   onMouseOver: (datum: InternalChartDatum<T>) => void;
+  onTouchStart: () => void;
 }
 
 export default function Segments<T extends PieChartProps.Datum>({
@@ -33,6 +34,7 @@ export default function Segments<T extends PieChartProps.Datum>({
   segmentAriaRoleDescription,
   onMouseDown,
   onMouseOver,
+  onTouchStart,
 }: SegmentsProps<T>) {
   const i18n = useInternalI18n('pie-chart');
 
@@ -76,6 +78,7 @@ export default function Segments<T extends PieChartProps.Datum>({
         return (
           <g
             key={datum.data.index}
+            onTouchStart={() => onTouchStart()}
             onMouseDown={e => {
               onMouseDown(datum.data);
               e.preventDefault();


### PR DESCRIPTION
### Description

Ensure that touches/taps always fully open the popover, and don't leave it in "hover"-style state if the touch
is somehow interrupted.

Related links, issue #, if available: AWSUI-46115

### How has this been tested?

Tested locally. Due to the combination of this only happening on touch devices, and only when tapping certain parts of certain segments, it's not easy to test in any of our existing integration or visual regression test suites.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
