### PR TITLE
feat: Add analytics metadata to internal Selectable item component

### DIFF
--- a/src/autosuggest/autosuggest-option.tsx
+++ b/src/autosuggest/autosuggest-option.tsx
@@ -89,6 +89,7 @@ const AutosuggestOption = (
       ariaSetsize={ariaSetsize}
       ariaPosinset={ariaPosinset}
       highlightType={highlightType.type}
+      value={option.value}
     >
       {optionContent}
     </SelectableItem>

--- a/src/internal/__tests__/analytics-metadata-test-utils.ts
+++ b/src/internal/__tests__/analytics-metadata-test-utils.ts
@@ -25,7 +25,8 @@ const validateLabels = (labelSelectors: Array<string>, labelsClassNames: Record<
     const parts = current
       .split(/\s+/)
       .filter(part => part.startsWith('.'))
-      .map(part => part.replace('.', ''));
+      .map(part => part.replace('.', ''))
+      .map(part => part.replace(/\[.*\]/, ''));
     acc = [...acc, ...parts];
     return acc;
   }, []);

--- a/src/internal/components/option/analytics-metadata/styles.scss
+++ b/src/internal/components/option/analytics-metadata/styles.scss
@@ -1,0 +1,8 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.label {
+  /* used in analytics metadata */
+}

--- a/src/internal/components/option/option-parts.tsx
+++ b/src/internal/components/option/option-parts.tsx
@@ -7,6 +7,7 @@ import { IconProps } from '../../../icon/interfaces';
 import InternalIcon from '../../../icon/internal';
 import HighlightMatch from './highlight-match';
 
