### PR TITLE
fix: Disable import sort rule for app-layout tests 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,7 @@ module.exports = {
       [' Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.', ' SPDX-License-Identifier: Apache-2.0'],
     ],
     'no-warning-comments': 'warn',
-    'simple-import-sort/imports': 'warn',
+    'simple-import-sort/imports': 'error',
   },
   settings: {
     react: {
@@ -196,7 +196,7 @@ module.exports = {
       files: ['src/**', 'pages/**'],
       rules: {
         'simple-import-sort/imports': [
-          'warn',
+          'error',
           {
             groups: [
               // External packages come first.

--- a/build-tools/stylelint/__tests__/license-headers.test.js
+++ b/build-tools/stylelint/__tests__/license-headers.test.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import stylelint from 'stylelint';
+
 import { configBasedir } from './common.js';
 
 function runPlugin(code, header, fix = false) {

--- a/build-tools/stylelint/__tests__/no-implicit-descendant.test.js
+++ b/build-tools/stylelint/__tests__/no-implicit-descendant.test.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import stylelint from 'stylelint';
+
 import { configBasedir } from './common.js';
 
 function runPlugin(code) {

--- a/build-tools/stylelint/__tests__/no-motion-outside-of-mixin.test.js
+++ b/build-tools/stylelint/__tests__/no-motion-outside-of-mixin.test.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import stylelint from 'stylelint';
+
 import { configBasedir } from './common.js';
 
 // This is for prettier format: https://github.com/prettier/prettier/issues/2330

--- a/build-tools/stylelint/index.js
+++ b/build-tools/stylelint/index.js
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import licenseHeaders from './license-headers.js';
 import noImplicitDescendant from './no-implicit-descendant.js';
 import noMotionOutsideOfMixin from './no-motion-outside-of-mixin.js';
-import licenseHeaders from './license-headers.js';
 
 export default [noImplicitDescendant, noMotionOutsideOfMixin, licenseHeaders];

--- a/pages/app-layout/multi-layout-iframe.page.tsx
+++ b/pages/app-layout/multi-layout-iframe.page.tsx
@@ -1,15 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+
 import AppLayout from '~components/app-layout';
 import Header from '~components/header';
-import SpaceBetween from '~components/space-between';
 import ScreenreaderOnly from '~components/internal/components/screenreader-only';
-import { Breadcrumbs, Containers, Navigation, Tools } from './utils/content-blocks';
-import * as toolsContent from './utils/tools-content';
-import { IframeWrapper } from './utils/iframe-wrapper';
+import SpaceBetween from '~components/space-between';
+
 import ScreenshotArea from '../utils/screenshot-area';
+import { Breadcrumbs, Containers, Navigation, Tools } from './utils/content-blocks';
+import { IframeWrapper } from './utils/iframe-wrapper';
 import labels from './utils/labels';
+import * as toolsContent from './utils/tools-content';
 
 function InnerApp() {
   return (

--- a/pages/app-layout/multi-layout-simple.page.tsx
+++ b/pages/app-layout/multi-layout-simple.page.tsx
@@ -1,13 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+
 import AppLayout from '~components/app-layout';
 import Header from '~components/header';
 import SpaceBetween from '~components/space-between';
+
 import ScreenshotArea from '../utils/screenshot-area';
 import { Containers, Navigation, Tools } from './utils/content-blocks';
-import * as toolsContent from './utils/tools-content';
 import labels from './utils/labels';
+import * as toolsContent from './utils/tools-content';
 
 export default function () {
   return (

--- a/src/app-layout/__integ__/multi-app-layout.test.ts
+++ b/src/app-layout/__integ__/multi-app-layout.test.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
 import createWrapper from '../../../lib/components/test-utils/selectors';
 
 describe.each([[true], [false]])('visualRefresh=%s', visualRefresh => {

--- a/src/app-layout/__tests__/background-overlap.test.tsx
+++ b/src/app-layout/__tests__/background-overlap.test.tsx
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import React, { useLayoutEffect } from 'react';
 import { render, screen } from '@testing-library/react';
-import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
-import { useDynamicOverlap } from '../../../lib/components/internal/hooks/use-dynamic-overlap';
-import { useAppLayoutInternals } from '../../../lib/components/app-layout/visual-refresh/context';
+
 import { ContainerQueryEntry } from '@cloudscape-design/component-toolkit';
+
+import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
+import { useAppLayoutInternals } from '../../../lib/components/app-layout/visual-refresh/context';
+import { useDynamicOverlap } from '../../../lib/components/internal/hooks/use-dynamic-overlap';
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({
   ...jest.requireActual('../../../lib/components/internal/hooks/use-visual-mode'),

--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 import { describeEachAppLayout, isDrawerClosed, renderComponent, testDrawer, testDrawerWithoutLabels } from './utils';

--- a/src/app-layout/__tests__/desktop.test.tsx
+++ b/src/app-layout/__tests__/desktop.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { act, fireEvent, screen, within } from '@testing-library/react';
 

--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import {
   describeEachAppLayout,

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React, { useState } from 'react';
 import { act, render, cleanup, waitFor } from '@testing-library/react';
 import { describeEachAppLayout } from './utils';

--- a/src/app-layout/__tests__/header-variant.test.tsx
+++ b/src/app-layout/__tests__/header-variant.test.tsx
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+
 import AppLayout from '../../../lib/components/app-layout';
-import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
-import { renderComponent } from './utils';
+import { useVisualRefresh } from '../../../lib/components/internal/hooks/use-visual-mode';
 import { highContrastHeaderClassName } from '../../../lib/components/internal/utils/content-header-utils';
+import { renderComponent } from './utils';
+
 import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => ({

--- a/src/app-layout/__tests__/i18n.test.tsx
+++ b/src/app-layout/__tests__/i18n.test.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
+
 import AppLayout from '../../../lib/components/app-layout';
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import { renderComponent } from './utils';

--- a/src/app-layout/__tests__/main.test.tsx
+++ b/src/app-layout/__tests__/main.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import * as React from 'react';
 import { waitFor } from '@testing-library/react';
 import { isDrawerClosed, renderComponent, testDrawer } from './utils';

--- a/src/app-layout/__tests__/mobile.test.tsx
+++ b/src/app-layout/__tests__/mobile.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import { within } from '@testing-library/react';

--- a/src/app-layout/__tests__/runtime-drawers.test.tsx
+++ b/src/app-layout/__tests__/runtime-drawers.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React, { useState } from 'react';
 import { act, render } from '@testing-library/react';
 import {

--- a/src/app-layout/__tests__/slots.test.tsx
+++ b/src/app-layout/__tests__/slots.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { describeEachAppLayout, renderComponent } from './utils';
 import AppLayout from '../../../lib/components/app-layout';

--- a/src/app-layout/__tests__/split-panel-provider.test.tsx
+++ b/src/app-layout/__tests__/split-panel-provider.test.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { act, render } from '@testing-library/react';
-import createWrapper, { SplitPanelWrapper } from '../../../lib/components/test-utils/dom';
+
 import { SplitPanelProvider, SplitPanelProviderProps } from '../../../lib/components/app-layout/split-panel';
 import SplitPanel, { SplitPanelProps } from '../../../lib/components/split-panel';
+import createWrapper, { SplitPanelWrapper } from '../../../lib/components/test-utils/dom';
 
 const defaultSplitPanelProps: SplitPanelProps = {
   header: '',

--- a/src/app-layout/__tests__/split-panel.test.tsx
+++ b/src/app-layout/__tests__/split-panel.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { screen } from '@testing-library/react';
 import AppLayout from '../../../lib/components/app-layout';

--- a/src/app-layout/__tests__/tools.test.tsx
+++ b/src/app-layout/__tests__/tools.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
+/* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';

--- a/src/app-layout/__tests__/warnings.test.tsx
+++ b/src/app-layout/__tests__/warnings.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 import { render } from '@testing-library/react';
+
 import AppLayout from '../../../lib/components/app-layout';
 
 let consoleWarnSpy: jest.SpyInstance;


### PR DESCRIPTION
### Description

Disable eslint import sort rule for app-layout tests because of a circular dependencies, which breaks the tests.
Raised eslint import sort rule to error.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
