### PR TITLE
chore: Fixes flaky app layout tests that depend on timeout

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 /* eslint simple-import-sort/imports: 0 */
 import React, { useState } from 'react';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { render, cleanup, waitFor, act } from '@testing-library/react';
 import { describeEachAppLayout } from './utils';
 import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
 import AppLayout from '../../../lib/components/app-layout';
@@ -48,10 +48,20 @@ afterEach(() => {
   });
 });
 
+function delay() {
+  // longer than a setTimeout(..., 0) used inside the implementation
+  return act(() => new Promise(resolve => setTimeout(resolve, 10)));
+}
+
+async function waitForWithDelay(testFn: () => void) {
+  await delay();
+  await waitFor(testFn);
+}
+
 describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
   test('renders normal breadcrumbs when no app layout is present', async () => {
     render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
     });
@@ -59,7 +69,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 
   test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
     render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
     });
@@ -67,7 +77,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 
   test('no relocation happens on the initial render', async () => {
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
       expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
@@ -81,7 +91,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         <BreadcrumbGroup items={defaultBreadcrumbs} />
       </>
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
     });
@@ -89,7 +99,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 
   test('renders breadcrumbs inside app layout content slot', async () => {
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
     });
@@ -98,20 +108,17 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
   test('event handlers work for relocated breadcrumbs', async () => {
     const onFollow = jest.fn(event => event.preventDefault());
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findRootBreadcrumb()).not.toBe(null);
     });
 
     findRootBreadcrumb().click();
-
-    await waitFor(() => {
-      expect(onFollow).toHaveBeenCalledTimes(1);
-      expect(onFollow).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: expect.objectContaining({ href: '/home', text: 'Home' }),
-        })
-      );
-    });
+    expect(onFollow).toHaveBeenCalledTimes(1);
+    expect(onFollow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ href: '/home', text: 'Home' }),
+      })
+    );
   });
 
   test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
@@ -121,7 +128,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
       />
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
       expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
@@ -139,7 +146,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         }
       />
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
       expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
@@ -158,7 +165,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         />
       </>
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(
         wrapper
@@ -189,7 +196,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         />
       </>
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(
         wrapper
@@ -216,7 +223,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       );
     }
     render(<AppLayout content={<DynamicBreadcrumb />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
     });
@@ -255,7 +262,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         }
       />
     );
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
     });
