### PR TITLE
feat: Support using text in main action dropdown tigger

### DIFF
--- a/pages/button-dropdown/permutations-main-action.page.tsx
+++ b/pages/button-dropdown/permutations-main-action.page.tsx
@@ -43,6 +43,7 @@ const permutations = createPermutations<ButtonDropdownProps>([
     disabled: [false, true],
     loading: [false, true],
     variant: ['primary', 'normal'],
+    children: ['Trigger', null],
   },
   {
     mainAction: [{ ...viewInstancesItem }, { ...viewInstancesItem, disabled: true }],

--- a/src/button-dropdown/internal.tsx
+++ b/src/button-dropdown/internal.tsx
@@ -260,7 +260,9 @@ const InternalButtonDropdown = React.forwardRef(
             )}
             {...getAnalyticsMetadataAttribute(analyticsMetadata)}
           >
-            <InternalButton ref={triggerRef} {...baseTriggerProps} __emitPerformanceMarks={false} />
+            <InternalButton ref={triggerRef} {...baseTriggerProps} __emitPerformanceMarks={false}>
+              {children}
+            </InternalButton>
           </div>
         </div>
       );


### PR DESCRIPTION
### Description

Currently the children slot passed to DropDown component is ignored when `mainAction` is used, this change supports this feature. 

### How has this been tested?

added new permutations 

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
