### PR TITLE
chore: I18n messages for property filter groups

### DIFF
--- a/src/i18n/messages/all.ar.json
+++ b/src/i18n/messages/all.ar.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "عوامل التصفية",
     "i18nStrings.propertyText": "الخاصية",
     "i18nStrings.removeTokenButtonAriaLabel": "إزالة عامل التصفية، {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "إجراءات عامل التصفية، {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "إزالة عامل التصفية، {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "إزالة عامل التصفية",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "إزالة عامل التصفية من المجموعة",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "إضافة إجراءات عامل التصفية",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "إضافة عامل تصفية جديد",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "إضافة عامل تصفية {token__formattedText} إلى المجموعة",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "إضافة عامل تصفية {token__propertyLabel} {token__operator} {token__value} إلى المجموعة",
     "i18nStrings.tokenLimitShowFewer": "إظهار عدد أقل من عوامل التصفية",
     "i18nStrings.tokenLimitShowMore": "عرض المزيد من عوامل التصفية",
     "i18nStrings.valueText": "عمود القيمة",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} تساوي {token__value}} not_equals {{token__propertyLabel} لا تساوي {token__value}} greater_than {{token__propertyLabel} أكبر من {token__value}} greater_than_equal {{token__propertyLabel} أكبر من أو تساوي {token__value}} less_than {{token__propertyLabel} أقل من {token__value}} less_than_equal {{token__propertyLabel} أقل من أو تساوي {token__value}} contains {{token__propertyLabel} تحتوي على {token__value}} not_contains {{token__propertyLabel} لا تحتوي على {token__value}} starts_with {{token__propertyLabel} تبدأ بـ {token__value}} not_starts_with {{token__propertyLabel} لا تبدأ بـ {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} تساوي {token__value}} not_equals {{token__propertyLabel} لا تساوي {token__value}} greater_than {{token__propertyLabel} أكبر من {token__value}} greater_than_equal {{token__propertyLabel} أكبر من أو تساوي {token__value}} less_than {{token__propertyLabel} أقل من {token__value}} less_than_equal {{token__propertyLabel} أقل من أو تساوي {token__value}} contains {{token__propertyLabel} تحتوي على {token__value}} not_contains {{token__propertyLabel} لا تحتوي على {token__value}} starts_with {{token__propertyLabel} تبدأ بـ {token__value}} not_starts_with {{token__propertyLabel} لا تبدأ بـ {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {تحرير مجموعة عوامل التصفية {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {تحرير مجموعة عوامل التصفية {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {تحرير مجموعة عوامل التصفية {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {تحرير مجموعة عوامل التصفية {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 إضافي} other {تحرير مجموعة عوامل التصفية {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} المزيد}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "اختر إصدارًا",

--- a/src/i18n/messages/all.de.json
+++ b/src/i18n/messages/all.de.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operatoren",
     "i18nStrings.propertyText": "Eigenschaft",
     "i18nStrings.removeTokenButtonAriaLabel": "Filter entfernen, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filteraktionen, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Filter entfernen, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Filter entfernen",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Filter aus Gruppe entfernen",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Filteraktionen hinzufügen",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Neuen Filter hinzufügen",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Filter {token__formattedText} zur Gruppe hinzufügen",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Filter {token__propertyLabel} {token__operator} {token__value} zur Gruppe hinzufügen",
     "i18nStrings.tokenLimitShowFewer": "Weniger anzeigen",
     "i18nStrings.tokenLimitShowMore": "Mehr anzeigen",
     "i18nStrings.valueText": "Wert",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} ist gleich {token__value}} not_equals {{token__propertyLabel} ist nicht gleich {token__value}} greater_than {{token__propertyLabel} ist größer als {token__value}} greater_than_equal {{token__propertyLabel} ist größer als oder gleich {token__value}} less_than {{token__propertyLabel} ist kleiner als {token__value}} less_than_equal {{token__propertyLabel} ist kleiner als oder gleich {token__value}} contains {{token__propertyLabel} enthält {token__value}} not_contains {{token__propertyLabel} enthält nicht {token__value}} starts_with {{token__propertyLabel} startet mit {token__value}} not_starts_with {{token__propertyLabel} startet nicht mit {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} ist gleich {token__value}} not_equals {{token__propertyLabel} ist nicht gleich {token__value}} greater_than {{token__propertyLabel} ist größer als {token__value}} greater_than_equal {{token__propertyLabel} ist größer als oder gleich {token__value}} less_than {{token__propertyLabel} ist kleiner als {token__value}} less_than_equal {{token__propertyLabel} ist kleiner als oder gleich {token__value}} contains {{token__propertyLabel} enthält {token__value}} not_contains {{token__propertyLabel} enthält nicht {token__value}} starts_with {{token__propertyLabel} startet mit {token__value}} not_starts_with {{token__propertyLabel} startet nicht mit {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Filtergruppe {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} bearbeiten} 3 {Filtergruppe {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} bearbeiten} 4 {Filtergruppe {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} bearbeiten} 5 {Filtergruppe {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} bearbeiten 1 mehr} other {Filtergruppe {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} bearbeiten mehr}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Version auswählen",

--- a/src/i18n/messages/all.en-GB.json
+++ b/src/i18n/messages/all.en-GB.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operators",
     "i18nStrings.propertyText": "Property",
     "i18nStrings.removeTokenButtonAriaLabel": "Remove filter, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filter actions, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Remove filter, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Remove filter",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Remove filter from group",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Add filter actions",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Add new filter",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Add filter {token__formattedText} to group",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Add filter {token__propertyLabel} {token__operator} {token__value} to group",
     "i18nStrings.tokenLimitShowFewer": "Show fewer",
     "i18nStrings.tokenLimitShowMore": "Show more",
     "i18nStrings.valueText": "Value",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} equals {token__value}} not_equals {{token__propertyLabel} does not equal {token__value}} greater_than {{token__propertyLabel} is greater than {token__value}} greater_than_equal {{token__propertyLabel} is greater than or equal to {token__value}} less_than {{token__propertyLabel} is less than {token__value}} less_than_equal {{token__propertyLabel} is less than or equal to {token__value}} contains {{token__propertyLabel} contains {token__value}} not_contains {{token__propertyLabel} does not contain {token__value}} starts_with {{token__propertyLabel} starts with {token__value}} not_starts_with {{token__propertyLabel} does not start with {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} equals {token__value}} not_equals {{token__propertyLabel} does not equal {token__value}} greater_than {{token__propertyLabel} is greater than {token__value}} greater_than_equal {{token__propertyLabel} is greater than or equal to {token__value}} less_than {{token__propertyLabel} is less than {token__value}} less_than_equal {{token__propertyLabel} is less than or equal to {token__value}} contains {{token__propertyLabel} contains {token__value}} not_contains {{token__propertyLabel} does not contain {token__value}} starts_with {{token__propertyLabel} starts with {token__value}} not_starts_with {{token__propertyLabel} does not start with {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Edit filter group {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Edit filter group {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Edit filter group {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Edit filter group {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 more} other {Edit filter group {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} more}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Choose a version",

--- a/src/i18n/messages/all.es.json
+++ b/src/i18n/messages/all.es.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propiedad",
     "i18nStrings.removeTokenButtonAriaLabel": "Quitar el filtro {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filtrar acciones, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Eliminar filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Eliminar filtro",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Eliminar filtro del grupo",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Agregar acciones de filtrado",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Agregar filtro nuevo",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Agregar filtro {token__formattedText} al grupo",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Agregar filtro {token__propertyLabel} {token__operator} {token__value} al grupo",
     "i18nStrings.tokenLimitShowFewer": "Mostrar menos",
     "i18nStrings.tokenLimitShowMore": "Mostrar más",
     "i18nStrings.valueText": "Valor",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} es igual a {token__value}} not_equals {{token__propertyLabel} no es igual a {token__value}} greater_than {{token__propertyLabel} es mayor que {token__value}} greater_than_equal {{token__propertyLabel} es mayor que {token__value} o igual} less_than {{token__propertyLabel} es menor que {token__value}} less_than_equal {{token__propertyLabel} es menor que {token__value} o igual} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} no contiene {token__value}} starts_with {{token__propertyLabel} empieza con {token__value}} not_starts_with {{token__propertyLabel} no empieza con {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} es igual a {token__value}} not_equals {{token__propertyLabel} no es igual a {token__value}} greater_than {{token__propertyLabel} es mayor que {token__value}} greater_than_equal {{token__propertyLabel} es mayor que {token__value} o igual} less_than {{token__propertyLabel} es menor que {token__value}} less_than_equal {{token__propertyLabel} es menor que {token__value} o igual} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} no contiene {token__value}} starts_with {{token__propertyLabel} empieza con {token__value}} not_starts_with {{token__propertyLabel} no empieza con {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 más} other {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} más}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Elija una versión",

--- a/src/i18n/messages/all.fr.json
+++ b/src/i18n/messages/all.fr.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Opérateurs",
     "i18nStrings.propertyText": "Propriété",
     "i18nStrings.removeTokenButtonAriaLabel": "Supprimer le filtre, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Actions de filtrage, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Supprimer le filtre, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Supprimer le filtre",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Supprimer le filtre du groupe",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Ajouter des actions de filtrage",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Ajouter un nouveau filtre",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Ajouter le filtre {token__formattedText} au groupe",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Ajouter le filtre {token__propertyLabel} {token__operator} {token__value} au groupe",
     "i18nStrings.tokenLimitShowFewer": "Afficher moins",
     "i18nStrings.tokenLimitShowMore": "Afficher plus",
     "i18nStrings.valueText": "Valeur",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} est égal à {token__value}} not_equals {{token__propertyLabel} n’est pas égal à {token__value}} greater_than {{token__propertyLabel} est supérieur à {token__value}} greater_than_equal {{token__propertyLabel} est supérieur ou égal à {token__value}} less_than {{token__propertyLabel} est inférieur à {token__value}} less_than_equal {{token__propertyLabel} est inférieur ou égal à {token__value}} contains {{token__propertyLabel} contient {token__value}} not_contains {{token__propertyLabel} ne contient pas {token__value}} starts_with {{token__propertyLabel} commence par {token__value}} not_starts_with {{token__propertyLabel} ne commence pas par {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} est égal à {token__value}} not_equals {{token__propertyLabel} n’est pas égal à {token__value}} greater_than {{token__propertyLabel} est supérieur à {token__value}} greater_than_equal {{token__propertyLabel} est supérieur ou égal à {token__value}} less_than {{token__propertyLabel} est inférieur à {token__value}} less_than_equal {{token__propertyLabel} est inférieur ou égal à {token__value}} contains {{token__propertyLabel} contient {token__value}} not_contains {{token__propertyLabel} ne contient pas {token__value}} starts_with {{token__propertyLabel} commence par {token__value}} not_starts_with {{token__propertyLabel} ne commence pas par {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Modifier le groupe de filtres {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Modifier le groupe de filtres {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Modifier le groupe de filtres {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Modifier le groupe de filtres {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}} other {Modifier le groupe de filtres {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Choisir une version",

--- a/src/i18n/messages/all.id.json
+++ b/src/i18n/messages/all.id.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operator",
     "i18nStrings.propertyText": "Properti",
     "i18nStrings.removeTokenButtonAriaLabel": "Hapus filter, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filter tindakan, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Hapus filter, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Hapus filter",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Hapus filter dari grup",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Tambahkan tindakan filter",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Tambahkan filter baru",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Tambahkan {token__formattedText} filter ke grup",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Tambahkan {token__propertyLabel} {token__operator} {token__value} filter ke grup",
     "i18nStrings.tokenLimitShowFewer": "Tampilkan lebih sedikit",
     "i18nStrings.tokenLimitShowMore": "Tampilkan selengkapnya",
     "i18nStrings.valueText": "Nilai",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} sama dengan {token__value}} not_equals {{token__propertyLabel} tidak sama dengan {token__value}} greater_than {{token__propertyLabel} lebih besar dari {token__value}} greater_than_equal {{token__propertyLabel} lebih besar dari atau sama dengan {token__value}} less_than {{token__propertyLabel} kurang dari {token__value}} less_than_equal {{token__propertyLabel} kurang dari atau sama dengan {token__value}} contains {{token__propertyLabel} berisi {token__value}} not_contains {{token__propertyLabel} tidak berisi {token__value}} starts_with {{token__propertyLabel} dimulai dengan {token__value}} not_starts_with {{token__propertyLabel} tidak dimulai dengan {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} sama dengan {token__value}} not_equals {{token__propertyLabel} tidak sama dengan {token__value}} greater_than {{token__propertyLabel} lebih besar dari {token__value}} greater_than_equal {{token__propertyLabel} lebih besar dari atau sama dengan {token__value}} less_than {{token__propertyLabel} kurang dari {token__value}} less_than_equal {{token__propertyLabel} kurang dari atau sama dengan {token__value}} contains {{token__propertyLabel} berisi {token__value}} not_contains {{token__propertyLabel} tidak berisi {token__value}} starts_with {{token__propertyLabel} dimulai dengan {token__value}} not_starts_with {{token__propertyLabel} tidak dimulai dengan {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Edit grup filter {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Edit grup filter {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Edit grup filter {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Edit grup filter {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 lagi} other {Edit grup filter {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} lagi}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Pilih versi",

--- a/src/i18n/messages/all.it.json
+++ b/src/i18n/messages/all.it.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operatori",
     "i18nStrings.propertyText": "Proprietà",
     "i18nStrings.removeTokenButtonAriaLabel": "Rimuovi filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Azioni di filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Rimuovi filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Rimuovi filtro",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Rimuovi filtro dal gruppo",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Aggiungere azioni di filtro",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Aggiungi nuovo filtro",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Aggiungi filtro {token__formattedText} al gruppo",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Aggiungi filtro {token__propertyLabel} {token__operator} {token__value} al gruppo",
     "i18nStrings.tokenLimitShowFewer": "Mostra meno",
     "i18nStrings.tokenLimitShowMore": "Mostra altro",
     "i18nStrings.valueText": "Valore",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} è uguale a {token__value}} not_equals {{token__propertyLabel} non è uguale a {token__value}} greater_than {{token__propertyLabel} è maggiore di {token__value}} greater_than_equal {{token__propertyLabel} è maggiore o uguale a {token__value}} less_than {{token__propertyLabel} è minore di {token__value}} less_than_equal {{token__propertyLabel} è minore o uguale a {token__value}} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} non contiene {token__value}} starts_with {{token__propertyLabel} inizia con {token__value}} not_starts_with {{token__propertyLabel} non inizia con {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} è uguale a {token__value}} not_equals {{token__propertyLabel} non è uguale a {token__value}} greater_than {{token__propertyLabel} è maggiore di {token__value}} greater_than_equal {{token__propertyLabel} è maggiore o uguale a {token__value}} less_than {{token__propertyLabel} è minore di {token__value}} less_than_equal {{token__propertyLabel} è minore o uguale a {token__value}} contains {{token__propertyLabel} contiene {token__value}} not_contains {{token__propertyLabel} non contiene {token__value}} starts_with {{token__propertyLabel} inizia con {token__value}} not_starts_with {{token__propertyLabel} non inizia con {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Modifica gruppo di filtri {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Modifica gruppo di filtri {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Modifica gruppo di filtri {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Modifica il gruppo di filtri {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 altro} other {Modifica il gruppo di filtri {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} altro}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Scegli una versione",

--- a/src/i18n/messages/all.ja.json
+++ b/src/i18n/messages/all.ja.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "演算子",
     "i18nStrings.propertyText": "プロパティ",
     "i18nStrings.removeTokenButtonAriaLabel": "フィルターを取り外し、{token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "アクションをフィルタリングし、{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "フィルターを取り外し、{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "フィルターを取り外す",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "グループからフィルターを取り外す",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "フィルターアクションを追加",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "新しいフィルターを追加",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "グループに {token__formattedText} フィルターを追加",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "グループに {token__propertyLabel}{token__operator}{token__value} フィルターを追加",
     "i18nStrings.tokenLimitShowFewer": "少なく表示",
     "i18nStrings.tokenLimitShowMore": "さらに表示",
     "i18nStrings.valueText": "値",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} は {token__value} と等しい} not_equals {{token__propertyLabel} は {token__value} と等しくない} greater_than {{token__propertyLabel} は {token__value} より大きい} greater_than_equal {{token__propertyLabel} は {token__value} 以上} less_than {{token__propertyLabel} は {token__value} 未満} less_than_equal {{token__propertyLabel} は {token__value} 以下} contains {{token__propertyLabel} は {token__value} を含む} not_contains {{token__propertyLabel} は {token__value} を含まない} starts_with {{token__propertyLabel} は {token__value} で始まる} not_starts_with {{token__propertyLabel} は {token__value} で始まらない} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} は {token__value} と等しい} not_equals {{token__propertyLabel} は {token__value} と等しくない} greater_than {{token__propertyLabel} は {token__value} より大きい} greater_than_equal {{token__propertyLabel} は {token__value} 以上} less_than {{token__propertyLabel} は {token__value} 未満} less_than_equal {{token__propertyLabel} は {token__value} 以下} contains {{token__propertyLabel} は {token__value} を含む} not_contains {{token__propertyLabel} は {token__value} を含まない} starts_with {{token__propertyLabel} は {token__value} で始まる} not_starts_with {{token__propertyLabel} は {token__value} で始まらない} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} のフィルターグループを編集} 3 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} のフィルターグループを編集} 4 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} のフィルターグループを編集} 5 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} ともう 1 つのフィルターグループを編集} other {{group__formattedTokens0__formattedText}{group__operationLabel}{group__formattedTokens1__formattedText}{group__operationLabel}{group__formattedTokens2__formattedText}{group__operationLabel}{group__formattedTokens3__formattedText}{group__operationLabel} を超えるフィルターグループを編集}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "バージョンを選択してください",

--- a/src/i18n/messages/all.ko.json
+++ b/src/i18n/messages/all.ko.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "연산자",
     "i18nStrings.propertyText": "속성",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} 필터 제거",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "필터 작업, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "필터 {token__formattedText} 제거",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "필터 제거",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "그룹에서 필터 제거",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "필터 작업 추가",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "새 필터 추가",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "그룹에 필터 {token__formattedText} 추가",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "그룹에 필터 {token__propertyLabel}{token__operator}{token__value} 추가",
     "i18nStrings.tokenLimitShowFewer": "간단히 표시",
     "i18nStrings.tokenLimitShowMore": "자세히 표시",
     "i18nStrings.valueText": "값",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel}이(가) {token__value}와(과) 같은} not_equals {{token__propertyLabel}이(가) {token__value}와(과) 같지 않은} greater_than {{token__propertyLabel}이(가) {token__value}보다 큰} greater_than_equal {{token__propertyLabel}이(가) {token__value}보다 크거나 같은} less_than {{token__propertyLabel}이(가) {token__value}보다 작은} less_than_equal {{token__propertyLabel}이(가) {token__value}보다 작거나 같은} contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하는} not_contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하지 않는} starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하는} not_starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하지 않는} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel}이(가) {token__value}와(과) 같은} not_equals {{token__propertyLabel}이(가) {token__value}와(과) 같지 않은} greater_than {{token__propertyLabel}이(가) {token__value}보다 큰} greater_than_equal {{token__propertyLabel}이(가) {token__value}보다 크거나 같은} less_than {{token__propertyLabel}이(가) {token__value}보다 작은} less_than_equal {{token__propertyLabel}이(가) {token__value}보다 작거나 같은} contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하는} not_contains {{token__propertyLabel}이(가) {token__value}을(를) 포함하지 않는} starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하는} not_starts_with {{token__propertyLabel}이(가) {token__value}(으)로 시작하지 않는} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {필터 그룹 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} 편집} 3 {필터 그룹 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} 편집} 4 {필터 그룹 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} 편집} 5 {필터 그룹 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}+1 편집} other {필터 그룹 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}+ 편집}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "버전 선택",

