### PR TITLE
fix: Fixes table sticky col padding in vr

### DIFF
--- a/pages/table/sticky-columns.page.tsx
+++ b/pages/table/sticky-columns.page.tsx
@@ -22,6 +22,7 @@ type DemoContext = React.Context<
     resizableColumns: boolean;
     stickyHeader: boolean;
     sortingDisabled: boolean;
+    stripedRows: boolean;
     selectionType: undefined | 'single' | 'multi';
     stickyColumnsFirst: string;
     stickyColumnsLast: string;
@@ -193,6 +194,13 @@ export default () => {
               onChange={event => setUrlParams({ sortingDisabled: event.detail.checked })}
             >
               Sorting disabled
+            </Checkbox>
+
+            <Checkbox
+              checked={urlParams.stripedRows}
+              onChange={event => setUrlParams({ stripedRows: event.detail.checked })}
+            >
+              Striped rows
             </Checkbox>
 
             <Checkbox

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -152,7 +152,7 @@ $cell-negative-space-vertical: 2px;
       }
     }
 
-    &.sticky-cell-pad-inline-start {
+    &.sticky-cell-pad-inline-start:not(.has-selection) {
       @include cell-padding-inline-start($cell-horizontal-padding);
     }
 

--- a/src/table/body-cell/styles.scss
+++ b/src/table/body-cell/styles.scss
@@ -152,15 +152,20 @@ $cell-negative-space-vertical: 2px;
       }
     }
 
+    &.sticky-cell-pad-inline-start {
+      @include cell-padding-inline-start($cell-horizontal-padding);
+    }
+
     /*
       Striped rows requires additional left padding because the
       shaded background makes the child content appear too close
       to the table edge.
-      */
+    */
     &:first-child.has-striped-rows {
       @include cell-padding-inline-start(awsui.$space-xxs);
-      &-sticky-cell-pad-inline-start {
-        @include cell-padding-inline-start(awsui.$space-table-horizontal);
+
+      &.sticky-cell-pad-inline-start {
+        @include cell-padding-inline-start($cell-horizontal-padding);
       }
     }
 
@@ -168,7 +173,7 @@ $cell-negative-space-vertical: 2px;
       Remove the placeholder border if the row is not selectable.
       Rows that are not selectable will reserve the horizontal space
       that the placeholder border would consume.
-      */
+    */
     &:not(.has-selection):not(.body-cell-editable) {
       border-inline-start: none;
     }

--- a/src/table/header-cell/styles.scss
+++ b/src/table/header-cell/styles.scss
@@ -7,6 +7,8 @@
 @use '../../internal/styles/tokens' as awsui;
 @use '../../internal/styles' as styles;
 
+$cell-horizontal-padding: awsui.$space-scaled-l;
+
 @mixin when-focus-visible-or-fake {
   @include focus-visible.when-visible {
     @content;
@@ -203,23 +205,24 @@ settings icon in the pagination slot.
     @include header-cell-focus-outline-first(awsui.$space-table-header-focus-outline-gutter);
   }
 
-  &:first-child:not(.has-striped-rows) {
+  &:first-child:not(.has-striped-rows):not(.sticky-cell-pad-inline-start) {
     @include cell-offset(awsui.$space-xxxs);
-    &.sticky-cell-pad-inline-start {
-      @include cell-offset(awsui.$space-table-horizontal);
-    }
   }
 
   /*
-  Striped rows requires additional left padding because the
-  shaded background makes the child content appear too close
-  to the table edge.
+    Striped rows requires additional left padding because the
+    shaded background makes the child content appear too close
+    to the table edge.
   */
-  &:first-child.has-striped-rows {
+  &:first-child.has-striped-rows:not(.sticky-cell-pad-inline-start) {
     @include cell-offset(awsui.$space-xxs);
   }
 
   &:last-child.header-cell-sortable {
     padding-inline-end: awsui.$space-xxxs;
+  }
+
+  &.sticky-cell-pad-inline-start {
+    @include cell-offset($cell-horizontal-padding);
   }
 }


### PR DESCRIPTION
### Description

Fixing a bug when first sticky column padding is missing in VR

Rel: AWSUI-57462

### How has this been tested?

* Manual tests in Classic, VR, with compact mode, with striped rows
* New screenshot tests, see: CR-146133400

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
