### PR TITLE
experiment: Add tag diffing support

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -15558,7 +15558,9 @@ Object {
       "cancelable": false,
       "description": "Called when any tag operation occurs.
 The event \`detail\` object contains the full updated state of \`tags\`,
-and whether the component is in a \`valid\` state.",
+and whether the component is in a \`valid\` state.
+Use this event handler to track the UI state of the component only.
+",
       "detailInlineType": Object {
         "name": "TagEditorProps.ChangeDetail",
         "properties": Array [
@@ -15577,6 +15579,37 @@ and whether the component is in a \`valid\` state.",
       },
       "detailType": "TagEditorProps.ChangeDetail",
       "name": "onChange",
+    },
+    Object {
+      "cancelable": false,
+      "description": "Called when any valid tag operation occurs if the initialTags property is provided.
+The event \`detail\` object contains the newly \`created\` tags, the \`updated\` tags and the
+\`removed\` tags relative to the \`initialTags\` property.
+Use this event handler to track the state that should be submitted to the backend.
+",
+      "detailInlineType": Object {
+        "name": "TagEditorProps.ChangeDiffDetail",
+        "properties": Array [
+          Object {
+            "name": "created",
+            "optional": false,
+            "type": "ReadonlyArray<TagEditorProps.Tag>",
+          },
+          Object {
+            "name": "removed",
+            "optional": false,
+            "type": "ReadonlyArray<TagEditorProps.Tag>",
+          },
+          Object {
+            "name": "updated",
+            "optional": false,
+            "type": "ReadonlyArray<TagEditorProps.Tag>",
+          },
+        ],
+        "type": "object",
+      },
+      "detailType": "TagEditorProps.ChangeDiffDetail",
+      "name": "onChangeDiff",
     },
   ],
   "functions": Array [
@@ -15800,6 +15833,12 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "name": "id",
       "optional": true,
       "type": "string",
+    },
+    Object {
+      "description": "Specifies the initial tags to compare the current state against when the onChangeDiff event is called.",
+      "name": "initialTags",
+      "optional": true,
+      "type": "ReadonlyArray<TagEditorProps.Tag>",
     },
     Object {
       "description": "Specifies a function that returns all the keys for a resource.

--- a/src/tag-editor/interfaces.tsx
+++ b/src/tag-editor/interfaces.tsx
@@ -20,6 +20,11 @@ export interface TagEditorProps extends BaseComponentProps {
   tags?: ReadonlyArray<TagEditorProps.Tag>;
 
   /**
+   * Specifies the initial tags to compare the current state against when the onChangeDiff event is called.
+   */
+  initialTags?: ReadonlyArray<TagEditorProps.Tag>;
+
+  /**
    * An object containing all the necessary localized strings required by the component.
    * @i18n
    */
@@ -61,8 +66,19 @@ export interface TagEditorProps extends BaseComponentProps {
    * Called when any tag operation occurs.
    * The event `detail` object contains the full updated state of `tags`,
    * and whether the component is in a `valid` state.
+   *
+   * Use this event handler to track the UI state of the component only.
    */
   onChange?: NonCancelableEventHandler<TagEditorProps.ChangeDetail>;
+
+  /**
+   * Called when any valid tag operation occurs if the initialTags property is provided.
+   * The event `detail` object contains the newly `created` tags, the `updated` tags and the
+   * `removed` tags relative to the `initialTags` property.
+   *
+   * Use this event handler to track the state that should be submitted to the backend.
+   */
+  onChangeDiff?: NonCancelableEventHandler<TagEditorProps.ChangeDiffDetail>;
 }
 
 export namespace TagEditorProps {
@@ -134,6 +150,12 @@ export namespace TagEditorProps {
   export interface ChangeDetail {
     tags: ReadonlyArray<TagEditorProps.Tag>;
     valid: boolean;
+  }
+
+  export interface ChangeDiffDetail {
+    created: ReadonlyArray<TagEditorProps.Tag>;
+    updated: ReadonlyArray<TagEditorProps.Tag>;
+    removed: ReadonlyArray<TagEditorProps.Tag>;
   }
 
   export interface Ref {


### PR DESCRIPTION
### Description

Just a quick proof of concept I played around with on Friday. I actually don't love the name `onChangeDiff`, but I didn't feel like thinking of a real name: maybe `onRelativeChange` or something that refers to the value of `initialTags`.

On `initialTags`: it *should* never change after the initial `loading` state is completed. I played around with enforcing this with a state variable on our side, but didn't really commit to it, cause, like, it's obvious you're not meant to mess with it after the initial state. I think a couple of dev warnings for (1) when you change the value of `initialState` after `loading` is complete and (2) when `initialState` contains any tags that don't have `existing: true` probably wouldn't hurt either. An exercise for the reader.

Related links, issue #, if available: n/a

### How has this been tested?

Quickly wrote a few unit tests to make sure I wasn't doing anything stupid. Integ tests could probably help too.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
