### PR TITLE
chore: Property filter token groups internal feature

### DIFF
--- a/pages/property-filter/common-props.tsx
+++ b/pages/property-filter/common-props.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PropertyFilterProps } from '~components/property-filter';
-import { I18nStringsExt } from '~components/property-filter/i18n-utils';
+import { I18nStringsTokenGroups } from '~components/property-filter/interfaces';
 
 import {
   DateForm,
@@ -146,7 +146,7 @@ export const labels = {
   filteringPlaceholder: 'Search',
 };
 
-export const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
+export const i18nStrings: PropertyFilterProps.I18nStrings = {
   dismissAriaLabel: 'Dismiss',
 
   groupValuesText: 'Values',
@@ -184,7 +184,9 @@ export const i18nStrings: PropertyFilterProps.I18nStrings & I18nStringsExt = {
 
   formatToken,
   removeTokenButtonAriaLabel: token => `Remove token, ${formatToken(token)}`,
+};
 
+export const i18nStringsTokenGroups: I18nStringsTokenGroups = {
   groupEditAriaLabel: group => `Edit group with ${group.tokens.length} tokens`,
   tokenEditorTokenActionsAriaLabel: token => `Filter remove actions for ${formatToken(token)}`,
   tokenEditorTokenRemoveAriaLabel: token => `Remove filter, ${formatToken(token)}`,

--- a/pages/property-filter/custom-forms.tsx
+++ b/pages/property-filter/custom-forms.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { DatePicker, FormField, RadioGroup, TimeInput, TimeInputProps } from '~components';
 import Calendar, { CalendarProps } from '~components/calendar';
 import DateInput from '~components/date-input';
-import Multiselect from '~components/multiselect';
+import InternalMultiselect from '~components/multiselect/internal';
 import { ExtendedOperatorFormProps } from '~components/property-filter/interfaces';
 
 import { allItems } from './table.data';
@@ -224,7 +224,7 @@ export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormPr
   value = value && Array.isArray(value) ? value : [];
   return (
     <FormField stretch={true}>
-      <Multiselect
+      <InternalMultiselect
         options={allOwners.map(owner => ({ value: owner, label: owner }))}
         selectedOptions={value.map(owner => ({ value: owner, label: owner })) ?? []}
         onChange={event =>
@@ -235,6 +235,7 @@ export function OwnerMultiSelectForm({ value, onChange }: ExtendedOperatorFormPr
           )
         }
         expandToViewport={true}
+        inlineTokens={true}
       />
     </FormField>
   );

--- a/pages/property-filter/property-filter-editor-permutations.page.tsx
+++ b/pages/property-filter/property-filter-editor-permutations.page.tsx
@@ -89,8 +89,9 @@ const defaultProps: Omit<TokenEditorProps, 'i18nStrings'> = {
   filteringOptions: [],
   onSubmit: () => {},
   onDismiss: () => {},
-  standaloneTokens: [],
-  onChangeStandalone: () => {},
+  tokensToCapture: [],
+  onTokenCapture: () => {},
+  onTokenRelease: () => {},
   tempGroup: [{ property: null, operator: ':', value: 'search text' }],
   onChangeTempGroup: () => {},
 };
@@ -118,13 +119,13 @@ const tokenPermutations = createPermutations<Partial<TokenEditorProps>>([
         { property: nameProperty, operator: '=', value: 'Jack' },
       ],
     ],
-    standaloneTokens: [
+    tokensToCapture: [
       [
-        { property: dateProperty, operator: '=', value: new Date('2020-01-01') },
-        { property: dateProperty, operator: '=', value: new Date('2020-01-02') },
-        { property: dateProperty, operator: '=', value: new Date('2020-01-03') },
-        { property: dateProperty, operator: '=', value: new Date('2020-01-04') },
-        { property: dateProperty, operator: '=', value: new Date('2020-01-05') },
+        { standaloneIndex: 0, property: dateProperty, operator: '=', value: new Date('2020-01-01') },
+        { standaloneIndex: 1, property: dateProperty, operator: '=', value: new Date('2020-01-02') },
+        { standaloneIndex: 2, property: dateProperty, operator: '=', value: new Date('2020-01-03') },
+        { standaloneIndex: 3, property: dateProperty, operator: '=', value: new Date('2020-01-04') },
+        { standaloneIndex: 4, property: dateProperty, operator: '=', value: new Date('2020-01-05') },
       ],
     ],
   },
@@ -132,23 +133,21 @@ const tokenPermutations = createPermutations<Partial<TokenEditorProps>>([
 
 function TokenEditorStateful(props: Omit<TokenEditorProps, 'i18nStrings'>) {
   const [tempGroup, setTempGroup] = useState(props.tempGroup);
-  const [standaloneTokens, setStandaloneTokens] = useState(props.standaloneTokens);
+  const capturedTokenIndices = tempGroup.map(token => token.standaloneIndex).filter(Boolean);
+  const tokensToCapture = props.tokensToCapture.filter((_, index) => !capturedTokenIndices.includes(index));
   const i18nStringsInternal = usePropertyFilterI18n(i18nStrings);
   return (
     <TokenEditor
       {...props}
       i18nStrings={i18nStringsInternal}
-      standaloneTokens={standaloneTokens}
-      onChangeStandalone={setStandaloneTokens}
+      tokensToCapture={tokensToCapture}
       tempGroup={tempGroup}
       onChangeTempGroup={setTempGroup}
       onDismiss={() => {
         setTempGroup(props.tempGroup);
-        setStandaloneTokens(props.standaloneTokens);
       }}
       onSubmit={() => {
         setTempGroup(props.tempGroup);
-        setStandaloneTokens(props.standaloneTokens);
       }}
     />
   );

--- a/pages/property-filter/split-panel-app-layout-integration.page.tsx
+++ b/pages/property-filter/split-panel-app-layout-integration.page.tsx
@@ -10,7 +10,7 @@ import Button from '~components/button';
 import Header from '~components/header';
 import I18nProvider from '~components/i18n';
 import messages from '~components/i18n/messages/all.en';
-import PropertyFilter from '~components/property-filter';
+import PropertyFilter from '~components/property-filter/internal';
 import SplitPanel from '~components/split-panel';
 import Table from '~components/table';
 
@@ -97,8 +97,11 @@ export default function () {
                   filteringOptions={filteringOptions}
                   virtualScroll={true}
                   countText={`${items.length} matches`}
+                  enableTokenGroups={true}
                   expandToViewport={true}
                   filteringEmpty="No properties"
+                  customGroupsText={[]}
+                  disableFreeTextFiltering={false}
                 />
               }
               columnDefinitions={columnDefinitions.slice(0, 2)}

--- a/pages/property-filter/token-editor.page.tsx
+++ b/pages/property-filter/token-editor.page.tsx
@@ -11,6 +11,7 @@ import {
   columnDefinitions,
   filteringProperties as commonFilteringProperties,
   i18nStrings,
+  i18nStringsTokenGroups,
   labels,
 } from './common-props';
 
@@ -27,6 +28,7 @@ const commonProps = {
   filteringProperties,
   filteringOptions: [],
   i18nStrings,
+  i18nStringsTokenGroups,
   countText: '5 matches',
   disableFreeTextFiltering: false,
   virtualScroll: true,

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12063,18 +12063,7 @@ Object {
       "description": "Fired when the \`query\` gets changed. Filter the dataset in response to this event using the values in the \`detail\` object.",
       "detailInlineType": Object {
         "name": "PropertyFilterProps.Query",
-        "properties": Array [
-          Object {
-            "name": "operation",
-            "optional": false,
-            "type": "PropertyFilterProps.JoinOperation",
-          },
-          Object {
-            "name": "tokens",
-            "optional": false,
-            "type": "ReadonlyArray<PropertyFilterProps.Token>",
-          },
-        ],
+        "properties": Array [],
         "type": "object",
       },
       "detailType": "PropertyFilterProps.Query",
@@ -12160,7 +12149,7 @@ To use it correctly, define an ID for the element you want to use as label and s
       "type": "string",
     },
     Object {
-      "description": "Set \`asyncProperties\` if you need to load \`filteringProperties\` asynchronousely. This would cause extra \`onLoadMore\`
+      "description": "Set \`asyncProperties\` if you need to load \`filteringProperties\` asynchronously. This would cause extra \`onLoadMore\`
 events to fire calling for more properties.",
       "name": "asyncProperties",
       "optional": true,
@@ -12552,18 +12541,7 @@ Each token has the following properties:
 ",
       "inlineType": Object {
         "name": "PropertyFilterProps.Query",
-        "properties": Array [
-          Object {
-            "name": "operation",
-            "optional": false,
-            "type": "PropertyFilterProps.JoinOperation",
-          },
-          Object {
-            "name": "tokens",
-            "optional": false,
-            "type": "ReadonlyArray<PropertyFilterProps.Token>",
-          },
-        ],
+        "properties": Array [],
         "type": "object",
       },
       "name": "query",

--- a/src/autosuggest/options-controller.ts
+++ b/src/autosuggest/options-controller.ts
@@ -63,6 +63,7 @@ export const useAutosuggestItems = ({
   const enteredItemLabel = i18n('enteredTextLabel', enteredTextLabel?.(filterValue), format =>
     format({ value: filterValue })
   );
+
   if (!enteredItemLabel) {
     warnOnce('Autosuggest', 'A value for enteredTextLabel must be provided.');
   }

--- a/src/property-filter/__tests__/common.tsx
+++ b/src/property-filter/__tests__/common.tsx
@@ -4,9 +4,17 @@
 import React, { useState } from 'react';
 
 import PropertyFilter from '../../../lib/components/property-filter';
-import { FilteringProperty, InternalFilteringProperty, PropertyFilterProps, Token } from '../interfaces';
+import PropertyFilterInternal, { PropertyFilterInternalProps } from '../../../lib/components/property-filter/internal';
+import {
+  FilteringProperty,
+  I18nStrings,
+  I18nStringsTokenGroups,
+  InternalFilteringProperty,
+  PropertyFilterProps,
+  Token,
+} from '../interfaces';
 
-export const i18nStrings = {
+export const i18nStrings: I18nStrings = {
   dismissAriaLabel: 'Dismiss',
 
   groupValuesText: 'Values',
@@ -37,10 +45,64 @@ export const i18nStrings = {
   tokenLimitShowFewer: 'Show fewer',
   clearFiltersText: 'Clear filters',
   tokenOperatorAriaLabel: 'Boolean Operator',
-  removeTokenButtonAriaLabel: (token: Token) =>
-    'Remove token ' + token.propertyKey + ' ' + token.operator + ' ' + token.value,
   enteredTextLabel: (text: string) => `Use: "${text}"`,
-} as const;
+
+  formatToken: token => `${token.propertyLabel} ${formatOperator(token.operator)} ${token.value}`,
+  removeTokenButtonAriaLabel: (token: Token) =>
+    'Remove token ' + token.propertyKey + ' ' + formatOperator(token.operator) + ' ' + token.value,
+};
+
+export const i18nStringsTokenGroups: I18nStringsTokenGroups = {
+  groupEditAriaLabel: group =>
+    'Edit filter, ' +
+    group.tokens
+      .map(token => `${token.propertyLabel} ${formatOperator(token.operator)} ${token.value}`)
+      .join(` ${group.operationLabel} `),
+  tokenEditorTokenActionsAriaLabel: token =>
+    `Remove actions, ${token.propertyLabel} ${formatOperator(token.operator)} ${token.value}`,
+  tokenEditorTokenRemoveAriaLabel: token =>
+    `Remove filter, ${token.propertyLabel} ${formatOperator(token.operator)} ${token.value}`,
+  tokenEditorTokenRemoveLabel: 'Remove filter',
+  tokenEditorTokenRemoveFromGroupLabel: 'Remove filter from group',
+  tokenEditorAddNewTokenLabel: 'Add new filter',
+  tokenEditorAddTokenActionsAriaLabel: 'Add filter actions',
+  tokenEditorAddExistingTokenAriaLabel: token =>
+    `Add filter ${token.propertyLabel} ${formatOperator(token.operator)} ${token.value} to group`,
+  tokenEditorAddExistingTokenLabel: token =>
+    `Add filter ${token.propertyLabel} ${token.operator} ${token.value} to group`,
+};
+
+export const providedI18nStrings = {
+  'property-filter': {
+    'i18nStrings.editTokenHeader': 'Edit token',
+    'i18nStrings.propertyText': 'Property',
+    'i18nStrings.operatorText': 'Operator',
+    'i18nStrings.valueText': 'Value',
+    'i18nStrings.cancelActionText': 'Cancel',
+    'i18nStrings.applyActionText': 'Apply',
+    'i18nStrings.formatToken': '{token__propertyLabel} {token__operator} {token__value}',
+    'i18nStrings.tokenEditorTokenActionsAriaLabel': 'Remove actions, {token__formattedText}',
+    'i18nStrings.tokenEditorTokenRemoveAriaLabel': 'Remove filter, {token__formattedText}',
+    'i18nStrings.tokenEditorTokenRemoveLabel': 'Remove filter',
+    'i18nStrings.tokenEditorTokenRemoveFromGroupLabel': 'Remove filter from group',
+    'i18nStrings.tokenEditorAddNewTokenLabel': 'Add new filter',
+    'i18nStrings.tokenEditorAddTokenActionsAriaLabel': 'Add filter actions',
+    'i18nStrings.tokenEditorAddExistingTokenAriaLabel': 'Add filter {token__formattedText} to group',
+    'i18nStrings.tokenEditorAddExistingTokenLabel':
+      'Add filter {token__propertyLabel} {token__operator} {token__value} to group',
+  },
+};
+
+function formatOperator(operator: string) {
+  switch (operator) {
+    case '=':
+      return 'equals';
+    case '!=':
+      return 'does_not_equal';
+    default:
+      return operator;
+  }
+}
 
 export const createDefaultProps = (
   filteringProperties: PropertyFilterProps['filteringProperties'],
@@ -74,4 +136,9 @@ export function toInternalProperties(properties: FilteringProperty[]): InternalF
 export function StatefulPropertyFilter(props: Omit<PropertyFilterProps, 'onChange'>) {
   const [query, setQuery] = useState<PropertyFilterProps.Query>(props.query);
   return <PropertyFilter {...props} query={query} onChange={e => setQuery(e.detail)} />;
+}
+
+export function StatefulInternalPropertyFilter(props: Omit<PropertyFilterInternalProps, 'onChange'>) {
+  const [query, setQuery] = useState<PropertyFilterInternalProps['query']>(props.query);
+  return <PropertyFilterInternal {...props} query={query} onChange={e => setQuery(e.detail)} />;
 }

--- a/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
+++ b/src/property-filter/filtering-token/__tests__/filtering-token.test.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { render } from '@testing-library/react';
 
 import FilteringToken, { FilteringTokenProps } from '../../../../lib/components/property-filter/filtering-token';
-import { InternalFilteringTokenWrapper as FilteringTokenWrapper } from '../../../../lib/components/test-utils/dom/property-filter';
+import { FilteringTokenWrapperInternal } from '../../../../lib/components/test-utils/dom/property-filter';
 
 const token1 = {
   content: 'property1 = value',
@@ -52,9 +52,11 @@ const defaultProps: FilteringTokenProps = {
   popoverSize: 'content',
 };
 
-function renderToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapper {
+function renderToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapperInternal {
   const { container } = render(<FilteringToken {...defaultProps} {...props} />);
-  return new FilteringTokenWrapper(container.querySelector<HTMLElement>(`.${FilteringTokenWrapper.rootSelector}`)!);
+  return new FilteringTokenWrapperInternal(
+    container.querySelector<HTMLElement>(`.${FilteringTokenWrapperInternal.rootSelector}`)!
+  );
 }
 
 function StatefulToken(props: FilteringTokenProps) {
@@ -69,9 +71,11 @@ function StatefulToken(props: FilteringTokenProps) {
   );
 }
 
-function renderStatefulToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapper {
+function renderStatefulToken(props: Partial<FilteringTokenProps>): FilteringTokenWrapperInternal {
   const { container } = render(<StatefulToken {...defaultProps} {...props} />);
-  return new FilteringTokenWrapper(container.querySelector<HTMLElement>(`.${FilteringTokenWrapper.rootSelector}`)!);
+  return new FilteringTokenWrapperInternal(
+    container.querySelector<HTMLElement>(`.${FilteringTokenWrapperInternal.rootSelector}`)!
+  );
 }
 
 test('renders a single token as role="group" with token ARIA label and dismiss button', () => {

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -13,8 +13,10 @@ import {
   PropertyFilterOperatorFormProps,
   PropertyFilterOption,
   PropertyFilterProperty,
+  PropertyFilterQuery,
   PropertyFilterToken,
 } from '@cloudscape-design/collection-hooks';
+import { PropertyFilterTokenGroup } from '@cloudscape-design/collection-hooks/cjs/interfaces';
 
 import { AutosuggestProps } from '../autosuggest/interfaces';
 import { BaseComponentProps } from '../internal/base-component';
@@ -147,7 +149,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   customFilterActions?: React.ReactNode;
   /**
-   * Set `asyncProperties` if you need to load `filteringProperties` asynchronousely. This would cause extra `onLoadMore`
+   * Set `asyncProperties` if you need to load `filteringProperties` asynchronously. This would cause extra `onLoadMore`
    * events to fire calling for more properties.
    */
   asyncProperties?: boolean;
@@ -223,11 +225,7 @@ export namespace PropertyFilterProps {
   export type FilteringOption = PropertyFilterOption;
   export type FilteringProperty = PropertyFilterProperty;
   export type FreeTextFiltering = PropertyFilterFreeTextFiltering;
-
-  export interface Query {
-    tokens: ReadonlyArray<PropertyFilterProps.Token>;
-    operation: PropertyFilterProps.JoinOperation;
-  }
+  export type Query = PropertyFilterQuery;
 
   export interface LoadItemsDetail {
     filteringProperty?: FilteringProperty;
@@ -314,6 +312,26 @@ export namespace PropertyFilterProps {
 
 // Re-exported namespace interfaces to use module-style imports internally
 
+export type TokenGroup = PropertyFilterTokenGroup;
+
+export interface FormattedTokenGroup {
+  tokens: FormattedToken[];
+  operation: string;
+  operationLabel: string;
+}
+
+export interface I18nStringsTokenGroups {
+  groupEditAriaLabel?: (group: FormattedTokenGroup) => string;
+  tokenEditorTokenActionsAriaLabel?: (token: FormattedToken) => string;
+  tokenEditorTokenRemoveAriaLabel?: (token: FormattedToken) => string;
+  tokenEditorTokenRemoveLabel?: string;
+  tokenEditorTokenRemoveFromGroupLabel?: string;
+  tokenEditorAddNewTokenLabel?: string;
+  tokenEditorAddTokenActionsAriaLabel?: string;
+  tokenEditorAddExistingTokenAriaLabel?: (token: FormattedToken) => string;
+  tokenEditorAddExistingTokenLabel?: (token: FormattedToken) => string;
+}
+
 export type Token = PropertyFilterProps.Token;
 export type JoinOperation = PropertyFilterProps.JoinOperation;
 export type ComparisonOperator = PropertyFilterProps.ComparisonOperator;
@@ -359,15 +377,18 @@ export interface InternalFreeTextFiltering {
 }
 
 export interface InternalToken<TokenValue = any> {
+  standaloneIndex?: number;
   property: null | InternalFilteringProperty<TokenValue>;
   operator: PropertyFilterOperator;
   value: TokenValue;
 }
 
-export interface InternalQuery {
+export interface InternalTokenGroup<TokenValue = any> {
   operation: PropertyFilterOperation;
-  tokens: readonly InternalToken[];
+  tokens: readonly (InternalToken<TokenValue> | InternalTokenGroup<TokenValue>)[];
 }
+
+export type InternalQuery = InternalTokenGroup;
 
 export type ParsedText =
   | { step: 'property'; property: InternalFilteringProperty; operator: ComparisonOperator; value: string }

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -145,7 +145,7 @@ $operator-field-width: 120px;
 
         &.token-editor-supports-groups {
           padding-block-end: awsui.$space-m;
-          border-block-end: 1px solid awsui.$color-border-divider-default;
+          border-block-end: awsui.$border-divider-section-width solid awsui.$color-border-divider-default;
         }
       }
     }

--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -138,10 +138,15 @@ $operator-field-width: 120px;
       grid-template-columns: minmax(100px, 1fr);
       gap: awsui.$space-m;
 
-      > .token-editor-group {
+      > .token-editor-grid-group {
         display: flex;
         flex-direction: column;
         gap: awsui.$space-s;
+
+        &.token-editor-supports-groups {
+          padding-block-end: awsui.$space-m;
+          border-block-end: 1px solid awsui.$color-border-divider-default;
+        }
       }
     }
 
@@ -156,6 +161,10 @@ $operator-field-width: 120px;
       &:not(.token-editor-narrow) {
         display: flex;
         align-items: flex-end;
+        justify-content: flex-end;
+      }
+      &.token-editor-narrow:nth-child(4) {
+        display: flex;
         justify-content: flex-end;
       }
     }

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -15,18 +15,20 @@ import {
   InternalFreeTextFiltering,
   InternalQuery,
   InternalToken,
+  InternalTokenGroup,
   JoinOperation,
   LoadItemsDetail,
 } from './interfaces';
 import { TokenEditor } from './token-editor';
+import { tokenGroupToTokens } from './utils';
 
 import styles from './styles.css.js';
 
 interface TokenProps {
   query: InternalQuery;
   tokenIndex: number;
-  onUpdateToken: (newToken: InternalToken) => void;
-  onUpdateOperation: (newOperation: JoinOperation) => void;
+  onUpdateToken: (updatedToken: InternalToken | InternalTokenGroup, releasedTokens: InternalToken[]) => void;
+  onUpdateOperation: (updatedOperation: JoinOperation) => void;
   onRemoveToken: () => void;
   asyncProperties?: boolean;
   asyncProps: DropdownStatusProps;
@@ -41,8 +43,6 @@ interface TokenProps {
   onLoadItems?: NonCancelableEventHandler<LoadItemsDetail>;
   enableTokenGroups: boolean;
 }
-
-const emptyHandler = () => {};
 
 export const TokenButton = ({
   query,
@@ -64,52 +64,85 @@ export const TokenButton = ({
   enableTokenGroups,
 }: TokenProps) => {
   const tokenRef = useRef<FilteringTokenRef>(null);
-  const token = query.tokens[tokenIndex];
+
+  const hasGroups = query.tokens.some(tokenOrGroup => 'operation' in tokenOrGroup);
   const first = tokenIndex === 0;
-  const formattedToken = i18nStrings.formatToken(token);
-  const [temporaryToken, setTemporaryToken] = useState<InternalToken>(token);
+
+  const tokenOrGroup = query.tokens[tokenIndex];
+  const tokens = tokenGroupToTokens<InternalToken>([tokenOrGroup]).map(t => ({ ...t, standaloneIndex: undefined }));
+  const operation = query.operation;
+  const groupOperation = 'operation' in tokenOrGroup ? tokenOrGroup.operation : operation === 'and' ? 'or' : 'and';
+
+  const [tempTokens, setTempTokens] = useState<InternalToken[]>(tokens);
+  const capturedTokenIndices = tempTokens.map(token => token.standaloneIndex).filter(index => index !== undefined);
+  const tokensToCapture: InternalToken[] = [];
+  for (let index = 0; index < query.tokens.length; index++) {
+    const token = query.tokens[index];
+    if ('operator' in token && token !== tokenOrGroup && !capturedTokenIndices.includes(index)) {
+      tokensToCapture.push(token);
+    }
+  }
+  const [tempReleasedTokens, setTempReleasedTokens] = useState<InternalToken[]>([]);
+  tokensToCapture.push(...tempReleasedTokens);
+
   return (
     <FilteringToken
       ref={tokenRef}
-      tokens={[
-        {
+      tokens={tokens.map(token => {
+        const formattedToken = i18nStrings.formatToken(token);
+        return {
           content: (
             <span className={styles['token-trigger']}>
               <TokenTrigger token={formattedToken} allProperties={token.property === null} />
             </span>
           ),
           ariaLabel: formattedToken.formattedText,
-          dismissAriaLabel: i18nStrings?.removeTokenButtonAriaLabel?.(token) ?? '',
-        },
-      ]}
+          dismissAriaLabel: i18nStrings.removeTokenButtonAriaLabel(token),
+        };
+      })}
       showOperation={!first && !hideOperations}
-      operation={query.operation}
+      operation={operation}
       andText={i18nStrings.operationAndText ?? ''}
       orText={i18nStrings.operationOrText ?? ''}
       operationAriaLabel={i18nStrings.tokenOperatorAriaLabel ?? ''}
       onChangeOperation={onUpdateOperation}
-      onDismissToken={onRemoveToken}
+      onDismissToken={(removeIndex: number) => {
+        if (tokens.length === 1) {
+          onRemoveToken();
+        } else {
+          const newTokens = tokens.filter((_, index) => index !== removeIndex);
+          const updatedToken = newTokens.length === 1 ? newTokens[0] : { operation: groupOperation, tokens: newTokens };
+          onUpdateToken(updatedToken, []);
+        }
+      }}
       disabled={disabled}
       editorContent={
         <TokenEditor
           supportsGroups={enableTokenGroups}
           filteringProperties={filteringProperties}
           filteringOptions={filteringOptions}
-          tempGroup={[temporaryToken]}
-          onChangeTempGroup={newGroup => setTemporaryToken(newGroup[0])}
-          // This property will be needed when supportsGroups={true}
-          standaloneTokens={[]}
-          // This property will be needed when supportsGroups={true}
-          onChangeStandalone={emptyHandler}
+          tempGroup={tempTokens}
+          onChangeTempGroup={setTempTokens}
+          tokensToCapture={tokensToCapture}
+          onTokenCapture={capturedToken => setTempReleasedTokens(prev => prev.filter(token => token !== capturedToken))}
+          onTokenRelease={releasedToken => {
+            if (releasedToken.standaloneIndex === undefined) {
+              setTempReleasedTokens(prev => [...prev, releasedToken]);
+            }
+          }}
           asyncProps={asyncProps}
           onLoadItems={onLoadItems}
           i18nStrings={i18nStrings}
           asyncProperties={asyncProperties}
           customGroupsText={customGroupsText}
           freeTextFiltering={freeTextFiltering}
-          onDismiss={() => tokenRef.current?.closeEditor()}
+          onDismiss={() => {
+            tokenRef.current?.closeEditor();
+          }}
           onSubmit={() => {
-            onUpdateToken(temporaryToken);
+            const updatedToken =
+              tempTokens.length === 1 ? tempTokens[0] : { operation: groupOperation, tokens: tempTokens };
+            onUpdateToken(updatedToken, tempReleasedTokens);
             tokenRef.current?.closeEditor();
           }}
         />
@@ -117,14 +150,15 @@ export const TokenButton = ({
       editorHeader={i18nStrings.editTokenHeader ?? ''}
       editorDismissAriaLabel={i18nStrings.dismissAriaLabel ?? ''}
       editorExpandToViewport={!!expandToViewport}
-      onEditorOpen={() => setTemporaryToken(token)}
-      // The properties below are only relevant for grouped tokens that are not supported
-      // by the property filter component yet.
-      groupOperation={query.operation}
-      groupAriaLabel={i18nStrings.formatToken(token).formattedText}
-      groupEditAriaLabel={i18nStrings.groupEditAriaLabel({ operation: query.operation, tokens: [token] })}
-      onChangeGroupOperation={() => {}}
-      hasGroups={false}
+      onEditorOpen={() => {
+        setTempTokens(tokens);
+        setTempReleasedTokens([]);
+      }}
+      groupOperation={groupOperation}
+      onChangeGroupOperation={operation => onUpdateToken({ operation, tokens }, [])}
+      groupAriaLabel={i18nStrings.groupAriaLabel({ operation: groupOperation, tokens })}
+      groupEditAriaLabel={i18nStrings.groupEditAriaLabel({ operation: groupOperation, tokens })}
+      hasGroups={hasGroups}
       popoverSize={enableTokenGroups ? 'content' : 'large'}
     />
   );

--- a/src/property-filter/utils.ts
+++ b/src/property-filter/utils.ts
@@ -119,3 +119,33 @@ export function removeOperator(source: string, operator: string) {
 function startsWith(source: string, target: string): boolean {
   return source.indexOf(target) === 0;
 }
+
+interface AbstractToken {
+  operator: any;
+}
+
+interface AbstractTokenGroup<T extends AbstractToken> {
+  operation: any;
+  tokens: readonly (T | AbstractTokenGroup<T>)[];
+}
+
+/**
+ * Transforms query token groups to tokens (only taking 1 level of nesting).
+ */
+export function tokenGroupToTokens<T extends AbstractToken>(tokenGroups: readonly (T | AbstractTokenGroup<T>)[]): T[] {
+  const tokens: T[] = [];
+  for (const tokenOrGroup of tokenGroups) {
+    if ('operator' in tokenOrGroup) {
+      tokens.push(tokenOrGroup);
+    } else {
+      for (const nestedTokenOrGroup of tokenOrGroup.tokens) {
+        if ('operator' in nestedTokenOrGroup) {
+          tokens.push(nestedTokenOrGroup);
+        } else {
+          // Ignore deeply nested tokens
+        }
+      }
+    }
+  }
+  return tokens;
+}

--- a/src/test-utils/dom/property-filter/index.ts
+++ b/src/test-utils/dom/property-filter/index.ts
@@ -88,36 +88,6 @@ export class FilteringTokenWrapper extends ComponentWrapper {
   }
 }
 
-// The internal wrapper has two extra methods that are not available publicly
-// until the property filter token grouping is supported.
-export class InternalFilteringTokenWrapper extends FilteringTokenWrapper {
-  findEditButton(): ElementWrapper<HTMLButtonElement> {
-    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-edit-button'])!;
-  }
-
-  findGroupTokens(): Array<FilteringGroupedTokenWrapper> {
-    return this.findAllByClassName(testUtilStyles['filtering-token-inner']).map(
-      w => new FilteringGroupedTokenWrapper(w.getElement())
-    );
-  }
-}
-
-export class FilteringGroupedTokenWrapper extends ComponentWrapper {
-  static rootSelector = testUtilStyles['filtering-token-inner'];
-
-  findLabel(): ElementWrapper {
-    return this.findByClassName(testUtilStyles['filtering-token-inner-content'])!;
-  }
-
-  findRemoveButton(): ElementWrapper<HTMLButtonElement> {
-    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-inner-dismiss-button'])!;
-  }
-
-  findTokenOperation(): SelectWrapper | null {
-    return this.findComponent(`.${testUtilStyles['filtering-token-inner-select']}`, SelectWrapper);
-  }
-}
-
 export class PropertyFilterEditorDropdownWrapper extends ComponentWrapper {
   findHeader(): ElementWrapper {
     return this.findByClassName(popoverStyles.header)!;
@@ -152,17 +122,49 @@ export class PropertyFilterEditorDropdownWrapper extends ComponentWrapper {
   }
 }
 
-// The internal wrapper has extra methods that are not available publicly
-// until the property filter token grouping is supported.
-export class InternalPropertyFilterEditorDropdownWrapper extends ComponentWrapper {
-  findHeader(): ElementWrapper {
-    return this.findByClassName(popoverStyles.header)!;
+export class PropertyFilterWrapperInternal extends PropertyFilterWrapper {
+  findTokens(): Array<FilteringTokenWrapperInternal> {
+    return this.findAllByClassName(FilteringTokenWrapperInternal.rootSelector).map(
+      (elementWrapper: ElementWrapper) => new FilteringTokenWrapperInternal(elementWrapper.getElement())
+    );
+  }
+}
+
+export class FilteringTokenWrapperInternal extends FilteringTokenWrapper {
+  findEditorDropdown(options = { expandToViewport: false }): null | PropertyFilterEditorDropdownWrapperInternal {
+    const root = options.expandToViewport ? createWrapper() : this;
+    const popoverBody = root.findByClassName(popoverStyles.body);
+    return popoverBody ? new PropertyFilterEditorDropdownWrapperInternal(popoverBody.getElement()) : null;
   }
 
-  findDismissButton(): ButtonWrapper {
-    return this.findComponent(`.${popoverStyles['dismiss-control']}`, ButtonWrapper)!;
+  findEditButton(): ElementWrapper<HTMLButtonElement> {
+    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-edit-button'])!;
   }
 
+  findGroupTokens(): Array<FilteringGroupedTokenWrapper> {
+    return this.findAllByClassName(testUtilStyles['filtering-token-inner']).map(
+      w => new FilteringGroupedTokenWrapper(w.getElement())
+    );
+  }
+}
+
+export class FilteringGroupedTokenWrapper extends ComponentWrapper {
+  static rootSelector = testUtilStyles['filtering-token-inner'];
+
+  findLabel(): ElementWrapper {
+    return this.findByClassName(testUtilStyles['filtering-token-inner-content'])!;
+  }
+
+  findRemoveButton(): ElementWrapper<HTMLButtonElement> {
+    return this.findByClassName<HTMLButtonElement>(testUtilStyles['filtering-token-inner-dismiss-button'])!;
+  }
+
+  findTokenOperation(): SelectWrapper | null {
+    return this.findComponent(`.${testUtilStyles['filtering-token-inner-select']}`, SelectWrapper);
+  }
+}
+
+export class PropertyFilterEditorDropdownWrapperInternal extends PropertyFilterEditorDropdownWrapper {
   findPropertyField(index = 1): FormFieldWrapper {
     const dataIndex = `[data-testindex="${index - 1}"]`;
     return this.findComponent(`.${testUtilStyles['token-editor-field-property']}${dataIndex}`, FormFieldWrapper)!;
@@ -187,13 +189,5 @@ export class InternalPropertyFilterEditorDropdownWrapper extends ComponentWrappe
   findTokenAddActions(): null | ButtonDropdownWrapper {
     const buttonDropdown = this.find(`.${testUtilStyles['token-editor-token-add-actions']}`)!;
     return buttonDropdown ? new ButtonDropdownWrapper(buttonDropdown.getElement()) : null;
-  }
-
-  findCancelButton(): ButtonWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-cancel']}`, ButtonWrapper)!;
-  }
-
-  findSubmitButton(): ButtonWrapper {
-    return this.findComponent(`.${testUtilStyles['token-editor-submit']}`, ButtonWrapper)!;
   }
 }


### PR DESCRIPTION
### Description

Introducing property filter token groups as an internal feature first.

Depends on https://github.com/cloudscape-design/collection-hooks/pull/74

Rel: [qUFhApKfmWEg]

### How has this been tested?

* New unit tests
* Manual testing
* Bug bash
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
