### PR TITLE
fix: Button group show no tooltip when menu closes

### DIFF
--- a/src/button-group/__integ__/button-group.test.ts
+++ b/src/button-group/__integ__/button-group.test.ts
@@ -156,9 +156,37 @@ test(
     await expect(page.isExisting(actionsMenu.findOpenDropdown().toSelector())).resolves.toBe(true);
     await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
 
+    // No tooltip is shown after menu closes.
     await page.click(actionsMenu.findItemById('edit').toSelector());
     await expect(page.isExisting(actionsMenu.findOpenDropdown().toSelector())).resolves.toBe(false);
-    await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(true);
+    await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
+
+    // The tooltip is shown when the menu trigger is hovered.
+    await page.hoverElement(actionsMenu.toSelector());
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('More actions');
+  })
+);
+
+test(
+  'shows tooltip over a menu after a menu item is pressed',
+  setup({}, async page => {
+    await page.click(actionsMenu.toSelector());
+    await expect(page.isExisting(actionsMenu.findOpenDropdown().toSelector())).resolves.toBe(true);
+    await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
+
+    // No tooltip is shown after menu closes with item selection.
+    await page.click(actionsMenu.findItemById('edit').toSelector());
+    await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
+    await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
+
+    // No tooltip is shown after menu closes with Escape.
+    await page.click(actionsMenu.toSelector());
+    await page.keys(['Escape']);
+    await expect(page.isExisting(buttonGroup.findTooltip().toSelector())).resolves.toBe(false);
+
+    // The tooltip is shown when the menu trigger is refocused.
+    await page.keys(['ArrowLeft', 'ArrowRight']);
+    await expect(page.getText(buttonGroup.findTooltip().toSelector())).resolves.toBe('More actions');
   })
 );
 

--- a/src/button-group/item-element.tsx
+++ b/src/button-group/item-element.tsx
@@ -4,9 +4,10 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react
 
 import { ButtonProps } from '../button/interfaces.js';
 import { ClickDetail, fireCancelableEvent, NonCancelableEventHandler } from '../internal/events';
-import IconButtonItem from './icon-button-item.js';
-import { ButtonGroupProps } from './interfaces.js';
-import MenuDropdownItem from './menu-dropdown-item.js';
+import { nodeBelongs } from '../internal/utils/node-belongs';
+import IconButtonItem from './icon-button-item';
+import { ButtonGroupProps } from './interfaces';
+import MenuDropdownItem from './menu-dropdown-item';
 
 import styles from './styles.css.js';
 
@@ -95,7 +96,14 @@ const ItemElement = forwardRef(
         ref={containerRef}
         onPointerEnter={() => onShowTooltipSoft(true)}
         onPointerLeave={() => onShowTooltipSoft(false)}
-        onFocus={() => onShowTooltipHard(true)}
+        onFocus={event => {
+          // Showing no tooltip when the focus comes from inside the container.
+          // This is needed to prevent the tooltip after a menu closes with item selection or Escape.
+          if (event && event.relatedTarget && nodeBelongs(containerRef.current, event.relatedTarget)) {
+            return;
+          }
+          onShowTooltipHard(true);
+        }}
         onBlur={() => onShowTooltipHard(false)}
       >
         {item.type === 'icon-button' && (


### PR DESCRIPTION
### Description

Fixing an issue when tooltip is shown after a menu closes with mouse click, keyboard select, or Escape keypress.

Related links, issue #, if available: n/a

### How has this been tested?

* New integration tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
