### PR TITLE
feat: Add analytics metadata to BreadcrumbGroup

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -8,6 +8,8 @@ import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/t
 import AppLayout from '../../../lib/components/app-layout';
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
 import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
+import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
 const wrapper = createWrapper();
 
@@ -256,5 +258,29 @@ describe('without feature flag', () => {
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
     expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+  });
+});
+
+test('renders analytics metadata information', async () => {
+  activateAnalyticsMetadata(true);
+  await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+  const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
+  const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
+  expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
+    action: 'click',
+    detail: {
+      position: '1',
+      label: 'Home',
+      href: '/home',
+    },
+    contexts: [
+      {
+        type: 'component',
+        detail: {
+          name: 'awsui.BreadcrumbGroup',
+          label: 'Home...Page',
+        },
+      },
+    ],
   });
 });

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -169,7 +169,9 @@ export function AppLayoutToolbarImplementation({
         {(breadcrumbs || discoveredBreadcrumbs) && (
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
             {breadcrumbs}
-            {discoveredBreadcrumbs && <InternalBreadcrumbGroup {...discoveredBreadcrumbs} />}
+            {discoveredBreadcrumbs && (
+              <InternalBreadcrumbGroup {...discoveredBreadcrumbs} __injectAnalyticsComponentMetadata={true} />
+            )}
           </div>
         )}
         {((drawers && drawers.length > 0) || (hasSplitPanel && splitPanelToggleProps?.displayed)) && (

--- a/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
+++ b/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
+
+import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
+import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
+
+import ownLabels from '../../../lib/components/breadcrumb-group/analytics-metadata/styles.css.js';
+import buttonDropdownLabels from '../../../lib/components/button-dropdown/analytics-metadata/styles.css.js';
+
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  useMobile: jest.fn().mockReturnValue(false),
+}));
+
+const labels = { ...ownLabels, ...buttonDropdownLabels };
+
+const items = [
+  { text: 'Long breacrumb long breacrumb long breacrumb', href: '#' },
+  { text: 'Components', href: '#one' },
+  { text: 'System', href: '#two' },
+  { text: 'Three', href: '#three' },
+];
+const ariaLabel = 'bcg';
+
+function renderBreadcrumbGroup() {
+  const renderResult = render(<BreadcrumbGroup items={items} ariaLabel={ariaLabel} />);
+  return createWrapper(renderResult.container).findBreadcrumbGroup()!;
+}
+
+const contexts = [
+  {
+    type: 'component',
+    detail: {
+      name: 'awsui.BreadcrumbGroup',
+      label: ariaLabel,
+    },
+  },
+];
+
+const getClickEventDetails = (position: number) => ({
+  action: 'click',
+  detail: {
+    position: `${position}`,
+    href: items[position - 1].href,
+    label: items[position - 1].text,
+  },
+});
+
+beforeAll(() => {
+  activateAnalyticsMetadata(true);
+});
+describe('BreadcrumbGroup renders correct analytics metadata', () => {
+  test('in desktop view', () => {
+    const wrapper = renderBreadcrumbGroup();
+
+    const firstBreadcrumb = wrapper.findBreadcrumbLink(1)!.getElement();
+    validateComponentNameAndLabels(firstBreadcrumb, labels);
+    expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
+      ...getClickEventDetails(1),
+      contexts,
+    });
+    const thirdBreadcrumb = wrapper.findBreadcrumbLink(3)!.getElement();
+    validateComponentNameAndLabels(thirdBreadcrumb, labels);
+    expect(getGeneratedAnalyticsMetadata(thirdBreadcrumb)).toEqual({
+      ...getClickEventDetails(3),
+      contexts,
+    });
+
+    // last breadcrumb is not decorated with click event information
+    const lastBreadcrumb = wrapper.findBreadcrumbLink(4)!.getElement();
+    expect(getGeneratedAnalyticsMetadata(lastBreadcrumb)).toEqual({
+      contexts,
+    });
+  });
+  test('in mobile view', () => {
+    (useMobile as jest.Mock).mockReturnValue(true);
+    const wrapper = renderBreadcrumbGroup();
+
+    const firstBreadcrumb = wrapper.findBreadcrumbLink(1)!.getElement();
+    validateComponentNameAndLabels(firstBreadcrumb, labels);
+    expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
+      ...getClickEventDetails(1),
+      contexts,
+    });
+    const triggerButton = wrapper.findDropdown()!.findTriggerButton()!;
+    validateComponentNameAndLabels(triggerButton.getElement(), labels);
+    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
+      action: 'expand',
+      detail: {
+        label: '...',
+        expanded: 'true',
+      },
+      contexts,
+    });
+
+    triggerButton.click();
+    expect(getGeneratedAnalyticsMetadata(triggerButton.getElement())).toEqual({
+      action: 'expand',
+      detail: {
+        label: '...',
+        expanded: 'false',
+      },
+      contexts,
+    });
+
+    const dropdownItems = wrapper.findDropdown()!.findItems()!;
+    const thirdBreadcrumb = dropdownItems[1].getElement();
+    validateComponentNameAndLabels(thirdBreadcrumb, labels);
+    expect(getGeneratedAnalyticsMetadata(thirdBreadcrumb)).toEqual({
+      ...getClickEventDetails(3),
+      contexts,
+    });
+  });
+});

