### PR TITLE
chore: Property filter token editor integration

### DIFF
--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PropertyFilterProps } from '~components/property-filter';
+import { I18nStringsExt } from '~components/property-filter/internal';
 
 import {
   DateForm,
@@ -131,7 +132,7 @@ export const columnDefinitions = [
   },
 ].map((item, ind) => ({ order: ind + 1, ...item }));
 
-export const i18nStrings: PropertyFilterProps.I18nStrings = {
+export const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
   filteringAriaLabel: 'your choice',
   dismissAriaLabel: 'Dismiss',
 
@@ -167,6 +168,15 @@ export const i18nStrings: PropertyFilterProps.I18nStrings = {
   tokenOperatorAriaLabel: 'Boolean Operator',
   removeTokenButtonAriaLabel: () => 'Remove token',
   enteredTextLabel: (text: string) => `Use: "${text}"`,
+
+  tokenEditorTokenActionsLabel: token =>
+    `Filter remove actions for ${token.propertyLabel} ${token.operator} ${token.value}`,
+  tokenEditorTokenRemoveLabel: () => 'Remove filter',
+  tokenEditorTokenRemoveFromGroupLabel: () => 'Remove filter from group',
+  tokenEditorAddNewTokenLabel: 'Add new filter',
+  tokenEditorAddTokenActionsLabel: 'Add filter actions',
+  tokenEditorAddExistingTokenLabel: token =>
+    `Add filter ${token.propertyLabel} ${token.operator} ${token.value} to group`,
 };
 
 export const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = columnDefinitions.map(def => {

--- a/pages/property-filter/custom-forms.tsx
+++ b/pages/property-filter/custom-forms.tsx
@@ -191,11 +191,12 @@ function formatTimezoneOffset(isoDate: string, offsetInMinutes?: number) {
 const allOwners = [...new Set(allItems.map(({ owner }) => owner))];
 
 export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormProps<string[]>) {
+  value = value && Array.isArray(value) ? value : [];
   return (
-    <FormField>
+    <FormField stretch={true}>
       <Multiselect
         options={allOwners.map(owner => ({ value: owner, label: owner }))}
-        selectedOptions={value?.map(owner => ({ value: owner, label: owner })) ?? []}
+        selectedOptions={value.map(owner => ({ value: owner, label: owner })) ?? []}
         onChange={event =>
           onChange(
             event.detail.selectedOptions
@@ -210,5 +211,5 @@ export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormPr
 }
 
 export function formatOwners(owners: string[]) {
-  return owners.join(', ');
+  return owners && Array.isArray(owners) ? owners.join(', ') : '';
 }

--- a/pages/property-filter/property-filter-editor-permutations.page.tsx
+++ b/pages/property-filter/property-filter-editor-permutations.page.tsx
@@ -88,17 +88,7 @@ const defaultProps: TokenEditorProps = {
   },
   filteringProperties: [nameProperty, dateProperty],
   filteringOptions: [],
-  i18nStrings: {
-    ...i18nStrings,
-    tokenEditorTokenActionsLabel: token =>
-      `Filter remove actions for ${token.propertyLabel} ${token.operator} ${token.value}`,
-    tokenEditorTokenRemoveLabel: () => 'Remove filter',
-    tokenEditorTokenRemoveFromGroupLabel: () => 'Remove filter from group',
-    tokenEditorAddNewTokenLabel: 'Add new filter',
-    tokenEditorAddTokenActionsLabel: 'Add filter actions',
-    tokenEditorAddExistingTokenLabel: token =>
-      `Add filter ${token.propertyLabel} ${token.operator} ${token.value} to group`,
-  },
+  i18nStrings,
   onSubmit: () => {},
   onDismiss: () => {},
   standaloneTokens: [],

--- a/pages/property-filter/property-filter-tokens-permutations.page.tsx
+++ b/pages/property-filter/property-filter-tokens-permutations.page.tsx
@@ -47,6 +47,7 @@ const tokenProps: FilteringTokenProps = {
   editorDismissAriaLabel: 'dismiss token editor',
   editorExpandToViewport: false,
   hasGroups: false,
+  popoverSize: 'content',
 };
 
 const tokenPermutations = createPermutations<Partial<FilteringTokenProps>>([

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -97,10 +97,14 @@ export default function () {
         <PropertyFilterInternal
           className="property-filter-group-editor"
           query={{
-            tokens: [{ propertyKey: 'instanceid', operator: '=', value: 'i123' }],
+            tokens: [
+              { propertyKey: 'instanceid', operator: '=', value: 'i123' },
+              { propertyKey: 'lasteventat', operator: '>', value: '2022-01-01T00:00:00' },
+            ],
             operation: 'and',
           }}
           {...commonProps}
+          filteringProperties={commonFilteringProperties}
           customGroupsText={[]}
           enableTokenGroups={true}
         />

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import PropertyFilter from '~components/property-filter';
 import { PropertyFilterProps } from '~components/property-filter/interfaces';
+import PropertyFilterInternal from '~components/property-filter/internal';
 
 import ScreenshotArea from '../utils/screenshot-area';
 import { columnDefinitions, filteringProperties as commonFilteringProperties, i18nStrings } from './common-props';
@@ -14,6 +15,16 @@ const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = co
   propertyLabel: def.propertyLabel,
   groupValuesLabel: `${def.propertyLabel} values`,
 }));
+
+const commonProps = {
+  onChange: () => {},
+  filteringProperties,
+  filteringOptions: [],
+  i18nStrings,
+  countText: '5 matches',
+  disableFreeTextFiltering: false,
+  virtualScroll: true,
+} as const;
 
 export default function () {
   return (
@@ -31,11 +42,7 @@ export default function () {
             ],
             operation: 'and',
           }}
-          onChange={() => {}}
-          filteringProperties={filteringProperties}
-          filteringOptions={[]}
-          virtualScroll={true}
-          countText="5 matches"
+          {...commonProps}
           i18nStrings={{
             ...i18nStrings,
             editTokenHeader: 'Edit filter editTokenHeadereditTokenHeadereditTokenHeadereditTokenHeader',
@@ -55,12 +62,7 @@ export default function () {
             ],
             operation: 'and',
           }}
-          onChange={() => {}}
-          filteringProperties={filteringProperties}
-          filteringOptions={[]}
-          virtualScroll={true}
-          countText="5 matches"
-          i18nStrings={i18nStrings}
+          {...commonProps}
         />
         <PropertyFilter
           className="property-filter-custom-prop-boolean"
@@ -68,12 +70,8 @@ export default function () {
             tokens: [{ propertyKey: 'stopped', operator: '=', value: 'true' }],
             operation: 'and',
           }}
-          onChange={() => {}}
+          {...commonProps}
           filteringProperties={commonFilteringProperties}
-          filteringOptions={[]}
-          virtualScroll={true}
-          countText="5 matches"
-          i18nStrings={i18nStrings}
         />
         <PropertyFilter
           className="property-filter-custom-prop-datetime"
@@ -81,12 +79,8 @@ export default function () {
             tokens: [{ propertyKey: 'lasteventat', operator: '>', value: '2022-01-01T00:00:00' }],
             operation: 'and',
           }}
-          onChange={() => {}}
+          {...commonProps}
           filteringProperties={commonFilteringProperties}
-          filteringOptions={[]}
-          virtualScroll={true}
-          countText="5 matches"
-          i18nStrings={i18nStrings}
         />
         <PropertyFilter
           className="property-filter-free-text-operators"
@@ -97,13 +91,18 @@ export default function () {
             ],
             operation: 'and',
           }}
-          onChange={() => {}}
-          filteringProperties={filteringProperties}
-          filteringOptions={[]}
+          {...commonProps}
           freeTextFiltering={{ operators: [':', '!:', '=', '!=', '^', '!^'] }}
-          virtualScroll={true}
-          countText="5 matches"
-          i18nStrings={i18nStrings}
+        />
+        <PropertyFilterInternal
+          className="property-filter-group-editor"
+          query={{
+            tokens: [{ propertyKey: 'instanceid', operator: '=', value: 'i123' }],
+            operation: 'and',
+          }}
+          {...commonProps}
+          customGroupsText={[]}
+          enableTokenGroups={true}
         />
       </ScreenshotArea>
     </>

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -57,7 +57,7 @@
 }
 
 .container-body-size-content {
-  // no styles
+  /* no styles */
 }
 
 .container-arrow {

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -56,6 +56,10 @@
   }
 }
 
