### PR TITLE
chore: Update API description for breadcrumb group items

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -2998,7 +2998,7 @@ You should specify the link even if you have a click handler for a breadcrumb it
 to ensure that valid markup is generated.
 
 Note: The last breadcrumb item is automatically considered the current item, and it's
-attributed with the proper \`aria-current\` value and rendered as inactive.
+not a link.
 ",
       "name": "items",
       "optional": false,

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -17,7 +17,7 @@ export interface BreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = Brea
    * to ensure that valid markup is generated.
 
    * Note: The last breadcrumb item is automatically considered the current item, and it's
-   * attributed with the proper `aria-current` value and rendered as inactive.
+   * not a link.
    */
   items: ReadonlyArray<T>;
   /**


### PR DESCRIPTION
### Description

Update outdated API description due to:
- removal of `aria-current` in https://github.com/cloudscape-design/components/pull/674
- make the item focusable in case it's truncated with a tooltip in https://github.com/cloudscape-design/components/pull/2671

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
