### PR TITLE
chore: Update expandable section analytics metadata to use new rootSe…

### DIFF
--- a/src/expandable-section/__tests__/analytics-metadata.test.tsx
+++ b/src/expandable-section/__tests__/analytics-metadata.test.tsx
@@ -138,7 +138,7 @@ test('Internal ExpandableSection does not render "component" metadata', () => {
   expect(getGeneratedAnalyticsMetadata(button)).toEqual({
     action: 'expand',
     detail: {
-      label: '',
+      label: 'whatever',
       expanded: 'true',
     },
   });

--- a/src/expandable-section/analytics-metadata/styles.scss
+++ b/src/expandable-section/analytics-metadata/styles.scss
@@ -3,6 +3,7 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-.header-label {
+.header-label,
+.root {
   /* used in analytics metadata */
 }

--- a/src/expandable-section/expandable-section-header.tsx
+++ b/src/expandable-section/expandable-section-header.tsx
@@ -65,7 +65,7 @@ const getExpandActionAnalyticsMetadataAttribute = (expanded: boolean) => {
   const metadata: GeneratedAnalyticsMetadataExpandableSectionExpand = {
     action: 'expand',
     detail: {
-      label: { root: 'component' },
+      label: { rootSelector: `.${analyticsSelectors.root}` },
       expanded: `${!expanded}`,
     },
   };

--- a/src/expandable-section/internal.tsx
+++ b/src/expandable-section/internal.tsx
@@ -15,6 +15,7 @@ import { ExpandableSectionHeader } from './expandable-section-header';
 import { ExpandableSectionProps, InternalVariant } from './interfaces';
 import { variantSupportsDescription } from './utils';
 
+import analyticsSelectors from './analytics-metadata/styles.css.js';
 import styles from './styles.css.js';
 
 export type InternalExpandableSectionProps = Omit<ExpandableSectionProps, 'variant'> &
@@ -100,7 +101,7 @@ export default function InternalExpandableSection({
     <ExpandableSectionContainer
       {...baseProps}
       expanded={expanded}
-      className={clsx(baseProps.className, styles.root)}
+      className={clsx(baseProps.className, styles.root, analyticsSelectors.root)}
       variant={variant}
       disableContentPaddings={disableContentPaddings}
       __injectAnalyticsComponentMetadata={__injectAnalyticsComponentMetadata}


### PR DESCRIPTION
…lector syntax

### Description

Use new syntax introduced in https://github.com/cloudscape-design/component-toolkit/commit/ba1e797024fe8cea02bb0011d1f000eb0a269ce7.

We currently use root="component" in Expandable section (https://github.com/cloudscape-design/components/blob/main/src/expandable-section/expandable-section-header.tsx#L68) to identify the label of the section.

This approach does not work when using the internal version of the component, because root="component"refers to the component that is using the internal version. For example, Side navigation.

This new approach allows to specify a root class name that becomes independent of whether the 'component' boundaries are set.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
