### PR TITLE
feat: Allow to hide entered text label in autosuggest

### DIFF
--- a/pages/autosuggest/hide-entered-text-label.page.tsx
+++ b/pages/autosuggest/hide-entered-text-label.page.tsx
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useContext, useRef, useState } from 'react';
+
+import Autosuggest, { AutosuggestProps } from '~components/autosuggest';
+import Toggle from '~components/toggle';
+
+import AppContext, { AppContextType } from '../app/app-context';
+
+const empty = <span>Nothing found</span>;
+
+const options = [
+  { value: 'Option 0', tags: ['tag1', 'tag2'], filteringTags: ['bla', 'opt'], description: 'description1' },
+  { value: 'Option 1', labelTag: 'This is a label tag' },
+  { value: 'Option 2' },
+  { value: 'Option', description: 'description2' },
+];
+
+const enteredTextLabel = (value: string) => `Use: ${value}`;
+
+type PageContext = React.Context<
+  AppContextType<{
+    hasOptions?: boolean;
+    hasEmpty?: boolean;
+    hasEnteredTextLabel?: boolean;
+  }>
+>;
+
+export default function AutosuggestPage() {
+  const [value, setValue] = useState('');
+  const {
+    urlParams: { hasOptions = true, hasEmpty = true, hasEnteredTextLabel = true },
+    setUrlParams,
+  } = useContext(AppContext as PageContext);
+  const ref = useRef<AutosuggestProps.Ref>(null);
+  return (
+    <div style={{ padding: 10 }}>
+      <h1>Hide entered text labebel in autosuggest</h1>
+      <Autosuggest
+        ref={ref}
+        value={value}
+        readOnly={false}
+        options={hasOptions ? options : []}
+        onChange={event => setValue(event.detail.value)}
+        enteredTextLabel={enteredTextLabel}
+        hideEnteredTextLabel={!hasEnteredTextLabel}
+        ariaLabel={'hide entered text label in autosuggest'}
+        selectedAriaLabel="Selected"
+        empty={hasEmpty ? empty : null}
+      />
+      <Toggle
+        checked={hasEnteredTextLabel}
+        onChange={({ detail }) => setUrlParams({ hasEnteredTextLabel: detail.checked })}
+      >
+        has entered text label
+      </Toggle>
+      <Toggle checked={hasEmpty} onChange={({ detail }) => setUrlParams({ hasEmpty: detail.checked })}>
+        has empty results text
+      </Toggle>
+      <Toggle checked={hasOptions} onChange={({ detail }) => setUrlParams({ hasOptions: detail.checked })}>
+        has options
+      </Toggle>
+    </div>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -1885,6 +1885,13 @@ Note: Manual filtering doesn't disable match highlighting.
       "type": "string",
     },
     Object {
+      "defaultValue": "false",
+      "description": "Specifies whether to display the custom value indicator (for example, \`Use \\"\${value}\\"\`).",
+      "name": "hideEnteredTextLabel",
+      "optional": true,
+      "type": "boolean",
+    },
+    Object {
       "deprecatedTag": "The usage of the \`id\` attribute is reserved for internal use cases. For testing and other use cases,
 use [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes). If you must
 use the \`id\` attribute, consider setting it on a parent element instead.",

--- a/src/autosuggest/__tests__/autosuggest.test.tsx
+++ b/src/autosuggest/__tests__/autosuggest.test.tsx
@@ -123,6 +123,21 @@ test('entered text option should not get screenreader override', () => {
   ).toBeFalsy();
 });
 
+test('should not show entered text if hideEnteredText is true', () => {
+  const { wrapper } = renderAutosuggest(<Autosuggest hideEnteredTextLabel={true} {...defaultProps} value="1" />);
+  wrapper.setInputValue('test');
+  expect(wrapper.findEnteredTextOption()).toBe(null);
+});
+
+test('should show other options if hideEnteredText is true', () => {
+  const { wrapper } = renderAutosuggest(
+    <Autosuggest hideEnteredTextLabel={true} options={defaultOptions} {...defaultProps} value="1" />
+  );
+  wrapper.setInputValue('1');
+  expect(wrapper.findEnteredTextOption()).toBeNull();
+  expect(wrapper.findDropdown().findOpenDropdown()).not.toBe(null);
+});
+
 test('should not close dropdown when no realted target in blur', () => {
   const { wrapper, container } = renderAutosuggest(
     <div>

--- a/src/autosuggest/index.tsx
+++ b/src/autosuggest/index.tsx
@@ -12,7 +12,13 @@ export { AutosuggestProps };
 
 const Autosuggest = React.forwardRef(
   (
-    { filteringType = 'auto', statusType = 'finished', disableBrowserAutocorrect = false, ...props }: AutosuggestProps,
+    {
+      filteringType = 'auto',
+      statusType = 'finished',
+      disableBrowserAutocorrect = false,
+      hideEnteredTextLabel = false,
+      ...props
+    }: AutosuggestProps,
     ref: React.Ref<AutosuggestProps.Ref>
   ) => {
     const baseComponentProps = useBaseComponent('Autosuggest', {
@@ -31,6 +37,7 @@ const Autosuggest = React.forwardRef(
         filteringType={filteringType}
         statusType={statusType}
         disableBrowserAutocorrect={disableBrowserAutocorrect}
+        hideEnteredTextLabel={hideEnteredTextLabel}
         {...externalProps}
         {...baseComponentProps}
         ref={ref}

--- a/src/autosuggest/interfaces.ts
+++ b/src/autosuggest/interfaces.ts
@@ -81,6 +81,11 @@ export interface AutosuggestProps
   enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
 
   /**
+   * Specifies whether to display the custom value indicator (for example, `Use "${value}"`).
+   */
+  hideEnteredTextLabel?: boolean;
+
+  /**
    * Specifies the text to display with the number of matches at the bottom of the dropdown menu while filtering.
    */
   filteringResultsText?: (matchesCount: number, totalCount: number) => string;

--- a/src/autosuggest/internal.tsx
+++ b/src/autosuggest/internal.tsx
@@ -48,6 +48,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     name,
     disabled,
     disableBrowserAutocorrect = false,
+    hideEnteredTextLabel = false,
     autoFocus,
     readOnly,
     ariaLabel,
@@ -91,7 +92,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
     filterText: value,
     filteringType,
     enteredTextLabel,
-    hideEnteredTextLabel: false,
+    hideEnteredTextLabel: hideEnteredTextLabel,
     onSelectItem: (option: AutosuggestItem) => {
       const value = option.value || '';
       fireNonCancelableEvent(onChange, { value });
@@ -179,7 +180,7 @@ const InternalAutosuggest = React.forwardRef((props: InternalAutosuggestProps, r
   const highlightedOptionIdSource = useUniqueId();
   const highlightedOptionId = autosuggestItemsState.highlightedOption ? highlightedOptionIdSource : undefined;
 
-  const isEmpty = !value && !autosuggestItemsState.items.length;
+  const isEmpty = !autosuggestItemsState.items.length;
   const isFiltered = !!value && value.length !== 0;
   const filteredText = isFiltered
     ? filteringResultsText?.(autosuggestItemsState.items.length, options?.length ?? 0)

--- a/src/autosuggest/options-controller.ts
+++ b/src/autosuggest/options-controller.ts
@@ -63,7 +63,7 @@ export const useAutosuggestItems = ({
   const enteredItemLabel = i18n('enteredTextLabel', enteredTextLabel?.(filterValue), format =>
     format({ value: filterValue })
   );
-  if (!enteredItemLabel) {
+  if (!hideEnteredTextLabel && !enteredItemLabel) {
     warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
   }
 


### PR DESCRIPTION
### Description

Allow the hideEnteredTextLabel to be set for Autosuggest. This will allow to hide the default _"Use: user input"_ option that's displayed when typing into Autosuggest. This is useful when Autosuggest is used to suggest options from a closed set.

The default behavior is the same as the current behavior, i.e. the entered text label is visible.

### How has this been tested?

- Added unit tests
- Added a test page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
