### PR TITLE
chore: adding focus delegation to nav toggle in toolbar

### DIFF
--- a/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
+++ b/src/app-layout/__integ__/app-layout-focus-delegation.test.ts
@@ -84,8 +84,7 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
         )
       );
 
-      //TODO create separate split panel test for 'visual-refresh-toolbar' theme
-      testIf(theme !== 'visual-refresh-toolbar')(
+      test(
         'navigation panel focus toggles between open and close buttons',
         setupTest(
           async page => {

--- a/src/app-layout/visual-refresh-toolbar/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/index.tsx
@@ -73,6 +73,14 @@ const AppLayoutVisualRefreshToolbar = React.forwardRef<AppLayoutProps.Ref, AppLa
     const [notificationsHeight, setNotificationsHeight] = useState(0);
 
     const onNavigationToggle = (open: boolean) => {
+      const { setFocus, refs } = navigationFocusControl;
+      const navToggleRef = refs?.toggle?.current;
+
+      if (open) {
+        setFocus();
+      } else if (navToggleRef) {
+        navToggleRef.focus();
+      }
       fireNonCancelableEvent(onNavigationChange, { open });
     };
 


### PR DESCRIPTION
### Description

This adds focus delegation to the toolbar variant of the AppLayout component where the focus shifts to the navigation panel close button when opened and back to the navigation toggle when the close button is clicked.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

Integ tests have been updated to assert the functionality works

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
