### PR TITLE
fix: Tooltip z-index

### DIFF
--- a/pages/button/disabled-reason-modal.page.tsx
+++ b/pages/button/disabled-reason-modal.page.tsx
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import { Button, Modal } from '~components';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+import styles from './styles.scss';
+
+export default function ButtonsScenario() {
+  return (
+    <article>
+      <ScreenshotArea>
+        <h1 className={styles.styledWrapper}>Button with disabled reason within a modal</h1>
+        <Modal
+          header="Delete instance"
+          visible={true}
+          onDismiss={() => {}}
+          closeAriaLabel="Close modal"
+          footer={
+            <span style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button variant="link">Cancel</Button>
+              <Button variant="primary" disabled={true} disabledReason="reason" data-testid="button">
+                Delete
+              </Button>
+            </span>
+          }
+        >
+          This will permanently delete your instance, and may affect the performance of other resources.
+        </Modal>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/internal/components/tooltip/index.tsx
+++ b/src/internal/components/tooltip/index.tsx
@@ -38,6 +38,7 @@ export default function Tooltip({
         <Transition in={true}>
           {() => (
             <PopoverContainer
+              className={styles.popover}
               trackRef={trackRef}
               trackKey={trackKey}
               size="small"

--- a/src/internal/components/tooltip/styles.scss
+++ b/src/internal/components/tooltip/styles.scss
@@ -6,3 +6,8 @@
 .root {
   /* used in tests */
 }
+
+// When used in modal we need z-index to be higher than modal's
+.popover {
+  z-index: 7000;
+}

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -39,6 +39,7 @@ export interface PopoverContainerProps {
   // Do not use this if the popover is open on hover, in order to avoid unexpected movement.
   allowScrollToFit?: boolean;
   allowVerticalOverflow?: boolean;
+  className?: string;
 }
 
 export default function PopoverContainer({
@@ -55,6 +56,7 @@ export default function PopoverContainer({
   keepPosition,
   allowScrollToFit,
   allowVerticalOverflow,
+  className,
 }: PopoverContainerProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -130,7 +132,7 @@ export default function PopoverContainer({
     <div
       ref={popoverRef}
       style={{ ...popoverStyle, zIndex }}
-      className={clsx(styles.container, isRefresh && styles.refresh)}
+      className={clsx(styles.container, isRefresh && styles.refresh, className)}
     >
       <div
         ref={arrowRef}


### PR DESCRIPTION
### Description

AWSUI-52761
Set tooltip z-index to 7000 to be higher than in modal. Introduced an additional page to add a test scenario with `disabledReason` button within a modal.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
