### PR TITLE
feat: New property filter i18n.formatToken function

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12377,6 +12377,11 @@ operations are communicated to the user in another way.",
             "type": "string",
           },
           Object {
+            "name": "formatToken",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          Object {
             "name": "groupPropertiesText",
             "optional": true,
             "type": "string",

--- a/src/i18n/messages-types.ts
+++ b/src/i18n/messages-types.ts
@@ -256,6 +256,11 @@ export interface I18nFormatArgTypes {
     "i18nStrings.tokenLimitShowFewer": never;
     "i18nStrings.tokenLimitShowMore": never;
     "i18nStrings.valueText": never;
+    "i18nStrings.formatToken": {
+      "token__operator": string;
+      "token__propertyLabel": string | number;
+      "token__value": string | number;
+    },
     "i18nStrings.removeTokenButtonAriaLabel": {
       "token__operator": string;
       "token__propertyLabel": string | number;

--- a/src/property-filter/__tests__/property-filter-i18n.test.tsx
+++ b/src/property-filter/__tests__/property-filter-i18n.test.tsx
@@ -174,18 +174,19 @@ describe('i18n', () => {
             'i18nStrings.tokenLimitShowFewer': 'Custom Show fewer',
             'i18nStrings.tokenLimitShowMore': 'Custom Show more',
             'i18nStrings.valueText': 'Custom Value',
-            'i18nStrings.removeTokenButtonAriaLabel': `{token__operator, select, 
-              equals {Remove filter, {token__propertyLabel} Custom equals {token__value}}
-              not_equals {Remove filter, {token__propertyLabel} Custom does not equal {token__value}}
-              greater_than {Remove filter, {token__propertyLabel} Custom greater than {token__value}}
-              greater_than_equal {Remove filter, {token__propertyLabel} Custom greater than or equals {token__value}}
-              less_than {Remove filter, {token__propertyLabel} Custom less than {token__value}}
-              less_than_equal {Remove filter, {token__propertyLabel} Custom less than or equals {token__value}}
-              contains {Remove filter, {token__propertyLabel} Custom contains {token__value}}
-              not_contains {Remove filter, {token__propertyLabel} Custom does not contain {token__value}}
-              starts_with {Remove filter, {token__propertyLabel} Custom starts with {token__value}}
-              not_starts_with {Remove filter, {token__propertyLabel} Custom does not start with {token__value}}
+            'i18nStrings.formatToken': `{token__operator, select, 
+              equals {{token__propertyLabel} Custom equals {token__value}}
+              not_equals {{token__propertyLabel} Custom does not equal {token__value}}
+              greater_than {{token__propertyLabel} Custom greater than {token__value}}
+              greater_than_equal {{token__propertyLabel} Custom greater than or equals {token__value}}
+              less_than {{token__propertyLabel} Custom less than {token__value}}
+              less_than_equal {{token__propertyLabel} Custom less than or equals {token__value}}
+              contains {{token__propertyLabel} Custom contains {token__value}}
+              not_contains {{token__propertyLabel} Custom does not contain {token__value}}
+              starts_with {{token__propertyLabel} Custom starts with {token__value}}
+              not_starts_with {{token__propertyLabel} Custom does not start with {token__value}}
               other {}}`,
+            'i18nStrings.removeTokenButtonAriaLabel': `Remove filter, {token__formattedText}`,
           },
         }}
       >
@@ -214,24 +215,27 @@ describe('i18n', () => {
       </TestI18nProvider>
     );
     const wrapper = createWrapper(container).findPropertyFilter()!;
+    const token = (index: number) => wrapper.findTokens()[index];
+
     expect(wrapper.findRemoveAllButton()!.getElement()).toHaveTextContent('Custom Clear filters');
     expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Custom Show more');
     wrapper.findTokenToggle()!.click();
     expect(wrapper.findTokenToggle()!.getElement()).toHaveTextContent('Custom Show fewer');
 
-    const getRemoveButton = (index: number) => wrapper.findTokens()[index].findRemoveButton().getElement();
-    expect(getRemoveButton(0)).toHaveAccessibleName('Remove filter, String Custom equals value1');
-    expect(getRemoveButton(1)).toHaveAccessibleName('Remove filter, String Custom does not equal value2');
-    expect(getRemoveButton(2)).toHaveAccessibleName('Remove filter, String Custom contains value3');
-    expect(getRemoveButton(3)).toHaveAccessibleName('Remove filter, String Custom does not contain value4');
-    expect(getRemoveButton(4)).toHaveAccessibleName('Remove filter, String Custom starts with value5');
-    expect(getRemoveButton(5)).toHaveAccessibleName('Remove filter, String Custom does not start with value6');
-    expect(getRemoveButton(6)).toHaveAccessibleName('Remove filter, Range Custom greater than 1');
-    expect(getRemoveButton(7)).toHaveAccessibleName('Remove filter, Range Custom less than 2');
-    expect(getRemoveButton(8)).toHaveAccessibleName('Remove filter, Range Custom greater than or equals 3');
-    expect(getRemoveButton(9)).toHaveAccessibleName('Remove filter, Range Custom less than or equals 4');
-    expect(getRemoveButton(10)).toHaveAccessibleName('Remove filter, Custom Custom equals empty');
-    expect(getRemoveButton(11)).toHaveAccessibleName('Remove filter, Custom All properties Custom contains all');
+    expect(token(0).getElement().textContent).toBe('String = value1');
+    expect(token(0).getElement()).toHaveAccessibleName('String Custom equals value1');
+    expect(token(1).getElement()).toHaveAccessibleName('String Custom does not equal value2');
+    expect(token(2).getElement()).toHaveAccessibleName('String Custom contains value3');
+    expect(token(3).getElement()).toHaveAccessibleName('String Custom does not contain value4');
+    expect(token(4).getElement()).toHaveAccessibleName('String Custom starts with value5');
+    expect(token(5).getElement()).toHaveAccessibleName('String Custom does not start with value6');
+    expect(token(6).getElement()).toHaveAccessibleName('Range Custom greater than 1');
+    expect(token(7).getElement()).toHaveAccessibleName('Range Custom less than 2');
+    expect(token(8).getElement()).toHaveAccessibleName('Range Custom greater than or equals 3');
+    expect(token(9).getElement()).toHaveAccessibleName('Range Custom less than or equals 4');
+    expect(token(10).getElement()).toHaveAccessibleName('Custom Custom equals empty');
+    expect(token(11).getElement()).toHaveAccessibleName('Custom All properties Custom contains all');
+    expect(token(0).findRemoveButton().getElement()).toHaveAccessibleName('Remove filter, String Custom equals value1');
 
     const tokenOperation = wrapper.findTokens()[1].findTokenOperation()!;
     tokenOperation.openDropdown();

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -3,25 +3,37 @@
 
 import { ComparisonOperator, FormattedToken, I18nStrings, InternalToken } from './interfaces';
 
-export function getI18nToken(token: FormattedToken): {
-  token__operator: string;
+export function getI18nToken(token: FormattedToken & { formattedTokenText?: string }): {
   token__propertyKey: string;
   token__propertyLabel: string;
+  token__operator: string;
   token__value: string;
+  token__formattedText?: string;
 } {
   return {
     token__propertyKey: token.propertyKey ?? '',
     token__propertyLabel: token.propertyLabel,
     token__operator: getOperatorI18nString(token.operator),
     token__value: token.value,
+    token__formattedText: token.formattedTokenText,
   };
 }
 
-export function getFormattedToken(token: InternalToken, i18nStrings: I18nStrings): FormattedToken {
+export function getFormattedToken(
+  token: InternalToken,
+  i18nStrings: I18nStrings
+): FormattedToken & { formattedTokenText: string } {
   const valueFormatter = token.property?.getValueFormatter(token.operator);
   const propertyLabel = token.property ? token.property.propertyLabel : i18nStrings.allPropertiesLabel ?? '';
   const tokenValue = valueFormatter ? valueFormatter(token.value) : token.value;
-  return { propertyKey: token.property?.propertyKey, propertyLabel, operator: token.operator, value: tokenValue };
+  const formatted = {
+    propertyKey: token.property?.propertyKey,
+    propertyLabel,
+    operator: token.operator,
+    value: tokenValue,
+  };
+  const getText = i18nStrings.formatToken ?? (token => `${token.propertyLabel} ${token.operator} ${token.value}`);
+  return { ...formatted, formattedTokenText: getText(formatted) };
 }
 
 function getOperatorI18nString(operator: ComparisonOperator): string {

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -276,6 +276,8 @@ export namespace PropertyFilterProps {
     applyActionText?: string;
     allPropertiesLabel?: string;
 
+    formatToken?: (token: FormattedToken) => string;
+
     tokenLimitShowMore?: string;
     tokenLimitShowFewer?: string;
     clearFiltersText?: string;

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -201,6 +201,10 @@ const PropertyFilterInternal = React.forwardRef(
       return { internalProperties: [...propertyByKey.values()], internalOptions, internalQuery, internalFreeText };
     })();
 
+    i18nStrings.formatToken =
+      i18n('i18nStrings.formatToken', rest.i18nStrings?.formatToken, format => token => format(getI18nToken(token))) ??
+      (token => `${token.propertyLabel} ${token.operator} ${token.value}`);
+
     i18nStrings.removeTokenButtonAriaLabel = i18n(
       'i18nStrings.removeTokenButtonAriaLabel',
       rest.i18nStrings?.removeTokenButtonAriaLabel,

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -80,7 +80,7 @@ export const TokenButton = ({
               <TokenTrigger token={formattedToken} allProperties={token.property === null} />
             </span>
           ),
-          ariaLabel: `${formattedToken.propertyLabel} ${formattedToken.operator} ${formattedToken.value}`,
+          ariaLabel: formattedToken.formattedTokenText,
           dismissAriaLabel: i18nStrings?.removeTokenButtonAriaLabel?.(formattedToken) ?? '',
         },
       ]}


### PR DESCRIPTION
### Description

Introducing new i18n string for property filter. The related i18n messages will come later, but before the messages are available the string `{propertyLabel} {operator} {value}` is used as default which is the same label that is used currently.

Rel: [tB42A7nNaXZN]

### How has this been tested?

* Updated unit test
* Manual checks with and without i18n provider

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
