### PR TITLE
fix: Resolved table sticky header misalignment

### DIFF
--- a/src/table/__integ__/sticky-header.test.ts
+++ b/src/table/__integ__/sticky-header.test.ts
@@ -24,10 +24,16 @@ class StickyHeaderPage extends BasePageObject {
       const elements = Array.prototype.slice.apply(document.querySelectorAll(selector));
       return elements
         .map(element => element.getBoundingClientRect())
-        .map(rect => ({
-          width: Math.round(rect.offsetWidth),
-        }));
+        .map(rect => ({ width: rect.width, height: rect.height }));
     }, selector);
+  }
+
+  getClosest(parentSelector: string, selector: string) {
+    return this.browser.execute(
+      (parentSelector: string, selector: string) => document.querySelector(selector)?.closest(parentSelector),
+      parentSelector,
+      selector
+    );
   }
 
   findTable() {
@@ -51,13 +57,27 @@ const setupTest = (testFn: (page: StickyHeaderPage) => Promise<void>) => {
   });
 };
 
+const originalHeadersSelector = originalTableHeader.findAll('tr > *').toSelector();
+const stickyHeadersSelector = tableWrapper.findColumnHeaders().toSelector();
+
 describe('Sticky header', () => {
+  test(
+    `ensure original and sticky header selectors have different parent tables`,
+    setupTest(async page => {
+      const originalTable = await page.getClosest('table', originalHeadersSelector);
+      const stickyTable = await page.getClosest('table', stickyHeadersSelector);
+      expect(originalTable).not.toBe(null);
+      expect(stickyTable).not.toBe(null);
+      expect(originalTable).not.toBe(stickyTable);
+    })
+  );
+
   test(
     `syncs column sizes from the hidden column headers`,
     setupTest(async page => {
-      const originalWidths = await page.getElementSizes(originalTableHeader.findAll('tr > *').toSelector());
-      const copyWidths = await page.getElementSizes(tableWrapper.findColumnHeaders().toSelector());
-      expect(copyWidths).toEqual(originalWidths);
+      const originalSizes = await page.getElementSizes(originalHeadersSelector);
+      const copySizes = await page.getElementSizes(stickyHeadersSelector);
+      expect(copySizes).toEqual(originalSizes);
     })
   );
 
@@ -67,9 +87,9 @@ describe('Sticky header', () => {
       const page = new StickyHeaderPage(browser);
       await browser.url('#/light/table/hooks');
       await page.click(tableWrapper.findPagination().findPageNumberByIndex(2).toSelector());
-      const originalWidths = await page.getElementSizes(originalTableHeader.findAll('tr > *').toSelector());
-      const copyWidths = await page.getElementSizes(tableWrapper.findColumnHeaders().toSelector());
-      expect(copyWidths).toEqual(originalWidths);
+      const originalSizes = await page.getElementSizes(originalHeadersSelector);
+      const copySizes = await page.getElementSizes(stickyHeadersSelector);
+      expect(copySizes).toEqual(originalSizes);
     })
   );
 

--- a/src/table/__tests__/resizable-columns.test.tsx
+++ b/src/table/__tests__/resizable-columns.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React, { useLayoutEffect } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import times from 'lodash/times';
 
 import { ContainerQueryEntry } from '@cloudscape-design/component-toolkit';
@@ -443,7 +443,7 @@ describe('column header content', () => {
   });
 });
 
