### PR TITLE
chore: Allow toolbar props to be empty in visual-refresh-toolbar app layout

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -50,7 +50,9 @@ interface AppLayoutToolbarImplementationProps {
 
 export function AppLayoutToolbarImplementation({
   appLayoutInternals,
-  toolbarProps,
+  // the value could be undefined if this component is loaded as a widget by a different app layout version
+  // not testable in a single-version setup
+  toolbarProps = {},
 }: AppLayoutToolbarImplementationProps) {
   const {
     breadcrumbs,


### PR DESCRIPTION
### Description

Fixed a widgetization issue. `AppLayoutToolbarImplementation` and `AppLayoutVisualRefreshToolbar` components may be coming from different versions, in which case `toolbarProps` is undefined

Related links, issue #, if available: n/a

### How has this been tested?

Not testable in a single-version dev page

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
