### PR TITLE
fix: Fixes property filter i18n labels derived from other components

### DIFF
--- a/src/property-filter/__tests__/common.tsx
+++ b/src/property-filter/__tests__/common.tsx
@@ -73,8 +73,14 @@ export const i18nStringsTokenGroups: I18nStringsTokenGroups = {
 };
 
 export const providedI18nStrings = {
+  autosuggest: {
+    enteredTextLabel: 'Use: "{value}"',
+  },
+  popover: {
+    dismissAriaLabel: 'Dismiss',
+  },
   'property-filter': {
-    'i18nStrings.editTokenHeader': 'Edit token',
+    'i18nStrings.editTokenHeader': 'Edit filter',
     'i18nStrings.propertyText': 'Property',
     'i18nStrings.operatorText': 'Operator',
     'i18nStrings.valueText': 'Value',

--- a/src/property-filter/__tests__/property-filter-i18n.test.tsx
+++ b/src/property-filter/__tests__/property-filter-i18n.test.tsx
@@ -70,6 +70,9 @@ function openTokenEditor(wrapper: PropertyFilterWrapper, index = 0) {
 
 describe('i18n', () => {
   const providerMessages = {
+    input: {
+      clearAriaLabel: 'Custom input clear',
+    },
     'property-filter': {
       'i18nStrings.allPropertiesLabel': 'Custom All properties',
       'i18nStrings.groupPropertiesText': 'Custom Properties',
@@ -125,6 +128,9 @@ describe('i18n', () => {
       'Custom Starts with',
       'Custom Does not start with',
     ]);
+
+    wrapper.setInputValue('123');
+    expect(wrapper.findClearButton()!.getElement()).toHaveAccessibleName('Custom input clear');
   });
 
   it('uses dropdown labels from i18n provider for a numeric property', () => {

--- a/src/property-filter/__tests__/property-filter-token-editor.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-editor.test.tsx
@@ -83,7 +83,7 @@ function renderComponent(props?: Partial<PropertyFilterInternalProps>, withI18nP
   return withI18nProvider
     ? reactRender(
         <TestI18nProvider messages={providedI18nStrings}>
-          <PropertyFilterInternal {...defaultProps} {...props} />
+          <PropertyFilterInternal {...defaultProps} {...props} i18nStrings={{}} i18nStringsTokenGroups={{}} />
         </TestI18nProvider>
       )
     : reactRender(<PropertyFilterInternal {...defaultProps} {...props} />);
@@ -321,6 +321,20 @@ describe.each([false, true])('token editor, expandToViewport=%s', expandToViewpo
         })
       );
     });
+  });
+});
+
+describe.each([false, true])('with i18n-provider %s', withI18nProvider => {
+  test('uses entered text label for token value autosuggest', () => {
+    renderComponent(
+      { query: { operation: 'and', tokens: [{ propertyKey: 'string', operator: '=', value: 'John' }] } },
+      withI18nProvider
+    );
+    const editor = openEditor(0, { expandToViewport: false });
+
+    editor.valueAutosuggest().focus();
+    editor.valueAutosuggest().setInputValue('123');
+    expect(editor.valueAutosuggest().findEnteredTextOption()!.getElement()).toHaveTextContent('Use: "123"');
   });
 });
 

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -35,7 +35,7 @@ export interface FilteringTokenProps {
   onDismissToken: (tokenIndex: number) => void;
   editorContent: React.ReactNode;
   editorHeader: string;
-  editorDismissAriaLabel: string;
+  editorDismissAriaLabel?: string;
   editorExpandToViewport: boolean;
   onEditorOpen?: () => void;
   hasGroups: boolean;

--- a/src/property-filter/token-editor-inputs.tsx
+++ b/src/property-filter/token-editor-inputs.tsx
@@ -157,7 +157,7 @@ export function ValueInput({
     <OperatorForm value={value} onChange={onChangeValue} operator={operator} />
   ) : (
     <InternalAutosuggest
-      enteredTextLabel={i18nStrings.enteredTextLabel ?? (value => value)}
+      enteredTextLabel={i18nStrings.enteredTextLabel}
       value={matchedOption?.label ?? value ?? ''}
       clearAriaLabel={i18nStrings.clearAriaLabel}
       onChange={e => onChangeValue(e.detail.value)}

--- a/src/property-filter/token.tsx
+++ b/src/property-filter/token.tsx
@@ -148,7 +148,7 @@ export const TokenButton = ({
         />
       }
       editorHeader={i18nStrings.editTokenHeader ?? ''}
-      editorDismissAriaLabel={i18nStrings.dismissAriaLabel ?? ''}
+      editorDismissAriaLabel={i18nStrings.dismissAriaLabel}
       editorExpandToViewport={!!expandToViewport}
       onEditorOpen={() => {
         setTempTokens(tokens);


### PR DESCRIPTION
### Description

Some i18n labels are not defined in property filter i18n messages but are expected to come from the internally used components: input, autosuggest, and popover. For it to work the labels must not use fallbacks when passed to the respective components.

### How has this been tested?

* New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
