### PR TITLE
fix: Fix dropdown click handling inside shadow DOM context

### DIFF
--- a/src/date-picker/__tests__/common.tsx
+++ b/src/date-picker/__tests__/common.tsx
@@ -14,13 +14,23 @@ import screenreaderOnlyStyles from '../../../lib/components/internal/components/
 
 export const outsideId = 'outside';
 
-export function renderDatePicker(props: DatePickerProps) {
+export function renderDatePicker(props: DatePickerProps, { withShadowRoot }: { withShadowRoot?: boolean } = {}) {
+  let customContainer: Element | undefined;
+  if (withShadowRoot) {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const shadowRoot = div.attachShadow({ mode: 'open' });
+    customContainer = shadowRoot.ownerDocument.createElement('div');
+    shadowRoot.ownerDocument.body.appendChild(customContainer);
+  }
+
   const { container, getByTestId } = render(
     <div>
       <button value={'Used to change the focus in this test suite'} data-testid={outsideId} />
       <br />
       <DatePicker {...props} />
-    </div>
+    </div>,
+    { container: customContainer }
   );
 
   const wrapper = createWrapper(container).findDatePicker()!;

--- a/src/date-picker/__tests__/date-picker-calendar.test.tsx
+++ b/src/date-picker/__tests__/date-picker-calendar.test.tsx
@@ -564,17 +564,16 @@ describe('Date picker calendar', () => {
     });
   });
 
-  describe('change event', () => {
+  describe.each([false, true])('change event (withShadowRoot=%s)', withShadowRoot => {
     let onChangeSpy: jest.Mock<NonCancelableEventHandler<DatePickerProps.ChangeDetail>>;
     let wrapper: DatePickerWrapper;
 
     beforeEach(() => {
       onChangeSpy = jest.fn();
-      ({ wrapper } = renderDatePicker({
-        ...defaultProps,
-        value: '2018-03-01',
-        onChange: onChangeSpy,
-      }));
+      ({ wrapper } = renderDatePicker(
+        { ...defaultProps, value: '2018-03-01', onChange: onChangeSpy },
+        { withShadowRoot }
+      ));
       wrapper.findOpenCalendarButton().click();
     });
 

--- a/src/internal/components/dropdown/index.tsx
+++ b/src/internal/components/dropdown/index.tsx
@@ -369,8 +369,11 @@ const Dropdown = ({
     if (!open) {
       return;
     }
-    const clickListener = (e: MouseEvent) => {
-      if (!nodeBelongs(dropdownRef.current, e.target) && !nodeBelongs(triggerRef.current, e.target)) {
+    const clickListener = (event: MouseEvent) => {
+      // Since the listener is registered on the window, `event.target` will incorrectly point at the
+      // shadow root if the component is rendered inside shadow DOM.
+      const target = event.composedPath()[0];
+      if (!nodeBelongs(dropdownRef.current, target) && !nodeBelongs(triggerRef.current, target)) {
         fireNonCancelableEvent(onDropdownClose);
       }
     };


### PR DESCRIPTION
### Description

Inside click detection in dropdowns is broken because we couldn't determine whether an element belonged to a dropdown inside a shadow DOM context. This is essentially the same root cause as in #781, manifesting in a different component.

Related links, issue #, if available: AWSUI-59038

### How has this been tested?

Added tests. We had a case previously where we had to revert because some packages had older JSDOMs didn't support composedPath, but enough time has passed that we should just ask them to upgrade if they hit this issue.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