--- a/src/breadcrumb-group/analytics-metadata/interfaces.ts
+++ b/src/breadcrumb-group/analytics-metadata/interfaces.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+
+export interface GeneratedAnalyticsMetadataBreadcrumbGroupClick {
+  action: 'click';
+  detail: {
+    label: string;
+    position: string;
+    href: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataBreadcrumbGroupExpand {
+  action: 'expand';
+  detail: {
+    label: string;
+    expanded: string;
+  };
+}
+
+export interface GeneratedAnalyticsMetadataBreadcrumbGroupComponent {
+  name: 'awsui.BreadcrumbGroup';
+  label: string | LabelIdentifier;
+}

--- a/src/breadcrumb-group/analytics-metadata/styles.scss
+++ b/src/breadcrumb-group/analytics-metadata/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.breadcrumb-item {
+  /* used in analytics metadata */
+}

--- a/src/breadcrumb-group/index.tsx
+++ b/src/breadcrumb-group/index.tsx
@@ -21,7 +21,14 @@ export default function BreadcrumbGroup<T extends BreadcrumbGroupProps.Item = Br
     return <></>;
   }
 
-  return <InternalBreadcrumbGroup items={items} {...props} {...baseComponentProps} />;
+  return (
+    <InternalBreadcrumbGroup
+      items={items}
+      {...props}
+      {...baseComponentProps}
+      __injectAnalyticsComponentMetadata={true}
+    />
+  );
 }
 
 applyDisplayName(BreadcrumbGroup, 'BreadcrumbGroup');

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -56,7 +56,10 @@ export namespace BreadcrumbGroupProps {
 }
 
 export type InternalBreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = BreadcrumbGroupProps.Item> =
-  BreadcrumbGroupProps<T> & InternalBaseComponentProps;
+  BreadcrumbGroupProps<T> &
+    InternalBaseComponentProps & {
+      __injectAnalyticsComponentMetadata?: boolean;
+    };
 
 export interface BreadcrumbItemProps<T extends BreadcrumbGroupProps.Item> {
   item: T;

--- a/src/breadcrumb-group/item/funnel.tsx
+++ b/src/breadcrumb-group/item/funnel.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../internal/analytics/selectors';
 
+import analyticsSelectors from '../analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
 
 interface FunnelBreadcrumbItemProps {
@@ -21,7 +22,11 @@ export const FunnelBreadcrumbItem = React.forwardRef<HTMLSpanElement, FunnelBrea
     }
 
     return (
-      <span {...funnelAttributes} className={clsx(styles.text, hidden && styles['text-hidden'])} ref={ref}>
+      <span
+        {...funnelAttributes}
+        className={clsx(styles.text, hidden && styles['text-hidden'], analyticsSelectors['breadcrumb-item'])}
+        ref={ref}
+      >
         {text}
       </span>
     );

--- a/src/button-dropdown/__tests__/analytics-metadata.test.tsx
+++ b/src/button-dropdown/__tests__/analytics-metadata.test.tsx
@@ -247,14 +247,36 @@ describe('Button Dropdown renders correct analytics metadata', () => {
   });
 });
 
