### PR TITLE
feat: Re-introduce responsive breadcrumb group

### DIFF
--- a/pages/breadcrumb-group/events.page.tsx
+++ b/pages/breadcrumb-group/events.page.tsx
@@ -6,7 +6,7 @@ import { SpaceBetween } from '~components';
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '~components/breadcrumb-group';
 
 import ScreenshotArea from '../utils/screenshot-area';
-const items = [
+const defaultItems = [
   'First that is very very very very very very long long long text',
   'Second',
   'Third',
@@ -14,8 +14,6 @@ const items = [
   'Fifth',
   'Sixth that is very very very very very very long long long text',
 ];
-
-const shortItems = ['1', '2', '3', '4'];
 
 export default function ButtonDropdownPage() {
   const [onFollowMessage, setOnFollowMessage] = useState('');
@@ -27,6 +25,7 @@ export default function ButtonDropdownPage() {
   const onClickCallback = (event: CustomEvent<BreadcrumbGroupProps.ClickDetail>) => {
     setOnClickMessage(`OnClick: ${event.detail.text} item was selected`);
   };
+  const [items, setItems] = useState(defaultItems);
   return (
     <ScreenshotArea disableAnimations={true}>
       <article>
@@ -50,12 +49,13 @@ export default function ButtonDropdownPage() {
             <button type="button" id="focus-target-short-text">
               focus short text
             </button>
-            <BreadcrumbGroup
-              ariaLabel="Navigation short text"
-              expandAriaLabel="Show path for short text"
-              items={shortItems.map(text => ({ text, href: `#` }))}
-            />
           </div>
+          <button type="button" id="add" onClick={() => setItems([...items, defaultItems[5]])}>
+            Add
+          </button>
+          <button type="button" id="remove" onClick={() => setItems(items.slice(0, items.length - 1))}>
+            Remove
+          </button>
         </SpaceBetween>
       </article>
     </ScreenshotArea>

--- a/src/breadcrumb-group/__integ__/breadcrumb-group.test.ts
+++ b/src/breadcrumb-group/__integ__/breadcrumb-group.test.ts
@@ -5,6 +5,7 @@ import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 
 import createWrapper from '../../../lib/components/test-utils/selectors';
 
+import breadcrumbGroupStyles from '../../../lib/components/breadcrumb-group/styles.selectors.js';
 import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const breadcrumbGroupWrapper = createWrapper().findBreadcrumbGroup();
@@ -15,7 +16,7 @@ const dropdownItemsSelector = dropdownWrapper.findItems().toSelector();
 
 class BreadcrumbGroupPage extends BasePageObject {
   setMobileViewport() {
-    return this.setWindowSize({ width: 600, height: 800 });
+    return this.setWindowSize({ width: 400, height: 800 });
   }
   isDropdownVisible() {
     return this.isDisplayed(dropdownSelector);
@@ -32,10 +33,35 @@ class BreadcrumbGroupPage extends BasePageObject {
   clickItem(index: number) {
     return this.click(dropdownWrapper.findItems().get(index).toSelector());
   }
+  getActiveElementId() {
+    return this.browser.execute(function () {
+      return document.activeElement?.id;
+    });
+  }
+  isEllipsisVisible() {
+    return this.isExisting(`.${breadcrumbGroupStyles.ellipsis}.${breadcrumbGroupStyles.visible}`);
+  }
+  isTooltipDisplayed() {
+    return this.isExisting(`.${tooltipStyles.root}`);
+  }
+  countTooltips() {
+    return this.browser.execute(function (selector) {
+      return Array.from(document.querySelectorAll(selector)).length;
+    }, `.${tooltipStyles.root}`);
+  }
+  getTooltipText() {
+    return this.getText(`.${tooltipStyles.root}`);
+  }
 }
-const setupTest = (testFn: (page: BreadcrumbGroupPage, browser: WebdriverIO.Browser) => Promise<void>) => {
+const setupTest = (
+  testFn: (page: BreadcrumbGroupPage, browser: WebdriverIO.Browser) => Promise<void>,
+  sizes?: { width: number; height: number }
+) => {
   return useBrowser(async browser => {
     const page = new BreadcrumbGroupPage(browser);
+    if (sizes) {
+      page.setWindowSize(sizes);
+    }
     await browser.url(`#/light/breadcrumb-group/events`);
     await page.waitForVisible(breadcrumbGroupWrapper.toSelector());
     await testFn(page, browser);
@@ -45,9 +71,35 @@ describe('BreadcrumbGroup', () => {
   test(
     'Has proper number of items in the dropdown',
     setupTest(async page => {
-      await page.setMobileViewport();
+      await page.setWindowSize({ width: 645, height: 800 });
+      await page.openDropdown();
+      expect(await page.getElementsCount(dropdownItemsSelector)).toBe(1);
+      await page.closeDropdown();
+
+      await page.setWindowSize({ width: 570, height: 800 });
+      await page.openDropdown();
+      expect(await page.getElementsCount(dropdownItemsSelector)).toBe(2);
+      await page.closeDropdown();
+
+      await page.setWindowSize({ width: 500, height: 800 });
+      await page.openDropdown();
+      expect(await page.getElementsCount(dropdownItemsSelector)).toBe(3);
+      await page.closeDropdown();
+
+      await page.setWindowSize({ width: 400, height: 800 });
       await page.openDropdown();
       expect(await page.getElementsCount(dropdownItemsSelector)).toBe(4);
+    })
+  );
+  test(
+    'Adjusts display when adding/removing items',
+    setupTest(async page => {
+      await page.setWindowSize({ width: 700, height: 800 });
+      expect(page.isEllipsisVisible()).resolves.toBe(false);
+      await page.click('#add');
+      expect(page.isEllipsisVisible()).resolves.toBe(true);
+      await page.click('#remove');
+      expect(page.isEllipsisVisible()).resolves.toBe(false);
     })
   );
 
@@ -77,37 +129,159 @@ describe('BreadcrumbGroup', () => {
     })
   );
 
-  test(
-    'Item popover should not show on large screen',
-    setupTest(async page => {
-      await page.setWindowSize({ width: 1200, height: 800 });
-      await page.click('#focus-target-long-text');
-      await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
-    })
-  );
+  describe('Item popover', () => {
+    test(
+      'should be displayed for truncated items on first render',
+      setupTest(
+        async page => {
+          await page.click('#focus-target-long-text');
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(true);
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+        },
+        { width: 100, height: 800 }
+      )
+    );
+
+    test(
+      'should not be displayed for non-truncated items on first render',
+      setupTest(
+        async page => {
+          await page.click('#focus-target-long-text');
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+        },
+        { width: 1200, height: 800 }
+      )
+    );
+
+    test(
+      'should be displayed for truncated items after resizing',
+      setupTest(
+        async page => {
+          await page.setWindowSize({ width: 1000, height: 800 });
+          await page.click('#focus-target-long-text');
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(true);
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+        },
+        { width: 1200, height: 800 }
+      )
+    );
+    test(
+      'should be displayed for truncated items after collapsing items into dropdown',
+      setupTest(
+        async page => {
+          await page.setMobileViewport();
+          await page.click('#focus-target-long-text');
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(true);
+        },
+        { width: 1200, height: 800 }
+      )
+    );
+    test(
+      'should not be displayed after making the viewport larger again',
+      setupTest(
+        async page => {
+          await page.setMobileViewport();
+          await page.setWindowSize({ width: 1200, height: 800 });
+          await page.click('#focus-target-long-text');
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+          await page.keys('Tab');
+          await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+          await page.keys('Tab');
+        },
+        { width: 1200, height: 800 }
+      )
+    );
+
+    test(
+      'Item popover should close after pressing Escape',
+      setupTest(async page => {
+        await page.setMobileViewport();
+        await page.click('#focus-target-long-text');
+        await page.keys('Tab');
+        await expect(page.isTooltipDisplayed()).resolves.toBe(true);
+        await page.keys('Escape');
+        await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+      })
+    );
+  });
 
   test(
-    'Item popover should show on small screen when text get truncated, and should close pressing Escape',
-    setupTest(async page => {
-      await page.setMobileViewport();
-      await page.click('#focus-target-long-text');
-      await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(true);
-      await page.keys('Escape');
-      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
-      await page.click('#focus-target-short-text');
-      await page.keys('Tab');
-      await expect(page.isExisting(createWrapper().find(`.${tooltipStyles.root}`).toSelector())).resolves.toBe(false);
-    })
-  );
-
-  test(
-    'Attachs funnel name attribute to last breadcrumb item',
+    'Attaches funnel name attribute to last breadcrumb item',
     setupTest(async (page, browser) => {
       await page.setMobileViewport();
       const funnelName = await browser.$('[data-analytics-funnel-key="funnel-name"]').getText();
       expect(funnelName).toBe('Sixth that is very very very very very very long long long text');
+    })
+  );
+
+  test(
+    'Focus does not go into ghost replica',
+    setupTest(
+      async page => {
+        await page.click('#focus-target-long-text');
+        await page.keys('Tab');
+        await page.keys('Tab');
+        await page.keys('Tab');
+        await page.keys('Tab');
+        await page.keys('Tab');
+        await page.keys('Tab');
+        await expect(page.getActiveElementId()).resolves.toBe('focus-target-short-text');
+      },
+      { width: 1200, height: 800 }
+    )
+  );
+
+  test(
+    'Last item is focusable when truncated',
+    setupTest(async page => {
+      await page.setMobileViewport();
+      await page.click('#focus-target-long-text');
+      await page.keys('Tab');
+      await page.keys('Tab');
+      await page.keys('Tab');
+      await expect(page.isTooltipDisplayed()).resolves.toBe(true);
+      await page.keys('Tab');
+      await expect(page.isTooltipDisplayed()).resolves.toBe(false);
+      await expect(page.getActiveElementId()).resolves.toBe('focus-target-short-text');
+    })
+  );
+
+  test(
+    'Displays only one tooltip at the time',
+    setupTest(async page => {
+      await page.setMobileViewport();
+      await page.click('#focus-target-long-text');
+      await page.keys('Tab');
+      await expect(page.countTooltips()).resolves.toBe(1);
+      await expect(page.getTooltipText()).resolves.toBe(
+        'First that is very very very very very very long long long text'
+      );
+      await page.hoverElement(breadcrumbGroupWrapper.findBreadcrumbLink(6).toSelector());
+      await expect(page.countTooltips()).resolves.toBe(1);
+      await expect(page.getTooltipText()).resolves.toBe(
+        'Sixth that is very very very very very very long long long text'
+      );
+
+      await page.hoverElement('#focus-target-long-text');
+      await page.click('#focus-target-long-text');
+      await expect(page.countTooltips()).resolves.toBe(0);
+      await page.hoverElement(breadcrumbGroupWrapper.findBreadcrumbLink(6).toSelector());
+      await expect(page.countTooltips()).resolves.toBe(1);
+      await expect(page.getTooltipText()).resolves.toBe(
+        'Sixth that is very very very very very very long long long text'
+      );
+      await page.keys('Tab');
+      await expect(page.countTooltips()).resolves.toBe(1);
+      await expect(page.getTooltipText()).resolves.toBe(
+        'First that is very very very very very very long long long text'
+      );
     })
   );
 });

--- a/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
+++ b/src/breadcrumb-group/__tests__/analytics-metadata.test.tsx
@@ -7,15 +7,19 @@ import { activateAnalyticsMetadata } from '@cloudscape-design/component-toolkit/
 import { getGeneratedAnalyticsMetadata } from '@cloudscape-design/component-toolkit/internal/analytics-metadata/utils';
 
 import BreadcrumbGroup from '../../../lib/components/breadcrumb-group';
-import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
+import { getItemsDisplayProperties } from '../../../lib/components/breadcrumb-group/utils';
 import createWrapper from '../../../lib/components/test-utils/dom';
 import { validateComponentNameAndLabels } from '../../internal/__tests__/analytics-metadata-test-utils';
 
 import ownLabels from '../../../lib/components/breadcrumb-group/analytics-metadata/styles.css.js';
 import buttonDropdownLabels from '../../../lib/components/button-dropdown/analytics-metadata/styles.css.js';
 
-jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
-  useMobile: jest.fn().mockReturnValue(false),
+jest.mock('../../../lib/components/breadcrumb-group/utils', () => ({
+  getItemsDisplayProperties: jest.fn().mockReturnValue({
+    shrinkFactors: [0, 0, 0, 0],
+    minWidths: [100, 100, 100, 100],
+    collapsed: 0,
+  }),
 }));
 
 const labels = { ...ownLabels, ...buttonDropdownLabels };
@@ -79,7 +83,11 @@ describe('BreadcrumbGroup renders correct analytics metadata', () => {
     });
   });
   test('in mobile view', () => {
-    (useMobile as jest.Mock).mockReturnValue(true);
+    (getItemsDisplayProperties as jest.Mock).mockReturnValue({
+      shrinkFactors: [0, 0, 0, 0],
+      minWidths: [100, 100, 100, 100],
+      collapsed: 2,
+    });
     const wrapper = renderBreadcrumbGroup();
 
     const firstBreadcrumb = wrapper.findBreadcrumbLink(1)!.getElement();

--- a/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-group.test.tsx
@@ -112,8 +112,8 @@ describe('BreadcrumbGroup Component', () => {
     // Test for AWSUI-6738
     test('all the icons stay visible when changing the items', () => {
       const { container, rerender } = render(<BreadcrumbGroup items={items} />);
-      const wrapper = createWrapper(container).findBreadcrumbGroup(`.${styles['breadcrumb-group']}`)!;
-      const getIcons = () => wrapper.findAll(`.${itemStyles.icon}`);
+      const wrapper = createWrapper(container).findBreadcrumbGroup()!;
+      const getIcons = () => wrapper.findAll(`.${itemStyles.breadcrumb} .${itemStyles.icon}`);
       expect(getIcons()).toHaveLength(2);
       rerender(<BreadcrumbGroup items={items.slice(0, 2)} />);
       rerender(<BreadcrumbGroup items={[]} />);
@@ -141,7 +141,7 @@ describe('BreadcrumbGroup Component', () => {
         }}
       />
     );
-    const wrapper = createWrapper(container).findBreadcrumbGroup(`.${styles['breadcrumb-group']}`)!;
+    const wrapper = createWrapper(container).findBreadcrumbGroup()!;
     wrapper.findBreadcrumbLink(2)!.click();
     expect(onClick).toHaveBeenCalledWith(items[1]);
   });
@@ -196,6 +196,39 @@ describe('BreadcrumbGroup Component', () => {
       );
       const wrapper = createWrapper(container).findBreadcrumbGroup()!;
       expect(wrapper.findDropdown()?.findNativeButton().getElement()).toHaveAttribute('aria-label', 'Custom show path');
+    });
+  });
+
+  describe('Ghost breadcrumb group', () => {
+    test('has aria-hidden property', () => {
+      const breadCrumbGroup = renderBreadcrumbGroup({ items: [] });
+      expect(breadCrumbGroup.find(`.${styles.ghost}`)?.getElement()).toHaveAttribute('aria-hidden', 'true');
+    });
+    test('has tab-index=-1', () => {
+      const breadCrumbGroup = renderBreadcrumbGroup({
+        items: [
+          {
+            text: 'Item 1',
+            href: '/#1',
+          },
+          {
+            text: 'Item 2',
+            href: '/#3',
+          },
+          {
+            text: 'Item 3',
+            href: '/#3',
+          },
+        ],
+      });
+      expect(breadCrumbGroup.find(`.${styles.ghost}`)?.getElement()).toHaveAttribute('tabindex', '-1');
+      const anchors = breadCrumbGroup
+        .find(`.${styles.ghost}`)!
+        .findAll('a')
+        .map(wrapper => wrapper.getElement());
+      anchors.forEach(anchor => {
+        expect(anchor).toHaveAttribute('tabindex', '-1');
+      });
     });
   });
 });

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -1,18 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { ElementWrapper } from '@cloudscape-design/test-utils-core/dom';
 
 import BreadcrumbGroup, { BreadcrumbGroupProps } from '../../../lib/components/breadcrumb-group';
+import { BreadcrumbItem } from '../../../lib/components/breadcrumb-group/item/item';
 import { DATA_ATTR_FUNNEL_KEY, FUNNEL_KEY_FUNNEL_NAME } from '../../../lib/components/internal/analytics/selectors';
-import { useMobile } from '../../../lib/components/internal/hooks/use-mobile';
 import createWrapper, { BreadcrumbGroupWrapper } from '../../../lib/components/test-utils/dom';
 
-jest.mock('../../../lib/components/internal/hooks/use-mobile', () => ({
-  useMobile: jest.fn().mockReturnValue(true),
-}));
+import breadcrumbItemStyles from '../../../lib/components/breadcrumb-group/item/styles.selectors.js';
+import tooltipStyles from '../../../lib/components/internal/components/tooltip/styles.selectors.js';
 
 const renderBreadcrumbGroup = (props: BreadcrumbGroupProps) => {
   const { container } = render(<BreadcrumbGroup {...props} />);
@@ -137,15 +136,16 @@ describe('BreadcrumbGroup Item', () => {
     });
   });
 
-  describe('compressed item', () => {
-    beforeEach(() => {
-      (useMobile as jest.Mock).mockReturnValue(true);
-    });
-
-    test('renders item content', () => {
-      const wrapper = renderBreadcrumbGroup({ items });
-
-      expect(wrapper.findBreadcrumbLinks()[0].getElement()).toHaveTextContent(items[0].text);
-    });
+  test('displays tooltip', () => {
+    const { container } = render(
+      <BreadcrumbItem item={{ text: 'Long Breadcrumb text', href: '#' }} isTruncated={true} />
+    );
+    const elementAnchor = createWrapper(container).find(`.${breadcrumbItemStyles.anchor}`)!.getElement();
+    elementAnchor.focus();
+    expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
+    elementAnchor.blur();
+    expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
+    fireEvent.mouseEnter(elementAnchor);
+    expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
   });
 });

--- a/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
+++ b/src/breadcrumb-group/__tests__/breadcrumb-item.test.tsx
@@ -147,5 +147,7 @@ describe('BreadcrumbGroup Item', () => {
     expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
     fireEvent.mouseEnter(elementAnchor);
     expect(document.querySelector(`.${tooltipStyles.root}`)).not.toBeNull();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(document.querySelector(`.${tooltipStyles.root}`)).toBeNull();
   });
 });

--- a/src/breadcrumb-group/__tests__/utils.test.ts
+++ b/src/breadcrumb-group/__tests__/utils.test.ts
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getItemsDisplayProperties } from '../utils';
+
+describe('getItemsDisplayProperties', () => {
+  test('does not break with zero items', () => {
+    const displayProperties = getItemsDisplayProperties([], 90);
+    expect(displayProperties).toEqual({
+      shrinkFactors: [],
+      minWidths: [],
+      collapsed: 0,
+    });
+  });
+  test('returns correct shrinkFactors', () => {
+    const { shrinkFactors } = getItemsDisplayProperties([20, 300, 0, 1000, 150], 0);
+    expect(shrinkFactors).toEqual([0, 300, 0, 1000, 0]);
+  });
+  test('returns correct minWidths', () => {
+    const { minWidths } = getItemsDisplayProperties([20, 300, 0, 1000, 150], 0);
+    expect(minWidths).toEqual([0, 150, 0, 150, 0]);
+  });
+  test('returns correct number of collapsed items', () => {
+    const itemsWidths = [20, 300, 500, 60, 150, 1000];
+    [
+      [3000, 0],
+      [730, 0],
+      [729, 1], // second breadcrumb collapses
+      [580, 1],
+      [579, 2], // third breadcrumb collapses
+      [430, 2],
+      [429, 3], // fourth breadcrumb collapses
+      [370, 3],
+      [369, 4], // fifth breadcrumb collapses
+      [250, 4],
+      [10, 4],
+      [-10, 4],
+    ].forEach(([navWidth, expectedCollapsed]) =>
+      expect(getItemsDisplayProperties(itemsWidths, navWidth).collapsed).toEqual(expectedCollapsed)
+    );
+  });
+  describe('adjusts to small container widths', () => {
+    describe('with one item', () => {
+      test('smaller than default min width and bigger than available width', () => {
+        expect(getItemsDisplayProperties([100], 90)).toEqual({
+          shrinkFactors: [100],
+          minWidths: [90],
+          collapsed: 0,
+        });
+      });
+      test('smaller than default min width and smaller than available width', () => {
+        expect(getItemsDisplayProperties([80], 90)).toEqual({
+          shrinkFactors: [0],
+          minWidths: [0],
+          collapsed: 0,
+        });
+      });
+
+      test('bigger than default min width and bigger than available width', () => {
+        expect(getItemsDisplayProperties([160], 90)).toEqual({
+          shrinkFactors: [160],
+          minWidths: [90],
+          collapsed: 0,
+        });
+      });
+    });
+  });
+  describe('with two items', () => {
+    test('both bigger than default min width and bigger than available width', () => {
+      expect(getItemsDisplayProperties([160, 160], 90)).toEqual({
+        shrinkFactors: [160, 160],
+        minWidths: [45, 45],
+        collapsed: 0,
+      });
+    });
+    test('both smaller than default min width and bigger than available width', () => {
+      expect(getItemsDisplayProperties([100, 100], 90)).toEqual({
+        shrinkFactors: [100, 100],
+        minWidths: [45, 45],
+        collapsed: 0,
+      });
+    });
+  });
+  describe('with more than two items', () => {
+    test('first and last bigger than default min width and bigger than available width', () => {
+      expect(getItemsDisplayProperties([160, 200, 20, 140, 160], 320)).toEqual({
+        shrinkFactors: [160, 200, 0, 140, 160],
+        minWidths: [135, 135, 0, 135, 135],
+        collapsed: 3,
+      });
+    });
+    test('first and last smaller than default min width and bigger than available width', () => {
+      expect(getItemsDisplayProperties([140, 200, 20, 140, 140], 320)).toEqual({
+        shrinkFactors: [140, 200, 0, 140, 140],
+        minWidths: [135, 135, 0, 135, 135],
+        collapsed: 3,
+      });
+    });
+  });
+});

--- a/src/breadcrumb-group/implementation.tsx
+++ b/src/breadcrumb-group/implementation.tsx
@@ -127,7 +127,7 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
     checkSafeUrl('BreadcrumbGroup', item.href);
   }
   const baseProps = getBaseProps(props);
-  const [navWidth, navRef] = useContainerQuery<number>(rect => rect.contentBoxWidth);
+  const [navWidth, navRef] = useContainerQuery<number>(rect => rect.borderBoxWidth);
   const mergedRef = useMergeRefs(navRef, __internalRootRef);
 
   const itemsRefs = useRef<ItemsRefsType>({ ghost: {}, real: {} });
@@ -152,14 +152,18 @@ export function BreadcrumbGroupImplementation<T extends BreadcrumbGroupProps.Ite
         const width = getLogicalBoundingClientRect(node).inlineSize;
         newItemsWidths.real.push(width);
       }
-      if (
-        !areArrayEqual(newItemsWidths.ghost, itemsWidths.ghost) ||
-        !areArrayEqual(newItemsWidths.real, itemsWidths.real)
-      ) {
-        setItemsWidths(newItemsWidths);
-      }
+      setItemsWidths(oldWidths => {
+        if (
+          !areArrayEqual(newItemsWidths.ghost, oldWidths.ghost) ||
+          !areArrayEqual(newItemsWidths.real, oldWidths.real)
+        ) {
+          return newItemsWidths;
+        } else {
+          return oldWidths;
+        }
+      });
     }
