### PR TITLE
fix: Toolbar mobile grid layout

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -23,9 +23,9 @@
 
   // mobile grid
   grid-template-areas:
-    'topBar    topBar     topBar'
-    '.      notifications .'
-    '.          main      .';
+    'toolbar    toolbar     toolbar'
+    '.       notifications  .'
+    '.           main       .';
   grid-template-columns:
     awsui.$space-layout-content-horizontal
     1fr


### PR DESCRIPTION
### Description

Usage of wrong grid area names led to very unfortunate layouts on mobile.

Related links, issue #, if available: n/a

### How has this been tested?

Locally
Mobile grid layout order should appear as indicated in the template.
```
<toolbar>
<notifications>
<main>
```


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
