### PR TITLE
feat: Adds aria label prop to button dropdown items

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3559,6 +3559,7 @@ The following properties are supported across all types:
 - \`disabled\` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
 - \`disabledReason\` (string) - (Optional) Displays text near the \`text\` property when item is disabled. Use to provide additional context.
 - \`description\` (string) - additional data that will be passed to a \`data-description\` attribute.
+- \`ariaLabel\` (string) - (Optional) - ARIA label of the item element.
 
 ### action
 

--- a/src/button-dropdown/__tests__/button-dropdown-accessibility.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-accessibility.test.tsx
@@ -18,7 +18,7 @@ const renderWithTrigger = (props: ButtonDropdownProps, triggerName: string) => {
 };
 
 const items: ButtonDropdownProps.Items = [
-  { id: 'i1', text: 'item1', description: 'Item 1 description' },
+  { id: 'i1', text: 'item1', description: 'Item 1 description', ariaLabel: 'item1 (aria)' },
   { id: 'i2', text: 'item2', description: 'Item 2 description', checked: true, itemType: 'checkbox' },
   {
     text: 'category1',
@@ -162,6 +162,14 @@ it('sets aria-owns attribute when dropdown is open and expandToViewport is activ
 it('can set ariaLabel', () => {
   const wrapper = renderButtonDropdown({ items, ariaLabel: 'Some dropdown' });
   expect(wrapper.findNativeButton().getElement()).toHaveAttribute('aria-label', 'Some dropdown');
+});
+
+it('can set item ariaLabel', () => {
+  const wrapper = renderButtonDropdown({ items });
+  wrapper.openDropdown();
+
+  expect(wrapper.findItems()[0].find('[role="menuitem"]')!.getElement().textContent).toBe('item1');
+  expect(wrapper.findItems()[0].find('[role="menuitem"]')!.getElement()).toHaveAccessibleName('item1 (aria)');
 });
 
 it('a11y: default', async () => {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -24,6 +24,7 @@ export interface ButtonDropdownProps extends BaseComponentProps, ExpandToViewpor
    * - `disabled` (boolean) - whether the item is disabled. Disabled items are not clickable, but they can be highlighted with the keyboard to make them accessible.
    * - `disabledReason` (string) - (Optional) Displays text near the `text` property when item is disabled. Use to provide additional context.
    * - `description` (string) - additional data that will be passed to a `data-description` attribute.
+   * - `ariaLabel` (string) - (Optional) - ARIA label of the item element.
    *
    * ### action
    *
@@ -144,6 +145,7 @@ export namespace ButtonDropdownProps {
     itemType?: ItemType;
     id: string;
     text: string;
+    ariaLabel?: string;
     lang?: string;
     disabled?: boolean;
     disabledReason?: string;


### PR DESCRIPTION
### Description

Adding ariaLabel property to button dropdown items so that the announced content can be different from the visible content. That is needed here: https://github.com/cloudscape-design/components/pull/2602. Context: for visible content such as "Add filter Label = Value" need to announce "Add filter Label equals Value" because the symbolic operators are not announced correctly.

### How has this been tested?

* New unit test
* Manual tests including a check with a screen-reader

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
