### PR TITLE
fix: Property filter keeps dropdown closed on autofocus

### DIFF
--- a/src/file-upload/internal.tsx
+++ b/src/file-upload/internal.tsx
@@ -57,13 +57,15 @@ function InternalFileUpload(
   externalRef: ForwardedRef<ButtonProps.Ref>
 ) {
   const [nextFocusIndex, setNextFocusIndex] = useState<null | number>(null);
-  const onFocusMoved = () => setNextFocusIndex(null);
   const tokenListRef = useListFocusController({
     nextFocusIndex,
-    onFocusMoved,
+    onFocusMoved: target => {
+      target.focus();
+      setNextFocusIndex(null);
+    },
     listItemSelector: `.${tokenListStyles['list-item']}`,
     showMoreSelector: `.${tokenListStyles.toggle}`,
-    outsideSelector: `.${fileInputStyles['upload-input']}`,
+    fallbackSelector: `.${fileInputStyles['upload-input']}`,
   });
 
   const baseProps = getBaseProps(restProps);

--- a/src/property-filter/__tests__/property-filter-token-list.test.tsx
+++ b/src/property-filter/__tests__/property-filter-token-list.test.tsx
@@ -188,6 +188,7 @@ describe('filtering tokens', () => {
       });
       act(() => wrapper.findTokens()![0].findRemoveButton()!.click());
       expect(wrapper.findNativeInput().getElement()).toHaveFocus();
+      expect(wrapper.findDropdown().findOpenDropdown()).toBe(null);
     });
 
     test('has a label from i18nStrings', () => {

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -85,12 +85,14 @@ const FilteringToken = forwardRef(
     ref: React.Ref<FilteringTokenRef>
   ) => {
     const [nextFocusIndex, setNextFocusIndex] = useState<null | number>(null);
-    const onFocusMoved = () => setNextFocusIndex(null);
     const tokenListRef = useListFocusController({
       nextFocusIndex,
-      onFocusMoved,
+      onFocusMoved: target => {
+        target.focus();
+        setNextFocusIndex(null);
+      },
       listItemSelector: `.${styles['inner-root']}`,
-      outsideSelector: `.${styles.root}`,
+      fallbackSelector: `.${styles.root}`,
     });
 
     const popoverRef = useRef<InternalPopoverRef>(null);

--- a/src/property-filter/internal.tsx
+++ b/src/property-filter/internal.tsx
@@ -96,13 +96,19 @@ const PropertyFilterInternal = React.forwardRef(
     ref: React.Ref<Ref>
   ) => {
     const [nextFocusIndex, setNextFocusIndex] = useState<null | number>(null);
-    const onFocusMoved = () => setNextFocusIndex(null);
     const tokenListRef = useListFocusController({
       nextFocusIndex,
-      onFocusMoved,
+      onFocusMoved: (target, targetType) => {
+        if (targetType === 'fallback') {
+          inputRef.current?.focus({ preventDropdown: true });
+        } else {
+          target.focus();
+        }
+        setNextFocusIndex(null);
+      },
       listItemSelector: `.${tokenListStyles['list-item']}`,
       showMoreSelector: `.${tokenListStyles.toggle}`,
-      outsideSelector: `.${styles.input}`,
+      fallbackSelector: `.${styles.input}`,
     });
 
     const mergedRef = useMergeRefs(tokenListRef, __internalRootRef);

--- a/src/property-filter/token-editor.tsx
+++ b/src/property-filter/token-editor.tsx
@@ -74,12 +74,14 @@ export function TokenEditor({
   onChangeTempGroup,
 }: TokenEditorProps) {
   const [nextFocusIndex, setNextFocusIndex] = useState<null | number>(null);
-  const onFocusMoved = () => setNextFocusIndex(null);
   const tokenListRef = useListFocusController({
     nextFocusIndex,
-    onFocusMoved,
+    onFocusMoved: target => {
+      target.focus();
+      setNextFocusIndex(null);
+    },
     listItemSelector: `.${styles['token-editor-field-property']}`,
-    outsideSelector: `.${styles['token-editor-add-token']}`,
+    fallbackSelector: `.${styles['token-editor-add-token']}`,
   });
 
   const groups = tempGroup.map((temporaryToken, index) => {

--- a/src/token-group/internal.tsx
+++ b/src/token-group/internal.tsx
@@ -38,10 +38,12 @@ export default function InternalTokenGroup({
   checkControlled('TokenGroup', 'items', items, 'onDismiss', onDismiss);
 
   const [nextFocusIndex, setNextFocusIndex] = useState<null | number>(null);
-  const onFocusMoved = () => setNextFocusIndex(null);
   const tokenListRef = useListFocusController({
     nextFocusIndex,
-    onFocusMoved,
+    onFocusMoved: target => {
+      target.focus();
+      setNextFocusIndex(null);
+    },
     listItemSelector: `.${tokenListStyles['list-item']}`,
     showMoreSelector: `.${tokenListStyles.toggle}`,
   });


### PR DESCRIPTION
### Description

In property filter when the focus comes back to input after the last token is removed the dropdown must stay closed.

### How has this been tested?

* Enhanced existing unit test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