@@ -277,7 +284,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 describe('without feature flag', () => {
   test('breadcrumbs are not globalized', async () => {
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitFor(() => {
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
       expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
@@ -288,7 +295,7 @@ describe('without feature flag', () => {
 test('renders analytics metadata information', async () => {
   activateAnalyticsMetadata(true);
   render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-  await waitFor(() => {
+  await waitForWithDelay(() => {
     const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
     const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
     expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -10,6 +10,7 @@ import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/b
 import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
+import { range } from 'lodash';
 
 const wrapper = createWrapper();
 
@@ -58,262 +59,262 @@ async function waitForWithDelay(testFn: () => void) {
   await waitFor(testFn);
 }
 
-describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
-  test('renders normal breadcrumbs when no app layout is present', async () => {
-    render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
+describe.each(range(0, 333))('%s', () => {
+  describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+    test('renders normal breadcrumbs when no app layout is present', async () => {
+      render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
+      });
     });
-  });
 
-  test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
-    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+    test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
+      render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+      });
     });
-  });
 
-  test('no relocation happens on the initial render', async () => {
-    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitForWithDelay(() => {
+    test('no relocation happens on the initial render', () => {
+      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
       expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
     });
-  });
 
-  test('renders breadcrumbs adjacent to app layout', async () => {
-    render(
-      <>
-        <AppLayout />
-        <BreadcrumbGroup items={defaultBreadcrumbs} />
-      </>
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-    });
-  });
-
-  test('renders breadcrumbs inside app layout content slot', async () => {
-    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-    });
-  });
-
-  test('event handlers work for relocated breadcrumbs', async () => {
-    const onFollow = jest.fn(event => event.preventDefault());
-    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
-    await waitForWithDelay(() => {
-      expect(findRootBreadcrumb()).not.toBe(null);
+    test('renders breadcrumbs adjacent to app layout', async () => {
+      render(
+        <>
+          <AppLayout />
+          <BreadcrumbGroup items={defaultBreadcrumbs} />
+        </>
+      );
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+      });
     });
 
-    findRootBreadcrumb().click();
-    expect(onFollow).toHaveBeenCalledTimes(1);
-    expect(onFollow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: expect.objectContaining({ href: '/home', text: 'Home' }),
-      })
-    );
-  });
-
-  test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
-    render(
-      <AppLayout
-        breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
-        content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
-      />
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+    test('renders breadcrumbs inside app layout content slot', async () => {
+      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+      });
     });
-  });
 
-  test('when multiple breadcrumbs instances are present the latest is applied', async () => {
-    render(
-      <AppLayout
-        content={
-          <>
-            <BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />
-            <BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />
-          </>
-        }
-      />
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+    test('event handlers work for relocated breadcrumbs', async () => {
+      const onFollow = jest.fn(event => event.preventDefault());
+      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
+      await waitForWithDelay(() => {
+        expect(findRootBreadcrumb()).not.toBe(null);
+      });
+
+      findRootBreadcrumb().click();
+      expect(onFollow).toHaveBeenCalledTimes(1);
+      expect(onFollow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: expect.objectContaining({ href: '/home', text: 'Home' }),
+        })
+      );
     });
-  });
 
-  test('when multiple app layouts rendered, only the first instance receives breadcrumbs %s', async () => {
-    render(
-      <>
-        <AppLayout {...defaultAppLayoutProps} data-testid="first" />
+    test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
+      render(
         <AppLayout
-          {...defaultAppLayoutProps}
-          data-testid="second"
-          navigationHide={true}
-          content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+          breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
+          content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
         />
-      </>
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(
-        wrapper
-          .find('[data-testid="first"]')!
-          .findAppLayout()!
-          .findBreadcrumbs()!
-          .findBreadcrumbGroup()!
-          .findBreadcrumbLinks()
-      ).toHaveLength(2);
-      expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+      );
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+      });
     });
-  });
 
-  test('when multiple nested app layouts rendered, the outer instance receives breadcrumbs', async () => {
-    render(
-      <>
+    test('when multiple breadcrumbs instances are present the latest is applied', async () => {
+      render(
         <AppLayout
-          {...defaultAppLayoutProps}
-          data-testid="first"
           content={
-            <AppLayout
-              {...defaultAppLayoutProps}
-              data-testid="second"
-              navigationHide={true}
-              breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
-            />
+            <>
+              <BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />
+              <BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />
+            </>
           }
         />
-      </>
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(
-        wrapper
-          .find('[data-testid="first"]')!
-          .findAppLayout()!
-          .findBreadcrumbs()!
-          .findBreadcrumbGroup()!
-          .findBreadcrumbLinks()
-      ).toHaveLength(2);
-      expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+      );
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+      });
     });
-  });
 
