### PR TITLE
fix: Breadcrumbs display in toolbar

### DIFF
--- a/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/styles.scss
@@ -35,7 +35,7 @@
     display: grid;
     column-gap: awsui.$space-static-xs;
     inline-size: 100%;
-    grid-template-columns: min-content auto minmax(140px, 1fr);
+    grid-template-columns: min-content minmax(0, 3fr) minmax(140px, 1fr);
     grid-template-rows: 1fr;
 
     > .universal-toolbar-nav {


### PR DESCRIPTION
### Description

With the latest changes for breadcrumbs (https://github.com/cloudscape-design/components/commit/d9a5f98307ffdf94d310ad9cd8a70bb8b4f45ce4), they are currently always collapsed when used with toolbar. This change creates a better balance between breadcrumbs and drawers triggers area.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
