### PR TITLE
fix: Allow column layout to extend to two columns inside large full-width popover in refresh

### DIFF
--- a/src/popover/__integ__/popover-placement.test.ts
+++ b/src/popover/__integ__/popover-placement.test.ts
@@ -170,7 +170,7 @@ test(
     const containerSelector = largePopover.findByClassName(styles.container).toSelector();
     await page.click(triggerSelector);
     const { width: desktopContainerWidth } = await page.getBoundingBox(containerSelector);
-    expect(desktopContainerWidth).toEqual(480);
+    expect(desktopContainerWidth).toEqual(482);
 
     // Set mobile window size
     const [width, height] = VIEWPORT_MOBILE;

--- a/src/popover/container.scss
+++ b/src/popover/container.scss
@@ -46,13 +46,13 @@
 }
 
 .container-body-size-large {
-  max-inline-size: 480px;
-  @media (max-width: 480px) {
+  max-inline-size: 482px;
+  @media (max-width: 482px) {
     // On viewports smaller than 480px, we default to the body-size-medium width
     max-inline-size: 310px;
   }
   &.fixed-width {
-    inline-size: 480px;
+    inline-size: 482px;
   }
 }
 


### PR DESCRIPTION
### Description

Turns out the 2px border in visual refresh is _just_ enough to force an inner column layout inside the popover to break to a single column. Talk about pixel perfect. Rather than any fancy calculations, it's just easier to add a couple of pixels to the large popover; it's not worth the complexity of making it conditional on the theme either IMO.

Related links, issue #, if available: AWSUI-59615

### How has this been tested?

Permutation tests, I assume.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
