### PR TITLE
chore: Update app layout deduplication order

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -135,30 +135,31 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
   });
 
-  test('when multiple app layouts rendered, only the last instance receives breadcrumbs', async () => {
+  test('when multiple app layouts rendered, only the first instance receives breadcrumbs', async () => {
     await renderAsync(
       <>
         <AppLayout {...defaultAppLayoutProps} data-testid="first" />
         <AppLayout
           {...defaultAppLayoutProps}
           data-testid="second"
+          navigationHide={true}
           content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
         />
       </>
     );
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-    expect(wrapper.find('[data-testid="first"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
     expect(
       wrapper
-        .find('[data-testid="second"]')!
+        .find('[data-testid="first"]')!
         .findAppLayout()!
         .findBreadcrumbs()!
         .findBreadcrumbGroup()!
         .findBreadcrumbLinks()
     ).toHaveLength(2);
+    expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
   });
 
-  test('when multiple nested app layouts rendered, the inner instance receives breadcrumbs', async () => {
+  test('when multiple nested app layouts rendered, the outer instance receives breadcrumbs', async () => {
     await renderAsync(
       <>
         <AppLayout
@@ -168,6 +169,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
             <AppLayout
               {...defaultAppLayoutProps}
               data-testid="second"
+              navigationHide={true}
               breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
             />
           }
@@ -177,12 +179,13 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(
       wrapper
-        .find('[data-testid="second"]')!
+        .find('[data-testid="first"]')!
         .findAppLayout()!
         .findBreadcrumbs()!
         .findBreadcrumbGroup()!
         .findBreadcrumbLinks()
     ).toHaveLength(2);
+    expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
   });
 
   test('updates when a single breadcrumbs instance changes', async () => {

--- a/src/app-layout/__tests__/multi-layout.test.tsx
+++ b/src/app-layout/__tests__/multi-layout.test.tsx
@@ -41,7 +41,8 @@ async function renderAsync(jsx: React.ReactElement) {
   const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
   const secondLayout = createWrapper().find('[data-testid="second"]')!.findAppLayout()!;
   expect(findAllToolbars()).toHaveLength(1);
-  expect(findToolbar(secondLayout)).toBeTruthy();
+  expect(findToolbar(firstLayout)).toBeTruthy();
+  expect(findToolbar(secondLayout)).toBeFalsy();
   return { firstLayout, secondLayout };
 }
 
@@ -70,7 +71,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(true);
     expect(secondLayout.findNavigation()).toBeFalsy();
 
-    secondLayout.findNavigationToggle().click();
+    firstLayout.findNavigationToggle().click();
     expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(false);
   });
 
@@ -86,7 +87,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     expect(firstLayout.findTools()).toBeFalsy();
     expect(secondLayout.findTools()).toBeFalsy();
 
-    secondLayout.findToolsToggle().click();
+    firstLayout.findToolsToggle().click();
     expect(secondLayout.findTools()).toBeTruthy();
   });
 
@@ -102,10 +103,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     );
     expect(firstLayout.findSplitPanel()).toBeTruthy();
     expect(secondLayout.findSplitPanel()).toBeFalsy();
-    expect(secondLayout.findSplitPanelOpenButton()).toBeTruthy();
+    expect(firstLayout.findSplitPanelOpenButton()).toBeTruthy();
+    expect(secondLayout.findSplitPanelOpenButton()).toBeFalsy();
     expect(firstLayout.findSplitPanel()!.findOpenPanelBottom()).toBeFalsy();
 
-    secondLayout.findSplitPanelOpenButton()!.click();
+    firstLayout.findSplitPanelOpenButton()!.click();
     expect(firstLayout.findSplitPanel()!.findOpenPanelBottom()).toBeTruthy();
   });
 
@@ -117,8 +119,8 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 
     const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
     const secondLayout = createWrapper().find('[data-testid="second"]')!.findAppLayout()!;
-    expect(firstLayout.findNavigationToggle()).toBeFalsy();
-    expect(secondLayout.findNavigationToggle()).toBeTruthy();
+    expect(firstLayout.findNavigationToggle()).toBeTruthy();
+    expect(secondLayout.findNavigationToggle()).toBeFalsy();
   });
 
   test('merges props from multiple instances', async () => {
@@ -149,12 +151,13 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     );
     await delay();
 
+    const firstLayout = createWrapper().find('[data-testid="first"]')!.findAppLayout()!;
     const thirdLayout = createWrapper().find('[data-testid="third"]')!.findAppLayout()!;
-    expect(findToolbar(thirdLayout)).toBeTruthy();
+    expect(findToolbar(thirdLayout)).toBeFalsy();
     expect(findAllToolbars()).toHaveLength(1);
-    expect(thirdLayout.findNavigationToggle()).toBeTruthy();
-    expect(thirdLayout.findToolsToggle()).toBeTruthy();
-    expect(thirdLayout.findSplitPanelOpenButton()).toBeTruthy();
+    expect(firstLayout.findNavigationToggle()).toBeTruthy();
+    expect(firstLayout.findToolsToggle()).toBeTruthy();
+    expect(firstLayout.findSplitPanelOpenButton()).toBeTruthy();
   });
 
   test('allows manual deduplication control', async () => {
@@ -196,7 +199,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     });
 
     test('ignores duplicate properties and prints a warning', async () => {
-      const { secondLayout } = await renderAsync(
+      const { firstLayout, secondLayout } = await renderAsync(
         <AppLayout
           {...defaultAppLayoutProps}
           data-testid="first"
@@ -208,27 +211,30 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Another app layout instance on this page already defines navigation property')
       );
-      secondLayout.findNavigationToggle().click();
-      expect(isDrawerClosed(secondLayout.findNavigation())).toEqual(false);
+      expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(true);
+      expect(isDrawerClosed(secondLayout.findNavigation())).toEqual(true);
+      firstLayout.findNavigationToggle().click();
+      expect(isDrawerClosed(firstLayout.findNavigation())).toEqual(false);
+      expect(isDrawerClosed(secondLayout.findNavigation())).toEqual(true);
     });
 
     test('deduplicates tools and drawers in a single entity', async () => {
-      const { secondLayout } = await renderAsync(
+      const { firstLayout } = await renderAsync(
         <AppLayout
           {...defaultAppLayoutProps}
           data-testid="first"
-          drawers={[testDrawer]}
-          content={<AppLayout {...defaultAppLayoutProps} data-testid="second" tools="second tools" />}
+          tools="second tools"
+          content={<AppLayout {...defaultAppLayoutProps} data-testid="second" drawers={[testDrawer]} />}
         />
       );
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Another app layout instance on this page already defines tools or drawers property')
       );
-      expect(secondLayout.findDrawersTriggers()).toHaveLength(0);
-      expect(secondLayout.findTools()).toBeFalsy();
+      expect(firstLayout.findDrawersTriggers()).toHaveLength(0);
+      expect(firstLayout.findTools()).toBeFalsy();
 
-      secondLayout.findToolsToggle().click();
-      expect(secondLayout.findTools()).toBeTruthy();
+      firstLayout.findToolsToggle().click();
+      expect(firstLayout.findTools()).toBeTruthy();
     });
   });
 });

--- a/src/internal/plugins/controllers/app-layout-widget.ts
+++ b/src/internal/plugins/controllers/app-layout-widget.ts
@@ -42,7 +42,7 @@ export class AppLayoutWidgetController<Props = unknown> {
     if (forcedPrimary) {
       return forcedPrimary;
     }
-    for (const registration of this.#registrations.slice().reverse()) {
+    for (const registration of this.#registrations.slice()) {
       if (registration.forceType !== 'secondary') {
         return registration;
       }


### PR DESCRIPTION
### Description

Follow up for https://github.com/cloudscape-design/components/pull/2624

After the design changes, we need to render the toolbar on the first app layout in the stack, not last

Related links, issue #, if available: n/a

### How has this been tested?

Updated related unit tests to reflect the new behavior

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
