### PR TITLE
chore: Infer resource type from breadcrumbs

### DIFF
--- a/src/alert/index.tsx
+++ b/src/alert/index.tsx
@@ -6,7 +6,7 @@ import { getAnalyticsMetadataAttribute } from '@cloudscape-design/component-tool
 
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytics/hooks/use-funnel';
-import { getNameFromSelector, getSubStepAllSelector } from '../internal/analytics/selectors';
+import { getSubStepAllSelector, getTextFromSelector } from '../internal/analytics/selectors';
 import { BasePropsWithAnalyticsMetadata, getAnalyticsMetadataProps } from '../internal/base-component';
 import useBaseComponent from '../internal/hooks/use-base-component';
 import { applyDisplayName } from '../internal/utils/apply-display-name';
@@ -36,8 +36,8 @@ const Alert = React.forwardRef(
 
     useEffect(() => {
       if (funnelInteractionId && visible && type === 'error' && funnelState.current !== 'complete') {
-        const stepName = getNameFromSelector(stepNameSelector);
-        const subStepName = getNameFromSelector(subStepNameSelector);
+        const stepName = getTextFromSelector(stepNameSelector);
+        const subStepName = getTextFromSelector(subStepNameSelector);
 
         errorCount.current++;
 

--- a/src/button/internal.tsx
+++ b/src/button/internal.tsx
@@ -13,8 +13,8 @@ import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytic
 import {
   DATA_ATTR_FUNNEL_VALUE,
   getFunnelValueSelector,
-  getNameFromSelector,
   getSubStepAllSelector,
+  getTextFromSelector,
 } from '../internal/analytics/selectors';
 import LiveRegion from '../internal/components/live-region';
 import Tooltip from '../internal/components/tooltip/index.js';
@@ -131,8 +131,8 @@ export const InternalButton = React.forwardRef(
         fireCancelableEvent(onFollow, { href, target }, event);
 
         if ((iconName === 'external' || target === '_blank') && funnelInteractionId) {
-          const stepName = getNameFromSelector(stepNameSelector);
-          const subStepName = getNameFromSelector(subStepNameSelector);
+          const stepName = getTextFromSelector(stepNameSelector);
+          const subStepName = getTextFromSelector(subStepNameSelector);
 
           FunnelMetrics.externalLinkInteracted({
             funnelInteractionId,

--- a/src/form-field/internal.tsx
+++ b/src/form-field/internal.tsx
@@ -15,8 +15,8 @@ import {
   DATA_ATTR_FIELD_ERROR,
   DATA_ATTR_FIELD_LABEL,
   getFieldSlotSeletor,
-  getNameFromSelector,
   getSubStepAllSelector,
+  getTextFromSelector,
 } from '../internal/analytics/selectors';
 import { getBaseProps } from '../internal/base-component';
 import LiveRegion from '../internal/components/live-region';
@@ -174,8 +174,8 @@ export default function InternalFormField({
 
   useEffect(() => {
     if (funnelInteractionId && errorText && funnelState.current !== 'complete') {
-      const stepName = getNameFromSelector(stepNameSelector);
-      const subStepName = getNameFromSelector(subStepNameSelector);
+      const stepName = getTextFromSelector(stepNameSelector);
+      const subStepName = getTextFromSelector(subStepNameSelector);
 
       errorCount.current++;
 

--- a/src/internal/analytics/__integ__/static-multi-page-create.test.ts
+++ b/src/internal/analytics/__integ__/static-multi-page-create.test.ts
@@ -54,6 +54,7 @@ describe('Multi-page create', () => {
         funnelIdentifier: FUNNEL_IDENTIFIER,
         flowType: 'create',
         funnelType: 'multi-page',
+        resourceType: 'Components',
         optionalStepNumbers: [2],
         componentTheme: 'vr',
         totalFunnelSteps: 3,

--- a/src/internal/analytics/__integ__/static-single-page-flow.test.ts
+++ b/src/internal/analytics/__integ__/static-single-page-flow.test.ts
@@ -54,6 +54,7 @@ describe('Single-page create', () => {
         funnelIdentifier: FUNNEL_IDENTIFIER,
         flowType: 'create',
         funnelType: 'single-page',
+        resourceType: 'Components',
         optionalStepNumbers: [],
         componentTheme: 'vr',
         totalFunnelSteps: 1,

--- a/src/internal/analytics/components/analytics-funnel.tsx
+++ b/src/internal/analytics/components/analytics-funnel.tsx
@@ -27,11 +27,12 @@ import {
 } from '../interfaces';
 import {
   DATA_ATTR_FUNNEL_STEP,
+  getBreadcrumbLinkSelector,
   getFunnelNameSelector,
-  getNameFromSelector,
   getSubStepAllSelector,
   getSubStepNameSelector,
   getSubStepSelector,
+  getTextFromSelector,
 } from '../selectors';
 
 export const FUNNEL_VERSION = '1.4';
@@ -146,7 +147,7 @@ const InnerAnalyticsFunnel = ({ children, stepConfiguration, ...props }: Analyti
         {
           number: 1,
           isOptional: false,
-          name: getNameFromSelector(funnelNameSelector.current) ?? '',
+          name: getTextFromSelector(funnelNameSelector.current) ?? '',
           stepIdentifier: props.funnelIdentifier,
         },
       ];
@@ -162,6 +163,7 @@ const InnerAnalyticsFunnel = ({ children, stepConfiguration, ...props }: Analyti
         componentTheme: isVisualRefresh ? 'vr' : 'classic',
         funnelVersion: FUNNEL_VERSION,
         stepConfiguration: stepConfiguration ?? singleStepFlowStepConfiguration,
+        resourceType: props.funnelResourceType || getTextFromSelector(getBreadcrumbLinkSelector(3)),
       });
 
       setFunnelInteractionId(funnelInteractionId);
@@ -390,7 +392,7 @@ const InnerAnalyticsFunnelStep = ({
       return;
     }
 
-    const stepName = getNameFromSelector(stepNameSelector);
+    const stepName = getTextFromSelector(stepNameSelector);
 
     if (funnelState.current === 'default') {
       FunnelMetrics.funnelStepStart({

--- a/src/internal/analytics/hooks/use-funnel.ts
+++ b/src/internal/analytics/hooks/use-funnel.ts
@@ -14,8 +14,8 @@ import {
 import {
   DATA_ATTR_FUNNEL_INTERACTION_ID,
   DATA_ATTR_FUNNEL_SUBSTEP,
-  getNameFromSelector,
   getSubStepAllSelector,
+  getTextFromSelector,
 } from '../selectors';
 
 /**
@@ -69,8 +69,8 @@ export const useFunnelSubStep = () => {
       */
       latestFocusCleanupFunction.current?.();
 
-      const subStepName = getNameFromSelector(subStepNameSelector);
-      const stepName = getNameFromSelector(stepNameSelector);
+      const subStepName = getTextFromSelector(subStepNameSelector);
+      const stepName = getTextFromSelector(stepNameSelector);
       const subStepNumber = subStepConfiguration.current
         ?.get(stepNumber)
         ?.find(step => step.name === subStepName)?.number;

--- a/src/internal/analytics/interfaces.ts
+++ b/src/internal/analytics/interfaces.ts
@@ -23,6 +23,7 @@ export interface FunnelErrorProps extends BaseFunnelProps {
 
 export interface FunnelStartProps extends Omit<BaseFunnelProps, 'funnelInteractionId'> {
   flowType?: FlowType;
+  resourceType?: string;
   funnelNameSelector: string;
   totalFunnelSteps: number;
   optionalStepNumbers: number[];

--- a/src/internal/analytics/selectors.ts
+++ b/src/internal/analytics/selectors.ts
@@ -1,5 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import breadcrumbGroupItemStyles from '../../breadcrumb-group/item/styles.css.js';
+import breadcrumbGroupStyles from '../../breadcrumb-group/styles.css.js';
+
+export const getBreadcrumbLinkSelector = (index: number) =>
+  `.${breadcrumbGroupStyles['breadcrumb-group']} .${breadcrumbGroupStyles.item}:nth-child(${index}) .${breadcrumbGroupItemStyles.anchor}`;
+
 export const DATA_ATTR_FUNNEL = 'data-analytics-funnel';
 export const DATA_ATTR_FUNNEL_INTERACTION_ID = `${DATA_ATTR_FUNNEL}-interaction-id`;
 export const DATA_ATTR_FUNNEL_KEY = `${DATA_ATTR_FUNNEL}-key`;
@@ -28,5 +34,5 @@ export const getSubStepNameSelector = (subStepId?: string) =>
 
 export const getFieldSlotSeletor = (id: string | undefined) => (id ? `[id="${id}"]` : undefined);
 
-export const getNameFromSelector = (selector: string | undefined): string | undefined =>
+export const getTextFromSelector = (selector: string | undefined): string | undefined =>
   selector ? document.querySelector<HTMLElement>(selector)?.innerText?.trim() : undefined;

--- a/src/link/internal.tsx
+++ b/src/link/internal.tsx
@@ -10,8 +10,8 @@ import { useFunnel, useFunnelStep, useFunnelSubStep } from '../internal/analytic
 import {
   DATA_ATTR_FUNNEL_VALUE,
   getFunnelValueSelector,
-  getNameFromSelector,
   getSubStepAllSelector,
+  getTextFromSelector,
 } from '../internal/analytics/selectors';
 import { getBaseProps } from '../internal/base-component';
 import { InfoLinkLabelContext } from '../internal/context/info-link-label-context';
@@ -77,8 +77,8 @@ const InternalLink = React.forwardRef(
 
     const fireFunnelEvent = (funnelInteractionId: string) => {
       if (variant === 'info') {
-        const stepName = getNameFromSelector(stepNameSelector);
-        const subStepName = getNameFromSelector(subStepNameSelector);
+        const stepName = getTextFromSelector(stepNameSelector);
+        const subStepName = getTextFromSelector(subStepNameSelector);
 
         FunnelMetrics.helpPanelInteracted({
           funnelIdentifier,
@@ -95,8 +95,8 @@ const InternalLink = React.forwardRef(
           subStepAllSelector: getSubStepAllSelector(),
         });
       } else if (external) {
-        const stepName = getNameFromSelector(stepNameSelector);
-        const subStepName = getNameFromSelector(subStepNameSelector);
+        const stepName = getTextFromSelector(stepNameSelector);
+        const subStepName = getTextFromSelector(subStepNameSelector);
 
         FunnelMetrics.externalLinkInteracted({
           funnelIdentifier,

--- a/src/wizard/internal.tsx
+++ b/src/wizard/internal.tsx
@@ -8,7 +8,7 @@ import { warnOnce } from '@cloudscape-design/component-toolkit/internal';
 import { useInternalI18n } from '../i18n/context';
 import { FunnelMetrics } from '../internal/analytics';
 import { useFunnel } from '../internal/analytics/hooks/use-funnel';
-import { getNameFromSelector, getSubStepAllSelector } from '../internal/analytics/selectors';
+import { getSubStepAllSelector, getTextFromSelector } from '../internal/analytics/selectors';
 import { getBaseProps } from '../internal/base-component';
 import { fireNonCancelableEvent } from '../internal/events';
 import { useContainerBreakpoints } from '../internal/hooks/container-queries';
@@ -62,7 +62,7 @@ export default function InternalWizard({
 
   const navigationEvent = (requestedStepIndex: number, reason: WizardProps.NavigationReason) => {
     if (funnelInteractionId) {
-      const stepName = getNameFromSelector(STEP_NAME_SELECTOR);
+      const stepName = getTextFromSelector(STEP_NAME_SELECTOR);
 
       FunnelMetrics.funnelStepNavigation({
         navigationType: reason,


### PR DESCRIPTION
### Description
As part of the resource creation funnel we can infer the type of resource from the breadcrumb. Based on our initial investigation this is always the second breadcrumb item. This value is then sent along with the funnelStart event.

Quip ref: [jWVWAxBtMgkK]

### How has this been tested?
Existing tests updated.

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
