### PR TITLE
fix: Fixes button dropdown main action aria label

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -268,24 +268,22 @@ describe('with main action', () => {
     expect(wrapper.findMainAction()!.getElement()).toHaveAccessibleName('Main #1');
   });
 
-  test('main action with external link has an icon and dedicated ARIA label', () => {
-    const mainAction = {
-      text: 'Main',
-      href: 'https://external.com',
-      external: true,
-      externalIconAriaLabel: '(opens in a new tab)',
-    };
-    const wrapper = renderSplitButtonDropdown({ mainAction });
+  test.each([undefined, 'Main #1'])(
+    'main action with external link has an icon and dedicated ARIA label, ariaLabel=%s',
+    ariaLabel => {
+      const text = 'Main';
+      const externalIconAriaLabel = '(opens in a new tab)';
+      const wrapper = renderSplitButtonDropdown({
+        mainAction: { text, ariaLabel, href: 'https://external.com', external: true, externalIconAriaLabel },
+      });
 
-    expect(wrapper.findMainAction()?.findByClassName(iconStyles.icon)).not.toBe(null);
-    expect(wrapper.findMainAction()!.getElement()).toHaveTextContent('Main');
-    expect(wrapper.findMainAction()!.getElement()).toHaveAccessibleName('Main (opens in a new tab)');
-
-    const wrapper2 = renderSplitButtonDropdown({ mainAction: { ...mainAction, ariaLabel: 'Main #1' } });
-
-    expect(wrapper2.findMainAction()!.getElement()).toHaveTextContent('Main');
-    expect(wrapper2.findMainAction()!.getElement()).toHaveAccessibleName('Main #1 (opens in a new tab)');
-  });
+      expect(wrapper.findMainAction()?.findByClassName(iconStyles.icon)).not.toBe(null);
+      expect(wrapper.findMainAction()!.getElement()).toHaveTextContent('Main');
+      expect(wrapper.findMainAction()!.getElement()).toHaveAccessibleName(
+        `${ariaLabel ?? text} ${externalIconAriaLabel}`
+      );
+    }
+  );
 
   test('main action can be set as disabled', () => {
     const wrapper = renderSplitButtonDropdown({

--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -256,19 +256,35 @@ describe('with main action', () => {
     expect(onFollow).toHaveBeenCalledTimes(1);
   });
 
-  test('main action with external link has an icon and dedicated ARIA label', () => {
+  test('main action assigns ARIA label', () => {
     const wrapper = renderSplitButtonDropdown({
       mainAction: {
         text: 'Main',
-        href: 'https://external.com',
-        external: true,
-        externalIconAriaLabel: '(opens in a new tab)',
+        ariaLabel: 'Main #1',
       },
     });
+
+    expect(wrapper.findMainAction()!.getElement()).toHaveTextContent('Main');
+    expect(wrapper.findMainAction()!.getElement()).toHaveAccessibleName('Main #1');
+  });
+
+  test('main action with external link has an icon and dedicated ARIA label', () => {
+    const mainAction = {
+      text: 'Main',
+      href: 'https://external.com',
+      external: true,
+      externalIconAriaLabel: '(opens in a new tab)',
+    };
+    const wrapper = renderSplitButtonDropdown({ mainAction });
 
     expect(wrapper.findMainAction()?.findByClassName(iconStyles.icon)).not.toBe(null);
     expect(wrapper.findMainAction()!.getElement()).toHaveTextContent('Main');
     expect(wrapper.findMainAction()!.getElement()).toHaveAccessibleName('Main (opens in a new tab)');
+
+    const wrapper2 = renderSplitButtonDropdown({ mainAction: { ...mainAction, ariaLabel: 'Main #1' } });
+
+    expect(wrapper2.findMainAction()!.getElement()).toHaveTextContent('Main');
+    expect(wrapper2.findMainAction()!.getElement()).toHaveAccessibleName('Main #1 (opens in a new tab)');
   });
 
   test('main action can be set as disabled', () => {

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -209,7 +209,7 @@ const InternalButtonDropdown = React.forwardRef(
         : ({ iconName, iconAlt, iconSvg, iconUrl } as const);
       const mainActionAriaLabel = externalIconAriaLabel
         ? `${mainAction.ariaLabel ?? mainAction.text} ${mainAction.externalIconAriaLabel}`
-        : undefined;
+        : mainAction.ariaLabel;
 
       trigger = (
         <div role="group" aria-label={ariaLabel} className={styles['split-trigger-wrapper']}>


### PR DESCRIPTION
### Description

Fixes a bug when button dropdown ARIA label is not assigned when external icon is not set.

The bug was discovered when implementing: https://github.com/cloudscape-design/components/pull/2603

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
