### PR TITLE
feat: Support for option group features in Select and Multiselect

### DIFF
--- a/pages/select/generate-options.ts
+++ b/pages/select/generate-options.ts
@@ -51,6 +51,7 @@ const randomOption = (): OptionDefinition => {
     value: generateValue(),
     label: generateLabel(),
     disabled: chance10(),
+    disabledReason: 'Disabled reason',
     description: generateDescription(),
     iconName: generateIcon(),
     tags: generateTags(),
@@ -62,13 +63,11 @@ const randomOption = (): OptionDefinition => {
 const randomOptionGroup = (): SelectProps.OptionGroup => {
   const childCount = getRandomInt(8);
   return {
+    ...randomOption(),
     label: 'group_' + generateLabel(),
     options: [...Array(childCount)].map(() => {
       return randomOption();
     }),
-    disabled: chance10(),
-    labelTag: chance50() ? 'Label tag' : undefined,
-    tags: chance50() ? ['Tag'] : undefined,
   };
 };
 

--- a/pages/select/generate-options.ts
+++ b/pages/select/generate-options.ts
@@ -67,6 +67,8 @@ const randomOptionGroup = (): SelectProps.OptionGroup => {
       return randomOption();
     }),
     disabled: chance10(),
+    labelTag: chance50() ? 'Label tag' : undefined,
+    tags: chance50() ? ['Tag'] : undefined,
   };
 };
 

--- a/pages/select/item.permutations.page.tsx
+++ b/pages/select/item.permutations.page.tsx
@@ -5,25 +5,29 @@ import React from 'react';
 import { DropdownOption } from '~components/internal/components/option/interfaces';
 import Item from '~components/select/parts/item';
 import { ItemProps } from '~components/select/parts/item';
-import SpaceBetween from '~components/space-between';
 
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
 
