### PR TITLE
feat: Add href in analytics metadata of button-dropdown

### DIFF
--- a/src/button-dropdown/__tests__/analytics-metadata.test.tsx
+++ b/src/button-dropdown/__tests__/analytics-metadata.test.tsx
@@ -41,7 +41,7 @@ const getMetadataContexts = (label: string, variant: string, disabled?: boolean)
 };
 
 const items: ButtonDropdownProps['items'] = [
-  { text: 'Delete', id: 'rm', disabled: false },
+  { text: 'Delete', id: 'rm', disabled: false, href: '#' },
   { text: 'Rename', id: 'rn', disabled: true },
   {
     text: 'Instances',
@@ -155,7 +155,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(enabledSimpleItem, labels);
       expect(getGeneratedAnalyticsMetadata(enabledSimpleItem)).toEqual({
         action: 'click',
-        detail: { label: 'Delete', id: 'rm', position: '1' },
+        detail: { label: 'Delete', id: 'rm', position: '1', href: '#' },
         ...getMetadataContexts(label, 'normal'),
       });
 
@@ -177,7 +177,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(enabledSimpleItem, labels);
       expect(getGeneratedAnalyticsMetadata(enabledSimpleItem)).toEqual({
         action: 'click',
-        detail: { label: 'Delete', id: 'rm', position: '1' },
+        detail: { label: 'Delete', id: 'rm', position: '1', href: '#' },
         ...getMetadataContexts(label, 'normal'),
       });
     });
@@ -192,7 +192,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(enabledNestedItem, labels);
       expect(getGeneratedAnalyticsMetadata(enabledNestedItem)).toEqual({
         action: 'click',
-        detail: { label: 'Restart', id: 'restart', position: '3,2' },
+        detail: { label: 'Restart', id: 'restart', position: '3,2', href: '' },
         ...getMetadataContexts(label, 'normal'),
       });
 
@@ -240,7 +240,7 @@ describe('Button Dropdown renders correct analytics metadata', () => {
       validateComponentNameAndLabels(enabledNestedItem, labels);
       expect(getGeneratedAnalyticsMetadata(enabledNestedItem)).toEqual({
         action: 'click',
-        detail: { label: 'Restart', id: 'restart', position: '3,2' },
+        detail: { label: 'Restart', id: 'restart', position: '3,2', href: '' },
         ...getMetadataContexts(label, 'normal'),
       });
     });

--- a/src/button-dropdown/analytics-metadata/interfaces.ts
+++ b/src/button-dropdown/analytics-metadata/interfaces.ts
@@ -9,6 +9,7 @@ export interface GeneratedAnalyticsMetadataButtonDropdownClick {
     label: string;
     position?: string;
     id?: string;
+    href?: string;
   };
 }
 

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -9,7 +9,7 @@ import InternalIcon, { InternalIconProps } from '../../icon/internal';
 import { useDropdownContext } from '../../internal/components/dropdown/context';
 import useHiddenDescription from '../../internal/hooks/use-hidden-description';
 import { GeneratedAnalyticsMetadataButtonDropdownClick } from '../analytics-metadata/interfaces';
-import { ItemProps } from '../interfaces';
+import { ItemProps, LinkItem } from '../interfaces';
 import { ButtonDropdownProps } from '../interfaces';
 import Tooltip from '../tooltip';
 import { getMenuItemCheckboxProps, getMenuItemProps } from '../utils/menu-item';
@@ -74,6 +74,7 @@ const ItemElement = ({
                 position,
                 id: item.id,
                 label: `.${analyticsLabels['menu-item']}`,
+                href: (item as LinkItem).href || '',
               },
             } as GeneratedAnalyticsMetadataButtonDropdownClick)
       )}


### PR DESCRIPTION
### Description

Additional property, needed, for example, for Breadcrumb Group

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
