### PR TITLE
chore: Fix flaky table keyboard scroll test

### DIFF
--- a/src/table/__integ__/keyboard-scroll.test.ts
+++ b/src/table/__integ__/keyboard-scroll.test.ts
@@ -19,15 +19,22 @@ test(
 
     await expect(page.isFocused(wrapperSelector)).resolves.toBeTruthy();
 
+    let leftBefore = 0;
+    let leftAfter = 0;
+
     await page.keys('ArrowRight');
-    await page.waitForJsTimers();
-    const { left } = await page.getElementScroll(wrapperSelector);
-    expect(left).toBeGreaterThan(0);
+    await page.waitForAssertion(async () => {
+      const result = await page.getElementScroll(wrapperSelector);
+      leftBefore = result.left;
+      expect(leftBefore).toBeGreaterThan(0);
+    });
 
     await page.keys('ArrowLeft');
-    await page.waitForJsTimers();
-    const { left: leftAgain } = await page.getElementScroll(wrapperSelector);
-    expect(leftAgain).toBeLessThan(left);
+    await page.waitForAssertion(async () => {
+      const result = await page.getElementScroll(wrapperSelector);
+      leftAfter = result.left;
+      expect(leftAfter).toBeLessThan(leftBefore);
+    });
 
     await page.setWindowSize({ width: 800, height: 871 });
     await page.click('h1');


### PR DESCRIPTION
### Description

Fixing a flaky integ test in a table that started to fail with an update of chromedriver.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