-  test('updates when a single breadcrumbs instance changes', async () => {
-    function DynamicBreadcrumb() {
-      const [changed, setChanged] = useState(false);
-      return (
+    test('when multiple app layouts rendered, only the first instance receives breadcrumbs %s', async () => {
+      render(
         <>
-          <button data-testid="change-button" onClick={() => setChanged(true)}>
-            Change
-          </button>
-          <BreadcrumbGroup items={[{ text: changed ? 'Changed' : 'Original', href: '/home' }]} />
+          <AppLayout {...defaultAppLayoutProps} data-testid="first" />
+          <AppLayout
+            {...defaultAppLayoutProps}
+            data-testid="second"
+            navigationHide={true}
+            content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+          />
         </>
       );
-    }
-    render(<AppLayout content={<DynamicBreadcrumb />} />);
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(
+          wrapper
+            .find('[data-testid="first"]')!
+            .findAppLayout()!
+            .findBreadcrumbs()!
+            .findBreadcrumbGroup()!
+            .findBreadcrumbLinks()
+        ).toHaveLength(2);
+        expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+      });
     });
 
-    wrapper.find('[data-testid="change-button"]')!.click();
-    await waitFor(() => {
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Changed');
-    });
-  });
-
-  test('updates when a new breadcrumb instance mounts and unmounts', async () => {
-    function ConditionalBreadcrumb() {
-      const [rendered, setRendered] = useState(false);
-      return (
+    test('when multiple nested app layouts rendered, the outer instance receives breadcrumbs', async () => {
+      render(
         <>
-          <label>
-            <input
-              data-testid="render-toggle"
-              type="checkbox"
-              checked={rendered}
-              onChange={event => setRendered(event.target.checked)}
-            />
-            Render
-          </label>
-          {rendered ? <BreadcrumbGroup items={[{ text: 'Conditional', href: '/home' }]} /> : null}
+          <AppLayout
+            {...defaultAppLayoutProps}
+            data-testid="first"
+            content={
+              <AppLayout
+                {...defaultAppLayoutProps}
+                data-testid="second"
+                navigationHide={true}
+                breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+              />
+            }
+          />
         </>
       );
-    }
-    render(
-      <AppLayout
-        content={
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(
+          wrapper
+            .find('[data-testid="first"]')!
+            .findAppLayout()!
+            .findBreadcrumbs()!
+            .findBreadcrumbGroup()!
+            .findBreadcrumbLinks()
+        ).toHaveLength(2);
+        expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+      });
+    });
+
+    test('updates when a single breadcrumbs instance changes', async () => {
+      function DynamicBreadcrumb() {
+        const [changed, setChanged] = useState(false);
+        return (
           <>
-            <BreadcrumbGroup items={[{ text: 'Static', href: '/home' }]} />
-            <ConditionalBreadcrumb />
+            <button data-testid="change-button" onClick={() => setChanged(true)}>
+              Change
+            </button>
+            <BreadcrumbGroup items={[{ text: changed ? 'Changed' : 'Original', href: '/home' }]} />
           </>
-        }
-      />
-    );
-    await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+        );
+      }
+      render(<AppLayout content={<DynamicBreadcrumb />} />);
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
+      });
+
+      wrapper.find('[data-testid="change-button"]')!.click();
+      await waitFor(() => {
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Changed');
+      });
     });
 
-    wrapper.find('[data-testid="render-toggle"]')!.click();
-    await waitFor(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Conditional');
-    });
+    test('updates when a new breadcrumb instance mounts and unmounts', async () => {
+      function ConditionalBreadcrumb() {
+        const [rendered, setRendered] = useState(false);
+        return (
+          <>
+            <label>
+              <input
+                data-testid="render-toggle"
+                type="checkbox"
+                checked={rendered}
+                onChange={event => setRendered(event.target.checked)}
+              />
+              Render
+            </label>
+            {rendered ? <BreadcrumbGroup items={[{ text: 'Conditional', href: '/home' }]} /> : null}
+          </>
+        );
+      }
+      render(
+        <AppLayout
+          content={
+            <>
+              <BreadcrumbGroup items={[{ text: 'Static', href: '/home' }]} />
+              <ConditionalBreadcrumb />
+            </>
+          }
+        />
+      );
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+      });
 
-    wrapper.find('[data-testid="render-toggle"]')!.click();
-    await waitFor(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+      wrapper.find('[data-testid="render-toggle"]')!.click();
+      await waitFor(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Conditional');
+      });
+
+      wrapper.find('[data-testid="render-toggle"]')!.click();
+      await waitFor(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+      });
     });
   });
-});
 