+.container-body-size-content {
+  // no styles
+}
+
 .container-arrow {
   $arrow-offset: 12px;
   $arrow-width: 20px;

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -56,10 +56,6 @@
   }
 }
 
-.container-body-size-content {
-  /* no styles */
-}
-
 .container-arrow {
   $arrow-offset: 12px;
   $arrow-width: 20px;

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -30,7 +30,7 @@ export interface PopoverContainerProps {
   arrow: (position: InternalPosition | null) => React.ReactNode;
   children: React.ReactNode;
   renderWithPortal?: boolean;
-  size: PopoverProps.Size;
+  size: PopoverProps.Size | 'content';
   fixedWidth: boolean;
   variant?: 'annotation';
   // When keepPosition is true, the popover will not recalculate its position when it resizes nor when it receives clicks.

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -30,6 +30,8 @@ export interface PopoverContainerProps {
   arrow: (position: InternalPosition | null) => React.ReactNode;
   children: React.ReactNode;
   renderWithPortal?: boolean;
+  // The "content" size is a special one that does not have the associated container-body-size-{size} class.
+  // It can be used to create larger popovers where the responsiveness is handled by the content.
   size: PopoverProps.Size | 'content';
   fixedWidth: boolean;
   variant?: 'annotation';

--- a/src/popover/container.tsx
+++ b/src/popover/container.tsx
@@ -30,8 +30,6 @@ export interface PopoverContainerProps {
   arrow: (position: InternalPosition | null) => React.ReactNode;
   children: React.ReactNode;
   renderWithPortal?: boolean;
-  // The "content" size is a special one that does not have the associated container-body-size-{size} class.
-  // It can be used to create larger popovers where the responsiveness is handled by the content.
   size: PopoverProps.Size | 'content';
   fixedWidth: boolean;
   variant?: 'annotation';

--- a/src/popover/internal.tsx
+++ b/src/popover/internal.tsx
@@ -23,9 +23,10 @@ import { PopoverProps } from './interfaces';
 
 import styles from './styles.css.js';
 
-export interface InternalPopoverProps extends Omit<PopoverProps, 'triggerType'>, InternalBaseComponentProps {
+export interface InternalPopoverProps extends Omit<PopoverProps, 'triggerType' | 'size'>, InternalBaseComponentProps {
   __onOpen?: NonCancelableEventHandler<null>;
   triggerType?: PopoverProps.TriggerType | 'filtering-token';
+  size: PopoverProps.Size | 'content';
 }
 
 export interface InternalPopoverRef {

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -7,7 +7,7 @@ import { format } from 'date-fns';
 
 import DatePicker from '../../../lib/components/date-picker';
 import FormField from '../../../lib/components/form-field';
-import { useContainerBreakpoints } from '../../../lib/components/internal/hooks/container-queries';
+import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import PropertyFilter from '../../../lib/components/property-filter';
 import {
   FilteringOption,
@@ -21,9 +21,9 @@ import createWrapper from '../../../lib/components/test-utils/dom';
 import { InternalPropertyFilterEditorDropdownWrapper } from '../../../lib/components/test-utils/dom/property-filter';
 import { createDefaultProps, i18nStrings } from './common';
 
-jest.mock('../../../lib/components/internal/hooks/container-queries', () => ({
-  ...jest.requireActual('../../../lib/components/internal/hooks/container-queries'),
-  useContainerBreakpoints: jest.fn().mockReturnValue(['xs', () => {}]),
+jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
+  ...jest.requireActual('../../../lib/components/internal/hooks/use-mobile'),
+  useMobile: jest.fn().mockReturnValue(true),
 }));
 
 const filteringProperties: readonly FilteringProperty[] = [
@@ -370,22 +370,20 @@ function renderTokenEditor(props?: Partial<TokenEditorProps>) {
   return new InternalPropertyFilterEditorDropdownWrapper(container);
 }
 
-describe.each(['xs', 'default'] as const)('breakpoints = %s', breakpoint => {
-  const isNarrow = breakpoint === 'default';
-
+describe.each([false, true] as const)('isMobile = %s', isMobile => {
   function findRemoveAction(wrapper: InternalPropertyFilterEditorDropdownWrapper, index: number) {
     wrapper.findTokenRemoveActions(index)!.openDropdown();
-    return isNarrow
+    return isMobile
       ? wrapper.findTokenRemoveActions(index)!.findMainAction()!
       : wrapper.findTokenRemoveActions(index)!.findItems()[0];
   }
   function findRemoveFromGroupAction(wrapper: InternalPropertyFilterEditorDropdownWrapper, index: number) {
     wrapper.findTokenRemoveActions(index)!.openDropdown();
-    return wrapper.findTokenRemoveActions(index)!.findItems()[isNarrow ? 0 : 1];
+    return wrapper.findTokenRemoveActions(index)!.findItems()[isMobile ? 0 : 1];
   }
 
   beforeEach(() => {
-    jest.mocked(useContainerBreakpoints).mockReturnValue([breakpoint, () => {}]);
+    jest.mocked(useMobile).mockReturnValue(isMobile);
   });
 
   test.each([false, true])('renders token editor with a single property, supportsGroups=%s', supportsGroups => {

--- a/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
+++ b/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
@@ -43,6 +43,7 @@ const defaultProps: FilteringTokenProps = {
   editorDismissAriaLabel: 'dismiss editor',
   editorExpandToViewport: false,
   hasGroups: false,
+  popoverSize: 'content',
 };
 
 function renderToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapper {

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -123,7 +123,7 @@ const FilteringToken = forwardRef(
         hasGroups={hasGroups}
       >
         {tokens.length === 1 ? (
-          <InternalPopover ref={popoverRef} {...popoverProps}>
+          <InternalPopover ref={popoverRef} {...popoverProps} size="content">
             {tokens[0].content}
           </InternalPopover>
         ) : (

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -37,6 +37,7 @@ export interface FilteringTokenProps {
   editorExpandToViewport: boolean;
   onEditorOpen?: () => void;
   hasGroups: boolean;
+  popoverSize: InternalPopoverProps['size'];
 }
 
 export interface FilteringTokenRef {
@@ -71,6 +72,7 @@ const FilteringToken = forwardRef(
       editorExpandToViewport,
       onEditorOpen,
       hasGroups,
+      popoverSize,
     }: FilteringTokenProps,
     ref: React.Ref<FilteringTokenRef>
   ) => {
@@ -79,7 +81,7 @@ const FilteringToken = forwardRef(
       content: editorContent,
       triggerType: 'text',
       header: editorHeader,
-      size: 'large',
+      size: popoverSize,
       position: 'right',
       dismissAriaLabel: editorDismissAriaLabel,
       renderWithPortal: editorExpandToViewport,
@@ -123,7 +125,7 @@ const FilteringToken = forwardRef(
         hasGroups={hasGroups}
       >
         {tokens.length === 1 ? (
-          <InternalPopover ref={popoverRef} {...popoverProps} size="content">
+          <InternalPopover ref={popoverRef} {...popoverProps}>
             {tokens[0].content}
           </InternalPopover>
         ) : (

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -1,435 +1,46 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React, { useImperativeHandle, useRef, useState } from 'react';
-import clsx from 'clsx';
+import React from 'react';
 
-import { PropertyFilterOperator } from '@cloudscape-design/collection-hooks';
-
-import { InternalButton } from '../button/internal';
-import { useInternalI18n } from '../i18n/context';
-import { getBaseProps } from '../internal/base-component';
-import { AutosuggestInputRef } from '../internal/components/autosuggest-input';
-import TokenList from '../internal/components/token-list';
-import { fireNonCancelableEvent } from '../internal/events';
 import useBaseComponent from '../internal/hooks/use-base-component';
-import { useUniqueId } from '../internal/hooks/use-unique-id/index';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
-import { joinStrings } from '../internal/utils/strings';
-import InternalSpaceBetween from '../space-between/internal';
-import { SearchResults } from '../text-filter/search-results';
-import { getAllowedOperators, getAutosuggestOptions, getQueryActions, parseText } from './controller';
-import { getI18nToken } from './i18n-utils';
-import {
-  ComparisonOperator,
-  ExtendedOperator,
-  FilteringProperty,
-  InternalFilteringOption,
-  InternalFilteringProperty,
-  InternalFreeTextFiltering,
-  InternalQuery,
-  ParsedText,
-  PropertyFilterProps,
-  Ref,
-  Token,
-} from './interfaces';
-import { PropertyEditor } from './property-editor';
-import PropertyFilterAutosuggest, { PropertyFilterAutosuggestProps } from './property-filter-autosuggest';
-import { TokenButton } from './token';
-import { useLoadItems } from './use-load-items';
-import { matchTokenValue } from './utils';
-
-import styles from './styles.css.js';
+import { PropertyFilterProps, Ref } from './interfaces';
+import PropertyFilterInternal from './internal';
 
 export { PropertyFilterProps };
 
 const PropertyFilter = React.forwardRef(
   (
     {
-      disabled,
-      countText,
-      query,
-      hideOperations,
-      onChange,
-      filteringProperties,
       filteringOptions = [],
       customGroupsText = [],
       disableFreeTextFiltering = false,
-      freeTextFiltering,
-      onLoadItems,
-      virtualScroll,
-      customControl,
-      customFilterActions,
-      filteringPlaceholder,
-      filteringAriaLabel,
-      filteringEmpty,
-      filteringLoadingText,
-      filteringFinishedText,
-      filteringErrorText,
-      filteringRecoveryText,
-      filteringConstraintText,
-      filteringStatusType,
       asyncProperties,
-      tokenLimit,
       expandToViewport,
-      tokenLimitShowFewerAriaLabel,
-      tokenLimitShowMoreAriaLabel,
+      hideOperations,
+      tokenLimit,
+      virtualScroll,
       ...rest
     }: PropertyFilterProps,
     ref: React.Ref<Ref>
   ) => {
-    const { __internalRootRef } = useBaseComponent('PropertyFilter', {
+    const baseComponentProps = useBaseComponent('PropertyFilter', {
       props: { asyncProperties, disableFreeTextFiltering, expandToViewport, hideOperations, tokenLimit, virtualScroll },
     });
-    const [removedTokenIndex, setRemovedTokenIndex] = useState<null | number>(null);
-
-    const inputRef = useRef<AutosuggestInputRef>(null);
-    const baseProps = getBaseProps(rest);
-
-    const i18n = useInternalI18n('property-filter');
-    const i18nStrings: PropertyFilterProps.I18nStrings = {
-      ...rest.i18nStrings,
-      allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings?.allPropertiesLabel),
-      applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings?.applyActionText),
-      cancelActionText: i18n('i18nStrings.cancelActionText', rest.i18nStrings?.cancelActionText),
-      clearFiltersText: i18n('i18nStrings.clearFiltersText', rest.i18nStrings?.clearFiltersText),
-      editTokenHeader: i18n('i18nStrings.editTokenHeader', rest.i18nStrings?.editTokenHeader),
-      groupPropertiesText: i18n('i18nStrings.groupPropertiesText', rest.i18nStrings?.groupPropertiesText),
-      groupValuesText: i18n('i18nStrings.groupValuesText', rest.i18nStrings?.groupValuesText),
-      operationAndText: i18n('i18nStrings.operationAndText', rest.i18nStrings?.operationAndText),
-      operationOrText: i18n('i18nStrings.operationOrText', rest.i18nStrings?.operationOrText),
-      operatorContainsText: i18n('i18nStrings.operatorContainsText', rest.i18nStrings?.operatorContainsText),
-      operatorDoesNotContainText: i18n(
-        'i18nStrings.operatorDoesNotContainText',
-        rest.i18nStrings?.operatorDoesNotContainText
-      ),
-      operatorDoesNotEqualText: i18n(
-        'i18nStrings.operatorDoesNotEqualText',
-        rest.i18nStrings?.operatorDoesNotEqualText
-      ),
-      operatorEqualsText: i18n('i18nStrings.operatorEqualsText', rest.i18nStrings?.operatorEqualsText),
-      operatorGreaterOrEqualText: i18n(
-        'i18nStrings.operatorGreaterOrEqualText',
-        rest.i18nStrings?.operatorGreaterOrEqualText
-      ),
-      operatorGreaterText: i18n('i18nStrings.operatorGreaterText', rest.i18nStrings?.operatorGreaterText),
-      operatorLessOrEqualText: i18n('i18nStrings.operatorLessOrEqualText', rest.i18nStrings?.operatorLessOrEqualText),
-      operatorLessText: i18n('i18nStrings.operatorLessText', rest.i18nStrings?.operatorLessText),
-      operatorStartsWithText: i18n('i18nStrings.operatorStartsWithText', rest.i18nStrings?.operatorStartsWithText),
-      operatorDoesNotStartWithText: i18n(
-        'i18nStrings.operatorDoesNotStartWithText',
-        rest.i18nStrings?.operatorDoesNotStartWithText
-      ),
-      operatorText: i18n('i18nStrings.operatorText', rest.i18nStrings?.operatorText),
-      operatorsText: i18n('i18nStrings.operatorsText', rest.i18nStrings?.operatorsText),
-      propertyText: i18n('i18nStrings.propertyText', rest.i18nStrings?.propertyText),
-      tokenLimitShowFewer: i18n('i18nStrings.tokenLimitShowFewer', rest.i18nStrings?.tokenLimitShowFewer),
-      tokenLimitShowMore: i18n('i18nStrings.tokenLimitShowMore', rest.i18nStrings?.tokenLimitShowMore),
-      valueText: i18n('i18nStrings.valueText', rest.i18nStrings?.valueText),
-    };
-
-    useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
-    const showResults = !!query.tokens?.length && !disabled && !!countText;
-    const { addToken, removeToken, setToken, setOperation, removeAllTokens } = getQueryActions(
-      query,
-      onChange,
-      inputRef
-    );
-    const [filteringText, setFilteringText] = useState<string>('');
-
-    const { internalProperties, internalOptions, internalQuery, internalFreeText } = (() => {
-      const propertyByKey = filteringProperties.reduce((acc, property) => {
-        const extendedOperators = (property?.operators ?? []).reduce(
-          (acc, operator) => (typeof operator === 'object' ? acc.set(operator.operator, operator) : acc),
-          new Map<PropertyFilterOperator, null | ExtendedOperator<any>>()
-        );
-        acc.set(property.key, {
-          propertyKey: property.key,
-          propertyLabel: property?.propertyLabel ?? '',
-          groupValuesLabel: property?.groupValuesLabel ?? '',
-          propertyGroup: property?.group,
-          operators: (property?.operators ?? []).map(op => (typeof op === 'string' ? op : op.operator)),
-          defaultOperator: property?.defaultOperator ?? '=',
-          getValueFormatter: operator => (operator ? extendedOperators.get(operator)?.format ?? null : null),
-          getValueFormRenderer: operator => (operator ? extendedOperators.get(operator)?.form ?? null : null),
-          externalProperty: property,
-        });
-        return acc;
-      }, new Map<string, InternalFilteringProperty>());
-      const getProperty = (propertyKey: string): null | InternalFilteringProperty =>
-        propertyByKey.get(propertyKey) ?? null;
-
-      const internalOptions: readonly InternalFilteringOption[] = filteringOptions.map(option => ({
-        property: getProperty(option.propertyKey),
-        value: option.value,
-        label: option.label ?? option.value ?? '',
-      }));
-
-      const internalQuery: InternalQuery = {
-        operation: query.operation,
-        tokens: query.tokens.map(token => ({
-          property: token.propertyKey ? getProperty(token.propertyKey) : null,
-          operator: token.operator,
-          value: token.value,
-          __source: token,
-        })),
-      };
-
-      const internalFreeText: InternalFreeTextFiltering = {
-        disabled: disableFreeTextFiltering,
-        operators: freeTextFiltering?.operators ?? [':', '!:'],
-        defaultOperator: freeTextFiltering?.defaultOperator ?? ':',
-      };
-
-      return { internalProperties: [...propertyByKey.values()], internalOptions, internalQuery, internalFreeText };
-    })();
-
-    i18nStrings.removeTokenButtonAriaLabel = i18n(
-      'i18nStrings.removeTokenButtonAriaLabel',
-      rest.i18nStrings?.removeTokenButtonAriaLabel,
-      format => token => format(getI18nToken(token))
-    );
-
-    const parsedText = parseText(filteringText, internalProperties, internalFreeText);
-    const autosuggestOptions = getAutosuggestOptions(
-      parsedText,
-      internalProperties,
-      internalOptions,
-      customGroupsText,
-      i18nStrings
-    );
-
-    const createToken = (currentText: string) => {
-      const parsedText = parseText(currentText, internalProperties, internalFreeText);
-      let newToken: Token;
-      switch (parsedText.step) {
-        case 'property': {
-          newToken = matchTokenValue(
-            {
-              property: parsedText.property,
-              operator: parsedText.operator,
-              value: parsedText.value,
-            },
-            internalOptions
-          );
-          break;
-        }
-        case 'free-text': {
-          newToken = {
-            operator: parsedText.operator || internalFreeText.defaultOperator,
-            value: parsedText.value,
-          };
-          break;
-        }
-        case 'operator': {
-          newToken = {
-            operator: internalFreeText.defaultOperator,
-            value: currentText,
-          };
-          break;
-        }
-      }
-      if (internalFreeText.disabled && !('propertyKey' in newToken)) {
-        return;
-      }
-      addToken(newToken);
-      setFilteringText('');
-    };
-    const getLoadMoreDetail = (parsedText: ParsedText, filteringText: string) => {
-      const loadMoreDetail: {
-        filteringProperty: FilteringProperty | undefined;
-        filteringText: string;
-        filteringOperator: ComparisonOperator | undefined;
-      } = {
-        filteringProperty: undefined,
-        filteringText,
-        filteringOperator: undefined,
-      };
-      if (parsedText.step === 'property') {
-        loadMoreDetail.filteringProperty = parsedText.property.externalProperty;
-        loadMoreDetail.filteringText = parsedText.value;
-        loadMoreDetail.filteringOperator = parsedText.operator;
-      }
-      return loadMoreDetail;
-    };
-    const loadMoreDetail = getLoadMoreDetail(parsedText, filteringText);
-    const inputLoadItemsHandlers = useLoadItems(
-      onLoadItems,
-      loadMoreDetail.filteringText,
-      loadMoreDetail.filteringProperty,
-      loadMoreDetail.filteringText,
-      loadMoreDetail.filteringOperator
-    );
-    const asyncProps = {
-      empty: filteringEmpty,
-      loadingText: filteringLoadingText,
-      finishedText: filteringFinishedText,
-      errorText: filteringErrorText,
-      recoveryText: filteringRecoveryText,
-      statusType: filteringStatusType,
-    };
-    const asyncAutosuggestProps =
-      !!filteringText.length || asyncProperties
-        ? {
-            ...inputLoadItemsHandlers,
-            ...asyncProps,
-          }
-        : {};
-    const handleSelected: PropertyFilterAutosuggestProps['onOptionClick'] = event => {
-      const { detail: option } = event;
-      const value = option.value || '';
-      if (!value) {
-        return;
-      }
-
-      if (!('keepOpenOnSelect' in option)) {
-        createToken(value);
-        return;
-      }
-
-      // stop dropdown from closing
-      event.preventDefault();
-
-      const parsedText = parseText(value, internalProperties, internalFreeText);
-      const loadMoreDetail = getLoadMoreDetail(parsedText, value);
-
-      // Insert operator automatically if only one operator is defined for the given property.
-      if (parsedText.step === 'operator') {
-        const operators = getAllowedOperators(parsedText.property);
-        if (value.trim() === parsedText.property.propertyLabel && operators.length === 1) {
-          loadMoreDetail.filteringProperty = parsedText.property.externalProperty ?? undefined;
-          loadMoreDetail.filteringOperator = operators[0];
-          loadMoreDetail.filteringText = '';
-          setFilteringText(parsedText.property.propertyLabel + ' ' + operators[0] + ' ');
-        }
-      }
-
-      fireNonCancelableEvent(onLoadItems, { ...loadMoreDetail, firstPage: true, samePage: false });
-    };
-
-    const operatorForm =
-      parsedText.step === 'property' && parsedText.property.getValueFormRenderer(parsedText.operator);
-
-    const searchResultsId = useUniqueId('property-filter-search-results');
-    const constraintTextId = useUniqueId('property-filter-constraint');
-    const textboxAriaDescribedBy = filteringConstraintText
-      ? joinStrings(rest.ariaDescribedby, constraintTextId)
-      : rest.ariaDescribedby;
-
     return (
-      <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
-        <div className={styles['search-field']}>
-          {customControl && <div className={styles['custom-control']}>{customControl}</div>}
-          <PropertyFilterAutosuggest
-            ref={inputRef}
-            virtualScroll={virtualScroll}
-            enteredTextLabel={i18nStrings.enteredTextLabel}
-            ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
-            placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
-            ariaLabelledby={rest.ariaLabelledby}
-            ariaDescribedby={textboxAriaDescribedBy}
-            controlId={rest.controlId}
-            value={filteringText}
-            disabled={disabled}
-            {...autosuggestOptions}
-            onChange={event => setFilteringText(event.detail.value)}
-            empty={filteringEmpty}
-            {...asyncAutosuggestProps}
-            expandToViewport={expandToViewport}
-            onOptionClick={handleSelected}
-            customForm={
-              operatorForm && (
-                <PropertyEditor
-                  property={parsedText.property}
-                  operator={parsedText.operator}
-                  filter={parsedText.value}
-                  operatorForm={operatorForm}
-                  i18nStrings={i18nStrings}
-                  onCancel={() => {
-                    setFilteringText('');
-                    inputRef.current?.close();
-                    inputRef.current?.focus({ preventDropdown: true });
-                  }}
-                  onSubmit={token => {
-                    addToken(token);
-                    setFilteringText('');
-                    inputRef.current?.focus({ preventDropdown: true });
-                    inputRef.current?.close();
-                  }}
-                />
-              )
-            }
-            hideEnteredTextOption={internalFreeText.disabled && parsedText.step !== 'property'}
-            clearAriaLabel={i18nStrings.clearAriaLabel}
-            searchResultsId={showResults ? searchResultsId : undefined}
-          />
-          {showResults ? (
-            <div className={styles.results}>
-              <SearchResults id={searchResultsId}>{countText}</SearchResults>
-            </div>
-          ) : null}
-        </div>
-        {filteringConstraintText && (
-          <div id={constraintTextId} className={styles.constraint}>
-            {filteringConstraintText}
-          </div>
-        )}
-        {internalQuery.tokens && internalQuery.tokens.length > 0 && (
-          <div className={styles.tokens}>
-            <InternalSpaceBetween size="xs" direction="horizontal">
-              <TokenList
-                alignment="inline"
-                limit={tokenLimit}
-                items={internalQuery.tokens}
-                limitShowFewerAriaLabel={tokenLimitShowFewerAriaLabel}
-                limitShowMoreAriaLabel={tokenLimitShowMoreAriaLabel}
-                renderItem={(token, tokenIndex) => (
-                  <TokenButton
-                    token={token}
-                    first={tokenIndex === 0}
-                    operation={internalQuery.operation}
-                    removeToken={() => {
-                      removeToken(tokenIndex);
-                      setRemovedTokenIndex(tokenIndex);
-                    }}
-                    setToken={(newToken: Token) => setToken(tokenIndex, newToken)}
-                    setOperation={setOperation}
-                    filteringProperties={internalProperties}
-                    filteringOptions={internalOptions}
-                    asyncProps={asyncProps}
-                    onLoadItems={onLoadItems}
-                    i18nStrings={i18nStrings}
-                    asyncProperties={asyncProperties}
-                    hideOperations={hideOperations}
-                    customGroupsText={customGroupsText}
-                    freeTextFiltering={internalFreeText}
-                    disabled={disabled}
-                    expandToViewport={expandToViewport}
-                  />
-                )}
-                i18nStrings={{
-                  limitShowFewer: i18nStrings.tokenLimitShowFewer,
-                  limitShowMore: i18nStrings.tokenLimitShowMore,
-                }}
-                after={
-                  customFilterActions ? (
-                    <div className={styles['custom-filter-actions']}>{customFilterActions}</div>
-                  ) : (
-                    <InternalButton
-                      formAction="none"
-                      onClick={removeAllTokens}
-                      className={styles['remove-all']}
-                      disabled={disabled}
-                    >
-                      {i18nStrings.clearFiltersText}
-                    </InternalButton>
-                  )
-                }
-                moveFocusNextToIndex={removedTokenIndex}
-              />
-            </InternalSpaceBetween>
-          </div>
-        )}
-      </div>
+      <PropertyFilterInternal
+        ref={ref}
+        {...baseComponentProps}
+        filteringOptions={filteringOptions}
+        customGroupsText={customGroupsText}
+        disableFreeTextFiltering={disableFreeTextFiltering}
+        asyncProperties={asyncProperties}
+        expandToViewport={expandToViewport}
+        hideOperations={hideOperations}
+        tokenLimit={tokenLimit}
+        virtualScroll={virtualScroll}
+        {...rest}
+      />
     );
   }
 );

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -23,6 +23,7 @@ import {
   ComparisonOperator,
   ExtendedOperator,
   FilteringProperty,
+  FormattedToken,
   InternalFilteringOption,
   InternalFilteringProperty,
   InternalFreeTextFiltering,
@@ -40,12 +41,22 @@ import { matchTokenValue } from './utils';
 
 import styles from './styles.css.js';
 
-type PropertyFilterInternalProps = SomeRequired<
+export interface I18nStringsExt {
+  tokenEditorTokenActionsLabel?: (token: FormattedToken) => string;
+  tokenEditorTokenRemoveLabel?: (token: FormattedToken) => string;
+  tokenEditorTokenRemoveFromGroupLabel?: (token: FormattedToken) => string;
+  tokenEditorAddNewTokenLabel?: string;
+  tokenEditorAddTokenActionsLabel?: string;
+  tokenEditorAddExistingTokenLabel?: (token: FormattedToken) => string;
+}
+
+export type PropertyFilterInternalProps = SomeRequired<
   PropertyFilterProps,
   'filteringOptions' | 'customGroupsText' | 'disableFreeTextFiltering'
 > &
   InternalBaseComponentProps & {
     enableTokenGroups?: boolean;
+    i18nStringsExt?: I18nStringsExt;
   };
 
 const PropertyFilterInternal = React.forwardRef(
@@ -79,6 +90,8 @@ const PropertyFilterInternal = React.forwardRef(
       expandToViewport,
       tokenLimitShowFewerAriaLabel,
       tokenLimitShowMoreAriaLabel,
+      enableTokenGroups = false,
+      i18nStringsExt = {},
       __internalRootRef,
       ...rest
     }: PropertyFilterInternalProps,
@@ -90,7 +103,7 @@ const PropertyFilterInternal = React.forwardRef(
     const baseProps = getBaseProps(rest);
 
     const i18n = useInternalI18n('property-filter');
-    const i18nStrings: PropertyFilterProps.I18nStrings = {
+    const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
       ...rest.i18nStrings,
       allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings?.allPropertiesLabel),
       applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings?.applyActionText),
@@ -129,6 +142,7 @@ const PropertyFilterInternal = React.forwardRef(
       tokenLimitShowFewer: i18n('i18nStrings.tokenLimitShowFewer', rest.i18nStrings?.tokenLimitShowFewer),
       tokenLimitShowMore: i18n('i18nStrings.tokenLimitShowMore', rest.i18nStrings?.tokenLimitShowMore),
       valueText: i18n('i18nStrings.valueText', rest.i18nStrings?.valueText),
+      ...i18nStringsExt,
     };
 
     useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
@@ -408,6 +422,7 @@ const PropertyFilterInternal = React.forwardRef(
                     freeTextFiltering={internalFreeText}
                     disabled={disabled}
                     expandToViewport={expandToViewport}
+                    enableTokenGroups={enableTokenGroups}
                   />
                 )}
                 i18nStrings={{

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -1,0 +1,441 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { useImperativeHandle, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+import { PropertyFilterOperator } from '@cloudscape-design/collection-hooks';
+
+import { InternalButton } from '../button/internal';
+import { useInternalI18n } from '../i18n/context';
+import { getBaseProps } from '../internal/base-component';
+import { AutosuggestInputRef } from '../internal/components/autosuggest-input';
+import TokenList from '../internal/components/token-list';
+import { fireNonCancelableEvent } from '../internal/events';
+import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { useUniqueId } from '../internal/hooks/use-unique-id/index';
+import { SomeRequired } from '../internal/types';
+import { joinStrings } from '../internal/utils/strings';
+import InternalSpaceBetween from '../space-between/internal';
+import { SearchResults } from '../text-filter/search-results';
+import { getAllowedOperators, getAutosuggestOptions, getQueryActions, parseText } from './controller';
+import { getI18nToken } from './i18n-utils';
+import {
+  ComparisonOperator,
+  ExtendedOperator,
+  FilteringProperty,
+  InternalFilteringOption,
+  InternalFilteringProperty,
+  InternalFreeTextFiltering,
+  InternalQuery,
+  ParsedText,
+  PropertyFilterProps,
+  Ref,
+  Token,
+} from './interfaces';
+import { PropertyEditor } from './property-editor';
+import PropertyFilterAutosuggest, { PropertyFilterAutosuggestProps } from './property-filter-autosuggest';
+import { TokenButton } from './token';
+import { useLoadItems } from './use-load-items';
+import { matchTokenValue } from './utils';
+
+import styles from './styles.css.js';
+
+type PropertyFilterInternalProps = SomeRequired<
+  PropertyFilterProps,
+  'filteringOptions' | 'customGroupsText' | 'disableFreeTextFiltering'
+> &
+  InternalBaseComponentProps & {
+    enableTokenGroups?: boolean;
+  };
+
+const PropertyFilterInternal = React.forwardRef(
+  (
+    {
+      disabled,
+      countText,
+      query,
+      hideOperations,
+      onChange,
+      filteringProperties,
+      filteringOptions,
+      customGroupsText,
+      disableFreeTextFiltering,
+      freeTextFiltering,
+      onLoadItems,
+      virtualScroll,
+      customControl,
+      customFilterActions,
+      filteringPlaceholder,
+      filteringAriaLabel,
+      filteringEmpty,
+      filteringLoadingText,
+      filteringFinishedText,
+      filteringErrorText,
+      filteringRecoveryText,
+      filteringConstraintText,
+      filteringStatusType,
+      asyncProperties,
+      tokenLimit,
+      expandToViewport,
+      tokenLimitShowFewerAriaLabel,
+      tokenLimitShowMoreAriaLabel,
+      __internalRootRef,
+      ...rest
+    }: PropertyFilterInternalProps,
+    ref: React.Ref<Ref>
+  ) => {
+    const [removedTokenIndex, setRemovedTokenIndex] = useState<null | number>(null);
+
+    const inputRef = useRef<AutosuggestInputRef>(null);
+    const baseProps = getBaseProps(rest);
+
+    const i18n = useInternalI18n('property-filter');
+    const i18nStrings: PropertyFilterProps.I18nStrings = {
+      ...rest.i18nStrings,
+      allPropertiesLabel: i18n('i18nStrings.allPropertiesLabel', rest.i18nStrings?.allPropertiesLabel),
+      applyActionText: i18n('i18nStrings.applyActionText', rest.i18nStrings?.applyActionText),
+      cancelActionText: i18n('i18nStrings.cancelActionText', rest.i18nStrings?.cancelActionText),
+      clearFiltersText: i18n('i18nStrings.clearFiltersText', rest.i18nStrings?.clearFiltersText),
+      editTokenHeader: i18n('i18nStrings.editTokenHeader', rest.i18nStrings?.editTokenHeader),
+      groupPropertiesText: i18n('i18nStrings.groupPropertiesText', rest.i18nStrings?.groupPropertiesText),
+      groupValuesText: i18n('i18nStrings.groupValuesText', rest.i18nStrings?.groupValuesText),
+      operationAndText: i18n('i18nStrings.operationAndText', rest.i18nStrings?.operationAndText),
+      operationOrText: i18n('i18nStrings.operationOrText', rest.i18nStrings?.operationOrText),
+      operatorContainsText: i18n('i18nStrings.operatorContainsText', rest.i18nStrings?.operatorContainsText),
+      operatorDoesNotContainText: i18n(
+        'i18nStrings.operatorDoesNotContainText',
+        rest.i18nStrings?.operatorDoesNotContainText
+      ),
+      operatorDoesNotEqualText: i18n(
+        'i18nStrings.operatorDoesNotEqualText',
+        rest.i18nStrings?.operatorDoesNotEqualText
+      ),
+      operatorEqualsText: i18n('i18nStrings.operatorEqualsText', rest.i18nStrings?.operatorEqualsText),
+      operatorGreaterOrEqualText: i18n(
+        'i18nStrings.operatorGreaterOrEqualText',
+        rest.i18nStrings?.operatorGreaterOrEqualText
+      ),
+      operatorGreaterText: i18n('i18nStrings.operatorGreaterText', rest.i18nStrings?.operatorGreaterText),
+      operatorLessOrEqualText: i18n('i18nStrings.operatorLessOrEqualText', rest.i18nStrings?.operatorLessOrEqualText),
+      operatorLessText: i18n('i18nStrings.operatorLessText', rest.i18nStrings?.operatorLessText),
+      operatorStartsWithText: i18n('i18nStrings.operatorStartsWithText', rest.i18nStrings?.operatorStartsWithText),
+      operatorDoesNotStartWithText: i18n(
+        'i18nStrings.operatorDoesNotStartWithText',
+        rest.i18nStrings?.operatorDoesNotStartWithText
+      ),
+      operatorText: i18n('i18nStrings.operatorText', rest.i18nStrings?.operatorText),
+      operatorsText: i18n('i18nStrings.operatorsText', rest.i18nStrings?.operatorsText),
+      propertyText: i18n('i18nStrings.propertyText', rest.i18nStrings?.propertyText),
+      tokenLimitShowFewer: i18n('i18nStrings.tokenLimitShowFewer', rest.i18nStrings?.tokenLimitShowFewer),
+      tokenLimitShowMore: i18n('i18nStrings.tokenLimitShowMore', rest.i18nStrings?.tokenLimitShowMore),
+      valueText: i18n('i18nStrings.valueText', rest.i18nStrings?.valueText),
+    };
+
+    useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
+    const showResults = !!query.tokens?.length && !disabled && !!countText;
+    const { addToken, removeToken, setToken, setOperation, removeAllTokens } = getQueryActions(
+      query,
+      onChange,
+      inputRef
+    );
+    const [filteringText, setFilteringText] = useState<string>('');
+
+    const { internalProperties, internalOptions, internalQuery, internalFreeText } = (() => {
+      const propertyByKey = filteringProperties.reduce((acc, property) => {
+        const extendedOperators = (property?.operators ?? []).reduce(
+          (acc, operator) => (typeof operator === 'object' ? acc.set(operator.operator, operator) : acc),
+          new Map<PropertyFilterOperator, null | ExtendedOperator<any>>()
+        );
+        acc.set(property.key, {
+          propertyKey: property.key,
+          propertyLabel: property?.propertyLabel ?? '',
+          groupValuesLabel: property?.groupValuesLabel ?? '',
+          propertyGroup: property?.group,
+          operators: (property?.operators ?? []).map(op => (typeof op === 'string' ? op : op.operator)),
+          defaultOperator: property?.defaultOperator ?? '=',
+          getValueFormatter: operator => (operator ? extendedOperators.get(operator)?.format ?? null : null),
+          getValueFormRenderer: operator => (operator ? extendedOperators.get(operator)?.form ?? null : null),
+          externalProperty: property,
+        });
+        return acc;
+      }, new Map<string, InternalFilteringProperty>());
+      const getProperty = (propertyKey: string): null | InternalFilteringProperty =>
+        propertyByKey.get(propertyKey) ?? null;
+
+      const internalOptions: readonly InternalFilteringOption[] = filteringOptions.map(option => ({
+        property: getProperty(option.propertyKey),
+        value: option.value,
+        label: option.label ?? option.value ?? '',
+      }));
+
+      const internalQuery: InternalQuery = {
+        operation: query.operation,
+        tokens: query.tokens.map(token => ({
+          property: token.propertyKey ? getProperty(token.propertyKey) : null,
+          operator: token.operator,
+          value: token.value,
+          __source: token,
+        })),
+      };
+
+      const internalFreeText: InternalFreeTextFiltering = {
+        disabled: disableFreeTextFiltering,
+        operators: freeTextFiltering?.operators ?? [':', '!:'],
+        defaultOperator: freeTextFiltering?.defaultOperator ?? ':',
+      };
+
+      return { internalProperties: [...propertyByKey.values()], internalOptions, internalQuery, internalFreeText };
+    })();
+
+    i18nStrings.removeTokenButtonAriaLabel = i18n(
+      'i18nStrings.removeTokenButtonAriaLabel',
+      rest.i18nStrings?.removeTokenButtonAriaLabel,
+      format => token => format(getI18nToken(token))
+    );
+
+    const parsedText = parseText(filteringText, internalProperties, internalFreeText);
+    const autosuggestOptions = getAutosuggestOptions(
+      parsedText,
+      internalProperties,
+      internalOptions,
+      customGroupsText,
+      i18nStrings
+    );
+
+    const createToken = (currentText: string) => {
+      const parsedText = parseText(currentText, internalProperties, internalFreeText);
+      let newToken: Token;
+      switch (parsedText.step) {
+        case 'property': {
+          newToken = matchTokenValue(
+            {
+              property: parsedText.property,
+              operator: parsedText.operator,
+              value: parsedText.value,
+            },
+            internalOptions
+          );
+          break;
+        }
+        case 'free-text': {
+          newToken = {
+            operator: parsedText.operator || internalFreeText.defaultOperator,
+            value: parsedText.value,
+          };
+          break;
+        }
+        case 'operator': {
+          newToken = {
+            operator: internalFreeText.defaultOperator,
+            value: currentText,
+          };
+          break;
+        }
+      }
+      if (internalFreeText.disabled && !('propertyKey' in newToken)) {
+        return;
+      }
+      addToken(newToken);
+      setFilteringText('');
+    };
+    const getLoadMoreDetail = (parsedText: ParsedText, filteringText: string) => {
+      const loadMoreDetail: {
+        filteringProperty: FilteringProperty | undefined;
+        filteringText: string;
+        filteringOperator: ComparisonOperator | undefined;
+      } = {
+        filteringProperty: undefined,
+        filteringText,
+        filteringOperator: undefined,
+      };
+      if (parsedText.step === 'property') {
+        loadMoreDetail.filteringProperty = parsedText.property.externalProperty;
+        loadMoreDetail.filteringText = parsedText.value;
+        loadMoreDetail.filteringOperator = parsedText.operator;
+      }
+      return loadMoreDetail;
+    };
+    const loadMoreDetail = getLoadMoreDetail(parsedText, filteringText);
+    const inputLoadItemsHandlers = useLoadItems(
+      onLoadItems,
+      loadMoreDetail.filteringText,
+      loadMoreDetail.filteringProperty,
+      loadMoreDetail.filteringText,
+      loadMoreDetail.filteringOperator
+    );
+    const asyncProps = {
+      empty: filteringEmpty,
+      loadingText: filteringLoadingText,
+      finishedText: filteringFinishedText,
+      errorText: filteringErrorText,
+      recoveryText: filteringRecoveryText,
+      statusType: filteringStatusType,
+    };
+    const asyncAutosuggestProps =
+      !!filteringText.length || asyncProperties
+        ? {
+            ...inputLoadItemsHandlers,
+            ...asyncProps,
+          }
+        : {};
+    const handleSelected: PropertyFilterAutosuggestProps['onOptionClick'] = event => {
+      const { detail: option } = event;
+      const value = option.value || '';
+      if (!value) {
+        return;
+      }
+
+      if (!('keepOpenOnSelect' in option)) {
+        createToken(value);
+        return;
+      }
+
+      // stop dropdown from closing
+      event.preventDefault();
+
+      const parsedText = parseText(value, internalProperties, internalFreeText);
+      const loadMoreDetail = getLoadMoreDetail(parsedText, value);
+
+      // Insert operator automatically if only one operator is defined for the given property.
+      if (parsedText.step === 'operator') {
+        const operators = getAllowedOperators(parsedText.property);
+        if (value.trim() === parsedText.property.propertyLabel && operators.length === 1) {
+          loadMoreDetail.filteringProperty = parsedText.property.externalProperty ?? undefined;
+          loadMoreDetail.filteringOperator = operators[0];
+          loadMoreDetail.filteringText = '';
+          setFilteringText(parsedText.property.propertyLabel + ' ' + operators[0] + ' ');
+        }
+      }
+
+      fireNonCancelableEvent(onLoadItems, { ...loadMoreDetail, firstPage: true, samePage: false });
+    };
+
+    const operatorForm =
+      parsedText.step === 'property' && parsedText.property.getValueFormRenderer(parsedText.operator);
+
+    const searchResultsId = useUniqueId('property-filter-search-results');
+    const constraintTextId = useUniqueId('property-filter-constraint');
+    const textboxAriaDescribedBy = filteringConstraintText
+      ? joinStrings(rest.ariaDescribedby, constraintTextId)
+      : rest.ariaDescribedby;
+
+    return (
+      <div {...baseProps} className={clsx(baseProps.className, styles.root)} ref={__internalRootRef}>
+        <div className={styles['search-field']}>
+          {customControl && <div className={styles['custom-control']}>{customControl}</div>}
+          <PropertyFilterAutosuggest
+            ref={inputRef}
+            virtualScroll={virtualScroll}
+            enteredTextLabel={i18nStrings.enteredTextLabel}
+            ariaLabel={filteringAriaLabel ?? i18nStrings.filteringAriaLabel}
+            placeholder={filteringPlaceholder ?? i18nStrings.filteringPlaceholder}
+            ariaLabelledby={rest.ariaLabelledby}
+            ariaDescribedby={textboxAriaDescribedBy}
+            controlId={rest.controlId}
+            value={filteringText}
+            disabled={disabled}
+            {...autosuggestOptions}
+            onChange={event => setFilteringText(event.detail.value)}
+            empty={filteringEmpty}
+            {...asyncAutosuggestProps}
+            expandToViewport={expandToViewport}
+            onOptionClick={handleSelected}
+            customForm={
+              operatorForm && (
+                <PropertyEditor
+                  property={parsedText.property}
+                  operator={parsedText.operator}
+                  filter={parsedText.value}
+                  operatorForm={operatorForm}
+                  i18nStrings={i18nStrings}
+                  onCancel={() => {
+                    setFilteringText('');
+                    inputRef.current?.close();
+                    inputRef.current?.focus({ preventDropdown: true });
+                  }}
+                  onSubmit={token => {
+                    addToken(token);
+                    setFilteringText('');
+                    inputRef.current?.focus({ preventDropdown: true });
+                    inputRef.current?.close();
+                  }}
+                />
+              )
+            }
+            hideEnteredTextOption={internalFreeText.disabled && parsedText.step !== 'property'}
+            clearAriaLabel={i18nStrings.clearAriaLabel}
+            searchResultsId={showResults ? searchResultsId : undefined}
+          />
+          {showResults ? (
+            <div className={styles.results}>
+              <SearchResults id={searchResultsId}>{countText}</SearchResults>
+            </div>
+          ) : null}
+        </div>
+        {filteringConstraintText && (
+          <div id={constraintTextId} className={styles.constraint}>
+            {filteringConstraintText}
+          </div>
+        )}
+        {internalQuery.tokens && internalQuery.tokens.length > 0 && (
+          <div className={styles.tokens}>
+            <InternalSpaceBetween size="xs" direction="horizontal">
+              <TokenList
+                alignment="inline"
+                limit={tokenLimit}
+                items={internalQuery.tokens}
+                limitShowFewerAriaLabel={tokenLimitShowFewerAriaLabel}
+                limitShowMoreAriaLabel={tokenLimitShowMoreAriaLabel}
+                renderItem={(token, tokenIndex) => (
+                  <TokenButton
+                    token={token}
+                    first={tokenIndex === 0}
+                    operation={internalQuery.operation}
+                    removeToken={() => {
+                      removeToken(tokenIndex);
+                      setRemovedTokenIndex(tokenIndex);
+                    }}
+                    setToken={(newToken: Token) => setToken(tokenIndex, newToken)}
+                    setOperation={setOperation}
+                    filteringProperties={internalProperties}
+                    filteringOptions={internalOptions}
+                    asyncProps={asyncProps}
+                    onLoadItems={onLoadItems}
+                    i18nStrings={i18nStrings}
+                    asyncProperties={asyncProperties}
+                    hideOperations={hideOperations}
+                    customGroupsText={customGroupsText}
+                    freeTextFiltering={internalFreeText}
+                    disabled={disabled}
+                    expandToViewport={expandToViewport}
+                  />
+                )}
+                i18nStrings={{
+                  limitShowFewer: i18nStrings.tokenLimitShowFewer,
+                  limitShowMore: i18nStrings.tokenLimitShowMore,
+                }}
+                after={
+                  customFilterActions ? (
+                    <div className={styles['custom-filter-actions']}>{customFilterActions}</div>
+                  ) : (
+                    <InternalButton
+                      formAction="none"
+                      onClick={removeAllTokens}
+                      className={styles['remove-all']}
+                      disabled={disabled}
+                    >
+                      {i18nStrings.clearFiltersText}
+                    </InternalButton>
+                  )
+                }
+                moveFocusNextToIndex={removedTokenIndex}
+              />
+            </InternalSpaceBetween>
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+export default PropertyFilterInternal;

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -128,14 +128,14 @@ $operator-field-width: 120px;
 
     display: grid;
     gap: awsui.$space-s;
-    grid-template-columns: minmax(100px, 2fr) minmax(100px, $operator-field-width) minmax(100px, 3fr) min-content;
+    grid-template-columns: minmax(min-content, 2fr) minmax(min-content, $operator-field-width) minmax(min-content, 3fr) min-content;
 
     &-group {
       display: contents;
     }
 
     &.token-editor-narrow {
-      grid-template-columns: minmax(100px, 1fr);
+      grid-template-columns: minmax(min-content, 1fr);
       gap: awsui.$space-m;
 
       > .token-editor-group {

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -135,7 +135,7 @@ $operator-field-width: 120px;
     }
 
     &.token-editor-narrow {
-      grid-template-columns: minmax(min-content, 1fr);
+      grid-template-columns: minmax(100px, 1fr);
       gap: awsui.$space-m;
 
       > .token-editor-group {

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -11,7 +11,7 @@ import InternalFormField from '../form-field/internal.js';
 import { DropdownStatusProps } from '../internal/components/dropdown-status/interfaces.js';
 import { FormFieldContext } from '../internal/context/form-field-context.js';
 import { NonCancelableEventHandler } from '../internal/events/index.js';
-import { useContainerBreakpoints } from '../internal/hooks/container-queries/index.js';
+import { useMobile } from '../internal/hooks/use-mobile/index.js';
 import { useUniqueId } from '../internal/hooks/use-unique-id/index.js';
 import { getAllowedOperators } from './controller.js';
 import { getFormattedToken } from './i18n-utils.js';
@@ -224,8 +224,8 @@ function TokenEditorFields({
   renderValue,
   i18nStrings,
 }: TokenEditorLayout) {
-  const [breakpoint, breakpointRef] = useContainerBreakpoints(['xs']);
-  const isNarrow = breakpoint === 'default' || !supportsGroups;
+  const isMobile = useMobile();
+  const isNarrow = isMobile || !supportsGroups;
 
   const propertyLabelId = useUniqueId();
   const operatorLabelId = useUniqueId();
@@ -252,7 +252,6 @@ function TokenEditorFields({
         isNarrow && styles['token-editor-narrow'],
         styles['token-editor-form']
       )}
-      ref={breakpointRef}
       onSubmit={event => {
         event.preventDefault();
         onSubmit();

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -26,19 +26,11 @@ import {
   InternalToken,
   LoadItemsDetail,
 } from './interfaces.js';
+import { I18nStringsExt } from './internal.js';
 import { OperatorInput, PropertyInput, ValueInput } from './token-editor-inputs.js';
 
 import styles from './styles.css.js';
 import testUtilStyles from './test-classes/styles.css.js';
-
-interface I18nStringsExt {
-  tokenEditorTokenActionsLabel: (token: FormattedToken) => string;
-  tokenEditorTokenRemoveLabel: (token: FormattedToken) => string;
-  tokenEditorTokenRemoveFromGroupLabel: (token: FormattedToken) => string;
-  tokenEditorAddNewTokenLabel: string;
-  tokenEditorAddTokenActionsLabel: string;
-  tokenEditorAddExistingTokenLabel: (token: FormattedToken) => string;
-}
 
 export interface TokenEditorProps {
   supportsGroups: boolean;
@@ -168,7 +160,7 @@ export function TokenEditor({
             ariaLabel={i18nStrings.tokenEditorAddTokenActionsLabel}
             items={standaloneTokens.map((token, index) => ({
               id: index.toString(),
-              text: i18nStrings.tokenEditorAddExistingTokenLabel(getFormattedToken(token, i18nStrings)),
+              text: i18nStrings.tokenEditorAddExistingTokenLabel?.(getFormattedToken(token, i18nStrings)) ?? '',
             }))}
             onItemClick={({ detail }) => {
               const index = parseInt(detail.id);
@@ -181,7 +173,7 @@ export function TokenEditor({
             }}
             disabled={standaloneTokens.length === 0}
             mainAction={{
-              text: i18nStrings.tokenEditorAddNewTokenLabel,
+              text: i18nStrings?.tokenEditorAddNewTokenLabel ?? '',
               onClick: () => onChangeTempGroup([...tempGroup, { property: null, operator: ':', value: null }]),
             }}
           />
@@ -316,11 +308,11 @@ function TokenEditorFields({
               <div className={styles['token-editor-remove-token']}>
                 <TokenEditorRemoveActions
                   isNarrow={isNarrow}
-                  ariaLabel={i18nStrings.tokenEditorTokenActionsLabel(token)}
+                  ariaLabel={i18nStrings.tokenEditorTokenActionsLabel?.(token) ?? ''}
                   disabled={tokens.length === 1}
                   items={[
-                    { id: 'remove', text: i18nStrings.tokenEditorTokenRemoveLabel(token) },
-                    { id: 'remove-from-group', text: i18nStrings.tokenEditorTokenRemoveFromGroupLabel(token) },
+                    { id: 'remove', text: i18nStrings.tokenEditorTokenRemoveLabel?.(token) ?? '' },
+                    { id: 'remove-from-group', text: i18nStrings.tokenEditorTokenRemoveFromGroupLabel?.(token) ?? '' },
                   ]}
                   onItemClick={itemId => {
                     switch (itemId) {

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -42,10 +42,10 @@ interface TokenProps {
   setOperation: (newOperation: JoinOperation) => void;
   setToken: (newToken: Token) => void;
   token: InternalToken;
+  enableTokenGroups: boolean;
 }
 
 const emptyHandler = () => {};
-const emptyLabel = () => '';
 
 export const TokenButton = ({
   token,
@@ -65,6 +65,7 @@ export const TokenButton = ({
   disabled,
   freeTextFiltering,
   expandToViewport,
+  enableTokenGroups,
 }: TokenProps) => {
   const tokenRef = useRef<FilteringTokenRef>(null);
   const formattedToken = getFormattedToken(token, i18nStrings);
@@ -93,7 +94,7 @@ export const TokenButton = ({
       disabled={disabled}
       editorContent={
         <TokenEditor
-          supportsGroups={false}
+          supportsGroups={enableTokenGroups}
           filteringProperties={filteringProperties}
           filteringOptions={filteringOptions}
           tempGroup={[temporaryToken]}
@@ -104,16 +105,7 @@ export const TokenButton = ({
           onChangeStandalone={emptyHandler}
           asyncProps={asyncProps}
           onLoadItems={onLoadItems}
-          i18nStrings={{
-            ...i18nStrings,
-            // These properties will be needed when supportsGroups={true}
-            tokenEditorTokenActionsLabel: emptyLabel,
-            tokenEditorTokenRemoveLabel: emptyLabel,
-            tokenEditorTokenRemoveFromGroupLabel: emptyLabel,
-            tokenEditorAddNewTokenLabel: '',
-            tokenEditorAddTokenActionsLabel: '',
-            tokenEditorAddExistingTokenLabel: emptyLabel,
-          }}
+          i18nStrings={i18nStrings}
           asyncProperties={asyncProperties}
           customGroupsText={customGroupsText}
           freeTextFiltering={freeTextFiltering}

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -127,6 +127,7 @@ export const TokenButton = ({
       groupEditAriaLabel={''}
       onChangeGroupOperation={() => {}}
       hasGroups={false}
+      popoverSize={enableTokenGroups ? 'content' : 'large'}
     />
   );
 };


### PR DESCRIPTION
### Description

Pass internal token editor props via property filter internal to feature the new editor in the editor test page.

Added a change to popover internal to allow no size setting: that is something we implicitly support as passing a size not matching small, medium or large does the same.

### How has this been tested?

* New test page asset
* Existing token editor permutations
* Existing unit- and integration tests
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
