### PR TITLE
refactor: Update integration tests to resolve chromium upgrade 3

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -224,11 +224,13 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
       // Simulating 200% zoom on medium screens (1366x768 / 2 ~= 680x360 ).
       await page.setWindowSize({ width: 680, height: 360 });
       await page.openPanel();
-      const { height } = await page.getViewportSize();
-      await page.dragResizerTo({ x: 0, y: height });
+      const { height: screenHeight } = await page.getViewportSize();
+      const headerRect = await page.getBoundingBox('#h');
+      await page.dragResizerTo({ x: 0, y: screenHeight });
       expect((await page.getSplitPanelSize()).height).toEqual(160);
       await page.dragResizerTo({ x: 0, y: 0 });
-      expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(277);
+      const splitPanelMaxSize = screenHeight - 40 - headerRect.height;
+      expect(Math.round((await page.getSplitPanelSize()).height)).toEqual(splitPanelMaxSize);
     })
   );
 


### PR DESCRIPTION
### Description

Related to https://github.com/cloudscape-design/browser-test-tools/pull/105 (see dry-run test failures).

Switching to Chromium --headless=new causes failures to our tests that depend on screen size. The refactoring fixes the issue for some of the app layout tests to either remove the dependency completely or make assertions depend on the measured viewport height.

Previous PR: https://github.com/cloudscape-design/components/pull/2660

### How has this been tested?

* Verified the tests work with old and new headless mode

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
