### PR TITLE
chore: Add cross-version compatbility in app layout internals

### DIFF
--- a/src/app-layout/__tests__/widget-compatibility.test.tsx
+++ b/src/app-layout/__tests__/widget-compatibility.test.tsx
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { FocusControlState } from '../../../lib/components/app-layout/utils/use-focus-control';
+import { SplitPanelFocusControlState } from '../../../lib/components/app-layout/utils/use-split-panel-focus-control';
+import { AppLayoutInternals } from '../../../lib/components/app-layout/visual-refresh-toolbar/interfaces';
+import {
+  AppLayoutToolbarImplementation,
+  ToolbarProps,
+} from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar';
+import createWrapper from '../../../lib/components/test-utils/dom';
+
+import testUtilsStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
+import splitPanelTestUtilStyles from '../../../lib/components/split-panel/test-classes/styles.selectors.js';
+
+const wrapper = createWrapper();
+
+function renderLegacyAppLayout({ appLayoutInternals }: { appLayoutInternals: Partial<AppLayoutInternals> }) {
+  render(
+    <AppLayoutToolbarImplementation
+      appLayoutInternals={
+        {
+          breadcrumbs: 'breadcrumbs',
+          discoveredBreadcrumbs: null,
+          verticalOffsets: { toolbar: 0, notifications: 0, header: 0 },
+          isMobile: false,
+          toolbarState: 'show',
+          setToolbarState: () => {},
+          setToolbarHeight: () => {},
+          ariaLabels: {},
+          activeDrawer: undefined,
+          drawers: [],
+          drawersFocusControl: { refs: { toggle: { current: null } } } as FocusControlState,
+          onActiveDrawerChange: () => {},
+          navigation: 'testing',
+          navigationOpen: false,
+          navigationFocusControl: { refs: { toggle: { current: null } } } as FocusControlState,
+          onNavigationToggle: () => {},
+          splitPanelFocusControl: { refs: { toggle: { current: null } } } as SplitPanelFocusControlState,
+          splitPanelToggleConfig: { displayed: true, ariaLabel: '' },
+          onSplitPanelToggle: () => {},
+          ...appLayoutInternals,
+        } as AppLayoutInternals
+      }
+      // undefined value is not allowed by types, but may happen in runtime
+      toolbarProps={undefined as any as ToolbarProps}
+    />
+  );
+}
+
+function renderNewAppLayout({
+  appLayoutInternals,
+  toolbarProps,
+}: {
+  appLayoutInternals?: Partial<AppLayoutInternals>;
+  toolbarProps?: Partial<ToolbarProps>;
+}) {
+  render(
+    <AppLayoutToolbarImplementation
+      appLayoutInternals={
+        {
+          breadcrumbs: 'breadcrumbs',
+          discoveredBreadcrumbs: null,
+          verticalOffsets: { toolbar: 0, notifications: 0, header: 0 },
+          isMobile: false,
+          toolbarState: 'show',
+          setToolbarState: () => {},
+          setToolbarHeight: () => {},
+          ...appLayoutInternals,
+        } as AppLayoutInternals
+      }
+      toolbarProps={{
+        ariaLabels: {},
+        activeDrawerId: null,
+        drawers: [],
+        drawersFocusRef: { current: null },
+        onActiveDrawerChange: () => {},
+        hasNavigation: true,
+        navigationOpen: false,
+        navigationFocusRef: { current: null },
+        onNavigationToggle: () => {},
+        hasSplitPanel: true,
+        splitPanelFocusRef: { current: null },
+        splitPanelToggleProps: { displayed: true, ariaLabel: '', controlId: '', position: 'side', active: false },
+        onSplitPanelToggle: () => {},
+        ...toolbarProps,
+      }}
+    />
+  );
+}
+
+test('renders visual refresh toolbar with navigation using toolbarProps', () => {
+  const onNavigationToggle = jest.fn();
+  renderNewAppLayout({ toolbarProps: { onNavigationToggle } });
+  wrapper.findByClassName(testUtilsStyles['navigation-toggle'])!.click();
+  expect(onNavigationToggle).toHaveBeenCalled();
+});
+
+test('renders visual refresh toolbar with navigation using legacy props', () => {
+  const onNavigationToggle = jest.fn();
+  renderLegacyAppLayout({ appLayoutInternals: { onNavigationToggle } });
+  wrapper.findByClassName(testUtilsStyles['navigation-toggle'])!.click();
+  expect(onNavigationToggle).toHaveBeenCalled();
+});
+
+test('renders visual refresh toolbar with split panel using toolbarProps', () => {
+  const onSplitPanelToggle = jest.fn();
+  renderNewAppLayout({ toolbarProps: { onSplitPanelToggle } });
+  wrapper.findByClassName(splitPanelTestUtilStyles['open-button'])!.click();
+  expect(onSplitPanelToggle).toHaveBeenCalled();
+});
+
+test('renders visual refresh toolbar with split panel using legacy props', () => {
+  const onSplitPanelToggle = jest.fn();
+  renderLegacyAppLayout({ appLayoutInternals: { onSplitPanelToggle } });
+  wrapper.findByClassName(splitPanelTestUtilStyles['open-button'])!.click();
+  expect(onSplitPanelToggle).toHaveBeenCalled();
+});

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -48,6 +48,30 @@ interface AppLayoutToolbarImplementationProps {
   toolbarProps: ToolbarProps;
 }
 
