### PR TITLE
fix: Remove user-select text style from property filter editor

### DIFF
--- a/src/property-filter/styles.scss
+++ b/src/property-filter/styles.scss
@@ -40,7 +40,6 @@ $operator-field-width: 120px;
 }
 
 .property-editor {
-  user-select: text;
   margin-block: awsui.$space-xxs;
   margin-inline: awsui.$space-xxs;
   padding-block: awsui.$space-m;
@@ -83,7 +82,6 @@ $operator-field-width: 120px;
   display: flex;
   flex-direction: column;
   gap: awsui.$space-s;
-  user-select: text;
   margin-block: awsui.$space-xxs;
   margin-inline: awsui.$space-xxs;
 


### PR DESCRIPTION
### Description

Removing user-select: text style from property filter editor that makes cursor look different when hovering above property and operator selects. There is seemingly no value in keeping the style.

Resolves feedback from [HJhfABYOa8OE]

### How has this been tested?

* Manual tests with custom forms

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
