### PR TITLE
fix: Revert change to visible all properties label

### DIFF
--- a/src/property-filter/__tests__/property-filter-token-list.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-list.test.tsx
@@ -73,6 +73,13 @@ describe('filtering tokens', () => {
       });
       expect(wrapper.findTokens()![0].getElement()).toHaveTextContent('range > value');
     });
+
+    test('property token with missing property key', () => {
+      const { propertyFilterWrapper: wrapper } = renderComponent({
+        query: { tokens: [{ propertyKey: undefined, value: 'value', operator: ':' }], operation: 'or' },
+      });
+      expect(wrapper.findTokens()![0].getElement().textContent).toBe(': value');
+    });
   });
 
   describe('join operation control', () => {

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -72,7 +72,7 @@ export const TokenButton = ({
         {
           content: (
             <span className={styles['token-trigger']}>
-              <TokenTrigger token={formattedToken} />
+              <TokenTrigger token={formattedToken} allProperties={token.property === null} />
             </span>
           ),
           ariaLabel: `${formattedToken.propertyLabel} ${formattedToken.operator} ${formattedToken.value}`,
@@ -118,7 +118,13 @@ export const TokenButton = ({
   );
 };
 
-const TokenTrigger = ({ token: { propertyLabel, operator, value } }: { token: FormattedToken }) => {
+const TokenTrigger = ({
+  token: { propertyLabel, operator, value },
+  allProperties,
+}: {
+  token: FormattedToken;
+  allProperties: boolean;
+}) => {
   if (propertyLabel) {
     propertyLabel += ' ';
   }
@@ -126,7 +132,7 @@ const TokenTrigger = ({ token: { propertyLabel, operator, value } }: { token: Fo
   const operatorText = freeTextContainsToken ? '' : operator + ' ';
   return (
     <>
-      {propertyLabel}
+      {allProperties ? '' : propertyLabel}
       <span className={styles['token-operator']}>{operatorText}</span>
       {value}
     </>


### PR DESCRIPTION
### Description

Reverts an accidental change from https://github.com/cloudscape-design/components/pull/2510 that made all properties label visible in the token. Use an empty string for that case instead.

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
