### PR TITLE
fix: Consistently fire onSelect even when closing the dropdown

### DIFF
--- a/pages/autosuggest/events.page.tsx
+++ b/pages/autosuggest/events.page.tsx
@@ -59,6 +59,7 @@ export default function AutosuggestEventsPage() {
             appendLog('onChange');
             setValue(event.detail.value);
           }}
+          onSelect={event => appendLog(`onSelect: ${event.detail.value}`)}
           onBlur={() => appendLog('onBlur')}
           onFocus={() => appendLog('onFocus')}
           enteredTextLabel={enteredTextLabel}

--- a/src/autosuggest/__integ__/events-autosuggest.test.ts
+++ b/src/autosuggest/__integ__/events-autosuggest.test.ts
@@ -21,7 +21,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
       await page.clearEventList();
 
       await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
-      await page.assertEventsFired(['onChange']);
+      await page.assertEventsFired(['onChange', 'onSelect: Option 0']);
     })
   );
 
@@ -46,7 +46,31 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
       await page.clearEventList();
 
       await page.clickOption(1);
-      await page.assertEventsFired(['onChange']);
+      await page.assertEventsFired(['onChange', 'onSelect: Option 0']);
+    })
+  );
+
+  test(
+    'should select use-entered item when highlighted',
+    setupTest(async page => {
+      await page.focusInput();
+      await page.keys(['opt']);
+      await page.clearEventList();
+
+      await page.keys(['ArrowDown', 'Enter']);
+      await page.assertEventsFired(['onChange', 'onSelect: opt']);
+    })
+  );
+
+  test(
+    'should select use-entered when pressing enter on the focused input',
+    setupTest(async page => {
+      await page.focusInput();
+      await page.keys(['opt']);
+      await page.clearEventList();
+
+      await page.keys(['Enter']);
+      await page.assertEventsFired(['onChange', 'onSelect: opt']);
     })
   );
 
@@ -92,7 +116,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
 
       await page.clickOption(1);
       await page.focusOutsideInput();
-      await page.assertEventsFired(['onChange', 'onBlur']);
+      await page.assertEventsFired(['onChange', 'onSelect: Option 0', 'onBlur']);
     })
   );
 
@@ -105,7 +129,7 @@ describe.each<boolean>([false, true])('Autosuggest events (expandToViewport=%s)'
 
       await page.keys(['ArrowDown', 'Enter']);
       await page.focusOutsideInput();
-      await page.assertEventsFired(['onChange', 'onBlur']);
+      await page.assertEventsFired(['onChange', 'onSelect: opt', 'onBlur']);
     })
   );
 

--- a/src/autosuggest/__tests__/options-controller.test.ts
+++ b/src/autosuggest/__tests__/options-controller.test.ts
@@ -165,7 +165,8 @@ describe('useAutosuggestItems', () => {
     });
 
     result.current[1].selectHighlightedOptionWithKeyboard();
-    expect(onSelectItem).not.toBeCalled();
+    expect(onSelectItem).toBeCalledWith({ value: '1', type: 'use-entered', option: { value: '1' } });
+    jest.mocked(onSelectItem).mockClear();
 
     result.current[1].moveHighlightWithKeyboard(1);
     result.current[1].selectHighlightedOptionWithKeyboard();

--- a/src/autosuggest/options-controller.ts
+++ b/src/autosuggest/options-controller.ts
@@ -87,11 +87,19 @@ export const useAutosuggestItems = ({
   });
 
   const selectHighlightedOptionWithKeyboard = () => {
-    if (highlightedOptionState.highlightedOption && isInteractive(highlightedOptionState.highlightedOption)) {
-      onSelectItem(highlightedOptionState.highlightedOption);
-      return true;
+    if (highlightedOptionState.highlightedOption && !isInteractive(highlightedOptionState.highlightedOption)) {
+      // skip selection when a non-interactive item is active
+      return false;
     }
-    return false;
+    onSelectItem(
+      highlightedOptionState.highlightedOption ?? {
+        // put use-entered item as a fallback
+        value: filterValue,
+        type: 'use-entered',
+        option: { value: filterValue },
+      }
+    );
+    return true;
   };
 
   const highlightVisibleOptionWithMouse = (index: number) => {

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -13,7 +13,6 @@ import TokenList from '../internal/components/token-list';
 import { fireNonCancelableEvent } from '../internal/events';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { useUniqueId } from '../internal/hooks/use-unique-id/index';
-import { KeyCode } from '../internal/keycode';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
 import { joinStrings } from '../internal/utils/strings';
 import InternalSpaceBetween from '../space-between/internal';
@@ -235,12 +234,6 @@ const PropertyFilter = React.forwardRef(
       addToken(newToken);
       setFilteringText('');
     };
-    const ignoreKeyDown = useRef<boolean>(false);
-    const handleKeyDown: PropertyFilterAutosuggestProps['onKeyDown'] = event => {
-      if (filteringText && !ignoreKeyDown.current && event.detail.keyCode === KeyCode.enter) {
-        createToken(filteringText);
-      }
-    };
     const getLoadMoreDetail = (parsedText: ParsedText, filteringText: string) => {
       const loadMoreDetail: {
         filteringProperty: FilteringProperty | undefined;
@@ -282,14 +275,11 @@ const PropertyFilter = React.forwardRef(
           }
         : {};
     const handleSelected: PropertyFilterAutosuggestProps['onOptionClick'] = event => {
-      // The ignoreKeyDown flag makes sure `createToken` routine runs only once. Autosuggest's `onKeyDown` fires,
-      // when an item is selected from the list using "enter" key.
-      ignoreKeyDown.current = true;
-      setTimeout(() => {
-        ignoreKeyDown.current = false;
-      }, 0);
       const { detail: option } = event;
       const value = option.value || '';
+      if (!value) {
+        return;
+      }
 
       if (!('keepOpenOnSelect' in option)) {
         createToken(value);
@@ -340,7 +330,6 @@ const PropertyFilter = React.forwardRef(
             controlId={rest.controlId}
             value={filteringText}
             disabled={disabled}
-            onKeyDown={handleKeyDown}
             {...autosuggestOptions}
             onChange={event => setFilteringText(event.detail.value)}
             empty={filteringEmpty}


### PR DESCRIPTION
### Description

Fixing an inconsistency in the events handling

1. When the input field is focused, pressing enter closes the dropdown, but no `onSelect` event fired
2. When the "Use current value" option is focused, the dropdown closes, with an `onSelect` event

Both interactions are the same for the end user – the dropdown closes while keeping the current value, so they should produce the same event.

For the context, this is a long way to fix AWSUI-53412. In that issue on our website there is a bug with the search autosuggest. It uses a workaround for the missing event. After this event is added, we can remove the workaround

Related links, issue #, if available: n/a

### How has this been tested?

Locally + updated existing events test to include the new events.

Dry-runs if anybody relied on the broken behavior: 6982713945, 6982715033, 6982780091

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
