### PR TITLE
refactor: Update integration tests to resolve chromium upgrade 2

### DIFF
--- a/src/collection-preferences/__integ__/collection-preferences.test.ts
+++ b/src/collection-preferences/__integ__/collection-preferences.test.ts
@@ -18,28 +18,31 @@ describe('Collection preferences', () => {
   test(
     'renders no columns if there is only custom content',
     setupTest(async page => {
-      const wrapper = createWrapper().findCollectionPreferences('.cp-3');
-      await page.openCollectionPreferencesModal(wrapper);
+      page.wrapper = createWrapper().findCollectionPreferences('.cp-3');
+
+      await page.openCollectionPreferencesModal();
 
       // The content is small enough so that it doesn't need column layout
-      const columnLayout = wrapper.findModal().findContent().findColumnLayout();
+      const columnLayout = page.wrapper.findModal().findContent().findColumnLayout();
       await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
 
-      await expect(page.isExisting(wrapper.findModal().findWrapLinesPreference().toSelector())).resolves.toBe(true);
+      await expect(page.isExisting(page.wrapper.findModal().findWrapLinesPreference().toSelector())).resolves.toBe(
+        true
+      );
     })
   );
 
   test(
     'renders no columns if there is only visible content preferences',
     setupTest(async page => {
-      const wrapper = createWrapper().findCollectionPreferences('.cp-4');
-      await page.openCollectionPreferencesModal(wrapper);
+      page.wrapper = createWrapper().findCollectionPreferences('.cp-4');
+      await page.openCollectionPreferencesModal();
 
       // The content is small enough so that it doesn't need column layout
-      const columnLayout = wrapper.findModal().findContent().findColumnLayout();
+      const columnLayout = page.wrapper.findModal().findContent().findColumnLayout();
       await expect(page.isExisting(columnLayout.toSelector())).resolves.toBe(false);
 
-      await expect(page.isExisting(wrapper.findModal().findVisibleContentPreference().toSelector())).resolves.toBe(
+      await expect(page.isExisting(page.wrapper.findModal().findVisibleContentPreference().toSelector())).resolves.toBe(
         true
       );
     })
@@ -48,10 +51,10 @@ describe('Collection preferences', () => {
   test(
     'renders 2 columns if all preferences are present',
     setupTest(async page => {
-      const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-      await page.openCollectionPreferencesModal(wrapper);
+      page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+      await page.openCollectionPreferencesModal();
 
-      const columnLayout = wrapper.findModal().findContent().findColumnLayout();
+      const columnLayout = page.wrapper.findModal().findContent().findColumnLayout();
       await expect(page.isExisting(columnLayout.findColumn(1).toSelector())).resolves.toBe(true);
       await expect(page.isExisting(columnLayout.findColumn(2).toSelector())).resolves.toBe(true);
       await expect(page.isExisting(columnLayout.findColumn(3).toSelector())).resolves.toBe(false);

--- a/src/collection-preferences/__integ__/pages/collection-preferences-page.ts
+++ b/src/collection-preferences/__integ__/pages/collection-preferences-page.ts
@@ -1,20 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
 
 import { CollectionPreferencesWrapper } from '../../../../lib/components/test-utils/selectors';
+import DndPageObject from '../../content-display/__integ__/pages/dnd-page-object';
 
-export const collectionPreferencesPageMixin = (Base: BasePageObject & any) =>
-  class extends Base {
-    wrapper: CollectionPreferencesWrapper | null = null;
-    constructor(browser: ConstructorParameters<typeof BasePageObject>[0]) {
-      super(browser);
-    }
-    async openCollectionPreferencesModal(wrapper: CollectionPreferencesWrapper) {
-      this.wrapper = wrapper;
-      await this.click(wrapper.findTriggerButton().toSelector());
-      return expect(this.isExisting(wrapper.findModal().toSelector())).resolves.toBe(true);
-    }
-  };
+export default class CollectionPreferencesPageObject extends DndPageObject {
+  protected _wrapper?: CollectionPreferencesWrapper;
 
-export default class CollectionPreferencesPageObject extends collectionPreferencesPageMixin(BasePageObject) {}
+  set wrapper(wrapper: CollectionPreferencesWrapper) {
+    this._wrapper = wrapper;
+  }
+
+  get wrapper() {
+    if (!this._wrapper) {
+      throw new Error('Must set collection preferences wrapper');
+    }
+    return this._wrapper;
+  }
+
+  async openCollectionPreferencesModal() {
+    await this.click(this.wrapper.findTriggerButton().toSelector());
+    return expect(this.isExisting(this.wrapper.findModal().toSelector())).resolves.toBe(true);
+  }
+}

--- a/src/collection-preferences/content-display/__integ__/content-reordering.test.ts
+++ b/src/collection-preferences/content-display/__integ__/content-reordering.test.ts
@@ -24,8 +24,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'moves item down',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2', 'Item 3', 'Item 4'])).toBe(true);
 
@@ -40,8 +40,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'moves item up',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2', 'Item 3', 'Item 4'])).toBe(true);
 
@@ -56,8 +56,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'cancels reordering when pressing Escape',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2', 'Item 3', 'Item 4'])).toBe(true);
 
@@ -67,16 +67,16 @@ describe('Collection preferences - Content Display preference', () => {
         await page.keys('Escape');
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2', 'Item 3', 'Item 4'])).toBe(true);
-        await expect(wrapper.findModal()).not.toBeNull();
+        await expect(page.wrapper.findModal()).not.toBeNull();
       })
     );
 
     describe('does not cause overflow when reaching the edge of the window', () => {
       const testByDraggingToPosition = async (page: ContentDisplayPageObject, x: number, y: number) => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
-        const modal = wrapper.findModal();
-        const modalContentSelector = wrapper.findModal().findContent().toSelector();
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
+        const modal = page.wrapper.findModal();
+        const modalContentSelector = page.wrapper.findModal().findContent().toSelector();
         const modalContentBox = await page.getBoundingBox(modalContentSelector);
 
         const dragHandleSelector = modal
@@ -97,12 +97,18 @@ describe('Collection preferences - Content Display preference', () => {
 
       test(
         'horizontally',
-        setupTest(page => testByDraggingToPosition(page, windowDimensions.width, windowDimensions.height / 2))
+        setupTest(async page => {
+          const { width: windowWidth, height: windowHeight } = await page.getViewportSize();
+          await testByDraggingToPosition(page, windowWidth, windowHeight / 2);
+        })
       );
 
       test(
         'vertically',
-        setupTest(page => testByDraggingToPosition(page, windowDimensions.width / 2, windowDimensions.height))
+        setupTest(async page => {
+          const { width: windowWidth, height: windowHeight } = await page.getViewportSize();
+          await testByDraggingToPosition(page, windowWidth / 2, windowHeight);
+        })
       );
     });
   });
@@ -111,8 +117,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'cancels reordering when pressing Tab',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2'])).toBe(true);
 
@@ -131,8 +137,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'cancels reordering when clicking somewhere else',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-1');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-1');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2'])).toBe(true);
 
@@ -141,7 +147,7 @@ describe('Collection preferences - Content Display preference', () => {
         await page.expectAnnouncement('Picked up item at position 1 of 6');
         await page.keys('ArrowDown');
         await page.expectAnnouncement('Moving item to position 2 of 6');
-        await page.click(wrapper.findModal().findContentDisplayPreference().findTitle().toSelector());
+        await page.click(page.wrapper.findModal().findContentDisplayPreference().findTitle().toSelector());
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2'])).toBe(true);
         await page.expectAnnouncement('Reordering canceled');
@@ -151,8 +157,8 @@ describe('Collection preferences - Content Display preference', () => {
     test(
       'scrolls if necessary',
       setupTest(async page => {
-        const wrapper = createWrapper().findCollectionPreferences('.cp-2');
-        await page.openCollectionPreferencesModal(wrapper);
+        page.wrapper = createWrapper().findCollectionPreferences('.cp-2');
+        await page.openCollectionPreferencesModal();
 
         await expect(await page.containsOptionsInOrder(['Item 1', 'Item 2'])).toBe(true);
 

--- a/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
+++ b/src/collection-preferences/content-display/__integ__/pages/content-display-page.ts
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CollectionPreferencesWrapper } from '../../../../../lib/components/test-utils/selectors';
-import { collectionPreferencesPageMixin } from '../../../__integ__/pages/collection-preferences-page';
-import DndPageObject from './dnd-page-object';
 
-export default class ContentDisplayPageObject extends collectionPreferencesPageMixin(DndPageObject) {
+import CollectionPreferencesPageObject from '../../../__integ__/pages/collection-preferences-page';
+
+export default class ContentDisplayPageObject extends CollectionPreferencesPageObject {
   async containsOptionsInOrder(options: string[]) {
     const texts = await this.getElementsText(this.findOptions().toSelector());
     return texts.join(`\n`).includes(options.join('\n'));
@@ -12,7 +11,7 @@ export default class ContentDisplayPageObject extends collectionPreferencesPageM
 
   async expectAnnouncement(announcement: string) {
     const liveRegion = await this.browser.$(
-      this.wrapper!.findModal().findContentDisplayPreference().find('[aria-live="assertive"]').toSelector()
+      this.wrapper.findModal().findContentDisplayPreference().find('[aria-live="assertive"]').toSelector()
     );
     // Using getHTML because getText returns an empty string if the live region is outside the viewport.
     // See https://webdriver.io/docs/api/element/getText/
@@ -26,16 +25,15 @@ export default class ContentDisplayPageObject extends collectionPreferencesPageM
   }
 
   findOptions() {
-    return this.wrapper!.findModal().findContentDisplayPreference().findOptions();
+    return this.wrapper.findModal().findContentDisplayPreference().findOptions();
   }
 
   focusDragHandle(index = 0) {
     return this.keys(new Array(5 + index * 2).fill('Tab'));
   }
 
-  async openCollectionPreferencesModal(wrapper: CollectionPreferencesWrapper) {
-    this.wrapper = wrapper;
-    await this.click(wrapper.findTriggerButton().toSelector());
-    return expect(this.isExisting(wrapper.findModal().toSelector())).resolves.toBe(true);
+  async openCollectionPreferencesModal() {
+    await this.click(this.wrapper.findTriggerButton().toSelector());
+    return expect(this.isExisting(this.wrapper.findModal().toSelector())).resolves.toBe(true);
   }
 }

--- a/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
+++ b/src/mixed-line-bar-chart/__integ__/mixed-line-bar-chart.test.ts
@@ -548,7 +548,7 @@ describe('Details popover', () => {
   describe('keeps the popover position when it resizes due to interacting with the popover itself', () => {
     test.each(['hover', 'click', 'keyboard'])('Interaction type: %s', interactionType =>
       setupPopoverPositionTest(async page => {
-        await page.setWindowSize({ width: 900, height: 500 });
+        await page.setWindowSize({ width: 900, height: 550 });
         await page.openPopoverOnBarGroup(1, interactionType);
         const popover = page.findDetailPopover();
         expect(page.isDisplayed(popover.toSelector())).resolves.toBe(true);

--- a/src/table/__integ__/sticky-scrollbar.test.ts
+++ b/src/table/__integ__/sticky-scrollbar.test.ts
@@ -71,12 +71,13 @@ describe('Sticky scrollbar', () => {
   test(
     `scrollbar position updates when window resizes`,
     setupTest(async page => {
-      await page.setWindowSize({ width: 600, height: 400 });
+      await page.setWindowSize({ width: 600, height: 600 });
       const { bottom: bottom1 } = await page.getBoundingBox(page.findVisibleScrollbar());
-      expect(bottom1).toEqual(400);
-      await page.setWindowSize({ width: 600, height: 200 });
+      expect(bottom1).toEqual((await page.getViewportSize()).height);
+
+      await page.setWindowSize({ width: 600, height: 400 });
       const { bottom: bottom2 } = await page.getBoundingBox(page.findVisibleScrollbar());
-      expect(bottom2).toEqual(200);
+      expect(bottom1 - bottom2).toBe(200);
     })
   );
 });


### PR DESCRIPTION
### Description

Related to https://github.com/cloudscape-design/browser-test-tools/pull/105 (see dry-run test failures).

Switching to Chromium --headless=new causes failures to our tests that depend on screen size. The refactoring fixes the issue for some of the app layout tests to either remove the dependency completely or make assertions depend on the measured viewport height.

Previous PR: https://github.com/cloudscape-design/components/pull/2657

### How has this been tested?

* Verified the tests work with old and new headless mode

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