-  }, [itemsWidths, items, navWidth]);
+  }, [items, navWidth]);
 
   const { shrinkFactors, minWidths, collapsed } = getItemsDisplayProperties(itemsWidths.ghost, navWidth);
 

--- a/src/breadcrumb-group/interfaces.ts
+++ b/src/breadcrumb-group/interfaces.ts
@@ -63,9 +63,9 @@ export type InternalBreadcrumbGroupProps<T extends BreadcrumbGroupProps.Item = B
 
 export interface BreadcrumbItemProps<T extends BreadcrumbGroupProps.Item> {
   item: T;
-  isDisplayed: boolean;
+  isTruncated?: boolean;
   isLast?: boolean;
-  isCompressed?: boolean;
+  isGhost?: boolean;
   onClick?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;
   onFollow?: CancelableEventHandler<BreadcrumbGroupProps.ClickDetail<T>>;
 }
@@ -75,4 +75,5 @@ export interface EllipsisDropdownProps {
   dropdownItems: ReadonlyArray<LinkItem>;
   onDropdownItemClick: CancelableEventHandler<{ id: string }>;
   onDropdownItemFollow: CancelableEventHandler<{ id: string }>;
+  visible?: boolean;
 }

--- a/src/breadcrumb-group/item/funnel.tsx
+++ b/src/breadcrumb-group/item/funnel.tsx
@@ -12,19 +12,20 @@ interface FunnelBreadcrumbItemProps {
   text: string;
   last: boolean;
   hidden?: boolean;
+  ghost?: boolean;
 }
 
 export const FunnelBreadcrumbItem = React.forwardRef<HTMLSpanElement, FunnelBreadcrumbItemProps>(
-  ({ text, hidden, last }, ref) => {
+  ({ text, hidden, last, ghost }, ref) => {
     const funnelAttributes: Record<string, string> = {};
-    if (last) {
+    if (last && !ghost) {
       funnelAttributes[DATA_ATTR_FUNNEL_KEY] = FUNNEL_KEY_FUNNEL_NAME;
     }
 
     return (
       <span
         {...funnelAttributes}
-        className={clsx(styles.text, hidden && styles['text-hidden'], analyticsSelectors['breadcrumb-item'])}
+        className={clsx(styles.text, hidden && styles['text-hidden'], !ghost && analyticsSelectors['breadcrumb-item'])}
         ref={ref}
       >
         {text}

--- a/src/breadcrumb-group/item/item.tsx
+++ b/src/breadcrumb-group/item/item.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import InternalIcon from '../../icon/internal';
 import Tooltip from '../../internal/components/tooltip';
+import { registerTooltip } from '../../internal/components/tooltip/registry';
 import { fireCancelableEvent, isPlainLeftClick } from '../../internal/events';
 import { BreadcrumbGroupProps, BreadcrumbItemProps } from '../interfaces';
 import { getEventDetail } from '../utils';
@@ -12,69 +13,45 @@ import { FunnelBreadcrumbItem } from './funnel';
 
 import styles from './styles.css.js';
 
-type BreadcrumbItemWithPopoverProps<T extends BreadcrumbGroupProps.Item> = React.HTMLAttributes<HTMLElement> & {
+interface BreadcrumbItemWithPopoverProps<T extends BreadcrumbGroupProps.Item> {
   item: T;
   isLast: boolean;
   anchorAttributes: React.AnchorHTMLAttributes<HTMLAnchorElement>;
-};
+}
 
 const BreadcrumbItemWithPopover = <T extends BreadcrumbGroupProps.Item>({
   item,
   isLast,
   anchorAttributes,
-  ...itemAttributes
 }: BreadcrumbItemWithPopoverProps<T>) => {
   const [showPopover, setShowPopover] = useState(false);
   const textRef = useRef<HTMLElement>(null);
-  const virtualTextRef = useRef<HTMLElement>(null);
-
-  const isTruncated = (textRef: React.RefObject<HTMLElement>, virtualTextRef: React.RefObject<HTMLElement>) => {
-    if (!textRef || !virtualTextRef || !textRef.current || !virtualTextRef.current) {
-      return false;
-    }
-    const virtualTextWidth = virtualTextRef.current.getBoundingClientRect().width;
-    const textWidth = textRef.current.getBoundingClientRect().width;
-    if (virtualTextWidth > textWidth) {
-      return true;
-    }
-    return false;
-  };
-
-  const popoverContent = <Tooltip trackRef={textRef} value={item.text} />;
+  const popoverContent = <Tooltip trackRef={textRef} value={item.text} size="medium" />;
 
   useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setShowPopover(false);
-      }
-    };
     if (showPopover) {
-      document.addEventListener('keydown', onKeyDown);
+      return registerTooltip(() => {
+        setShowPopover(false);
+      });
     }
-    return () => {
-      document.removeEventListener('keydown', onKeyDown);
-    };
   }, [showPopover]);
 
   return (
     <>
       <Item
         isLast={isLast}
-        {...itemAttributes}
         onFocus={() => {
-          isTruncated(textRef, virtualTextRef) && setShowPopover(true);
+          setShowPopover(true);
         }}
         onBlur={() => setShowPopover(false)}
         onMouseEnter={() => {
-          isTruncated(textRef, virtualTextRef) && setShowPopover(true);
+          setShowPopover(true);
         }}
         onMouseLeave={() => setShowPopover(false)}
         anchorAttributes={anchorAttributes}
+        {...(isLast ? { tabIndex: 0 } : {})}
       >
         <FunnelBreadcrumbItem ref={textRef} text={item.text} last={isLast} />
-        <span className={styles['virtual-item']} ref={virtualTextRef}>
-          {item.text}
-        </span>
       </Item>
       {showPopover && popoverContent}
     </>
@@ -87,9 +64,11 @@ type ItemProps = React.HTMLAttributes<HTMLElement> & {
 };
 const Item = ({ anchorAttributes, children, isLast, ...itemAttributes }: ItemProps) =>
   isLast ? (
-    <span {...itemAttributes}>{children}</span>
+    <span className={styles.anchor} {...itemAttributes}>
+      {children}
+    </span>
   ) : (
-    <a {...itemAttributes} {...anchorAttributes}>
+    <a className={styles.anchor} {...itemAttributes} {...anchorAttributes}>
       {children}
     </a>
   );
@@ -98,9 +77,9 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
   item,
   onClick,
   onFollow,
-  isDisplayed,
   isLast = false,
-  isCompressed = false,
+  isGhost = false,
+  isTruncated = false,
 }: BreadcrumbItemProps<T>) {
   const preventDefault = (event: React.MouseEvent) => event.preventDefault();
   const onClickHandler = (event: React.MouseEvent) => {
@@ -110,26 +89,21 @@ export function BreadcrumbItem<T extends BreadcrumbGroupProps.Item>({
     fireCancelableEvent(onClick, getEventDetail(item), event);
   };
 
-  const itemAttributes: React.HTMLAttributes<HTMLElement> = {
-    className: clsx(styles.anchor, { [styles.compressed]: isCompressed }),
-  };
   const anchorAttributes: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
     href: item.href || '#',
     onClick: isLast ? preventDefault : onClickHandler,
   };
+  if (isGhost) {
+    anchorAttributes.tabIndex = -1;
+  }
 
   return (
-    <div className={clsx(styles.breadcrumb, isLast && styles.last)}>
-      {isDisplayed && isCompressed ? (
-        <BreadcrumbItemWithPopover
-          item={item}
-          isLast={isLast}
-          anchorAttributes={anchorAttributes}
-          {...itemAttributes}
-        />
+    <div className={clsx(!isGhost && styles.breadcrumb, isGhost && styles['ghost-breadcrumb'], isLast && styles.last)}>
+      {isTruncated && !isGhost ? (
+        <BreadcrumbItemWithPopover item={item} isLast={isLast} anchorAttributes={anchorAttributes} />
       ) : (
-        <Item isLast={isLast} anchorAttributes={anchorAttributes} {...itemAttributes}>
-          <FunnelBreadcrumbItem text={item.text} last={isLast} />
+        <Item isLast={isLast} anchorAttributes={anchorAttributes}>
+          <FunnelBreadcrumbItem text={item.text} last={isLast} ghost={isGhost} />
         </Item>
       )}
       {!isLast ? (

--- a/src/breadcrumb-group/item/styles.scss
+++ b/src/breadcrumb-group/item/styles.scss
@@ -11,7 +11,8 @@
   display: none;
 }
 
-.breadcrumb {
+.breadcrumb,
+.ghost-breadcrumb {
   display: flex;
 
   > .icon {
@@ -22,6 +23,14 @@
 
   > .anchor {
     @include styles.link-inline('body-m');
+    min-inline-size: 0;
+    overflow: hidden;
+    > .text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: block;
+    }
 
     @include focus-visible.when-visible {
       @include styles.link-focus;
@@ -39,20 +48,6 @@
       cursor: default;
     }
   }
-}
-.compressed {
-  min-inline-size: 0;
-  overflow: hidden;
-  > .text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: block;
-  }
-}
-.virtual-item {
-  @include styles.awsui-util-hide;
-  visibility: hidden;
 }
 
 .text-hidden {

--- a/src/breadcrumb-group/styles.scss
+++ b/src/breadcrumb-group/styles.scss
@@ -13,11 +13,6 @@
   padding-block: awsui.$space-xxs;
   padding-inline: 0;
 
-  > .item {
-    @include styles.styles-reset;
-    display: inline;
-  }
-
   > .breadcrumb-group-list {
     display: flex;
     align-items: center;
@@ -27,7 +22,13 @@
     margin-inline: 0;
     list-style: none;
     inline-size: 100%;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+
+    &.ghost {
+      flex-wrap: wrap;
+      position: absolute;
+      inset-inline-start: -9000px;
+    }
 
     > .item,
     > .ellipsis {
@@ -38,43 +39,22 @@
       margin-inline: 0;
     }
 
+    > .item.hide {
+      display: none;
+    }
+
     > .ellipsis {
       display: none;
+
+      &.visible {
+        display: flex;
+        flex-shrink: 0;
+      }
 
       > .icon {
         margin-block: 0;
         margin-inline: styles.$base-size;
         color: awsui.$color-text-breadcrumb-icon;
-      }
-    }
-  }
-
-  // In the smallest screen, breadcrumbs truncate into
-  // BC1 > ... > BCL
-  // and we apply ellipsis if the breadcrumb items are too long
-  &.mobile {
-    > .breadcrumb-group-list {
-      flex-wrap: nowrap;
-
-      > .ellipsis {
-        display: flex;
-        flex-shrink: 0;
-      }
-      > .item {
-        min-inline-size: 0;
-        &:not(:first-child):not(:last-child) {
-          display: none;
-        }
-      }
-    }
-  }
-
-  // Test utils rely on the ellipsis being present even if there are
-  // only 2 items in the list, so we display but hide it.
-  &.mobile-short {
-    > .breadcrumb-group-list {
-      > .ellipsis {
-        display: none;
       }
     }
   }

--- a/src/breadcrumb-group/utils.ts
+++ b/src/breadcrumb-group/utils.ts
@@ -7,3 +7,64 @@ export const getEventDetail = <T extends BreadcrumbGroupProps.Item>(item: T) => 
   text: item.text,
   href: item.href,
 });
+
+const defaultMinBreadcrumbWidth = 150;
+const ellipsisWidth = 50;
+
+export const getItemsDisplayProperties = (itemsWidths: Array<number>, navWidth: number | null) => {
+  const minBreadcrumbWidth = optimizeMinWidth(itemsWidths, navWidth);
+  const shrinkFactors = itemsWidths.map(width => (width <= minBreadcrumbWidth ? 0 : Math.round(width)));
+  const minWidths = itemsWidths.map(width => (width <= minBreadcrumbWidth ? 0 : minBreadcrumbWidth));
+  const collapsedWidths = itemsWidths.map(width => Math.min(width, minBreadcrumbWidth));
+
+  return {
+    shrinkFactors,
+    minWidths,
+    collapsed: computeNumberOfCollapsedItems(collapsedWidths, navWidth),
+  };
+};
+
+const computeNumberOfCollapsedItems = (collapsedWidths: Array<number>, navWidth: number | null): number => {
+  if (!navWidth) {
+    return 0;
+  }
+  let collapsed = 0;
+  const itemsCount = collapsedWidths.length;
+  if (itemsCount > 2) {
+    collapsed = itemsCount - 2;
+    let remainingWidth = navWidth - collapsedWidths[0] - collapsedWidths[itemsCount - 1] - ellipsisWidth;
+    let j = 1;
+    while (remainingWidth > 0 && j < itemsCount - 1) {
+      remainingWidth -= collapsedWidths[itemsCount - 1 - j];
+      j++;
+      if (remainingWidth >= 0) {
+        collapsed--;
+      }
+    }
+  }
+  return collapsed;
+};
+
+const optimizeMinWidth = (itemsWidths: Array<number>, navWidth: number | null): number => {
+  const collapsedWidths = itemsWidths.map(width => Math.min(width, defaultMinBreadcrumbWidth));
+  if (!navWidth) {
+    return defaultMinBreadcrumbWidth;
+  }
+  const itemsCount = collapsedWidths.length;
+  if (itemsCount > 2) {
+    const minCollapsedWidth = collapsedWidths[0] + ellipsisWidth + collapsedWidths[collapsedWidths.length - 1];
+    if (minCollapsedWidth > navWidth) {
+      return (navWidth - ellipsisWidth) / 2;
+    }
+  }
+  if (itemsCount === 2) {
+    const minCollapsedWidth = collapsedWidths[0] + collapsedWidths[1];
+    if (minCollapsedWidth > navWidth) {
+      return navWidth / 2;
+    }
+  }
+  if (itemsCount === 1) {
+    return Math.min(navWidth, collapsedWidths[0]);
+  }
+  return defaultMinBreadcrumbWidth;
+};


### PR DESCRIPTION
### Description

This PR reverts the partial revert of responsive breadcrumbs (https://github.com/cloudscape-design/components/commit/a1f027553b7b1c43a8cda5f675bb67e0ba3991e1) and introduces a small performance improvement.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
