### PR TITLE
feat: Additional settings for KeyValuePairs to enable compact border setting

### DIFF
--- a/pages/key-value-pairs/compact.page.tsx
+++ b/pages/key-value-pairs/compact.page.tsx
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+
+import CopyToClipboard from '~components/copy-to-clipboard';
+import KeyValuePairs from '~components/key-value-pairs';
+import Link from '~components/link';
+import ProgressBar from '~components/progress-bar';
+import StatusIndicator from '~components/status-indicator';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function () {
+  return (
+    <article>
+      <h1>Text wrapping example</h1>
+      <ScreenshotArea>
+        <h2>Key-value-pairs with a long description</h2>
+
+        <KeyValuePairs
+          columns={3}
+          variant="compact"
+          items={[
+            {
+              label: 'Distribution ID',
+              value:
+                'E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4E1WG1ZNPRXT0D4',
+              info: (
+                <Link variant="info" href="#">
+                  Info
+                </Link>
+              ),
+            },
+            {
+              label: 'ARN',
+              value: (
+                <CopyToClipboard
+                  copyButtonAriaLabel="Copy ARN"
+                  copyErrorText="ARN failed to copy"
+                  copySuccessText="ARN copied"
+                  textToCopy="arn:service23G24::111122223333:distribution/23E1WG1ZNPRXT0D4"
+                  variant="inline"
+                />
+              ),
+            },
+            {
+              label: 'Status',
+              value: <StatusIndicator>Available</StatusIndicator>,
+            },
+            {
+              label: 'SSL Certificate',
+              id: 'ssl-certificate-id',
+              value: (
+                <ProgressBar
+                  value={30}
+                  additionalInfo="Additional information"
+                  description="Progress bar description"
+                  ariaLabelledby="ssl-certificate-id"
+                />
+              ),
+            },
+            {
+              label: 'Price class',
+              value: 'Use only US, Canada, Europe',
+            },
+            {
+              label: 'CNAMEs',
+              value: (
+                <Link external={true} href="#">
+                  abc.service23G24.xyz
+                </Link>
+              ),
+            },
+          ]}
+        />
+      </ScreenshotArea>
+    </article>
+  );
+}

--- a/src/key-value-pairs/index.tsx
+++ b/src/key-value-pairs/index.tsx
@@ -10,7 +10,14 @@ import InternalKeyValuePairs from './internal';
 
 export { KeyValuePairsProps };
 
-export default function KeyValuePairs({ columns = 1, items, ariaLabel, ariaLabelledby, ...rest }: KeyValuePairsProps) {
+export default function KeyValuePairs({
+  columns = 1,
+  items,
+  ariaLabel,
+  ariaLabelledby,
+  variant = 'default',
+  ...rest
+}: KeyValuePairsProps) {
   const { __internalRootRef } = useBaseComponent('KeyValuePairs', {
     props: { columns },
   });
@@ -22,6 +29,7 @@ export default function KeyValuePairs({ columns = 1, items, ariaLabel, ariaLabel
       items={items}
       ariaLabel={ariaLabel}
       ariaLabelledby={ariaLabelledby}
+      variant={variant}
       {...baseProps}
       ref={__internalRootRef}
     />

--- a/src/key-value-pairs/interfaces.ts
+++ b/src/key-value-pairs/interfaces.ts
@@ -39,9 +39,14 @@ export interface KeyValuePairsProps extends BaseComponentProps {
    * Don't use `ariaLabel` and `ariaLabelledby` at the same time.
    */
   ariaLabelledby?: string;
-}
 
+  /**
+   * Specifies the content type. This determines the spacing of the grid.
+   */
+  variant?: KeyValuePairsProps.Variant;
+}
 export namespace KeyValuePairsProps {
+  export type Variant = 'default' | 'compact';
   export type Item = Group | Pair;
 
   export interface Group {

--- a/src/key-value-pairs/internal.tsx
+++ b/src/key-value-pairs/internal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import clsx from 'clsx';
 
 import Box from '../box/internal';
+import { InternalColumnLayoutProps } from '../column-layout/interfaces';
 import ColumnLayout from '../column-layout/internal';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
@@ -45,10 +46,22 @@ const InternalKeyValuePairs = React.forwardRef(
       className,
       ariaLabel,
       ariaLabelledby,
+      variant,
       ...rest
     }: KeyValuePairsProps & Required<Pick<KeyValuePairsProps, 'columns'>>,
     ref: React.Ref<HTMLDivElement>
   ) => {
+    const columnLayoutProps: InternalColumnLayoutProps = {
+      __tagOverride: 'dl',
+      columns: Math.min(columns, 4),
+    };
+    if (variant === 'compact') {
+      columnLayoutProps.variant = 'default';
+      columnLayoutProps.borders = 'vertical';
+    } else {
+      columnLayoutProps.variant = 'text-grid';
+      columnLayoutProps.minColumnWidth = 150;
+    }
     return (
       <LinkDefaultVariantContext.Provider value={{ defaultVariant: 'primary' }}>
         <div
@@ -62,7 +75,7 @@ const InternalKeyValuePairs = React.forwardRef(
           minColumnWidth={150} is set to use FlexibleColumnLayout which has only 1 nested div wrapper for column items,
           otherwise GridColumnLayout will be used, which has 2 nested div, therefore it is not a11y compatible for dl -> dt/dd relationship
         */}
-          <ColumnLayout __tagOverride="dl" columns={Math.min(columns, 4)} variant="text-grid" minColumnWidth={150}>
+          <ColumnLayout {...{ ...columnLayoutProps }}>
             {items.map((pair, index) => {
               if (pair.type === 'group') {
                 return (


### PR DESCRIPTION
### Description

Enabled variants for KeyValuePair

- default - unchanged
- compact - seamless vertical borders

Related links, issue #, if available: n/a

### How has this been tested?

A `pages/key-value-pairs/compact.page.tsx` page has been created to visualise the feature change

![Screenshot 2024-08-12 at 11 19 12](https://github.com/user-attachments/assets/06ae5c98-e4f6-4f91-8594-cbe277542b05)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
