### PR TITLE
fix: Use border radius design token for column headers in sticky header table

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -314,6 +314,19 @@ const permutations = createPermutations<TableProps>([
     items: [createSimpleItems(3)],
     variant: [undefined, 'full-page'],
   },
+  {
+    columnDefinitions: [PROPERTY_COLUMNS],
+    items: [
+      [
+        {
+          name: 'Color',
+          value: '#000000',
+          type: 'String',
+        },
+      ],
+    ],
+    stickyHeader: [true],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/src/table/styles.scss
+++ b/src/table/styles.scss
@@ -164,6 +164,11 @@ filter search icon.
     & > .table {
       padding-inline: awsui.$space-table-horizontal;
     }
+
+    &:not(.table-has-header) {
+      border-start-start-radius: awsui.$border-radius-container;
+      border-start-end-radius: awsui.$border-radius-container;
+    }
   }
   &::-webkit-scrollbar {
     display: none; /* Safari and Chrome */


### PR DESCRIPTION
### Description

When a table has a sticky header and doesn't have anything in the header slot, the table top border doesn't have the right border radius.

in this PR I used the border radius design token instead of the previous 0 value.

Related links, issue #, if available: n/a

### How has this been tested?

- added a new permutation to cover the case
- ran visual regression tests in dev pipeline.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
