### PR TITLE
test: Enable partial toolbar unit tests

### DIFF
--- a/src/app-layout/__tests__/common.test.tsx
+++ b/src/app-layout/__tests__/common.test.tsx
@@ -3,7 +3,14 @@
 /* eslint simple-import-sort/imports: 0 */
 import React from 'react';
 import { AppLayoutWrapper } from '../../../lib/components/test-utils/dom';
-import { describeEachAppLayout, isDrawerClosed, renderComponent, testDrawer, testDrawerWithoutLabels } from './utils';
+import {
+  describeEachAppLayout,
+  isDrawerClosed,
+  renderComponent,
+  testDrawer,
+  testDrawerWithoutLabels,
+  testIf,
+} from './utils';
 import AppLayout from '../../../lib/components/app-layout';
 
 jest.mock('@cloudscape-design/component-toolkit', () => ({
@@ -11,8 +18,9 @@ jest.mock('@cloudscape-design/component-toolkit', () => ({
   useContainerQuery: () => [100, () => {}],
 }));
 
-describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
-  test('Default state', () => {
+describeEachAppLayout(({ size, theme }) => {
+  // TODO[Toolbar]: Ensure tools are rendered in the dom by default
+  testIf(theme !== 'refresh-toolbar')('Default state', () => {
     const { wrapper } = renderComponent(<AppLayout />);
 
     expect(wrapper.findNavigationToggle()).toBeTruthy();
@@ -43,7 +51,7 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
       openProp: 'navigationOpen',
       hideProp: 'navigationHide',
       handler: 'onNavigationChange',
-      expectedCallsOnMobileToggle: 2,
+      expectedCallsOnMobileToggle: theme === 'refresh-toolbar' ? 1 : 2,
       findLandmarks: (wrapper: AppLayoutWrapper) => wrapper.findAll('nav'),
       findElement: (wrapper: AppLayoutWrapper) => wrapper.findNavigation(),
       findToggle: (wrapper: AppLayoutWrapper) => wrapper.findNavigationToggle(),
@@ -111,7 +119,8 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
           expect(onToggle).toHaveBeenLastCalledWith(expect.objectContaining({ detail: { open: false } }));
         });
 
-        test('Renders two landmarks in closed state', () => {
+        // TODO[Toolbar]: Ensure tools are rendered in the dom by default
+        testIf(theme !== 'refresh-toolbar')('Renders two landmarks in closed state', () => {
           const props = {
             [openProp]: false,
             [handler]: () => {},
@@ -131,8 +140,8 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'true');
           }
         });
-
-        test('Renders two landmarks in open state', () => {
+        // TODO[Toolbar]: Ensure tools are rendered in the dom by default
+        testIf(theme !== 'refresh-toolbar')('Renders two landmarks in open state', () => {
           const props = {
             [openProp]: true,
             [handler]: () => {},
@@ -142,7 +151,17 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
           expect(landmarks).toHaveLength(2);
           const toggleElement = findToggle(wrapper).getElement();
 
-          if (landmarks[0].getElement().contains(toggleElement)) {
+          // Toolbar toggles remain visible regardless of panel state
+          if (theme === 'refresh-toolbar') {
+            if (landmarks[0].getElement().contains(toggleElement)) {
+              expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'false');
+              expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'false');
+            } else {
+              expect(landmarks[1].getElement()).toContainElement(toggleElement);
+              expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'false');
+              expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'false');
+            }
+          } else if (landmarks[0].getElement().contains(toggleElement)) {
             expect(landmarks[0].getElement()).toHaveAttribute('aria-hidden', 'true');
             expect(landmarks[1].getElement()).toHaveAttribute('aria-hidden', 'false');
           } else {
@@ -152,7 +171,8 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
           }
         });
 
-        test('Renders aria-expanded only on toggle', () => {
+        // TODO[Toolbar]: Ensure tools are rendered in the dom by default
+        testIf(theme !== 'refresh-toolbar')('Renders aria-expanded only on toggle', () => {
           const props = {
             [openProp]: false,
             [handler]: () => {},
@@ -202,7 +222,8 @@ describeEachAppLayout({ themes: ['classic', 'refresh'] }, ({ size }) => {
           expect(findClose(wrapper).getElement()).not.toHaveAttribute('aria-label');
         });
 
-        test('Opens and closes drawer in uncontrolled mode', () => {
+        // TODO[Toolbar]: Ensure tools are rendered in the dom by default
+        testIf(theme !== 'refresh-toolbar')('Opens and closes drawer in uncontrolled mode', () => {
           // use content type with initial closed state for all drawers
           const { wrapper } = renderComponent(<AppLayout contentType="form" />);
           expect(isDrawerClosed(findElement(wrapper))).toBe(true);

--- a/src/app-layout/__tests__/utils.tsx
+++ b/src/app-layout/__tests__/utils.tsx
@@ -44,6 +44,8 @@ export function renderComponent(jsx: React.ReactElement) {
   return { wrapper, rerender, isUsingGridLayout, container };
 }
 
+export const testIf = (condition: boolean) => (condition ? test : test.skip);
+
 type Theme = 'refresh' | 'refresh-toolbar' | 'classic';
 type Size = 'desktop' | 'mobile';
 

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -73,6 +73,7 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     const [notificationsHeight, setNotificationsHeight] = useState(0);
 
     const onNavigationToggle = (open: boolean) => {
+      navigationFocusControl.setFocus();
       fireNonCancelableEvent(onNavigationChange, { open });
     };
 

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -87,13 +87,12 @@ export function DrawerTriggers({
   return (
     <aside
       className={styles['drawers-desktop-triggers-container']}
-      aria-label={ariaLabels?.drawers}
+      aria-label={toolsOnlyMode ? ariaLabels?.tools : ariaLabels?.drawers}
       ref={triggersContainerRef}
       role="region"
     >
       <div
         className={clsx(styles['drawers-trigger-content'], {
-          [styles['has-multiple-triggers']]: hasMultipleTriggers,
           [styles['has-open-drawer']]: activeDrawerId,
         })}
         role="toolbar"

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -154,7 +154,11 @@ export function AppLayoutToolbarImplementation({
     >
       <div className={styles['toolbar-container']}>
         {hasNavigation && (
-          <nav className={clsx(styles['universal-toolbar-nav'], testutilStyles['drawer-closed'])}>
+          <nav
+            aria-hidden={false}
+            aria-label={ariaLabels?.navigation ?? undefined}
+            className={clsx(styles['universal-toolbar-nav'], !navigationOpen && testutilStyles['drawer-closed'])}
+          >
             <TriggerButton
               ariaLabel={ariaLabels?.navigationToggle ?? undefined}
               ariaExpanded={false}


### PR DESCRIPTION
### Description

Enables toolbar unit tests for `common.tsx`
- Fixes focus delegation for navigation
- Adds missing aria-labels 

Skipped tests that rely on tools being present in the DOM even when they are closed. This update has a wider blast radius and thus, should be addressed in it's own PR. The current toolbar implementation treats tools as if they were a drawer, and while drawers don't rely on being present in the dom, we need to ensure backwards compatibility of `findTools()` test util.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
