### PR TITLE
fix: Toolbar disabled buttons in mobile and display of breadcrumbs

### DIFF
--- a/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
+++ b/src/app-layout/__integ__/app-layout-sticky-elements.test.ts
@@ -125,7 +125,8 @@ describe.each(['classic', 'refresh', 'refresh-toolbar'] as Theme[])('%s', theme 
         const pageHeaderBottom = (await page.getBoundingBox(pageHeaderSelector)).bottom;
         await page.windowScrollTo({ top: 200 });
         const tableStickyHeaderTop = (await page.getBoundingBox(tableStickyHeaderSelector.toSelector())).top;
-        expect(tableStickyHeaderTop).toEqual(pageHeaderBottom);
+        // Take into account toolbar height
+        expect(tableStickyHeaderTop).toEqual(pageHeaderBottom + (theme === 'refresh-toolbar' ? 42 : 0));
       }
     )
   );

--- a/src/app-layout/visual-refresh-toolbar/multi-layout.ts
+++ b/src/app-layout/visual-refresh-toolbar/multi-layout.ts
@@ -61,6 +61,9 @@ function mergeProps(ownProps: SharedProps, additionalProps: ReadonlyArray<Partia
       toolbar.splitPanelToggleProps = props.splitPanelToggleProps;
       toolbar.onSplitPanelToggle = props.onSplitPanelToggle;
     }
+    if (props.breadcrumbs && !checkAlreadyExists(!!toolbar.hasBreadcrumbsPortal, 'hasBreadcrumbsPortal')) {
+      toolbar.hasBreadcrumbsPortal = true;
+    }
   }
   // do not render toolbar if no fields are defined, except ariaLabels, which are always there
   return Object.keys(toolbar).filter(key => key !== 'ariaLabels').length > 0 ? toolbar : null;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -52,7 +52,7 @@ export function DrawerTriggers({
   splitPanelFocusRef,
   splitPanelToggleProps,
   onSplitPanelToggle,
-  disabled = false,
+  disabled,
 }: DrawerTriggersProps) {
   const isMobile = useMobile();
   const hasMultipleTriggers = drawers.length > 1;

--- a/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/drawer-triggers.tsx
@@ -38,6 +38,7 @@ interface DrawerTriggersProps {
   splitPanelToggleProps: SplitPanelToggleProps | undefined;
   splitPanelFocusRef: React.Ref<Focusable> | undefined;
   onSplitPanelToggle: (() => void) | undefined;
+  disabled: boolean;
 }
 
 export function DrawerTriggers({
@@ -51,6 +52,7 @@ export function DrawerTriggers({
   splitPanelFocusRef,
   splitPanelToggleProps,
   onSplitPanelToggle,
+  disabled = false,
 }: DrawerTriggersProps) {
   const isMobile = useMobile();
   const hasMultipleTriggers = drawers.length > 1;
@@ -120,6 +122,7 @@ export function DrawerTriggers({
               isMobile={isMobile}
               isForPreviousActiveDrawer={splitPanelToggleProps.active}
               isForSplitPanel={true}
+              disabled={disabled}
             />
             {hasMultipleTriggers ? <div className={styles['group-divider']}></div> : null}
           </>
@@ -149,6 +152,7 @@ export function DrawerTriggers({
               tooltipText={item.ariaLabels?.drawerName}
               isForPreviousActiveDrawer={isForPreviousActiveDrawer}
               isMobile={isMobile}
+              disabled={disabled}
             />
           );
         })}
@@ -165,6 +169,7 @@ export function DrawerTriggers({
                 className={clsx(styles['drawers-trigger'], testutilStyles['drawers-trigger'], testUtilsClass)}
                 iconName="ellipsis"
                 onClick={onClick}
+                disabled={disabled}
               />
             )}
             onItemClick={event => onActiveDrawerChange?.(event.detail.id)}

--- a/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/toolbar/index.tsx
@@ -140,6 +140,7 @@ export function AppLayoutToolbarImplementation({
   }, [pinnedToolbar, setToolbarState, toolbarState]);
 
   const toolbarHidden = toolbarState === 'hide' && !pinnedToolbar;
+  const disableButtons = !!isMobile && (!!activeDrawerId || !!navigationOpen);
 
   return (
     <ToolbarSlot
@@ -163,6 +164,7 @@ export function AppLayoutToolbarImplementation({
               onClick={() => onNavigationToggle?.(!navigationOpen)}
               ref={navigationFocusRef}
               selected={navigationOpen}
+              disabled={disableButtons}
             />
           </nav>
         )}
@@ -189,6 +191,7 @@ export function AppLayoutToolbarImplementation({
               splitPanelToggleProps={splitPanelToggleProps?.displayed ? splitPanelToggleProps : undefined}
               splitPanelFocusRef={splitPanelFocusRef}
               onSplitPanelToggle={onSplitPanelToggle}
+              disabled={disableButtons}
             />
           </span>
         )}


### PR DESCRIPTION
### Description

1 - Disable trigger buttons in mobile view
2 - Display toolbar even if it only has breadcrumbs
3 - activate many of the mobile tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
