### PR TITLE
fix: Fix nodeBelongs utility for iframes

### DIFF
--- a/src/internal/utils/__tests__/dom.test.ts
+++ b/src/internal/utils/__tests__/dom.test.ts
@@ -106,3 +106,19 @@ test('an SVGElement is recognized as a Node and SVGElement', () => {
   expect(isHTMLElement(rect)).toBe(false);
   expect(isSVGElement(rect)).toBe(true);
 });
+
+test('an object is recognized as Node', () => {
+  expect(isNode({ nodeType: 3, nodeName: '', parentNode: {} })).toBe(true);
+});
+
+test('an object is recognized as HTMLElement', () => {
+  const node = { nodeType: 1, nodeName: '', parentNode: {} };
+  expect(isHTMLElement({ ...node, style: {}, ownerDocument: {} })).toBe(true);
+  expect(isHTMLElement({ ...node, style: {}, ownerDocument: {}, ownerSVGElement: {} })).toBe(false);
+});
+
+test('an object is recognized as SVGElement', () => {
+  const node = { nodeType: 1, nodeName: '', parentNode: {} };
+  expect(isSVGElement({ ...node, style: {}, ownerDocument: {} })).toBe(false);
+  expect(isSVGElement({ ...node, style: {}, ownerDocument: {}, ownerSVGElement: {} })).toBe(true);
+});