-test('Internal Button Dropdown does not render "component" metadata', () => {
-  const renderResult = render(<InternalButtonDropdown items={items}>Action text</InternalButtonDropdown>);
-  const wrapper = createWrapper(renderResult.container).findButtonDropdown()!.findTriggerButton()!;
-  expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
-    action: 'expand',
-    detail: {
-      label: 'Action text',
-      expanded: 'true',
-    },
+describe('Internal Button Dropdown', () => {
+  test('does not render "component" metadata', () => {
+    const renderResult = render(<InternalButtonDropdown items={items}>Action text</InternalButtonDropdown>);
+    const wrapper = createWrapper(renderResult.container).findButtonDropdown()!.findTriggerButton()!;
+    expect(getGeneratedAnalyticsMetadata(wrapper.getElement())).toEqual({
+      action: 'expand',
+      detail: {
+        label: 'Action text',
+        expanded: 'true',
+      },
+    });
+  });
+  test('accepts analyticsMetadataTransformer', () => {
+    const renderResult = render(
+      <InternalButtonDropdown
+        analyticsMetadataTransformer={md => {
+          delete md!.detail!.id;
+          return md;
+        }}
+        items={items}
+      >
+        Action text
+      </InternalButtonDropdown>
+    );
+    const wrapper = createWrapper(renderResult.container).findButtonDropdown()!;
+    wrapper.openDropdown();
+    const enabledSimpleItem = wrapper.findItemById('rm')!.getElement();
+    expect(getGeneratedAnalyticsMetadata(enabledSimpleItem)).toEqual({
+      action: 'click',
+      detail: { label: 'Delete', position: '1', href: '#' },
+    });
   });
 });

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { GeneratedAnalyticsMetadataFragment } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+
 import { ButtonProps } from '../button/interfaces';
 import { IconProps } from '../icon/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
@@ -229,6 +231,7 @@ export interface ItemListProps extends HighlightProps {
   expandToViewport?: boolean;
   variant?: InternalButtonDropdownProps['variant'];
   position?: string;
+  analyticsMetadataTransformer?: InternalButtonDropdownProps['analyticsMetadataTransformer'];
 }
 
 export interface LinkItem extends ButtonDropdownProps.Item {
@@ -246,6 +249,7 @@ export interface ItemProps {
   isKeyboardHighlighted?: boolean;
   variant?: ItemListProps['variant'];
   position?: string;
+  analyticsMetadataTransformer?: InternalButtonDropdownProps['analyticsMetadataTransformer'];
 }
 
 export interface InternalItem extends ButtonDropdownProps.Item {
@@ -282,6 +286,7 @@ export interface InternalButtonDropdownProps
    * instead of dropping left or right.
    */
   preferCenter?: boolean;
+  analyticsMetadataTransformer?: (input: GeneratedAnalyticsMetadataFragment) => GeneratedAnalyticsMetadataFragment;
 }
 
 export interface CustomTriggerProps {

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -49,6 +49,7 @@ const InternalButtonDropdown = React.forwardRef(
       preferCenter,
       mainAction,
       __internalRootRef,
+      analyticsMetadataTransformer,
       ...props
     }: InternalButtonDropdownProps,
     ref: React.Ref<ButtonDropdownProps.Ref>
@@ -187,7 +188,7 @@ const InternalButtonDropdown = React.forwardRef(
 
     if (customTriggerBuilder) {
       trigger = (
-        <div className={styles['dropdown-trigger']}>
+        <div className={styles['dropdown-trigger']} {...getAnalyticsMetadataAttribute(analyticsMetadata)}>
           {customTriggerBuilder({
             testUtilsClass: styles['test-utils-button-trigger'],
             ariaExpanded: canBeOpened && isOpen,
@@ -350,6 +351,7 @@ const InternalButtonDropdown = React.forwardRef(
               highlightItem={highlightItem}
               expandToViewport={expandToViewport}
               variant={variant}
+              analyticsMetadataTransformer={analyticsMetadataTransformer}
             />
           </OptionsList>
         </Dropdown>

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -3,7 +3,10 @@
 import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 
-import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import {
+  GeneratedAnalyticsMetadataFragment,
+  getAnalyticsMetadataAttribute,
+} from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import InternalIcon, { InternalIconProps } from '../../icon/internal';
 import { useDropdownContext } from '../../internal/components/dropdown/context';
@@ -29,6 +32,7 @@ const ItemElement = ({
   showDivider,
   hasCategoryHeader,
   isKeyboardHighlighted = false,
+  analyticsMetadataTransformer = (metadata: GeneratedAnalyticsMetadataFragment) => metadata,
   variant = 'normal',
 }: ItemProps) => {
   const isLink = isLinkItem(item);
@@ -68,7 +72,7 @@ const ItemElement = ({
       {...getAnalyticsMetadataAttribute(
         disabled
           ? {}
-          : ({
+          : (analyticsMetadataTransformer!({
               action: 'click',
               detail: {
                 position,
@@ -76,7 +80,7 @@ const ItemElement = ({
                 label: `.${analyticsLabels['menu-item']}`,
                 href: (item as LinkItem).href || '',
               },
-            } as GeneratedAnalyticsMetadataButtonDropdownClick)
+            }) as GeneratedAnalyticsMetadataButtonDropdownClick)
       )}
     >
       <MenuItem item={item} disabled={disabled} highlighted={highlighted} />

--- a/src/button-dropdown/items-list.tsx
+++ b/src/button-dropdown/items-list.tsx
@@ -25,6 +25,7 @@ export default function ItemsList({
   hasCategoryHeader = false,
   expandToViewport = false,
   variant = 'normal',
+  analyticsMetadataTransformer,
   position,
 }: ItemListProps) {
   const isMobile = useMobile();
@@ -46,6 +47,7 @@ export default function ItemsList({
           hasCategoryHeader={hasCategoryHeader}
           variant={variant}
           position={`${position ? `${position},` : ''}${index + 1}`}
+          analyticsMetadataTransformer={analyticsMetadataTransformer}
         />
       );
     }


### PR DESCRIPTION
### Description

Similar to https://github.com/cloudscape-design/components/commit/dde24620bceb97c2fd3e59aa45b0e95af8402313, however it required to add properties to other components including:
- Button dropdown
  - to surface the right information from custom triggers
  - to process analytics properties set by the button dropdown, which do not make sense for Breadcrumbs
- App layout, to test that widgetized breadcrumbs are also decorated with analytics information


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ N/A
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._ Y
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._ Y
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ N/A

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
