### PR TITLE
chore: updating toolbar focus to inside the drawers and enhance focus delegation test for app layout to include appLayoutWidget param

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -6,298 +6,318 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import createWrapper from '../../../lib/components/test-utils/selectors';
 import { viewports } from './constants';
 
+const testIf = (condition: boolean) => (condition ? test : test.skip);
+
 const wrapper = createWrapper().findAppLayout();
+
+interface SetupTestObj {
+  theme: string;
+  pageName: string;
+  splitPanelPosition?: string;
+  mobile: boolean;
+}
 
 function setupTest(
   testFn: (page: BasePageObject) => Promise<void>,
-  { pageName = 'with-split-panel', visualRefresh = false, splitPanelPosition = '', mobile = false }
+  { theme, pageName = 'with-split-panel', splitPanelPosition = '', mobile = false }: SetupTestObj
 ) {
   return useBrowser(async browser => {
-    const url = `#/light/app-layout/${pageName}?visualRefresh=${visualRefresh}${
-      splitPanelPosition ? `&splitPanelPosition=${splitPanelPosition}` : ''
-    }`;
     const page = new BasePageObject(browser);
+    const params = new URLSearchParams({
+      visualRefresh: `${theme.startsWith('visual-refresh')}`,
+      appLayoutWidget: `${theme === 'visual-refresh-toolbar'}`,
+      ...(splitPanelPosition
+        ? {
+            splitPanelPosition,
+          }
+        : {}),
+    });
     await page.setWindowSize(mobile ? viewports.mobile : viewports.desktop);
-    await browser.url(url);
+    await browser.url(`#/light/app-layout/${pageName}?${params.toString()}`);
     await page.waitForVisible(wrapper.findContentRegion().toSelector());
     await testFn(page);
   });
 }
 
