### PR TITLE
fix: Do not wrap text after icon in copy-to-clipboard

### DIFF
--- a/pages/copy-to-clipboard/simple.page.tsx
+++ b/pages/copy-to-clipboard/simple.page.tsx
@@ -60,6 +60,18 @@ export default function DateInputScenario() {
             copySuccessText="Lorem ipsum sentence copied"
             copyErrorText="Lorem ipsum sentence failed to copy"
           />
+
+          <div style={{ width: '150px' }}>
+            <div style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+              <CopyToClipboard
+                variant="inline"
+                copyButtonAriaLabel="Copy lorem ipsum sentence"
+                textToCopy="Relatively long text that we don't want to wrap"
+                copySuccessText="Lorem ipsum sentence copied"
+                copyErrorText="Lorem ipsum sentence failed to copy"
+              />
+            </div>
+          </div>
         </SpaceBetween>
       </Box>
     </ScreenshotArea>

--- a/src/copy-to-clipboard/internal.tsx
+++ b/src/copy-to-clipboard/internal.tsx
@@ -60,8 +60,10 @@ export default function InternalCopyToClipboard({
     } as const
   )[variant];
 
+  const isInline = variant === 'inline';
   const trigger = (
     <InternalPopover
+      className={clsx(isInline && styles['inline-trigger'])}
       size="medium"
       position="top"
       triggerType="custom"
@@ -84,7 +86,7 @@ export default function InternalCopyToClipboard({
 
   return (
     <span {...baseProps} ref={__internalRootRef} className={clsx(baseProps.className, styles.root, testStyles.root)}>
-      {variant === 'inline' ? (
+      {isInline ? (
         <span className={styles['inline-container']}>
           <span className={styles['inline-container-trigger']}>{trigger}</span>
           <span className={testStyles['text-to-copy']}>{textToCopy}</span>

--- a/src/copy-to-clipboard/styles.scss
+++ b/src/copy-to-clipboard/styles.scss
@@ -16,3 +16,7 @@
     margin-inline-end: awsui.$space-scaled-xxs;
   }
 }
+
+.inline-trigger {
+  white-space: nowrap;
+}


### PR DESCRIPTION
### Description

Prevent copy-to-clipboard trigger text from wrapping to a separate line in tables

Related links, issue #, if available: AWSUI-54773

![image](https://github.com/user-attachments/assets/7f410321-8b92-4628-8869-dfb80c193f19)


### How has this been tested?

- In my dev pipeline
- new screenshot test added

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
