### PR TITLE
chore: Tolerate other analytics events in flashbar analytics tests

### DIFF
--- a/src/flashbar/__tests__/analytics.test.tsx
+++ b/src/flashbar/__tests__/analytics.test.tsx
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render as reactRender } from '@testing-library/react';
+
+import { clearOneTimeMetricsCache } from '@cloudscape-design/component-toolkit/internal/testing';
+
+import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
+import { DATA_ATTR_ANALYTICS_FLASHBAR } from '../../../lib/components/internal/analytics/selectors';
+import { createFlashbarWrapper } from './common';
+
+declare global {
+  interface Window {
+    panorama?: any;
+  }
+}
+
+const toggleButtonSelector = 'button';
+
+function findFlashbarMetric() {
+  return jest.mocked(window.panorama).mock.calls.filter((args: any) => args[1].eventContext === 'csa_flashbar');
+}
+
+describe('Analytics', () => {
+  beforeEach(() => {
+    window.panorama = () => {};
+    jest.spyOn(window, 'panorama');
+  });
+  afterEach(() => {
+    clearOneTimeMetricsCache();
+  });
+
+  it('does not send a metric when an empty array is provided', () => {
+    createFlashbarWrapper(<Flashbar items={[]} />);
+    expect(findFlashbarMetric()).toHaveLength(0);
+  });
+
+  it('sends a render metric when items are provided', () => {
+    createFlashbarWrapper(
+      <Flashbar
+        items={[
+          { type: 'error', header: 'Error', content: 'There was an error' },
+          { type: 'success', header: 'Success', content: 'Everything went fine' },
+        ]}
+      />
+    );
+
+    expect(findFlashbarMetric()).toEqual([
+      [
+        'trackCustomEvent',
+        expect.objectContaining({
+          eventContext: 'csa_flashbar',
+          eventType: 'render',
+          eventValue: '2',
+          eventDetail: expect.any(String),
+          timestamp: expect.any(Number),
+        }),
+      ],
+    ]);
+  });
+
+  it('sends a render metric when stacked items are provided', () => {
+    createFlashbarWrapper(
+      <Flashbar
+        stackItems={true}
+        items={[
+          { type: 'error', header: 'Error', content: 'There was an error' },
+          { type: 'success', header: 'Success', content: 'Everything went fine' },
+        ]}
+      />
+    );
+
+    expect(findFlashbarMetric()).toEqual([
+      [
+        'trackCustomEvent',
+        expect.objectContaining({
+          eventContext: 'csa_flashbar',
+          eventType: 'render',
+          eventValue: '2',
+          eventDetail: expect.any(String),
+          timestamp: expect.any(Number),
+        }),
+      ],
+    ]);
+  });
+
+  it('does not send duplicate render metrics on multiple renders', () => {
+    const items: FlashbarProps['items'] = [
+      { type: 'error', header: 'Error', content: 'There was an error' },
+      { type: 'success', header: 'Success', content: 'Everything went fine' },
+    ];
+
+    const { rerender } = reactRender(<Flashbar items={items} />);
+    jest.mocked(window.panorama).mockClear();
+    rerender(<Flashbar items={items} />);
+    expect(window.panorama).toBeCalledTimes(0);
+  });
+
+  it('sends an expand metric when collapsed', () => {
+    const wrapper = createFlashbarWrapper(
+      <Flashbar
+        stackItems={true}
+        items={[
+          { type: 'error', header: 'Error', content: 'There was an error' },
+          { type: 'success', header: 'Success', content: 'Everything went fine' },
+        ]}
+      />
+    );
+    jest.mocked(window.panorama).mockClear();
+
+    wrapper.find(toggleButtonSelector)!.click();
+
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_flashbar',
+        eventType: 'expand',
+        eventValue: '2',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  it('sends a collapse metric when collapsed', () => {
+    const wrapper = createFlashbarWrapper(
+      <Flashbar
+        stackItems={true}
+        items={[
+          { type: 'error', header: 'Error', content: 'There was an error' },
+          { type: 'success', header: 'Success', content: 'Everything went fine' },
+        ]}
+      />
+    );
+    wrapper.find(toggleButtonSelector)!.click(); // expand
+    jest.mocked(window.panorama).mockClear(); // clear previous events
+
+    wrapper.find(toggleButtonSelector)!.click(); // collapse
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_flashbar',
+        eventType: 'collapse',
+        eventValue: '2',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  it('sends a dismiss metric when a flash item is dismissed', () => {
+    const wrapper = createFlashbarWrapper(
+      <Flashbar
+        items={[
+          { type: 'error', header: 'Error', content: 'There was an error', dismissible: true, onDismiss: () => {} },
+        ]}
+      />
+    );
+    jest.mocked(window.panorama).mockClear(); // clear render event
+    wrapper.findItems()[0].findDismissButton()!.click();
+
+    expect(window.panorama).toBeCalledTimes(1);
+    expect(window.panorama).toHaveBeenCalledWith(
+      'trackCustomEvent',
+      expect.objectContaining({
+        eventContext: 'csa_flashbar',
+        eventType: 'dismiss',
+        eventValue: 'error',
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  describe('analytics', () => {
+    test(`adds ${DATA_ATTR_ANALYTICS_FLASHBAR} attribute with the flashbar type`, () => {
+      const { container } = reactRender(<Flashbar items={[{ id: '0', type: 'success' }]} />);
+      expect(container.querySelector(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="success"]`)).toBeInTheDocument();
+    });
+
+    test(`adds ${DATA_ATTR_ANALYTICS_FLASHBAR} attribute with the effective flashbar type when loading`, () => {
+      const { container } = reactRender(<Flashbar items={[{ id: '0', type: 'success', loading: true }]} />);
+      expect(container.querySelector(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="info"]`)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/flashbar/__tests__/flashbar.test.tsx
+++ b/src/flashbar/__tests__/flashbar.test.tsx
@@ -7,7 +7,6 @@ import { disableMotion } from '@cloudscape-design/global-styles';
 
 import Button from '../../../lib/components/button';
 import Flashbar, { FlashbarProps } from '../../../lib/components/flashbar';
-import { DATA_ATTR_ANALYTICS_FLASHBAR } from '../../../lib/components/internal/analytics/selectors';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { mockInnerText } from '../../internal/analytics/__tests__/mocks';
 import { createFlashbarWrapper, findList, testFlashDismissal } from './common';
@@ -20,7 +19,6 @@ let useVisualRefresh = false;
 jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => {
   const originalVisualModeModule = jest.requireActual('../../../lib/components/internal/hooks/use-visual-mode');
   return {
-    __esModule: true,
     ...originalVisualModeModule,
     useVisualRefresh: (...args: any) => useVisualRefresh || originalVisualModeModule.useVisualRefresh(...args),
   };
@@ -28,14 +26,7 @@ jest.mock('../../../lib/components/internal/hooks/use-visual-mode', () => {
 
 mockInnerText();
 
-declare global {
-  interface Window {
-    panorama?: any;
-  }
-}
-
 const noop = () => void 0;
-const toggleButtonSelector = 'button';
 
 let consoleWarnSpy: jest.SpyInstance;
 afterEach(() => {
@@ -448,157 +439,5 @@ describe('Flashbar component', () => {
     // https://cloudscape.design/foundation/visual-foundation/motion/#implementation
     setAnimations(false);
     testFlashDismissal({ stackItems: false });
-  });
-});
-
-describe('Analytics', () => {
-  beforeEach(() => {
-    window.panorama = () => {};
-    jest.spyOn(window, 'panorama');
-  });
-  it('does not send a metric when an empty array is provided', () => {
-    createFlashbarWrapper(<Flashbar items={[]} />);
-    expect(window.panorama).toBeCalledTimes(0);
-  });
-
-  it('sends a render metric when items are provided', () => {
-    createFlashbarWrapper(
-      <Flashbar
-        items={[
-          { type: 'error', header: 'Error', content: 'There was an error' },
-          { type: 'success', header: 'Success', content: 'Everything went fine' },
-        ]}
-      />
-    );
-
-    expect(window.panorama).toBeCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith(
-      'trackCustomEvent',
-      expect.objectContaining({
-        eventContext: 'csa_flashbar',
-        eventType: 'render',
-        eventValue: '2',
-        eventDetail: expect.any(String),
-        timestamp: expect.any(Number),
-      })
-    );
-  });
-
-  it('sends a render metric when stacked items are provided', () => {
-    createFlashbarWrapper(
-      <Flashbar
-        stackItems={true}
-        items={[
-          { type: 'error', header: 'Error', content: 'There was an error' },
-          { type: 'success', header: 'Success', content: 'Everything went fine' },
-        ]}
-      />
-    );
-
-    expect(window.panorama).toBeCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith(
-      'trackCustomEvent',
-      expect.objectContaining({
-        eventContext: 'csa_flashbar',
-        eventType: 'render',
-        eventValue: '2',
-        eventDetail: expect.any(String),
-        timestamp: expect.any(Number),
-      })
-    );
-  });
-
-  it('does not send duplicate render metrics on multiple renders', () => {
-    const items: FlashbarProps['items'] = [
-      { type: 'error', header: 'Error', content: 'There was an error' },
-      { type: 'success', header: 'Success', content: 'Everything went fine' },
-    ];
-
-    const { rerender } = reactRender(<Flashbar items={items} />);
-    rerender(<Flashbar items={items} />);
-    expect(window.panorama).toBeCalledTimes(1);
-  });
-
-  it('sends an expand metric when collapsed', () => {
-    const wrapper = createFlashbarWrapper(
-      <Flashbar
-        stackItems={true}
-        items={[
-          { type: 'error', header: 'Error', content: 'There was an error' },
-          { type: 'success', header: 'Success', content: 'Everything went fine' },
-        ]}
-      />
-    );
-    window.panorama?.mockClear(); // clear render event
-
-    wrapper.find(toggleButtonSelector)!.click();
-
-    expect(window.panorama).toBeCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith(
-      'trackCustomEvent',
-      expect.objectContaining({
-        eventContext: 'csa_flashbar',
-        eventType: 'expand',
-        eventValue: '2',
-        timestamp: expect.any(Number),
-      })
-    );
-  });
-
-  it('sends a collapse metric when collapsed', () => {
-    const wrapper = createFlashbarWrapper(
-      <Flashbar
-        stackItems={true}
-        items={[
-          { type: 'error', header: 'Error', content: 'There was an error' },
-          { type: 'success', header: 'Success', content: 'Everything went fine' },
-        ]}
-      />
-    );
-    wrapper.find(toggleButtonSelector)!.click(); // expand
-    window.panorama?.mockClear(); // clear previous events
-
-    wrapper.find(toggleButtonSelector)!.click(); // collapse
-    expect(window.panorama).toBeCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith(
-      'trackCustomEvent',
-      expect.objectContaining({
-        eventContext: 'csa_flashbar',
-        eventType: 'collapse',
-        eventValue: '2',
-        timestamp: expect.any(Number),
-      })
-    );
-  });
-
-  it('sends a dismiss metric when a flash item is dismissed', () => {
-    const wrapper = createFlashbarWrapper(
-      <Flashbar items={[{ type: 'error', header: 'Error', content: 'There was an error', dismissible: true }]} />
-    );
-    window.panorama?.mockClear(); // clear render event
-    wrapper.findItems()[0].findDismissButton()!.click();
-
-    expect(window.panorama).toBeCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith(
-      'trackCustomEvent',
-      expect.objectContaining({
-        eventContext: 'csa_flashbar',
-        eventType: 'dismiss',
-        eventValue: 'error',
-        timestamp: expect.any(Number),
-      })
-    );
-  });
-
-  describe('analytics', () => {
-    test(`adds ${DATA_ATTR_ANALYTICS_FLASHBAR} attribute with the flashbar type`, () => {
-      const { container } = reactRender(<Flashbar items={[{ id: '0', type: 'success' }]} />);
-      expect(container.querySelector(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="success"]`)).toBeInTheDocument();
-    });
-
-    test(`adds ${DATA_ATTR_ANALYTICS_FLASHBAR} attribute with the effective flashbar type when loading`, () => {
-      const { container } = reactRender(<Flashbar items={[{ id: '0', type: 'success', loading: true }]} />);
-      expect(container.querySelector(`[${DATA_ATTR_ANALYTICS_FLASHBAR}="info"]`)).toBeInTheDocument();
-    });
   });
 });


### PR DESCRIPTION
### Description

1. Fixing the tests to make them compatible with this change: https://github.com/cloudscape-design/component-toolkit/pull/96
2. Extracted analytics tests in a separate file. Previously, one-time metrics were not captured, because they happened in unrelated unit tests

Related links, issue #, if available: n/a

### How has this been tested?

1. PR build passes
2. Ran tests locally using the changes from the other PR (https://github.com/cloudscape-design/component-toolkit/pull/96), they pass too

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
