### PR TITLE
chore: Add component render metric hook

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -14860,6 +14860,11 @@ scroll parent scrolls to reveal the first row of the table.",
         "name": "TableProps.AnalyticsMetadata",
         "properties": [
           {
+            "name": "flowType",
+            "optional": true,
+            "type": ""view-resource"",
+          },
+          {
             "name": "instanceIdentifier",
             "optional": true,
             "type": "string",

--- a/src/internal/analytics/index.ts
+++ b/src/internal/analytics/index.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 /* istanbul ignore file */
 
-import { IFunnelMetrics, IPerformanceMetrics } from './interfaces';
+import { IComponentMetrics, IFunnelMetrics, IPerformanceMetrics } from './interfaces';
 
 export function setFunnelMetrics(funnelMetrics: IFunnelMetrics) {
   FunnelMetrics = funnelMetrics;
 }
 export function setPerformanceMetrics(performanceMetrics: IPerformanceMetrics) {
   PerformanceMetrics = performanceMetrics;
+}
+export function setComponentMetrics(componentMetrics: IComponentMetrics) {
+  ComponentMetrics = componentMetrics;
 }
 
 /**
@@ -43,4 +46,10 @@ export let FunnelMetrics: IFunnelMetrics = {
  */
 export let PerformanceMetrics: IPerformanceMetrics = {
   tableInteraction(): void {},
+};
+
+export let ComponentMetrics: IComponentMetrics = {
+  componentMounted(): string {
+    return '';
+  },
 };

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type FunnelType = 'single-page' | 'multi-page';
-export type FlowType = 'create' | 'edit' | 'home' | 'dashboard';
+export type FlowType = 'create' | 'edit' | 'home' | 'dashboard' | 'view-resource';
 export interface AnalyticsMetadata {
   instanceIdentifier?: string;
   flowType?: FlowType;
@@ -154,4 +154,13 @@ export interface IFunnelMetrics {
 
 export interface IPerformanceMetrics {
   tableInteraction: TableInteractionMethod;
+}
+
+export interface ComponentMountedProps {
+  componentName: string;
+  details: Record<string, string | boolean | number | undefined>;
+}
+export type ComponentMountedMethod = (props: ComponentMountedProps) => string;
+export interface IComponentMetrics {
+  componentMounted: ComponentMountedMethod;
 }

--- a/src/internal/hooks/use-component-analytics/__tests__/use-component-analytics.test.tsx
+++ b/src/internal/hooks/use-component-analytics/__tests__/use-component-analytics.test.tsx
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { setComponentMetrics } from '../../../analytics';
+import { useComponentAnalytics } from '../index';
+
+function Demo() {
+  useComponentAnalytics('demo', () => ({
+    key: 'value',
+  }));
+
+  return <div />;
+}
+
+describe('useComponentAnalytics', () => {
+  let componentMounted: jest.Mock;
+
+  beforeEach(() => {
+    componentMounted = jest.fn();
+    setComponentMetrics({
+      componentMounted,
+    });
+  });
+
+  test('should emit ComponentMount event on mount', () => {
+    render(<Demo />);
+
+    expect(componentMounted).toHaveBeenCalledTimes(1);
+    expect(componentMounted).toHaveBeenCalledWith({ componentName: 'demo', details: { key: 'value' } });
+  });
+});

--- a/src/internal/hooks/use-component-analytics/index.ts
+++ b/src/internal/hooks/use-component-analytics/index.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+import { ComponentMetrics } from '../../analytics';
+
+export function useComponentAnalytics(
+  componentName: string,
+  getDetails: () => Record<string, string | boolean | number | undefined>
+) {
+  useEffect(() => {
+    ComponentMetrics.componentMounted({ componentName, details: getDetails() });
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/table/interfaces.tsx
+++ b/src/table/interfaces.tsx
@@ -381,6 +381,7 @@ export interface TableProps<T = any> extends BaseComponentProps {
 export namespace TableProps {
   export interface AnalyticsMetadata {
     instanceIdentifier?: string;
+    flowType?: 'view-resource';
   }
 
   export type TrackBy<T> = string | ((item: T) => string);

--- a/src/table/internal.tsx
+++ b/src/table/internal.tsx
@@ -19,6 +19,7 @@ import { CollectionLabelContext } from '../internal/context/collection-label-con
 import { LinkDefaultVariantContext } from '../internal/context/link-default-variant-context';
 import { fireNonCancelableEvent } from '../internal/events';
 import { InternalBaseComponentProps } from '../internal/hooks/use-base-component';
+import { useComponentAnalytics } from '../internal/hooks/use-component-analytics';
 import { useMergeRefs } from '../internal/hooks/use-merge-refs';
 import { useMobile } from '../internal/hooks/use-mobile';
 import useMouseDownTarget from '../internal/hooks/use-mouse-down-target';
@@ -58,6 +59,7 @@ import { useRowEvents } from './use-row-events';
 import useTableFocusNavigation from './use-table-focus-navigation';
 import { checkSortingState, getColumnKey, getItemKey, getVisibleColumnDefinitions, toContainerVariant } from './utils';
 
+import buttonStyles from '../button/styles.css.js';
 import headerStyles from '../header/styles.css.js';
 import styles from './styles.css.js';
 
@@ -182,6 +184,17 @@ const InternalTable = React.forwardRef(
     const getHeaderText = () =>
       toolsHeaderPerformanceMarkRef.current?.querySelector<HTMLElement>(`.${headerStyles['heading-text']}`)
         ?.innerText ?? toolsHeaderPerformanceMarkRef.current?.innerText;
+    const getPatternIdentifier = () => {
+      const hasActions = !!toolsHeaderPerformanceMarkRef.current?.querySelector<HTMLElement>(
+        `.${headerStyles.actions} .${buttonStyles.button}`
+      );
+
+      if (hasActions) {
+        return 'table-with-actions';
+      }
+
+      return '';
+    };
 
     const performanceMarkAttributes = usePerformanceMarks(
       'table',
@@ -195,6 +208,13 @@ const InternalTable = React.forwardRef(
     );
 
     const analyticsMetadata = getAnalyticsMetadataProps(rest);
+    useComponentAnalytics('table', () => ({
+      variant,
+      flowType: rest.analyticsMetadata?.flowType,
+      instanceIdentifier: analyticsMetadata?.instanceIdentifier,
+      taskName: getHeaderText(),
+      patternIdentifier: getPatternIdentifier(),
+    }));
 
     const { setLastUserAction } = useTableInteractionMetrics({
       loading,


### PR DESCRIPTION
### Description

Adds a Component Metric hook that will be used to support the funnel metrics through pattern identification. In this revision Table has been instrumented to emit a metric on render with some additional metadata.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
