### PR TITLE
chore: I18n translations for property filter format token

### DIFF
--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "عامل التصفية",
     "i18nStrings.operatorsText": "عوامل التصفية",
     "i18nStrings.propertyText": "الخاصية",
+    "i18nStrings.removeTokenButtonAriaLabel": "إزالة عامل التصفية، {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "إظهار عدد أقل من عوامل التصفية",
     "i18nStrings.tokenLimitShowMore": "عرض المزيد من عوامل التصفية",
     "i18nStrings.valueText": "عمود القيمة",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {إزالة عامل التصفية، {token__propertyLabel} تساوي {token__value}} not_equals {إزالة عامل التصفية، {token__propertyLabel} لا تساوي {token__value}} greater_than {إزالة عامل التصفية، {token__propertyLabel} أكبر من {token__value}} greater_than_equal {إزالة عامل التصفية، {token__propertyLabel} أكبر من أو تساوي {token__value}} less_than {إزالة عامل التصفية، {token__propertyLabel} أقل من {token__value}} less_than_equal {إزالة عامل التصفية، {token__propertyLabel} أقل من أو تساوي {token__value}} contains {إزالة عامل التصفية، {token__propertyLabel} تحتوي على {token__value}} not_contains {إزالة عامل التصفية، {token__propertyLabel} لا تحتوي على {token__value}} starts_with {إزالة عامل التصفية، {token__propertyLabel} تبدأ بـ {token__value}} not_starts_with {إزالة عامل التصفية، {token__propertyLabel} لا تبدأ بـ {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} تساوي {token__value}} not_equals {{token__propertyLabel} لا تساوي {token__value}} greater_than {{token__propertyLabel} أكبر من {token__value}} greater_than_equal {{token__propertyLabel} أكبر من أو تساوي {token__value}} less_than {{token__propertyLabel} أقل من {token__value}} less_than_equal {{token__propertyLabel} أقل من أو تساوي {token__value}} contains {{token__propertyLabel} تحتوي على {token__value}} not_contains {{token__propertyLabel} لا تحتوي على {token__value}} starts_with {{token__propertyLabel} تبدأ بـ {token__value}} not_starts_with {{token__propertyLabel} لا تبدأ بـ {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "اختر إصدارًا",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operatoren",
     "i18nStrings.propertyText": "Eigenschaft",
+    "i18nStrings.removeTokenButtonAriaLabel": "Filter entfernen, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Weniger anzeigen",
     "i18nStrings.tokenLimitShowMore": "Mehr anzeigen",
     "i18nStrings.valueText": "Wert",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Filter entfernen, {token__propertyLabel} ist gleich {token__value}} not_equals {Filter entfernen, {token__propertyLabel} ist nicht gleich {token__value}} greater_than {Filter entfernen, {token__propertyLabel} ist größer als {token__value}} greater_than_equal {Filter entfernen, {token__propertyLabel} ist größer oder gleich {token__value}} less_than {Filter entfernen, {token__propertyLabel} ist kleiner als {token__value}} less_than_equal {Filter entfernen, {token__propertyLabel} ist kleiner als oder gleich {token__value}} contains {Filter entfernen, {token__propertyLabel} enthält {token__value}} not_contains {Filter entfernen, {token__propertyLabel} enthält nicht {token__value}} starts_with {Filter entfernen, {token__propertyLabel} beginnt mit {token__value}} not_starts_with {Filter entfernen, {token__propertyLabel} beginnt nicht mit {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} ist gleich {token__value}} not_equals {{token__propertyLabel} ist nicht gleich {token__value}} greater_than {{token__propertyLabel} ist größer als {token__value}} greater_than_equal {{token__propertyLabel} ist größer als oder gleich {token__value}} less_than {{token__propertyLabel} ist kleiner als {token__value}} less_than_equal {{token__propertyLabel} ist kleiner als oder gleich {token__value}} contains {{token__propertyLabel} enthält {token__value}} not_contains {{token__propertyLabel} enthält nicht {token__value}} starts_with {{token__propertyLabel} startet mit {token__value}} not_starts_with {{token__propertyLabel} startet nicht mit {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Version auswählen",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operators",
     "i18nStrings.propertyText": "Property",
+    "i18nStrings.removeTokenButtonAriaLabel": "Remove filter, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Show fewer",
     "i18nStrings.tokenLimitShowMore": "Show more",
     "i18nStrings.valueText": "Value",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remove filter, {token__propertyLabel} equals {token__value}} not_equals {Remove filter, {token__propertyLabel} does not equal {token__value}} greater_than {Remove filter, {token__propertyLabel} is greater than {token__value}} greater_than_equal {Remove filter, {token__propertyLabel} is greater than or equal to {token__value}} less_than {Remove filter, {token__propertyLabel} is less than {token__value}} less_than_equal {Remove filter, {token__propertyLabel} is less than or equal to {token__value}} contains {Remove filter, {token__propertyLabel} contains {token__value}} not_contains {Remove filter, {token__propertyLabel} does not contain {token__value}} starts_with {Remove filter, {token__propertyLabel} starts with {token__value}} not_starts_with {Remove filter, {token__propertyLabel} does not start with {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} equals {token__value}} not_equals {{token__propertyLabel} does not equal {token__value}} greater_than {{token__propertyLabel} is greater than {token__value}} greater_than_equal {{token__propertyLabel} is greater than or equal to {token__value}} less_than {{token__propertyLabel} is less than {token__value}} less_than_equal {{token__propertyLabel} is less than or equal to {token__value}} contains {{token__propertyLabel} contains {token__value}} not_contains {{token__propertyLabel} does not contain {token__value}} starts_with {{token__propertyLabel} starts with {token__value}} not_starts_with {{token__propertyLabel} does not start with {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Choose a version",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -158,7 +158,7 @@
     "loadingText": "Cargando contenido"
   },
   "input": {
-    "clearAriaLabel": "Borrar"
+    "clearAriaLabel": "Despejar"
   },
   "link": {
     "externalIconAriaLabel": "Se abre en una pestaña nueva."
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operador",
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propiedad",
+    "i18nStrings.removeTokenButtonAriaLabel": "Quitar el filtro {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Mostrar menos",
     "i18nStrings.tokenLimitShowMore": "Mostrar más",
     "i18nStrings.valueText": "Valor",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Eliminar filtro, {token__propertyLabel} igual a {token__value}} not_equals {Eliminar filtro, {token__propertyLabel} no es igual a {token__value}} greater_than {Eliminar filtro, {token__propertyLabel} es mayor que {token__value}} greater_than_equal {Eliminar filtro, {token__propertyLabel} es mayor o igual que {token__value}} less_than {Eliminar filtro, {token__propertyLabel} es menor que {token__value}} less_than_equal {Eliminar filtro, {token__propertyLabel} es menor o igual que {token__value}} contains {Eliminar filtro, {token__propertyLabel} contiene {token__value}} not_contains {Eliminar filtro, {token__propertyLabel} no contiene {token__value}} starts_with {Eliminar filtro, {token__propertyLabel} comienza con {token__value}} not_starts_with {Eliminar filtro, {token__propertyLabel} no comienza con {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} es igual a {token__value}} not_equals {{token__propertyLabel} no es igual a {token__value}} greater_than {{token__propertyLabel} es mayor que {token__value}} greater_than_equal {{token__propertyLabel} es mayor que {token__value} o igual} less_than {{token__propertyLabel} es menor que {token__value}} less_than_equal {{token__propertyLabel} es menor que {token__value} o igual} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} no contiene {token__value}} starts_with {{token__propertyLabel} empieza con {token__value}} not_starts_with {{token__propertyLabel} no empieza con {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Elija una versión",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Opérateur",
     "i18nStrings.operatorsText": "Opérateurs",
     "i18nStrings.propertyText": "Propriété",
+    "i18nStrings.removeTokenButtonAriaLabel": "Supprimer le filtre, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Afficher moins",
     "i18nStrings.tokenLimitShowMore": "Afficher plus",
     "i18nStrings.valueText": "Valeur",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Supprimer le filtre, {token__propertyLabel} est égal à {token__value}} not_equals {Supprimer le filtre, {token__propertyLabel} n'est pas égal à {token__value}} greater_than {Supprimer le filtre, {token__propertyLabel} est supérieur à {token__value}} greater_than_equal {Supprimer le filtre, {token__propertyLabel} est supérieur ou égal à {token__value}} less_than {Supprimer le filtre, {token__propertyLabel} est inférieur à {token__value}} less_than_equal {Supprimer le filtre, {token__propertyLabel} est inférieur ou égal à {token__value}} contains {Supprimer le filtre, {token__propertyLabel} contient {token__value}} not_contains {Supprimer le filtre, {token__propertyLabel} ne contient pas {token__value}} starts_with {Supprimer le filtre, {token__propertyLabel} commence par {token__value}} not_starts_with {Supprimer le filtre, {token__propertyLabel} ne commence pas par {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} est égal à {token__value}} not_equals {{token__propertyLabel} n’est pas égal à {token__value}} greater_than {{token__propertyLabel} est supérieur à {token__value}} greater_than_equal {{token__propertyLabel} est supérieur ou égal à {token__value}} less_than {{token__propertyLabel} est inférieur à {token__value}} less_than_equal {{token__propertyLabel} est inférieur ou égal à {token__value}} contains {{token__propertyLabel} contient {token__value}} not_contains {{token__propertyLabel} ne contient pas {token__value}} starts_with {{token__propertyLabel} commence par {token__value}} not_starts_with {{token__propertyLabel} ne commence pas par {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Choisir une version",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operator",
     "i18nStrings.operatorsText": "Operator",
     "i18nStrings.propertyText": "Properti",
+    "i18nStrings.removeTokenButtonAriaLabel": "Hapus filter, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Tampilkan lebih sedikit",
     "i18nStrings.tokenLimitShowMore": "Tampilkan selengkapnya",
     "i18nStrings.valueText": "Nilai",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Hapus filter, {token__propertyLabel} sama dengan {token__value}} not_equals {Hapus filter, {token__propertyLabel} tidak sama dengan {token__value}} greater_than {Hapus filter, {token__propertyLabel} lebih besar dari {token__value}} greater_than_equal {Hapus filter, {token__propertyLabel} lebih besar dari atau sama dengan {token__value}} less_than {Hapus filter, {token__propertyLabel} kurang dari {token__value}} less_than_equal {Hapus filter, {token__propertyLabel} kurang dari atau sama dengan {token__value}} contains {Hapus filter, {token__propertyLabel} berisi {token__value}} not_contains {Hapus filter, {token__propertyLabel} tidak berisi {token__value}} starts_with {Hapus filter, {token__propertyLabel} dimulai dengan {token__value}} not_starts_with {Hapus filter, {token__propertyLabel} tidak dimulai dengan {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} sama dengan {token__value}} not_equals {{token__propertyLabel} tidak sama dengan {token__value}} greater_than {{token__propertyLabel} lebih besar dari {token__value}} greater_than_equal {{token__propertyLabel} lebih besar dari atau sama dengan {token__value}} less_than {{token__propertyLabel} kurang dari {token__value}} less_than_equal {{token__propertyLabel} kurang dari atau sama dengan {token__value}} contains {{token__propertyLabel} berisi {token__value}} not_contains {{token__propertyLabel} tidak berisi {token__value}} starts_with {{token__propertyLabel} dimulai dengan {token__value}} not_starts_with {{token__propertyLabel} tidak dimulai dengan {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Pilih versi",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operatore",
     "i18nStrings.operatorsText": "Operatori",
     "i18nStrings.propertyText": "Proprietà",
+    "i18nStrings.removeTokenButtonAriaLabel": "Rimuovi filtro, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Mostra meno",
     "i18nStrings.tokenLimitShowMore": "Mostra altro",
     "i18nStrings.valueText": "Valore",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Rimuovi filtro, {token__propertyLabel} uguale a {token__value}} not_equals {Rimuovi filtro, {token__propertyLabel} non è uguale a {token__value}} greater_than {Rimuovi filtro, {token__propertyLabel} è maggiore di {token__value}} greater_than_equal {Rimuovi filtro, {token__propertyLabel} è maggiore o uguale a {token__value}} less_than {Rimuovi filtro, {token__propertyLabel} è inferiore a {token__value}} less_than_equal {Rimuovi filtro, {token__propertyLabel} è minore o uguale a {token__value}} contains {Rimuovi filtro, {token__propertyLabel} contiene {token__value}} not_contains {Rimuovi filtro, {token__propertyLabel} non contiene {token__value}} starts_with {Rimuovi filtro, {token__propertyLabel} inizia con {token__value}} not_starts_with {Rimuovi filtro, {token__propertyLabel} non inizia con {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} è uguale a {token__value}} not_equals {{token__propertyLabel} non è uguale a {token__value}} greater_than {{token__propertyLabel} è maggiore di {token__value}} greater_than_equal {{token__propertyLabel} è maggiore o uguale a {token__value}} less_than {{token__propertyLabel} è minore di {token__value}} less_than_equal {{token__propertyLabel} è minore o uguale a {token__value}} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} non contiene {token__value}} starts_with {{token__propertyLabel} inizia con {token__value}} not_starts_with {{token__propertyLabel} non inizia con {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Scegli una versione",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "演算子",
     "i18nStrings.operatorsText": "演算子",
     "i18nStrings.propertyText": "プロパティ",
+    "i18nStrings.removeTokenButtonAriaLabel": "フィルターを取り外し、{token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "少なく表示",
     "i18nStrings.tokenLimitShowMore": "さらに表示",
     "i18nStrings.valueText": "値",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {フィルターを削除、{token__propertyLabel} は {token__value} と等しい} not_equals {フィルターを削除、{token__propertyLabel} は {token__value} と等しくない} greater_than {フィルターを削除、{token__propertyLabel} は {token__value} より大きい} greater_than_equal {フィルターを削除、{token__propertyLabel} は {token__value} 以上} less_than {フィルターを削除、{token__propertyLabel} は {token__value} 未満} less_than_equal {フィルターを削除、{token__propertyLabel} は {token__value} 以下} contains {フィルターを削除、{token__propertyLabel} は {token__value} を含む} not_contains {フィルターを削除、{token__propertyLabel} は {token__value} を含まない} starts_with {フィルターを削除、{token__propertyLabel} は {token__value} で始まる} not_starts_with {フィルターを削除、{token__propertyLabel} は {token__value} で始まらない} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} は {token__value} と等しい} not_equals {{token__propertyLabel} は {token__value} と等しくない} greater_than {{token__propertyLabel} は {token__value} より大きい} greater_than_equal {{token__propertyLabel} は {token__value} 以上} less_than {{token__propertyLabel} は {token__value} 未満} less_than_equal {{token__propertyLabel} は {token__value} 以下} contains {{token__propertyLabel} は {token__value} を含む} not_contains {{token__propertyLabel} は {token__value} を含まない} starts_with {{token__propertyLabel} は {token__value} で始まる} not_starts_with {{token__propertyLabel} は {token__value} で始まらない} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "バージョンを選択してください",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "연산자",
     "i18nStrings.operatorsText": "연산자",
     "i18nStrings.propertyText": "속성",
+    "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} 필터 제거",
     "i18nStrings.tokenLimitShowFewer": "간단히 표시",
     "i18nStrings.tokenLimitShowMore": "자세히 표시",
     "i18nStrings.valueText": "값",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {{token__propertyLabel}이(가) {token__value}과(와) 같음 필터 제거} not_equals {{token__propertyLabel}이(가) {token__value}과(와) 같지 않음 필터 제거} greater_than {{token__propertyLabel}이(가) {token__value}보다 큼 필터 제거} greater_than_equal {{token__propertyLabel}이(가) {token__value}보다 크거나 같음 필터 제거} less_than {{token__propertyLabel}이(가) {token__value}보다 작음 필터 제거} less_than_equal {{token__propertyLabel}이(가) {token__value}보다 작거나 같음 필터 제거} contains {{token__propertyLabel}이(가) {token__value}을(를) 포함함 필터 제거} not_contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하지 않음 필터 제거} starts_with {필터 제거, {token__value}(으)로 시작하는 {token__propertyLabel}} not_starts_with {필터 제거, {token__propertyLabel}이(가) {token__value}(으)로 시작하지 않음} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel}이(가) {token__value}와(과) 같은} not_equals {{token__propertyLabel}이(가) {token__value}와(과) 같지 않은} greater_than {{token__propertyLabel}이(가) {token__value}보다 큰} greater_than_equal {{token__propertyLabel}이(가) {token__value}보다 크거나 같은} less_than {{token__propertyLabel}이(가) {token__value}보다 작은} less_than_equal {{token__propertyLabel}이(가) {token__value}보다 작거나 같은} contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하는} not_contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하지 않는} starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하는} not_starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하지 않는} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "버전 선택",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operador",
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propriedade",
+    "i18nStrings.removeTokenButtonAriaLabel": "Remover filtro, {token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "Mostrar menos",
     "i18nStrings.tokenLimitShowMore": "Mostrar mais",
     "i18nStrings.valueText": "Valor",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {Remover filtro, {token__propertyLabel} é igual a {token__value}} not_equals {Remover filtro, {token__propertyLabel} diferente de {token__value}} greater_than {Remover filtro, {token__propertyLabel} é maior que {token__value}} greater_than_equal {Remover filtro, {token__propertyLabel} é maior que ou igual a {token__value}} less_than {Remover filtro, {token__propertyLabel} é menor que {token__value}} less_than_equal {Remover filtro, {token__propertyLabel} é menor que ou igual a {token__value}} contains {Remove filtro, {token__propertyLabel} contém {token__value}} not_contains {Remover filtro, {token__propertyLabel} não contém {token__value}} starts_with {Remover filtro, {token__propertyLabel} começa com {token__value}} not_starts_with {Remova o filtro, {token__propertyLabel} não começa com {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} é igual a {token__value}} not_equals {{token__propertyLabel} é diferente de {token__value}} greater_than {{token__propertyLabel} é maior que {token__value}} greater_than_equal {{token__propertyLabel} é maior que ou igual a {token__value}} less_than {{token__propertyLabel} é menor que {token__value}} less_than_equal {{token__propertyLabel} é menor que ou igual a {token__value}} contains {{token__propertyLabel} contém {token__value}} not_contains {{token__propertyLabel} não contém {token__value}} starts_with {{token__propertyLabel} começa com {token__value}} not_starts_with {{token__propertyLabel} não começa com {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Escolher uma versão",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "Operatör",
     "i18nStrings.operatorsText": "Operatörler",
     "i18nStrings.propertyText": "Özellik",
+    "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} filtresini kaldır",
     "i18nStrings.tokenLimitShowFewer": "Daha az göster",
     "i18nStrings.tokenLimitShowMore": "Daha fazla göster",
     "i18nStrings.valueText": "Değer",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {{token__propertyLabel}, {token__value} değerine eşittir filtresini kaldır} not_equals {{token__propertyLabel}, {token__value} değerine eşit değildir filtresini kaldır} greater_than {{token__propertyLabel}, {token__value} değerinden büyüktür filtresini kaldır} greater_than_equal {{token__propertyLabel}, {token__value} değerinden büyük veya buna eşittir filtresini kaldır} less_than {{token__propertyLabel}, {token__value} değerinden küçüktür filtresini kaldır} less_than_equal {{token__propertyLabel}, {token__value} değerinden küçük veya buna eşittir filtresini kaldır} contains {{token__propertyLabel}, {token__value} değerini içerir filtresini kaldır} not_contains {{token__propertyLabel}, {token__value} değerini içermez filtresini kaldır} starts_with {{token__propertyLabel}, {token__value} değerinden şunla başlar filtresini kaldır} not_starts_with {{token__propertyLabel}, {token__value} değeri ile başlamaz filtresini kaldır} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} eşittir {token__value}} not_equals {{token__propertyLabel} eşit değildir {token__value}} greater_than {{token__propertyLabel} büyüktür {token__value}} greater_than_equal {{token__propertyLabel} büyük veya eşittir {token__value}} less_than {{token__propertyLabel} küçüktür {token__value}} less_than_equal {{token__propertyLabel} küçük veya eşittir {token__value}} contains {{token__propertyLabel}, {token__value} içerir} not_contains {{token__propertyLabel}, {token__value} içermez} starts_with {{token__propertyLabel}, {token__value} ile başlar} not_starts_with {{token__propertyLabel}, {token__value} ile başlamaz} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Bir sürüm seçin",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "运算符",
     "i18nStrings.operatorsText": "运算符",
     "i18nStrings.propertyText": "属性",