+import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
 
 interface LabelProps {
@@ -16,7 +17,7 @@ interface LabelProps {
   triggerVariant: boolean;
 }
 export const Label = ({ label, prefix, highlightText, triggerVariant }: LabelProps) => (
-  <span className={clsx(styles.label, triggerVariant && styles['trigger-variant'])}>
+  <span className={clsx(styles.label, analyticsSelectors.label, triggerVariant && styles['trigger-variant'])}>
     {prefix && (
       <span className={clsx(styles['label-prefix'], triggerVariant && styles['trigger-variant'])}>{prefix} </span>
     )}

--- a/src/internal/components/selectable-item/__tests__/analytics-metadata.test.tsx
+++ b/src/internal/components/selectable-item/__tests__/analytics-metadata.test.tsx
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
+
+import createWrapper from '../../../../..//lib/components/test-utils/dom';
+import Option from '../../../../../lib/components/internal/components/option';
+import SelectableItems from '../../../../../lib/components/internal/components/selectable-item';
+import {
+  ItemDataAttributes,
+  SelectableItemProps,
+} from '../../../../../lib/components/internal/components/selectable-item/interfaces';
+import { validateComponentNameAndLabels } from '../../../../internal/__tests__/analytics-metadata-test-utils';
+
+import optionLabels from '../../../../../lib/components/internal/components/option/analytics-metadata/styles.css.js';
+import selectableItemsLabels from '../../../../../lib/components/internal/components/selectable-item/analytics-metadata/styles.css.js';
+import styles from '../../../../../lib/components/internal/components/selectable-item/styles.css.js';
+
+const labels = { ...selectableItemsLabels, ...optionLabels };
+
+function renderSelectableItem(props: Partial<SelectableItemProps> & ItemDataAttributes) {
+  const children = props.children || 'content';
+  const renderResult = render(<SelectableItems {...props}>{children}</SelectableItems>);
+  return createWrapper(renderResult.container).find(`.${styles['selectable-item']}`)!.getElement();
+}
+beforeAll(() => {
+  activateAnalyticsMetadata(true);
+});
+
+describe('SelectableItem renders correct analytics metadata', () => {
+  test('when isParent=true', () => {
+    const element = renderSelectableItem({ isParent: true });
+    expect(getGeneratedAnalyticsMetadata(element)).toEqual({});
+  });
+  test('when disabled', () => {
+    const element = renderSelectableItem({ disabled: true });
+    expect(getGeneratedAnalyticsMetadata(element)).toEqual({});
+  });
+  test('with simple content', () => {
+    const element = renderSelectableItem({ children: 'content label' });
+    validateComponentNameAndLabels(element, labels);
+    expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+      action: 'select',
+      detail: {
+        label: 'content label',
+      },
+    });
+  });
+  test('with value', () => {
+    const element = renderSelectableItem({ value: 'item-value' });
+    validateComponentNameAndLabels(element, labels);
+    expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+      action: 'select',
+      detail: {
+        label: 'content',
+        value: 'item-value',
+      },
+    });
+  });
+  test('with data-test-index', () => {
+    const element = renderSelectableItem({ 'data-test-index': '50' });
+    validateComponentNameAndLabels(element, labels);
+    expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+      action: 'select',
+      detail: {
+        label: 'content',
+        position: '50',
+      },
+    });
+  });
+  describe('with Option component', () => {
+    test('simple option', () => {
+      const renderResult = render(
+        <SelectableItems>
+          <Option option={{ value: 'test value' }} />
+        </SelectableItems>
+      );
+      const element = createWrapper(renderResult.container).find(`.${styles['selectable-item']}`)!.getElement();
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'test value',
+        },
+      });
+    });
+    test('complex option', () => {
+      const renderResult = render(
+        <SelectableItems>
+          <Option
+            option={{
+              value: 'test value',
+              label: 'label',
+              tags: ['A', 'B', 'C'],
+              description: 'to ignore',
+            }}
+            highlightText="lab"
+          />
+        </SelectableItems>
+      );
+      const element = createWrapper(renderResult.container).find(`.${styles['selectable-item']}`)!.getElement();
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'label',
+        },
+      });
+    });
+  });
+  describe('with isChild=true', () => {
+    test('with simple content', () => {
+      const element = renderSelectableItem({ isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with value', () => {
+      const element = renderSelectableItem({ value: 'item-value', isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          value: 'item-value',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with data-test-index', () => {
+      const element = renderSelectableItem({ 'data-test-index': '50', isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          position: '50',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with data-group-index', () => {
+      const element = renderSelectableItem({ 'data-group-index': '5', isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with data-group-index and data-in-group-index', () => {
+      const element = renderSelectableItem({ 'data-group-index': '5', 'data-in-group-index': '1', isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          position: '5,1',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with data-group-index and data-child-index', () => {
+      const element = renderSelectableItem({ 'data-group-index': '5', 'data-child-index': '2', isChild: true });
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'content',
+          position: '5,2',
+          groupLabel: '',
+        },
+      });
+    });
+    test('with parent element', () => {
+      const renderResult = render(
+        <>
+          <SelectableItems isParent={true} data-group-index="6">
+            Parent label
+          </SelectableItems>
+          <div id="test">
+            <SelectableItems isChild={true} data-group-index="6" data-in-group-index="1">
+              item label
+            </SelectableItems>
+          </div>
+        </>
+      );
+      const element = createWrapper(renderResult.container)
+        .find('#test')!
+        .find(`.${styles['selectable-item']}`)!
+        .getElement();
+      validateComponentNameAndLabels(element, labels);
+      expect(getGeneratedAnalyticsMetadata(element)).toEqual({
+        action: 'select',
+        detail: {
+          label: 'item label',
+          position: '6,1',
+          groupLabel: 'Parent label',
+        },
+      });
+    });
+  });
+});

--- a/src/internal/components/selectable-item/analytics-metadata/interfaces.ts
+++ b/src/internal/components/selectable-item/analytics-metadata/interfaces.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { LabelIdentifier } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
+
+export interface GeneratedAnalyticsMetadataSelectableItemSelect {
+  action: 'select';
+  detail: {
+    label: LabelIdentifier;
+    position?: string;
+    value?: string;
+    groupLabel?: LabelIdentifier;
+  };
+}

--- a/src/internal/components/selectable-item/analytics-metadata/styles.scss
+++ b/src/internal/components/selectable-item/analytics-metadata/styles.scss
@@ -1,0 +1,9 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.parent,
+.option-content {
+  /* used in analytics metadata */
+}

--- a/src/internal/components/selectable-item/analytics-metadata/utils.ts
+++ b/src/internal/components/selectable-item/analytics-metadata/utils.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ItemDataAttributes, SelectableItemProps } from '../interfaces';
+import { GeneratedAnalyticsMetadataSelectableItemSelect } from './interfaces';
+
+import optionAnalyticsSelectors from './../../option/analytics-metadata/styles.css.js';
+import analyticsSelectors from './styles.css.js';
+
+export const getAnalyticsSelectActionMetadata = ({
+  isChild,
+  value,
+  ...restProps
+}: Partial<SelectableItemProps>): GeneratedAnalyticsMetadataSelectableItemSelect => {
+  const dataAttributes = restProps as ItemDataAttributes;
+
+  const analyticsMetadata: GeneratedAnalyticsMetadataSelectableItemSelect = {
+    action: 'select',
+    detail: {
+      label: {
+        selector: [`.${optionAnalyticsSelectors.label}`, `.${analyticsSelectors['option-content']}`],
+      },
+    },
+  };
+
+  let position = undefined;
+  if (
+    (isChild && dataAttributes['data-group-index'] && dataAttributes['data-in-group-index']) ||
+    dataAttributes['data-child-index']
+  ) {
+    position = `${dataAttributes['data-group-index']},${dataAttributes['data-in-group-index'] || dataAttributes['data-child-index']}`;
+  } else if (dataAttributes['data-test-index']) {
+    position = `${dataAttributes['data-test-index']}`;
+  }
+  if (position) {
+    analyticsMetadata.detail.position = position;
+  }
+  if (value) {
+    analyticsMetadata.detail.value = value;
+  }
+  if (isChild) {
+    analyticsMetadata.detail.groupLabel = {
+      root: 'body',
+      selector: `.${analyticsSelectors.parent}[data-group-index="${dataAttributes['data-group-index']}"] .${analyticsSelectors['option-content']}`,
+    };
+  }
+  return analyticsMetadata;
+};

--- a/src/internal/components/selectable-item/index.tsx
+++ b/src/internal/components/selectable-item/index.tsx
@@ -3,29 +3,16 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import clsx from 'clsx';
 
-import { BaseComponentProps, getBaseProps } from '../../base-component';
-import { HighlightType } from '../options-list/utils/use-highlight-option.js';
+import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 
+import { getBaseProps } from '../../base-component';
+import { getAnalyticsSelectActionMetadata } from './analytics-metadata/utils';
+import { SelectableItemProps } from './interfaces';
+
+import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
 
-export type SelectableItemProps = BaseComponentProps & {
-  children: React.ReactNode;
-  selected?: boolean;
-  highlighted?: boolean;
-  disabled?: boolean;
-  hasBackground?: boolean;
-  isParent?: boolean;
-  isChild?: boolean;
-  virtualPosition?: number;
-  padBottom?: boolean;
-  isNextSelected?: boolean;
-  useInteractiveGroups?: boolean;
-  screenReaderContent?: string;
-  ariaPosinset?: number;
-  ariaSetsize?: number;
-  highlightType?: HighlightType['type'];
-  ariaDescribedby?: string;
-} & ({ ariaSelected?: boolean; ariaChecked?: never } | { ariaSelected?: never; ariaChecked?: boolean | 'mixed' });
+export { SelectableItemProps };
 
 const SelectableItem = (
   {
@@ -46,6 +33,7 @@ const SelectableItem = (
     ariaPosinset,
     ariaSetsize,
     highlightType,
+    value,
     ...restProps
   }: SelectableItemProps,
   ref: React.Ref<HTMLDivElement>
@@ -56,6 +44,7 @@ const SelectableItem = (
     [styles.highlighted]: highlighted,
     [styles['has-background']]: hasBackground,
     [styles.parent]: isParent,
+    [analyticsSelectors.parent]: isParent,
     [styles.child]: isChild,
     [styles['is-keyboard']]: highlightType === 'keyboard',
     [styles.disabled]: disabled,
@@ -118,8 +107,17 @@ const SelectableItem = (
   }
 
   return (
-    <li role="option" className={classNames} style={style} {...a11yProperties} {...rest}>
-      <div className={styles['option-content']} ref={contentRef}>
+    <li
+      role="option"
+      className={classNames}
+      style={style}
+      {...a11yProperties}
+      {...rest}
+      {...(isParent || disabled
+        ? {}
+        : getAnalyticsMetadataAttribute(getAnalyticsSelectActionMetadata({ isChild, value, ...restProps })))}
+    >
+      <div className={clsx(styles['option-content'], analyticsSelectors['option-content'])} ref={contentRef}>
         {content}
       </div>
       <div className={styles['measure-strut']} ref={ref} />

--- a/src/internal/components/selectable-item/interfaces.ts
+++ b/src/internal/components/selectable-item/interfaces.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BaseComponentProps } from '../../base-component';
+import { HighlightType } from '../options-list/utils/use-highlight-option';
+
+export type SelectableItemProps = BaseComponentProps & {
+  children: React.ReactNode;
+  selected?: boolean;
+  highlighted?: boolean;
+  disabled?: boolean;
+  hasBackground?: boolean;
+  isParent?: boolean;
+  isChild?: boolean;
+  virtualPosition?: number;
+  padBottom?: boolean;
+  isNextSelected?: boolean;
+  useInteractiveGroups?: boolean;
+  screenReaderContent?: string;
+  ariaPosinset?: number;
+  ariaSetsize?: number;
+  highlightType?: HighlightType['type'];
+  ariaDescribedby?: string;
+  value?: string;
+} & ({ ariaSelected?: boolean; ariaChecked?: never } | { ariaSelected?: never; ariaChecked?: boolean | 'mixed' });
+
+export interface ItemDataAttributes {
+  'data-group-index'?: string;
+  'data-child-index'?: string;
+  'data-in-group-index'?: string;
+  'data-test-index'?: string;
+}

--- a/src/select/parts/item.tsx
+++ b/src/select/parts/item.tsx
@@ -78,6 +78,7 @@ const Item = (
       ariaSetsize={ariaSetsize}
       highlightType={highlightType}
       ariaDescribedby={isDisabledWithReason ? descriptionId : ''}
+      value={option.option.value}
       {...baseProps}
     >
       <div className={clsx(styles.item, !isParent && wrappedOption.labelTag && styles['show-label-tag'])}>

--- a/src/select/parts/multiselect-item.tsx
+++ b/src/select/parts/multiselect-item.tsx
@@ -70,6 +70,7 @@ const MultiSelectItem = (
       ariaPosinset={ariaPosinset}
       ariaSetsize={ariaSetsize}
       ariaDescribedby={isDisabledWithReason ? descriptionId : ''}
+      value={option.option.value}
       {...baseProps}
     >
       <div className={className}>


### PR DESCRIPTION
### Description

Needed to introduce analytics metadata for Select, Multiselect, Autosuggest, Property filter.
Note that it depends on https://github.com/cloudscape-design/component-toolkit/pull/94

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
