### PR TITLE
chore: adding selected prop to drawers and unit tests

### DIFF
--- a/src/app-layout/__tests__/drawers.test.tsx
+++ b/src/app-layout/__tests__/drawers.test.tsx
@@ -13,6 +13,8 @@ import {
 
 import { act } from '@testing-library/react';
 import AppLayout, { AppLayoutProps } from '../../../lib/components/app-layout';
+import visualRefreshStyles from '../../../lib/components/app-layout/visual-refresh/styles.css.js';
+import toolbarTriggerButtonStyles from '../../../lib/components/app-layout/visual-refresh-toolbar/toolbar/trigger-button/styles.css.js';
 
 jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
   useMobile: jest.fn().mockReturnValue(true),
@@ -25,7 +27,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout(({ size }) => {
+describeEachAppLayout(({ size, theme }) => {
   test(`should not render drawer when it is not defined`, () => {
     const { wrapper, rerender } = renderComponent(<AppLayout toolsHide={true} drawers={[testDrawer]} />);
     expect(wrapper.findDrawersTriggers()).toHaveLength(1);
@@ -168,5 +170,18 @@ describeEachAppLayout(({ size }) => {
     drawerTrigger.click();
     expect(drawerTrigger!.getElement()).toHaveAttribute('aria-controls', 'security');
     expect(wrapper.findActiveDrawer()!.getElement()).toHaveAttribute('id', 'security');
+  });
+
+  testIf(size !== 'mobile' && theme !== 'classic')('shows trigger button as selected when drawer opened', () => {
+    const { wrapper } = renderComponent(<AppLayout drawers={[testDrawer]} />);
+    const drawerTrigger = wrapper.findDrawerTriggerById('security')!;
+    const selectedClass = theme === 'refresh' ? visualRefreshStyles.selected : toolbarTriggerButtonStyles.selected;
+    expect(drawerTrigger!.getElement()).not.toHaveClass(selectedClass);
+
+    drawerTrigger.click();
+    expect(drawerTrigger!.getElement()).toHaveClass(selectedClass);
+
+    drawerTrigger.click();
+    expect(drawerTrigger!.getElement()).not.toHaveClass(selectedClass);
   });
 });

--- a/src/app-layout/__tests__/trigger-button.test.tsx
+++ b/src/app-layout/__tests__/trigger-button.test.tsx
@@ -52,6 +52,8 @@ const mockEventBubbleWithShiftFocus = {
   },
 };
 
+const testIf = (condition: boolean) => (condition ? test : test.skip);
+
 const renderVisualRefreshTriggerButton = (
   props: Partial<VisualRefreshTriggerButtonProps> = {},
   useAppLayoutInternalsValues: Partial<AllContext.AppLayoutInternals> = {},
@@ -92,11 +94,32 @@ describe('Visual refresh trigger-button (not in appLayoutWidget toolbar)', () =>
 
   describe.each([true, false])('Toolbar trigger-button with isMobile=%s', isMobile => {
     describe.each([true, false])('AppLayoutInternals with hasOpenDrawer=%s', hasOpenDrawer => {
+      testIf(!isMobile)('applies the correct class when selected', () => {
+        const ref: React.MutableRefObject<ButtonProps.Ref | null> = React.createRef();
+        const { wrapper } = renderVisualRefreshTriggerButton(
+          {
+            selected: true,
+          },
+          {
+            isMobile,
+            hasOpenDrawer,
+          },
+          ref
+        );
+        expect(wrapper).not.toBeNull();
+        const seletedButton = wrapper.findByClassName(visualRefreshStyles.selected);
+        expect(seletedButton).toBeTruthy();
+      });
+
       test('renders correctly with wit badge', () => {
         const ref: React.MutableRefObject<ButtonProps.Ref | null> = React.createRef();
-        const { wrapper, getByTestId } = renderVisualRefreshToolbarTriggerButton(
+        const { wrapper, getByTestId } = renderVisualRefreshTriggerButton(
           {
             badge: false,
+          },
+          {
+            isMobile,
+            hasOpenDrawer,
           },
           ref
         );
@@ -256,6 +279,19 @@ describe('Visual Refresh Toolbar trigger-button', () => {
     expect(button).toBeTruthy();
     expect(wrapper!.findIcon()).toBeTruthy();
     expect(wrapper.findByClassName(toolbarTriggerButtonStyles.dot)).toBeTruthy();
+  });
+
+  test('applies the correct class when selected', () => {
+    const ref: React.MutableRefObject<ButtonProps.Ref | null> = React.createRef();
+    const { wrapper } = renderVisualRefreshToolbarTriggerButton(
+      {
+        selected: true,
+      },
+      ref
+    );
+    expect(wrapper).not.toBeNull();
+    const seletedButton = wrapper.findByClassName(toolbarTriggerButtonStyles.selected);
+    expect(seletedButton).toBeTruthy();
   });
 
   test.each([true, false])('icon renders correctly when iconSvg prop has a %s value', hasIconSvg => {

--- a/src/app-layout/visual-refresh/drawers.tsx
+++ b/src/app-layout/visual-refresh/drawers.tsx
@@ -262,6 +262,7 @@ function DesktopTriggers() {
               badge={item.badge}
               testId={`awsui-app-layout-trigger-${item.id}`}
               highContrastHeader={headerVariant === 'high-contrast'}
+              selected={item.id === activeDrawerId}
             />
           );
         })}
@@ -367,6 +368,7 @@ export function MobileTriggers() {
             onClick={() => handleDrawersClick(item.id)}
             testId={`awsui-app-layout-trigger-${item.id}`}
             highContrastHeader={headerVariant === 'high-contrast'}
+            selected={item.id === activeDrawerId}
           />
         ))}
         {overflowItems.length > 0 && (


### PR DESCRIPTION
### Description

Uses the selected prop in the TriggerButton for visual refresh.  

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Added unit tests so this will be detected before making it to visual tests

Related links, issue #, if available: n/a

This fixes the issue the visual tests have detected, and they will pass. Follow up to https://github.com/cloudscape-design/components/pull/2594

### How has this been tested?

<!-- How did you test to verify your changes? -->
- On local host, visually
- adding unit tests for trigger-button
- adding unit tests for drawers

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