--- a/src/i18n/messages/all.pt-BR.json
+++ b/src/i18n/messages/all.pt-BR.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operadores",
     "i18nStrings.propertyText": "Propriedade",
     "i18nStrings.removeTokenButtonAriaLabel": "Remover filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Ações de filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Remover filtro, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Remover filtro",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Remover filtro do grupo",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Adicionar ações de filtro",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Adicionar novo filtro",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "Adicionar filtro {token__formattedText} ao grupo",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "Adicionar filtro {token__propertyLabel} {token__operator} {token__value} ao grupo",
     "i18nStrings.tokenLimitShowFewer": "Mostrar menos",
     "i18nStrings.tokenLimitShowMore": "Mostrar mais",
     "i18nStrings.valueText": "Valor",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} é igual a {token__value}} not_equals {{token__propertyLabel} é diferente de {token__value}} greater_than {{token__propertyLabel} é maior que {token__value}} greater_than_equal {{token__propertyLabel} é maior que ou igual a {token__value}} less_than {{token__propertyLabel} é menor que {token__value}} less_than_equal {{token__propertyLabel} é menor que ou igual a {token__value}} contains {{token__propertyLabel} contém {token__value}} not_contains {{token__propertyLabel} não contém {token__value}} starts_with {{token__propertyLabel} começa com {token__value}} not_starts_with {{token__propertyLabel} não começa com {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} é igual a {token__value}} not_equals {{token__propertyLabel} é diferente de {token__value}} greater_than {{token__propertyLabel} é maior que {token__value}} greater_than_equal {{token__propertyLabel} é maior que ou igual a {token__value}} less_than {{token__propertyLabel} é menor que {token__value}} less_than_equal {{token__propertyLabel} é menor que ou igual a {token__value}} contains {{token__propertyLabel} contém {token__value}} not_contains {{token__propertyLabel} não contém {token__value}} starts_with {{token__propertyLabel} começa com {token__value}} not_starts_with {{token__propertyLabel} não começa com {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} mais 1} other {Editar grupo de filtros {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} mais}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Escolher uma versão",

