### PR TITLE
fix: Fix split panel vertical offset calculation

### DIFF
--- a/src/app-layout/__integ__/app-layout-split-panel.test.ts
+++ b/src/app-layout/__integ__/app-layout-split-panel.test.ts
@@ -313,6 +313,19 @@ describe.each(['classic', 'visual-refresh', 'visual-refresh-toolbar'] as const)(
     })
   );
 
+  test(
+    'side panel stays in the viewport when scrolling down',
+    setupTest(async page => {
+      const splitPanelSelector = wrapper.findSplitPanel().findOpenPanelSide().toSelector();
+      await page.openPanel();
+      await page.switchPosition('side');
+      const { top: offsetBefore } = await page.getBoundingBox(splitPanelSelector);
+      await page.windowScrollTo({ top: 500 });
+      const { top: offsetAfter } = await page.getBoundingBox(splitPanelSelector);
+      expect(offsetAfter).toEqual(offsetBefore);
+    })
+  );
+
   describe('interaction with table sticky header', () => {
     // bottom padding is included into the offset in VR but not in classic
     const splitPanelPadding = theme === 'visual-refresh' ? 40 : 0;

--- a/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
+++ b/src/app-layout/visual-refresh-toolbar/split-panel/index.tsx
@@ -19,15 +19,16 @@ export function AppLayoutSplitPanelDrawerSideImplementation({
   appLayoutInternals,
   splitPanelInternals,
 }: AppLayoutSplitPanelDrawerSideImplementationProps) {
-  const { splitPanelControlId, placement } = appLayoutInternals;
+  const { splitPanelControlId, placement, verticalOffsets } = appLayoutInternals;
+  const drawerTopOffset = verticalOffsets.drawers ?? placement.insetBlockStart;
   return (
     <SplitPanelProvider {...splitPanelInternals}>
       <section
         id={splitPanelControlId}
         className={styles['split-panel-side']}
         style={{
-          blockSize: `calc(100vh - ${placement.insetBlockStart}px - ${placement.insetBlockEnd}px)`,
-          insetBlockStart: placement.insetBlockStart,
+          blockSize: `calc(100vh - ${drawerTopOffset}px - ${placement.insetBlockEnd}px)`,
+          insetBlockStart: drawerTopOffset,
         }}
       >
         {children}


### PR DESCRIPTION
### Description

We already do that for the navigation and tools panel, but not the split panel

https://github.com/cloudscape-design/components/blob/8ca4c6a55dd13eb572df364cb420527fa1366035/src/app-layout/visual-refresh-toolbar/navigation/index.tsx#L31

Related links, issue #, if available: n/a

### How has this been tested?

1. Manually
2. Added an integration test

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](https://github.com/cloudscape-design/components/blob/main/CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
