### PR TITLE
fix: Column layout text wrapping

### DIFF
--- a/pages/key-value-pairs/text-wrap.page.tsx
+++ b/pages/key-value-pairs/text-wrap.page.tsx
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import CopyToClipboard from '~components/copy-to-clipboard';
+import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
+import ProgressBar from '~components/progress-bar';
+import StatusIndicator from '~components/status-indicator';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  return (
+    <article>
+      <h1>Text wrapping example</h1>
+      <ScreenshotArea>
+        <h2>Simple key-value-pairs</h2>
+        <div style={{ maxWidth: '600px' }}>
+          <KeyValuePairs
+            columns={3}
+            items={[
+              {
+                label: 'Distribution ID',
+                value:
+                  'E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4',
+                info: (
+                  <Link variant="info" href="#">
+                    Info
+                  </Link>
+                ),
+              },
+              {
+                label: 'ARN',
+                value: (
+                  <CopyToClipboard
+                    copyButtonAriaLabel="Copy ARN"
+                    copyErrorText="ARN failed to copy"
+                    copySuccessText="ARN copied"
+                    textToCopy="arn:service23G24::111122223333:distribution/23E1WG1ZNPRXT0D4"
+                    variant="inline"
+                  />
+                ),
+              },
+              {
+                label: 'Status',
+                value: <StatusIndicator>Available</StatusIndicator>,
+              },
+              {
+                label: 'SSL Certificate',
+                id: 'ssl-certificate-id',
+                value: (
+                  <ProgressBar
+                    value={30}
+                    additionalInfo="Additional information"
+                    description="Progress bar description"
+                    ariaLabelledby="ssl-certificate-id"
+                  />
+                ),
+              },
+              {
+                label: 'Price class',
+                value: 'Use only US, Canada, Europe',
+              },
+              {
+                label: 'CNAMEs',
+                value: (
+                  <Link external={true} href="#">
+                    abc.service23G24.xyz
+                  </Link>
+                ),
+              },
+            ]}
+          />
+        </div>
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/pages/key-value-pairs/text-wrap.page.tsx
+++ b/pages/key-value-pairs/text-wrap.page.tsx
@@ -15,7 +15,7 @@ export default function () {
     <article>
       <h1>Text wrapping example</h1>
       <ScreenshotArea>
-        <h2>Simple key-value-pairs</h2>
+        <h2>Key-value-pairs with a long description</h2>
         <div style={{ maxWidth: '600px' }}>
           <KeyValuePairs
             columns={3}

--- a/src/column-layout/__tests__/with-css.test.tsx
+++ b/src/column-layout/__tests__/with-css.test.tsx
@@ -38,7 +38,7 @@ describe('ColumnLayout (with CSS grid) component', () => {
     });
 
     expect(wrapper.getElement().childElementCount).toBe(4);
-    expect(getGridColumns()).toBe('repeat(2, 1fr)');
+    expect(getGridColumns()).toBe('repeat(2, minmax(0, 1fr))');
   });
 
   it('wraps columns if necessary', () => {
@@ -57,6 +57,6 @@ describe('ColumnLayout (with CSS grid) component', () => {
       ),
     });
 
-    expect(getGridColumns()).toBe('repeat(4, 1fr)');
+    expect(getGridColumns()).toBe('repeat(4, minmax(0, 1fr))');
   });
 });

--- a/src/column-layout/flexible-column-layout/index.tsx
+++ b/src/column-layout/flexible-column-layout/index.tsx
@@ -64,7 +64,7 @@ export default function FlexibleColumnLayout({
         styles[`grid-variant-${variant}`],
         shouldDisableGutters && [styles['grid-no-gutters']]
       )}
-      style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}
+      style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr) )` }}
     >
       {flattenedChildren.map((child, i) => {
         // If this react child is a primitive value, the key will be undefined

--- a/src/column-layout/flexible-column-layout/index.tsx
+++ b/src/column-layout/flexible-column-layout/index.tsx
@@ -64,7 +64,7 @@ export default function FlexibleColumnLayout({
         styles[`grid-variant-${variant}`],
         shouldDisableGutters && [styles['grid-no-gutters']]
       )}
-      style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr) )` }}
+      style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }}
     >
       {flattenedChildren.map((child, i) => {
         // If this react child is a primitive value, the key will be undefined


### PR DESCRIPTION
### Description

AWSUI-52998
Replaced `1fr` with `minmax(0, 1fr)` in layout columns, because `1ft` is equivalent to `minmax(auto, 1fr)` that prevents proper text-wrapping. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
