### PR TITLE
chore: Hides disabled split button in property filter editor

### DIFF
--- a/src/button-dropdown/__tests__/button-dropdown.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 
 import ButtonDropdown, { ButtonDropdownProps } from '../../../lib/components/button-dropdown';
+import InternalButtonDropdown from '../../../lib/components/button-dropdown/internal';
 import { KeyCode } from '../../../lib/components/internal/keycode';
 import createWrapper, { ButtonWrapper, IconWrapper } from '../../../lib/components/test-utils/dom';
 
@@ -230,6 +231,20 @@ describe('with main action', () => {
 
     wrapper.openDropdown();
     expect(wrapper.findItems()).toHaveLength(1);
+  });
+
+  test('renders main action only', () => {
+    const onClick = jest.fn();
+    const renderResult = render(
+      <InternalButtonDropdown items={[]} mainAction={{ text: 'Main action', onClick }} showMainActionOnly={true} />
+    );
+    const wrapper = createWrapper(renderResult.container).findButtonDropdown()!;
+
+    expect(wrapper.findTriggerButton()).toBe(null);
+    expect(wrapper.findMainAction()).not.toBe(null);
+
+    wrapper.findMainAction()!.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   test('main action onClick is triggered', () => {

--- a/src/button-dropdown/interfaces.ts
+++ b/src/button-dropdown/interfaces.ts
@@ -284,6 +284,12 @@ export interface InternalButtonDropdownProps
   description?: string;
 
   /**
+   * Only show main action button as a regular, non-split button.
+   * That is needed so that button dropdown test utils wrapper can still be used.
+   */
+  showMainActionOnly?: boolean;
+
+  /**
    * Determines that the dropdown should preferably be aligned to the center of the trigger
    * instead of dropping left or right.
    */

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -48,6 +48,7 @@ const InternalButtonDropdown = React.forwardRef(
       description,
       preferCenter,
       mainAction,
+      showMainActionOnly,
       __internalRootRef,
       analyticsMetadataTransformer,
       ...props
@@ -211,7 +212,26 @@ const InternalButtonDropdown = React.forwardRef(
         ? `${mainAction.ariaLabel ?? mainAction.text} ${mainAction.externalIconAriaLabel}`
         : mainAction.ariaLabel;
       const hasNoText = !text;
-      trigger = (
+      const mainActionButton = (
+        <InternalButton
+          ref={mainActionRef}
+          {...mainActionProps}
+          {...mainActionIconProps}
+          className={clsx(
+            styles['trigger-button'],
+            hasNoText && styles['has-no-text'],
+            isVisualRefresh && styles['visual-refresh']
+          )}
+          variant={variant}
+          ariaLabel={mainActionAriaLabel}
+          formAction="none"
+        >
+          {text}
+        </InternalButton>
+      );
+      trigger = showMainActionOnly ? (
+        <div className={styles['split-trigger']}>{mainActionButton}</div>
+      ) : (
         <div role="group" aria-label={ariaLabel} className={styles['split-trigger-wrapper']}>
           <div
             className={clsx(
@@ -233,21 +253,7 @@ const InternalButtonDropdown = React.forwardRef(
               },
             })}
           >
-            <InternalButton
-              ref={mainActionRef}
-              {...mainActionProps}
-              {...mainActionIconProps}
-              className={clsx(
-                styles['trigger-button'],
-                hasNoText && styles['has-no-text'],
-                isVisualRefresh && styles['visual-refresh']
-              )}
-              variant={variant}
-              ariaLabel={mainActionAriaLabel}
-              formAction="none"
-            >
-              {text}
-            </InternalButton>
+            {mainActionButton}
           </div>
           <div
             className={clsx(

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -361,8 +361,7 @@ describe.each([false, true] as const)('token editor labels, isMobile = %s', isMo
         );
         expect(removeActions.actionsMenu.findNativeButton().getElement()).toBeDisabled();
 
-        expect(editor.addActions.findNativeButton().getElement()).toHaveAccessibleName('Add filter actions');
-        expect(editor.addActions.findNativeButton().getElement()).toBeDisabled();
+        expect(editor.addActions.findTriggerButton()).toBe(null);
         expect(editor.addActions.findMainAction()!.getElement()).toHaveTextContent('Add new filter');
       } else {
         expect(editor.removeActions().actionsMenu).toBe(null);

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -186,6 +186,7 @@ export function TokenEditor({
               }
             }}
             disabled={tokensToCapture.length === 0}
+            showMainActionOnly={tokensToCapture.length === 0}
             mainAction={{
               text: i18nStrings.tokenEditorAddNewTokenLabel ?? '',
               onClick: () => {


### PR DESCRIPTION
### Description

When there are no external tokens to be included to the property filter token editor group the add filter split button is hidden instead of being disabled.

Rel: [wb0HA1pclrCr]

### How has this been tested?

* New unit test in button dropdown and adjusted unit test in property filter
* Screenshot tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
