### PR TITLE
feat: Property filter token groups

### DIFF
--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PropertyFilterProps } from '~components/property-filter';
-import { I18nStringsTokenGroups } from '~components/property-filter/interfaces';
 
 import {
   DateForm,
@@ -184,9 +183,7 @@ export const i18nStrings: PropertyFilterProps.I18nStrings = {
 
   formatToken,
   removeTokenButtonAriaLabel: token => `Remove token, ${formatToken(token)}`,
-};
 
-export const i18nStringsTokenGroups: I18nStringsTokenGroups = {
   groupEditAriaLabel: group => `Edit group with ${group.tokens.length} tokens`,
   tokenEditorTokenActionsAriaLabel: token => `Filter remove actions for ${formatToken(token)}`,
   tokenEditorTokenRemoveAriaLabel: token => `Remove filter, ${formatToken(token)}`,

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -10,7 +10,7 @@ import Button from '~components/button';
 import Header from '~components/header';
 import I18nProvider from '~components/i18n';
 import messages from '~components/i18n/messages/all.en';
-import PropertyFilter from '~components/property-filter/internal';
+import PropertyFilter from '~components/property-filter';
 import SplitPanel from '~components/split-panel';
 import Table from '~components/table';
 

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -4,14 +4,12 @@ import React from 'react';
 
 import PropertyFilter from '~components/property-filter';
 import { PropertyFilterProps } from '~components/property-filter/interfaces';
-import PropertyFilterInternal from '~components/property-filter/internal';
 
 import ScreenshotArea from '../utils/screenshot-area';
 import {
   columnDefinitions,
   filteringProperties as commonFilteringProperties,
   i18nStrings,
-  i18nStringsTokenGroups,
   labels,
 } from './common-props';
 
@@ -28,7 +26,6 @@ const commonProps = {
   filteringProperties,
   filteringOptions: [],
   i18nStrings,
-  i18nStringsTokenGroups,
   countText: '5 matches',
   disableFreeTextFiltering: false,
   virtualScroll: true,
@@ -102,7 +99,7 @@ export default function () {
           {...commonProps}
           freeTextFiltering={{ operators: [':', '!:', '=', '!=', '^', '!^'] }}
         />
-        <PropertyFilterInternal
+        <PropertyFilter
           className="property-filter-group-editor"
           query={{
             tokens: [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2998,7 +2998,7 @@ You should specify the link even if you have a click handler for a breadcrumb it
 to ensure that valid markup is generated.
 
 Note: The last breadcrumb item is automatically considered the current item, and it's
-attributed with the proper \`aria-current\` value and rendered as inactive.
+not a link.
 ",
       "name": "items",
       "optional": false,
@@ -14124,7 +14124,13 @@ Object that represents an expandable group of links.
       "type": "ReadonlyArray<SideNavigationProps.Item>",
     },
   ],
-  "regions": [],
+  "regions": [
+    {
+      "description": "A slot located below the header and above the items.",
+      "isDefault": false,
+      "name": "itemsControl",
+    },
+  ],
   "releaseStatus": "stable",
 }
 `;

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2998,7 +2998,7 @@ You should specify the link even if you have a click handler for a breadcrumb it
 to ensure that valid markup is generated.
 
 Note: The last breadcrumb item is automatically considered the current item, and it's
-not a link.
+attributed with the proper \`aria-current\` value and rendered as inactive.
 ",
       "name": "items",
       "optional": false,
@@ -12217,6 +12217,14 @@ in order to prevent the user from changing the filtering query.",
       "type": "boolean",
     },
     {
+      "defaultValue": "false",
+      "description": "Activates token grouping mechanism to support tokens nesting (up to one level).
+When \`true\`, the \`query.tokens\` property is ignored and \`query.tokenGroups\` is used instead.",
+      "name": "enableTokenGroups",
+      "optional": true,
+      "type": "boolean",
+    },
+    {
       "description": "By default, the dropdown height is constrained to fit inside the height of its next scrollable container element.
 Enabling this property will allow the dropdown to extend beyond that container by using fixed positioning and
 [React Portals](https://reactjs.org/docs/portals.html).
@@ -12341,6 +12349,7 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "type": "PropertyFilterProps.FreeTextFiltering",
     },
     {
+      "defaultValue": "false",
       "description": "If hideOperations it set, the indicator of the operation (that is, \`and\` or \`or\`) and the selection of operations
 (applied to the property and value token) are hidden from the user. Only use when you have a custom
 filtering logic which combines tokens in different way than the default one. When used, ensure that
@@ -12409,6 +12418,11 @@ operations are communicated to the user in another way.",
             "name": "formatToken",
             "optional": true,
             "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          {
+            "name": "groupEditAriaLabel",
+            "optional": true,
+            "type": "(group: PropertyFilterProps.FormattedTokenGroup) => string",
           },
           {
             "name": "groupPropertiesText",
@@ -12501,6 +12515,46 @@ operations are communicated to the user in another way.",
             "type": "(token: PropertyFilterProps.FormattedToken) => string",
           },
           {
+            "name": "tokenEditorAddExistingTokenAriaLabel",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          {
+            "name": "tokenEditorAddExistingTokenLabel",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          {
+            "name": "tokenEditorAddNewTokenLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "tokenEditorAddTokenActionsAriaLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "tokenEditorTokenActionsAriaLabel",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          {
+            "name": "tokenEditorTokenRemoveAriaLabel",
+            "optional": true,
+            "type": "(token: PropertyFilterProps.FormattedToken) => string",
+          },
+          {
+            "name": "tokenEditorTokenRemoveFromGroupLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
+            "name": "tokenEditorTokenRemoveLabel",
+            "optional": true,
+            "type": "string",
+          },
+          {
             "name": "tokenLimitShowFewer",
             "optional": true,
             "type": "string",
@@ -12537,14 +12591,14 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "An object representing the current query displayed in the property filter. Has two properties: \`tokens\` and \`operation\`.
-\`tokens\` is an array of objects that will be displayed to the user beneath the filtering input.
+      "description": "An object representing the current query displayed in the property filter. Has three properties: \`operation\`, \`tokens\`, and \`tokenGroups\`.
+The \`operation\` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
+The \`tokens\` property is an array of objects that will be displayed to the user beneath the filtering input. When \`enableTokenGroups=true\`, the
+\`tokenGroups\` property is used instead, which supports nested tokens.
 Each token has the following properties:
 * value [string]: The string value of the token to be used as a filter.
 * propertyKey [string]: The key of the corresponding property in filteringProperties.
 * operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.
-
-\`operation\` has two valid values [and, or] and controls the join operation to be applied between tokens when filtering the items.
 ",
       "inlineType": {
         "name": "PropertyFilterProps.Query",
@@ -14070,13 +14124,7 @@ Object that represents an expandable group of links.
       "type": "ReadonlyArray<SideNavigationProps.Item>",
     },
   ],
-  "regions": [
-    {
-      "description": "A slot located below the header and above the items.",
-      "isDefault": false,
-      "name": "itemsControl",
-    },
-  ],
+  "regions": [],
   "releaseStatus": "stable",
 }
 `;

--- a/src/property-filter/__tests__/common.tsx
+++ b/src/property-filter/__tests__/common.tsx
@@ -4,15 +4,7 @@
 import React, { useState } from 'react';
 
 import PropertyFilter from '../../../lib/components/property-filter';
-import PropertyFilterInternal, { PropertyFilterInternalProps } from '../../../lib/components/property-filter/internal';
-import {
-  FilteringProperty,
-  I18nStrings,
-  I18nStringsTokenGroups,
-  InternalFilteringProperty,
-  PropertyFilterProps,
-  Token,
-} from '../interfaces';
+import { FilteringProperty, I18nStrings, InternalFilteringProperty, PropertyFilterProps, Token } from '../interfaces';
 
 export const i18nStrings: I18nStrings = {
   dismissAriaLabel: 'Dismiss',
@@ -51,9 +43,7 @@ export const i18nStrings: I18nStrings = {
   formatToken: token => `${token.propertyLabel} ${formatOperator(token.operator)} ${token.value}`,
   removeTokenButtonAriaLabel: (token: Token) =>
     'Remove token ' + token.propertyKey + ' ' + formatOperator(token.operator) + ' ' + token.value,
-};
 
-export const i18nStringsTokenGroups: I18nStringsTokenGroups = {
   groupEditAriaLabel: group =>
     'Edit filter, ' +
     group.tokens
@@ -143,9 +133,4 @@ export function toInternalProperties(properties: FilteringProperty[]): InternalF
 export function StatefulPropertyFilter(props: Omit<PropertyFilterProps, 'onChange'>) {
   const [query, setQuery] = useState<PropertyFilterProps.Query>(props.query);
   return <PropertyFilter {...props} query={query} onChange={e => setQuery(e.detail)} />;
-}
-
-export function StatefulInternalPropertyFilter(props: Omit<PropertyFilterInternalProps, 'onChange'>) {
-  const [query, setQuery] = useState<PropertyFilterInternalProps['query']>(props.query);
-  return <PropertyFilterInternal {...props} query={query} onChange={e => setQuery(e.detail)} />;
 }

--- a/src/property-filter/__tests__/property-filter-i18n.test.tsx
+++ b/src/property-filter/__tests__/property-filter-i18n.test.tsx
@@ -6,9 +6,7 @@ import { act, render } from '@testing-library/react';
 
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import PropertyFilter from '../../../lib/components/property-filter';
-import InternalPropertyFilter from '../../../lib/components/property-filter/internal';
 import createWrapper, { ElementWrapper, PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
-import { PropertyFilterWrapperInternal } from '../../../lib/components/test-utils/dom/property-filter/index.js';
 import { createDefaultProps } from './common';
 
 import styles from '../../../lib/components/property-filter/styles.selectors.js';
@@ -280,7 +278,7 @@ describe('i18n', () => {
           },
         }}
       >
-        <InternalPropertyFilter
+        <PropertyFilter
           {...defaultProps}
           i18nStrings={{}}
           query={{
@@ -306,7 +304,7 @@ describe('i18n', () => {
         />
       </TestI18nProvider>
     );
-    const wrapper = new PropertyFilterWrapperInternal(createWrapper(container).findPropertyFilter()!.getElement());
+    const wrapper = createWrapper(container).findPropertyFilter()!;
     const token = (index: number) => wrapper.findTokens()[index];
     const groupToken = (index: number, inGroupIndex: number) => token(index).findGroupTokens()[inGroupIndex];
 

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -6,17 +6,14 @@ import { act, fireEvent, render as reactRender } from '@testing-library/react';
 
 import TestI18nProvider from '../../../lib/components/i18n/testing';
 import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
-import { FilteringOption, FilteringProperty } from '../../../lib/components/property-filter/interfaces';
-import PropertyFilterInternal, { PropertyFilterInternalProps } from '../../../lib/components/property-filter/internal';
-import createWrapper from '../../../lib/components/test-utils/dom';
-import { PropertyFilterWrapperInternal } from '../../../lib/components/test-utils/dom/property-filter';
+import PropertyFilter from '../../../lib/components/property-filter';
 import {
-  createDefaultProps,
-  i18nStrings,
-  i18nStringsTokenGroups,
-  providedI18nStrings,
-  StatefulInternalPropertyFilter,
-} from './common';
+  FilteringOption,
+  FilteringProperty,
+  PropertyFilterProps,
+} from '../../../lib/components/property-filter/interfaces';
+import createWrapper from '../../../lib/components/test-utils/dom';
+import { createDefaultProps, i18nStrings, providedI18nStrings, StatefulPropertyFilter } from './common';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   ...jest.requireActual('../../../lib/components/internal/hooks/use-mobile'),
@@ -71,26 +68,25 @@ const filteringOptions: readonly FilteringOption[] = [
   { propertyKey: 'default-operator', value: 'value' },
 ];
 
-const defaultProps: PropertyFilterInternalProps = {
+const defaultProps: PropertyFilterProps = {
   filteringOptions: [],
   customGroupsText: [],
   disableFreeTextFiltering: false,
-  i18nStringsTokenGroups,
   ...createDefaultProps(filteringProperties, filteringOptions),
 };
 
-function renderComponent(props?: Partial<PropertyFilterInternalProps>, withI18nProvider = false) {
+function renderComponent(props?: Partial<PropertyFilterProps>, withI18nProvider = false) {
   return withI18nProvider
     ? reactRender(
         <TestI18nProvider messages={providedI18nStrings}>
-          <PropertyFilterInternal {...defaultProps} {...props} i18nStrings={{}} i18nStringsTokenGroups={{}} />
+          <PropertyFilter {...defaultProps} {...props} i18nStrings={{}} />
         </TestI18nProvider>
       )
-    : reactRender(<PropertyFilterInternal {...defaultProps} {...props} />);
+    : reactRender(<PropertyFilter {...defaultProps} {...props} />);
 }
 
 function openEditor(tokenIndex: number, options: { expandToViewport?: boolean; isMobile?: boolean }) {
-  const propertyFilter = new PropertyFilterWrapperInternal(createWrapper().findPropertyFilter()!.getElement());
+  const propertyFilter = createWrapper().findPropertyFilter()!;
   const token = propertyFilter.findTokens()[tokenIndex];
   if (token.findEditButton()) {
     token.findEditButton()!.click();
@@ -104,7 +100,7 @@ function findEditor(
   tokenIndex: number,
   { expandToViewport = false, isMobile = false }: { expandToViewport?: boolean; isMobile?: boolean }
 ) {
-  const propertyFilter = new PropertyFilterWrapperInternal(createWrapper().findPropertyFilter()!.getElement());
+  const propertyFilter = createWrapper().findPropertyFilter()!;
   const editor = propertyFilter.findTokens()[tokenIndex].findEditorDropdown({ expandToViewport })!;
   return editor
     ? {
@@ -450,12 +446,12 @@ describe('token editor with groups', () => {
     jest.mocked(useMobile).mockReturnValue(false);
   });
 
-  function render(props: Partial<PropertyFilterInternalProps>) {
+  function render(props: Partial<PropertyFilterProps>) {
     return renderComponent({ enableTokenGroups: true, ...props });
   }
 
-  function renderStateful(props?: Partial<PropertyFilterInternalProps>) {
-    return reactRender(<StatefulInternalPropertyFilter {...defaultProps} {...props} enableTokenGroups={true} />);
+  function renderStateful(props?: Partial<PropertyFilterProps>) {
+    return reactRender(<StatefulPropertyFilter {...defaultProps} {...props} enableTokenGroups={true} />);
   }
 
   test('changes filter property', () => {

--- a/src/property-filter/__tests__/property-filter-token-list.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-list.test.tsx
@@ -6,16 +6,8 @@ import { act, render } from '@testing-library/react';
 
 import PropertyFilter from '../../../lib/components/property-filter';
 import { PropertyFilterProps, Ref } from '../../../lib/components/property-filter/interfaces';
-import PropertyFilterInternal, { PropertyFilterInternalProps } from '../../../lib/components/property-filter/internal';
 import createWrapper, { PropertyFilterWrapper } from '../../../lib/components/test-utils/dom';
-import { PropertyFilterWrapperInternal } from '../../../lib/components/test-utils/dom/property-filter';
-import {
-  createDefaultProps,
-  i18nStrings,
-  i18nStringsTokenGroups,
-  StatefulInternalPropertyFilter,
-  StatefulPropertyFilter,
-} from './common';
+import { createDefaultProps, i18nStrings, StatefulPropertyFilter } from './common';
 
 const defaultProps = createDefaultProps(
   [
@@ -51,34 +43,14 @@ const renderStatefulComponent = (props?: Partial<PropertyFilterProps>) => {
   return { container, propertyFilterWrapper: createWrapper(container).findPropertyFilter()! };
 };
 
-function renderInternalComponent(props: Partial<PropertyFilterInternalProps>) {
-  const { container } = render(
-    <PropertyFilterInternal
-      {...defaultProps}
-      enableTokenGroups={true}
-      i18nStringsTokenGroups={i18nStringsTokenGroups}
-      filteringOptions={[]}
-      customGroupsText={[]}
-      disableFreeTextFiltering={false}
-      {...props}
-    />
-  );
-  return new PropertyFilterWrapperInternal(container);
+function renderWithGroups(props: Partial<PropertyFilterProps>) {
+  const { container } = render(<PropertyFilter {...defaultProps} enableTokenGroups={true} {...props} />);
+  return createWrapper(container).findPropertyFilter()!;
 }
 
-const renderStatefulInternalComponent = (props?: Partial<PropertyFilterInternalProps>) => {
-  const { container } = render(
-    <StatefulInternalPropertyFilter
-      {...defaultProps}
-      enableTokenGroups={true}
-      i18nStringsTokenGroups={i18nStringsTokenGroups}
-      filteringOptions={[]}
-      customGroupsText={[]}
-      disableFreeTextFiltering={false}
-      {...props}
-    />
-  );
-  return new PropertyFilterWrapperInternal(container);
+const renderWithGroupsStateful = (props?: Partial<PropertyFilterProps>) => {
+  const { container } = render(<StatefulPropertyFilter {...defaultProps} enableTokenGroups={true} {...props} />);
+  return createWrapper(container).findPropertyFilter()!;
 };
 
 describe('filtering tokens', () => {
@@ -213,7 +185,7 @@ describe('filtering tokens', () => {
     });
 
     test('moves focus to the adjacent grouped token and to the single remaining token', () => {
-      const wrapper = renderStatefulInternalComponent({
+      const wrapper = renderWithGroupsStateful({
         query: {
           operation: 'and',
           tokenGroups: [
@@ -372,7 +344,7 @@ describe('grouped token', () => {
   const tokenJack = { propertyKey: 'string', operator: '=', value: 'Jack' };
 
   test('token group has correct ARIA label and edit button ARIA label', () => {
-    const wrapper = renderInternalComponent({
+    const wrapper = renderWithGroups({
       query: { operation: 'and', tokenGroups: [{ operation: 'or', tokens: [tokenJohn, tokenJane] }], tokens: [] },
     });
 
@@ -384,7 +356,7 @@ describe('grouped token', () => {
 
   test('changes group operation', () => {
     const onChange = jest.fn();
-    const wrapper = renderInternalComponent({
+    const wrapper = renderWithGroups({
       query: { operation: 'and', tokenGroups: [{ operation: 'and', tokens: [tokenJohn, tokenJane] }], tokens: [] },
       onChange,
     });
@@ -406,7 +378,7 @@ describe('grouped token', () => {
 
   test('removes token from group', () => {
     const onChange = jest.fn();
-    const wrapper = renderInternalComponent({
+    const wrapper = renderWithGroups({
       query: {
         operation: 'and',
         tokenGroups: [{ operation: 'and', tokens: [tokenJohn, tokenJane, tokenJack] }],

--- a/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
+++ b/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { render } from '@testing-library/react';
 
 import FilteringToken, { FilteringTokenProps } from '../../../../lib/components/property-filter/filtering-token';
-import { FilteringTokenWrapperInternal } from '../../../../lib/components/test-utils/dom/property-filter';
+import { FilteringTokenWrapper } from '../../../../lib/components/test-utils/dom/property-filter';
 
 const token1 = {
   content: 'property1 = value',
@@ -52,11 +52,9 @@ const defaultProps: FilteringTokenProps = {
   popoverSize: 'content',
 };
 
-function renderToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapperInternal {
+function renderToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapper {
   const { container } = render(<FilteringToken {...defaultProps} {...props} />);
-  return new FilteringTokenWrapperInternal(
-    container.querySelector<HTMLElement>(`.${FilteringTokenWrapperInternal.rootSelector}`)!
-  );
+  return new FilteringTokenWrapper(container.querySelector<HTMLElement>(`.${FilteringTokenWrapper.rootSelector}`)!);
 }
 
 function StatefulToken(props: FilteringTokenProps) {
@@ -71,11 +69,9 @@ function StatefulToken(props: FilteringTokenProps) {
   );
 }
 
-function renderStatefulToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapperInternal {
+function renderStatefulToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapper {
   const { container } = render(<StatefulToken {...defaultProps} {...props} />);
-  return new FilteringTokenWrapperInternal(
-    container.querySelector<HTMLElement>(`.${FilteringTokenWrapperInternal.rootSelector}`)!
-  );
+  return new FilteringTokenWrapper(container.querySelector<HTMLElement>(`.${FilteringTokenWrapper.rootSelector}`)!);
 }
 
 test('renders a single token as role="group" with token ARIA label and dismiss button', () => {

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -247,7 +247,7 @@ const TokenGroup = forwardRef(
 
         <div
           className={clsx(
-            styles.token,
+            parent ? styles.token : styles['inner-token'],
             !!operation && styles['show-operation'],
             grouped && styles.grouped,
             disabled && styles['token-disabled']

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -99,7 +99,7 @@ const FilteringToken = forwardRef(
       triggerType: 'text',
       header: editorHeader,
       size: popoverSize,
-      position: 'right',
+      position: 'bottom',
       dismissAriaLabel: editorDismissAriaLabel,
       renderWithPortal: editorExpandToViewport,
       __onOpen: onEditorOpen,

--- a/src/property-filter/filtering-token/styles.scss
+++ b/src/property-filter/filtering-token/styles.scss
@@ -14,6 +14,8 @@ $token-grouped-padding-block: 2px;
 $token-grouped-padding-inline: styles.$control-padding-horizontal;
 $inner-token-padding-block: 1px;
 $inner-token-padding-inline: styles.$control-padding-horizontal;
+$border-radius-token: awsui.$border-radius-token;
+$border-radius-inner-token: calc(#{awsui.$border-radius-token} / 2);
 
 .root,
 .inner-root {
@@ -31,6 +33,7 @@ $inner-token-padding-inline: styles.$control-padding-horizontal;
     }
   }
 }
+
 .inner-root {
   block-size: 100%;
 }
@@ -42,16 +45,23 @@ $inner-token-padding-inline: styles.$control-padding-horizontal;
   display: flex;
   align-items: stretch;
   background: constants.$token-background;
-  border-start-start-radius: awsui.$border-radius-token;
-  border-start-end-radius: awsui.$border-radius-token;
-  border-end-start-radius: awsui.$border-radius-token;
-  border-end-end-radius: awsui.$border-radius-token;
+  border-start-start-radius: $border-radius-token;
+  border-start-end-radius: $border-radius-token;
+  border-end-start-radius: $border-radius-token;
+  border-end-end-radius: $border-radius-token;
   color: awsui.$color-text-body-default;
   box-sizing: border-box;
 
   &.grouped {
     justify-content: space-between;
   }
+}
+
+.inner-token {
+  border-start-start-radius: $border-radius-inner-token;
+  border-start-end-radius: $border-radius-inner-token;
+  border-end-start-radius: $border-radius-inner-token;
+  border-end-end-radius: $border-radius-inner-token;
 }
 
 .list {

--- a/src/property-filter/filtering-token/styles.scss
+++ b/src/property-filter/filtering-token/styles.scss
@@ -31,6 +31,9 @@ $inner-token-padding-inline: styles.$control-padding-horizontal;
     }
   }
 }
+.inner-root {
+  block-size: 100%;
+}
 
 .token,
 .inner-token {

--- a/src/property-filter/i18n-utils.ts
+++ b/src/property-filter/i18n-utils.ts
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useInternalI18n } from '../i18n/context';
-import {
-  ComparisonOperator,
-  FormattedToken,
-  I18nStrings,
-  I18nStringsTokenGroups,
-  InternalToken,
-  InternalTokenGroup,
-} from './interfaces';
+import { ComparisonOperator, FormattedToken, I18nStrings, InternalToken, InternalTokenGroup } from './interfaces';
 import { tokenGroupToTokens } from './utils';
 
 export type I18nStringsOperators = Pick<
@@ -27,31 +20,32 @@ export type I18nStringsOperators = Pick<
 >;
 
 // Replacing i18n function with ones taking internal tokens as argument.
-export type I18nStringsInternal = Omit<I18nStrings, 'formatToken' | 'removeTokenButtonAriaLabel'> &
-  Omit<
-    I18nStringsTokenGroups,
-    | 'groupEditAriaLabel'
-    | 'tokenEditorTokenActionsAriaLabel'
-    | 'tokenEditorTokenRemoveAriaLabel'
-    | 'tokenEditorAddExistingTokenAriaLabel'
-    | 'tokenEditorAddExistingTokenLabel'
-  > & {
-    formatToken: (token: InternalToken) => {
-      propertyLabel: string;
-      operator: string;
-      value: string;
-      formattedText: string;
-    };
-    groupAriaLabel: (group: InternalTokenGroup) => string;
-    groupEditAriaLabel: (group: InternalTokenGroup) => string;
-    removeTokenButtonAriaLabel: (token: InternalToken) => string;
-    tokenEditorTokenActionsAriaLabel: (token: InternalToken) => string;
-    tokenEditorTokenRemoveAriaLabel: (token: InternalToken) => string;
-    tokenEditorAddExistingTokenAriaLabel: (token: InternalToken) => string;
-    tokenEditorAddExistingTokenLabel: (token: InternalToken) => string;
+export type I18nStringsInternal = Omit<
+  I18nStrings,
+  | 'formatToken'
+  | 'removeTokenButtonAriaLabel'
+  | 'groupEditAriaLabel'
+  | 'tokenEditorTokenActionsAriaLabel'
+  | 'tokenEditorTokenRemoveAriaLabel'
+  | 'tokenEditorAddExistingTokenAriaLabel'
+  | 'tokenEditorAddExistingTokenLabel'
+> & {
+  formatToken: (token: InternalToken) => {
+    propertyLabel: string;
+    operator: string;
+    value: string;
+    formattedText: string;
   };
+  groupAriaLabel: (group: InternalTokenGroup) => string;
+  groupEditAriaLabel: (group: InternalTokenGroup) => string;
+  removeTokenButtonAriaLabel: (token: InternalToken) => string;
+  tokenEditorTokenActionsAriaLabel: (token: InternalToken) => string;
+  tokenEditorTokenRemoveAriaLabel: (token: InternalToken) => string;
+  tokenEditorAddExistingTokenAriaLabel: (token: InternalToken) => string;
+  tokenEditorAddExistingTokenLabel: (token: InternalToken) => string;
+};
 
-export function usePropertyFilterI18n(def: I18nStrings & I18nStringsTokenGroups = {}): I18nStringsInternal {
+export function usePropertyFilterI18n(def: I18nStrings = {}): I18nStringsInternal {
   const i18n = useInternalI18n('property-filter');
 
   const allPropertiesLabel = i18n('i18nStrings.allPropertiesLabel', def?.allPropertiesLabel);

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -19,6 +19,7 @@ const PropertyFilter = React.forwardRef(
     {
       filteringOptions = [],
       customGroupsText = [],
+      enableTokenGroups = false,
       disableFreeTextFiltering = false,
       asyncProperties,
       expandToViewport,
@@ -48,6 +49,7 @@ const PropertyFilter = React.forwardRef(
         {...baseComponentProps}
         filteringOptions={filteringOptions}
         customGroupsText={customGroupsText}
+        enableTokenGroups={enableTokenGroups}
         disableFreeTextFiltering={disableFreeTextFiltering}
         asyncProperties={asyncProperties}
         expandToViewport={expandToViewport}

--- a/src/property-filter/index.tsx
+++ b/src/property-filter/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
 
+import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
 import useBaseComponent from '../internal/hooks/use-base-component';
@@ -23,7 +24,7 @@ const PropertyFilter = React.forwardRef(
       disableFreeTextFiltering = false,
       asyncProperties,
       expandToViewport,
-      hideOperations,
+      hideOperations = false,
       tokenLimit,
       virtualScroll,
       ...rest
@@ -31,7 +32,15 @@ const PropertyFilter = React.forwardRef(
     ref: React.Ref<Ref>
   ) => {
     const baseComponentProps = useBaseComponent('PropertyFilter', {
-      props: { asyncProperties, disableFreeTextFiltering, expandToViewport, hideOperations, tokenLimit, virtualScroll },
+      props: {
+        asyncProperties,
+        disableFreeTextFiltering,
+        enableTokenGroups,
+        expandToViewport,
+        hideOperations,
+        tokenLimit,
+        virtualScroll,
+      },
     });
 
     const componentAnalyticsMetadata: GeneratedAnalyticsMetadataPropertyFilterComponent = {
@@ -42,6 +51,11 @@ const PropertyFilter = React.forwardRef(
         queryTokensCount: `${rest.query && rest.query.tokens ? rest.query.tokens.length : 0}`,
       },
     };
+
+    if (hideOperations && enableTokenGroups) {
+      warnOnce('PropertyFilter', 'Operations cannot be hidden when token groups are enabled.');
+      hideOperations = false;
+    }
 
     return (
       <PropertyFilterInternal

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -47,9 +47,9 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
   countText?: string;
   /**
    * An object representing the current query displayed in the property filter. Has three properties: `operation`, `tokens`, and `tokenGroups`.
-   * The `operation` has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
-   * The `tokens` is an array of objects that will be displayed to the user beneath the filtering input. When `enableTokenGroups=true`, the
-   * `tokenGroups` property is populated instead, which supports nested tokens.
+   * The `operation` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
+   * The `tokens` property is an array of objects that will be displayed to the user beneath the filtering input. When `enableTokenGroups=true`, the
+   * `tokenGroups` property is used instead, which supports nested tokens.
    *
    * Each token has the following properties:
    * * value [string]: The string value of the token to be used as a filter.

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -64,6 +64,11 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * operations are communicated to the user in another way.
    */
   hideOperations?: boolean;
+  /*
+   * Activates token grouping mechanism to support tokens nesting (up to one level).
+   * When `true`, the `query.tokens` property is ignored and `query.tokenGroups` is used instead.
+   */
+  enableTokenGroups?: boolean;
   /**
    * Fired when the `query` gets changed. Filter the dataset in response to this event using the values in the `detail` object.
    */
@@ -216,6 +221,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
 
 export namespace PropertyFilterProps {
   export type Token = PropertyFilterToken;
+  export type TokenGroup = PropertyFilterTokenGroup;
   export type JoinOperation = PropertyFilterOperation;
   export type ComparisonOperator = PropertyFilterOperator;
   export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtended<TokenValue>;
@@ -282,6 +288,16 @@ export namespace PropertyFilterProps {
     tokenOperatorAriaLabel?: string;
     removeTokenButtonAriaLabel?: (token: FormattedToken) => string;
     enteredTextLabel?: AutosuggestProps.EnteredTextLabel;
+
+    groupEditAriaLabel?: (group: FormattedTokenGroup) => string;
+    tokenEditorTokenActionsAriaLabel?: (token: FormattedToken) => string;
+    tokenEditorTokenRemoveAriaLabel?: (token: FormattedToken) => string;
+    tokenEditorTokenRemoveLabel?: string;
+    tokenEditorTokenRemoveFromGroupLabel?: string;
+    tokenEditorAddNewTokenLabel?: string;
+    tokenEditorAddTokenActionsAriaLabel?: string;
+    tokenEditorAddExistingTokenAriaLabel?: (token: FormattedToken) => string;
+    tokenEditorAddExistingTokenLabel?: (token: FormattedToken) => string;
   }
 
   export interface FormattedToken {
@@ -289,6 +305,12 @@ export namespace PropertyFilterProps {
     propertyLabel: string;
     operator: ComparisonOperator;
     value: string;
+  }
+
+  export interface FormattedTokenGroup {
+    tokens: FormattedToken[];
+    operation: string;
+    operationLabel: string;
   }
 
   export interface GroupText {
@@ -312,27 +334,8 @@ export namespace PropertyFilterProps {
 
 // Re-exported namespace interfaces to use module-style imports internally
 
-export type TokenGroup = PropertyFilterTokenGroup;
-
-export interface FormattedTokenGroup {
-  tokens: FormattedToken[];
-  operation: string;
-  operationLabel: string;
-}
-
-export interface I18nStringsTokenGroups {
-  groupEditAriaLabel?: (group: FormattedTokenGroup) => string;
-  tokenEditorTokenActionsAriaLabel?: (token: FormattedToken) => string;
-  tokenEditorTokenRemoveAriaLabel?: (token: FormattedToken) => string;
-  tokenEditorTokenRemoveLabel?: string;
-  tokenEditorTokenRemoveFromGroupLabel?: string;
-  tokenEditorAddNewTokenLabel?: string;
-  tokenEditorAddTokenActionsAriaLabel?: string;
-  tokenEditorAddExistingTokenAriaLabel?: (token: FormattedToken) => string;
-  tokenEditorAddExistingTokenLabel?: (token: FormattedToken) => string;
-}
-
 export type Token = PropertyFilterProps.Token;
+export type TokenGroup = PropertyFilterProps.TokenGroup;
 export type JoinOperation = PropertyFilterProps.JoinOperation;
 export type ComparisonOperator = PropertyFilterProps.ComparisonOperator;
 export type ExtendedOperator<TokenValue> = PropertyFilterOperatorExtended<TokenValue>;
@@ -347,6 +350,7 @@ export type I18nStrings = PropertyFilterProps.I18nStrings;
 export type GroupText = PropertyFilterProps.GroupText;
 export type FilteringChangeDetail = PropertyFilterProps.FilteringChangeDetail;
 export type FormattedToken = PropertyFilterProps.FormattedToken;
+export type FormattedTokenGroup = PropertyFilterProps.FormattedTokenGroup;
 export type Ref = PropertyFilterProps.Ref;
 
 // Utility types

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -46,15 +46,15 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   countText?: string;
   /**
-   * An object representing the current query displayed in the property filter. Has two properties: `tokens` and `operation`.
-   * `tokens` is an array of objects that will be displayed to the user beneath the filtering input.
-   * Each token has the following properties:
+   * An object representing the current query displayed in the property filter. Has three properties: `operation`, `tokens`, and `tokenGroups`.
+   * The `operation` has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
+   * The `tokens` is an array of objects that will be displayed to the user beneath the filtering input. When `enableTokenGroups=true`, the
+   * `tokenGroups` property is populated instead, which supports nested tokens.
    *
+   * Each token has the following properties:
    * * value [string]: The string value of the token to be used as a filter.
    * * propertyKey [string]: The key of the corresponding property in filteringProperties.
    * * operator ['<' | '<=' | '>' | '>=' | ':' | '!:' | '=' | '!=' | '^' | '!^']: The operator which indicates how to filter the dataset using this token.
-   *
-   * `operation` has two valid values [and, or] and controls the join operation to be applied between tokens when filtering the items.
    */
   query: PropertyFilterProps.Query;
   /**

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -64,7 +64,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * operations are communicated to the user in another way.
    */
   hideOperations?: boolean;
-  /*
+  /**
    * Activates token grouping mechanism to support tokens nesting (up to one level).
    * When `true`, the `query.tokens` property is ignored and `query.tokenGroups` is used instead.
    */

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -26,7 +26,6 @@ import {
   ComparisonOperator,
   ExtendedOperator,
   FilteringProperty,
-  I18nStringsTokenGroups,
   InternalFilteringOption,
   InternalFilteringProperty,
   InternalFreeTextFiltering,
@@ -50,12 +49,9 @@ import styles from './styles.css.js';
 
 export type PropertyFilterInternalProps = SomeRequired<
   PropertyFilterProps,
-  'filteringOptions' | 'customGroupsText' | 'disableFreeTextFiltering'
+  'filteringOptions' | 'customGroupsText' | 'enableTokenGroups' | 'disableFreeTextFiltering'
 > &
-  InternalBaseComponentProps & {
-    enableTokenGroups?: boolean;
-    i18nStringsTokenGroups?: I18nStringsTokenGroups;
-  };
+  InternalBaseComponentProps;
 
 const PropertyFilterInternal = React.forwardRef(
   (
@@ -88,8 +84,7 @@ const PropertyFilterInternal = React.forwardRef(
       expandToViewport,
       tokenLimitShowFewerAriaLabel,
       tokenLimitShowMoreAriaLabel,
-      enableTokenGroups = false,
-      i18nStringsTokenGroups,
+      enableTokenGroups,
       __internalRootRef,
       ...rest
     }: PropertyFilterInternalProps,
@@ -109,7 +104,7 @@ const PropertyFilterInternal = React.forwardRef(
     const inputRef = useRef<AutosuggestInputRef>(null);
     const baseProps = getBaseProps(rest);
 
-    const i18nStrings = usePropertyFilterI18n({ ...rest.i18nStrings, ...i18nStringsTokenGroups });
+    const i18nStrings = usePropertyFilterI18n(rest.i18nStrings);
 
     useImperativeHandle(ref, () => ({ focus: () => inputRef.current?.focus() }), []);
     const showResults = !!query.tokens?.length && !disabled && !!countText;

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -49,7 +49,7 @@ import styles from './styles.css.js';
 
 export type PropertyFilterInternalProps = SomeRequired<
   PropertyFilterProps,
-  'filteringOptions' | 'customGroupsText' | 'enableTokenGroups' | 'disableFreeTextFiltering'
+  'filteringOptions' | 'customGroupsText' | 'enableTokenGroups' | 'disableFreeTextFiltering' | 'hideOperations'
 > &
   InternalBaseComponentProps;
 

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -86,6 +86,16 @@ export class FilteringTokenWrapper extends ComponentWrapper {
     const popoverBody = root.findByClassName(popoverStyles.body);
     return popoverBody ? new PropertyFilterEditorDropdownWrapper(popoverBody.getElement()) : null;
   }
+
+  findEditButton(): ElementWrapper<HTMLButtonElement> {
+    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-edit-button'])!;
+  }
+
+  findGroupTokens(): Array<FilteringGroupedTokenWrapper> {
+    return this.findAllByClassName(testUtilStyles['filtering-token-inner']).map(
+      w => new FilteringGroupedTokenWrapper(w.getElement())
+    );
+  }
 }
 
 export class PropertyFilterEditorDropdownWrapper extends ComponentWrapper {
@@ -101,70 +111,6 @@ export class PropertyFilterEditorDropdownWrapper extends ComponentWrapper {
     return this.findByClassName(styles['token-editor-form'])!;
   }
 
-  findPropertyField(): FormFieldWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-field-property']}`, FormFieldWrapper)!;
-  }
-
-  findOperatorField(): FormFieldWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-field-operator']}`, FormFieldWrapper)!;
-  }
-
-  findValueField(): FormFieldWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-field-value']}`, FormFieldWrapper)!;
-  }
-
-  findCancelButton(): ButtonWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-cancel']}`, ButtonWrapper)!;
-  }
-
-  findSubmitButton(): ButtonWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-submit']}`, ButtonWrapper)!;
-  }
-}
-
-export class PropertyFilterWrapperInternal extends PropertyFilterWrapper {
-  findTokens(): Array<FilteringTokenWrapperInternal> {
-    return this.findAllByClassName(FilteringTokenWrapperInternal.rootSelector).map(
-      (elementWrapper: ElementWrapper) => new FilteringTokenWrapperInternal(elementWrapper.getElement())
-    );
-  }
-}
-
-export class FilteringTokenWrapperInternal extends FilteringTokenWrapper {
-  findEditorDropdown(options = { expandToViewport: false }): null | PropertyFilterEditorDropdownWrapperInternal {
-    const root = options.expandToViewport ? createWrapper() : this;
-    const popoverBody = root.findByClassName(popoverStyles.body);
-    return popoverBody ? new PropertyFilterEditorDropdownWrapperInternal(popoverBody.getElement()) : null;
-  }
-
-  findEditButton(): ElementWrapper<HTMLButtonElement> {
-    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-edit-button'])!;
-  }
-
-  findGroupTokens(): Array<FilteringGroupedTokenWrapper> {
-    return this.findAllByClassName(testUtilStyles['filtering-token-inner']).map(
-      w => new FilteringGroupedTokenWrapper(w.getElement())
-    );
-  }
-}
-
-export class FilteringGroupedTokenWrapper extends ComponentWrapper {
-  static rootSelector = testUtilStyles['filtering-token-inner'];
-
-  findLabel(): ElementWrapper {
-    return this.findByClassName(testUtilStyles['filtering-token-inner-content'])!;
-  }
-
-  findRemoveButton(): ElementWrapper<HTMLButtonElement> {
-    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-inner-dismiss-button'])!;
-  }
-
-  findTokenOperation(): SelectWrapper | null {
-    return this.findComponent(`.${testUtilStyles['filtering-token-inner-select']}`, SelectWrapper);
-  }
-}
-
-export class PropertyFilterEditorDropdownWrapperInternal extends PropertyFilterEditorDropdownWrapper {
   findPropertyField(index = 1): FormFieldWrapper {
     const dataIndex = `[data-testindex="${index - 1}"]`;
     return this.findComponent(`.${testUtilStyles['token-editor-field-property']}${dataIndex}`, FormFieldWrapper)!;
@@ -189,5 +135,29 @@ export class PropertyFilterEditorDropdownWrapperInternal extends PropertyFilterE
   findTokenAddActions(): null | ButtonDropdownWrapper {
     const buttonDropdown = this.find(`.${testUtilStyles['token-editor-token-add-actions']}`)!;
     return buttonDropdown ? new ButtonDropdownWrapper(buttonDropdown.getElement()) : null;
+  }
+
+  findCancelButton(): ButtonWrapper {
+    return this.findComponent(`.${testUtilStyles['token-editor-cancel']}`, ButtonWrapper)!;
+  }
+
+  findSubmitButton(): ButtonWrapper {
+    return this.findComponent(`.${testUtilStyles['token-editor-submit']}`, ButtonWrapper)!;
+  }
+}
+
+export class FilteringGroupedTokenWrapper extends ComponentWrapper {
+  static rootSelector = testUtilStyles['filtering-token-inner'];
+
+  findLabel(): ElementWrapper {
+    return this.findByClassName(testUtilStyles['filtering-token-inner-content'])!;
+  }
+
+  findRemoveButton(): ElementWrapper<HTMLButtonElement> {
+    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-inner-dismiss-button'])!;
+  }
+
+  findTokenOperation(): SelectWrapper | null {
+    return this.findComponent(`.${testUtilStyles['filtering-token-inner-select']}`, SelectWrapper);
   }
 }


### PR DESCRIPTION
### Description

Making property filter token groups API public. The PR also includes small changes to default popover position, alignment and border radius of nested tokens, dev-warning for hide-tokens.

Rel: [HJhfABYOa8OE]

### How has this been tested?

* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
