### PR TITLE
fix: Safari token gap in FileUpload with multiple files

### DIFF
--- a/src/internal/components/token-list/styles.scss
+++ b/src/internal/components/token-list/styles.scss
@@ -9,12 +9,12 @@
 
 .root {
   display: flex;
-  flex-wrap: wrap;
   gap: awsui.$space-scaled-xs;
 
   &.horizontal {
     gap: awsui.$space-xs;
     flex-direction: row;
+    flex-wrap: wrap;
   }
   &.vertical {
     flex-direction: column;
@@ -32,11 +32,11 @@
   &.horizontal,
   &.vertical {
     display: flex;
-    flex-wrap: wrap;
     gap: awsui.$space-xs;
   }
   &.horizontal {
     flex-direction: row;
+    flex-wrap: wrap;
   }
   &.vertical {
     flex-direction: column;


### PR DESCRIPTION
### Description

Safari flexbox quirks does not calculate the height of the parent correctly.

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/2433

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
