### PR TITLE
fix: Fixed property filter tokens e2e selector

### DIFF
--- a/src/property-filter/__integ__/property-filter.test.ts
+++ b/src/property-filter/__integ__/property-filter.test.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+import createWrapper from '../../../lib/components/test-utils/selectors';
+
+const wrapper = createWrapper().findPropertyFilter();
+const token2Wrapper = wrapper.findTokens().get(2);
+const token2EditorWrapper = wrapper.findTokens().get(2).findEditorDropdown({ expandToViewport: true })!;
+
+function setupTest(testFn: (page: BasePageObject) => Promise<void>) {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url('#/light/property-filter/split-panel-app-layout-integration');
+    await page.waitForVisible('main');
+    await testFn(page);
+  });
+}
+
+test(
+  'can create an edit a second token',
+  setupTest(async page => {
+    // Create second token
+    await page.click(wrapper.findNativeInput().toSelector());
+    await page.keys(['i', 'd']);
+    await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
+    await page.keys(['=']);
+    await page.keys(['ArrowDown', 'ArrowDown', 'Enter']);
+
+    console.log('selector: ', token2Wrapper.toSelector());
+
+    await expect(page.getElementsText(token2Wrapper.toSelector())).resolves.toEqual([
+      'and\nInstance ID = i-2dc5ce28a0328391',
+    ]);
+
+    // Update second token operator
+    await page.click(token2Wrapper.findLabel().toSelector());
+    await page.click(token2EditorWrapper.findOperatorField().findControl().findSelect().findTrigger().toSelector());
+    await page.keys(['ArrowDown', 'Enter']);
+    await page.click(token2EditorWrapper!.findSubmitButton().toSelector());
+
+    await expect(page.getElementsText(token2Wrapper.toSelector())).resolves.toEqual([
+      'and\nInstance ID != i-2dc5ce28a0328391',
+    ]);
+  })
+);

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -22,7 +22,7 @@ export default class PropertyFilterWrapper extends AutosuggestWrapper {
   }
 
   findTokens(): Array<FilteringTokenWrapper> {
-    return this.findAllByClassName(FilteringTokenWrapper.rootSelector).map(
+    return this.findAllByClassName(tokenListSelectors['list-item']).map(
       (elementWrapper: ElementWrapper) => new FilteringTokenWrapper(elementWrapper.getElement())
     );
   }


### PR DESCRIPTION
### Description

Changed token selector to work consistently in unit- and e2e tests. A downside is that the updated selector matches an element higher in the hierarchy so that e.g. asserting the ARIA label won't work.

An alternative solution is available requiring changes to test-utils code, see:
* https://github.com/cloudscape-design/test-utils/pull/70
* [4QRKAKIJD3RX]

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
