### PR TITLE
fix: Adjust inline offset in chart X-axis based on direction

### DIFF
--- a/src/area-chart/chart-container.tsx
+++ b/src/area-chart/chart-container.tsx
@@ -45,6 +45,7 @@ interface ChartContainerProps<T extends AreaChartProps.DataTypes>
   autoWidth: (value: number) => void;
   fitHeight?: boolean;
   minHeight: number;
+  isRTL?: boolean;
 }
 
 export default memo(ChartContainer) as typeof ChartContainer;
@@ -74,6 +75,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
   xTickFormatter = deprecatedXTickFormatter,
   yTickFormatter = deprecatedYTickFormatter,
   detailTotalFormatter = deprecatedDetailTotalFormatter,
+  isRTL,
 }: ChartContainerProps<T>) {
   const [inlineStartLabelsWidth, setInlineStartLabelsWidth] = useState(0);
   const [containerWidth, containerWidthRef] = useContainerWidth(DEFAULT_CHART_WIDTH);
@@ -182,6 +184,7 @@ function ChartContainer<T extends AreaChartProps.DataTypes>({
             ariaRoleDescription={xAxisAriaRoleDescription}
             offsetLeft={inlineStartLabelsWidth + BLOCK_END_LABELS_OFFSET}
             offsetRight={BLOCK_END_LABELS_OFFSET}
+            isRTL={isRTL}
           />
 
           <EmphasizedBaseline width={model.width} height={model.height} scale={model.computed.yScale} />

--- a/src/area-chart/internal.tsx
+++ b/src/area-chart/internal.tsx
@@ -190,6 +190,7 @@ export default function InternalAreaChart<T extends AreaChartProps.DataTypes>({
             i18nStrings={i18nStrings}
             fitHeight={fitHeight}
             minHeight={height}
+            isRTL={isRtl}
           />
         ) : null
       }

--- a/src/internal/components/cartesian-chart/block-end-labels.tsx
+++ b/src/internal/components/cartesian-chart/block-end-labels.tsx
@@ -22,6 +22,7 @@ interface BlockEndLabelsProps {
   offsetRight?: number;
   virtualTextRef: React.Ref<SVGTextElement>;
   formattedTicks: readonly FormattedTick[];
+  isRTL?: boolean;
 }
 
 export function useBLockEndLabels({
@@ -76,13 +77,17 @@ function BlockEndLabels({
   offsetRight = 0,
   virtualTextRef,
   formattedTicks,
+  isRTL = false,
 }: BlockEndLabelsProps) {
   const i18n = useInternalI18n('[charts]');
 
   const xOffset = scale.isCategorical() && axis === 'x' ? Math.max(0, scale.d3Scale.bandwidth() - 1) / 2 : 0;
 
-  const from = 0 - offsetLeft - xOffset;
-  const until = width + offsetRight - xOffset;
+  const offsetInlineStart = isRTL ? offsetRight : offsetLeft;
+  const offsetInlineEnd = isRTL ? offsetLeft : offsetRight;
+
+  const from = 0 - offsetInlineStart - xOffset;
+  const until = width + offsetInlineEnd - xOffset;
   const balanceLabels = axis === 'x' && scale.scaleType !== 'log';
   const visibleTicks = getVisibleTicks(formattedTicks, from, until, balanceLabels);
 

--- a/src/mixed-line-bar-chart/chart-container.tsx
+++ b/src/mixed-line-bar-chart/chart-container.tsx
@@ -629,6 +629,7 @@ export default function ChartContainer<T extends ChartDataTypes>({
             width={plotWidth}
             offsetLeft={inlineStartLabelsWidth + BLOCK_END_LABELS_OFFSET}
             offsetRight={BLOCK_END_LABELS_OFFSET}
+            isRTL={isRtl}
           />
         </ChartPlot>
       }


### PR DESCRIPTION
### Description
X-axis labels in mixed line-bar chart didn't respect document's direction. This PR fixes it.

Bonus: Area-chart fix

![image](https://github.com/user-attachments/assets/a7aa621f-e014-4cb9-bf7c-7c466559a7ff)

Related links, issue #, if available: AWSUI-53402

### How has this been tested?

- manually
- dev-pipeline - IN-PROGRESS

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
