### PR TITLE
chore: Fix incorrect import

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import { useResizeObserver } from '@cloudscape-design/component-toolkit/internal';
 
-import { InternalBreadcrumbGroup } from '../../../breadcrumb-group/internal';
+import { BreadcrumbGroupImplementation } from '../../../breadcrumb-group/implementation';
 import { createWidgetizedComponent } from '../../../internal/widgets';
 import { AppLayoutProps } from '../../interfaces';
 import { Focusable } from '../../utils/use-focus-control';
@@ -170,7 +170,7 @@ export function AppLayoutToolbarImplementation({
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
             {breadcrumbs}
             {discoveredBreadcrumbs && (
-              <InternalBreadcrumbGroup {...discoveredBreadcrumbs} __injectAnalyticsComponentMetadata={true} />
+              <BreadcrumbGroupImplementation {...discoveredBreadcrumbs} __injectAnalyticsComponentMetadata={true} />
             )}
           </div>
         )}


### PR DESCRIPTION
### Description

Fixing widgetization issue. `breadcrumb-group/implementation` contains the pure (non-widgetized) component. Using `breadcrumb-group/internal` loaded the widgetized breadcrumbs which were running another loop of widgetization inside the already widgetized app layout toolbar.

Fixing the import removes some unnecessary side effects

Related links, issue #, if available: n/a

### How has this been tested?

PR build. [This test suite](https://github.com/cloudscape-design/components/blob/main/src/app-layout/__tests__/global-breadcrumbs.test.tsx) will capture possible issues

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
