### PR TITLE
fix: Use correct width for bottom split panel when drawer is present

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -327,18 +327,6 @@ const permutations = createPermutations<TableProps>([
     ],
     stickyHeader: [true],
   },
-  {
-    columnDefinitions: [PROPERTY_COLUMNS],
-    items: [
-      [
-        {
-          name: 'Color',
-          value: '#000000',
-          type: 'String',
-        },
-      ],
-    ],
-  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -327,6 +327,18 @@ const permutations = createPermutations<TableProps>([
     ],
     stickyHeader: [true],
   },
+  {
+    columnDefinitions: [PROPERTY_COLUMNS],
+    items: [
+      [
+        {
+          name: 'Color',
+          value: '#000000',
+          type: 'String',
+        },
+      ],
+    ],
+  },
 ]);
 /* eslint-enable react/jsx-key */
 

--- a/src/app-layout/classic.tsx
+++ b/src/app-layout/classic.tsx
@@ -212,24 +212,6 @@ const ClassicAppLayout = React.forwardRef(
     const closedDrawerWidth = 40;
     const effectiveNavigationWidth = navigationHide ? 0 : navigationOpen ? navigationWidth : closedDrawerWidth;
 
-    const getEffectiveToolsWidth = () => {
-      if (activeDrawerSize) {
-        return activeDrawerSize;
-      }
-
-      if (toolsHide || drawers) {
-        return 0;
-      }
-
-      if (toolsOpen) {
-        return toolsWidth;
-      }
-
-      return closedDrawerWidth;
-    };
-
-    const effectiveToolsWidth = getEffectiveToolsWidth();
-
     const defaultSplitPanelSize = getSplitPanelDefaultSize(splitPanelPosition);
     const [splitPanelSize = defaultSplitPanelSize, setSplitPanelSize] = useControllable(
       controlledSplitPanelSize,
@@ -295,6 +277,24 @@ const ClassicAppLayout = React.forwardRef(
       placement.inlineSize - effectiveNavigationWidth - minContentWidth - contentPadding - rightDrawerBarWidth
     );
 
+    const getEffectiveToolsWidth = () => {
+      if (activeDrawerSize) {
+        return Math.min(resizableSpaceAvailable, activeDrawerSize);
+      }
+
+      if (toolsHide || drawers) {
+        return 0;
+      }
+
+      if (toolsOpen) {
+        return toolsWidth;
+      }
+
+      return closedDrawerWidth;
+    };
+
+    const effectiveToolsWidth = getEffectiveToolsWidth();
+
     // if there is no space to display split panel in the side, force to bottom
     const isSplitPanelForcedPosition =
       isMobile || resizableSpaceAvailable - effectiveToolsWidth < SPLIT_PANEL_MIN_WIDTH;
@@ -303,7 +303,7 @@ const ClassicAppLayout = React.forwardRef(
     const splitPaneAvailableOnTheSide = splitPanelDisplayed && finalSplitPanePosition === 'side';
 
     const sideSplitPanelSize = splitPaneAvailableOnTheSide ? (splitPanelOpen ? splitPanelSize : closedDrawerWidth) : 0;
-    const splitPanelMaxWidth = Math.max(0, resizableSpaceAvailable - effectiveToolsWidth);
+    const sideSplitPanelMaxWidth = Math.max(0, resizableSpaceAvailable - effectiveToolsWidth);
     const drawerMaxSize = Math.max(0, resizableSpaceAvailable - sideSplitPanelSize);
 
     const navigationClosedWidth = navigationHide || isMobile ? 0 : closedDrawerWidth;
@@ -322,7 +322,7 @@ const ClassicAppLayout = React.forwardRef(
       rightOffset: isMobile ? 0 : placement.insetInlineEnd + effectiveToolsWidth + rightDrawerBarWidth,
       position: finalSplitPanePosition,
       size: splitPanelSize,
-      maxWidth: splitPanelMaxWidth,
+      maxWidth: sideSplitPanelMaxWidth,
       getMaxHeight: getSplitPanelMaxHeight,
       disableContentPaddings,
       contentWidthStyles: contentMaxWidthStyle,


### PR DESCRIPTION
### Description

When the split panel is positioned at the bottom, it does not calculate correctly its available horizontal space in Classic if a drawer is active which has a `defaultSize` such that it won't fit into the available space for the drawers. (The drawer itself will narrow itself down as expected, but the bottom split panel will not calculate that narrowing, resulting in empty space between the split panel and the drawer).

Issue #: AWSUI-55244

### How has this been tested?

- Manually by following the steps in the aforementioned ticket
- I am adding a test in the pipeline (CR-144062151)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
