### PR TITLE
fix: Fixes border radius in property filter nested tokens

### DIFF
--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -12218,7 +12218,7 @@ in order to prevent the user from changing the filtering query.",
     },
     {
       "defaultValue": "false",
-      "description": "Activates token grouping mechanism to support tokens nesting (up to one level).
+      "description": "Activates token grouping mechanism to support token nesting (up to one level).
 When \`true\`, the \`query.tokens\` property is ignored and \`query.tokenGroups\` is used instead.",
       "name": "enableTokenGroups",
       "optional": true,
@@ -12353,7 +12353,9 @@ Use the \`onLoadItems\` event to perform a recovery action (for example, retryin
       "description": "If hideOperations it set, the indicator of the operation (that is, \`and\` or \`or\`) and the selection of operations
 (applied to the property and value token) are hidden from the user. Only use when you have a custom
 filtering logic which combines tokens in different way than the default one. When used, ensure that
-operations are communicated to the user in another way.",
+operations are communicated to the user in another way.
+This property cannot be set when \`enableTokenGroups=true\`.
+",
       "name": "hideOperations",
       "optional": true,
       "type": "boolean",
@@ -12591,7 +12593,7 @@ use the \`id\` attribute, consider setting it on a parent element instead.",
       "type": "string",
     },
     {
-      "description": "An object representing the current query displayed in the property filter. Has three properties: \`operation\`, \`tokens\`, and \`tokenGroups\`.
+      "description": "An object representing the current query displayed in the property filter, which has three properties: \`operation\`, \`tokens\`, and \`tokenGroups\`.
 The \`operation\` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
 The \`tokens\` property is an array of objects that will be displayed to the user beneath the filtering input. When \`enableTokenGroups=true\`, the
 \`tokenGroups\` property is used instead, which supports nested tokens.

--- a/src/internal/components/button-trigger/index.tsx
+++ b/src/internal/components/button-trigger/index.tsx
@@ -21,7 +21,7 @@ export interface ButtonTriggerProps extends BaseComponentProps {
   readOnly?: boolean;
   invalid?: boolean;
   warning?: boolean;
-  inFilteringToken?: boolean;
+  inFilteringToken?: 'root' | 'nested';
   inlineTokens?: boolean;
   ariaHasPopup?: 'true' | 'listbox' | 'dialog';
   ariaControls?: string;
@@ -78,7 +78,7 @@ const ButtonTrigger = (
       warning && !invalid && styles.warning,
       !hideCaret && styles['has-caret'],
       readOnly && styles.readonly,
-      inFilteringToken && styles['in-filtering-token'],
+      inFilteringToken && styles[`in-filtering-token-${inFilteringToken}`],
       inlineTokens && styles['inline-tokens']
     ),
     disabled: disabled,

--- a/src/internal/components/button-trigger/styles.scss
+++ b/src/internal/components/button-trigger/styles.scss
@@ -33,7 +33,8 @@ $padding-block-inner-filtering-token: 0px;
   border-inline: styles.$control-border-width solid awsui.$color-border-input-default;
   min-block-size: awsui.$size-vertical-input;
 
-  &.in-filtering-token {
+  &.in-filtering-token-root,
+  &.in-filtering-token-nested {
     padding-block: $padding-block-inner-filtering-token;
     padding-inline: $padding-inline-inner-filtering-token;
 
@@ -46,6 +47,11 @@ $padding-block-inner-filtering-token: 0px;
     @include focus-visible.when-visible {
       @include styles.focus-highlight(awsui.$space-filtering-token-operation-select-focus-outline-gutter);
     }
+  }
+
+  &.in-filtering-token-nested {
+    border-start-start-radius: calc(#{styles.$control-border-radius} / 2);
+    border-end-start-radius: calc(#{styles.$control-border-radius} / 2);
   }
 
   &.has-caret {

--- a/src/property-filter/filtering-token/index.tsx
+++ b/src/property-filter/filtering-token/index.tsx
@@ -293,7 +293,7 @@ function OperationSelector({
 }) {
   return (
     <InternalSelect
-      __inFilteringToken={true}
+      __inFilteringToken={parent ? 'root' : 'nested'}
       className={clsx(
         parent
           ? clsx(styles.select, testUtilStyles['filtering-token-select'])

--- a/src/property-filter/interfaces.ts
+++ b/src/property-filter/interfaces.ts
@@ -46,7 +46,7 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    */
   countText?: string;
   /**
-   * An object representing the current query displayed in the property filter. Has three properties: `operation`, `tokens`, and `tokenGroups`.
+   * An object representing the current query displayed in the property filter, which has three properties: `operation`, `tokens`, and `tokenGroups`.
    * The `operation` property has two valid values: "and", "or", and controls the join operation to be applied between tokens when filtering the items.
    * The `tokens` property is an array of objects that will be displayed to the user beneath the filtering input. When `enableTokenGroups=true`, the
    * `tokenGroups` property is used instead, which supports nested tokens.
@@ -62,10 +62,12 @@ export interface PropertyFilterProps extends BaseComponentProps, ExpandToViewpor
    * (applied to the property and value token) are hidden from the user. Only use when you have a custom
    * filtering logic which combines tokens in different way than the default one. When used, ensure that
    * operations are communicated to the user in another way.
+   *
+   * This property cannot be set when `enableTokenGroups=true`.
    */
   hideOperations?: boolean;
   /**
-   * Activates token grouping mechanism to support tokens nesting (up to one level).
+   * Activates token grouping mechanism to support token nesting (up to one level).
    * When `true`, the `query.tokens` property is ignored and `query.tokenGroups` is used instead.
    */
   enableTokenGroups?: boolean;

--- a/src/select/internal.tsx
+++ b/src/select/internal.tsx
@@ -34,7 +34,7 @@ import { useSelect } from './utils/use-select';
 import styles from './styles.css.js';
 
 export interface InternalSelectProps extends SomeRequired<SelectProps, 'options'>, InternalBaseComponentProps {
-  __inFilteringToken?: boolean;
+  __inFilteringToken?: 'root' | 'nested';
 }
 
 const InternalSelect = React.forwardRef(
@@ -248,7 +248,7 @@ const InternalSelect = React.forwardRef(
             dropdownProps.dropdownContentRole ? (dropdownStatus.content ? footerId : undefined) : undefined
           }
           open={isOpen}
-          stretchTriggerHeight={__inFilteringToken}
+          stretchTriggerHeight={!!__inFilteringToken}
           stretchBeyondTriggerWidth={true}
           trigger={trigger}
           header={filter}

--- a/src/select/parts/trigger.tsx
+++ b/src/select/parts/trigger.tsx
@@ -26,7 +26,7 @@ export interface TriggerProps extends FormFieldValidationControlProps {
   inlineLabelText?: string;
   isOpen?: boolean;
   triggerVariant?: SelectProps.TriggerVariant | MultiselectProps.TriggerVariant;
-  inFilteringToken?: boolean;
+  inFilteringToken?: 'root' | 'nested';
   selectedOptions?: ReadonlyArray<OptionDefinition>;
 }
 


### PR DESCRIPTION
### Description

Fixing nested token radius on the left side when operation selector is present.

Additionally, there are small improvements to the api docs.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
