### PR TITLE
fix: Fix flaky global breadcrumbs test

### DIFF
--- a/src/app-layout/__tests__/global-breadcrumbs.test.tsx
+++ b/src/app-layout/__tests__/global-breadcrumbs.test.tsx
@@ -42,9 +42,12 @@ function delay() {
   return act(() => new Promise(resolve => setTimeout(resolve, 10)));
 }
 
-function renderAsync(jsx: React.ReactElement) {
+async function renderAsync(jsx: React.ReactElement) {
   render(jsx);
-  return delay();
+  await waitFor(() => {
+    expect(wrapper.findAppLayout()!.find('[data-awsui-discovered-breadcrumbs="true"]')).toBeTruthy();
+    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
+  });
 }
 
 afterEach(() => {
@@ -60,14 +63,14 @@ afterEach(() => {
 
 describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () => {
   test('renders normal breadcrumbs when no app layout is present', async () => {
-    await renderAsync(<BreadcrumbGroup items={defaultBreadcrumbs} />);
+    render(<BreadcrumbGroup items={defaultBreadcrumbs} />);
+    await delay();
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(wrapper.findBreadcrumbGroup()!.findBreadcrumbLinks()).toHaveLength(2);
   });
 
   test('renders breadcrumbs inside app layout breadcrumbs slot', async () => {
     await renderAsync(<AppLayout breadcrumbs={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
   });
 
@@ -85,13 +88,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         <BreadcrumbGroup items={defaultBreadcrumbs} />
       </>
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
   });
 
   test('renders breadcrumbs inside app layout content slot', async () => {
     await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(2);
   });
 
@@ -114,7 +115,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         content={<BreadcrumbGroup items={[{ text: 'Second', href: '/second' }]} />}
       />
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
   });
@@ -130,7 +130,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         }
       />
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findAppLayoutBreadcrumbItems()).toHaveLength(1);
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Second');
   });
@@ -147,7 +146,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         />
       </>
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(
       wrapper
         .find('[data-testid="first"]')!
@@ -176,7 +174,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         />
       </>
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(
       wrapper
         .find('[data-testid="first"]')!
@@ -201,7 +198,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
       );
     }
     await renderAsync(<AppLayout content={<DynamicBreadcrumb />} />);
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Original');
 
     wrapper.find('[data-testid="change-button"]')!.click();
@@ -238,7 +234,6 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         }
       />
     );
-    expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(findRootBreadcrumb().getElement()).toHaveTextContent('Static');
 
     wrapper.find('[data-testid="render-toggle"]')!.click();
@@ -257,7 +252,8 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
 
 describe('without feature flag', () => {
   test('breadcrumbs are not globalized', async () => {
-    await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+    await delay();
     expect(findAllBreadcrumbsInstances()).toHaveLength(1);
     expect(wrapper.findAppLayout()!.findBreadcrumbs()).toBeFalsy();
     expect(wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()).toBeTruthy();
@@ -266,7 +262,8 @@ describe('without feature flag', () => {
 
 test('renders analytics metadata information', async () => {
   activateAnalyticsMetadata(true);
-  await renderAsync(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+  render(<AppLayout content={<BreadcrumbGroup items={defaultBreadcrumbs} />} />);
+  await delay();
   const breadcrumbsWrapper = wrapper.findAppLayout()!.findContentRegion().findBreadcrumbGroup()!;
   const firstBreadcrumb = breadcrumbsWrapper.findBreadcrumbLink(1)!.getElement();
   expect(getGeneratedAnalyticsMetadata(firstBreadcrumb)).toEqual({

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -170,7 +170,11 @@ export function AppLayoutToolbarImplementation({
           <div className={clsx(styles['universal-toolbar-breadcrumbs'], testutilStyles.breadcrumbs)}>
             {breadcrumbs}
             {discoveredBreadcrumbs && (
-              <BreadcrumbGroupImplementation {...discoveredBreadcrumbs} __injectAnalyticsComponentMetadata={true} />
+              <BreadcrumbGroupImplementation
+                {...discoveredBreadcrumbs}
+                data-awsui-discovered-breadcrumbs={true}
+                __injectAnalyticsComponentMetadata={true}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
### Description

Replacement for this PR: https://github.com/cloudscape-design/components/pull/2666

Related links, issue #, if available: n/a

### How has this been tested?

Build passes

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