-describe('without feature flag', () => {
-  test('breadcrumbs are not globalized', async () => {
+  describe('without feature flag', () => {
+    test('breadcrumbs are not globalized', async () => {
+      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+      await waitForWithDelay(() => {
+        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+        expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+        expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+      });
+    });
+  });
+
+  test('renders analytics metadata information', async () => {
+    activateAnalyticsMetadata(true);
     render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
     await waitForWithDelay(() => {
-      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-      expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
-      expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
-    });
-  });
-});
-
-test('renders analytics metadata information', async () => {
-  activateAnalyticsMetadata(true);
-  render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-  await waitForWithDelay(() => {
-    const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
-    const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
-    expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
-      action: 'click',
-      detail: {
-        position: '1',
-        label: 'Home',
-        href: '/home',
-      },
-      contexts: [
-        {
-          type: 'component',
-          detail: {
-            name: 'awsui.BreadcrumbGroup',
-            label: 'Home...Page',
-          },
+      const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
+      const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
+      expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
+        action: 'click',
+        detail: {
+          position: '1',
+          label: 'Home',
+          href: '/home',
         },
-      ],
+        contexts: [
+          {
+            type: 'component',
+            detail: {
+              name: 'awsui.BreadcrumbGroup',
+              label: 'Home...Page',
+            },
+          },
+        ],
+      });
     });
   });
 });

--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -10,7 +10,6 @@ import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/b
 import { awsuiPluginsInternal } from '../../../lib/components/internal/plugins/api';
 import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata';
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
-import { range } from 'lodash';
 
 const wrapper = createWrapper();
 
@@ -59,262 +58,260 @@ async function waitForWithDelay(testFn: () => void) {
   await waitFor(testFn);
 }
 
-describe.each(range(0, 333))('%s', () => {
-  describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
-    test('renders normal breadcrumbs when no app layout is present', async () => {
-      render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
-      });
+describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
+  test('renders normal breadcrumbs when no app layout is present', async () => {
+    render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
+    });
+  });
+
+  test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
+    render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+    });
+  });
+
+  test('no relocation happens on the initial render', () => {
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+    expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
+  });
+
+  test('renders breadcrumbs adjacent to app layout', async () => {
+    render(
+      <>
+        <AppLayout />
+        <BreadcrumbGroup items={defaultBreadcrumbs} />
+      </>
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+    });
+  });
+
+  test('renders breadcrumbs inside app layout content slot', async () => {
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
+    });
+  });
+
+  test('event handlers work for relocated breadcrumbs', async () => {
+    const onFollow = jest.fn(event => event.preventDefault());
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
+    await waitForWithDelay(() => {
+      expect(findRootBreadcrumb()).not.toBe(null);
     });
 
-    test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
-      render(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-      });
+    findRootBreadcrumb().click();
+    expect(onFollow).toHaveBeenCalledTimes(1);
+    expect(onFollow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ href: '/home', text: 'Home' }),
+      })
+    );
+  });
+
+  test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
+    render(
+      <AppLayout
+        breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
+        content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
+      />
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+    });
+  });
+
+  test('when multiple breadcrumbs instances are present the latest is applied', async () => {
+    render(
+      <AppLayout
+        content={
+          <>
+            <BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />
+            <BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />
+          </>
+        }
+      />
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
+    });
+  });
+
+  test('when multiple app layouts rendered, only the first instance receives breadcrumbs %s', async () => {
+    render(
+      <>
+        <AppLayout {...defaultAppLayoutProps} data-testid="first" />
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="second"
+          navigationHide={true}
+          content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+        />
+      </>
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(
+        wrapper
+          .find('[data-testid="first"]')!
+          .findAppLayout()!
+          .findBreadcrumbs()!
+          .findBreadcrumbGroup()!
+          .findBreadcrumbLinks()
+      ).toHaveLength(2);
+      expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    });
+  });
+
+  test('when multiple nested app layouts rendered, the outer instance receives breadcrumbs', async () => {
+    render(
+      <>
+        <AppLayout
+          {...defaultAppLayoutProps}
+          data-testid="first"
+          content={
+            <AppLayout
+              {...defaultAppLayoutProps}
+              data-testid="second"
+              navigationHide={true}
+              breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
+            />
+          }
+        />
+      </>
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(
+        wrapper
+          .find('[data-testid="first"]')!
+          .findAppLayout()!
+          .findBreadcrumbs()!
+          .findBreadcrumbGroup()!
+          .findBreadcrumbLinks()
+      ).toHaveLength(2);
+      expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
+    });
+  });
+
+  test('updates when a single breadcrumbs instance changes', async () => {
+    function DynamicBreadcrumb() {
+      const [changed, setChanged] = useState(false);
+      return (
+        <>
+          <button data-testid="change-button" onClick={() => setChanged(true)}>
+            Change
+          </button>
+          <BreadcrumbGroup items={[{ text: changed ? 'Changed' : 'Original', href: '/home' }]} />
+        </>
+      );
+    }
+    render(<AppLayout content={<DynamicBreadcrumb />} />);
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
     });
 
