### PR TITLE
fix: Fix split panel offset issue (vr-toolbar flag only)

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -69,239 +69,272 @@ class AppLayoutSplitViewPage extends BasePageObject {
     return parseFloat(attrValue);
   }
 
-  getContentMarginBottom() {
-    return this.browser.execute(contentRegion => {
-      return document.querySelector(contentRegion)?.parentElement?.parentElement?.style.marginBottom;
-    }, wrapper.findContentRegion().toSelector());
+  getContentOffsetBottom(theme: string) {
+    const contentSelector = wrapper.findContentRegion().toSelector();
+    switch (theme) {
+      case 'classic':
+        return this.browser.execute(contentSelector => {
+          return getComputedStyle(document.querySelector(contentSelector)!.parentElement!.parentElement!).marginBottom;
+        }, contentSelector);
+      case 'visual-refresh':
+        return this.browser.execute(contentSelector => {
+          return getComputedStyle(document.querySelector(contentSelector)!).paddingBottom;
+        }, contentSelector);
+      case 'visual-refresh-toolbar':
+        return this.browser.execute(contentSelector => {
+          return getComputedStyle(document.querySelector(contentSelector)!.parentElement!).paddingBottom;
+        }, contentSelector);
+    }
   }
 }
 
-function setupTest(
-  testFn: (page: AppLayoutSplitViewPage) => Promise<void>,
-  url = '#/light/app-layout/with-split-panel'
-) {
-  return useBrowser(async browser => {
-    const page = new AppLayoutSplitViewPage(browser);
-    await page.setWindowSize(viewports.desktop);
-    await browser.url(`${url}?visualRefresh=false`);
-    await page.waitForVisible(wrapper.findContentRegion().toSelector());
-    await testFn(page);
-  });
-}
+describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+  function setupTest(
+    testFn: (page: AppLayoutSplitViewPage) => Promise<void>,
+    url = '#/light/app-layout/with-split-panel'
+  ) {
+    return useBrowser(async browser => {
+      const page = new AppLayoutSplitViewPage(browser);
+      await page.setWindowSize(viewports.desktop);
+      const params = new URLSearchParams({
+        visualRefresh: `${theme.startsWith('visual-refresh')}`,
+        appLayoutToolbar: `${theme === 'visual-refresh-toolbar'}`,
+      });
+      await browser.url(`${url}?${params.toString()}`);
+      await page.waitForVisible(wrapper.findContentRegion().toSelector());
+      await testFn(page);
+    });
+  }
 
