### PR TITLE
fix: Button dropdown with main action creates duplicate performance mark

### DIFF
--- a/pages/button-dropdown/main-action.page.tsx
+++ b/pages/button-dropdown/main-action.page.tsx
@@ -4,17 +4,10 @@ import * as React from 'react';
 
 import ButtonDropdown from '~components/button-dropdown';
 
-import ScreenshotArea from '../utils/screenshot-area';
-
 export default function ButtonDropdownPage() {
   return (
-    <ScreenshotArea
-      disableAnimations={true}
-      style={{
-        // extra space to include dropdown in the screenshot area
-        paddingBlockEnd: 100,
-      }}
-    >
+    <>
+      <h1>Button dropdown with main action</h1>
       <ButtonDropdown
         items={[
           {
@@ -23,8 +16,9 @@ export default function ButtonDropdownPage() {
           },
         ]}
         mainAction={{ text: 'Launch instance' }}
+        ariaLabel="More launch options"
         variant="primary"
       />
-    </ScreenshotArea>
+    </>
   );
 }

--- a/pages/button-dropdown/main-action.page.tsx
+++ b/pages/button-dropdown/main-action.page.tsx
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as React from 'react';
+
+import ButtonDropdown from '~components/button-dropdown';
+
+import ScreenshotArea from '../utils/screenshot-area';
+
+export default function ButtonDropdownPage() {
+  return (
+    <ScreenshotArea
+      disableAnimations={true}
+      style={{
+        // extra space to include dropdown in the screenshot area
+        paddingBlockEnd: 100,
+      }}
+    >
+      <ButtonDropdown
+        items={[
+          {
+            text: 'Launch instance from template',
+            id: 'launch-instance-from-template',
+          },
+        ]}
+        mainAction={{ text: 'Launch instance' }}
+        variant="primary"
+      />
+    </ScreenshotArea>
+  );
+}

--- a/src/button-dropdown/__integ__/performance-marks.test.ts
+++ b/src/button-dropdown/__integ__/performance-marks.test.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+
+function setupTest(
+  pageName: string,
+  testFn: (parameters: {
+    page: BasePageObject;
+    getMarks: () => Promise<PerformanceMark[]>;
+    getElementByPerformanceMark: (id: string) => Promise<WebdriverIO.Element>;
+  }) => Promise<void>
+) {
+  return useBrowser(async browser => {
+    const page = new BasePageObject(browser);
+    await browser.url(`#/light/button-dropdown/${pageName}`);
+    const getMarks = async () => {
+      const marks = await browser.execute(() => performance.getEntriesByType('mark') as PerformanceMark[]);
+      return marks.filter(m => m.detail?.source === 'awsui');
+    };
+    const getElementByPerformanceMark = (id: string) => browser.$(`[data-analytics-performance-mark="${id}"]`);
+
+    await testFn({ page, getMarks, getElementByPerformanceMark });
+  });
+}
+
+describe('ButtonDropdown', () => {
+  test(
+    'Emits a single mark',
+    setupTest('main-action', async ({ getMarks, getElementByPerformanceMark }) => {
+      const marks = await getMarks();
+
+      expect(marks).toHaveLength(1);
+      expect(marks[0].name).toBe('primaryButtonRendered');
+      expect(marks[0].detail).toMatchObject({
+        source: 'awsui',
+        instanceIdentifier: expect.any(String),
+        loading: false,
+        disabled: false,
+        text: 'Launch instance',
+      });
+
+      expect(await getElementByPerformanceMark(marks[0].detail.instanceIdentifier).then(e => e.getText())).toBe(
+        'Launch instance'
+      );
+    })
+  );
+});

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -256,7 +256,7 @@ const InternalButtonDropdown = React.forwardRef(
             )}
             {...getAnalyticsMetadataAttribute(analyticsMetadata)}
           >
-            <InternalButton ref={triggerRef} {...baseTriggerProps} />
+            <InternalButton ref={triggerRef} {...baseTriggerProps} __emitPerformanceMarks={false} />
           </div>
         </div>
       );

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -46,6 +46,7 @@ export type InternalButtonProps = Omit<ButtonProps, 'variant'> & {
   __focusable?: boolean;
   __injectAnalyticsComponentMetadata?: boolean;
   __title?: string;
+  __emitPerformanceMarks?: boolean;
 } & InternalBaseComponentProps<HTMLAnchorElement | HTMLButtonElement>;
 
 export const InternalButton = React.forwardRef(
@@ -82,6 +83,7 @@ export const InternalButton = React.forwardRef(
       __focusable = false,
       __injectAnalyticsComponentMetadata = false,
       __title,
+      __emitPerformanceMarks = true,
       ...props
     }: InternalButtonProps,
     ref: React.Ref<ButtonProps.Ref>
@@ -108,7 +110,7 @@ export const InternalButton = React.forwardRef(
 
     const performanceMarkAttributes = usePerformanceMarks(
       'primaryButton',
-      variant === 'primary',
+      variant === 'primary' && __emitPerformanceMarks,
       buttonRef,
       () => ({
         loading,


### PR DESCRIPTION
### Description

All primary buttons (including the button dropdown) emit a performance mark when they are rendered, to allow for measuring the page load performance. When a button dropdown had a primary action, there was a bug: it emits _two_ performance marks (one for the main action, and one for the dropdown trigger), while it should emit only one.

This PR fixes that bug, by suppressing any performance marks in the dropdown trigger.

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-57722

### How has this been tested?

Added a new integration test. The test is mostly copied from the same test for the Button component ([button/\_\_integ\_\_/performance-marks.test.ts](https://github.com/cloudscape-design/components/blob/main/src/button/__integ__/performance-marks.test.ts)).
<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