+    "i18nStrings.removeTokenButtonAriaLabel": "移除筛选条件，{token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "显示更少",
     "i18nStrings.tokenLimitShowMore": "显示更多",
     "i18nStrings.valueText": "值",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {删除筛选条件，{token__propertyLabel} 等于 {token__value}} not_equals {删除筛选条件，{token__propertyLabel} 不等于 {token__value}} greater_than {删除筛选条件，{token__propertyLabel} 大于 {token__value}} greater_than_equal {删除筛选条件，{token__propertyLabel} 大于或等于 {token__value}} less_than {删除筛选条件，{token__propertyLabel} 小于 {token__value}} less_than_equal {删除筛选条件，{token__propertyLabel} 小于或等于 {token__value}} contains {删除筛选条件，{token__propertyLabel} 包含 {token__value}} not_contains {删除筛选条件，{token__propertyLabel} 不包含 {token__value}} starts_with {删除筛选条件，{token__propertyLabel} 开头为 {token__value}} not_starts_with {删除筛选条件，{token__propertyLabel} 不是以 {token__value} 开头} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等于 {token__value}} not_equals {{token__propertyLabel} 不等于 {token__value}} greater_than {{token__propertyLabel} 大于 {token__value}} greater_than_equal {{token__propertyLabel} 大于或等于 {token__value}} less_than {{token__propertyLabel} 小于 {token__value}} less_than_equal {{token__propertyLabel} 小于或等于 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 开头为 {token__value}} not_starts_with {{token__propertyLabel} 开头不为 {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "选择版本",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -206,10 +206,11 @@
     "i18nStrings.operatorText": "運算子",
     "i18nStrings.operatorsText": "運算子",
     "i18nStrings.propertyText": "屬性",
+    "i18nStrings.removeTokenButtonAriaLabel": "移除篩選條件，{token__formattedText}",
     "i18nStrings.tokenLimitShowFewer": "顯示較少",
     "i18nStrings.tokenLimitShowMore": "顯示更多",
     "i18nStrings.valueText": "值",
-    "i18nStrings.removeTokenButtonAriaLabel": "{token__operator, select, equals {移除篩選條件，{token__propertyLabel} 等於 {token__value}} not_equals {移除篩選條件，{token__propertyLabel} 不等於 {token__value}} greater_than {移除篩選條件，{token__propertyLabel} 大於 {token__value}} greater_than_equal {移除篩選條件，{token__propertyLabel} 大於或等於 {token__value}} less_than {移除篩選條件，{token__propertyLabel} 小於 {token__value}} less_than_equal {移除篩選條件，{token__propertyLabel} 小於或等於 {token__value}} contains {移除篩選條件，{token__propertyLabel} 包含 {token__value}} not_contains {移除篩選條件，{token__propertyLabel} 不包含 {token__value}} starts_with {移除篩選條件，{token__propertyLabel} 開始為 {token__value}} not_starts_with {移除篩選條件，{token__propertyLabel} 不是以 {token__value} 開頭} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等於 {token__value}} not_equals {{token__propertyLabel} 不等於 {token__value}} greater_than {{token__propertyLabel} 大於 {token__value}} greater_than_equal {{token__propertyLabel} 大於或等於 {token__value}} less_than {{token__propertyLabel} 小於 {token__value}} less_than_equal {{token__propertyLabel} 小於或等於 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 開頭為 {token__value}} not_starts_with {{token__propertyLabel} 開頭不能為 {token__value}} other {}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "選擇一個版本",

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -93,26 +93,6 @@ export function usePropertyFilterI18n(def: I18nStrings & I18nStringsExt): I18nSt
     return { propertyKey: token.property?.propertyKey, propertyLabel, operator: token.operator, value: tokenValue };
   }
 
-  function toI18n(
-    token: InternalToken,
-    { ariaLabel }: { ariaLabel: boolean }
-  ): {
-    token__propertyKey: string;
-    token__propertyLabel: string;
-    token__operator: string;
-    token__value: string;
-    token__formattedText: string;
-  } {
-    const formatted = toFormatted(token);
-    return {
-      token__propertyKey: formatted.propertyKey ?? '',
-      token__propertyLabel: formatted.propertyLabel,
-      token__operator: ariaLabel ? getOperatorI18nString(formatted.operator) : formatted.operator,
-      token__value: formatted.value,
-      token__formattedText: formatToken(formatted),
-    };
-  }
-
   return {
     ...def,
     allPropertiesLabel,
@@ -177,7 +157,7 @@ export function usePropertyFilterI18n(def: I18nStrings & I18nStringsExt): I18nSt
       const formatter = i18n(
         'i18nStrings.removeTokenButtonAriaLabel',
         def.removeTokenButtonAriaLabel,
-        format => () => format(toI18n(token, { ariaLabel: true }))
+        format => () => format({ token__formattedText: formatToken(toFormatted(token)) })
       );
       return formatter?.(toFormatted(token)) ?? '';
     },
@@ -185,7 +165,7 @@ export function usePropertyFilterI18n(def: I18nStrings & I18nStringsExt): I18nSt
       const formatter = i18n(
         'i18nStrings.tokenEditorTokenActionsAriaLabel',
         def.tokenEditorTokenActionsAriaLabel,
-        format => () => format(toI18n(token, { ariaLabel: true }))
+        format => () => format({ token__formattedText: formatToken(toFormatted(token)) })
       );
       return formatter?.(toFormatted(token)) ?? '';
     },