-test(
-  'slider is accessible by keyboard in side position',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('side');
-    await page.keys(['Shift', 'Tab', 'Shift']);
-    await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-
-    const { width: initialWidth } = await page.getSplitPanelSize();
-    const initialSliderValue = await page.getSplitPanelSliderValue();
-
-    await page.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
-
-    const expectedWidth = initialWidth + 30;
-    expect((await page.getSplitPanelSize()).width).toEqual(expectedWidth);
-    expect(await page.getSplitPanelSliderValue()).toBeLessThan(initialSliderValue);
-  })
-);
-
-test(
-  'slider is accessible by keyboard in bottom position',
-  setupTest(async page => {
-    await page.openPanel();
-    await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-
-    const { height } = await page.getSplitPanelSize();
-    const initialSliderValue = await page.getSplitPanelSliderValue();
-
-    await page.keys(['ArrowUp', 'ArrowUp', 'ArrowUp']);
-
-    const expectedHeight = height + 30;
-    expect((await page.getSplitPanelSize()).height).toEqual(expectedHeight);
-    expect(await page.getSplitPanelSliderValue()).toBeGreaterThan(initialSliderValue);
-  })
-);
-
-test.each([
-  { position: 'side', repeatKey: 'ArrowLeft', expectedValue: 0 },
-  { position: 'side', repeatKey: 'ArrowRight', expectedValue: 100 },
-  { position: 'bottom', repeatKey: 'ArrowLeft', expectedValue: 0 },
-  { position: 'bottom', repeatKey: 'ArrowRight', expectedValue: 100 },
-])(
-  'allows split panel slider in $position position to be adjusted to $expectedValue',
-  ({ position, repeatKey, expectedValue }) =>
-    setupTest(async page => {
-      await page.openPanel();
-      if (position === 'side') {
-        await page.switchPosition('side');
-        await page.keys(['Shift', 'Tab', 'Shift']);
-      }
-      await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-      // send each keystroke as individual command to allow UI re-rendering between keys
-      for (const key of Array(30).fill(repeatKey)) {
-        await page.keys(key);
-      }
-      await expect(page.getSplitPanelSliderValue()).resolves.toBe(expectedValue);
-    })()
-);
-
-test(
-  'renders with initial side position',
-  useBrowser(async browser => {
-    const page = new AppLayoutSplitViewPage(browser);
-    await page.setWindowSize(viewports.desktop);
-    await browser.url(`#/light/app-layout/with-split-panel?visualRefresh=false&splitPanelPosition=side`);
-    await page.waitForVisible(wrapper.findContentRegion().toSelector());
-    await page.openPanel();
-    await expect(page.getPanelPosition()).resolves.toEqual('side');
-  })
-);
-test(
-  'switches to bottom position when screen resizes to mobile',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('side');
-    await expect(page.getPanelPosition()).resolves.toEqual('side');
-
-    await page.setWindowSize(viewports.mobile);
-    await expect(page.getPanelPosition()).resolves.toEqual('bottom');
-    await expect(page.getContentMarginBottom()).resolves.toEqual('160px');
-  })
-);
-test(
-  'switches to bottom position when screen is too narrow and restores back on resize',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('side');
-    await expect(page.getPanelPosition()).resolves.toEqual('side');
-
-    // narrow enough to force bottom position, but still not mobile
-    await page.setWindowSize({ ...viewports.desktop, width: 820 });
-    await expect(page.isExisting(`.${mobileStyles['mobile-bar']}`)).resolves.toBe(false);
-    await expect(page.getPanelPosition()).resolves.toEqual('bottom');
-
-    await page.setWindowSize(viewports.desktop);
-    await expect(page.getPanelPosition()).resolves.toEqual('side');
-  })
-);
-
-test(
-  'switches to bottom position when when tools panel opens and available space is too small',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('side');
-    await page.click(wrapper.findToolsToggle().toSelector());
-    await expect(page.getPanelPosition()).resolves.toEqual('bottom');
-
-    await page.click(wrapper.findToolsClose().toSelector());
-    await expect(page.getPanelPosition()).resolves.toEqual('side');
-  })
-);
-
-test(
-  `should have extended max height for constrained heights`,
-  setupTest(async page => {
-    // Simulating 200% zoom on medium screens (1366x768 / 2 ~= 680x360 ).
-    await page.setWindowSize({ width: 680, height: 360 });
-    await page.openPanel();
-    const { height } = await page.getWindowSize();
-    await page.dragResizerTo({ x: 0, y: height });
-    expect((await page.getSplitPanelSize()).height).toEqual(160);
-    await page.dragResizerTo({ x: 0, y: 0 });
-    expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
-  })
-);
-
-[
-  { url: '#/light/app-layout/disable-paddings-with-split-panel', name: 'paddings disabled' },
-  { url: '#/light/app-layout/with-split-panel', name: 'paddings enabled' },
-].forEach(({ url, name }) => {
   test(
-    `should not allow resize split panel beyond min and max limits (side position) (${name})`,
+    'slider is accessible by keyboard in side position',
     setupTest(async page => {
       await page.openPanel();
       await page.switchPosition('side');
-      const { width } = await page.getWindowSize();
-      await page.dragResizerTo({ x: width, y: 0 });
-      expect((await page.getSplitPanelSize()).width).toEqual(280);
+      await page.keys(['Shift', 'Tab', 'Shift']);
+      await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+
+      const { width: initialWidth } = await page.getSplitPanelSize();
+      const initialSliderValue = await page.getSplitPanelSliderValue();
+
+      await page.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+
+      const expectedWidth = initialWidth + 30;
+      expect((await page.getSplitPanelSize()).width).toEqual(expectedWidth);
+      expect(await page.getSplitPanelSliderValue()).toBeLessThan(initialSliderValue);
+    })
+  );
+
+  (theme === 'classic' ? test : test.skip)(
+    'slider is accessible by keyboard in bottom position',
+    setupTest(async page => {
+      await page.openPanel();
+      await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+
+      const { height } = await page.getSplitPanelSize();
+      const initialSliderValue = await page.getSplitPanelSliderValue();
+
+      await page.keys(['ArrowUp', 'ArrowUp', 'ArrowUp']);
+
+      const expectedHeight = height + 30;
+      expect((await page.getSplitPanelSize()).height).toEqual(expectedHeight);
+      expect(await page.getSplitPanelSliderValue()).toBeGreaterThan(initialSliderValue);
+    })
+  );
+
+  (theme === 'classic' ? test : test.skip).each([
+    { position: 'side', repeatKey: 'ArrowLeft', expectedValue: 0 },
+    { position: 'side', repeatKey: 'ArrowRight', expectedValue: 100 },
+    { position: 'bottom', repeatKey: 'ArrowLeft', expectedValue: 0 },
+    { position: 'bottom', repeatKey: 'ArrowRight', expectedValue: 100 },
+  ])(
+    'allows split panel slider in $position position to be adjusted to $expectedValue',
+    ({ position, repeatKey, expectedValue }) =>
+      setupTest(async page => {
+        await page.openPanel();
+        if (position === 'side') {
+          await page.switchPosition('side');
+          await page.keys(['Shift', 'Tab', 'Shift']);
+        }
+        await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+        // send each keystroke as individual command to allow UI re-rendering between keys
+        for (const key of Array(30).fill(repeatKey)) {
+          await page.keys(key);
+        }
+        await expect(page.getSplitPanelSliderValue()).resolves.toBe(expectedValue);
+      })()
+  );
+
+  test(
+    'renders with initial side position',
+    useBrowser(async browser => {
+      const page = new AppLayoutSplitViewPage(browser);
+      await page.setWindowSize(viewports.desktop);
+      await browser.url(`#/light/app-layout/with-split-panel?visualRefresh=false&splitPanelPosition=side`);
+      await page.waitForVisible(wrapper.findContentRegion().toSelector());
+      await page.openPanel();
+      await expect(page.getPanelPosition()).resolves.toEqual('side');
+    })
+  );
+  test(
+    'switches to bottom position when screen resizes to mobile',
+    setupTest(async page => {
+      await page.openPanel();
+      await page.switchPosition('side');
+      await expect(page.getPanelPosition()).resolves.toEqual('side');
+
+      await page.setWindowSize(viewports.mobile);
+      await expect(page.getPanelPosition()).resolves.toEqual('bottom');
+      // in VR design, split panel keeps same size as it was open on the side
+      const expectedBottomOffset = theme === 'visual-refresh' ? '440px' : '160px';
+      await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(expectedBottomOffset);
+    })
+  );
+  test(
+    'switches to bottom position when screen is too narrow and restores back on resize',
+    setupTest(async page => {
+      await page.openPanel();
+      await page.switchPosition('side');
+      await expect(page.getPanelPosition()).resolves.toEqual('side');
+
+      // narrow enough to force bottom position, but still not mobile
+      await page.setWindowSize({ ...viewports.desktop, width: 820 });
+      await expect(page.isExisting(`.${mobileStyles['mobile-bar']}`)).resolves.toBe(false);
+      await expect(page.getPanelPosition()).resolves.toEqual('bottom');
+
+      await page.setWindowSize(viewports.desktop);
+      await expect(page.getPanelPosition()).resolves.toEqual('side');
+    })
+  );
+
+  test(
+    'switches to bottom position when when tools panel opens and available space is too small',
+    setupTest(async page => {
+      await page.setWindowSize({ ...viewports.desktop, width: 1100 });
+      await page.openPanel();
+      await page.switchPosition('side');
+      await page.click(wrapper.findToolsToggle().toSelector());
+      await expect(page.getPanelPosition()).resolves.toEqual('bottom');
+
+      await page.click(wrapper.findToolsClose().toSelector());
+      await expect(page.getPanelPosition()).resolves.toEqual('side');
+    })
+  );
+
+  test(
+    `should have extended max height for constrained heights`,
+    setupTest(async page => {
+      // Simulating 200% zoom on medium screens (1366x768 / 2 ~= 680x360 ).
+      await page.setWindowSize({ width: 680, height: 360 });
+      await page.openPanel();
+      const { height } = await page.getWindowSize();
+      await page.dragResizerTo({ x: 0, y: height });
+      expect((await page.getSplitPanelSize()).height).toEqual(160);
+      await page.dragResizerTo({ x: 0, y: 0 });
+      expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
+    })
+  );
+
+  [
+    { url: '#/light/app-layout/disable-paddings-with-split-panel', name: 'paddings disabled' },
+    { url: '#/light/app-layout/with-split-panel', name: 'paddings enabled' },
+  ].forEach(({ url, name }) => {
+    test(
+      `should not allow resize split panel beyond min and max limits (side position) (${name})`,
+      setupTest(async page => {
+        await page.openPanel();
+        await page.switchPosition('side');
+        const { width } = await page.getWindowSize();
+        await page.dragResizerTo({ x: width, y: 0 });
+        expect((await page.getSplitPanelSize()).width).toEqual(280);
+
+        await page.dragResizerTo({ x: 0, y: 0 });
+        // different design allows for different split panel max width
+        const expectedWidth = {
+          classic: 520,
+          'visual-refresh': name === 'paddings enabled' ? 445 : 469,
+          'visual-refresh-toolbar': 592,
+        };
+        expect((await page.getSplitPanelSize()).width).toEqual(expectedWidth[theme]);
+      }, url)
+    );
+  });
+
+  test(
+    'should not allow resize split panel beyond min and max limits (bottom position)',
+    setupTest(async page => {
+      await page.openPanel();
+      const { height } = await page.getWindowSize();
+      const { height: headerHeight } = await page.getBoundingBox('#h');
+      await page.dragResizerTo({ x: 0, y: height });
+      expect((await page.getSplitPanelSize()).height).toEqual(160);
 
       await page.dragResizerTo({ x: 0, y: 0 });
-      expect((await page.getSplitPanelSize()).width).toEqual(520);
-    }, url)
+      expect((await page.getSplitPanelSize()).height).toEqual(height - headerHeight - 250);
+    })
   );