-    test('no relocation happens on the initial render', () => {
-      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    wrapper.find('[data-testid="change-button"]')!.click();
+    await waitFor(() => {
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Changed');
+    });
+  });
+
+  test('updates when a new breadcrumb instance mounts and unmounts', async () => {
+    function ConditionalBreadcrumb() {
+      const [rendered, setRendered] = useState(false);
+      return (
+        <>
+          <label>
+            <input
+              data-testid="render-toggle"
+              type="checkbox"
+              checked={rendered}
+              onChange={event => setRendered(event.target.checked)}
+            />
+            Render
+          </label>
+          {rendered ? <BreadcrumbGroup items={[{ text: 'Conditional', href: '/home' }]} /> : null}
+        </>
+      );
+    }
+    render(
+      <AppLayout
+        content={
+          <>
+            <BreadcrumbGroup items={[{ text: 'Static', href: '/home' }]} />
+            <ConditionalBreadcrumb />
+          </>
+        }
+      />
+    );
+    await waitForWithDelay(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+    });
+
+    wrapper.find('[data-testid="render-toggle"]')!.click();
+    await waitFor(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Conditional');
+    });
+
+    wrapper.find('[data-testid="render-toggle"]')!.click();
+    await waitFor(() => {
+      expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+      expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
+    });
+  });
+});
+
+describe('without feature flag', () => {
+  test('breadcrumbs are not globalized', async () => {
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    await waitForWithDelay(() => {
       expect(findAllBreadcrumbsInstances()).toHaveLength(1);
       expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
       expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
     });
-
-    test('renders breadcrumbs adjacent to app layout', async () => {
-      render(
-        <>
-          <AppLayout />
-          <BreadcrumbGroup items={defaultBreadcrumbs} />
-        </>
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-      });
-    });
-
-    test('renders breadcrumbs inside app layout content slot', async () => {
-      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
-      });
-    });
-
-    test('event handlers work for relocated breadcrumbs', async () => {
-      const onFollow = jest.fn(event => event.preventDefault());
-      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} onFollow={onFollow} />} />);
-      await waitForWithDelay(() => {
-        expect(findRootBreadcrumb()).not.toBe(null);
-      });
-
-      findRootBreadcrumb().click();
-      expect(onFollow).toHaveBeenCalledTimes(1);
-      expect(onFollow).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: expect.objectContaining({ href: '/home', text: 'Home' }),
-        })
-      );
-    });
-
-    test('when breadcrumbs are rendered in multiple slots, the last one takes precedence', async () => {
-      render(
-        <AppLayout
-          breadcrumbs={<BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />}
-          content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
-        />
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
-      });
-    });
-
-    test('when multiple breadcrumbs instances are present the latest is applied', async () => {
-      render(
-        <AppLayout
-          content={
-            <>
-              <BreadcrumbGroup items={[{ text: 'First', href: '/first' }]} />
-              <BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />
-            </>
-          }
-        />
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
-      });
-    });
-
-    test('when multiple app layouts rendered, only the first instance receives breadcrumbs %s', async () => {
-      render(
-        <>
-          <AppLayout {...defaultAppLayoutProps} data-testid="first" />
-          <AppLayout
-            {...defaultAppLayoutProps}
-            data-testid="second"
-            navigationHide={true}
-            content={<BreadcrumbGroup items={defaultBreadcrumbs} />}
-          />
-        </>
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(
-          wrapper
-            .find('[data-testid="first"]')!
-            .findAppLayout()!
-            .findBreadcrumbs()!
-            .findBreadcrumbGroup()!
-            .findBreadcrumbLinks()
-        ).toHaveLength(2);
-        expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
-      });
-    });
-
-    test('when multiple nested app layouts rendered, the outer instance receives breadcrumbs', async () => {
-      render(
-        <>
-          <AppLayout
-            {...defaultAppLayoutProps}
-            data-testid="first"
-            content={
-              <AppLayout
-                {...defaultAppLayoutProps}
-                data-testid="second"
-                navigationHide={true}
-                breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />}
-              />
-            }
-          />
-        </>
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(
-          wrapper
-            .find('[data-testid="first"]')!
-            .findAppLayout()!
-            .findBreadcrumbs()!
-            .findBreadcrumbGroup()!
-            .findBreadcrumbLinks()
-        ).toHaveLength(2);
-        expect(wrapper.find('[data-testid="second"]')!.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
-      });
-    });
-
-    test('updates when a single breadcrumbs instance changes', async () => {
-      function DynamicBreadcrumb() {
-        const [changed, setChanged] = useState(false);
-        return (
-          <>
-            <button data-testid="change-button" onClick={() => setChanged(true)}>
-              Change
-            </button>
-            <BreadcrumbGroup items={[{ text: changed ? 'Changed' : 'Original', href: '/home' }]} />
-          </>
-        );
-      }
-      render(<AppLayout content={<DynamicBreadcrumb />} />);
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
-      });
-
-      wrapper.find('[data-testid="change-button"]')!.click();
-      await waitFor(() => {
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Changed');
-      });
-    });
-
-    test('updates when a new breadcrumb instance mounts and unmounts', async () => {
-      function ConditionalBreadcrumb() {
-        const [rendered, setRendered] = useState(false);
-        return (
-          <>
-            <label>
-              <input
-                data-testid="render-toggle"
-                type="checkbox"
-                checked={rendered}
-                onChange={event => setRendered(event.target.checked)}
-              />
-              Render
-            </label>
-            {rendered ? <BreadcrumbGroup items={[{ text: 'Conditional', href: '/home' }]} /> : null}
-          </>
-        );
-      }
-      render(
-        <AppLayout
-          content={
-            <>
-              <BreadcrumbGroup items={[{ text: 'Static', href: '/home' }]} />
-              <ConditionalBreadcrumb />
-            </>
-          }
-        />
-      );
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
-      });
-
-      wrapper.find('[data-testid="render-toggle"]')!.click();
-      await waitFor(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Conditional');
-      });
-
-      wrapper.find('[data-testid="render-toggle"]')!.click();
-      await waitFor(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
-      });
-    });
   });
