### PR TITLE
test: Enable more toolbar unit tests

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
+describeEachAppLayout(({ theme, size }) => {
   test('Default state', () => {
     const { wrapper } = renderComponent(<AppLayout />);
 
@@ -43,7 +43,8 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
       openProp: 'navigationOpen',
       hideProp: 'navigationHide',
       handler: 'onNavigationChange',
-      expectedCallsOnMobileToggle: 2,
+      // TODO: Figure out why this needs to be called twice on mobile
+      expectedCallsOnMobileToggle: theme === 'refresh-toolbar' ? 1 : 2,
       findLandmarks: (wrapper: AppLayoutWrapper) => wrapper.findAll('nav'),
       findElement: (wrapper: AppLayoutWrapper) => wrapper.findNavigation(),
       findToggle: (wrapper: AppLayoutWrapper) => wrapper.findNavigationToggle(),
@@ -122,10 +123,11 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
 
           const toggleElement = findToggle(wrapper).getElement();
 
-          if (landmarks[0].getElement().contains(toggleElement)) {
+          // Toolbar toggles always remain visible
+          if (theme !== 'refresh-toolbar' && landmarks[0].getElement().contains(toggleElement)) {
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'false');
             expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'true');
-          } else {
+          } else if (theme !== 'refresh-toolbar') {
             expect(landmarks[1].getElement()).toContainElement(toggleElement);
             expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'false');
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'true');
@@ -142,10 +144,10 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
           expect(landmarks).toHaveLength(2);
           const toggleElement = findToggle(wrapper).getElement();
 
-          if (landmarks[0].getElement().contains(toggleElement)) {
+          if (theme !== 'refresh-toolbar' && landmarks[0].getElement().contains(toggleElement)) {
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'true');
             expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'false');
-          } else {
+          } else if (theme !== 'refresh-toolbar') {
             expect(landmarks[1].getElement()).toContainElement(toggleElement);
             expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'true');
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'false');

--- a/src/app-layout/__tests__/multi-layout.test.tsx
+++ b/src/app-layout/__tests__/multi-layout.test.tsx
@@ -84,10 +84,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         content={<AppLayout data-testid="second" navigationHide={true} tools="testing tools" />}
       />
     );
-    expect(firstLayout.findTools()).toBeFalsy();
-    expect(secondLayout.findTools()).toBeFalsy();
+    expect(isDrawerClosed(firstLayout.findTools())).toEqual(true);
+    expect(isDrawerClosed(secondLayout.findTools())).toEqual(true);
 
     firstLayout.findToolsToggle().click();
+    expect(isDrawerClosed(secondLayout.findTools())).toEqual(false);
     expect(secondLayout.findTools()).toBeTruthy();
   });
 
@@ -219,7 +220,7 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
     });
 
     test('deduplicates tools and drawers in a single entity', async () => {
-      const { firstLayout } = await renderAsync(
+      const { firstLayout, secondLayout } = await renderAsync(
         <AppLayout
           {...defaultAppLayoutProps}
           data-testid="first"
@@ -231,10 +232,11 @@ describeEachAppLayout({ themes: ['refresh-toolbar'], sizes: ['desktop'] }, () =>
         expect.stringContaining('Another app layout instance on this page already defines tools or drawers property')
       );
       expect(firstLayout.findDrawersTriggers()).toHaveLength(0);
-      expect(firstLayout.findTools()).toBeFalsy();
+      expect(isDrawerClosed(firstLayout.findTools())).toEqual(true);
+      expect(secondLayout.findTools()).toBeFalsy();
 
       firstLayout.findToolsToggle().click();
-      expect(firstLayout.findTools()).toBeTruthy();
+      expect(isDrawerClosed(firstLayout.findTools())).toEqual(false);
     });
   });
 });

--- a/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/drawer/index.tsx
@@ -42,8 +42,8 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
   };
 
   const drawersTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
-  const isToolsDrawer = activeDrawer?.id === TOOLS_DRAWER_ID;
   const toolsOnlyMode = drawers.length === 1 && drawers[0].id === TOOLS_DRAWER_ID;
