### PR TITLE
chore: Add a page for the toggle button to test hover styles

### DIFF
--- a/pages/toggle-button/test-hover.page.tsx
+++ b/pages/toggle-button/test-hover.page.tsx
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import ToggleButton, { ToggleButtonProps } from '~components/toggle-button';
+
+import createPermutations from '../utils/permutations';
+import PermutationsView from '../utils/permutations-view';
+import ScreenshotArea from '../utils/screenshot-area';
+
+const permutations = createPermutations<ToggleButtonProps>([
+  {
+    variant: ['normal'],
+    children: ['Favorite'],
+    iconName: ['star'],
+    pressedIconName: ['star-filled'],
+    pressed: [false, true],
+  },
+  {
+    variant: ['icon'],
+    iconName: ['star'],
+    ariaLabel: ['Favorite'],
+    pressedIconName: ['star-filled'],
+    pressed: [false, true],
+  },
+]);
+
+export default function ToggleButtonTestHover() {
+  return (
+    <>
+      <h1>Toggle button test hover</h1>
+      <ScreenshotArea>
+        <PermutationsView
+          permutations={permutations}
+          render={permutation => {
+            const testId = `variant-${permutation.variant ?? 'normal'}-${permutation.pressed ? 'pressed' : 'not-pressed'}`;
+            return <ToggleButton {...permutation} data-testid={testId} />;
+          }}
+        />
+      </ScreenshotArea>
+    </>
+  );
+}


### PR DESCRIPTION
### Description

Added a new page for the toggle button with test IDs that reflect the button's states to test hover behavior in screenshot tests.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
