### PR TITLE
fix: fix focus indicator styling issue (vr-toolbar flag only) 

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -13,6 +13,8 @@
   box-sizing: border-box;
   padding-block: 0;
   padding-inline: awsui.$space-m;
+  //right padding set in child trigger-container below for focus indicator to show correctly
+  padding-inline-end: 0;
   position: sticky;
   z-index: 840;
   @include styles.with-motion {
@@ -53,13 +55,18 @@
       column-gap: awsui.$space-static-xs;
       display: flex;
       justify-content: flex-end;
+      block-size: 100%;
     }
   }
 }
 
-.drawers-desktop-triggers-container {
+.drawers-desktop-triggers-container,
+.drawers-mobile-triggers-container {
   @include styles.styles-reset;
   background-color: transparent;
+  padding-inline: 0;
+  //matches the left padding of .universal-toolbar but allows for focus indicator to show correctly
+  padding-inline-end: awsui.$space-m;
   box-sizing: border-box;
   overflow-y: hidden;
   overflow-x: hidden;
@@ -71,6 +78,7 @@
 }
 
 .drawers-trigger-content {
+  block-size: 100%;
   align-items: center;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### Description

fixing the focus indicatory styling on the visual refresh toolbar  where the indicator styling was being cur off by parent elements. 

Here the parent elements all have a height adjusted to 100% of the toolbar and the items aligned to the center, which allows for the indicator styling on the top and the bottom to be seen like such

<img width="389" alt="Screenshot 2024-08-20 at 11 20 01" src="https://github.com/user-attachments/assets/addcf327-76cf-43f8-944e-17d91c1f7124">

Also in this PR, the horizontal padding of the toolbar is set in two different elements. The left side remains in the `.universal-toolbar` with the right padding set as zero and the matching right padding is set in its child element with `.drawers-desktop-triggers-container, .drawers-mobile-triggers-container`. This allows for the right side styling of the focus indicator on the last item to show correctly

Related links, issue #, if available: n/a

This bug has been surfaced while working into the tooltips issue.

### How has this been tested?

The issue has been tested manually on firefox and chrome browser. A visual test of the focus inducator of the first and especially the last element should be added to ensure future changes do not have unintended changes to this focus indicator.

To test yourself, go to https://d21d5uik3ws71m.cloudfront.net/components/470e001b53e44b06d07239c29aa13c77d5bf255a/dev-pages/index.html#/light/app-layout/with-drawers?appLayoutWidget=true

Use the Tab to navigate the toolbar, left and right, and notice the indicator styling
Note: this does not address the focus control issue for opening the drawers

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_ existing
- _Changes are covered with new/existing integration tests?_ existing. 

</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