+
+  test(
+    'automatically shrinks split panel when screen resizes (bottom position)',
+    setupTest(async page => {
+      await page.openPanel();
+      const windowHeight = 400;
+      const { height: originalHeight } = await page.getSplitPanelSize();
+      await page.setWindowSize({ ...viewports.desktop, height: windowHeight });
+      const { height: newHeight } = await page.getSplitPanelSize();
+      expect(newHeight).toBeLessThan(originalHeight);
+      expect(newHeight).toBeLessThan(windowHeight);
+    })
+  );
+
+  test(
+    'respects min width when switching panel from bottom to side',
+    setupTest(async page => {
+      await page.openPanel();
+      await page.dragResizerTo({ x: 0, y: viewports.desktop.height });
+      const { height } = await page.getSplitPanelSize();
+      expect(height).toEqual(160);
+      await page.switchPosition('side');
+      const { width } = await page.getSplitPanelSize();
+      expect(width).toEqual(280);
+    })
+  );
+
+  test(
+    'should keep split panel position during drag',
+    setupTest(async page => {
+      await page.openPanel();
+      await page.switchPosition('side');
+      await page.dragResizerTo({ x: 0, y: 0 });
+      await page.setWindowSize({ ...viewports.desktop, width: 820 });
+      const { height } = await page.getWindowSize();
+      await page.dragResizerTo({ x: 0, y: height });
+      await expect(page.getPanelPosition()).resolves.toEqual('bottom');
+    })
+  );
+
+  describe('interaction with table sticky header', () => {
+    // bottom padding is included into the offset in VR but not in classic
+    const splitPanelOpenOffset = theme === 'visual-refresh' ? '440px' : '400px';
+    const splitPanelClosedOffset = theme === 'visual-refresh' ? '40px' : '0px';
+
+    test(
+      'should resize main content area when switching to side',
+      setupTest(async page => {
+        await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(splitPanelOpenOffset);
+        await page.switchPosition('side');
+        await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(splitPanelClosedOffset);
+      }, '#/light/app-layout/with-full-page-table-and-split-panel')
+    );
+
+    test(
+      'should resize main content area when switching to side then back to bottom',
+      setupTest(async page => {
+        await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(splitPanelOpenOffset);
+        await page.switchPosition('side');
+        await page.switchPosition('bottom');
+        await expect(page.getContentOffsetBottom(theme)).resolves.toEqual(splitPanelOpenOffset);
+      }, '#/light/app-layout/with-full-page-table-and-split-panel')
+    );
+  });
 });
