### PR TITLE
refactor: Property filter controller operates internal objects

### DIFF
--- a/src/property-filter/property-editor.tsx
+++ b/src/property-filter/property-editor.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import InternalButton from '../button/internal';
 import InternalFormField from '../form-field/internal';
 import { I18nStringsInternal } from './i18n-utils';
-import { ComparisonOperator, ExtendedOperatorForm, InternalFilteringProperty, Token } from './interfaces';
+import { ComparisonOperator, ExtendedOperatorForm, InternalFilteringProperty, InternalToken } from './interfaces';
 
 import styles from './styles.css.js';
 
@@ -16,7 +16,7 @@ interface PropertyEditorProps<TokenValue> {
   filter: string;
   operatorForm: ExtendedOperatorForm<TokenValue>;
   onCancel: () => void;
-  onSubmit: (value: Token) => void;
+  onSubmit: (value: InternalToken) => void;
   i18nStrings: I18nStringsInternal;
 }
 
@@ -30,7 +30,7 @@ export function PropertyEditor<TokenValue = any>({
   i18nStrings,
 }: PropertyEditorProps<TokenValue>) {
   const [value, onChange] = useState<null | TokenValue>(null);
-  const submitToken = () => onSubmit({ propertyKey: property.propertyKey, operator, value });
+  const submitToken = () => onSubmit({ property, operator, value });
   return (
     <div className={styles['property-editor']}>
       <div className={styles['property-editor-form']}>


### PR DESCRIPTION
### Description

Refactor property filter controller so that:
* Focusing logic is moved to the component;
* Match tokens logic is consolidated in the controller (the controller operates internal objects and transforms to external).

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