-[true, false].forEach(visualRefresh =>
-  describe(`visualRefresh=${visualRefresh}`, () => {
-    [true, false].forEach(mobile =>
-      describe(`mobile=${mobile}`, () => {
-        test(
-          'should not focus panels on page load',
-          setupTest(
-            async page => {
-              await expect(page.isFocused('body')).resolves.toBe(true);
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile }
-          )
-        );
-        test(
-          'split panel focus moves to slider on open and open button on close',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-              await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
-              await page.keys(['Tab', 'Tab']);
-              await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
-              await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile }
-          )
-        );
+describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)('%s', theme => {
+  [true, false].forEach(mobile =>
+    describe(`mobile=${mobile}`, () => {
+      test(
+        'should not focus panels on page load',
+        setupTest(
+          async page => {
+            await expect(page.isFocused('body')).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
 
+      //TODO create separate split panel test for appLayoutWidget is true
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'split panel focus moves to slider on open and open button on close',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await expect(page.isFocused(wrapper.findSplitPanel().findSlider().toSelector())).resolves.toBe(true);
+            await page.keys(['Tab', 'Tab']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findCloseButton().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findSplitPanel().findOpenButton().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      test(
+        'tools panel focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findToolsToggle().toSelector());
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      //TODO create separate split panel test for 'visual-refresh-toolbar' theme
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'navigation panel focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            // panel is closed by default on mobile
+            if (mobile) {
+              await page.click(wrapper.findNavigationToggle().toSelector());
+            }
+            await page.click(wrapper.findNavigationClose().toSelector());
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile }
+        )
+      );
+
+      //todo create test specifically for mobile and visual-refresh-toolbar
+      testIf(theme !== 'visual-refresh-toolbar')(
+        'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
+        setupTest(
+          async page => {
+            await page.setWindowSize({ width: 1000, height: 800 });
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
+        )
+      );
+
+      test(
+        'focuses split panel preferences button when its position changes from bottom to side',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
+            await page.keys(['Tab', 'Right', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
+              true
+            );
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'bottom' }
+        )
+      );
+
+      test(
+        'focuses split panel preferences button when its position changes from side to bottom',
+        setupTest(
+          async page => {
+            await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
+            await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
+            await page.keys(['Tab', 'Left', 'Tab', 'Tab', 'Enter']);
+            await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
+              true
+            );
+          },
+          { pageName: 'with-split-panel', theme, mobile, splitPanelPosition: 'side' }
+        )
+      );
+
+      test(
+        'does not focus split panel when opening programatically',
+        setupTest(
+          async page => {
+            const selection = wrapper.findContentRegion().findTable().findRowSelectionArea(1).toSelector();
+            await page.click(selection);
+            await expect(page.isFocused(selection + ' input')).resolves.toBe(true);
+          },
+          {
+            pageName: 'with-table-and-split-panel',
+            theme,
+            mobile,
+          }
+        )
+      );
+
+      describe('focus interaction with info links', () => {
         test(
-          'tools panel focus toggles between open and close buttons',
+          'moves focus to close button when panel is opened from info link',
           setupTest(
             async page => {
-              await page.click(wrapper.findToolsToggle().toSelector());
-              await page.keys('Enter');
-              await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
               await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus to close button when panel content is changed using second info link',
+          setupTest(
+            async page => {
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector());
+              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus back to last opened info link when panel is closed',
+          setupTest(
+            async page => {
+              await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
+              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findToolsClose().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(true);
+            },
+            { pageName: 'with-fixed-header-footer', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'does not move focus back to last opened info link when panel has lost focus - instead focuses tools toggle',
+          setupTest(
+            async page => {
+              const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findContentRegion().findContainer().toSelector());
+              await page.click(wrapper.findToolsClose().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(false);
               await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
             },
-            { pageName: 'with-split-panel', visualRefresh, mobile }
+            { pageName: 'with-fixed-header-footer', theme, mobile }
           )
         );
+      });
 
-        test(
-          'navigation panel focus toggles between open and close buttons',
+      test(
+        'drawers focus toggles between open and close buttons',
+        setupTest(
+          async page => {
+            //Altermatomg between triggers because test-1 trigger hidden in overflow menu on mobile,
+            //security has resize button on desktop
+            const triggerSelector = wrapper.findDrawerTriggerById(mobile ? 'security' : 'test-1').toSelector();
+            await page.click(triggerSelector);
+            await page.keys('Enter');
+            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+            await page.keys('Enter');
+            await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
+          },
+          { pageName: 'with-drawers', theme, mobile }
+        )
+      );
+
+      describe('drawer focus interaction with tools buttons', () => {
+        //todo resolve focus issue returning to previously focued element on mobile for drawer open button
+        testIf(theme !== 'visual-refresh-toolbar')(
+          'moves focus to close button when panel is opened from button',
           setupTest(
             async page => {
-              // panel is closed by default on mobile
-              if (mobile) {
-                await page.click(wrapper.findNavigationToggle().toSelector());
-              }
-              await page.click(wrapper.findNavigationClose().toSelector());
-              await page.keys('Enter');
-              await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
-              await expect(page.isFocused(wrapper.findNavigationToggle().toSelector())).resolves.toBe(true);
-              await page.keys('Enter');
-              await expect(page.isFocused(wrapper.findNavigationClose().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile }
-          )
-        );
-
-        test(
-          'drawers focus toggles between open and close buttons',
-          setupTest(
-            async page => {
-              const triggerSelector = wrapper.findDrawerTriggerById('pro-help').toSelector();
-              await page.click(triggerSelector);
-              await page.keys('Enter');
-              await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
-              await page.keys('Enter');
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
               await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
               await page.keys('Enter');
-              await expect(page.isFocused(triggerSelector)).resolves.toBe(true);
-            },
-            { pageName: 'with-drawers', visualRefresh, mobile }
-          )
-        );
-
-        test(
-          'focuses tools panel closed button when it is opened using keyboard and caused split panel to change position',
-          setupTest(
-            async page => {
-              await page.setWindowSize({ width: 1000, height: 800 });
-              await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-              await page.keys(['Tab', 'Tab', 'Tab', 'Tab', 'Enter']);
-              await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile, splitPanelPosition: 'side' }
-          )
-        );
-
-        test(
-          'focuses split panel preferences button when its position changes from bottom to side',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-              await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-              await page.keys(['Tab', 'Right', 'Tab', 'Tab', 'Enter']);
-              await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
-                true
-              );
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile, splitPanelPosition: 'bottom' }
-          )
-        );
-
-        test(
-          'focuses split panel preferences button when its position changes from side to bottom',
-          setupTest(
-            async page => {
-              await page.click(wrapper.findSplitPanel().findOpenButton().toSelector());
-              await page.click(wrapper.findSplitPanel().findPreferencesButton().toSelector());
-              await page.keys(['Tab', 'Left', 'Tab', 'Tab', 'Enter']);
-              await expect(page.isFocused(wrapper.findSplitPanel().findPreferencesButton().toSelector())).resolves.toBe(
-                true
-              );
-            },
-            { pageName: 'with-split-panel', visualRefresh, mobile, splitPanelPosition: 'side' }
-          )
-        );
-
-        test(
-          'does not focus split panel when opening programatically',
-          setupTest(
-            async page => {
-              const selection = wrapper.findContentRegion().findTable().findRowSelectionArea(1).toSelector();
-              await page.click(selection);
-              await expect(page.isFocused(selection + ' input')).resolves.toBe(true);
-            },
-            {
-              pageName: 'with-table-and-split-panel',
-              visualRefresh,
-              mobile,
-            }
-          )
-        );
-
-        describe('focus interaction with info links', () => {
-          test(
-            'moves focus to close button when panel is opened from info link',
-            setupTest(
-              async page => {
-                await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-                await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-              },
-              { pageName: 'with-fixed-header-footer', visualRefresh, mobile }
-            )
-          );
-          // tests not relevant for mobile, as panel overlays content
-          if (!mobile) {
-            test(
-              'moves focus to close button when panel content is changed using second info link',
-              setupTest(
-                async page => {
-                  await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-                  await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector());
-                  await expect(page.isFocused(wrapper.findToolsClose().toSelector())).resolves.toBe(true);
-                },
-                { pageName: 'with-fixed-header-footer', visualRefresh, mobile }
-              )
-            );
-            test(
-              'moves focus back to last opened info link when panel is closed',
-              setupTest(
-                async page => {
-                  await page.click(wrapper.findContentRegion().findLink('[data-testid="info-link-1"]').toSelector());
-                  const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
-                  await page.click(infoLink);
-                  await page.click(wrapper.findToolsClose().toSelector());
-                  await expect(page.isFocused(infoLink)).resolves.toBe(true);
-                },
-                { pageName: 'with-fixed-header-footer', visualRefresh, mobile }
-              )
-            );
-            test(
-              'does not move focus back to last opened info link when panel has lost focus - instead focuses tools toggle',
-              setupTest(
-                async page => {
-                  const infoLink = wrapper.findContentRegion().findLink('[data-testid="info-link-2"]').toSelector();
-                  await page.click(infoLink);
-                  await page.click(wrapper.findContentRegion().findContainer().toSelector());
-                  await page.click(wrapper.findToolsClose().toSelector());
-                  await expect(page.isFocused(infoLink)).resolves.toBe(false);
-                  await expect(page.isFocused(wrapper.findToolsToggle().toSelector())).resolves.toBe(true);
-                },
-                { pageName: 'with-fixed-header-footer', visualRefresh, mobile }
-              )
-            );
-          }
-        });
-
-        describe('drawer focus interaction with buttons', () => {
-          test(
-            'moves focus to close button when panel is opened from button',
-            setupTest(
-              async page => {
-                await page.click(
+              await expect(
+                page.isFocused(
                   wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                );
-                await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
-                await page.keys('Enter');
-                await expect(
-                  page.isFocused(
-                    wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                  )
-                ).resolves.toBe(true);
-              },
-              { pageName: 'with-drawers', visualRefresh, mobile }
-            )
-          );
-          // tests not relevant for mobile, as panel overlays content
-          if (!mobile) {
-            test(
-              'moves focus to close button when panel content is changed using second button',
-              setupTest(
-                async page => {
-                  await page.click(
-                    wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-                  );
-                  await page.click(
-                    wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                  );
-                  await page.keys('Tab');
-                  await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
-                },
-                { pageName: 'with-drawers', visualRefresh, mobile }
-              )
-            );
-            test(
-              'moves focus back to last opened button when panel is closed',
-              setupTest(
-                async page => {
-                  await page.click(
-                    wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
-                  );
-                  await page.click(
-                    wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                  );
+                )
+              ).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
 
-                  await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
-                  await expect(
-                    page.isFocused(
-                      wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
-                    )
-                  ).resolves.toBe(true);
-                },
-                { pageName: 'with-drawers', visualRefresh, mobile }
-              )
-            );
-            test(
-              'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
-              setupTest(
-                async page => {
-                  const infoLink = wrapper
-                    .findContentRegion()
-                    .findButton('[data-testid="open-drawer-button-2"]')
-                    .toSelector();
-                  await page.click(infoLink);
-                  await page.click(wrapper.findContentRegion().findContainer().toSelector());
-                  await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
-                  await expect(page.isFocused(infoLink)).resolves.toBe(false);
-                  await expect(page.isFocused(wrapper.findDrawerTriggerById('pro-help').toSelector())).resolves.toBe(
-                    true
-                  );
-                },
-                { pageName: 'with-drawers', visualRefresh, mobile }
-              )
-            );
-          }
-        });
-      })
-    );
-  })
-);
+        //tests not relevant for mobile, as panel overlays content
+        testIf(!mobile)(
+          'moves focus to close button when panel content is changed using second button',
+          setupTest(
+            async page => {
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
+              );
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
+              await page.keys('Tab');
+              await expect(page.isFocused(wrapper.findActiveDrawerCloseButton().toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+
+        testIf(!mobile)(
+          'moves focus back to last opened button when panel is closed',
+          setupTest(
+            async page => {
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button"]').toSelector()
+              );
+              await page.click(
+                wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+              );
+
+              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
+              await expect(
+                page.isFocused(
+                  wrapper.findContentRegion().findButton('[data-testid="open-drawer-button-2"]').toSelector()
+                )
+              ).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+
+        testIf(!mobile && theme !== 'visual-refresh-toolbar')(
+          'does not move focus back to last opened button when panel has lost focus - instead focuses drawer trigger',
+          setupTest(
+            async page => {
+              const infoLink = wrapper
+                .findContentRegion()
+                .findButton('[data-testid="open-drawer-button-2"]')
+                .toSelector();
+              await page.click(infoLink);
+              await page.click(wrapper.findContentRegion().findContainer().toSelector());
+              await page.click(wrapper.findActiveDrawerCloseButton().toSelector());
+              await expect(page.isFocused(infoLink)).resolves.toBe(false);
+
+              await expect(page.isFocused(wrapper.findDrawerTriggerById('pro-help').toSelector())).resolves.toBe(true);
+            },
+            { pageName: 'with-drawers', theme, mobile }
+          )
+        );
+      });
+    })
+  );
+});

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -104,6 +104,11 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       onToolsToggle,
     });
 
+    const onActiveDrawerChangeHandler = (drawerId: string | null) => {
+      onActiveDrawerChange(drawerId);
+      drawersFocusControl.setFocus();
+    };
+
     const [splitPanelOpen = false, setSplitPanelOpen] = useControllable(
       controlledSplitPanelOpen,
       onSplitPanelToggle,
@@ -156,7 +161,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       displayed: false,
     });
 
-    const drawersFocusControl = useFocusControl(!!activeDrawer?.id);
+    const drawersFocusControl = useFocusControl(!!activeDrawer?.id, !isMobile, activeDrawer?.id);
     const navigationFocusControl = useFocusControl(navigationOpen);
     const splitPanelFocusControl = useSplitPanelFocusControl([splitPanelPreferences, splitPanelOpen]);
 
@@ -192,7 +197,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       activeDrawerId: activeDrawer?.id ?? null,
       // only pass it down if there are non-empty drawers or tools
       drawers: drawers?.length || !toolsHide ? drawers : undefined,
-      onActiveDrawerChange,
+      onActiveDrawerChange: onActiveDrawerChangeHandler,
       drawersFocusRef: drawersFocusControl.refs.toggle,
       splitPanel,
       splitPanelToggleProps: {
@@ -245,7 +250,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
       setNotificationsHeight,
       onSplitPanelToggle: onSplitPanelToggleHandler,
       onNavigationToggle,
-      onActiveDrawerChange,
+      onActiveDrawerChange: onActiveDrawerChangeHandler,
       onActiveDrawerResize,
     };
 


### PR DESCRIPTION
### Description

- Manages the focus from the toolbar trigger button to inside the drawers when opened and returns that focus to the toolbar trigger when closed 
- This only applies focus changes for the drawers, not split panel. That will come in a follow up
- Here we also tests for the focus delegation for the AppLayout component. We skip the tests with known issues that will be addressed in follups pull request

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->
Test added and skipped where needed

<!-- How can reviewers test these changes efficiently? -->
Go to https://d21d5uik3ws71m.cloudfront.net/components/42a4e8c5a4fa120648dc84733850516790b93a18/dev-pages/index.html?visualRefresh=true&appLayoutWidget=true#/light/app-layout/with-drawers?visualRefresh=true&appLayoutWidget=true
- click a drawer trigger (any button in the toolbar except the first (that opens a split panel), notice the focus shift, close the drawer, notice the drawer shift.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_ Yes, except a separate issue that needs to be addressed independently.  Toolbar focus return is hijacked on toolbar where button is not in dom when ref is trying to focus on it (due to trigger being hidden in overflow menu and not yet returned to the toolbar when more horizontal space is added)
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