-
-test(
-  'should not allow resize split panel beyond min and max limits (bottom position)',
-  setupTest(async page => {
-    await page.openPanel();
-    const { height } = await page.getWindowSize();
-    const { height: headerHeight } = await page.getBoundingBox('#h');
-    await page.dragResizerTo({ x: 0, y: height });
-    expect((await page.getSplitPanelSize()).height).toEqual(160);
-
-    await page.dragResizerTo({ x: 0, y: 0 });
-    expect((await page.getSplitPanelSize()).height).toEqual(height - headerHeight - 250);
-  })
-);
-
-test(
-  'automatically shrinks split panel when screen resizes (bottom position)',
-  setupTest(async page => {
-    await page.openPanel();
-    const windowHeight = 400;
-    const { height: originalHeight } = await page.getSplitPanelSize();
-    await page.setWindowSize({ ...viewports.desktop, height: windowHeight });
-    const { height: newHeight } = await page.getSplitPanelSize();
-    expect(newHeight).toBeLessThan(originalHeight);
-    expect(newHeight).toBeLessThan(windowHeight);
-  })
-);
-
-test(
-  'respects min width when switching panel from bottom to side',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.dragResizerTo({ x: 0, y: viewports.desktop.height });
-    const { height } = await page.getSplitPanelSize();
-    expect(height).toEqual(160);
-    await page.switchPosition('side');
-    const { width } = await page.getSplitPanelSize();
-    expect(width).toEqual(280);
-  })
-);
-
-test(
-  'should keep split panel position during drag',
-  setupTest(async page => {
-    await page.openPanel();
-    await page.switchPosition('side');
-    await page.dragResizerTo({ x: 0, y: 0 });
-    await page.setWindowSize({ ...viewports.desktop, width: 820 });
-    const { height } = await page.getWindowSize();
-    await page.dragResizerTo({ x: 0, y: height });
-    await expect(page.getPanelPosition()).resolves.toEqual('bottom');
-  })
-);
-
-test(
-  'should resize main content area when switching to side',
-  setupTest(async page => {
-    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
-    await page.switchPosition('side');
-    await expect(page.getContentMarginBottom()).resolves.toEqual('');
-  }, '#/light/app-layout/with-full-page-table-and-split-panel')
-);
-
-test(
-  'should resize main content area when switching to side then back to bottom',
-  setupTest(async page => {
-    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
-    await page.switchPosition('side');
-    await page.switchPosition('bottom');
-    await expect(page.getContentMarginBottom()).resolves.toEqual('400px');
-  }, '#/light/app-layout/with-full-page-table-and-split-panel')
-);

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -283,7 +283,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
           style={{
             [globalVars.stickyVerticalTopOffset]: `${verticalOffsets.header}px`,
             [globalVars.stickyVerticalBottomOffset]: `${placement.insetBlockEnd}px`,
-            paddingBlockEnd: splitPanelOpen ? splitPanelReportedSize : '',
+            paddingBlockEnd: splitPanelOpen && splitPanelPosition === 'bottom' ? splitPanelReportedSize : '',
           }}
           toolbar={
             hasToolbar && <AppLayoutToolbar appLayoutInternals={appLayoutInternals} toolbarProps={toolbarProps} />


### PR DESCRIPTION
### Description

1. Fix an issue where incorrect split panel offset was set
2. Expand split panel integration tests on all 3 app layout versions

Related links, issue #, if available: n/a

### How has this been tested?

Enabled existing integ tests to cover all app layout versions

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
