### PR TITLE
chore: Make column widths fixed to workaround flaky test

### DIFF
--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -315,7 +315,28 @@ const permutations = createPermutations<TableProps>([
     variant: [undefined, 'full-page'],
   },
   {
-    columnDefinitions: [PROPERTY_COLUMNS],
+    columnDefinitions: [
+      [
+        {
+          id: 'variable',
+          header: 'Property',
+          cell: item => <Link href="#">{item.name}</Link>,
+          isRowHeader: true,
+          width: 150,
+        },
+        {
+          id: 'type',
+          header: 'Type',
+          cell: item => item.type,
+          width: 150,
+        },
+        {
+          id: 'value',
+          header: 'Value',
+          cell: item => item.value,
+        },
+      ],
+    ],
     items: [
       [
         {


### PR DESCRIPTION
### Description

Issue: AWSUI-56245

Also related: AWSUI-56256

### How has this been tested?

Manually tested by following these steps:
- Open the page in two tabs and simulate a 500px-wide device in each using the browser's built-in device simulator
- Reload the page only for one of the tabs
- Switch tabs and check for the difference in the table header of the last table

The steps above made the issue reproducible before the changes and not after the changes.

We will be able to verify that the test works without flakiness once the updated test page is deployed on both stages.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