--- a/src/i18n/messages/all.tr.json
+++ b/src/i18n/messages/all.tr.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "Operatörler",
     "i18nStrings.propertyText": "Özellik",
     "i18nStrings.removeTokenButtonAriaLabel": "{token__formattedText} filtresini kaldır",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "Filtre eylemleri, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "Filtreyi kaldır, {token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "Filtreyi kaldır",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "Filtreyi gruptan kaldır",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "Filtre ekleme eylemleri",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "Yeni filtre ekle",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "{token__formattedText} filtresini gruba ekle",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "{token__propertyLabel} {token__operator} {token__value} filtresini gruba ekle",
     "i18nStrings.tokenLimitShowFewer": "Daha az göster",
     "i18nStrings.tokenLimitShowMore": "Daha fazla göster",
     "i18nStrings.valueText": "Değer",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} eşittir {token__value}} not_equals {{token__propertyLabel} eşit değildir {token__value}} greater_than {{token__propertyLabel} büyüktür {token__value}} greater_than_equal {{token__propertyLabel} büyük veya eşittir {token__value}} less_than {{token__propertyLabel} küçüktür {token__value}} less_than_equal {{token__propertyLabel} küçük veya eşittir {token__value}} contains {{token__propertyLabel}, {token__value} içerir} not_contains {{token__propertyLabel}, {token__value} içermez} starts_with {{token__propertyLabel}, {token__value} ile başlar} not_starts_with {{token__propertyLabel}, {token__value} ile başlamaz} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} eşittir {token__value}} not_equals {{token__propertyLabel} eşit değildir {token__value}} greater_than {{token__propertyLabel} büyüktür {token__value}} greater_than_equal {{token__propertyLabel} büyük veya eşittir {token__value}} less_than {{token__propertyLabel} küçüktür {token__value}} less_than_equal {{token__propertyLabel} küçük veya eşittir {token__value}} contains {{token__propertyLabel}, {token__value} içerir} not_contains {{token__propertyLabel}, {token__value} içermez} starts_with {{token__propertyLabel}, {token__value} ile başlar} not_starts_with {{token__propertyLabel}, {token__value} ile başlamaz} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} filtre grubunu düzenle} 3 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} filtre grubunu düzenle} 4 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} filtre grubunu düzenle} 5 {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} 1 tane daha filtre grubunu düzenle} other {{group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel} tane daha filtre grubunu düzenle}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "Bir sürüm seçin",