@@ -193,7 +173,7 @@ export function usePropertyFilterI18n(def: I18nStrings & I18nStringsExt): I18nSt
       const formatter = i18n(
         'i18nStrings.tokenEditorTokenRemoveAriaLabel',
         def.tokenEditorTokenRemoveAriaLabel,
-        format => () => format(toI18n(token, { ariaLabel: true }))
+        format => () => format({ token__formattedText: formatToken(toFormatted(token)) })
       );
       return formatter?.(toFormatted(token)) ?? '';
     },
@@ -201,15 +181,21 @@ export function usePropertyFilterI18n(def: I18nStrings & I18nStringsExt): I18nSt
       const formatter = i18n(
         'i18nStrings.tokenEditorAddExistingTokenAriaLabel',
         def.tokenEditorAddExistingTokenAriaLabel,
-        format => () => format(toI18n(token, { ariaLabel: true }))
+        format => () => format({ token__formattedText: formatToken(toFormatted(token)) })
       );
       return formatter?.(toFormatted(token)) ?? '';
     },
     tokenEditorAddExistingTokenLabel: token => {
+      const formattedToken = toFormatted(token);
       const formatter = i18n(
         'i18nStrings.tokenEditorAddExistingTokenLabel',
         def.tokenEditorAddExistingTokenLabel,
-        format => () => format(toI18n(token, { ariaLabel: false }))
+        format => () =>
+          format({
+            token__propertyLabel: formattedToken.propertyLabel,
+            token__operator: formattedToken.operator,
+            token__value: formattedToken.value,
+          })
       );
       return formatter?.(toFormatted(token)) ?? '';
     },


### PR DESCRIPTION
### Description

Translations for property filter token formatter (see https://github.com/cloudscape-design/components/pull/2602).

Rel: [qUFhApKfmWEg]

### How has this been tested?

* Existing unit tests
* Manual test with i18n strings and i18n provider

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
