### PR TITLE
feat: Update toolbar layout so it spans full page width (non-deduplicated)

### DIFF
--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -34,6 +34,12 @@ describe('toolbar mode only features', () => {
       expect(findToolbar(wrapper)).toContainElement(wrapper.findToolsToggle().getElement());
     });
 
+    test('renders navigation toggle button for open state', () => {
+      const { wrapper } = renderComponent(<AppLayout navigationOpen={true} onNavigationChange={noop} />);
+      expect(findToolbar(wrapper)).toBeTruthy();
+      expect(wrapper.findNavigationToggle()).toBeTruthy();
+    });
+
     test('renders toolbar with split panel trigger', () => {
       const { wrapper } = renderComponent(
         <AppLayout splitPanel={<SplitPanel header="Testing">Dummy for testing</SplitPanel>} />

--- a/src/app-layout/__tests__/toolbar.test.tsx
+++ b/src/app-layout/__tests__/toolbar.test.tsx
@@ -34,12 +34,6 @@ describe('toolbar mode only features', () => {
       expect(findToolbar(wrapper)).toContainElement(wrapper.findToolsToggle().getElement());
     });
 
-    test('does not render navigation toggle button for open state', () => {
-      const { wrapper } = renderComponent(<AppLayout navigationOpen={true} onNavigationChange={noop} />);
-      expect(findToolbar(wrapper)).toBeTruthy();
-      expect(wrapper.findNavigationToggle()).toBeFalsy();
-    });
-
     test('renders toolbar with split panel trigger', () => {
       const { wrapper } = renderComponent(
         <AppLayout splitPanel={<SplitPanel header="Testing">Dummy for testing</SplitPanel>} />

--- a/src/app-layout/resize/styles.scss
+++ b/src/app-layout/resize/styles.scss
@@ -10,7 +10,7 @@
   @include styles.media-breakpoint-up(styles.$breakpoint-x-small) {
     @include styles.with-motion {
       transition: awsui.$motion-duration-refresh-only-medium;
-      transition-property: border-color, opacity, block-size, inline-size;
+      transition-property: border-color, opacity, block-size, inline-size, inset-block-start;
     }
   }
 }

--- a/src/app-layout/visual-refresh-toolbar/compute-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/compute-layout.ts
@@ -62,6 +62,7 @@ export interface VerticalLayoutOutput {
   toolbar: number;
   notifications: number;
   header: number;
+  drawers: number;
 }
 
 export function computeVerticalLayout({
@@ -73,13 +74,16 @@ export function computeVerticalLayout({
 }: VerticalLayoutInput): VerticalLayoutOutput {
   const toolbar = topOffset;
   let notifications = topOffset;
+  let drawers = topOffset;
+
   if (hasVisibleToolbar) {
     notifications += toolbarHeight;
+    drawers += toolbarHeight;
   }
   let header = notifications;
   if (stickyNotifications) {
     header += notificationsHeight;
   }
 
-  return { toolbar, notifications, header };
+  return { toolbar, notifications, header, drawers };
 }

--- a/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
@@ -29,6 +29,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     drawersFocusControl,
     isMobile,
     placement,
+    verticalOffsets,
     onActiveDrawerChange,
     onActiveDrawerResize,
   } = appLayoutInternals;
@@ -57,7 +58,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
       id={activeDrawerId}
       aria-hidden={!activeDrawer}
       aria-label={computedAriaLabels.content}
-      className={clsx(styles.drawer, {
+      className={clsx(styles.drawer, sharedStyles['with-motion'], {
         [testutilStyles['active-drawer']]: !toolsOnlyMode && activeDrawerId,
         [testutilStyles.tools]: isToolsDrawer,
       })}
@@ -68,8 +69,8 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
         }
       }}
       style={{
-        blockSize: `calc(100vh - ${placement.insetBlockStart}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: placement.insetBlockStart,
+        blockSize: `calc(100vh - ${verticalOffsets.drawers}px - ${placement.insetBlockEnd}px)`,
+        insetBlockStart: verticalOffsets.drawers,
       }}
     >
       {!isMobile && activeDrawer?.resizable && (

--- a/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
@@ -41,6 +41,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
     content: activeDrawer ? activeDrawer.ariaLabels?.drawerName : ariaLabels?.tools,
   };
 
+  const drawersTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
   const isToolsDrawer = activeDrawer?.id === TOOLS_DRAWER_ID;
   const toolsOnlyMode = drawers.length === 1 && drawers[0].id === TOOLS_DRAWER_ID;
   const toolsContent = drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content;
@@ -69,8 +70,8 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
         }
       }}
       style={{
-        blockSize: `calc(100vh - ${verticalOffsets.drawers}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: verticalOffsets.drawers,
+        blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
+        insetBlockStart: drawersTopOffset,
       }}
     >
       {!isMobile && activeDrawer?.resizable && (

--- a/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/drawer/styles.scss
@@ -8,7 +8,7 @@
 
 .drawer {
   position: sticky;
-  z-index: 830;
+  z-index: constants.$drawer-z-index;
   background-color: awsui.$color-background-container-content;
   display: grid;
   grid-template-columns: awsui.$space-m 1fr;

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -210,7 +210,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
 
     const verticalOffsets = computeVerticalLayout({
       topOffset: placement.insetBlockStart,
-      hasVisibleToolbar: hasToolbar && toolbarState !== 'hide',
+      hasVisibleToolbar: hasToolbar && toolbarState !== 'hide' && !isMobile,
       notificationsHeight: notificationsHeight ?? 0,
       toolbarHeight: toolbarHeight ?? 0,
       stickyNotifications: !!stickyNotifications,

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -28,6 +28,8 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
     verticalOffsets,
   } = appLayoutInternals;
 
+  const drawersTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
+
   // Close the Navigation drawer on mobile when a user clicks a link inside.
   const onNavigationClick = (event: React.MouseEvent) => {
     const hasLink = findUpUntil(
@@ -54,8 +56,8 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
       aria-hidden={!navigationOpen}
       onClick={onNavigationClick}
       style={{
-        blockSize: `calc(100vh - ${verticalOffsets.drawers}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: verticalOffsets.drawers,
+        blockSize: `calc(100vh - ${drawersTopOffset}px - ${placement.insetBlockEnd}px)`,
+        insetBlockStart: drawersTopOffset,
       }}
     >
       <div className={clsx(styles['animated-content'])}>

--- a/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/navigation/index.tsx
@@ -8,6 +8,7 @@ import { findUpUntil } from '../../../internal/utils/dom';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutInternals } from '../interfaces';
 
+import sharedStyles from '../../resize/styles.css.js';
 import testutilStyles from '../../test-classes/styles.css.js';
 import styles from './styles.css.js';
 
@@ -16,8 +17,16 @@ interface AppLayoutNavigationImplementationProps {
 }
 
 export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLayoutNavigationImplementationProps) {
-  const { ariaLabels, onNavigationToggle, isMobile, navigationOpen, navigation, navigationFocusControl, placement } =
-    appLayoutInternals;
+  const {
+    ariaLabels,
+    onNavigationToggle,
+    isMobile,
+    navigationOpen,
+    navigation,
+    navigationFocusControl,
+    placement,
+    verticalOffsets,
+  } = appLayoutInternals;
 
   // Close the Navigation drawer on mobile when a user clicks a link inside.
   const onNavigationClick = (event: React.MouseEvent) => {
@@ -39,13 +48,14 @@ export function AppLayoutNavigationImplementation({ appLayoutInternals }: AppLay
           [styles['is-navigation-open']]: navigationOpen,
           [testutilStyles['drawer-closed']]: !navigationOpen,
         },
-        testutilStyles.navigation
+        testutilStyles.navigation,
+        sharedStyles['with-motion']
       )}
       aria-hidden={!navigationOpen}
       onClick={onNavigationClick}
       style={{
-        blockSize: `calc(100vh - ${placement.insetBlockStart}px - ${placement.insetBlockEnd}px)`,
-        insetBlockStart: placement.insetBlockStart,
+        blockSize: `calc(100vh - ${verticalOffsets.drawers}px - ${placement.insetBlockEnd}px)`,
+        insetBlockStart: verticalOffsets.drawers,
       }}
     >
       <div className={clsx(styles['animated-content'])}>

--- a/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/navigation/styles.scss
@@ -10,6 +10,7 @@
 
 .navigation {
   position: sticky;
+  z-index: constants.$drawer-z-index;
   background-color: awsui.$color-background-container-content;
   inset-block-end: 0;
   block-size: 100%;
@@ -19,7 +20,6 @@
   overscroll-behavior-y: contain;
   word-wrap: break-word;
   pointer-events: auto;
-  z-index: 1001;
 
   // All content is hidden by the overflow-x property
   &:not(.is-navigation-open) {
@@ -40,6 +40,7 @@
   // The Navigation drawer will take up the entire viewport on mobile
   @include styles.media-breakpoint-down(styles.$breakpoint-x-small) {
     #{custom-props.$navigationWidth}: 100vw;
+    z-index: constants.$drawer-z-index-mobile;
   }
 }
 

--- a/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/index.tsx
@@ -71,6 +71,7 @@ export function SkeletonLayout({
         [customCssProps.toolsWidth]: `${toolsWidth}px`,
       }}
     >
+      {toolbar}
       {navigation && (
         <div
           className={clsx(
@@ -83,7 +84,6 @@ export function SkeletonLayout({
           {navigation}
         </div>
       )}
-      {toolbar}
       <main className={clsx(styles['main-landmark'], anyPanelOpen && styles['unfocusable-mobile'])}>
         {notifications}
         <div className={clsx(styles.main, { [styles['main-disable-paddings']]: disableContentPaddings })} style={style}>

--- a/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/skeleton/styles.scss
@@ -41,7 +41,7 @@
   // desktop grid
   @include desktop-only {
     grid-template-areas:
-      'navigation toolbar      toolbar       toolbar   toolbar         tools'
+      'toolbar    toolbar      toolbar       toolbar   toolbar         toolbar'
       'navigation .         notifications    .         sideSplitPanel  tools'
       'navigation .             main         .         sideSplitPanel  tools';
     grid-template-columns:
@@ -76,10 +76,11 @@
   grid-row: 1 / -1;
   grid-column: 1 / -1;
   background: awsui.$color-background-container-content;
-  z-index: 850;
+  z-index: constants.$drawer-z-index;
   opacity: 1;
   @include mobile-only {
     inline-size: 100%;
+    z-index: constants.$drawer-z-index-mobile;
   }
 }
 

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -100,16 +100,19 @@ export function DrawerTriggers({
         aria-orientation="horizontal"
       >
         {splitPanelToggleProps && (
-          <TriggerButton
-            ariaLabel={splitPanelToggleProps.ariaLabel}
-            ariaControls={splitPanelToggleProps.controlId}
-            ariaExpanded={splitPanelToggleProps.active}
-            className={clsx(styles['drawers-trigger'], splitPanelTestUtilStyles['open-button'])}
-            iconName={splitPanelToggleProps.position === 'side' ? 'view-vertical' : 'view-horizontal'}
-            onClick={() => onSplitPanelToggle?.()}
-            selected={splitPanelToggleProps.active}
-            ref={splitPanelFocusRef}
-          />
+          <>
+            <TriggerButton
+              ariaLabel={splitPanelToggleProps.ariaLabel}
+              ariaControls={splitPanelToggleProps.controlId}
+              ariaExpanded={splitPanelToggleProps.active}
+              className={clsx(styles['drawers-trigger'], splitPanelTestUtilStyles['open-button'])}
+              iconName={splitPanelToggleProps.position === 'side' ? 'view-vertical' : 'view-horizontal'}
+              onClick={() => onSplitPanelToggle?.()}
+              selected={splitPanelToggleProps.active}
+              ref={splitPanelFocusRef}
+            />
+            {hasMultipleTriggers ? <div className={styles['group-divider']}></div> : null}
+          </>
         )}
         {visibleItems.map(item => {
           return (

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -153,14 +153,14 @@ export function AppLayoutToolbarImplementation({
       }}
     >
       <div className={styles['toolbar-container']}>
-        {hasNavigation && !navigationOpen && (
+        {hasNavigation && (
           <nav className={clsx(styles['universal-toolbar-nav'], testutilStyles['drawer-closed'])}>
             <TriggerButton
               ariaLabel={ariaLabels?.navigationToggle ?? undefined}
               ariaExpanded={false}
               iconName="menu"
               className={testutilStyles['navigation-toggle']}
-              onClick={() => onNavigationToggle?.(true)}
+              onClick={() => onNavigationToggle?.(!navigationOpen)}
               ref={navigationFocusRef}
               selected={navigationOpen}
             />

--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -83,14 +83,11 @@
   flex-direction: row;
   gap: awsui.$space-xs;
   justify-content: flex-end;
+}
 
-  &:not(.has-multiple-triggers).has-open-drawer {
-    opacity: 0;
-  }
-
-  &:not(.has-multiple-triggers):not(.has-open-drawer) {
-    opacity: 1;
-  }
+.group-divider {
+  border-inline-end: awsui.$border-divider-section-width solid awsui.$color-border-layout;
+  block-size: 60%;
 }
 
 .drawers-trigger {


### PR DESCRIPTION
### Description

Adjust the orientation of the toolbar so it is positioned above the drawers to support the asks from Sidecar team.
This commit also adds a divider between the split panel and the other drawers.

#### Before
![Screenshot 2024-08-27 at 8 53 07 PM](https://github.com/user-attachments/assets/54463c45-25eb-4f82-abfc-981197ee31a4)

#### After
![Screenshot 2024-08-27 at 8 53 29 PM](https://github.com/user-attachments/assets/f98048af-579f-4db4-a61c-8260886d6f40)

Related links, issue #, if available: n/a

### How has this been tested?

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
