### PR TITLE
fix: Focus color contrast on active runtime drawer trigger

### DIFF
--- a/src/__tests__/__snapshots__/design-tokens.test.ts.snap
+++ b/src/__tests__/__snapshots__/design-tokens.test.ts.snap
@@ -2410,6 +2410,2413 @@ exports[`Design tokens artifacts Design tokens JSON for classic matches the snap
         },
       },
     },
+    "app-layout-tools-drawer-trigger": {
+      "tokens": {
+        "border-radius-alert": {
+          "$description": "The border radius of alerts.",
+          "$value": "2px",
+        },
+        "border-radius-badge": {
+          "$description": "The border radius of badges.",
+          "$value": "16px",
+        },
+        "border-radius-button": {
+          "$description": "The border radius of buttons and segmented control's segments.",
+          "$value": "2px",
+        },
+        "border-radius-calendar-day-focus-ring": {
+          "$description": "The border radius of the focused day in date picker and date range picker.",
+          "$value": "2px",
+        },
+        "border-radius-container": {
+          "$description": "The border radius of containers. Also used in container-based components like table, cards, expandable section, and modal.",
+          "$value": "0px",
+        },
+        "border-radius-control-circular-focus-ring": {
+          "$description": "The border radius of the focus indicator of circular controls. For example: radio button.",
+          "$value": "50%",
+        },
+        "border-radius-control-default-focus-ring": {
+          "$description": "The border radius of the focus indicator of interactive elements. For example: button, link, toggle, pagination controls, expandable section header, popover trigger.",
+          "$value": "2px",
+        },
+        "border-radius-dropdown": {
+          "$description": "The border radius of dropdown containers. For example: button dropdown, select, multiselect, autosuggest, date picker, date range picker.",
+          "$value": "0px",
+        },
+        "border-radius-flashbar": {
+          "$description": "The border radius of flash messages in flashbars.",
+          "$value": "0px",
+        },
+        "border-radius-input": {
+          "$description": "The border radius of form controls. For example: input, select.",
+          "$value": "2px",
+        },
+        "border-radius-item": {
+          "$description": "The border radius of items that can be selected from a list. For example: select options, table rows, calendar days.",
+          "$value": "0px",
+        },
+        "border-radius-popover": {
+          "$description": "The border radius of popovers.",
+          "$value": "2px",
+        },
+        "border-radius-tabs-focus-ring": {
+          "$description": "The border radius of tabs' focus indicator. Used in tabs and in the code editor status bar.",
+          "$value": "0px",
+        },
+        "border-radius-tiles": {
+          "$description": "The border radius of tiles.",
+          "$value": "2px",
+        },
+        "border-radius-token": {
+          "$description": "The border radius of tokens. For example: token groups, multiselect tokens, property filter tokens.",
+          "$value": "2px",
+        },
+        "border-radius-tutorial-panel-item": {
+          "$description": "The border radius of tutorials inside a tutorial panel.",
+          "$value": "2px",
+        },
+        "color-background-avatar-default": {
+          "$description": "The default background color of avatars.",
+          "$value": {
+            "dark": "#545b64",
+            "light": "#545b64",
+          },
+        },
+        "color-background-avatar-gen-ai": {
+          "$description": "The gen-ai background color of avatars.",
+          "$value": {
+            "dark": "radial-gradient(circle farthest-corner at top left,rgba(0, 150, 250, 1) -25%,rgba(0, 150, 250, 0) 55%),radial-gradient(circle farthest-corner at top right, rgba(216, 178, 255, 1) -10%, rgba(115, 0, 229, 1) 50%)",
+            "light": "radial-gradient(circle farthest-corner at top left,rgba(0, 150, 250, 1) -25%,rgba(0, 150, 250, 0) 55%),radial-gradient(circle farthest-corner at top right, rgba(216, 178, 255, 1) -10%, rgba(115, 0, 229, 1) 50%)",
+          },
+        },
+        "color-background-button-normal-active": {
+          "$description": "The background color of normal buttons in active state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-button-normal-default": {
+          "$description": "The default background color of normal buttons.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-button-normal-disabled": {
+          "$description": "The background color of normal buttons in disabled state.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-button-normal-hover": {
+          "$description": "The background color of normal buttons in hover state.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
+          },
+        },
+        "color-background-button-primary-active": {
+          "$description": "The background color of primary buttons in active state.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#12293b",
+          },
+        },
+        "color-background-button-primary-default": {
+          "$description": "The default background color of primary buttons.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-button-primary-disabled": {
+          "$description": "The background color of primary buttons in disabled state.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-button-primary-hover": {
+          "$description": "The background color of primary buttons in hover state.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0a4a74",
+          },
+        },
+        "color-background-cell-shaded": {
+          "$description": "The background color of shaded table cells.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#f2f3f3",
+          },
+        },
+        "color-background-container-content": {
+          "$description": "The background color of container main content areas. For example: content areas of form sections, containers, tables, and cards.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-container-header": {
+          "$description": "The background color of container headers. For example: headers of form sections, containers, tables, and card collections.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#fafafa",
+          },
+        },
+        "color-background-control-checked": {
+          "$description": "The background color of a checked form control. For example: background fill of a selected radio button, checked checkbox, and toggle that is switched on.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-control-default": {
+          "$description": "The default background color of form controls. For example: radio buttons and checkboxes default background fill color.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-control-disabled": {
+          "$description": "The background color of a disabled form control. For example: background fill of a disabled radio button and checkbox.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-background-dropdown-item-default": {
+          "$description": "The default background color of dropdown items. For example: select, multiselect, autosuggest, and datepicker dropdown backgrounds.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-dropdown-item-filter-match": {
+          "$description": "The background color of text that matches a user's query. For example: the background of text matching a query entered into a table filter, select, multiselect, or autosuggest.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
+        "color-background-dropdown-item-hover": {
+          "$description": "The background color of dropdown items on hover. For example: background of hovered items in select, multiselect, autosuggest, and datepicker dropdowns.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#f2f3f3",
+          },
+        },
+        "color-background-home-header": {
+          "$description": "The background color of the home header, displayed on the Service's home page.",
+          "$value": {
+            "dark": "#000000",
+            "light": "#000000",
+          },
+        },
+        "color-background-input-default": {
+          "$description": "The default background color of form inputs. For example: background fill of an input, textarea, autosuggest, and trigger of a select and multiselect.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-input-disabled": {
+          "$description": "The background color of a disabled form input. For example: background fill of a disabled input, textarea, autosuggest, and trigger of a select and multiselect.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-item-selected": {
+          "$description": "The background color of a selected item. For example: tokens, selected table rows, cards, and tile backgrounds.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
+        "color-background-layout-main": {
+          "$description": "The background color of the main content area on a page. For example: content area in app layout.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#f2f3f3",
+          },
+        },
+        "color-background-layout-toggle-active": {
+          "$description": "The background color of the app layout toggle button when it's active.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#2a2e33",
+          },
+        },
+        "color-background-layout-toggle-default": {
+          "$description": "The default background color of the app layout toggle button.",
+          "$value": {
+            "dark": "transparent",
+            "light": "transparent",
+          },
+        },
+        "color-background-layout-toggle-hover": {
+          "$description": "The background color of the app layout toggle button on hover.",
+          "$value": {
+            "dark": "#545b64",
+            "light": "#545b64",
+          },
+        },
+        "color-background-layout-toggle-selected-active": {
+          "$description": "The background color of the app layout toggle button when it's selected and active.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-layout-toggle-selected-default": {
+          "$description": "The default background color of the app layout toggle button when it's selected.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-layout-toggle-selected-hover": {
+          "$description": "The background color of the app layout toggle button on hover when it's selected.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0a4a74",
+          },
+        },
+        "color-background-loading-bar-gen-ai": {
+          "$description": "The background color of gen-ai loading bars.",
+          "$value": {
+            "dark": "linear-gradient(90deg, #99f7ff 0%, #0096fa 10%, #bf80ff 24%, #7300e5 50%, #bf80ff 76%, #0096fa 90%, #99f7ff 100%)",
+            "light": "linear-gradient(90deg, #99f7ff 0%, #0096fa 10%, #bf80ff 24%, #7300e5 50%, #bf80ff 76%, #0096fa 90%, #99f7ff 100%)",
+          },
+        },
+        "color-background-notification-blue": {
+          "$description": "Background color for blue notifications. For example: blue badges and info flash messages.",
+          "$value": {
+            "dark": "#0073bb",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-notification-green": {
+          "$description": "Background color for green notifications. For example: green badges and success flash messages.",
+          "$value": {
+            "dark": "#1d8102",
+            "light": "#1d8102",
+          },
+        },
+        "color-background-notification-grey": {
+          "$description": "Background color for grey notifications. For example: grey badges.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#545b64",
+          },
+        },
+        "color-background-notification-red": {
+          "$description": "Background color for red notifications. For example: red badges and error flash messages.",
+          "$value": {
+            "dark": "#d13212",
+            "light": "#d13212",
+          },
+        },
+        "color-background-notification-yellow": {
+          "$description": "Background color for yellow notifications. For example: yellow badges and warning flash messages.",
+          "$value": {
+            "dark": "#ffe347",
+            "light": "#ffe347",
+          },
+        },
+        "color-background-popover": {
+          "$description": "Background color for the popover container.",
+          "$value": {
+            "dark": "#21252c",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-segment-active": {
+          "$description": "The background color of the active segment in a segmented control.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-background-segment-default": {
+          "$description": "The background color of inactive segments in a segmented control.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-segment-disabled": {
+          "$description": "The background color of disabled segments in a segmented control.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-segment-hover": {
+          "$description": "The background color of inactive segments in a segmented control on hover.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#ffffff",
+          },
+        },
+        "color-background-status-error": {
+          "$description": "The background color of an item in error state. For example: error alerts.",
+          "$value": {
+            "dark": "#270a11",
+            "light": "#fdf3f1",
+          },
+        },
+        "color-background-status-info": {
+          "$description": "The background color of an informational item. For example: information alerts.",
+          "$value": {
+            "dark": "#12293b",
+            "light": "#f1faff",
+          },
+        },
+        "color-background-status-success": {
+          "$description": "The background color of an item in success state. For example: success alerts.",
+          "$value": {
+            "dark": "#172211",
+            "light": "#f2f8f0",
+          },
+        },
+        "color-background-status-warning": {
+          "$description": "The background color of an item in warning state. For example: warning alerts.",
+          "$value": {
+            "dark": "#191100",
+            "light": "#fffef0",
+          },
+        },
+        "color-background-toggle-button-normal-pressed": {
+          "$description": "The background color of normal toggle buttons in pressed state.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#eaeded",
+          },
+        },
+        "color-background-toggle-checked-disabled": {
+          "$description": "The background color of checked toggles in disabled state.",
+          "$value": {
+            "dark": "#0a4a74",
+            "light": "#99cbe4",
+          },
+        },
+        "color-board-placeholder-active": {
+          "$description": "The color of board placeholder in active state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-board-placeholder-hover": {
+          "$description": "The color of board placeholder in hovered state.",
+          "$value": {
+            "dark": "#0073bb",
+            "light": "#99cbe4",
+          },
+        },
+        "color-border-button-normal-active": {
+          "$description": "The border color of normal buttons in active state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#545b64",
+          },
+        },
+        "color-border-button-normal-default": {
+          "$description": "The border color of normal buttons.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#545b64",
+          },
+        },
+        "color-border-button-normal-disabled": {
+          "$description": "The border color of normal buttons in disabled state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-border-button-normal-hover": {
+          "$description": "The border color of normal buttons in hover state.",
+          "$value": {
+            "dark": "#aab7b8",
+            "light": "#16191f",
+          },
+        },
+        "color-border-button-primary-disabled": {
+          "$description": "The border color of primary buttons in disabled state.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-border-container-top": {
+          "$description": "The top border color for containers and first item in dropdowns. For example: the top border of a card, dropdown, and table.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#eaeded",
+          },
+        },
+        "color-border-control-default": {
+          "$description": "The default border color of form controls. For example: radio buttons and checkboxes.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#687078",
+          },
+        },
+        "color-border-divider-default": {
+          "$description": "The default color for dividers. For example: dividers in column layout, expanding sections, side nav, help panel, between table rows and dropdown items, and inside containers.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#eaeded",
+          },
+        },
+        "color-border-divider-secondary": {
+          "$description": "The border color for row dividers. For example: row dividers for table and collection preferences.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#eaeded",
+          },
+        },
+        "color-border-dropdown-item-focused": {
+          "$description": "The color of focus states for dropdown items. For example: the focus ring around selectable elements in the dropdown of button dropdown, select, and multi-select.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-dropdown-item-hover": {
+          "$description": "The border color of dropdown items on hover. For example: border of hovered items in select, multiselect, autosuggest, and hovered days in datepicker.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
+        "color-border-input-default": {
+          "$description": "The default border color of form inputs. For example: input, textarea, autosuggest, datepicker, select, and multiselect.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#687078",
+          },
+        },
+        "color-border-input-focused": {
+          "$description": "The color of focus states for form inputs. For example: input, textarea, autosuggest, datepicker, select, and multiselect.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#fafafa",
+          },
+        },
+        "color-border-item-focused": {
+          "$description": "The color of focus states. For example: the focus ring around interactive elements.",
+          "$value": {
+            "dark": "#2a2e33",
+            "light": "#fafafa",
+          },
+        },
+        "color-border-item-selected": {
+          "$description": "The border color of a selected item. For example: tokens, selected table rows, selected cards, and selected tile borders.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-segment-active": {
+          "$description": "The border color of the active segment in a segmented control.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#16191f",
+          },
+        },
+        "color-border-segment-default": {
+          "$description": "The border color of inactive segments in a segmented control.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#687078",
+          },
+        },
+        "color-border-segment-disabled": {
+          "$description": "The border color of disabled segments in a segmented control.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-border-segment-hover": {
+          "$description": "The border color of inactive segments in a segmented control on hover.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#16191f",
+          },
+        },
+        "color-border-status-error": {
+          "$description": "The border color of an item in error state. For example: error alerts.",
+          "$value": {
+            "dark": "#d13212",
+            "light": "#d13212",
+          },
+        },
+        "color-border-status-info": {
+          "$description": "The border color of an informational item. For example: information alerts.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-border-status-success": {
+          "$description": "The border color of an item in success state. For example: success alerts.",
+          "$value": {
+            "dark": "#1d8102",
+            "light": "#1d8102",
+          },
+        },
+        "color-border-status-warning": {
+          "$description": "The border color of an item in warning state. For example: warning alerts.",
+          "$value": {
+            "dark": "#fbd332",
+            "light": "#906806",
+          },
+        },
+        "color-border-toggle-button-normal-pressed": {
+          "$description": "The border color of normal toggle buttons in pressed state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#545b64",
+          },
+        },
+        "color-charts-blue-1-1000": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#b3e4f8",
+            "light": "#01437d",
+          },
+        },
+        "color-charts-blue-1-1100": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#caedfc",
+            "light": "#003c75",
+          },
+        },
+        "color-charts-blue-1-1200": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ddf4ff",
+            "light": "#00366d",
+          },
+        },
+        "color-charts-blue-1-300": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#00819c",
+            "light": "#529ccb",
+          },
+        },
+        "color-charts-blue-1-400": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#0497ba",
+            "light": "#3184c2",
+          },
+        },
+        "color-charts-blue-1-500": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#08aad2",
+            "light": "#0273bb",
+          },
+        },
+        "color-charts-blue-1-600": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#44b9dd",
+            "light": "#0166ab",
+          },
+        },
+        "color-charts-blue-1-700": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#63c6e7",
+            "light": "#015b9d",
+          },
+        },
+        "color-charts-blue-1-800": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#79d2f0",
+            "light": "#015292",
+          },
+        },
+        "color-charts-blue-1-900": {
+          "$description": "Color from the 'blue-1' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#98dcf5",
+            "light": "#014a87",
+          },
+        },
+        "color-charts-blue-2-1000": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#d2dcff",
+            "light": "#23379b",
+          },
+        },
+        "color-charts-blue-2-1100": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#dfe6ff",
+            "light": "#1f3191",
+          },
+        },
+        "color-charts-blue-2-1200": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ecf0ff",
+            "light": "#1b2b88",
+          },
+        },
+        "color-charts-blue-2-300": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#486de8",
+            "light": "#688ae8",
+          },
+        },
+        "color-charts-blue-2-400": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#6384f5",
+            "light": "#5978e3",
+          },
+        },
+        "color-charts-blue-2-500": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#7698fe",
+            "light": "#4066df",
+          },
+        },
+        "color-charts-blue-2-600": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#8ea9ff",
+            "light": "#3759ce",
+          },
+        },
+        "color-charts-blue-2-700": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#a2b8ff",
+            "light": "#314fbf",
+          },
+        },
+        "color-charts-blue-2-800": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#b1c5ff",
+            "light": "#2c46b1",
+          },
+        },
+        "color-charts-blue-2-900": {
+          "$description": "Color from the 'blue-2' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#c3d1ff",
+            "light": "#273ea5",
+          },
+        },
+        "color-charts-green-1000": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#c5e7a8",
+            "light": "#104d01",
+          },
+        },
+        "color-charts-green-1100": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#d5efbe",
+            "light": "#0f4601",
+          },
+        },
+        "color-charts-green-1200": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#e4f7d5",
+            "light": "#0d4000",
+          },
+        },
+        "color-charts-green-300": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#48851a",
+            "light": "#67a353",
+          },
+        },
+        "color-charts-green-400": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#5a9b29",
+            "light": "#41902c",
+          },
+        },
+        "color-charts-green-500": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#69ae34",
+            "light": "#1f8104",
+          },
+        },
+        "color-charts-green-600": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#7dbd4c",
+            "light": "#1a7302",
+          },
+        },
+        "color-charts-green-700": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#8fca61",
+            "light": "#176702",
+          },
+        },
+        "color-charts-green-800": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#9fd673",
+            "light": "#145d02",
+          },
+        },
+        "color-charts-green-900": {
+          "$description": "Color from the 'green' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#b2df8d",
+            "light": "#125502",
+          },
+        },
+        "color-charts-line-axis": {
+          "$description": "Color of the axis lines in a chart.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-charts-line-grid": {
+          "$description": "Color of the grid lines in a chart.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-charts-line-tick": {
+          "$description": "Color of the tick marks in a chart.",
+          "$value": {
+            "dark": "#414750",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-charts-orange-1000": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#ffd4bb",
+            "light": "#732c02",
+          },
+        },
+        "color-charts-orange-1100": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#ffe1cf",
+            "light": "#692801",
+          },
+        },
+        "color-charts-orange-1200": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ffede2",
+            "light": "#602400",
+          },
+        },
+        "color-charts-orange-300": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#c55305",
+            "light": "#e07941",
+          },
+        },
+        "color-charts-orange-400": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#de6923",
+            "light": "#cc5f21",
+          },
+        },
+        "color-charts-orange-500": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#f27c36",
+            "light": "#bc4d01",
+          },
+        },
+        "color-charts-orange-600": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#f89256",
+            "light": "#a84401",
+          },
+        },
+        "color-charts-orange-700": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#fca572",
+            "light": "#983c02",
+          },
+        },
+        "color-charts-orange-800": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#ffb68b",
+            "light": "#8a3603",
+          },
+        },
+        "color-charts-orange-900": {
+          "$description": "Color from the 'orange' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#ffc6a4",
+            "light": "#7e3103",
+          },
+        },
+        "color-charts-palette-categorical-1": {
+          "$description": "Color #1 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#486de8",
+            "light": "#688ae8",
+          },
+        },
+        "color-charts-palette-categorical-10": {
+          "$description": "Color #10 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#f89256",
+            "light": "#a84401",
+          },
+        },
+        "color-charts-palette-categorical-11": {
+          "$description": "Color #11 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#c3d1ff",
+            "light": "#273ea5",
+          },
+        },
+        "color-charts-palette-categorical-12": {
+          "$description": "Color #12 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffdfe8",
+            "light": "#780d35",
+          },
+        },
+        "color-charts-palette-categorical-13": {
+          "$description": "Color #13 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#94e0d0",
+            "light": "#03524a",
+          },
+        },
+        "color-charts-palette-categorical-14": {
+          "$description": "Color #14 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#efe2ff",
+            "light": "#4a238b",
+          },
+        },
+        "color-charts-palette-categorical-15": {
+          "$description": "Color #15 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffc6a4",
+            "light": "#7e3103",
+          },
+        },
+        "color-charts-palette-categorical-16": {
+          "$description": "Color #16 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ecf0ff",
+            "light": "#1b2b88",
+          },
+        },
+        "color-charts-palette-categorical-17": {
+          "$description": "Color #17 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#d56889",
+            "light": "#ce567c",
+          },
+        },
+        "color-charts-palette-categorical-18": {
+          "$description": "Color #18 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#d7f7f0",
+            "light": "#003e38",
+          },
+        },
+        "color-charts-palette-categorical-19": {
+          "$description": "Color #19 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#a173ea",
+            "light": "#9469d6",
+          },
+        },
+        "color-charts-palette-categorical-2": {
+          "$description": "Color #2 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#e07f9d",
+            "light": "#c33d69",
+          },
+        },
+        "color-charts-palette-categorical-20": {
+          "$description": "Color #20 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffede2",
+            "light": "#602400",
+          },
+        },
+        "color-charts-palette-categorical-21": {
+          "$description": "Color #21 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#7698fe",
+            "light": "#4066df",
+          },
+        },
+        "color-charts-palette-categorical-22": {
+          "$description": "Color #22 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#f5a2bb",
+            "light": "#a32952",
+          },
+        },
+        "color-charts-palette-categorical-23": {
+          "$description": "Color #23 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#00b09b",
+            "light": "#0d7d70",
+          },
+        },
+        "color-charts-palette-categorical-24": {
+          "$description": "Color #24 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#cbabfc",
+            "light": "#6b40b2",
+          },
+        },
+        "color-charts-palette-categorical-25": {
+          "$description": "Color #25 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#f27c36",
+            "light": "#bc4d01",
+          },
+        },
+        "color-charts-palette-categorical-26": {
+          "$description": "Color #26 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#b1c5ff",
+            "light": "#2c46b1",
+          },
+        },
+        "color-charts-palette-categorical-27": {
+          "$description": "Color #27 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffd1de",
+            "light": "#81143b",
+          },
+        },
+        "color-charts-palette-categorical-28": {
+          "$description": "Color #28 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#77d7c3",
+            "light": "#045b52",
+          },
+        },
+        "color-charts-palette-categorical-29": {
+          "$description": "Color #29 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#e8d5ff",
+            "light": "#512994",
+          },
+        },
+        "color-charts-palette-categorical-3": {
+          "$description": "Color #3 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#018977",
+            "light": "#2ea597",
+          },
+        },
+        "color-charts-palette-categorical-30": {
+          "$description": "Color #30 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffb68b",
+            "light": "#8a3603",
+          },
+        },
+        "color-charts-palette-categorical-31": {
+          "$description": "Color #31 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#dfe6ff",
+            "light": "#1f3191",
+          },
+        },
+        "color-charts-palette-categorical-32": {
+          "$description": "Color #32 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#c64a70",
+            "light": "#da7596",
+          },
+        },
+        "color-charts-palette-categorical-33": {
+          "$description": "Color #33 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#c2f0e6",
+            "light": "#01443e",
+          },
+        },
+        "color-charts-palette-categorical-34": {
+          "$description": "Color #34 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#8d59de",
+            "light": "#a783e1",
+          },
+        },
+        "color-charts-palette-categorical-35": {
+          "$description": "Color #35 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffe1cf",
+            "light": "#692801",
+          },
+        },
+        "color-charts-palette-categorical-36": {
+          "$description": "Color #36 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#6384f5",
+            "light": "#5978e3",
+          },
+        },
+        "color-charts-palette-categorical-37": {
+          "$description": "Color #37 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#eb92ad",
+            "light": "#b1325c",
+          },
+        },
+        "color-charts-palette-categorical-38": {
+          "$description": "Color #38 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#009d89",
+            "light": "#1c8e81",
+          },
+        },
+        "color-charts-palette-categorical-39": {
+          "$description": "Color #39 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#bf9bf9",
+            "light": "#7749bf",
+          },
+        },
+        "color-charts-palette-categorical-4": {
+          "$description": "Color #4 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#b088f5",
+            "light": "#8456ce",
+          },
+        },
+        "color-charts-palette-categorical-40": {
+          "$description": "Color #40 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#de6923",
+            "light": "#cc5f21",
+          },
+        },
+        "color-charts-palette-categorical-41": {
+          "$description": "Color #41 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#a2b8ff",
+            "light": "#314fbf",
+          },
+        },
+        "color-charts-palette-categorical-42": {
+          "$description": "Color #42 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffc1d4",
+            "light": "#8b1b42",
+          },
+        },
+        "color-charts-palette-categorical-43": {
+          "$description": "Color #43 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#5fccb7",
+            "light": "#06645a",
+          },
+        },
+        "color-charts-palette-categorical-44": {
+          "$description": "Color #44 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#dfc8ff",
+            "light": "#59309d",
+          },
+        },
+        "color-charts-palette-categorical-45": {
+          "$description": "Color #45 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#fca572",
+            "light": "#983c02",
+          },
+        },
+        "color-charts-palette-categorical-46": {
+          "$description": "Color #46 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#d2dcff",
+            "light": "#23379b",
+          },
+        },
+        "color-charts-palette-categorical-47": {
+          "$description": "Color #47 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffecf1",
+            "light": "#6f062f",
+          },
+        },
+        "color-charts-palette-categorical-48": {
+          "$description": "Color #48 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ace9db",
+            "light": "#014b44",
+          },
+        },
+        "color-charts-palette-categorical-49": {
+          "$description": "Color #49 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#f5edff",
+            "light": "#431d84",
+          },
+        },
+        "color-charts-palette-categorical-5": {
+          "$description": "Color #5 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#c55305",
+            "light": "#e07941",
+          },
+        },
+        "color-charts-palette-categorical-50": {
+          "$description": "Color #50 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffd4bb",
+            "light": "#732c02",
+          },
+        },
+        "color-charts-palette-categorical-6": {
+          "$description": "Color #6 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#8ea9ff",
+            "light": "#3759ce",
+          },
+        },
+        "color-charts-palette-categorical-7": {
+          "$description": "Color #7 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#ffb0c8",
+            "light": "#962249",
+          },
+        },
+        "color-charts-palette-categorical-8": {
+          "$description": "Color #8 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#40bfa9",
+            "light": "#096f64",
+          },
+        },
+        "color-charts-palette-categorical-9": {
+          "$description": "Color #9 on the categorical data visualization palette.",
+          "$value": {
+            "dark": "#d6baff",
+            "light": "#6237a7",
+          },
+        },
+        "color-charts-pink-1000": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#ffd1de",
+            "light": "#81143b",
+          },
+        },
+        "color-charts-pink-1100": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#ffdfe8",
+            "light": "#780d35",
+          },
+        },
+        "color-charts-pink-1200": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ffecf1",
+            "light": "#6f062f",
+          },
+        },
+        "color-charts-pink-300": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#c64a70",
+            "light": "#da7596",
+          },
+        },
+        "color-charts-pink-400": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#d56889",
+            "light": "#ce567c",
+          },
+        },
+        "color-charts-pink-500": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#e07f9d",
+            "light": "#c33d69",
+          },
+        },
+        "color-charts-pink-600": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#eb92ad",
+            "light": "#b1325c",
+          },
+        },
+        "color-charts-pink-700": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#f5a2bb",
+            "light": "#a32952",
+          },
+        },
+        "color-charts-pink-800": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#ffb0c8",
+            "light": "#962249",
+          },
+        },
+        "color-charts-pink-900": {
+          "$description": "Color from the 'pink' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#ffc1d4",
+            "light": "#8b1b42",
+          },
+        },
+        "color-charts-purple-1000": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#e8d5ff",
+            "light": "#512994",
+          },
+        },
+        "color-charts-purple-1100": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#efe2ff",
+            "light": "#4a238b",
+          },
+        },
+        "color-charts-purple-1200": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#f5edff",
+            "light": "#431d84",
+          },
+        },
+        "color-charts-purple-300": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#8d59de",
+            "light": "#a783e1",
+          },
+        },
+        "color-charts-purple-400": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#a173ea",
+            "light": "#9469d6",
+          },
+        },
+        "color-charts-purple-500": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#b088f5",
+            "light": "#8456ce",
+          },
+        },
+        "color-charts-purple-600": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#bf9bf9",
+            "light": "#7749bf",
+          },
+        },
+        "color-charts-purple-700": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#cbabfc",
+            "light": "#6b40b2",
+          },
+        },
+        "color-charts-purple-800": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#d6baff",
+            "light": "#6237a7",
+          },
+        },
+        "color-charts-purple-900": {
+          "$description": "Color from the 'purple' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#dfc8ff",
+            "light": "#59309d",
+          },
+        },
+        "color-charts-red-1000": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#ffd2cf",
+            "light": "#7d2105",
+          },
+        },
+        "color-charts-red-1100": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#ffe0dd",
+            "light": "#721e03",
+          },
+        },
+        "color-charts-red-1200": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ffecea",
+            "light": "#671c00",
+          },
+        },
+        "color-charts-red-300": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#d63f38",
+            "light": "#ea7158",
+          },
+        },
+        "color-charts-red-400": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#ed5958",
+            "light": "#dc5032",
+          },
+        },
+        "color-charts-red-500": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#fe6e73",
+            "light": "#d13313",
+          },
+        },
+        "color-charts-red-600": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#ff8a8a",
+            "light": "#ba2e0f",
+          },
+        },
+        "color-charts-red-700": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#ffa09e",
+            "light": "#a82a0c",
+          },
+        },
+        "color-charts-red-800": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#ffb3b0",
+            "light": "#972709",
+          },
+        },
+        "color-charts-red-900": {
+          "$description": "Color from the 'red' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#ffc4c0",
+            "light": "#892407",
+          },
+        },
+        "color-charts-status-critical": {
+          "$description": "Color to represent a critical error or a critically high-level of severity. For example: "Sev-1"",
+          "$value": {
+            "dark": "#d63f38",
+            "light": "#7d2105",
+          },
+        },
+        "color-charts-status-high": {
+          "$description": "Color to represent an error status or a high-level of severity. Use this color to represent a default error status when there is only one applicable to a chart. For example: "Failed" or "Sev-2"",
+          "$value": {
+            "dark": "#fe6e73",
+            "light": "#ba2e0f",
+          },
+        },
+        "color-charts-status-info": {
+          "$description": "Color to represent an informational status. For example: "In-progress" or "Updating"",
+          "$value": {
+            "dark": "#08aad2",
+            "light": "#3184c2",
+          },
+        },
+        "color-charts-status-low": {
+          "$description": "Color to represent a warning or a low-level of severity. For example: "Warning" or "Sev-4"",
+          "$value": {
+            "dark": "#dfb52c",
+            "light": "#b2911c",
+          },
+        },
+        "color-charts-status-medium": {
+          "$description": "Color to represent a medium-level of severity. For example: "Sev-3"",
+          "$value": {
+            "dark": "#f89256",
+            "light": "#cc5f21",
+          },
+        },
+        "color-charts-status-neutral": {
+          "$description": "Color to represent a neutral status, a severity level of no impact, or the lowest-level of severity. For example: "Pending" or "Sev-5"",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
+        "color-charts-status-positive": {
+          "$description": "Color to represent a positive status. *For example: "Success" or "Running"",
+          "$value": {
+            "dark": "#69ae34",
+            "light": "#67a353",
+          },
+        },
+        "color-charts-teal-1000": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#ace9db",
+            "light": "#014b44",
+          },
+        },
+        "color-charts-teal-1100": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#c2f0e6",
+            "light": "#01443e",
+          },
+        },
+        "color-charts-teal-1200": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#d7f7f0",
+            "light": "#003e38",
+          },
+        },
+        "color-charts-teal-300": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#018977",
+            "light": "#2ea597",
+          },
+        },
+        "color-charts-teal-400": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#009d89",
+            "light": "#1c8e81",
+          },
+        },
+        "color-charts-teal-500": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#00b09b",
+            "light": "#0d7d70",
+          },
+        },
+        "color-charts-teal-600": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#40bfa9",
+            "light": "#096f64",
+          },
+        },
+        "color-charts-teal-700": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#5fccb7",
+            "light": "#06645a",
+          },
+        },
+        "color-charts-teal-800": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#77d7c3",
+            "light": "#045b52",
+          },
+        },
+        "color-charts-teal-900": {
+          "$description": "Color from the 'teal' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#94e0d0",
+            "light": "#03524a",
+          },
+        },
+        "color-charts-threshold-info": {
+          "$description": "The color to represent an informational threshold to highlight special circumstances that may have or will occur. For example: A forecasted estimate",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-charts-threshold-negative": {
+          "$description": "The color to represent a threshold with a negative outcome. For example: A maximum limit",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
+          },
+        },
+        "color-charts-threshold-neutral": {
+          "$description": "The color to represent a threshold with a neutral outcome. For example: An average or baseline",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
+        "color-charts-threshold-positive": {
+          "$description": "The color to represent a threshold with a positive outcome. For example: A designated pass rate",
+          "$value": {
+            "dark": "#6aaf35",
+            "light": "#1d8102",
+          },
+        },
+        "color-charts-yellow-1000": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 10:1",
+          "$value": {
+            "dark": "#f7db8a",
+            "light": "#553f03",
+          },
+        },
+        "color-charts-yellow-1100": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 11:1",
+          "$value": {
+            "dark": "#fce5a8",
+            "light": "#4d3901",
+          },
+        },
+        "color-charts-yellow-1200": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 12:1",
+          "$value": {
+            "dark": "#ffefc9",
+            "light": "#483300",
+          },
+        },
+        "color-charts-yellow-300": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 3:1",
+          "$value": {
+            "dark": "#977001",
+            "light": "#b2911c",
+          },
+        },
+        "color-charts-yellow-400": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 4:1",
+          "$value": {
+            "dark": "#b08400",
+            "light": "#9c7b0b",
+          },
+        },
+        "color-charts-yellow-500": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 5:1",
+          "$value": {
+            "dark": "#c59600",
+            "light": "#8a6b05",
+          },
+        },
+        "color-charts-yellow-600": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 6:1",
+          "$value": {
+            "dark": "#d3a61c",
+            "light": "#7b5f04",
+          },
+        },
+        "color-charts-yellow-700": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 7:1",
+          "$value": {
+            "dark": "#dfb52c",
+            "light": "#6f5504",
+          },
+        },
+        "color-charts-yellow-800": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 8:1",
+          "$value": {
+            "dark": "#eac33a",
+            "light": "#654d03",
+          },
+        },
+        "color-charts-yellow-900": {
+          "$description": "Color from the 'yellow' data visualization palette at a contrast ratio of 9:1",
+          "$value": {
+            "dark": "#f1cf65",
+            "light": "#5d4503",
+          },
+        },
+        "color-drag-placeholder-active": {
+          "$description": "The color of drag placeholder in active state.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-drag-placeholder-hover": {
+          "$description": "The color of drag placeholder in hovered state.",
+          "$value": {
+            "dark": "#0073bb",
+            "light": "#99cbe4",
+          },
+        },
+        "color-foreground-control-default": {
+          "$description": "The color used to mark enabled form controls. For example: the checkmark on checkboxes, inner circle on radio buttons, and handle on toggles.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#ffffff",
+          },
+        },
+        "color-foreground-control-disabled": {
+          "$description": "The color used to mark disabled form controls. For example: the checkmark on checkboxes, inner circle on radio buttons, and handle on toggles.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#ffffff",
+          },
+        },
+        "color-foreground-control-read-only": {
+          "$description": "The color used to mark readonly form controls. For example: the checkmark on checkboxes, inner circle on radio buttons, and handle on toggles.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
+        "color-text-accent": {
+          "$description": "The accent color used to guide a user. *For example: the highlighted page in the side navigation and active tab text.*",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-avatar": {
+          "$description": "The text and icon color of avatars.",
+          "$value": {
+            "dark": "#ffffff",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-body-default": {
+          "$description": "The default color of non-heading text and body content. For example: text in a paragraph tag, table cell data, form field labels and values.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#16191f",
+          },
+        },
+        "color-text-body-secondary": {
+          "$description": "The color of text that is secondary to base text. For example: text in the navigation and tools panels.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-breadcrumb-current": {
+          "$description": "The text color that marks the breadcrumb item for the page the user is currently viewing.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#687078",
+          },
+        },
+        "color-text-breadcrumb-icon": {
+          "$description": "The color used for the icon delimiter between breadcrumb items.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#687078",
+          },
+        },
+        "color-text-button-normal-active": {
+          "$description": "The active text color of normal buttons. For example: Active text color in normal and link buttons.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-button-normal-default": {
+          "$description": "The default text color of normal buttons.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-button-normal-disabled": {
+          "$description": "The text color of normal buttons in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
+        "color-text-button-normal-hover": {
+          "$description": "The hover text color of normal buttons.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-button-primary-active": {
+          "$description": "The active text color of primary buttons.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-button-primary-default": {
+          "$description": "The default text color of primary buttons.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-button-primary-disabled": {
+          "$description": "The text color of primary buttons in disabled state.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#879596",
+          },
+        },
+        "color-text-button-primary-hover": {
+          "$description": "The hover text color of primary buttons.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-counter": {
+          "$description": "The default color for counters. For example: counters in table headers",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
+        "color-text-dropdown-item-default": {
+          "$description": "The default text color of dropdown items. For example: label and label tag text color for autosuggest, select, and multiselect.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#16191f",
+          },
+        },
+        "color-text-dropdown-item-disabled": {
+          "$description": "The text color of disabled dropdown items. For example: label, label tag, description, and tag text color of a disabled item in a select, multiselect, and autosuggest.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-text-dropdown-item-filter-match": {
+          "$description": "The color of text matching a user's query. For example: the text matching a query entered into a table filter, select, multiselect, or autosuggest.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-dropdown-item-highlighted": {
+          "$description": "The text color of hovered or selected dropdown items. *For example: selected day text color in date picker, label text color of the item on hover in a select, multiselect, and autosuggest.*",
+          "$value": {
+            "dark": "#eaeded",
+            "light": "#16191f",
+          },
+        },
+        "color-text-empty": {
+          "$description": "The color of text in non-dropdown empty states. For example: tables, card collections, and attribute editor empty state text.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#687078",
+          },
+        },
+        "color-text-form-default": {
+          "$description": "The default color of form field labels and values. For example: the label in form fields, checkboxes, radio buttons, toggles, and the value in inputs and text areas.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#16191f",
+          },
+        },
+        "color-text-form-secondary": {
+          "$description": "The color of secondary text in form fields and controls. For example: the description and constraint text in form fields, the descriptions in checkboxes, radio buttons, toggles, and any additional info in an attribute editor.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
+        "color-text-group-label": {
+          "$description": "The default color for group labels. For example: group label in dropdown part of button dropdown, select, and multiselect, and group label in table and cards' preferences content selector.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#545b64",
+          },
+        },
+        "color-text-heading-default": {
+          "$description": "The default color for headings 2-5. For example: headings in containers, form sections, forms, and app layout panels.",
+          "$value": {
+            "dark": "#eaeded",
+            "light": "#16191f",
+          },
+        },
+        "color-text-heading-secondary": {
+          "$description": "The default color for secondary heading text such as page and container descriptions. For example: descriptions in containers such as form sections, tables, and card collections, as well as form page descriptions.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-home-header-default": {
+          "$description": "The color of the home header's text, displayed on the Service's home page.",
+          "$value": {
+            "dark": "#eaeded",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-home-header-secondary": {
+          "$description": "The color of the home header's secondary text, displayed on the Service's home page.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-text-input-disabled": {
+          "$description": "The color of the text value in a disabled input. For example: text in a disabled input, autosuggest, datepicker, and the trigger of a select and multiselect.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#879596",
+          },
+        },
+        "color-text-input-placeholder": {
+          "$description": "The color of placeholder text in an input. For example: placeholder text in an input, autosuggest, datepicker, and the trigger of a select and multiselect.",
+          "$value": {
+            "dark": "#879596",
+            "light": "#687078",
+          },
+        },
+        "color-text-interactive-active": {
+          "$description": "The color of clickable elements in their active state. For example: tabs and icons.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-interactive-default": {
+          "$description": "The color of clickable elements in their default state. *For example: expandable sections, tabs, and icons.*",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-interactive-disabled": {
+          "$description": "The color of clickable elements in their disabled state. For example: disabled tabs, button text, and icons.",
+          "$value": {
+            "dark": "#687078",
+            "light": "#aab7b8",
+          },
+        },
+        "color-text-interactive-hover": {
+          "$description": "The color of clickable elements on hover. *For example: expandable sections, and icons on hover.*",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-interactive-inverted-default": {
+          "$description": "The default color of clickable elements in the flashbar. For example: The dismiss icon button in a flashbar.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#d5dbdb",
+          },
+        },
+        "color-text-interactive-inverted-hover": {
+          "$description": "The hover color of clickable elements in the flashbar. For example: The dismiss icon button in a flashbar.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#fafafa",
+          },
+        },
+        "color-text-label": {
+          "$description": "The default color for non-form labels. For example: the key in key/value pairs and card's sections labels.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#545b64",
+          },
+        },
+        "color-text-label-gen-ai": {
+          "$description": "The default color for labels indicating that content is produced by generative AI.",
+          "$value": {
+            "dark": "#bf80ff",
+            "light": "#7300e5",
+          },
+        },
+        "color-text-layout-toggle": {
+          "$description": "The default color of the app layout toggle.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-layout-toggle-active": {
+          "$description": "The color of the app layout toggle button when it's active.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-layout-toggle-hover": {
+          "$description": "The color of the app layout toggle button on hover.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-layout-toggle-selected": {
+          "$description": "The color of the app layout toggle button when it's selected.",
+          "$value": {
+            "dark": "#16191f",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-link-default": {
+          "$description": "The default color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-link-hover": {
+          "$description": "The hover color for links. For example: text in an anchor tag, info links, breadcrumb links, and icon links.",
+          "$value": {
+            "dark": "#99cbe4",
+            "light": "#0a4a74",
+          },
+        },
+        "color-text-notification-default": {
+          "$description": "Default text color for notifications. For example: the text on badges and flashes.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#fafafa",
+          },
+        },
+        "color-text-segment-active": {
+          "$description": "The text color of the active segment in a segmented control.",
+          "$value": {
+            "dark": "#1a2029",
+            "light": "#ffffff",
+          },
+        },
+        "color-text-segment-default": {
+          "$description": "The text color of inactive segments in a segmented control.",
+          "$value": {
+            "dark": "#d5dbdb",
+            "light": "#545b64",
+          },
+        },
+        "color-text-segment-hover": {
+          "$description": "The text color of inactive segments in a segmented control on hover.",
+          "$value": {
+            "dark": "#00a1c9",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-status-error": {
+          "$description": "The color of error text and icons. For example: form field error text and error status indicators.",
+          "$value": {
+            "dark": "#ff5d64",
+            "light": "#d13212",
+          },
+        },
+        "color-text-status-inactive": {
+          "$description": "The color of inactive and loading text and icons. For example: table and card collection loading states icon and text and inactive and pending status indicators.",
+          "$value": {
+            "dark": "#95a5a6",
+            "light": "#687078",
+          },
+        },
+        "color-text-status-info": {
+          "$description": "The color of info text and icons. For example: info status indicators and info alert icon.",
+          "$value": {
+            "dark": "#44b9d6",
+            "light": "#0073bb",
+          },
+        },
+        "color-text-status-success": {
+          "$description": "The color of success text and icons. For example: success status indicators and success alert icon.",
+          "$value": {
+            "dark": "#6aaf35",
+            "light": "#1d8102",
+          },
+        },
+        "color-text-status-warning": {
+          "$description": "The color of warning icons.",
+          "$value": {
+            "dark": "#fbd332",
+            "light": "#906806",
+          },
+        },
+        "color-text-toggle-button-icon-pressed": {
+          "$description": "The pressed text color of icon toggle buttons.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-toggle-button-normal-pressed": {
+          "$description": "The pressed text color of normal toggle buttons.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "color-text-top-navigation-title": {
+          "$description": "The color of the title in the top navigation.",
+          "$value": {
+            "dark": "#fafafa",
+            "light": "#16191f",
+          },
+        },
+        "font-family-base": {
+          "$description": "The default font family that will be applied globally to the product interface.",
+          "$value": "'Noto Sans', 'Helvetica Neue', Roboto, Arial, sans-serif",
+        },
+        "font-family-monospace": {
+          "$description": "The monospace font family that will be applied globally to the product interface.",
+          "$value": "Monaco, Menlo, Consolas, 'Courier Prime', Courier, 'Courier New', monospace",
+        },
+        "font-size-body-m": {
+          "$description": "The default font size for regular body text. For example, <p> tags in text content, or button text.",
+          "$value": "14px",
+        },
+        "font-size-body-s": {
+          "$description": "The default font size for small body text. For example, form field descriptions, or badge text.",
+          "$value": "12px",
+        },
+        "font-size-display-l": {
+          "$description": "The default font size for large display text.",
+          "$value": "44px",
+        },
+        "font-size-heading-l": {
+          "$description": "The default font size for h2s.",
+          "$value": "18px",
+        },
+        "font-size-heading-m": {
+          "$description": "The default font size for h3s.",
+          "$value": "18px",
+        },
+        "font-size-heading-s": {
+          "$description": "The default font size for h4s.",
+          "$value": "16px",
+        },
+        "font-size-heading-xl": {
+          "$description": "The default font size for h1s.",
+          "$value": "28px",
+        },
+        "font-size-heading-xs": {
+          "$description": "The default font size for h5s.",
+          "$value": "16px",
+        },
+        "font-weight-heading-l": {
+          "$description": "The default font weight for h2s.",
+          "$value": "700",
+        },
+        "font-weight-heading-m": {
+          "$description": "The default font weight for h3s.",
+          "$value": "400",
+        },
+        "font-weight-heading-s": {
+          "$description": "The default font weight for h4s.",
+          "$value": "700",
+        },
+        "font-weight-heading-xl": {
+          "$description": "The default font weight for h1s.",
+          "$value": "400",
+        },
+        "font-weight-heading-xs": {
+          "$description": "The default font weight for h5s.",
+          "$value": "400",
+        },
+        "line-height-body-m": {
+          "$description": "The default line height for regular body text.",
+          "$value": "22px",
+        },
+        "line-height-body-s": {
+          "$description": "The default line height for small body text.",
+          "$value": "16px",
+        },
+        "line-height-display-l": {
+          "$description": "The default line height for large display text.",
+          "$value": "56px",
+        },
+        "line-height-heading-l": {
+          "$description": "The default line height for h2s.",
+          "$value": "22px",
+        },
+        "line-height-heading-m": {
+          "$description": "The default line height for h3s.",
+          "$value": "22px",
+        },
+        "line-height-heading-s": {
+          "$description": "The default line height for h4s.",
+          "$value": "20px",
+        },
+        "line-height-heading-xl": {
+          "$description": "The default line height for h1s.",
+          "$value": "36px",
+        },
+        "line-height-heading-xs": {
+          "$description": "The default line height for h5s.",
+          "$value": "20px",
+        },
+        "motion-duration-avatar-gen-ai-gradient": {
+          "$description": "The duration for gradient motion of gen-ai avatars.",
+          "$value": {
+            "default": "3600ms",
+            "disabled": "0ms",
+          },
+        },
+        "motion-duration-avatar-loading-dots": {
+          "$description": "The duration for loading motion of avatars.",
+          "$value": {
+            "default": "1200ms",
+            "disabled": "0ms",
+          },
+        },
+        "motion-duration-complex": {
+          "$description": "The duration for drawing more attention or accommodating for more complexity.",
+          "$value": {
+            "default": "270ms",
+            "disabled": "0ms",
+          },
+        },
+        "motion-duration-expressive": {
+          "$description": "The duration for accommodating the motion with more expressiveness.",
+          "$value": {
+            "default": "180ms",
+            "disabled": "0ms",
+          },
+        },
+        "motion-duration-responsive": {
+          "$description": "The duration for making the motion feel quick and responsive.",
+          "$value": {
+            "default": "135ms",
+            "disabled": "0ms",
+          },
+        },
+        "motion-easing-avatar-gen-ai-gradient": {
+          "$description": "The easing curve for gradient motion of gen-ai avatars.",
+          "$value": {
+            "default": "cubic-bezier(0.7, 0, 0.3, 1)",
+            "disabled": "cubic-bezier(0.7, 0, 0.3, 1)",
+          },
+        },
+        "motion-easing-expressive": {
+          "$description": "The easing curve for drawing a user's attention in an expressive way.",
+          "$value": {
+            "default": "ease-out",
+            "disabled": "ease-out",
+          },
+        },
+        "motion-easing-responsive": {
+          "$description": "The easing curve for providing responsive yet smooth visual feedback.",
+          "$value": {
+            "default": "ease-out",
+            "disabled": "ease-out",
+          },
+        },
+        "motion-easing-sticky": {
+          "$description": "The easing curve for making an element sticky to a certain state.",
+          "$value": {
+            "default": "ease-out",
+            "disabled": "ease-out",
+          },
+        },
+        "motion-keyframes-fade-in": {
+          "$description": "The CSS keyframes for showing an element.",
+          "$value": {
+            "default": "awsui-fade-in-35003c",
+            "disabled": "awsui-fade-in-35003c",
+          },
+        },
+        "motion-keyframes-fade-out": {
+          "$description": "The CSS keyframes for hiding an element.",
+          "$value": {
+            "default": "awsui-fade-out-35003c",
+            "disabled": "awsui-fade-out-35003c",
+          },
+        },
+        "motion-keyframes-scale-popup": {
+          "$description": "The CSS keyframes for scaling up an element to draw the user's attention.",
+          "$value": {
+            "default": "awsui-none-35003c",
+            "disabled": "awsui-none-35003c",
+          },
+        },
+        "motion-keyframes-status-icon-error": {
+          "$description": "The CSS keyframes applied to an error status icon to draw the user's attention.",
+          "$value": {
+            "default": "awsui-none-35003c",
+            "disabled": "awsui-none-35003c",
+          },
+        },
+        "shadow-container-active": {
+          "$description": "Shadow for containers and cards in active state.",
+          "$value": {
+            "dark": "0px 4px 8px rgba(0, 28, 36, 0.45)",
+            "light": "0px 4px 8px rgba(0, 28, 36, 0.45)",
+          },
+        },
+        "space-container-horizontal": {
+          "$description": "The horizontal padding inside a container.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-field-horizontal": {
+          "$description": "The horizontal padding inside field components.",
+          "$value": {
+            "comfortable": "8px",
+            "compact": "8px",
+          },
+        },
+        "space-scaled-l": {
+          "$description": "The L spacing unit which scales between modes. For example: vertical space between form fields.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "16px",
+          },
+        },
+        "space-scaled-m": {
+          "$description": "The M spacing unit which scales between modes. For example: top padding of content inside a container",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "12px",
+          },
+        },
+        "space-scaled-s": {
+          "$description": "The S spacing unit which scales between modes. For example: vertical padding inside a popover.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "8px",
+          },
+        },
+        "space-scaled-xl": {
+          "$description": "The XL spacing unit which scales between modes. For example: horizontal space between wizard navigation and content.",
+          "$value": {
+            "comfortable": "24px",
+            "compact": "20px",
+          },
+        },
+        "space-scaled-xs": {
+          "$description": "The XS spacing unit which scales between modes. For example: horizontal space between buttons in an action stripe.",
+          "$value": {
+            "comfortable": "8px",
+            "compact": "4px",
+          },
+        },
+        "space-scaled-xxl": {
+          "$description": "The XXL spacing unit which scales between modes. For example: horizontal padding for side navigation and help panel content.",
+          "$value": {
+            "comfortable": "32px",
+            "compact": "24px",
+          },
+        },
+        "space-scaled-xxs": {
+          "$description": "The XXS spacing unit which scales between modes. For example: vertical space between form field label and control.",
+          "$value": {
+            "comfortable": "4px",
+            "compact": "2px",
+          },
+        },
+        "space-scaled-xxxl": {
+          "$description": "The XXXL spacing unit which scales between modes. For example: horizontal padding for app layout and split panel content on large screens.",
+          "$value": {
+            "comfortable": "40px",
+            "compact": "32px",
+          },
+        },
+        "space-scaled-xxxs": {
+          "$description": "The XXXS spacing unit which scales between modes.",
+          "$value": {
+            "comfortable": "2px",
+            "compact": "0px",
+          },
+        },
+        "space-static-l": {
+          "$description": "The static L spacing unit.",
+          "$value": {
+            "comfortable": "20px",
+            "compact": "20px",
+          },
+        },
+        "space-static-m": {
+          "$description": "The static M spacing unit.",
+          "$value": {
+            "comfortable": "16px",
+            "compact": "16px",
+          },
+        },
+        "space-static-s": {
+          "$description": "The static S spacing unit.",
+          "$value": {
+            "comfortable": "12px",
+            "compact": "12px",
+          },
+        },
+        "space-static-xl": {
+          "$description": "The static XL spacing unit.",
+          "$value": {
+            "comfortable": "24px",
+            "compact": "24px",
+          },
+        },
+        "space-static-xs": {
+          "$description": "The static XS spacing unit.",
+          "$value": {
+            "comfortable": "8px",
+            "compact": "8px",
+          },
+        },
+        "space-static-xxl": {
+          "$description": "The static XXL spacing unit.",
+          "$value": {
+            "comfortable": "32px",
+            "compact": "32px",
+          },
+        },
+        "space-static-xxs": {
+          "$description": "The static XXS spacing unit.",
+          "$value": {
+            "comfortable": "4px",
+            "compact": "4px",
+          },
+        },
+        "space-static-xxxl": {
+          "$description": "The static XXXL spacing unit.",
+          "$value": {
+            "comfortable": "40px",
+            "compact": "40px",
+          },
+        },
+        "space-static-xxxs": {
+          "$description": "The static XXXS spacing unit.",
+          "$value": {
+            "comfortable": "2px",
+            "compact": "2px",
+          },
+        },
+      },
+    },
     "compact-table": {
       "tokens": {
         "border-radius-alert": {

--- a/src/app-layout/drawer/index.tsx
+++ b/src/app-layout/drawer/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useContainerQuery } from '@cloudscape-design/component-toolkit';
 import { useDensityMode } from '@cloudscape-design/component-toolkit/internal';
 
+import { getVisualContextClassname } from '../../internal/components/visual-context';
 import { AppLayoutProps } from '../interfaces';
 import { CloseButton, ToggleButton, togglesConfig } from '../toggles';
 import { TOOLS_DRAWER_ID } from '../utils/use-drawers';
@@ -165,7 +166,14 @@ const DrawerTrigger = React.forwardRef(
     }: DrawerTriggerProps,
     ref: React.Ref<{ focus: () => void }>
   ) => (
-    <div className={clsx(styles['drawer-trigger'], isActive && styles['drawer-trigger-active'])} onClick={onClick}>
+    <div
+      className={clsx(
+        styles['drawer-trigger'],
+        isActive && styles['drawer-trigger-active'],
+        isActive && getVisualContextClassname('app-layout-tools-drawer-trigger')
+      )}
+      onClick={onClick}
+    >
       <ToggleButton
         ref={ref}
         className={testUtilsClassName}

--- a/style-dictionary/classic/contexts/tools-drawer-trigger.ts
+++ b/style-dictionary/classic/contexts/tools-drawer-trigger.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import merge from 'lodash/merge';
+
+import { expandColorDictionary } from '../../utils';
+import { StyleDictionary } from '../../utils/interfaces';
+import { tokens as parentTokens } from '../colors';
+
+const appLayoutToolsDrawerTriggerFocusedButton: StyleDictionary.ColorsDictionary = {
+  colorBorderItemFocused: {
+    light: '{colorGrey100}',
+    dark: '{colorGrey700}',
+  },
+};
+
+const expandedTokens: StyleDictionary.ExpandedColorScopeDictionary = expandColorDictionary(
+  merge({}, parentTokens, appLayoutToolsDrawerTriggerFocusedButton)
+);
+
+export { expandedTokens as tokens };

--- a/style-dictionary/classic/index.ts
+++ b/style-dictionary/classic/index.ts
@@ -4,6 +4,7 @@ import { ThemeBuilder } from '@cloudscape-design/theming-build';
 
 import {
   createAlertContext,
+  createAppLayoutToolsDrawerTriggerContext,
   createCompactTableContext,
   createFlashbarContext,
   createFlashbarWarningContext,
@@ -46,6 +47,8 @@ export function buildClassicOpenSource(builder: ThemeBuilder) {
   builder.addContext(createFlashbarWarningContext(require('./contexts/flashbar-warning').tokens));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   builder.addContext(createAlertContext(require('./contexts/alert').tokens));
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  builder.addContext(createAppLayoutToolsDrawerTriggerContext(require('./contexts/tools-drawer-trigger').tokens));
 
   return builder.build();
 }

--- a/style-dictionary/utils/contexts.ts
+++ b/style-dictionary/utils/contexts.ts
@@ -49,3 +49,11 @@ export const createAlertContext = (tokens: TokenCategory<string, GlobalValue | M
     tokens,
   };
 };
+
+export const createAppLayoutToolsDrawerTriggerContext = (tokens: TokenCategory<string, GlobalValue | ModeValue>) => {
+  return {
+    id: 'app-layout-tools-drawer-trigger',
+    selector: '.awsui-context-app-layout-tools-drawer-trigger',
+    tokens,
+  };
+};


### PR DESCRIPTION
### Description

Adjust color contrast for the active runtime drawer trigger buttons.
The color contrast (Button background color vs focus ring color) changed:
- light mode:
  -  1:1 before this change
  -  4.82:1 after this change

Before/after this change:

|<img width="208" alt="pr-2708-before-light" src="https://github.com/user-attachments/assets/21b57896-f1fb-4817-96fe-4b5ffccf066a">   |<img width="208" alt="pr-2708-after-light" src="https://github.com/user-attachments/assets/a2de6d96-2882-49a7-ae9d-d74be2dc7a1e">   |
|---|---|


- dark mode: 
  -  1.31:1 before this change
  -  5.95:1 after this change

Before/after this change:

|<img width="208" alt="pr-2708-before-dark" src="https://github.com/user-attachments/assets/9c6c5ef7-79cc-4553-8b78-d03bec891d94">   |<img width="208" alt="pr-2708-after-dark" src="https://github.com/user-attachments/assets/500b23db-9ac4-4c07-a094-8280f0022206">   |
|---|---|




Related links, issue #, if available: AWSUI-58442

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
