### PR TITLE
chore: Add deterministic app layout toolbar selector

### DIFF
--- a/src/app-layout/__tests__/multi-layout.test.tsx
+++ b/src/app-layout/__tests__/multi-layout.test.tsx
@@ -13,14 +13,14 @@ import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/a
 import SplitPanel from '../../../lib/components/split-panel';
 import createWrapper, { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 
-import appLayoutToolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.css.js';
+import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 
 function findToolbar(wrapper: AppLayoutWrapper) {
-  return wrapper.findByClassName(appLayoutToolbarStyles['universal-toolbar']);
+  return wrapper.findByClassName(testUtilStyles.toolbar);
 }
 
 function findAllToolbars() {
-  return createWrapper().findAllByClassName(appLayoutToolbarStyles['universal-toolbar']);
+  return createWrapper().findAllByClassName(testUtilStyles.toolbar);
 }
 
 function delay() {

--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -9,10 +9,10 @@ import AppLayout from '../../../lib/components/app-layout';
 import SplitPanel from '../../../lib/components/split-panel';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
 
-import appLayoutToolbarStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/styles.css.js';
+import testUtilStyles from '../../../lib/components/app-layout/test-classes/styles.css.js';
 
 function findToolbar(wrapper: AppLayoutWrapper) {
-  return wrapper.findByClassName(appLayoutToolbarStyles['universal-toolbar'])?.getElement();
+  return wrapper.findByClassName(testUtilStyles.toolbar)?.getElement();
 }
 
 // no-op function to suppress controllability warnings

--- a/src/app-layout/test-classes/styles.scss
+++ b/src/app-layout/test-classes/styles.scss
@@ -58,3 +58,6 @@
 .drawers-slider {
   /* used in tests */
 }
+.toolbar {
+  /* used in tests */
+}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -144,7 +144,7 @@ export function AppLayoutToolbarImplementation({
   return (
     <ToolbarSlot
       ref={ref}
-      className={clsx(styles['universal-toolbar'], {
+      className={clsx(styles['universal-toolbar'], testutilStyles.toolbar, {
         [testutilStyles['mobile-bar']]: isMobile,
         [styles['toolbar-hidden']]: toolbarHidden,
       })}


### PR DESCRIPTION
### Description

This will be used in integration tests to detect which app layout version is currently running.

Not exposed as a public test util, because which app layout design is used is still our internal implementation detail (may change in the future)

Related links, issue #, if available: n/a

### How has this been tested?

Updated related unit tests which currently use an unreliable class name

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
