### PR TITLE
chore: Support appLayoutToolbar feature flag

### DIFF
--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -20,6 +20,7 @@ import styles from './styles.scss';
 
 interface GlobalFlags {
   appLayoutWidget?: boolean;
+  appLayoutToolbar?: boolean;
 }
 const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
 const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
@@ -91,7 +92,7 @@ function App() {
 }
 
 const history = createHashHistory();
-const { direction, visualRefresh, appLayoutWidget } = parseQuery(history.location.search);
+const { direction, visualRefresh, appLayoutWidget, appLayoutToolbar } = parseQuery(history.location.search);
 
 // The VR class needs to be set before any React rendering occurs.
 window[awsuiVisualRefreshFlag] = () => visualRefresh;
@@ -99,6 +100,7 @@ if (!window[awsuiGlobalFlagsSymbol]) {
   window[awsuiGlobalFlagsSymbol] = {};
 }
 window[awsuiGlobalFlagsSymbol].appLayoutWidget = appLayoutWidget;
+window[awsuiGlobalFlagsSymbol].appLayoutToolbar = appLayoutToolbar;
 
 // Apply the direction value to the HTML element dir attribute
 document.documentElement.setAttribute('dir', direction);

--- a/src/app-layout/__tests__/app-layout.ssr.test.tsx
+++ b/src/app-layout/__tests__/app-layout.ssr.test.tsx
@@ -32,9 +32,15 @@ test('should render refresh app layout', () => {
   const content = renderToStaticMarkup(<AppLayout />);
   expect(content).toContain(refreshStyles.layout);
 });