+  const isToolsDrawer = activeDrawerId === TOOLS_DRAWER_ID;
   const toolsContent = drawers?.find(drawer => drawer.id === TOOLS_DRAWER_ID)?.content;
   const resizeProps = useResize({
     currentWidth: activeDrawerSize,
@@ -60,8 +60,9 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
       aria-hidden={!activeDrawer}
       aria-label={computedAriaLabels.content}
       className={clsx(styles.drawer, sharedStyles['with-motion'], {
-        [testutilStyles['active-drawer']]: !toolsOnlyMode && activeDrawerId,
-        [testutilStyles.tools]: isToolsDrawer,
+        [testutilStyles['active-drawer']]: activeDrawerId,
+        [testutilStyles.tools]: isToolsDrawer || toolsOnlyMode,
+        [testutilStyles['drawer-closed']]: !activeDrawer,
       })}
       ref={drawerRef}
       onBlur={e => {
@@ -96,7 +97,7 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
             ariaLabel={computedAriaLabels.closeButton}
             className={clsx({
               [testutilStyles['active-drawer-close-button']]: !isToolsDrawer && activeDrawerId,
-              [testutilStyles['tools-close']]: isToolsDrawer,
+              [testutilStyles['tools-close']]: isToolsDrawer || toolsOnlyMode,
             })}
             formAction="none"
             iconName={isMobile ? 'close' : 'angle-right'}
@@ -105,15 +106,10 @@ export function AppLayoutDrawerImplementation({ appLayoutInternals }: AppLayoutD
             variant="icon"
           />
         </div>
-        <div
-          className={clsx(
-            styles['drawer-content'],
-            activeDrawerId !== TOOLS_DRAWER_ID && styles['drawer-content-hidden']
-          )}
-        >
+        <div className={clsx(styles['drawer-content'], !isToolsDrawer && styles['drawer-content-hidden'])}>
           {toolsContent}
         </div>
-        {activeDrawerId !== TOOLS_DRAWER_ID && <div className={styles['drawer-content']}>{activeDrawer?.content}</div>}
+        {!isToolsDrawer && <div className={styles['drawer-content']}>{activeDrawer?.content}</div>}
       </div>
     </aside>
   );

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -73,6 +73,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     const [notificationsHeight, setNotificationsHeight] = useState(0);
 
     const onNavigationToggle = (open: boolean) => {
+      navigationFocusControl.setFocus();
       fireNonCancelableEvent(onNavigationChange, { open });
     };
 
@@ -305,7 +306,11 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
           navigation={resolvedNavigation && <AppLayoutNavigation appLayoutInternals={appLayoutInternals} />}
           navigationOpen={navigationOpen}
           navigationWidth={navigationWidth}
-          tools={activeDrawer && <AppLayoutDrawer appLayoutInternals={appLayoutInternals} />}
+          tools={
+            ((drawers!.length > 0 && !toolsHide) || activeDrawer) && (
+              <AppLayoutDrawer appLayoutInternals={appLayoutInternals} />
+            )
+          }
           toolsOpen={!!activeDrawer}
           toolsWidth={activeDrawerSize}
           sideSplitPanel={

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -87,13 +87,12 @@ export function DrawerTriggers({
   return (
     <aside
       className={styles['drawers-desktop-triggers-container']}
-      aria-label={ariaLabels?.drawers}
+      aria-label={toolsOnlyMode ? ariaLabels?.tools : ariaLabels?.drawers}
       ref={triggersContainerRef}
       role="region"
     >
       <div
         className={clsx(styles['drawers-trigger-content'], {
-          [styles['has-multiple-triggers']]: hasMultipleTriggers,
           [styles['has-open-drawer']]: activeDrawerId,
         })}
         role="toolbar"

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -154,7 +154,10 @@ export function AppLayoutToolbarImplementation({
     >
       <div className={styles['toolbar-container']}>
         {hasNavigation && (
-          <nav className={clsx(styles['universal-toolbar-nav'], testutilStyles['drawer-closed'])}>
+          <nav
+            aria-label={ariaLabels?.navigation ?? undefined}
+            className={clsx(styles['universal-toolbar-nav'], !navigationOpen && testutilStyles['drawer-closed'])}
+          >
             <TriggerButton
               ariaLabel={ariaLabels?.navigationToggle ?? undefined}
               ariaExpanded={false}


### PR DESCRIPTION
### Description

Enables tests in `common.tsx`, `runtime-drawers.tsx`, and `multi-layout.tsx`.
Fixes focus delegation for navigation 
Ensures tools remain mounted even when closed

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
