### PR TITLE
fix: Fix tabs dismiss button test-utils

### DIFF
--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -543,7 +543,6 @@ Object {
     "awsui_tabs-content-active_14rmt",
     "awsui_tabs-tab-action_14rmt",
     "awsui_tabs-tab-active_14rmt",
-    "awsui_tabs-tab-dismiss_14rmt",
     "awsui_tabs-tab-focused_14rmt",
     "awsui_tabs-tab-header-container_14rmt",
     "awsui_tabs-tab-link_14rmt",

--- a/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-selectors.test.tsx.snap
@@ -539,6 +539,7 @@ Object {
   "tabs": Array [
     "awsui_disabled-reason-tooltip_14rmt",
     "awsui_root_14rmt",
+    "awsui_tab-dismiss-button_1nq1i",
     "awsui_tabs-content-active_14rmt",
     "awsui_tabs-tab-action_14rmt",
     "awsui_tabs-tab-active_14rmt",

--- a/src/tabs/__tests__/tabs.test.tsx
+++ b/src/tabs/__tests__/tabs.test.tsx
@@ -788,15 +788,13 @@ describe('Tabs', () => {
       expect(requestAnimationFrameSpy).not.toBeCalledTimes(0);
       requestAnimationFrameSpy.mockRestore();
     });
+
     test('renders the correct dismiss label', () => {
       const dismissibleButton = renderTabs(
         <Tabs tabs={actionDismissibleTabs} />
       ).wrapper.findDismissibleButtonByTabIndex(1);
       expect(dismissibleButton).toBeTruthy();
-      expect(dismissibleButton?.getElement().firstElementChild).toHaveAttribute(
-        'aria-label',
-        'first-tab-dismissible-button'
-      );
+      expect(dismissibleButton?.getElement()).toHaveAttribute('aria-label', 'first-tab-dismissible-button');
     });
 
     test('does not render the dismiss button when dismissible false', () => {
@@ -814,10 +812,9 @@ describe('Tabs', () => {
 
     test('calls onDismiss event', () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-      const dismissibleButtonWrapper = renderTabs(
+      const dismissibleButton = renderTabs(
         <Tabs tabs={actionDismissibleTabs} activeTabId="first" />
       ).wrapper.findDismissibleButtonByTabId('first');
-      const dismissibleButton = dismissibleButtonWrapper?.find('button');
       dismissibleButton?.click();
       expect(consoleSpy).toHaveBeenCalledWith('I have been called!');
       consoleSpy.mockClear();

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -32,10 +32,14 @@ $label-horizontal-spacing: awsui.$space-xs;
   // do not use pointer-events none because it disables scroll by sliding
 
   // Hide scrollbar in all browsers
-  -ms-overflow-style: none; /* Internet Explorer 10+ */
-  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;
+  /* Internet Explorer 10+ */
+  scrollbar-width: none;
+
+  /* Firefox */
   &::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
+    display: none;
+    /* Safari and Chrome */
   }
 }
 
@@ -45,8 +49,10 @@ $label-horizontal-spacing: awsui.$space-xs;
   padding-block: 0;
   padding-inline: awsui.$space-xxs;
   display: flex;
+
   &-left {
     border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-control-disabled;
+
     &-scrollable {
       z-index: 1;
       box-shadow:
@@ -54,8 +60,10 @@ $label-horizontal-spacing: awsui.$space-xs;
         1px 0px 0px 0px awsui.$color-border-tabs-shadow;
     }
   }
+
   &-right {
     border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-control-disabled;
+
     &-scrollable {
       z-index: 1;
       box-shadow:
@@ -85,11 +93,6 @@ $label-horizontal-spacing: awsui.$space-xs;
   position: relative;
 
   @include styles.text-wrapping;
-}
-
-.tabs-tab-dismiss,
-.tabs-tab-action {
-  /* Used as a selector for tests */
 }
 
 .tabs-tab-header-container {
@@ -147,6 +150,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 .tabs-tab:not(:last-child) {
   & > .tabs-tab-header-container {
     margin-inline-end: calc(-1 * #{awsui.$border-divider-section-width});
+
     // This is the divider for the tab
     &:before {
       content: '';
@@ -211,6 +215,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:first-child {
   margin-inline-start: 1px;
+
   & > .tabs-tab-header-container {
     padding-inline-start: calc(#{$label-horizontal-spacing} - 1px);
   }
@@ -219,6 +224,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:last-child {
   margin-inline-end: 1px;
+
   & > .tabs-tab-header-container {
     padding-inline-end: calc(#{$label-horizontal-spacing} - 1px);
   }
@@ -235,6 +241,7 @@ $label-horizontal-spacing: awsui.$space-xs;
 
 .tabs-tab-active:not(.tabs-tab-disabled) {
   color: awsui.$color-text-accent;
+
   &:after {
     opacity: 1;
   }

--- a/src/tabs/tab-header-bar.scss
+++ b/src/tabs/tab-header-bar.scss
@@ -32,14 +32,10 @@ $label-horizontal-spacing: awsui.$space-xs;
   // do not use pointer-events none because it disables scroll by sliding
 
   // Hide scrollbar in all browsers
-  -ms-overflow-style: none;
-  /* Internet Explorer 10+ */
-  scrollbar-width: none;
-
-  /* Firefox */
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox */
   &::-webkit-scrollbar {
-    display: none;
-    /* Safari and Chrome */
+    display: none; /* Safari and Chrome */
   }
 }
 
@@ -49,10 +45,8 @@ $label-horizontal-spacing: awsui.$space-xs;
   padding-block: 0;
   padding-inline: awsui.$space-xxs;
   display: flex;
-
   &-left {
     border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-control-disabled;
-
     &-scrollable {
       z-index: 1;
       box-shadow:
@@ -60,10 +54,8 @@ $label-horizontal-spacing: awsui.$space-xs;
         1px 0px 0px 0px awsui.$color-border-tabs-shadow;
     }
   }
-
   &-right {
     border-inline-start: awsui.$border-divider-section-width solid awsui.$color-border-control-disabled;
-
     &-scrollable {
       z-index: 1;
       box-shadow:
@@ -150,7 +142,6 @@ $label-horizontal-spacing: awsui.$space-xs;
 .tabs-tab:not(:last-child) {
   & > .tabs-tab-header-container {
     margin-inline-end: calc(-1 * #{awsui.$border-divider-section-width});
-
     // This is the divider for the tab
     &:before {
       content: '';
@@ -215,7 +206,6 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:first-child {
   margin-inline-start: 1px;
-
   & > .tabs-tab-header-container {
     padding-inline-start: calc(#{$label-horizontal-spacing} - 1px);
   }
@@ -224,7 +214,6 @@ $label-horizontal-spacing: awsui.$space-xs;
 // Remediate focus shadow
 .tabs-tab:last-child {
   margin-inline-end: 1px;
-
   & > .tabs-tab-header-container {
     padding-inline-end: calc(#{$label-horizontal-spacing} - 1px);
   }
@@ -241,7 +230,6 @@ $label-horizontal-spacing: awsui.$space-xs;
 
 .tabs-tab-active:not(.tabs-tab-disabled) {
   color: awsui.$color-text-accent;
-
   &:after {
     opacity: 1;
   }

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -32,6 +32,7 @@ import {
 } from './scroll-utils';
 
 import styles from './styles.css.js';
+import testUtilStyles from './test-classes/styles.css.js';
 
 const tabSelector = `.${styles['tabs-tab-link']}`;
 const focusedTabSelector = `[role="tab"].${styles['tabs-tab-focused']}`;
@@ -50,6 +51,7 @@ function dismissButton(
       formAction="none"
       ariaLabel={dismissLabel}
       disabled={dismissDisabled}
+      className={testUtilStyles['tab-dismiss-button']}
     />
   );
 }

--- a/src/tabs/tab-header-bar.tsx
+++ b/src/tabs/tab-header-bar.tsx
@@ -38,11 +38,17 @@ const tabSelector = `.${styles['tabs-tab-link']}`;
 const focusedTabSelector = `[role="tab"].${styles['tabs-tab-focused']}`;
 const focusableTabSelector = `.${styles['tabs-tab-focusable']}`;
 
-function dismissButton(
-  dismissLabel: TabsProps.Tab['dismissLabel'],
-  dismissDisabled: TabsProps.Tab['dismissDisabled'],
-  onDismiss: TabsProps.Tab['onDismiss']
-) {
+function dismissButton({
+  dismissLabel,
+  dismissDisabled,
+  onDismiss,
+  tabId,
+}: {
+  dismissLabel?: string;
+  dismissDisabled?: boolean;
+  onDismiss: ButtonProps['onClick'];
+  tabId: string;
+}) {
   return (
     <InternalButton
       onClick={onDismiss}
@@ -52,6 +58,7 @@ function dismissButton(
       ariaLabel={dismissLabel}
       disabled={dismissDisabled}
       className={testUtilStyles['tab-dismiss-button']}
+      data-testid={`awsui-tab-dismiss-button-${tabId}`}
     />
   );
 }
@@ -453,7 +460,7 @@ export function TabHeaderBar({
           {action && <span className={tabActionClasses}>{action}</span>}
           {dismissible && (
             <span className={styles['tabs-tab-dismiss']}>
-              {dismissButton(dismissLabel, dismissDisabled, handleDismiss)}
+              {dismissButton({ dismissLabel, dismissDisabled, onDismiss: handleDismiss, tabId: tab.id })}
             </span>
           )}
         </div>

--- a/src/tabs/test-classes/styles.scss
+++ b/src/tabs/test-classes/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.tab-dismiss-button {
+  /* used in test-utils */
+}

--- a/src/test-utils/dom/tabs/index.ts
+++ b/src/test-utils/dom/tabs/index.ts
@@ -76,7 +76,7 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
    */
   findDismissibleButtonByTabId(id: string): ButtonWrapper | null {
     return this.findComponent(
-      `.${styles['tabs-tab-link']}[data-testid="${id}"] ~ .${styles['tabs-tab-dismiss']} .${testUtilStyles['tab-dismiss-button']}`,
+      `.${testUtilStyles['tab-dismiss-button']}[data-testid="awsui-tab-dismiss-button-${id}"]`,
       ButtonWrapper
     );
   }

--- a/src/test-utils/dom/tabs/index.ts
+++ b/src/test-utils/dom/tabs/index.ts
@@ -5,6 +5,7 @@ import { ComponentWrapper, createWrapper, ElementWrapper } from '@cloudscape-des
 import ButtonWrapper from '../button';
 
 import styles from '../../../tabs/styles.selectors.js';
+import testUtilStyles from '../../../tabs/test-classes/styles.selectors.js';
 
 export class TabWrapper extends ComponentWrapper {
   findDisabledReason(): ElementWrapper | null {
@@ -63,7 +64,7 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
    */
   findDismissibleButtonByTabIndex(index: number): ButtonWrapper | null {
     return this.findComponent(
-      `.${styles['tabs-tab']}:nth-child(${index}) .${styles['tabs-tab-dismiss']}`,
+      `.${styles['tabs-tab']}:nth-child(${index}) .${testUtilStyles['tab-dismiss-button']}`,
       ButtonWrapper
     );
   }
@@ -75,7 +76,7 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
    */
   findDismissibleButtonByTabId(id: string): ButtonWrapper | null {
     return this.findComponent(
-      `.${styles['tabs-tab-link']}[data-testid="${id}"] ~ .${styles['tabs-tab-dismiss']}`,
+      `.${styles['tabs-tab-link']}[data-testid="${id}"] ~ .${styles['tabs-tab-dismiss']} .${testUtilStyles['tab-dismiss-button']}`,
       ButtonWrapper
     );
   }
@@ -114,7 +115,7 @@ export default class TabsWrapper extends ComponentWrapper<HTMLButtonElement> {
    * Finds the dismissible button for the active tab
    */
   findActiveTabDismissibleButton(): ButtonWrapper | null {
-    return this.findComponent(`.${styles['tabs-tab-active']} .${styles['tabs-tab-dismiss']}`, ButtonWrapper);
+    return this.findComponent(`.${styles['tabs-tab-active']} .${testUtilStyles['tab-dismiss-button']}`, ButtonWrapper);
   }
 
   /**


### PR DESCRIPTION
### Description

Fixing tabs test utils for dismiss button so that the selectors return the button and not its wrapper.

Rel: [AWSUI-54108]

### How has this been tested?

* Updated existing unit tests
* Dry-run to live

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
