### PR TITLE
fix: Prevent expandable table expand buttons from submitting forms

### DIFF
--- a/src/table/expandable-rows/expand-toggle-button.tsx
+++ b/src/table/expandable-rows/expand-toggle-button.tsx
@@ -24,6 +24,7 @@ export function ExpandToggleButton({
   const { tabIndex } = useSingleTabStopNavigation(buttonRef);
   return (
     <button
+      type="button"
       ref={buttonRef}
       tabIndex={tabIndex}
       aria-label={isExpanded ? collapseButtonLabel : expandButtonLabel}


### PR DESCRIPTION
### Description

A plain `<button>` will submit the closest surrounding form. Need to add `type="button"` for non-form buttons like expand toggles.

Related links, issue #, if available: n/a

### How has this been tested?

No test for this specifically - we'd just be testing that a static attribute exists. That said, we do have a generic test, but it looks like it's getting less and less applicable as our components get more complex, so...

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