--- a/src/i18n/messages/all.zh-CN.json
+++ b/src/i18n/messages/all.zh-CN.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "运算符",
     "i18nStrings.propertyText": "属性",
     "i18nStrings.removeTokenButtonAriaLabel": "移除筛选条件，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "筛选条件操作，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "移除筛选条件，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "移除筛选条件",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "从组中移除筛选条件",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "添加筛选条件操作",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "添加新筛选条件",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "向组添加筛选条件 {token__formattedText}",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "向组添加筛选条件 {token__propertyLabel} {token__operator} {token__value}",
     "i18nStrings.tokenLimitShowFewer": "显示更少",
     "i18nStrings.tokenLimitShowMore": "显示更多",
     "i18nStrings.valueText": "值",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等于 {token__value}} not_equals {{token__propertyLabel} 不等于 {token__value}} greater_than {{token__propertyLabel} 大于 {token__value}} greater_than_equal {{token__propertyLabel} 大于或等于 {token__value}} less_than {{token__propertyLabel} 小于 {token__value}} less_than_equal {{token__propertyLabel} 小于或等于 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 开头为 {token__value}} not_starts_with {{token__propertyLabel} 开头不为 {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等于 {token__value}} not_equals {{token__propertyLabel} 不等于 {token__value}} greater_than {{token__propertyLabel} 大于 {token__value}} greater_than_equal {{token__propertyLabel} 大于或等于 {token__value}} less_than {{token__propertyLabel} 小于 {token__value}} less_than_equal {{token__propertyLabel} 小于或等于 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 开头为 {token__value}} not_starts_with {{token__propertyLabel} 开头不为 {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {编辑筛选条件组 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {编辑筛选条件组 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {编辑筛选条件组 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {再一次编辑筛选条件组 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}} other {再多次编辑筛选条件组 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "选择版本",

--- a/src/i18n/messages/all.zh-TW.json
+++ b/src/i18n/messages/all.zh-TW.json
@@ -207,10 +207,19 @@
     "i18nStrings.operatorsText": "運算子",
     "i18nStrings.propertyText": "屬性",
     "i18nStrings.removeTokenButtonAriaLabel": "移除篩選條件，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenActionsAriaLabel": "篩選動作，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveAriaLabel": "移除篩選條件，{token__formattedText}",
+    "i18nStrings.tokenEditorTokenRemoveLabel": "移除篩選條件",
+    "i18nStrings.tokenEditorTokenRemoveFromGroupLabel": "從群組中移除篩選條件",
+    "i18nStrings.tokenEditorAddTokenActionsAriaLabel": "新增篩選動作",
+    "i18nStrings.tokenEditorAddNewTokenLabel": "新增新的篩選條件",
+    "i18nStrings.tokenEditorAddExistingTokenAriaLabel": "新增篩選條件 {token__formattedText} 至群組",
+    "i18nStrings.tokenEditorAddExistingTokenLabel": "新增篩選條件 {token__propertyLabel} {token__operator} {token__value} 至群組",
     "i18nStrings.tokenLimitShowFewer": "顯示較少",
     "i18nStrings.tokenLimitShowMore": "顯示更多",
     "i18nStrings.valueText": "值",
-    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等於 {token__value}} not_equals {{token__propertyLabel} 不等於 {token__value}} greater_than {{token__propertyLabel} 大於 {token__value}} greater_than_equal {{token__propertyLabel} 大於或等於 {token__value}} less_than {{token__propertyLabel} 小於 {token__value}} less_than_equal {{token__propertyLabel} 小於或等於 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 開頭為 {token__value}} not_starts_with {{token__propertyLabel} 開頭不能為 {token__value}} other {}}"
+    "i18nStrings.formatToken": "{token__operator, select, equals {{token__propertyLabel} 等於 {token__value}} not_equals {{token__propertyLabel} 不等於 {token__value}} greater_than {{token__propertyLabel} 大於 {token__value}} greater_than_equal {{token__propertyLabel} 大於或等於 {token__value}} less_than {{token__propertyLabel} 小於 {token__value}} less_than_equal {{token__propertyLabel} 小於或等於 {token__value}} contains {{token__propertyLabel} 包含 {token__value}} not_contains {{token__propertyLabel} 不包含 {token__value}} starts_with {{token__propertyLabel} 開頭為 {token__value}} not_starts_with {{token__propertyLabel} 開頭不能為 {token__value}} other {}}",
+    "i18nStrings.groupEditAriaLabel": "{group__formattedTokens__length, select, 2 {編輯篩選群組 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText}} 3 {編輯篩選群組 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText}} 4 {編輯篩選群組 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText}} 5 {再編輯 1 個篩選群組 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}} other {編輯更多篩選群組 {group__formattedTokens0__formattedText} {group__operationLabel} {group__formattedTokens1__formattedText} {group__operationLabel} {group__formattedTokens2__formattedText} {group__operationLabel} {group__formattedTokens3__formattedText} {group__operationLabel}}}"
   },
   "s3-resource-selector": {
     "i18nStrings.inContextSelectPlaceholder": "選擇一個版本",


### PR DESCRIPTION
### Description

New i18n messages for property filter

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
