### PR TITLE
feat: Make token editor form submit on onSubmit event

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -447,6 +447,7 @@ Object {
     "awsui_token-editor-field-operator_1heb1",
     "awsui_token-editor-field-property_1heb1",
     "awsui_token-editor-field-value_1heb1",
+    "awsui_token-editor-form_1wzqe",
     "awsui_token-editor-submit_1heb1",
   ],
   "radio-group": Array [

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -257,7 +257,7 @@ describe.each([false, true])('token editor, expandToViewport=%s', expandToViewpo
       );
     });
 
-    test('enter keydown closes the popover and saves the changes', () => {
+    test('form submit closes the popover and saves the changes', () => {
       const handleChange = jest.fn();
       renderComponent({
         onChange: handleChange,

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import PropertyFilter from '../../../lib/components/property-filter';
 import {
@@ -90,6 +90,7 @@ function findEditor(tokenIndex: number, { expandToViewport }: { expandToViewport
         valueAutosuggest: editor.findValueField().findControl()!.findAutosuggest()!,
         cancelButton: editor.findCancelButton(),
         submitButton: editor.findSubmitButton(),
+        form: editor.findForm(),
       }
     : null;
 }
@@ -248,6 +249,28 @@ describe.each([false, true])('token editor, expandToViewport=%s', expandToViewpo
       act(() => editor.propertySelect.selectOption(1));
       act(() => editor.valueAutosuggest.setInputValue('123'));
       act(() => editor.submitButton.click());
+      expect(findEditor(0, { expandToViewport })).toBeNull();
+      expect(handleChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { operation: 'or', tokens: [{ operator: ':', propertyKey: undefined, value: '123' }] },
+        })
+      );
+    });
+
+    test('enter keydown closes the popover and saves the changes', () => {
+      const handleChange = jest.fn();
+      renderComponent({
+        onChange: handleChange,
+        query: { tokens: [{ propertyKey: 'string', value: 'first', operator: '!:' }], operation: 'or' },
+      });
+      const editor = openEditor(0, { expandToViewport });
+
+      act(() => editor.operatorSelect.openDropdown());
+      act(() => editor.operatorSelect.selectOption(1));
+      act(() => editor.propertySelect.openDropdown());
+      act(() => editor.propertySelect.selectOption(1));
+      act(() => editor.valueAutosuggest.setInputValue('123'));
+      fireEvent.submit(editor.form!.getElement());
       expect(findEditor(0, { expandToViewport })).toBeNull();
       expect(handleChange).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { FormEvent } from 'react';
 import clsx from 'clsx';
 
 import InternalAutosuggest from '../autosuggest/internal';
@@ -225,9 +225,19 @@ export function TokenEditor({
     onChangeTemporaryToken({ ...temporaryToken, value: newValue });
   };
 
+  const onApply = () => {
+    setToken(matchTokenValue(temporaryToken, filteringOptions));
+    onDismiss();
+  };
+
+  const onFormSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onApply();
+  };
+
   return (
     <div className={styles['token-editor']}>
-      <div className={styles['token-editor-form']}>
+      <form className={styles['token-editor-form']} onSubmit={onFormSubmit}>
         <InternalFormField
           label={i18nStrings.propertyText}
           className={clsx(styles['token-editor-field-property'], testUtilStyles['token-editor-field-property'])}
@@ -272,7 +282,7 @@ export function TokenEditor({
             i18nStrings={i18nStrings}
           />
         </InternalFormField>
-      </div>
+      </form>
 
       <div className={styles['token-editor-actions']}>
         <InternalButton
@@ -286,10 +296,7 @@ export function TokenEditor({
         <InternalButton
           className={clsx(styles['token-editor-submit'], testUtilStyles['token-editor-submit'])}
           formAction="none"
-          onClick={() => {
-            setToken(matchTokenValue(temporaryToken, filteringOptions));
-            onDismiss();
-          }}
+          onClick={onApply}
         >
           {i18nStrings.applyActionText}
         </InternalButton>

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -126,6 +126,10 @@ export class PropertyFilterEditorDropdownWrapper extends ComponentWrapper {
     return this.findComponent(`.${popoverStyles['dismiss-control']}`, ButtonWrapper)!;
   }
 
+  findForm(): ElementWrapper {
+    return this.findByClassName(styles['token-editor-form'])!;
+  }
+
   findPropertyField(): FormFieldWrapper {
     return this.findComponent(`.${testUtilStyles['token-editor-field-property']}`, FormFieldWrapper)!;
   }


### PR DESCRIPTION
### Description

AWSUI-22585
Turned token editor popover into `form` and make it submit on `onSubmit` event.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
