### PR TITLE
fix: Property filter with disableFreeTextFiltering

### DIFF
--- a/src/property-filter/__tests__/property-filter.test.tsx
+++ b/src/property-filter/__tests__/property-filter.test.tsx
@@ -368,51 +368,57 @@ describe('property filter parts', () => {
       ).toEqual(['state = Stopped']);
     });
 
-    test('query is created with actual value when clicking on option', () => {
-      const onChange = jest.fn();
-      const { propertyFilterWrapper: wrapper } = renderComponent({ onChange });
+    test.each([false, true])(
+      'query is created with actual value when clicking on option, disableFreeTextFiltering=%s',
+      disableFreeTextFiltering => {
+        const onChange = jest.fn();
+        const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering, onChange });
 
-      // Selecting matched option from the list
-      act(() => wrapper.setInputValue('state=Stopp'));
-      act(() => wrapper.selectSuggestion(1));
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: {
-            tokens: [{ propertyKey: 'state', value: '0', operator: '=' }],
-            operation: 'and',
-          },
-        })
-      );
-    });
+        // Selecting matched option from the list
+        act(() => wrapper.setInputValue('state=Stopp'));
+        act(() => wrapper.selectSuggestion(1));
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detail: {
+              tokens: [{ propertyKey: 'state', value: '0', operator: '=' }],
+              operation: 'and',
+            },
+          })
+        );
+      }
+    );
 
-    test('query is created with actual value when pressing enter', () => {
-      const onChange = jest.fn();
-      const { propertyFilterWrapper: wrapper } = renderComponent({ onChange });
+    test.each([false, true])(
+      'query is created with actual value when pressing enter, disableFreeTextFiltering=%s',
+      disableFreeTextFiltering => {
+        const onChange = jest.fn();
+        const { propertyFilterWrapper: wrapper } = renderComponent({ disableFreeTextFiltering, onChange });
 
-      // Entering full label
-      act(() => wrapper.setInputValue('state=Stopping'));
-      act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: {
-            tokens: [{ propertyKey: 'state', value: '1', operator: '=' }],
-            operation: 'and',
-          },
-        })
-      );
+        // Entering full label
+        act(() => wrapper.setInputValue('state=Stopping'));
+        act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detail: {
+              tokens: [{ propertyKey: 'state', value: '1', operator: '=' }],
+              operation: 'and',
+            },
+          })
+        );
 
-      // Entering full value
-      act(() => wrapper.setInputValue('state=2'));
-      act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: {
-            tokens: [{ propertyKey: 'state', value: '2', operator: '=' }],
-            operation: 'and',
-          },
-        })
-      );
-    });
+        // Entering full value
+        act(() => wrapper.setInputValue('state=2'));
+        act(() => wrapper.findNativeInput().keydown(KeyCode.enter));
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            detail: {
+              tokens: [{ propertyKey: 'state', value: '2', operator: '=' }],
+              operation: 'and',
+            },
+          })
+        );
+      }
+    );
   });
 
   describe('custom element slots', () => {

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -187,7 +187,7 @@ const PropertyFilterInternal = React.forwardRef(
           break;
         }
       }
-      if (internalFreeText.disabled && !('propertyKey' in newToken)) {
+      if (internalFreeText.disabled && !newToken.property) {
         return;
       }
       addToken(newToken);


### PR DESCRIPTION
### Description

Fixes a bug introduced in https://github.com/cloudscape-design/components/pull/2618 that makes a property filter with disableFreeTextFiltering no longer submit a token

### How has this been tested?

* New unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
