### PR TITLE
feat: Allow button dropdown items to have an external icon without requiring href

### DIFF
--- a/pages/button-dropdown/item-element.permutations.page.tsx
+++ b/pages/button-dropdown/item-element.permutations.page.tsx
@@ -42,6 +42,12 @@ const permutations = createPermutations<ItemProps>([
         external: true,
         externalIconAriaLabel: ' (opens in new tab)',
       },
+      {
+        id: '1',
+        text: 'External link option without href',
+        external: true,
+        externalIconAriaLabel: ' (opens in new tab)',
+      },
     ],
     disabled: [false, true],
     highlighted: [false],

--- a/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
+++ b/src/button-dropdown/__tests__/button-dropdown-items.test.tsx
@@ -358,14 +358,6 @@ const items: ButtonDropdownProps.Items = [
       expect(icon.getElement()).toHaveAttribute('aria-label', simpleItems[0].externalIconAriaLabel);
     });
 
-    it('items without a link cannot be external', () => {
-      const simpleItems = [{ id: 'i1', text: 'item1', external: true }];
-      const wrapper = renderButtonDropdown({ ...props, items: simpleItems });
-
-      wrapper.openDropdown();
-      expect(wrapper.findItemById('i1')!.findIcon()).toBeFalsy();
-    });
-
     describe('should render icons', () => {
       const url = 'data:image/png;base64,aaaa';
       const svg = (

--- a/src/button-dropdown/item-element/index.tsx
+++ b/src/button-dropdown/item-element/index.tsx
@@ -16,7 +16,7 @@ import { ItemProps, LinkItem } from '../interfaces';
 import { ButtonDropdownProps } from '../interfaces';
 import Tooltip from '../tooltip';
 import { getMenuItemCheckboxProps, getMenuItemProps } from '../utils/menu-item';
-import { isCheckboxItem, isLinkItem } from '../utils/utils';
+import { isCheckboxItem, isItemGroup, isLinkItem } from '../utils/utils';
 import { getItemTarget } from '../utils/utils';
 
 import analyticsLabels from '../analytics-metadata/styles.css.js';
@@ -162,7 +162,6 @@ const MenuItemContent = ({
   disabled: boolean;
 }) => {
   const hasIcon = !!(item.iconName || item.iconUrl || item.iconSvg);
-  const hasExternal = isLinkItem(item) && item.external;
   const isCheckbox = isCheckboxItem(item);
   return (
     <>
@@ -177,7 +176,9 @@ const MenuItemContent = ({
         />
       )}
       {item.text}
-      {hasExternal && <ExternalIcon disabled={disabled} ariaLabel={item.externalIconAriaLabel} />}
+      {!isItemGroup(item) && !isCheckboxItem(item) && item.external && (
+        <ExternalIcon disabled={disabled} ariaLabel={item.externalIconAriaLabel} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
