### PR TITLE
feat: [POC] Introduce property filter token formatter i18n

### DIFF
--- a/pages/dropdown/expandable.page.tsx
+++ b/pages/dropdown/expandable.page.tsx
@@ -12,7 +12,7 @@ import Select, { SelectProps } from '~components/select';
 import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
-import { i18nStrings as propertyFilterI18n } from '../property-filter/common-props';
+import { i18nStrings as propertyFilterI18n, labels as propertyFilterLabels } from '../property-filter/common-props';
 import ScreenshotArea from '../utils/screenshot-area';
 import { SampleDropdown, SampleModal } from './common';
 
@@ -175,6 +175,7 @@ const components = {
         filteringErrorText={'error text'}
         filteringRecoveryText={'recovery text'}
         filteringFinishedText={'finished text'}
+        {...propertyFilterLabels}
         i18nStrings={propertyFilterI18n}
         expandToViewport={expandToViewport}
       />

--- a/pages/property-filter/async-loading.integ.page.tsx
+++ b/pages/property-filter/async-loading.integ.page.tsx
@@ -9,7 +9,7 @@ import { PropertyFilterProps } from '~components/property-filter/interfaces';
 import AppContext, { AppContextType } from '../app/app-context';
 import { useOptionsLoader } from '../common/options-loader';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './common-props';
+import { i18nStrings, labels } from './common-props';
 
 type PropertyFilterDemoContext = React.Context<
   AppContextType<{
@@ -81,6 +81,7 @@ export default function () {
       <h1>Integration tests fixture for async loading suggestions</h1>
       <ScreenshotArea disableAnimations={true}>
         <PropertyFilter
+          {...labels}
           i18nStrings={i18nStrings}
           query={query}
           onChange={e => setQuery(e.detail)}

--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -131,11 +131,14 @@ export const columnDefinitions = [
   },
 ].map((item, ind) => ({ order: ind + 1, ...item }));
 
-export const i18nStrings: PropertyFilterProps.I18nStrings = {
+export const labels = {
   filteringAriaLabel: 'your choice',
+  filteringPlaceholder: 'Search',
+};
+
+export const i18nStrings: PropertyFilterProps.I18nStrings = {
   dismissAriaLabel: 'Dismiss',
 
-  filteringPlaceholder: 'Search',
   groupValuesText: 'Values',
   groupPropertiesText: 'Properties',
   operatorsText: 'Operators',

--- a/pages/property-filter/hooks.page.tsx
+++ b/pages/property-filter/hooks.page.tsx
@@ -13,7 +13,7 @@ import PropertyFilter from '~components/property-filter';
 import Table from '~components/table';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties, i18nStrings, labels } from './common-props';
 import { allItems, TableItem } from './table.data';
 
 export default function () {
@@ -101,6 +101,7 @@ export default function () {
           {...collectionProps}
           filter={
             <PropertyFilter
+              {...labels}
               {...propertyFilterProps}
               virtualScroll={true}
               countText={`${items.length} matches`}

--- a/pages/property-filter/permutations.page.tsx
+++ b/pages/property-filter/permutations.page.tsx
@@ -10,7 +10,7 @@ import Select from '~components/select';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties, i18nStrings, labels } from './common-props';
 import { allItems, TableItem } from './table.data';
 
 const filteringOptions: readonly PropertyFilterProps.FilteringOption[] = columnDefinitions.reduce<
@@ -141,6 +141,7 @@ export default function () {
           permutations={permutations}
           render={permutation => (
             <PropertyFilter
+              {...labels}
               countText={`5 matches`}
               i18nStrings={i18nStrings}
               query={{ tokens: [], operation: 'and' }}

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -8,6 +8,8 @@ import AppLayout from '~components/app-layout';
 import Box from '~components/box';
 import Button from '~components/button';
 import Header from '~components/header';
+import I18nProvider from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
 import PropertyFilter from '~components/property-filter';
 import SplitPanel from '~components/split-panel';
 import Table from '~components/table';
@@ -16,7 +18,7 @@ import { Breadcrumbs, Navigation, Tools } from '../app-layout/utils/content-bloc
 import labels from '../app-layout/utils/labels';
 import * as toolsContent from '../app-layout/utils/tools-content';
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties } from './common-props';
 import { allItems, states, TableItem } from './table.data';
 
 export default function () {
@@ -53,53 +55,54 @@ export default function () {
 
   return (
     <ScreenshotArea gutters={false}>
-      <AppLayout
-        ariaLabels={labels}
-        breadcrumbs={<Breadcrumbs />}
-        navigation={<Navigation />}
-        tools={<Tools>{toolsContent.long}</Tools>}
-        splitPanelOpen={true}
-        splitPanel={
-          <SplitPanel
-            header="Split panel header"
-            i18nStrings={{
-              preferencesTitle: 'Preferences',
-              preferencesPositionLabel: 'Split panel position',
-              preferencesPositionDescription: 'Choose the default split panel position for the service.',
-              preferencesPositionSide: 'Side',
-              preferencesPositionBottom: 'Bottom',
-              preferencesConfirm: 'Confirm',
-              preferencesCancel: 'Cancel',
-              closeButtonAriaLabel: 'Close panel',
-              openButtonAriaLabel: 'Open panel',
-              resizeHandleAriaLabel: 'Slider',
-            }}
-          >
-            {' '}
-          </SplitPanel>
-        }
-        content={
-          <Table<TableItem>
-            className="main-content"
-            stickyHeader={true}
-            header={<Header headingTagOverride={'h1'}>Instances</Header>}
-            items={items}
-            {...collectionProps}
-            filter={
-              <PropertyFilter
-                {...propertyFilterProps}
-                filteringOptions={filteringOptions}
-                virtualScroll={true}
-                countText={`${items.length} matches`}
-                i18nStrings={i18nStrings}
-                expandToViewport={true}
-                filteringEmpty="No properties"
-              />
-            }
-            columnDefinitions={columnDefinitions.slice(0, 2)}
-          />
-        }
-      />
+      <I18nProvider messages={[messages]} locale="en">
+        <AppLayout
+          ariaLabels={labels}
+          breadcrumbs={<Breadcrumbs />}
+          navigation={<Navigation />}
+          tools={<Tools>{toolsContent.long}</Tools>}
+          splitPanelOpen={true}
+          splitPanel={
+            <SplitPanel
+              header="Split panel header"
+              i18nStrings={{
+                preferencesTitle: 'Preferences',
+                preferencesPositionLabel: 'Split panel position',
+                preferencesPositionDescription: 'Choose the default split panel position for the service.',
+                preferencesPositionSide: 'Side',
+                preferencesPositionBottom: 'Bottom',
+                preferencesConfirm: 'Confirm',
+                preferencesCancel: 'Cancel',
+                closeButtonAriaLabel: 'Close panel',
+                openButtonAriaLabel: 'Open panel',
+                resizeHandleAriaLabel: 'Slider',
+              }}
+            >
+              {' '}
+            </SplitPanel>
+          }
+          content={
+            <Table<TableItem>
+              className="main-content"
+              stickyHeader={true}
+              header={<Header headingTagOverride={'h1'}>Instances</Header>}
+              items={items}
+              {...collectionProps}
+              filter={
+                <PropertyFilter
+                  {...propertyFilterProps}
+                  filteringOptions={filteringOptions}
+                  virtualScroll={true}
+                  countText={`${items.length} matches`}
+                  expandToViewport={true}
+                  filteringEmpty="No properties"
+                />
+              }
+              columnDefinitions={columnDefinitions.slice(0, 2)}
+            />
+          }
+        />
+      </I18nProvider>
     </ScreenshotArea>
   );
 }

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -15,10 +15,10 @@ import SplitPanel from '~components/split-panel';
 import Table from '~components/table';
 
 import { Breadcrumbs, Navigation, Tools } from '../app-layout/utils/content-blocks';
-import labels from '../app-layout/utils/labels';
+import appLayoutLabels from '../app-layout/utils/labels';
 import * as toolsContent from '../app-layout/utils/tools-content';
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties } from './common-props';
+import { columnDefinitions, filteringProperties, labels } from './common-props';
 import { allItems, states, TableItem } from './table.data';
 
 export default function () {
@@ -58,7 +58,7 @@ export default function () {
     <ScreenshotArea gutters={false}>
       <I18nProvider messages={[messages]} locale="en">
         <AppLayout
-          ariaLabels={labels}
+          ariaLabels={appLayoutLabels}
           breadcrumbs={<Breadcrumbs />}
           navigation={<Navigation />}
           tools={<Tools>{toolsContent.long}</Tools>}
@@ -92,6 +92,7 @@ export default function () {
               {...collectionProps}
               filter={
                 <PropertyFilter
+                  {...labels}
                   {...propertyFilterProps}
                   filteringOptions={filteringOptions}
                   virtualScroll={true}

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
@@ -22,6 +22,7 @@ import { columnDefinitions, filteringProperties } from './common-props';
 import { allItems, states, TableItem } from './table.data';
 
 export default function () {
+  const [splitPanelOpen, setSplitPanelOpen] = useState(true);
   const { items, collectionProps, actions, propertyFilterProps } = useCollection(allItems, {
     propertyFiltering: {
       empty: 'empty',
@@ -61,7 +62,8 @@ export default function () {
           breadcrumbs={<Breadcrumbs />}
           navigation={<Navigation />}
           tools={<Tools>{toolsContent.long}</Tools>}
-          splitPanelOpen={true}
+          splitPanelOpen={splitPanelOpen}
+          onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
           splitPanel={
             <SplitPanel
               header="Split panel header"

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -6,7 +6,12 @@ import PropertyFilter from '~components/property-filter';
 import { PropertyFilterProps } from '~components/property-filter/interfaces';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties as commonFilteringProperties, i18nStrings } from './common-props';
+import {
+  columnDefinitions,
+  filteringProperties as commonFilteringProperties,
+  i18nStrings,
+  labels,
+} from './common-props';
 
 const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = columnDefinitions.map(def => ({
   key: def.id,
@@ -36,6 +41,7 @@ export default function () {
           filteringOptions={[]}
           virtualScroll={true}
           countText="5 matches"
+          {...labels}
           i18nStrings={{
             ...i18nStrings,
             editTokenHeader: 'Edit filter editTokenHeadereditTokenHeadereditTokenHeadereditTokenHeader',
@@ -60,6 +66,7 @@ export default function () {
           filteringOptions={[]}
           virtualScroll={true}
           countText="5 matches"
+          {...labels}
           i18nStrings={i18nStrings}
         />
         <PropertyFilter
@@ -73,6 +80,7 @@ export default function () {
           filteringOptions={[]}
           virtualScroll={true}
           countText="5 matches"
+          {...labels}
           i18nStrings={i18nStrings}
         />
         <PropertyFilter
@@ -86,6 +94,7 @@ export default function () {
           filteringOptions={[]}
           virtualScroll={true}
           countText="5 matches"
+          {...labels}
           i18nStrings={i18nStrings}
         />
         <PropertyFilter
@@ -103,6 +112,7 @@ export default function () {
           freeTextFiltering={{ operators: [':', '!:', '=', '!=', '^', '!^'] }}
           virtualScroll={true}
           countText="5 matches"
+          {...labels}
           i18nStrings={i18nStrings}
         />
       </ScreenshotArea>

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -10,7 +10,7 @@ import Link from '~components/link';
 import PropertyFilter from '~components/property-filter';
 import Table, { TableProps } from '~components/table';
 
-import { i18nStrings } from '../property-filter/common-props';
+import { i18nStrings, labels as propertyFilterLabels } from '../property-filter/common-props';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -267,6 +267,7 @@ const permutations = createPermutations<TableProps>([
             groupValuesLabel: 'Number values',
           },
         ]}
+        {...propertyFilterLabels}
         i18nStrings={i18nStrings}
         query={{
           operation: 'or',

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12376,6 +12376,11 @@ operations are communicated to the user in another way.",
             "type": "string",
           },
           Object {
+            "name": "formatToken",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.PreFormattedToken) => string",
+          },
+          Object {
             "name": "groupPropertiesText",
             "optional": true,
             "type": "string",

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -253,10 +253,13 @@ export interface I18nFormatArgTypes {
     "i18nStrings.operatorText": never;
     "i18nStrings.operatorsText": never;
     "i18nStrings.propertyText": never;
+    "i18nStrings.removeTokenButtonAriaLabel": {
+      "token__formattedText": string | number;
+    }
     "i18nStrings.tokenLimitShowFewer": never;
     "i18nStrings.tokenLimitShowMore": never;
     "i18nStrings.valueText": never;
-    "i18nStrings.removeTokenButtonAriaLabel": {
+    "i18nStrings.formatToken": {
       "token__operator": string;
       "token__propertyLabel": string | number;
       "token__value": string | number;

--- a/src/i18n/messages/all.en.json
+++ b/src/i18n/messages/all.en.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operators",
     "i18nStrings.propertyText": "Property",
+    "i18nStrings.removeTokenButtonAriaLabel": "Remove filter, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Show fewer",
     "i18nStrings.tokenLimitShowMore": "Show more",
     "i18nStrings.valueText": "Value",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyLabel} equals {token__value}} not_equals {Remove filter, {token__propertyLabel} does not equal {token__value}} greater_than {Remove filter, {token__propertyLabel} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyLabel} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyLabel} is less than {token__value}} less_than_equal {Remove filter, {token__propertyLabel} is less than or equal to {token__value}} contains {Remove filter, {token__propertyLabel} contains {token__value}} not_contains {Remove filter, {token__propertyLabel} does not contain {token__value}} starts_with {Remove filter, {token__propertyLabel} starts with {token__value}} not_starts_with {Remove filter, {token__propertyLabel} does not start with {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} equals {token__value}} not_equals {{token__propertyLabel} does not equal {token__value}} greater_than {{token__propertyLabel} is greater than {token__value}} greater_than_equal {{token__propertyLabel} is greater than or equal to {token__value}} less_than {{token__propertyLabel} is less than {token__value}} less_than_equal {{token__propertyLabel} is less than or equal to {token__value}} contains {{token__propertyLabel} contains {token__value}} not_contains {{token__propertyLabel} does not contain {token__value}} starts_with {{token__propertyLabel} starts with {token__value}} not_starts_with {{token__propertyLabel} does not start with {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Choose a version",

--- a/src/property-filter/__tests__/property-filter-i18n.test.tsx
+++ b/src/property-filter/__tests__/property-filter-i18n.test.tsx
@@ -174,18 +174,19 @@ describe('i18n', () => {
             'i18nStrings.tokenLimitShowFewer': 'Custom Show fewer',
             'i18nStrings.tokenLimitShowMore': 'Custom Show more',
             'i18nStrings.valueText': 'Custom Value',
-            'i18nStrings.removeTokenButtonAriaLabel': `{token__operator, select, 
-              equals {Remove filter, {token__propertyLabel} Custom equals {token__value}}
-              not_equals {Remove filter, {token__propertyLabel} Custom does not equal {token__value}}
-              greater_than {Remove filter, {token__propertyLabel} Custom greater than {token__value}}
-              greater_than_equal {Remove filter, {token__propertyLabel} Custom greater than or equals {token__value}}
-              less_than {Remove filter, {token__propertyLabel} Custom less than {token__value}}
-              less_than_equal {Remove filter, {token__propertyLabel} Custom less than or equals {token__value}}
-              contains {Remove filter, {token__propertyLabel} Custom contains {token__value}}
-              not_contains {Remove filter, {token__propertyLabel} Custom does not contain {token__value}}
-              starts_with {Remove filter, {token__propertyLabel} Custom starts with {token__value}}
-              not_starts_with {Remove filter, {token__propertyLabel} Custom does not start with {token__value}}
+            'i18nStrings.formatToken': `{token__operator, select, 
+              equals {{token__propertyLabel} Custom equals {token__value}}
+              not_equals {{token__propertyLabel} Custom does not equal {token__value}}
+              greater_than {{token__propertyLabel} Custom greater than {token__value}}
+              greater_than_equal {{token__propertyLabel} Custom greater than or equals {token__value}}
+              less_than {{token__propertyLabel} Custom less than {token__value}}
+              less_than_equal {{token__propertyLabel} Custom less than or equals {token__value}}
+              contains {{token__propertyLabel} Custom contains {token__value}}
+              not_contains {{token__propertyLabel} Custom does not contain {token__value}}
+              starts_with {{token__propertyLabel} Custom starts with {token__value}}
+              not_starts_with {{token__propertyLabel} Custom does not start with {token__value}}
               other {}}`,
+            'i18nStrings.removeTokenButtonAriaLabel': `Remove filter, {token__formattedText}`,
           },
         }}
       >
@@ -214,24 +215,27 @@ describe('i18n', () => {
       </TestI18nProvider>
     );
     const wrapper = createWrapper(container).findPropertyFilter()!;
+    const token = (index: number) => wrapper.findTokens()[index];
+
     expect(wrapper.findRemoveAllButton()!.getElement()).toHaveTextContent('Custom Clear filters');
     expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Custom Show more');
     wrapper.findTokenToggle()!.click();
     expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Custom Show fewer');
 
-    const getRemoveButton = (index: number) => wrapper.findTokens()[index].findRemoveButton().getElement();
-    expect(getRemoveButton(0)).toHaveAccessibleName('Remove filter, String Custom equals value1');
-    expect(getRemoveButton(1)).toHaveAccessibleName('Remove filter, String Custom does not equal value2');
-    expect(getRemoveButton(2)).toHaveAccessibleName('Remove filter, String Custom contains value3');
-    expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, String Custom does not contain value4');
-    expect(getRemoveButton(4)).toHaveAccessibleName('Remove filter, String Custom starts with value5');
-    expect(getRemoveButton(5)).toHaveAccessibleName('Remove filter, String Custom does not start with value6');
-    expect(getRemoveButton(6)).toHaveAccessibleName('Remove filter, Range Custom greater than 1');
-    expect(getRemoveButton(7)).toHaveAccessibleName('Remove filter, Range Custom less than 2');
-    expect(getRemoveButton(8)).toHaveAccessibleName('Remove filter, Range Custom greater than or equals 3');
-    expect(getRemoveButton(9)).toHaveAccessibleName('Remove filter, Range Custom less than or equals 4');
-    expect(getRemoveButton(10)).toHaveAccessibleName('Remove filter, Custom Custom equals empty');
-    expect(getRemoveButton(11)).toHaveAccessibleName('Remove filter, Custom All properties Custom contains all');
+    expect(token(0).getElement().textContent).toBe('String = value1');
+    expect(token(0).getElement()).toHaveAccessibleName('String Custom equals value1');
+    expect(token(1).getElement()).toHaveAccessibleName('String Custom does not equal value2');
+    expect(token(2).getElement()).toHaveAccessibleName('String Custom contains value3');
+    expect(token(3).getElement()).toHaveAccessibleName('String Custom does not contain value4');
+    expect(token(4).getElement()).toHaveAccessibleName('String Custom starts with value5');
+    expect(token(5).getElement()).toHaveAccessibleName('String Custom does not start with value6');
+    expect(token(6).getElement()).toHaveAccessibleName('Range Custom greater than 1');
+    expect(token(7).getElement()).toHaveAccessibleName('Range Custom less than 2');
+    expect(token(8).getElement()).toHaveAccessibleName('Range Custom greater than or equals 3');
+    expect(token(9).getElement()).toHaveAccessibleName('Range Custom less than or equals 4');
+    expect(token(10).getElement()).toHaveAccessibleName('Custom Custom equals empty');
+    expect(token(11).getElement()).toHaveAccessibleName('Custom All properties Custom contains all');
+    expect(token(0).findRemoveButton().getElement()).toHaveAccessibleName('Remove filter, String Custom equals value1');
 
     const tokenOperation = wrapper.findTokens()[1].findTokenOperation()!;
     tokenOperation.openDropdown();

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ComparisonOperator, FormattedToken, I18nStrings, InternalToken } from './interfaces';
+import { ComparisonOperator, FormattedToken, I18nStrings, InternalToken, PreFormattedToken } from './interfaces';
 
-export function getI18nToken(token: FormattedToken): {
-  token__operator: string;
+export function getI18nTokenPreFormatted(token: PreFormattedToken): {
   token__propertyKey: string;
   token__propertyLabel: string;
+  token__operator: string;
   token__value: string;
 } {
   return {
@@ -17,11 +17,28 @@ export function getI18nToken(token: FormattedToken): {
   };
 }
 
+export function getI18nTokenFormatted(token: FormattedToken): {
+  token__formattedText: string;
+  token__propertyKey: string;
+  token__propertyLabel: string;
+  token__operator: string;
+  token__value: string;
+} {
+  return { ...getI18nTokenPreFormatted(token), token__formattedText: token.formattedTokenText };
+}
+
 export function getFormattedToken(token: InternalToken, i18nStrings: I18nStrings): FormattedToken {
   const valueFormatter = token.property?.getValueFormatter(token.operator);
   const propertyLabel = token.property ? token.property.propertyLabel : i18nStrings.allPropertiesLabel ?? '';
   const tokenValue = valueFormatter ? valueFormatter(token.value) : token.value;
-  return { propertyKey: token.property?.propertyKey, propertyLabel, operator: token.operator, value: tokenValue };
+  const preFormatted = {
+    propertyKey: token.property?.propertyKey,
+    propertyLabel,
+    operator: token.operator,
+    value: tokenValue,
+  };
+  const formatter = i18nStrings.formatToken ?? (token => `${token.propertyLabel} ${token.operator} ${token.value}`);
+  return { ...preFormatted, formattedTokenText: formatter(preFormatted) };
 }
 
 function getOperatorI18nString(operator: ComparisonOperator): string {

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -18,7 +18,7 @@ import { joinStrings } from '../internal/utils/strings';
 import InternalSpaceBetween from '../space-between/internal';
 import { SearchResults } from '../text-filter/search-results';
 import { getAllowedOperators, getAutosuggestOptions, getQueryActions, parseText } from './controller';
-import { getI18nToken } from './i18n-utils';
+import { getI18nTokenFormatted, getI18nTokenPreFormatted } from './i18n-utils';
 import {
   ComparisonOperator,
   ExtendedOperator,
@@ -183,10 +183,16 @@ const PropertyFilter = React.forwardRef(
       return { internalProperties: [...propertyByKey.values()], internalOptions, internalQuery, internalFreeText };
     })();
 
+    i18nStrings.formatToken = i18n(
+      'i18nStrings.formatToken',
+      rest.i18nStrings?.formatToken,
+      format => token => format(getI18nTokenPreFormatted(token))
+    );
+
     i18nStrings.removeTokenButtonAriaLabel = i18n(
       'i18nStrings.removeTokenButtonAriaLabel',
       rest.i18nStrings?.removeTokenButtonAriaLabel,
-      format => token => format(getI18nToken(token))
+      format => token => format(getI18nTokenFormatted(token))
     );
 
     const parsedText = parseText(filteringText, internalProperties, internalFreeText);

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -276,6 +276,8 @@ export namespace PropertyFilterProps {
     applyActionText?: string;
     allPropertiesLabel?: string;
 
+    formatToken?: (token: PreFormattedToken) => string;
+
     tokenLimitShowMore?: string;
     tokenLimitShowFewer?: string;
     clearFiltersText?: string;
@@ -284,11 +286,15 @@ export namespace PropertyFilterProps {
     enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
   }
 
-  export interface FormattedToken {
+  export interface PreFormattedToken {
     propertyKey?: string;
     propertyLabel: string;
     operator: ComparisonOperator;
     value: string;
+  }
+
+  export interface FormattedToken extends PreFormattedToken {
+    formattedTokenText: string;
   }
 
   export interface GroupText {
@@ -326,6 +332,7 @@ export type LoadItemsDetail = PropertyFilterProps.LoadItemsDetail;
 export type I18nStrings = PropertyFilterProps.I18nStrings;
 export type GroupText = PropertyFilterProps.GroupText;
 export type FilteringChangeDetail = PropertyFilterProps.FilteringChangeDetail;
+export type PreFormattedToken = PropertyFilterProps.PreFormattedToken;
 export type FormattedToken = PropertyFilterProps.FormattedToken;
 export type Ref = PropertyFilterProps.Ref;
 

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -8,7 +8,6 @@ import { NonCancelableEventHandler } from '../internal/events';
 import FilteringToken, { FilteringTokenRef } from './filtering-token';
 import { getFormattedToken } from './i18n-utils';
 import {
-  FormattedToken,
   GroupText,
   I18nStrings,
   InternalFilteringOption,
@@ -17,6 +16,7 @@ import {
   InternalToken,
   JoinOperation,
   LoadItemsDetail,
+  PreFormattedToken,
   Token,
 } from './interfaces';
 import { TokenEditor } from './token-editor';
@@ -79,7 +79,7 @@ export const TokenButton = ({
               <TokenTrigger token={formattedToken} allProperties={token.property === null} />
             </span>
           ),
-          ariaLabel: `${formattedToken.propertyLabel} ${formattedToken.operator} ${formattedToken.value}`,
+          ariaLabel: formattedToken.formattedTokenText,
           dismissAriaLabel: i18nStrings?.removeTokenButtonAriaLabel?.(formattedToken) ?? '',
         },
       ]}
@@ -143,7 +143,7 @@ const TokenTrigger = ({
   token: { propertyLabel, operator, value },
   allProperties,
 }: {
-  token: FormattedToken;
+  token: PreFormattedToken;
   allProperties: boolean;
 }) => {
   if (propertyLabel) {


### PR DESCRIPTION
### Description

Introducing new property filter i18n string to format tokens. The output is used on the token group ARIA label and as a new argument for the remove label i18n function. The formatting is needed to replace operators with the corresponding descriptions as symbolic operators are not announced correctly.

Rel: [tB42A7nNaXZN]

### How has this been tested?

* Unit tests
* Manual check in test pages
* Dry run to live

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