--- a/src/internal/utils/__tests__/dom.test.ts
+++ b/src/internal/utils/__tests__/dom.test.ts
@@ -1,6 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { findUpUntil, parseCssVariable } from '../../../../lib/components/internal/utils/dom';
+import {
+  findUpUntil,
+  isHTMLElement,
+  isNode,
+  isSVGElement,
+  parseCssVariable,
+} from '../../../../lib/components/internal/utils/dom';
 
 describe('findUpUntil', () => {
   test('returns null if there is no match', () => {
@@ -85,4 +91,18 @@ describe('parseCssVariable', () => {
       );
     });
   });
+});
+
+test('an HTMLElement is recognized as a Node and HTMLElement', () => {
+  const div = document.createElement('div');
+  expect(isNode(div)).toBe(true);
+  expect(isHTMLElement(div)).toBe(true);
+  expect(isSVGElement(div)).toBe(false);
+});
+
+test('an SVGElement is recognized as a Node and SVGElement', () => {
+  const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  expect(isNode(rect)).toBe(true);
+  expect(isHTMLElement(rect)).toBe(false);
+  expect(isSVGElement(rect)).toBe(true);
 });

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -66,35 +66,38 @@ export function parseCssVariable(value: string) {
 // The instanceof Node/HTMLElement/SVGElement checks can fail if the target element
 // belongs to a different window than the respective type.
 
-export function isNode(target: any): target is Node {
+export function isNode(target: unknown): target is Node {
   return (
     target instanceof Node ||
     (target !== null &&
       typeof target === 'object' &&
+      'nodeType' in target &&
       typeof target.nodeType === 'number' &&
+      'nodeName' in target &&
       typeof target.nodeName === 'string' &&
+      'parentNode' in target &&
       typeof target.parentNode === 'object')
   );
 }
 
-export function isHTMLElement(target: any): target is HTMLElement {
+export function isHTMLElement(target: unknown): target is HTMLElement {
   return (
     target instanceof HTMLElement ||
-    (target !== null &&
-      typeof target === 'object' &&
+    (isNode(target) &&
       target.nodeType === Node.ELEMENT_NODE &&
+      'style' in target &&
       typeof target.style === 'object' &&
       typeof target.ownerDocument === 'object' &&
       !isSVGElement(target))
   );
 }
 
-export function isSVGElement(target: any): target is SVGElement {
+export function isSVGElement(target: unknown): target is SVGElement {
   return (
     target instanceof SVGElement ||
-    (target !== null &&
-      typeof target === 'object' &&
+    (isNode(target) &&
       target.nodeType === Node.ELEMENT_NODE &&
+      'ownerSVGElement' in target &&
       typeof target.ownerSVGElement === 'object')
   );
 }

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -9,8 +9,8 @@ export function findUpUntil(node: HTMLElement, callback: (element: HTMLElement) 
     // If a component is used within an svg (i.e. as foreignObject), then it will
     // have some ancestor nodes that are SVGElement. We want to skip those,
     // as they have very different properties to HTMLElements.
-    while (isHTMLElement(current)) {
-      current = current.parentElement;
+    while (current && !isHTMLElement(current)) {
+      current = (current as Element).parentElement;
     }
   }
   return current;
@@ -69,29 +69,32 @@ export function parseCssVariable(value: string) {
 
 export function isNode(target: any): target is Node {
   return (
-    target !== null &&
-    typeof target === 'object' &&
-    typeof target.nodeType === 'number' &&
-    typeof target.nodeName === 'string' &&
-    typeof target.parentNode === 'object'
+    target instanceof Node ||
+    (target !== null &&
+      typeof target === 'object' &&
+      typeof target.nodeType === 'number' &&
+      typeof target.nodeName === 'string' &&
+      typeof target.parentNode === 'object')
   );
 }
 
 export function isHTMLElement(target: any): target is HTMLElement {
   return (
-    target !== null &&
-    typeof target === 'object' &&
-    target.nodeType === Node.ELEMENT_NODE &&
-    typeof target.style === 'object' &&
-    typeof target.ownerDocument === 'object'
+    target instanceof HTMLElement ||
+    (target !== null &&
+      typeof target === 'object' &&
+      target.nodeType === Node.ELEMENT_NODE &&
+      typeof target.style === 'object' &&
+      typeof target.ownerDocument === 'object')
   );
 }
 
 export function isSVGElement(target: any): target is SVGElement {
   return (
-    target !== null &&
-    typeof target === 'object' &&
-    target.nodeType === Node.ELEMENT_NODE &&
-    typeof target.ownerSVGElement === 'object'
+    target instanceof SVGElement ||
+    (target !== null &&
+      typeof target === 'object' &&
+      target.nodeType === Node.ELEMENT_NODE &&
+      typeof target.ownerSVGElement === 'object')
   );
 }

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -84,7 +84,8 @@ export function isHTMLElement(target: any): target is HTMLElement {
       typeof target === 'object' &&
       target.nodeType === Node.ELEMENT_NODE &&
       typeof target.style === 'object' &&
-      typeof target.ownerDocument === 'object')
+      typeof target.ownerDocument === 'object' &&
+      !isSVGElement(target))
   );
 }
 

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -9,8 +9,8 @@ export function findUpUntil(node: HTMLElement, callback: (element: HTMLElement) 
     // If a component is used within an svg (i.e. as foreignObject), then it will
     // have some ancestor nodes that are SVGElement. We want to skip those,
     // as they have very different properties to HTMLElements.
-    while (current && !(current instanceof HTMLElement)) {
-      current = (current as Element).parentElement;
+    while (isHTMLElement(current)) {
+      current = current.parentElement;
     }
   }
   return current;
@@ -61,4 +61,37 @@ export function parseCssVariable(value: string) {
 
   const match = expr.body.match(cssVariableExpression);
   return match ? match[1] : value;
+}
+
+// We avoid instanceof Node/HTMLElement/SVGElement checks as the interfaces are tied to the window they are created in.
+// If an element was moved to an iframe after it was created, then element instanceof HTMLElement
+// will be false since the interface has a different window.
+
+export function isNode(target: any): target is Node {
+  return (
+    target !== null &&
+    typeof target === 'object' &&
+    typeof target.nodeType === 'number' &&
+    typeof target.nodeName === 'string' &&
+    typeof target.parentNode === 'object'
+  );
+}
+
+export function isHTMLElement(target: any): target is HTMLElement {
+  return (
+    target !== null &&
+    typeof target === 'object' &&
+    target.nodeType === Node.ELEMENT_NODE &&
+    typeof target.style === 'object' &&
+    typeof target.ownerDocument === 'object'
+  );
+}
+
+export function isSVGElement(target: any): target is SVGElement {
+  return (
+    target !== null &&
+    typeof target === 'object' &&
+    target.nodeType === Node.ELEMENT_NODE &&
+    typeof target.ownerSVGElement === 'object'
+  );
 }

--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -63,9 +63,8 @@ export function parseCssVariable(value: string) {
   return match ? match[1] : value;
 }
 
-// We avoid instanceof Node/HTMLElement/SVGElement checks as the interfaces are tied to the window they are created in.
-// If an element was moved to an iframe after it was created, then element instanceof HTMLElement
-// will be false since the interface has a different window.
+// The instanceof Node/HTMLElement/SVGElement checks can fail if the target element
+// belongs to a different window than the respective type.
 
 export function isNode(target: any): target is Node {
   return (

--- a/src/internal/utils/handle-key.ts
+++ b/src/internal/utils/handle-key.ts
@@ -3,9 +3,10 @@
 import { getIsRtl } from '@cloudscape-design/component-toolkit/internal';
 
 import { KeyCode } from '../keycode';
+import { isHTMLElement, isSVGElement } from './dom';
 
 export function isEventLike(event: any): event is EventLike {
-  return event.currentTarget instanceof HTMLElement || event.currentTarget instanceof SVGElement;
+  return isHTMLElement(event.currentTarget) || isSVGElement(event.currentTarget);
 }
 
 export interface EventLike {

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -3,11 +3,7 @@
 
 import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 
-import { findUpUntil } from './dom';
-
-// We avoid instanceof Node/HTMLElement checks as the interfaces are tied to the window they are created in.
-// If an element was moved to an iframe after it was created, then element instanceof Node/HTMLElement
-// will be false since the interface has a different window.
+import { findUpUntil, isHTMLElement, isNode } from './dom';
 
 /**
  * Checks whether the given node (target) belongs to the container.
@@ -17,17 +13,17 @@ import { findUpUntil } from './dom';
  * @param target Node that is checked to be a descendant of the container
  */
 export function nodeBelongs(container: Node | null, target: Node | EventTarget | null): boolean {
-  if (!target || !('nodeType' in target)) {
+  if (!isNode(target)) {
     return false;
   }
   const portal = findUpUntil(
     target as HTMLElement,
-    node => node === container || ('dataset' in node && !!node.dataset.awsuiReferrerId)
+    node => node === container || (isHTMLElement(node) && !!node.dataset.awsuiReferrerId)
   );
   if (portal && portal === container) {
     // We found the container as a direct ancestor without a portal
     return true;
   }
-  const referrer = portal && 'dataset' in portal ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
+  const referrer = isHTMLElement(portal) ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
   return referrer ? nodeContains(container, referrer) : nodeContains(container, target);
 }

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -13,7 +13,7 @@ import { findUpUntil } from './dom';
  * @param target Node that is checked to be a descendant of the container
  */
 export function nodeBelongs(container: Node | null, target: Node | EventTarget | null): boolean {
-  if (!(target instanceof Node)) {
+  if (!target || !('nodeType' in target)) {
     return false;
   }
   const portal = findUpUntil(

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -13,6 +13,9 @@ import { findUpUntil } from './dom';
  * @param target Node that is checked to be a descendant of the container
  */
 export function nodeBelongs(container: Node | null, target: Node | EventTarget | null): boolean {
+  // ('nodeType' in target) is a workaround to check if target is a node
+  //  Node interface is tied to the window it's created in, if the target was moved to an iframe after it was created,
+  //  target instanceof Node will be false since Node has a different window
   if (!target || !('nodeType' in target)) {
     return false;
   }

--- a/src/internal/utils/node-belongs.ts
+++ b/src/internal/utils/node-belongs.ts
@@ -5,6 +5,10 @@ import { nodeContains } from '@cloudscape-design/component-toolkit/dom';
 
 import { findUpUntil } from './dom';
 
+// We avoid instanceof Node/HTMLElement checks as the interfaces are tied to the window they are created in.
+// If an element was moved to an iframe after it was created, then element instanceof Node/HTMLElement
+// will be false since the interface has a different window.
+
 /**
  * Checks whether the given node (target) belongs to the container.
  * The function is similar to nodeContains but also accounts for dropdowns with expandToViewport=true.
@@ -13,20 +17,17 @@ import { findUpUntil } from './dom';
  * @param target Node that is checked to be a descendant of the container
  */
 export function nodeBelongs(container: Node | null, target: Node | EventTarget | null): boolean {
-  // ('nodeType' in target) is a workaround to check if target is a node
-  //  Node interface is tied to the window it's created in, if the target was moved to an iframe after it was created,
-  //  target instanceof Node will be false since Node has a different window
   if (!target || !('nodeType' in target)) {
     return false;
   }
   const portal = findUpUntil(
     target as HTMLElement,
-    node => node === container || (node instanceof HTMLElement && !!node.dataset.awsuiReferrerId)
+    node => node === container || ('dataset' in node && !!node.dataset.awsuiReferrerId)
   );
   if (portal && portal === container) {
     // We found the container as a direct ancestor without a portal
     return true;
   }
-  const referrer = portal instanceof HTMLElement ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
+  const referrer = portal && 'dataset' in portal ? document.getElementById(portal.dataset.awsuiReferrerId ?? '') : null;
   return referrer ? nodeContains(container, referrer) : nodeContains(container, target);
 }


### PR DESCRIPTION
### Description

Fixing an issue when element instanceof Node/HTMLElement/SVGElement would not work when the window of the element is different from the window of the respective type.

Similar fix: https://github.com/cloudscape-design/component-toolkit/pull/44

Rel: [AWSUI-53831]

### How has this been tested?

* Manual testing in an environment with an iframe

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
