### PR TITLE
fix: Fixed table cell overflow

### DIFF
--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -21,12 +21,14 @@ $selected-border-placeholder: awsui.$border-divider-list-width solid awsui.$colo
 $border-placeholder: awsui.$border-item-width solid transparent;
 $icon-width-with-spacing: calc(#{awsui.$size-icon-normal} + #{awsui.$space-xs});
 // Right paddings of the absolute positioned icons (success icon is shown next to the edit icon)
-$edit-button-padding-right: calc(
-  #{awsui.$space-xs} + #{awsui.$space-xxs}
-); // Cell vertical padding + xxs space that would normally come from the button.
+$edit-button-padding-right: calc(#{awsui.$space-xs} + #{awsui.$space-xxs});
+// Cell vertical padding + xxs space that would normally come from the button.
 $success-icon-padding-right: calc(#{$edit-button-padding-right} + #{$icon-width-with-spacing});
 $interactive-column-padding-inline-end: calc(#{$cell-horizontal-padding} + #{awsui.$space-l});
 $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
+
+// Ensuring enough space for absolute-positioned focus outlines of focus-able cell content elements.
+$cell-negative-space-vertical: 2px;
 
 @mixin cell-focus-outline {
   @include styles.focus-highlight(calc(-1 * #{awsui.$space-scaled-xxs}));
@@ -63,7 +65,7 @@ $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
   $offset-padding: calc($padding - 1 * awsui.$border-divider-list-width);
 
   > .body-cell-content {
-    margin-inline-start: $offset-padding;
+    padding-inline-start: $offset-padding;
   }
   > .expandable-toggle-wrapper {
     margin-inline-start: $offset-padding;
@@ -72,7 +74,8 @@ $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
   @for $i from 0 through $max-nesting-levels {
     &.expandable-level-#{$i} {
       > .body-cell-content {
-        margin-inline-start: calc($offset-padding + $i * $cell-offset);
+        padding-inline-start: calc(#{$offset-padding} / 2);
+        margin-inline-start: calc(#{$offset-padding} / 2 + #{$i} * #{$cell-offset});
       }
       > .expandable-toggle-wrapper {
         margin-inline-start: calc($offset-padding + ($i - 1) * $cell-offset);
@@ -95,17 +98,20 @@ $cell-offset: calc(#{awsui.$space-m} + #{awsui.$space-xs});
 }
 @mixin cell-padding-block($padding) {
   > .body-cell-content {
-    padding-block: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
+    padding-block: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block: calc(-1 * #{$cell-negative-space-vertical});
   }
 }
 @mixin cell-padding-block-start($padding) {
   > .body-cell-content {
-    padding-block-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
+    padding-block-start: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block-start: calc(-1 * #{$cell-negative-space-vertical});
   }
 }
 @mixin cell-padding-block-end($padding) {
   > .body-cell-content {
-    padding-block-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width});
+    padding-block-end: calc(#{$padding} - 1 * #{awsui.$border-divider-list-width} + #{$cell-negative-space-vertical});
+    margin-block-end: calc(-1 * #{$cell-negative-space-vertical});
   }
 }
 

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -84,7 +84,8 @@ $cell-negative-space-vertical: 2px;
   }
   &.expandable-level-next {
     > .body-cell-content {
-      margin-inline-start: calc(#{$offset-padding} + #{$max-nesting-levels} * #{$cell-offset});
+      padding-inline-start: calc(#{$offset-padding} / 2);
+      margin-inline-start: calc(#{$offset-padding} / 2 + #{$max-nesting-levels} * #{$cell-offset});
     }
     > .expandable-toggle-wrapper {
       margin-inline-start: calc(#{$offset-padding} + (#{$max-nesting-levels} - 1) * #{$cell-offset});


### PR DESCRIPTION
### Description

Fixing table cell spacing to give space for the focus outlines of the cell content.

The cell can include various focusable content such as links, buttons, button dropdown, popover trigger and more. The cells are also focusable when keyboard navigation is on or when editable.

The cell content includes overflow hidden to prevent cell content to exceed cell boundaries and the inline content is truncated with ellipsis (...). However, that style also makes the focus outline of the content being cut off as we add it with an absolute position and some negative offset to render around the element within some distance.

Before:

<img width="1706" alt="Screenshot 2024-08-16 at 13 55 16" src="https://github.com/user-attachments/assets/921f456d-40ae-4f9e-887d-8930c469c94d">

<img width="1706" alt="Screenshot 2024-08-16 at 13 55 41" src="https://github.com/user-attachments/assets/b3fabc46-0606-49e1-8c22-707c50483bd3">

After:

<img width="1706" alt="Screenshot 2024-08-16 at 14 00 18" src="https://github.com/user-attachments/assets/e52088a0-6f1b-4ebf-8e09-5b87c1765679">

<img width="1706" alt="Screenshot 2024-08-16 at 14 00 34" src="https://github.com/user-attachments/assets/61ca9745-ecdd-402b-aeae-a27611e2c85b">



Rel: AWSUI-53403

### How has this been tested?

* Manual testing
* Existing and new screenshot tests [CR-143543797]

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
