### PR TITLE
chore: Adds background color to page and permutation containers

### DIFF
--- a/pages/app/components/page-view.scss
+++ b/pages/app/components/page-view.scss
@@ -1,0 +1,13 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+@use '~design-tokens' as tokens;
+
+/*
+ This sets a background color to the page's container
+ to reveal the effects of negative z-index.
+*/
+.page-container {
+  background-color: tokens.$color-background-container-content;
+}

--- a/pages/app/components/page-view.tsx
+++ b/pages/app/components/page-view.tsx
@@ -5,6 +5,8 @@ import React, { lazy, Suspense } from 'react';
 import pagesContext from '../pages-context';
 import ErrorBoundary from './error-boundary';
 
+import styles from './page-view.scss';
+
 const pagesComponents: Record<string, ReturnType<typeof lazy>> = {};
 
 export default function PageView({ pageId }: { pageId: string }) {
@@ -15,7 +17,9 @@ export default function PageView({ pageId }: { pageId: string }) {
   return (
     <ErrorBoundary key={pageId}>
       <Suspense fallback={<span>Loading...</span>}>
-        <Page />
+        <div className={styles['page-container']}>
+          <Page />
+        </div>
       </Suspense>
     </ErrorBoundary>
   );


### PR DESCRIPTION
### Description

Setting negative `z-index` values causes the element to go behind its container element's background.

This effect is not visible in the dev pages and consequently in the visual tests. This PR adds a white background color to the page container in to make the effects of `z-index: -1` visible.

Related links, issue #, if available: `AWSUI-55591`

### How has this been tested?

<!-- How did you test to verify your changes? -->

Setting the same `z-index` issue caused by #2550: Verified in Chrome, Firefox and Safari that the change in this PR can reveal the issue it in the component pages.

<img width="330" alt="image" src="https://github.com/user-attachments/assets/67a8e62a-748d-499f-97c1-87ebf90e0213">


<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
