### PR TITLE
feat: Support icon only main action in button dropdown

### DIFF
--- a/pages/button-dropdown/permutations-main-action.page.tsx
+++ b/pages/button-dropdown/permutations-main-action.page.tsx
@@ -32,6 +32,7 @@ const permutations = createPermutations<ButtonDropdownProps>([
       { ...launchInstanceItem },
       { ...launchInstanceItem, disabled: true },
       { ...launchInstanceItem, loading: true, loadingText: 'Loading' },
+      { iconName: 'add-plus' },
     ],
     items: [
       [

--- a/pages/button-dropdown/permutations-main-action.page.tsx
+++ b/pages/button-dropdown/permutations-main-action.page.tsx
@@ -32,7 +32,7 @@ const permutations = createPermutations<ButtonDropdownProps>([
       { ...launchInstanceItem },
       { ...launchInstanceItem, disabled: true },
       { ...launchInstanceItem, loading: true, loadingText: 'Loading' },
-      { iconName: 'add-plus' },
+      { iconName: 'add-plus', ariaLabel: 'Add resource' },
     ],
     items: [
       [

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -3732,7 +3732,7 @@ The main action also supports the following properties of the [button](/componen
           },
           Object {
             "name": "text",
-            "optional": false,
+            "optional": true,
             "type": "string",
           },
         ],

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -121,7 +121,7 @@ export namespace ButtonDropdownProps {
   export type ItemType = 'action' | 'group';
 
   export interface MainAction {
-    text: string;
+    text?: string;
     ariaLabel?: string;
     onClick?: CancelableEventHandler<ButtonProps.ClickDetail>;
     onFollow?: CancelableEventHandler<ButtonProps.FollowDetail>;

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -210,7 +210,7 @@ const InternalButtonDropdown = React.forwardRef(
       const mainActionAriaLabel = externalIconAriaLabel
         ? `${mainAction.ariaLabel ?? mainAction.text} ${mainAction.externalIconAriaLabel}`
         : mainAction.ariaLabel;
-
+      const hasNoText = !text;
       trigger = (
         <div role="group" aria-label={ariaLabel} className={styles['split-trigger-wrapper']}>
           <div
@@ -218,6 +218,8 @@ const InternalButtonDropdown = React.forwardRef(
               styles['trigger-item'],
               styles['split-trigger'],
               styles[`variant-${variant}`],
+              hasNoText && styles['has-no-text'],
+              isVisualRefresh && styles['visual-refresh'],
               mainActionProps.disabled && styles.disabled,
               mainActionProps.loading && styles.loading
             )}

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -218,8 +218,6 @@ const InternalButtonDropdown = React.forwardRef(
               styles['trigger-item'],
               styles['split-trigger'],
               styles[`variant-${variant}`],
-              hasNoText && styles['has-no-text'],
-              isVisualRefresh && styles['visual-refresh'],
               mainActionProps.disabled && styles.disabled,
               mainActionProps.loading && styles.loading
             )}
@@ -239,7 +237,11 @@ const InternalButtonDropdown = React.forwardRef(
               ref={mainActionRef}
               {...mainActionProps}
               {...mainActionIconProps}
-              className={clsx(styles['trigger-button'])}
+              className={clsx(
+                styles['trigger-button'],
+                hasNoText && styles['has-no-text'],
+                isVisualRefresh && styles['visual-refresh']
+              )}
               variant={variant}
               ariaLabel={mainActionAriaLabel}
               formAction="none"

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -71,6 +71,18 @@ $dropdown-trigger-icon-offset: 2px;
       padding-inline-end: awsui.$space-m;
       margin-inline-end: awsui.$space-xxxs;
     }
+
+    // &.has-no-text {
+    //   > .trigger-button {
+    //     padding-inline: awsui.$space-button-icon-only-horizontal;
+    //   }
+    // }
+
+    // &.visual-refresh {
+    //   & > .trigger-button {
+    //     padding-inline-start: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
+    //   }
+    // }
   }
 
   & > .trigger-item:not(:first-child) {

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -70,13 +70,13 @@ $dropdown-trigger-icon-offset: 2px;
       border-end-end-radius: 0;
       padding-inline-end: awsui.$space-m;
       margin-inline-end: awsui.$space-xxxs;
-    }
 
-    &.has-no-text {
-      padding-inline: awsui.$space-button-icon-only-horizontal;
+      &.has-no-text {
+        padding-inline: awsui.$space-button-icon-only-horizontal;
 
-      &.visual-refresh {
-        padding-inline-start: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
+        &.visual-refresh {
+          padding-inline-start: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
+        }
       }
     }
   }

--- a/src/button-dropdown/styles.scss
+++ b/src/button-dropdown/styles.scss
@@ -72,17 +72,13 @@ $dropdown-trigger-icon-offset: 2px;
       margin-inline-end: awsui.$space-xxxs;
     }
 
-    // &.has-no-text {
-    //   > .trigger-button {
-    //     padding-inline: awsui.$space-button-icon-only-horizontal;
-    //   }
-    // }
+    &.has-no-text {
+      padding-inline: awsui.$space-button-icon-only-horizontal;
 
-    // &.visual-refresh {
-    //   & > .trigger-button {
-    //     padding-inline-start: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
-    //   }
-    // }
+      &.visual-refresh {
+        padding-inline-start: calc(#{awsui.$space-s} - #{$dropdown-trigger-icon-offset});
+      }
+    }
   }
 
   & > .trigger-item:not(:first-child) {


### PR DESCRIPTION
### Description

- make `text` property in `mainAction` optional
- remove extra padding when there is no text in main action using the same padding as dropdown trigger

Related links, issue #, if available: HgxDAw1K2GBU

### How has this been tested?

added new permutations

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