+});
 
-  describe('without feature flag', () => {
-    test('breadcrumbs are not globalized', async () => {
-      render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-      await waitForWithDelay(() => {
-        expect(findAllBreadcrumbsInstances()).toHaveLength(1);
-        expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
-        expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
-      });
-    });
-  });
-
-  test('renders analytics metadata information', async () => {
-    activateAnalyticsMetadata(true);
-    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    await waitForWithDelay(() => {
-      const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
-      const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
-      expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
-        action: 'click',
-        detail: {
-          position: '1',
-          label: 'Home',
-          href: '/home',
-        },
-        contexts: [
-          {
-            type: 'component',
-            detail: {
-              name: 'awsui.BreadcrumbGroup',
-              label: 'Home...Page',
-            },
+test('renders analytics metadata information', async () => {
+  activateAnalyticsMetadata(true);
+  render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+  await waitForWithDelay(() => {
+    const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
+    const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
+    expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({
+      action: 'click',
+      detail: {
+        position: '1',
+        label: 'Home',
+        href: '/home',
+      },
+      contexts: [
+        {
+          type: 'component',
+          detail: {
+            name: 'awsui.BreadcrumbGroup',
+            label: 'Home...Page',
           },
-        ],
-      });
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
### Description

Use waitFor instead of delay for global-breadcrumbs.test.tsx tests.

See failing test: https://github.com/cloudscape-design/components/actions/runs/10718898212/job/29722075662

### How has this been tested?

* Confirmed flakiness with multiple test run
* Verified not a single test in the fail fails after 1500 test runs

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