-test('should render refresh-toolbar app layout', () => {
+test('should render refresh-toolbar app layout with the widget flag', () => {
   globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
   globalWithFlags[Symbol.for('awsui-global-flags')] = { appLayoutWidget: true };
+  const content = renderToStaticMarkup(<AppLayout />);
+  expect(content).toContain(refreshToolbarStyles.root);
+});
+test('should render refresh-toolbar app layout with the toolbar flag', () => {
+  globalWithFlags[Symbol.for('awsui-visual-refresh-flag')] = () => true;
+  globalWithFlags[Symbol.for('awsui-global-flags')] = { appLayoutToolbar: true };
   const content = renderToStaticMarkup(<AppLayout />);
   expect(content).toContain(refreshToolbarStyles.root);
 });

--- a/src/app-layout/internal.tsx
+++ b/src/app-layout/internal.tsx
@@ -2,18 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
 import { useVisualRefresh } from '../internal/hooks/use-visual-mode';
 import ClassicAppLayout from './classic';
 import { AppLayoutProps, AppLayoutPropsWithDefaults } from './interfaces';
+import { isAppLayoutToolbarEnabled } from './utils/feature-flags';
 import RefreshedAppLayout from './visual-refresh';
 import ToolbarAppLayout from './visual-refresh-toolbar';
 
 export const AppLayoutInternal = React.forwardRef<AppLayoutProps.Ref, AppLayoutPropsWithDefaults>((props, ref) => {
   const isRefresh = useVisualRefresh();
   if (isRefresh) {
-    if (getGlobalFlag('appLayoutWidget')) {
+    if (isAppLayoutToolbarEnabled()) {
       return <ToolbarAppLayout ref={ref} {...props} />;
     } else {
       return <RefreshedAppLayout ref={ref} {...props} />;

--- a/src/app-layout/utils/feature-flags.ts
+++ b/src/app-layout/utils/feature-flags.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
+
+export const isAppLayoutToolbarEnabled = () => getGlobalFlag('appLayoutWidget') || getGlobalFlag('appLayoutToolbar');

--- a/src/drawer/implementation.tsx
+++ b/src/drawer/implementation.tsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
+import { isAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { useInternalI18n } from '../i18n/context';
 import { getBaseProps } from '../internal/base-component';
 import LiveRegion from '../internal/components/live-region';
@@ -27,10 +26,9 @@ export function DrawerImplementation({
 }: DrawerInternalProps) {
   const baseProps = getBaseProps(restProps);
   const i18n = useInternalI18n('drawer');
-  const hasToolbar = getGlobalFlag('appLayoutWidget');
   const containerProps = {
     ...baseProps,
-    className: clsx(baseProps.className, styles.drawer, hasToolbar && styles['with-toolbar']),
+    className: clsx(baseProps.className, styles.drawer, isAppLayoutToolbarEnabled() && styles['with-toolbar']),
   };
   return loading ? (
     <div {...containerProps} ref={__internalRootRef}>

--- a/src/internal/plugins/helpers/use-global-breadcrumbs.ts
+++ b/src/internal/plugins/helpers/use-global-breadcrumbs.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
+import { isAppLayoutToolbarEnabled } from '../../../app-layout/utils/feature-flags';
 import { BreadcrumbGroupProps } from '../../../breadcrumb-group/interfaces';
 import { awsuiPluginsInternal } from '../api';
 import { BreadcrumbsGlobalRegistration } from '../controllers/breadcrumbs';
@@ -32,7 +31,7 @@ function useSetGlobalBreadcrumbsImplementation(props: BreadcrumbGroupProps<any>)
 
 export function useSetGlobalBreadcrumbs<T extends BreadcrumbGroupProps.Item>(props: BreadcrumbGroupProps<T>) {
   // avoid additional side effects when this feature is not active
-  if (!getGlobalFlag('appLayoutWidget')) {
+  if (!isAppLayoutToolbarEnabled()) {
     return false;
   }
   // getGlobalFlag() value does not change without full page reload

--- a/src/side-navigation/implementation.tsx
+++ b/src/side-navigation/implementation.tsx
@@ -3,8 +3,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
+import { isAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { getBaseProps } from '../internal/base-component';
 import { fireCancelableEvent, fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
@@ -29,7 +28,6 @@ export function SideNavigationImplementation({
 }: SideNavigationInternalProps) {
   const baseProps = getBaseProps(props);
   const parentMap = useMemo(() => generateExpandableItemsMapping(items), [items]);
-  const hasToolbar = getGlobalFlag('appLayoutWidget');
 
   if (isDevelopment) {
     // This code should be wiped in production anyway.
@@ -63,7 +61,7 @@ export function SideNavigationImplementation({
   return (
     <div
       {...baseProps}
-      className={clsx(styles.root, baseProps.className, hasToolbar && styles['with-toolbar'])}
+      className={clsx(styles.root, baseProps.className, isAppLayoutToolbarEnabled() && styles['with-toolbar'])}
       ref={__internalRootRef}
     >
       {header && (

--- a/src/split-panel/bottom.tsx
+++ b/src/split-panel/bottom.tsx
@@ -3,8 +3,9 @@
 import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
-import { getGlobalFlag, useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
+import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
+import { isAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { TransitionStatus } from '../internal/components/transition';
 import { useSplitPanelContext } from '../internal/context/split-panel-context';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
@@ -36,7 +37,6 @@ export function SplitPanelContentBottom({
   onToggle,
 }: SplitPanelContentBottomProps) {
   const isRefresh = useVisualRefresh();
-  const hasToolbar = getGlobalFlag('appLayoutWidget');
   const { bottomOffset, leftOffset, rightOffset, disableContentPaddings, contentWrapperPaddings, reportHeaderHeight } =
     useSplitPanelContext();
   const transitionContentBottomRef = useMergeRefs(splitPanelRef || null, transitioningElementRef);
@@ -66,7 +66,7 @@ export function SplitPanelContentBottom({
         [styles['drawer-disable-content-paddings']]: disableContentPaddings,
         [styles.animating]: isRefresh && (state === 'entering' || state === 'exiting'),
         [styles.refresh]: isRefresh,
-        [styles['with-toolbar']]: hasToolbar,
+        [styles['with-toolbar']]: isAppLayoutToolbarEnabled(),
       })}
       onClick={() => !isOpen && onToggle()}
       style={{

--- a/src/split-panel/implementation.tsx
+++ b/src/split-panel/implementation.tsx
@@ -3,8 +3,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
+import { isAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { SizeControlProps } from '../app-layout/utils/interfaces';
 import { useKeyboardEvents } from '../app-layout/utils/use-keyboard-events';
 import { usePointerEvents } from '../app-layout/utils/use-pointer-events';
@@ -54,7 +53,6 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
     } = useSplitPanelContext();
     const baseProps = getBaseProps(restProps);
     const i18n = useInternalI18n('split-panel');
-    const hasToolbar = getGlobalFlag('appLayoutWidget');
     const [isPreferencesOpen, setPreferencesOpen] = useState<boolean>(false);
 
     const appLayoutMaxWidth = isRefresh && position === 'bottom' ? contentWidthStyles : undefined;
@@ -83,7 +81,10 @@ export const SplitPanelImplementation = React.forwardRef<HTMLElement, SplitPanel
     const panelHeaderId = useUniqueId('split-panel-header');
 
     const wrappedHeader = (
-      <div className={clsx(styles.header, hasToolbar && styles['with-toolbar'])} style={appLayoutMaxWidth}>
+      <div
+        className={clsx(styles.header, isAppLayoutToolbarEnabled() && styles['with-toolbar'])}
+        style={appLayoutMaxWidth}
+      >
         <h2 className={clsx(styles['header-text'], testUtilStyles['header-text'])} id={panelHeaderId}>
           {header}
         </h2>

--- a/src/split-panel/side.tsx
+++ b/src/split-panel/side.tsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import clsx from 'clsx';
 
-import { getGlobalFlag } from '@cloudscape-design/component-toolkit/internal';
-
+import { isAppLayoutToolbarEnabled } from '../app-layout/utils/feature-flags';
 import { ButtonProps } from '../button/interfaces';
 import InternalButton from '../button/internal';
 import { useSplitPanelContext } from '../internal/context/split-panel-context';
@@ -35,14 +34,13 @@ export function SplitPanelContentSide({
 }: SplitPanelContentSideProps) {
   const { topOffset, bottomOffset } = useSplitPanelContext();
   const isRefresh = useVisualRefresh();
-  const hasToolbar = getGlobalFlag('appLayoutWidget');
   return (
     <div
       {...baseProps}
       className={clsx(baseProps.className, styles.drawer, styles['position-side'], testUtilStyles.root, {
         [testUtilStyles['open-position-side']]: isOpen,
         [styles['drawer-closed']]: !isOpen,
-        [styles['with-toolbar']]: hasToolbar,
+        [styles['with-toolbar']]: isAppLayoutToolbarEnabled(),
       })}
       style={{
         width: isOpen && isRefresh ? cappedSize : undefined,
@@ -74,7 +72,10 @@ export function SplitPanelContentSide({
             ref={isRefresh ? null : toggleRef}
           />
         )}
-        <div className={clsx(styles['content-side'], hasToolbar && styles['with-toolbar'])} aria-hidden={!isOpen}>
+        <div
+          className={clsx(styles['content-side'], isAppLayoutToolbarEnabled() && styles['with-toolbar'])}
+          aria-hidden={!isOpen}
+        >
           <div className={styles['pane-header-wrapper-side']}>{header}</div>
           <div className={styles['pane-content-wrapper-side']}>{children}</div>
         </div>


### PR DESCRIPTION
### Description

Support activating app layout toolbar UI only, without the widgetization.

Related links, issue #, if available: n/a

### How has this been tested?

Ran locally, works.

The PR build will pass after this change is released: https://github.com/cloudscape-design/component-toolkit/pull/86

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