-test('should set last column width to "auto" when container width exceeds total column width', () => {
+test('should set last column width to "auto" when container width exceeds total column width', async () => {
   const totalColumnsWidth = 150 + 300;
 
   const callbacks: ((entry: ContainerQueryEntry) => void)[] = [];
@@ -460,13 +460,19 @@ test('should set last column width to "auto" when container width exceeds total 
   });
 
   const { wrapper } = renderTable(<Table {...defaultProps} />);
-  expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
+  await waitFor(() => {
+    expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
+  });
 
   fireCallbacks({ contentBoxWidth: totalColumnsWidth } as unknown as ContainerQueryEntry);
-  expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', '300px']);
+  await waitFor(() => {
+    expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', '300px']);
+  });
 
   fireCallbacks({ contentBoxWidth: totalColumnsWidth + 1 } as unknown as ContainerQueryEntry);
-  expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
+  await waitFor(() => {
+    expect(wrapper.findColumnHeaders().map(w => w.getElement().style.width)).toEqual(['150px', 'auto']);
+  });
 });
 
 describe('resize in rtl', () => {

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -99,7 +99,11 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
     }
 
     if (sticky) {
-      return { width: cellsRef.current.get(column.id)?.offsetWidth || (columnWidths?.get(column.id) ?? column.width) };
+      return {
+        width:
+          cellsRef.current.get(column.id)?.getBoundingClientRect().width ||
+          (columnWidths?.get(column.id) ?? column.width),
+      };
     }
 
     if (resizableColumns && columnWidths) {
@@ -124,6 +128,8 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   // Imperatively sets width style for a cell avoiding React state.
   // This allows setting the style as soon container's size change is observed.
   const updateColumnWidths = useStableCallback(() => {
+    console.log('set widths');
+
     for (const { id } of visibleColumns) {
       const element = cellsRef.current.get(id);
       if (element) {
@@ -133,6 +139,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
     // Sticky column widths must be synchronized once all real column widths are assigned.
     for (const { id } of visibleColumns) {
       const element = stickyCellsRef.current.get(id);
+      console.log('set width', id, getColumnStyles(true, id));
       if (element) {
         setElementWidths(element, getColumnStyles(true, id));
       }

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -128,8 +128,6 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   // Imperatively sets width style for a cell avoiding React state.
   // This allows setting the style as soon container's size change is observed.
   const updateColumnWidths = useStableCallback(() => {
-    console.log('set widths');
-
     for (const { id } of visibleColumns) {
       const element = cellsRef.current.get(id);
       if (element) {
@@ -139,7 +137,6 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
     // Sticky column widths must be synchronized once all real column widths are assigned.
     for (const { id } of visibleColumns) {
       const element = stickyCellsRef.current.get(id);
-      console.log('set width', id, getColumnStyles(true, id));
       if (element) {
         setElementWidths(element, getColumnStyles(true, id));
       }

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -146,13 +146,13 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   // Observes container size and requests an update to the last cell width as it depends on the container's width.
   useResizeObserver(containerRef, ({ contentBoxWidth: containerWidth }) => {
     containerWidthRef.current = containerWidth;
-    updateColumnWidths();
+    requestAnimationFrame(() => updateColumnWidths());
   });
 
   // The widths of the dynamically added columns (after the first render) if not set explicitly
   // will default to the DEFAULT_COLUMN_WIDTH.
   useEffect(() => {
-    requestAnimationFrame(() => updateColumnWidths());
+    updateColumnWidths();
 
     if (!resizableColumns) {
       return;

--- a/src/table/use-column-widths.tsx
+++ b/src/table/use-column-widths.tsx
@@ -152,7 +152,7 @@ export function ColumnWidthsProvider({ visibleColumns, resizableColumns, contain
   // The widths of the dynamically added columns (after the first render) if not set explicitly
   // will default to the DEFAULT_COLUMN_WIDTH.
   useEffect(() => {
-    updateColumnWidths();
+    requestAnimationFrame(() => updateColumnWidths());
 
     if (!resizableColumns) {
       return;

--- a/src/table/use-sticky-header.ts
+++ b/src/table/use-sticky-header.ts
@@ -24,12 +24,12 @@ export const useStickyHeader = (
       secondaryTableRef.current &&
       tableWrapperRef.current
     ) {
-      // Using the tableRef offsetWidth instead of the theadRef because in VR
+      // Using the tableRef getBoundingClientRect().width instead of the theadRef because in VR
       // the tableRef adds extra padding to the table and by default the theadRef will have a width
       // without the padding and will make the sticky header width incorrect.
-      secondaryTableRef.current.style.inlineSize = `${tableRef.current.offsetWidth}px`;
+      secondaryTableRef.current.style.inlineSize = `${tableRef.current.getBoundingClientRect().width}px`;
 
-      tableWrapperRef.current.style.marginBlockStart = `-${theadRef.current.offsetHeight}px`;
+      tableWrapperRef.current.style.marginBlockStart = `-${theadRef.current.getBoundingClientRect().height}px`;
     }
   }, [theadRef, secondaryTheadRef, secondaryTableRef, tableWrapperRef, tableRef]);
   useLayoutEffect(() => {


### PR DESCRIPTION
### Description

Applied two updates to table sticky header width sync:
1. Use bounding client rect width instead of overflow width to remove error caused by rounding
2. Use request animation frame when sync width with observer to give browser more time to settle column widths

Rel: AWSUI-56256

### How has this been tested?

* Manual checks
* Screenshot tests
* Updated integ test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
