### PR TITLE
fix: fixes the z-index offset.

### DIFF
--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -87,13 +87,6 @@ $dropdown-trigger-icon-offset: 2px;
     }
   }
 
-  & > .trigger-item.disabled,
-  & > .trigger-item.loading {
-    & > .trigger-button:not(:focus) {
-      z-index: -1;
-    }
-  }
-
   & > .trigger-item.variant-normal {
     &:not(:last-child) > .trigger-button {
       margin-inline-end: 0;


### PR DESCRIPTION
### Description

Fixes the issue with drop down button arrow going behind container's background.

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-53531

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
