### PR TITLE
chore: Fix resize icon of Code Editor for RTL

### DIFF
--- a/src/code-editor/resizable-box/styles.scss
+++ b/src/code-editor/resizable-box/styles.scss
@@ -2,6 +2,7 @@
  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 */
+@use '../../internal/styles' as styles;
 @use '../../internal/styles/tokens' as awsui;
 @use '../background-inline-svg.scss' as utils;
 
@@ -28,6 +29,10 @@
     $path: '../assets/resize-handler.svg',
     $stroke: 'colorStrokeCodeEditorResizeHandler'
   );
+
+  @include styles.with-direction('rtl') {
+    transform: scaleX(-1);
+  }
 
   cursor: ns-resize;
 }


### PR DESCRIPTION
### Description
Mirror resize icon of Code Editor when viewed in a RTL document.

Related links, issue #, if available: AWSUI-53401

Before
![image](https://github.com/user-attachments/assets/c66d3299-7612-48f8-bd1e-daa8299b3f51)

After
![image](https://github.com/user-attachments/assets/848dbf6a-6cfa-4ed6-aa3e-1257a81a3dcb)


### How has this been tested?

Viewable on dev page locally. Seems our [deployed dev pages](https://d21d5uik3ws71m.cloudfront.net/components/dea4ef812982c3fa6ad84b48d6aac6ec547ba84a/dev-pages/index.html#/light/code-editor/simple?direction=rtl) CSP do not allow the icon to be viewed.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

Expected screenshot test failure.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
