### PR TITLE
refactor: Replace deprecated i18n strings with labels

### DIFF
--- a/pages/dropdown/expandable.page.tsx
+++ b/pages/dropdown/expandable.page.tsx
@@ -12,7 +12,7 @@ import Select, { SelectProps } from '~components/select';
 import SpaceBetween from '~components/space-between';
 
 import AppContext, { AppContextType } from '../app/app-context';
-import { i18nStrings as propertyFilterI18n } from '../property-filter/common-props';
+import { i18nStrings as propertyFilterI18n, labels as propertyFilterLabels } from '../property-filter/common-props';
 import ScreenshotArea from '../utils/screenshot-area';
 import { SampleDropdown, SampleModal } from './common';
 
@@ -175,6 +175,7 @@ const components = {
         filteringErrorText={'error text'}
         filteringRecoveryText={'recovery text'}
         filteringFinishedText={'finished text'}
+        {...propertyFilterLabels}
         i18nStrings={propertyFilterI18n}
         expandToViewport={expandToViewport}
       />

--- a/pages/property-filter/async-loading.integ.page.tsx
+++ b/pages/property-filter/async-loading.integ.page.tsx
@@ -9,7 +9,7 @@ import { PropertyFilterProps } from '~components/property-filter/interfaces';
 import AppContext, { AppContextType } from '../app/app-context';
 import { useOptionsLoader } from '../common/options-loader';
 import ScreenshotArea from '../utils/screenshot-area';
-import { i18nStrings } from './common-props';
+import { i18nStrings, labels } from './common-props';
 
 type PropertyFilterDemoContext = React.Context<
   AppContextType<{
@@ -81,6 +81,7 @@ export default function () {
       <h1>Integration tests fixture for async loading suggestions</h1>
       <ScreenshotArea disableAnimations={true}>
         <PropertyFilter
+          {...labels}
           i18nStrings={i18nStrings}
           query={query}
           onChange={e => setQuery(e.detail)}

--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -141,11 +141,14 @@ export const columnDefinitions = [
   },
 ].map((item, ind) => ({ order: ind + 1, ...item }));
 
-export const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
+export const labels = {
   filteringAriaLabel: 'your choice',
+  filteringPlaceholder: 'Search',
+};
+
+export const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
   dismissAriaLabel: 'Dismiss',
 
-  filteringPlaceholder: 'Search',
   groupValuesText: 'Values',
   groupPropertiesText: 'Properties',
   operatorsText: 'Operators',

--- a/pages/property-filter/hooks.page.tsx
+++ b/pages/property-filter/hooks.page.tsx
@@ -13,7 +13,7 @@ import PropertyFilter from '~components/property-filter';
 import Table from '~components/table';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties, i18nStrings, labels } from './common-props';
 import { allItems, TableItem } from './table.data';
 
 export default function () {
@@ -101,6 +101,7 @@ export default function () {
           {...collectionProps}
           filter={
             <PropertyFilter
+              {...labels}
               {...propertyFilterProps}
               virtualScroll={true}
               countText={`${items.length} matches`}

--- a/pages/property-filter/permutations.page.tsx
+++ b/pages/property-filter/permutations.page.tsx
@@ -10,7 +10,7 @@ import Select from '~components/select';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties, i18nStrings, labels } from './common-props';
 import { allItems, TableItem } from './table.data';
 
 const filteringOptions: readonly PropertyFilterProps.FilteringOption[] = columnDefinitions.reduce<
@@ -141,6 +141,7 @@ export default function () {
           permutations={permutations}
           render={permutation => (
             <PropertyFilter
+              {...labels}
               countText={`5 matches`}
               i18nStrings={i18nStrings}
               query={{ tokens: [], operation: 'and' }}

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
 
@@ -8,18 +8,21 @@ import AppLayout from '~components/app-layout';
 import Box from '~components/box';
 import Button from '~components/button';
 import Header from '~components/header';
+import I18nProvider from '~components/i18n';
+import messages from '~components/i18n/messages/all.en';
 import PropertyFilter from '~components/property-filter';
 import SplitPanel from '~components/split-panel';
 import Table from '~components/table';
 
 import { Breadcrumbs, Navigation, Tools } from '../app-layout/utils/content-blocks';
-import labels from '../app-layout/utils/labels';
+import appLayoutLabels from '../app-layout/utils/labels';
 import * as toolsContent from '../app-layout/utils/tools-content';
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties, i18nStrings } from './common-props';
+import { columnDefinitions, filteringProperties, labels } from './common-props';
 import { allItems, states, TableItem } from './table.data';
 
 export default function () {
+  const [splitPanelOpen, setSplitPanelOpen] = useState(true);
   const { items, collectionProps, actions, propertyFilterProps } = useCollection(allItems, {
     propertyFiltering: {
       empty: 'empty',
@@ -53,53 +56,56 @@ export default function () {
 
   return (
     <ScreenshotArea gutters={false}>
-      <AppLayout
-        ariaLabels={labels}
-        breadcrumbs={<Breadcrumbs />}
-        navigation={<Navigation />}
-        tools={<Tools>{toolsContent.long}</Tools>}
-        splitPanelOpen={true}
-        splitPanel={
-          <SplitPanel
-            header="Split panel header"
-            i18nStrings={{
-              preferencesTitle: 'Preferences',
-              preferencesPositionLabel: 'Split panel position',
-              preferencesPositionDescription: 'Choose the default split panel position for the service.',
-              preferencesPositionSide: 'Side',
-              preferencesPositionBottom: 'Bottom',
-              preferencesConfirm: 'Confirm',
-              preferencesCancel: 'Cancel',
-              closeButtonAriaLabel: 'Close panel',
-              openButtonAriaLabel: 'Open panel',
-              resizeHandleAriaLabel: 'Slider',
-            }}
-          >
-            {' '}
-          </SplitPanel>
-        }
-        content={
-          <Table<TableItem>
-            className="main-content"
-            stickyHeader={true}
-            header={<Header headingTagOverride={'h1'}>Instances</Header>}
-            items={items}
-            {...collectionProps}
-            filter={
-              <PropertyFilter
-                {...propertyFilterProps}
-                filteringOptions={filteringOptions}
-                virtualScroll={true}
-                countText={`${items.length} matches`}
-                i18nStrings={i18nStrings}
-                expandToViewport={true}
-                filteringEmpty="No properties"
-              />
-            }
-            columnDefinitions={columnDefinitions.slice(0, 2)}
-          />
-        }
-      />
+      <I18nProvider messages={[messages]} locale="en">
+        <AppLayout
+          ariaLabels={appLayoutLabels}
+          breadcrumbs={<Breadcrumbs />}
+          navigation={<Navigation />}
+          tools={<Tools>{toolsContent.long}</Tools>}
+          splitPanelOpen={splitPanelOpen}
+          onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
+          splitPanel={
+            <SplitPanel
+              header="Split panel header"
+              i18nStrings={{
+                preferencesTitle: 'Preferences',
+                preferencesPositionLabel: 'Split panel position',
+                preferencesPositionDescription: 'Choose the default split panel position for the service.',
+                preferencesPositionSide: 'Side',
+                preferencesPositionBottom: 'Bottom',
+                preferencesConfirm: 'Confirm',
+                preferencesCancel: 'Cancel',
+                closeButtonAriaLabel: 'Close panel',
+                openButtonAriaLabel: 'Open panel',
+                resizeHandleAriaLabel: 'Slider',
+              }}
+            >
+              {' '}
+            </SplitPanel>
+          }
+          content={
+            <Table<TableItem>
+              className="main-content"
+              stickyHeader={true}
+              header={<Header headingTagOverride={'h1'}>Instances</Header>}
+              items={items}
+              {...collectionProps}
+              filter={
+                <PropertyFilter
+                  {...labels}
+                  {...propertyFilterProps}
+                  filteringOptions={filteringOptions}
+                  virtualScroll={true}
+                  countText={`${items.length} matches`}
+                  expandToViewport={true}
+                  filteringEmpty="No properties"
+                />
+              }
+              columnDefinitions={columnDefinitions.slice(0, 2)}
+            />
+          }
+        />
+      </I18nProvider>
     </ScreenshotArea>
   );
 }

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -7,7 +7,12 @@ import { PropertyFilterProps } from '~components/property-filter/interfaces';
 import PropertyFilterInternal from '~components/property-filter/internal';
 
 import ScreenshotArea from '../utils/screenshot-area';
-import { columnDefinitions, filteringProperties as commonFilteringProperties, i18nStrings } from './common-props';
+import {
+  columnDefinitions,
+  filteringProperties as commonFilteringProperties,
+  i18nStrings,
+  labels,
+} from './common-props';
 
 const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = columnDefinitions.map(def => ({
   key: def.id,
@@ -17,6 +22,7 @@ const filteringProperties: readonly PropertyFilterProps.FilteringProperty[] = co
 }));
 
 const commonProps = {
+  ...labels,
   onChange: () => {},
   filteringProperties,
   filteringOptions: [],

--- a/pages/table/permutations.page.tsx
+++ b/pages/table/permutations.page.tsx
@@ -10,7 +10,10 @@ import Link from '~components/link';
 import PropertyFilter from '~components/property-filter';
 import Table, { TableProps } from '~components/table';
 
-import { i18nStrings } from '../property-filter/common-props';
+import {
+  i18nStrings as propertyFilterI18nStrings,
+  labels as propertyFilterLabels,
+} from '../property-filter/common-props';
 import createPermutations from '../utils/permutations';
 import PermutationsView from '../utils/permutations-view';
 import ScreenshotArea from '../utils/screenshot-area';
@@ -267,7 +270,8 @@ const permutations = createPermutations<TableProps>([
             groupValuesLabel: 'Number values',
           },
         ]}
-        i18nStrings={i18nStrings}
+        {...propertyFilterLabels}
+        i18nStrings={propertyFilterI18nStrings}
         query={{
           operation: 'or',
           tokens: [


### PR DESCRIPTION
### Description

Remove usage of deprecated labels and add i18n provider to one of the property filter test pages

### How has this been tested?

* Manual check
* Existing a11y tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