+const complexOption: DropdownOption = {
+  option: {
+    value: 'Complex option',
+    labelTag: 'tag',
+    description: 'description',
+    iconName: 'share',
+    tags: ['tag 1', 'tag 2', 'tag 3'],
+    filteringTags: ['tag 1', 'tag 2'],
+  },
+};
+
 const options: Record<string, DropdownOption> = {
   simpleOption: {
     option: { value: 'Option 1' },
   },
-  complexOption: {
-    option: {
-      value: 'Complex option',
-      labelTag: 'tag',
-      description: 'description',
-      iconName: 'share',
-      tags: ['tag 1', 'tag 2', 'tag 3'],
-      filteringTags: ['tag 1', 'tag 2'],
-    },
+  complexOption,
+  complexOptionGroup: {
+    option: { ...complexOption.option, options: [complexOption.option] },
   },
   longOption: {
     option: {
@@ -131,6 +135,13 @@ const permutations = createPermutations<ItemProps>([
     selected: [true],
     hasCheckbox: [false],
   },
+  {
+    option: [options.complexOptionGroup],
+    highlighted: [false],
+    highlightType: ['keyboard'],
+    selected: [true],
+    hasCheckbox: [false, true],
+  },
 ]);
 
 export default function InputPermutations() {
@@ -138,11 +149,9 @@ export default function InputPermutations() {
     <>
       <h1>Select item permutations</h1>
       <ScreenshotArea>
-        <SpaceBetween size="xs">
-          <ul role="listbox" aria-label="list">
-            <PermutationsView permutations={permutations} render={permutation => <Item {...permutation} />} />
-          </ul>
-        </SpaceBetween>
+        <ul role="listbox" aria-label="list">
+          <PermutationsView permutations={permutations} render={permutation => <Item {...permutation} />} />
+        </ul>
       </ScreenshotArea>
     </>
   );

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10479,6 +10479,7 @@ The options can be grouped using \`OptionGroup\` objects.
 - \`label\` (string) - Option group text displayed to the user.
 - \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
 - \`options\` (Option[]) - (Optional) The options under this group.
+- \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
 - \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.
@@ -13659,6 +13660,7 @@ The options can be grouped using \`OptionGroup\` objects.
 - \`label\` (string) - Option group text displayed to the user.
 - \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
 - \`options\` (Option[]) - (Optional) The options under this group.
+- \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
 - \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10462,25 +10462,24 @@ single form field.",
 The options can be grouped using \`OptionGroup\` objects.
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
-- \`label\` (string) - (Optional) Option text displayed to the user.
-- \`lang\` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
-- \`description\` (string) - (Optional) Further information about the option that appears below the label.
-- \`disabled\` (boolean) - (Optional) Determines whether the option is disabled.
+
+#### OptionGroup
+- \`value\` (string) - Used to locate option group in test utils.
+- \`options\` (Option[]) - (Optional) The options under this group.
+
+#### Shared Option and OptionGroup properties
+- \`label\` (string) - (Optional) Option or group text displayed to the user.
+- \`lang\` (string) - (Optional) The language of the option or group, provided as a BCP 47 language tag.
+- \`description\` (string) - (Optional) Further information about the option or group that appears below the label.
+- \`disabled\` (boolean) - (Optional) Determines whether the option or group is disabled.
 - \`disabledReason\` (string) - (Optional) Displays tooltip near the item when disabled. Use to provide additional context.
 - \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the option.
+- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the option or group.
 - \`filteringTags\` [string[]] - (Optional) A list of additional tags used for automatic filtering.
-- \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option.
+- \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option or group.
 - \`iconAlt\` (string) - (Optional) Specifies alternate text for a custom icon, for use with \`iconUrl\`.
 - \`iconUrl\` (string) - (Optional) URL of a custom icon.
 - \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
-
-#### OptionGroup
-- \`label\` (string) - Option group text displayed to the user.
-- \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
-- \`options\` (Option[]) - (Optional) The options under this group.
-- \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.
 
@@ -13643,25 +13642,24 @@ single form field.",
 The options can be grouped using \`OptionGroup\` objects.
 #### Option
 - \`value\` (string) - The returned value of the option when selected.
-- \`label\` (string) - (Optional) Option text displayed to the user.
-- \`lang\` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
-- \`description\` (string) - (Optional) Further information about the option that appears below the label.
-- \`disabled\` (boolean) - (Optional) Determines whether the option is disabled.
+
+#### OptionGroup
+- \`value\` (string) - Used to locate option group in test utils.
+- \`options\` (Option[]) - (Optional) The options under this group.
+
+#### Shared Option and OptionGroup properties
+- \`label\` (string) - (Optional) Option or group text displayed to the user.
+- \`lang\` (string) - (Optional) The language of the option or group, provided as a BCP 47 language tag.
+- \`description\` (string) - (Optional) Further information about the option or group that appears below the label.
+- \`disabled\` (boolean) - (Optional) Determines whether the option or group is disabled.
 - \`disabledReason\` (string) - (Optional) Displays tooltip near the item when disabled. Use to provide additional context.
 - \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the option.
+- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the option or group.
 - \`filteringTags\` [string[]] - (Optional) A list of additional tags used for automatic filtering.
-- \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option.
+- \`iconName\` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option or group.
 - \`iconAlt\` (string) - (Optional) Specifies alternate text for a custom icon, for use with \`iconUrl\`.
 - \`iconUrl\` (string) - (Optional) URL of a custom icon.
 - \`iconSvg\` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the \`svg\` slot of the [icon component](/components/icon/).
-
-#### OptionGroup
-- \`label\` (string) - Option group text displayed to the user.
-- \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
-- \`options\` (Option[]) - (Optional) The options under this group.
-- \`labelTag\` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.
 

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -10479,6 +10479,7 @@ The options can be grouped using \`OptionGroup\` objects.
 - \`label\` (string) - Option group text displayed to the user.
 - \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
 - \`options\` (Option[]) - (Optional) The options under this group.
+- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.
 
@@ -13658,6 +13659,7 @@ The options can be grouped using \`OptionGroup\` objects.
 - \`label\` (string) - Option group text displayed to the user.
 - \`disabled\` (boolean) - (Optional) Determines whether the option group is disabled.
 - \`options\` (Option[]) - (Optional) The options under this group.
+- \`tags\` [string[]] - (Optional) A list of tags giving further guidance about the group.
 
 Note: Only one level of option nesting is supported.
 

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -6,22 +6,22 @@ import { IconProps } from '../../../icon/interfaces';
 import { BaseComponentProps } from '../../base-component';
 
 export interface BaseOption {
+  value?: string;
   label?: string;
+  lang?: string;
+  description?: string;
   disabled?: boolean;
   disabledReason?: string;
   labelTag?: string;
   tags?: ReadonlyArray<string>;
-}
-
-export interface OptionDefinition extends BaseOption {
-  value?: string;
-  lang?: string;
-  description?: string;
+  filteringTags?: ReadonlyArray<string>;
   iconAlt?: string;
   iconName?: IconProps.Name;
   iconUrl?: string;
   iconSvg?: React.ReactNode;
-  filteringTags?: ReadonlyArray<string>;
+}
+
+export interface OptionDefinition extends BaseOption {
   __labelPrefix?: string;
 }
 

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -9,6 +9,7 @@ export interface BaseOption {
   label?: string;
   disabled?: boolean;
   disabledReason?: string;
+  tags?: ReadonlyArray<string>;
 }
 
 export interface OptionDefinition extends BaseOption {
@@ -20,7 +21,6 @@ export interface OptionDefinition extends BaseOption {
   iconName?: IconProps.Name;
   iconUrl?: string;
   iconSvg?: React.ReactNode;
-  tags?: ReadonlyArray<string>;
   filteringTags?: ReadonlyArray<string>;
   __labelPrefix?: string;
 }

--- a/src/internal/components/option/interfaces.ts
+++ b/src/internal/components/option/interfaces.ts
@@ -9,13 +9,13 @@ export interface BaseOption {
   label?: string;
   disabled?: boolean;
   disabledReason?: string;
+  labelTag?: string;
   tags?: ReadonlyArray<string>;
 }
 
 export interface OptionDefinition extends BaseOption {
   value?: string;
   lang?: string;
-  labelTag?: string;
   description?: string;
   iconAlt?: string;
   iconName?: IconProps.Name;

--- a/src/multiselect/__tests__/i18n.test.tsx
+++ b/src/multiselect/__tests__/i18n.test.tsx
@@ -71,7 +71,7 @@ describe('i18n provider', () => {
     expect(statusIcon).toHaveAttribute('aria-label', 'Custom error icon');
   });
 
-  test('utilises selectedAriaLabel from Select messages', () => {
+  test('utilizes selectedAriaLabel from Select messages', () => {
     const { wrapper } = renderElement(
       <TestI18nProvider messages={{ select: { selectedAriaLabel: 'Custom selected' } }}>
         <Multiselect {...defaultProps} selectedOptions={[{ label: 'First', value: '1' }]} />

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -803,11 +803,12 @@ test('group options can have description, label tag, tags, disabled reason', () 
   wrapper.openDropdown();
 
   const groupOption = wrapper.findDropdown().findOptionByValue('group2')!;
+  const groupOptionByIndex = wrapper.findDropdown()!.find('[data-group-index="2"]')!;
 
   expect(groupOption.findLabel()!.getElement().textContent).toBe('Second category');
   expect(groupOption.findDescription()!.getElement().textContent).toBe('Description');
   expect(groupOption.findLabelTag()!.getElement().textContent).toBe('Label tag');
   expect(groupOption.findTags()![0].getElement().textContent).toBe('Tag 1');
   expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
-  expect(groupOption.find('span[hidden]')!.getElement()).toHaveTextContent('Disabled reason');
+  expect(groupOptionByIndex.find('span[hidden]')!.getElement()).toHaveTextContent('Disabled reason');
 });

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -30,7 +30,6 @@ const groupOptions: MultiselectProps.Options = [
       { label: 'Third', value: '3' },
       { label: 'Fourth', value: '4' },
     ],
-    labelTag: 'Label tag',
   },
   { label: 'Fifth', value: '5' },
   {
@@ -40,7 +39,6 @@ const groupOptions: MultiselectProps.Options = [
       { label: 'sixth', value: '6' },
       { label: 'seventh', value: '7', disabled: true },
     ],
-    tags: ['Tag1', 'Tag2'],
   },
 ];
 function renderMultiselect(jsx: React.ReactElement) {
@@ -779,16 +777,37 @@ describe('Disabled item with reason', () => {
   });
 });
 
-test('group options can have label tag', () => {
-  const { wrapper } = renderMultiselect(<Multiselect options={groupOptions} selectedOptions={[]} />);
+test('group options can have description, label tag, tags, disabled reason', () => {
+  const { wrapper } = renderMultiselect(
+    <Multiselect
+      options={[
+        {
+          label: 'First category',
+          value: 'group1',
+          options: [{ value: '1.1' }],
+        },
+        {
+          label: 'Second category',
+          value: 'group2',
+          description: 'Description',
+          labelTag: 'Label tag',
+          tags: ['Tag 1', 'Tag 2'],
+          disabled: true,
+          disabledReason: 'Disabled reason',
+          options: [{ value: '2.1' }],
+        },
+      ]}
+      selectedOptions={[]}
+    />
+  );
   wrapper.openDropdown();
 
-  expect(wrapper.findDropdown().findOptionByValue('group')!.getElement().textContent).toBe('First categoryLabel tag');
-});
+  const groupOption = wrapper.findDropdown().findOptionByValue('group2')!;
 
-test('group options can have tags', () => {
-  const { wrapper } = renderMultiselect(<Multiselect options={groupOptions} selectedOptions={[]} />);
-  wrapper.openDropdown();
-
-  expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryTag1Tag2');
+  expect(groupOption.findLabel()!.getElement().textContent).toBe('Second category');
+  expect(groupOption.findDescription()!.getElement().textContent).toBe('Description');
+  expect(groupOption.findLabelTag()!.getElement().textContent).toBe('Label tag');
+  expect(groupOption.findTags()![0].getElement().textContent).toBe('Tag 1');
+  expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
+  expect(groupOption.find('span[hidden]')!.getElement()).toHaveTextContent('Disabled reason');
 });

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -30,6 +30,7 @@ const groupOptions: MultiselectProps.Options = [
       { label: 'Third', value: '3' },
       { label: 'Fourth', value: '4' },
     ],
+    labelTag: 'Label tag',
   },
   { label: 'Fifth', value: '5' },
   {
@@ -39,7 +40,7 @@ const groupOptions: MultiselectProps.Options = [
       { label: 'sixth', value: '6' },
       { label: 'seventh', value: '7', disabled: true },
     ],
-    tags: ['One', 'Two'],
+    tags: ['Tag1', 'Tag2'],
   },
 ];
 function renderMultiselect(jsx: React.ReactElement) {
@@ -778,9 +779,16 @@ describe('Disabled item with reason', () => {
   });
 });
 
+test('group options can have label tag', () => {
+  const { wrapper } = renderMultiselect(<Multiselect options={groupOptions} selectedOptions={[]} />);
+  wrapper.openDropdown();
+
+  expect(wrapper.findDropdown().findOptionByValue('group')!.getElement().textContent).toBe('First categoryLabel tag');
+});
+
 test('group options can have tags', () => {
   const { wrapper } = renderMultiselect(<Multiselect options={groupOptions} selectedOptions={[]} />);
   wrapper.openDropdown();
 
-  expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryOneTwo');
+  expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryTag1Tag2');
 });

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -802,13 +802,17 @@ test('group options can have description, label tag, tags, disabled reason', () 
   );
   wrapper.openDropdown();
 
+  // Moving focus to the second group to make the disabled reason visible.
+  wrapper.findTrigger()!.keydown(KeyCode.down);
+  wrapper.findDropdown().find('ul')!.keydown(KeyCode.down);
+  wrapper.findDropdown().find('ul')!.keydown(KeyCode.down);
+
   const groupOption = wrapper.findDropdown().findOptionByValue('group2')!;
-  const groupOptionByIndex = wrapper.findDropdown()!.find('[data-group-index="2"]')!;
 
   expect(groupOption.findLabel()!.getElement().textContent).toBe('Second category');
   expect(groupOption.findDescription()!.getElement().textContent).toBe('Description');
   expect(groupOption.findLabelTag()!.getElement().textContent).toBe('Label tag');
   expect(groupOption.findTags()![0].getElement().textContent).toBe('Tag 1');
   expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
-  expect(groupOptionByIndex.find('span[hidden]')!.getElement()).toHaveTextContent('Disabled reason');
+  expect(groupOption.findDisabledReason()!.getElement().textContent).toBe('Disabled reason');
 });

--- a/src/multiselect/__tests__/multiselect.test.tsx
+++ b/src/multiselect/__tests__/multiselect.test.tsx
@@ -39,6 +39,7 @@ const groupOptions: MultiselectProps.Options = [
       { label: 'sixth', value: '6' },
       { label: 'seventh', value: '7', disabled: true },
     ],
+    tags: ['One', 'Two'],
   },
 ];
 function renderMultiselect(jsx: React.ReactElement) {
@@ -775,4 +776,11 @@ describe('Disabled item with reason', () => {
     wrapper.selectOptionByValue('1');
     expect(onChange).not.toHaveBeenCalled();
   });
+});
+
+test('group options can have tags', () => {
+  const { wrapper } = renderMultiselect(<Multiselect options={groupOptions} selectedOptions={[]} />);
+  wrapper.openDropdown();
+
+  expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryOneTwo');
 });

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -46,6 +46,28 @@ const defaultOptions: SelectProps.Options = [
     ],
   },
 ];
+const groupOptions: SelectProps.Options = [
+  {
+    label: 'First category',
+    value: 'group',
+    options: [
+      { label: 'First', value: '1' },
+      { label: 'Second', value: '2' },
+      { label: 'Third', value: '3' },
+      { label: 'Fourth', value: '4' },
+    ],
+  },
+  { label: 'Fifth', value: '5' },
+  {
+    label: 'Second category',
+    value: 'group2',
+    options: [
+      { label: 'sixth', value: '6' },
+      { label: 'seventh', value: '7', disabled: true },
+    ],
+    tags: ['One', 'Two'],
+  },
+];
 
 describe.each([false, true])('expandToViewport=%s', expandToViewport => {
   const defaultProps = {
@@ -559,5 +581,12 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
   test('should render with focus when autoFocus=true', () => {
     const { wrapper } = renderSelect({ autoFocus: true });
     expect(wrapper.findTrigger().getElement()).toHaveFocus();
+  });
+
+  test('group options can have tags', () => {
+    const { wrapper } = renderSelect({ options: groupOptions });
+    wrapper.openDropdown();
+
+    expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryOneTwo');
   });
 });

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -561,7 +561,7 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     expect(wrapper.findTrigger().getElement()).toHaveFocus();
   });
 
-  test('group options can have description, label tag, tags, disabled reason', () => {
+  test('group options can have description, label tag, tags', () => {
     const { wrapper } = renderSelect({
       options: [
         {

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -56,6 +56,7 @@ const groupOptions: SelectProps.Options = [
       { label: 'Third', value: '3' },
       { label: 'Fourth', value: '4' },
     ],
+    labelTag: 'Label tag',
   },
   { label: 'Fifth', value: '5' },
   {
@@ -65,7 +66,7 @@ const groupOptions: SelectProps.Options = [
       { label: 'sixth', value: '6' },
       { label: 'seventh', value: '7', disabled: true },
     ],
-    tags: ['One', 'Two'],
+    tags: ['Tag1', 'Tag2'],
   },
 ];
 
@@ -583,10 +584,21 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     expect(wrapper.findTrigger().getElement()).toHaveFocus();
   });
 
+  test('group options can have label tag', () => {
+    const { wrapper } = renderSelect({ options: groupOptions });
+    wrapper.openDropdown();
+
+    expect(wrapper.findDropdown({ expandToViewport }).findOptionByValue('group')!.getElement().textContent).toBe(
+      'First categoryLabel tag'
+    );
+  });
+
   test('group options can have tags', () => {
     const { wrapper } = renderSelect({ options: groupOptions });
     wrapper.openDropdown();
 
-    expect(wrapper.findDropdown().findOptionByValue('group2')!.getElement().textContent).toBe('Second categoryOneTwo');
+    expect(wrapper.findDropdown({ expandToViewport }).findOptionByValue('group2')!.getElement().textContent).toBe(
+      'Second categoryTag1Tag2'
+    );
   });
 });

--- a/src/select/__tests__/select.test.tsx
+++ b/src/select/__tests__/select.test.tsx
@@ -46,29 +46,6 @@ const defaultOptions: SelectProps.Options = [
     ],
   },
 ];
-const groupOptions: SelectProps.Options = [
-  {
-    label: 'First category',
-    value: 'group',
-    options: [
-      { label: 'First', value: '1' },
-      { label: 'Second', value: '2' },
-      { label: 'Third', value: '3' },
-      { label: 'Fourth', value: '4' },
-    ],
-    labelTag: 'Label tag',
-  },
-  { label: 'Fifth', value: '5' },
-  {
-    label: 'Second category',
-    value: 'group2',
-    options: [
-      { label: 'sixth', value: '6' },
-      { label: 'seventh', value: '7', disabled: true },
-    ],
-    tags: ['Tag1', 'Tag2'],
-  },
-];
 
 describe.each([false, true])('expandToViewport=%s', expandToViewport => {
   const defaultProps = {
@@ -584,21 +561,32 @@ describe.each([false, true])('expandToViewport=%s', expandToViewport => {
     expect(wrapper.findTrigger().getElement()).toHaveFocus();
   });
 
-  test('group options can have label tag', () => {
-    const { wrapper } = renderSelect({ options: groupOptions });
+  test('group options can have description, label tag, tags, disabled reason', () => {
+    const { wrapper } = renderSelect({
+      options: [
+        {
+          label: 'First category',
+          value: 'group1',
+          options: [{ value: '1.1' }],
+        },
+        {
+          label: 'Second category',
+          value: 'group2',
+          description: 'Description',
+          labelTag: 'Label tag',
+          tags: ['Tag 1', 'Tag 2'],
+          options: [{ value: '2.1' }],
+        },
+      ],
+    });
     wrapper.openDropdown();
 
-    expect(wrapper.findDropdown({ expandToViewport }).findOptionByValue('group')!.getElement().textContent).toBe(
-      'First categoryLabel tag'
-    );
-  });
+    const groupOption = wrapper.findDropdown({ expandToViewport }).findOptionByValue('group2')!;
 
-  test('group options can have tags', () => {
-    const { wrapper } = renderSelect({ options: groupOptions });
-    wrapper.openDropdown();
-
-    expect(wrapper.findDropdown({ expandToViewport }).findOptionByValue('group2')!.getElement().textContent).toBe(
-      'Second categoryTag1Tag2'
-    );
+    expect(groupOption.findLabel()!.getElement().textContent).toBe('Second category');
+    expect(groupOption.findDescription()!.getElement().textContent).toBe('Description');
+    expect(groupOption.findLabelTag()!.getElement().textContent).toBe('Label tag');
+    expect(groupOption.findTags()![0].getElement().textContent).toBe('Tag 1');
+    expect(groupOption.findTags()![1].getElement().textContent).toBe('Tag 2');
   });
 });

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -41,6 +41,7 @@ export interface BaseSelectProps
    * - `label` (string) - Option group text displayed to the user.
    * - `disabled` (boolean) - (Optional) Determines whether the option group is disabled.
    * - `options` (Option[]) - (Optional) The options under this group.
+   * - `tags` [string[]] - (Optional) A list of tags giving further guidance about the group.
    *
    * Note: Only one level of option nesting is supported.
    *

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -24,25 +24,24 @@ export interface BaseSelectProps
    *
    * #### Option
    * - `value` (string) - The returned value of the option when selected.
-   * - `label` (string) - (Optional) Option text displayed to the user.
-   * - `lang` (string) - (Optional) The language of the option, provided as a BCP 47 language tag.
-   * - `description` (string) - (Optional) Further information about the option that appears below the label.
-   * - `disabled` (boolean) - (Optional) Determines whether the option is disabled.
+   *
+   * #### OptionGroup
+   * - `value` (string) - Used to locate option group in test utils.
+   * - `options` (Option[]) - (Optional) The options under this group.
+   *
+   * #### Shared Option and OptionGroup properties
+   * - `label` (string) - (Optional) Option or group text displayed to the user.
+   * - `lang` (string) - (Optional) The language of the option or group, provided as a BCP 47 language tag.
+   * - `description` (string) - (Optional) Further information about the option or group that appears below the label.
+   * - `disabled` (boolean) - (Optional) Determines whether the option or group is disabled.
    * - `disabledReason` (string) - (Optional) Displays tooltip near the item when disabled. Use to provide additional context.
    * - `labelTag` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-   * - `tags` [string[]] - (Optional) A list of tags giving further guidance about the option.
+   * - `tags` [string[]] - (Optional) A list of tags giving further guidance about the option or group.
    * - `filteringTags` [string[]] - (Optional) A list of additional tags used for automatic filtering.
-   * - `iconName` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option.
+   * - `iconName` (string) - (Optional) Specifies the name of an [icon](/components/icon/) to display in the option or group.
    * - `iconAlt` (string) - (Optional) Specifies alternate text for a custom icon, for use with `iconUrl`.
    * - `iconUrl` (string) - (Optional) URL of a custom icon.
    * - `iconSvg` (ReactNode) - (Optional) Custom SVG icon. Equivalent to the `svg` slot of the [icon component](/components/icon/).
-   *
-   * #### OptionGroup
-   * - `label` (string) - Option group text displayed to the user.
-   * - `disabled` (boolean) - (Optional) Determines whether the option group is disabled.
-   * - `options` (Option[]) - (Optional) The options under this group.
-   * - `labelTag` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
-   * - `tags` [string[]] - (Optional) A list of tags giving further guidance about the group.
    *
    * Note: Only one level of option nesting is supported.
    *

--- a/src/select/interfaces.ts
+++ b/src/select/interfaces.ts
@@ -41,6 +41,7 @@ export interface BaseSelectProps
    * - `label` (string) - Option group text displayed to the user.
    * - `disabled` (boolean) - (Optional) Determines whether the option group is disabled.
    * - `options` (Option[]) - (Optional) The options under this group.
+   * - `labelTag` (string) - (Optional) A label tag that provides additional guidance, shown next to the label.
    * - `tags` [string[]] - (Optional) A list of tags giving further guidance about the group.
    *
    * Note: Only one level of option nesting is supported.

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -86,16 +86,13 @@ const Item = (
             <CheckboxIcon checked={selected || false} disabled={option.disabled} />
           </div>
         )}
-        {isParent ? (
-          <span>{wrappedOption.label || wrappedOption.value}</span>
-        ) : (
-          <Option
-            option={{ ...wrappedOption, disabled }}
-            highlightedOption={highlighted}
-            selectedOption={selected}
-            highlightText={filteringValue}
-          />
-        )}
+        <Option
+          option={{ ...wrappedOption, disabled }}
+          highlightedOption={highlighted}
+          selectedOption={selected}
+          highlightText={filteringValue}
+          isGroupOption={isParent}
+        />
         {!hasCheckbox && !isParent && selected && (
           <div className={styles['selected-icon']}>
             <InternalIcon name="check" />

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useRef } from 'react';
-import clsx from 'clsx';
 
 import { getBaseProps } from '../../internal/base-component';
 import CheckboxIcon from '../../internal/components/checkbox-icon';
@@ -49,9 +48,7 @@ const MultiSelectItem = (
       : '';
   const isDisabledWithReason = !!disabledReason;
   const internalRef = useRef<HTMLDivElement>(null);
-  const className = clsx(styles.item, {
-    [styles.disabled]: disabled,
-  });
+  const className = styles.item;
 
   const { descriptionId, descriptionEl } = useHiddenDescription(disabledReason);
 


### PR DESCRIPTION
### Description

Enhancing Select and Multiselect option group type with features such as description, tags, labelTag and more.

Rel:
* AWSUI-54638
* [1YVQAGeLk8iH]

### How has this been tested?

* Unit tests
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