+// support compatibility with changes before this commit: cf0f2b0755af1a28ac7c3c9476418a7ea807d0fd
+function convertLegacyProps(toolbarProps: ToolbarProps, legacyProps: AppLayoutInternals): ToolbarProps {
+  return {
+    ariaLabels: toolbarProps.ariaLabels ?? legacyProps.ariaLabels,
+    activeDrawerId: toolbarProps.activeDrawerId ?? legacyProps.activeDrawer?.id,
+    drawers: toolbarProps.drawers ?? legacyProps.drawers,
+    drawersFocusRef: toolbarProps.drawersFocusRef ?? legacyProps.drawersFocusControl?.refs.toggle,
+    onActiveDrawerChange: toolbarProps.onActiveDrawerChange ?? legacyProps.onActiveDrawerChange,
+    hasNavigation: toolbarProps.hasNavigation ?? !!legacyProps.navigation,
+    navigationOpen: toolbarProps.navigationOpen ?? legacyProps.navigationOpen,
+    navigationFocusRef: toolbarProps.navigationFocusRef ?? legacyProps.navigationFocusControl?.refs.toggle,
+    onNavigationToggle: toolbarProps.onNavigationToggle ?? legacyProps.onNavigationToggle,
+    hasSplitPanel: toolbarProps.hasSplitPanel ?? true,
+    splitPanelFocusRef: legacyProps.splitPanelFocusControl?.refs.toggle,
+    splitPanelToggleProps: toolbarProps.splitPanelToggleProps ?? {
+      ...legacyProps.splitPanelToggleConfig,
+      active: legacyProps.splitPanelOpen,
+      controlId: legacyProps.splitPanelControlId,
+      position: legacyProps.splitPanelPosition,
+    },
+    onSplitPanelToggle: toolbarProps.onSplitPanelToggle ?? legacyProps.onSplitPanelToggle,
+  };
+}
+
 export function AppLayoutToolbarImplementation({
   appLayoutInternals,
   // the value could be undefined if this component is loaded as a widget by a different app layout version
@@ -77,7 +101,7 @@ export function AppLayoutToolbarImplementation({
     splitPanelFocusRef,
     splitPanelToggleProps,
     onSplitPanelToggle,
-  } = toolbarProps;
+  } = convertLegacyProps(toolbarProps, appLayoutInternals);
   // TODO: expose configuration property
   const pinnedToolbar = true;
   const ref = useRef<HTMLElement>(null);


### PR DESCRIPTION
### Description

The main `<AppLayout>` component and its `<AppLayoutToolbarImplementation />` may come from different versions.

Support some backward compatibility via providing some aliases for props

Related links, issue #, if available: n/a

### How has this been tested?

Added some tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
